### PR TITLE
docs: refine README header badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Awesome for Agents](https://img.shields.io/badge/Awesome%20for-Agents-6f42c1)](#why-lark-cli)
 [![npm downloads](https://img.shields.io/npm/dw/%40larksuite%2Fcli?label=npm%20downloads)](https://www.npmjs.com/package/@larksuite/cli)
-[![npm version](https://img.shields.io/npm/v/@larksuite/cli.svg)](https://www.npmjs.com/package/@larksuite/cli)
-[![Go Version](https://img.shields.io/badge/go-%3E%3D1.23-blue.svg)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [中文版](./README.zh.md) | [English](./README.md)

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,8 +2,6 @@
 
 [![Awesome for Agents](https://img.shields.io/badge/Awesome%20for-Agents-6f42c1)](#为什么选-lark-cli)
 [![npm downloads](https://img.shields.io/npm/dw/%40larksuite%2Fcli?label=npm%20downloads)](https://www.npmjs.com/package/@larksuite/cli)
-[![npm version](https://img.shields.io/npm/v/@larksuite/cli.svg)](https://www.npmjs.com/package/@larksuite/cli)
-[![Go Version](https://img.shields.io/badge/go-%3E%3D1.23-blue.svg)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 [中文版](./README.zh.md) | [English](./README.md)


### PR DESCRIPTION
## Summary

Refine the README header badges in both English and Chinese READMEs.

## Why

The original header felt visually sparse, but adding too many badges quickly made it look noisy and overly engineering-heavy.

This PR keeps the header intentionally restrained and product-facing:
- `Awesome for Agents` explains the project flavor at a glance
- `npm downloads` gives a lightweight usage/activity signal
- `License` keeps the open-source status visible

## What changed

- Added `Awesome for Agents`
- Added `npm downloads`
- Kept `License`
- Removed `GitHub stars`
- Removed `npm version`
- Removed `Go Version`
- Updated both `README.md` and `README.zh.md`

## Why remove the other badges

- `GitHub stars`: useful as a social signal, but visually abrupt in this header and not essential
- `npm version`: adds package metadata, but not much value for first-time readers
- `Go Version`: emphasizes implementation details rather than user value, which is less helpful for a product-style CLI README

## Result

The final header focuses on three signals only:
- project positioning
- lightweight activity signal
- license

This keeps the top of the README cleaner and easier to scan.
