### PR TITLE
fix(docs): normalize board_tokens in +create response for mermaid/whiteboard content

### DIFF
--- a/shortcuts/doc/docs_create.go
+++ b/shortcuts/doc/docs_create.go
@@ -83,6 +83,7 @@ var DocsCreate = common.Shortcut{
 			return err
 		}
 
+		normalizeDocsUpdateResult(result, runtime.Str("markdown"))
 		runtime.Out(result, nil)
 		return nil
 	},


### PR DESCRIPTION
## Problem

`docs +update` calls `normalizeDocsUpdateResult` after executing, which surfaces `board_tokens` in the response when the markdown contains mermaid/plantuml/whiteboard blocks. `docs +create` is missing the same call.

As a result, a caller who creates a document with mermaid diagrams via `+create` cannot know how many whiteboards were created or retrieve their tokens — even though the exact same information is available from the underlying MCP response.

**Repro:**
```sh
lark-cli docs +create --title "test" --markdown $'```mermaid\nflowchart LR\n  A-->B\n```'
# board_tokens is absent from output

lark-cli docs +update --doc <id> --mode append --markdown $'```mermaid\nflowchart LR\n  A-->B\n```'
# board_tokens is present in output ✓
```

## Fix

Call `normalizeDocsUpdateResult` in `DocsCreate.Execute` after `CallMCPTool`, identical to how `DocsUpdate.Execute` does it. One-line change.

## Notes

- `normalizeDocsUpdateResult` (and its helpers `isWhiteboardCreateMarkdown`, `normalizeBoardTokens`) live in the same `doc` package and are accessible without any export changes.
- No behavior change when markdown contains no mermaid/whiteboard blocks (`normalizeDocsUpdateResult` is a no-op in that case).