### PR TITLE
docs: rename user-facing Bitable references to Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Built-in shortcuts for commonly used Lark APIs, enabling concise commands like `
 - **Drive** — Upload, download, and manage cloud documents.
 - **Docs** — Work with Lark documents.
 - **Sheets** — Interact with spreadsheets.
-- **Base (Bitable)** — Manage multi-dimensional tables.
+- **Base** — Manage multi-dimensional tables.
 - **Calendar** — Create and manage calendar events.
 - **Mail** — Send and manage emails.
 - **Contact** — Look up users and departments.

--- a/shortcuts/base/base_data_query.go
+++ b/shortcuts/base/base_data_query.go
@@ -14,7 +14,7 @@ import (
 var BaseDataQuery = common.Shortcut{
 	Service:     "base",
 	Command:     "+data-query",
-	Description: "Query and analyze Bitable data with JSON DSL (aggregation, filter, sort)",
+	Description: "Query and analyze Base data with JSON DSL (aggregation, filter, sort)",
 	Risk:        "read",
 	Scopes:      []string{"base:table:read"},
 	AuthTypes:   authTypes(),

--- a/skills/lark-base/references/formula-field-guide.md
+++ b/skills/lark-base/references/formula-field-guide.md
@@ -1,4 +1,4 @@
-# Bitable Formula Writing Guide
+# Base Formula Writing Guide
 
 ## Mandatory Read Acknowledgement
 
@@ -121,7 +121,7 @@ When using comparison operators (`>`, `>=`, `<`, `<=`, `=`, `!=`), **both sides 
 
 ## Section 4: Operators
 
-Bitable formulas **only allow** the following operators. `like`, `in`, `<>`, `**`, `^` etc. are prohibited.
+Base formulas **only allow** the following operators. `like`, `in`, `<>`, `**`, `^` etc. are prohibited.
 
 | Category      | Operators                  | Description                                                                |
 | ------------- | -------------------------- | -------------------------------------------------------------------------- |

--- a/skills/lark-base/references/lookup-field-guide.md
+++ b/skills/lark-base/references/lookup-field-guide.md
@@ -1,4 +1,4 @@
-# Bitable Lookup Field Configuration Guide
+# Base Lookup Field Configuration Guide
 
 ## Mandatory Read Acknowledgement
 

--- a/skills/lark-doc/references/lark-doc-create.md
+++ b/skills/lark-doc/references/lark-doc-create.md
@@ -437,7 +437,7 @@ lark-cli docs +create --title "空白画板示例" --markdown '<whiteboard type=
 - 读取时只能获取 token，可通过 media-download 查看内容，无法直接读出画板内部内容
 - 画板编辑：详见 [SKILL.md](../SKILL.md#重要说明画板编辑)
 
-### 多维表格（Bitable）
+### 多维表格（Base）
 
 ```html
 <bitable view="table"/>


### PR DESCRIPTION
## Summary

This PR standardizes user-facing naming from `Bitable` to `Base` in documentation and CLI help text where the old term is only serving as product copy, not as a schema or protocol identifier.

## Why rename

The CLI command surface, tokens, and current product terminology already use `base` / `Base`:
- users run `lark-cli base +...`
- users pass `--base-token`
- the docs and issue discussions increasingly refer to the product as Base

Keeping `Bitable` in user-facing docs creates unnecessary naming drift and makes it harder to understand whether `Base` and `Bitable` are different things. They are not, at the product level. This PR reduces that confusion while preserving compatibility-level identifiers where they still matter.

## What changed

Updated user-facing wording in these places:
- `CHANGELOG.md`
- `skills/lark-base/references/formula-field-guide.md`
- `skills/lark-base/references/lookup-field-guide.md`
- `skills/lark-doc/references/lark-doc-create.md`
- `shortcuts/base/base_data_query.go`

Concretely:
- `Base (Bitable)` -> `Base`
- `Bitable Formula Writing Guide` -> `Base Formula Writing Guide`
- `Bitable Lookup Field Configuration Guide` -> `Base Lookup Field Configuration Guide`
- `多维表格（Bitable）` -> `多维表格（Base）`
- `Query and analyze Bitable data ...` -> `Query and analyze Base data ...`

## What this PR intentionally does NOT change

This PR keeps `bitable` where it appears to be a compatibility or schema-level identifier rather than product copy, including:
- `obj_type=bitable`
- `<bitable ... />` doc DSL tags
- `type=.../bitable` style enum/schema values
- legacy API path references like `bitable/v1`
- scopes/tests/internal identifiers that still rely on the underlying name

## Rationale for the non-changes

Those occurrences are more like protocol or schema contracts than human-facing naming. Renaming them in the same pass would risk breaking docs accuracy or code compatibility. It is safer to keep them until the underlying platform identifiers themselves change.

## Validation

- Searched the repo for `Bitable` / `bitable` after the edit.
- Confirmed remaining matches are in the intentionally preserved categories above.
- `go test ./...` could not be run in the current environment because `go` is not installed.
