### PR TITLE
docs: add Star History chart to readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,10 @@ We recommend using the Lark/Feishu bot integrated with this tool as a private co
 
 Please fully understand all usage risks. By using this tool, you are deemed to voluntarily assume all related responsibilities.
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=larksuite/cli&type=Date)](https://star-history.com/#larksuite/cli&Date)
+
 ## Contributing
 
 Community contributions are welcome! If you find a bug or have feature suggestions, please submit an [Issue](https://github.com/larksuite/cli/issues) or [Pull Request](https://github.com/larksuite/cli/pulls).

--- a/README.zh.md
+++ b/README.zh.md
@@ -257,6 +257,10 @@ lark-cli schema im.messages.delete
 
 请您充分知悉全部使用风险，使用本工具即视为您自愿承担相关所有责任。
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=larksuite/cli&type=Date)](https://star-history.com/#larksuite/cli&Date)
+
 ## 贡献
 
 欢迎社区贡献！如果你发现 bug 或有功能建议，请提交 [Issue](https://github.com/larksuite/cli/issues) 或 [Pull Request](https://github.com/larksuite/cli/pulls)。


### PR DESCRIPTION
## Summary

Add a Star History chart to both English and Chinese READMEs.

## What changed

- Added a `Star History` section to `README.md`
- Added a `Star History` section to `README.zh.md`
- Used the chart generated by [star-history.com](https://star-history.com/)

## Why

This gives readers a quick visual view of repository growth directly from the README, which is a common pattern in open-source project pages.

## Validation

- Verified both README files render a standard Markdown image link.
- No code paths changed.
