### PR TITLE
[codex] Respect --brand lark in config init --new

### DIFF
--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -157,3 +157,54 @@ func TestConfigRemoveCmd_FlagParsing(t *testing.T) {
 		t.Fatal("expected factory to be preserved in options")
 	}
 }
+
+func TestConfigInitRun_NewPropagatesBrandFlagToCreateFlow(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+	opts := &ConfigInitOptions{
+		Factory: f,
+		Ctx:     context.Background(),
+		New:     true,
+		Brand:   "lark",
+		Lang:    "en",
+	}
+
+	oldRunCreateAppFlow := runCreateAppFlowFn
+	defer func() {
+		runCreateAppFlowFn = oldRunCreateAppFlow
+	}()
+
+	var gotBrand core.LarkBrand
+	runCreateAppFlowFn = func(ctx context.Context, f *cmdutil.Factory, brandOverride core.LarkBrand, msg *initMsg) (*configInitResult, error) {
+		gotBrand = brandOverride
+		return &configInitResult{
+			Mode:      "create",
+			Brand:     brandOverride,
+			AppID:     "cli_test_lark",
+			AppSecret: "secret123",
+		}, nil
+	}
+
+	if err := configInitRun(opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotBrand != core.BrandLark {
+		t.Fatalf("runCreateAppFlow received brand %q, want %q", gotBrand, core.BrandLark)
+	}
+
+	cfg, err := core.LoadMultiAppConfig()
+	if err != nil {
+		t.Fatalf("failed to load saved config: %v", err)
+	}
+	if len(cfg.Apps) != 1 {
+		t.Fatalf("expected exactly one app in config, got %d", len(cfg.Apps))
+	}
+	if cfg.Apps[0].Brand != core.BrandLark {
+		t.Fatalf("saved config brand = %q, want %q", cfg.Apps[0].Brand, core.BrandLark)
+	}
+	if !strings.Contains(stdout.String(), `"brand": "lark"`) {
+		t.Fatalf("stdout = %q, want JSON output to include saved lark brand", stdout.String())
+	}
+}

--- a/cmd/config/init.go
+++ b/cmd/config/init.go
@@ -153,7 +153,7 @@ func configInitRun(opts *ConfigInitOptions) error {
 
 	// Mode 3: Create new app directly (--new)
 	if opts.New {
-		result, err := runCreateAppFlow(opts.Ctx, f, core.BrandFeishu, msg)
+		result, err := runCreateAppFlowFn(opts.Ctx, f, parseBrand(opts.Brand), msg)
 		if err != nil {
 			return err
 		}

--- a/cmd/config/init_interactive.go
+++ b/cmd/config/init_interactive.go
@@ -26,6 +26,9 @@ type configInitResult struct {
 	AppSecret string
 }
 
+// runCreateAppFlowFn is a small test seam for configInitRun.
+var runCreateAppFlowFn = runCreateAppFlow
+
 // runInteractiveConfigInit shows an interactive TUI for config init.
 func runInteractiveConfigInit(ctx context.Context, f *cmdutil.Factory, msg *initMsg) (*configInitResult, error) {
 	// Phase 1: Choose mode
@@ -196,7 +199,7 @@ func runCreateAppFlow(ctx context.Context, f *cmdutil.Factory, brandOverride cor
 	// Step 4: Handle Lark brand special case
 	// If tenant_brand=lark and no client_secret, retry with lark brand endpoint
 	if result.ClientSecret == "" && result.UserInfo != nil && result.UserInfo.TenantBrand == "lark" {
-		// fmt.Fprintf(f.IOStreams.ErrOut, "%s\n", msg.DetectedLarkTenant)
+		fmt.Fprintf(f.IOStreams.ErrOut, "%s\n", msg.DetectedLarkTenant)
 		result, err = larkauth.PollAppRegistration(ctx, httpClient, core.BrandLark, authResp.DeviceCode, authResp.Interval, authResp.ExpiresIn, f.IOStreams.ErrOut)
 		if err != nil {
 			return nil, output.ErrAuth("lark endpoint retry failed: %v", err)


### PR DESCRIPTION
## Summary

- respect `--brand lark` in `config init --new`
- preserve the requested Lark brand in the saved config and JSON output
- surface the existing Lark endpoint retry message during app registration
- add a regression test for the `--new --brand lark` path

## Root cause

`config init --new` hard-coded `core.BrandFeishu` when entering the create-app flow, so the requested brand never reached the setup URL generation path.

## Testing

- `go test ./cmd/config`
- `go test ./internal/auth ./internal/core`
- `go test ./...`  
  - this still fails in `internal/registry` on pre-existing tests:
    - `TestColdStart_UsesEmbedded`
    - `TestCacheHit_WithinTTL`
