### PR TITLE
feat: support auto extension for downloads

### DIFF
--- a/shortcuts/im/helpers_network_test.go
+++ b/shortcuts/im/helpers_network_test.go
@@ -263,7 +263,7 @@ func TestDownloadIMResourceToPathSuccess(t *testing.T) {
 	}))
 
 	target := filepath.Join(t.TempDir(), "nested", "resource.bin")
-	size, err := downloadIMResourceToPath(context.Background(), runtime, "om_123", "file_123", "file", target)
+	_, size, err := downloadIMResourceToPath(context.Background(), runtime, "om_123", "file_123", "file", target)
 	if err != nil {
 		t.Fatalf("downloadIMResourceToPath() error = %v", err)
 	}
@@ -307,7 +307,7 @@ func TestDownloadIMResourceToPathHTTPErrorBody(t *testing.T) {
 		}
 	}))
 
-	_, err := downloadIMResourceToPath(context.Background(), runtime, "om_403", "file_403", "file", filepath.Join(t.TempDir(), "out.bin"))
+	_, _, err := downloadIMResourceToPath(context.Background(), runtime, "om_403", "file_403", "file", filepath.Join(t.TempDir(), "out.bin"))
 	if err == nil || !strings.Contains(err.Error(), "HTTP 403: denied") {
 		t.Fatalf("downloadIMResourceToPath() error = %v", err)
 	}

--- a/shortcuts/im/helpers_test.go
+++ b/shortcuts/im/helpers_test.go
@@ -483,7 +483,7 @@ func TestDownloadIMResourceToPathHTTPClientError(t *testing.T) {
 		},
 	}
 
-	_, err := downloadIMResourceToPath(context.Background(), runtime, "om_123", "img_123", "image", "out.bin")
+	_, _, err := downloadIMResourceToPath(context.Background(), runtime, "om_123", "img_123", "image", "out.bin")
 	if err == nil || !strings.Contains(err.Error(), "http client unavailable") {
 		t.Fatalf("downloadIMResourceToPath() error = %v", err)
 	}

--- a/shortcuts/im/im_messages_resources_download.go
+++ b/shortcuts/im/im_messages_resources_download.go
@@ -72,12 +72,12 @@ var ImMessagesResourcesDownload = common.Shortcut{
 			return output.ErrValidation("unsafe output path: %s", err)
 		}
 
-		sizeBytes, err := downloadIMResourceToPath(ctx, runtime, messageId, fileKey, fileType, safePath)
+		finalPath, sizeBytes, err := downloadIMResourceToPath(ctx, runtime, messageId, fileKey, fileType, safePath)
 		if err != nil {
 			return err
 		}
 
-		runtime.Out(map[string]interface{}{"saved_path": safePath, "size_bytes": sizeBytes}, nil)
+		runtime.Out(map[string]interface{}{"saved_path": finalPath, "size_bytes": sizeBytes}, nil)
 		return nil
 	},
 }
@@ -108,7 +108,38 @@ func normalizeDownloadOutputPath(fileKey, outputPath string) (string, error) {
 
 const defaultIMResourceDownloadTimeout = 120 * time.Second
 
-func downloadIMResourceToPath(ctx context.Context, runtime *common.RuntimeContext, messageID, fileKey, fileType, safePath string) (int64, error) {
+var imMimeToExt = map[string]string{
+	"image/png":                   ".png",
+	"image/jpeg":                  ".jpg",
+	"image/gif":                   ".gif",
+	"image/webp":                  ".webp",
+	"image/svg+xml":               ".svg",
+	"application/pdf":             ".pdf",
+	"video/mp4":                   ".mp4",
+	"video/3gpp":                  ".3gp",
+	"video/x-msvideo":             ".avi",
+	"audio/mpeg":                  ".mp3",
+	"audio/ogg":                   ".ogg",
+	"audio/wav":                   ".wav",
+	"text/plain":                  ".txt",
+	"text/html":                   ".html",
+	"text/css":                    ".css",
+	"text/csv":                    ".csv",
+	"application/zip":             ".zip",
+	"application/x-zip-compressed": ".zip",
+	"application/x-rar-compressed": ".rar",
+	"application/json":            ".json",
+	"application/xml":             ".xml",
+	"application/octet-stream":    ".bin",
+	"application/msword":          ".doc",
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+	"application/vnd.ms-excel":    ".xls",
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+	"application/vnd.ms-powerpoint": ".ppt",
+	"application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+}
+
+func downloadIMResourceToPath(ctx context.Context, runtime *common.RuntimeContext, messageID, fileKey, fileType, safePath string) (string, int64, error) {
 	query := larkcore.QueryParams{}
 	query.Set("type", fileType)
 	downloadResp, err := runtime.DoAPIStream(ctx, &larkcore.ApiReq{
@@ -121,24 +152,36 @@ func downloadIMResourceToPath(ctx context.Context, runtime *common.RuntimeContex
 		QueryParams: query,
 	}, defaultIMResourceDownloadTimeout)
 	if err != nil {
-		return 0, err
+		return "", 0, err
 	}
 	defer downloadResp.Body.Close()
 
 	if downloadResp.StatusCode >= 400 {
 		body, _ := io.ReadAll(io.LimitReader(downloadResp.Body, 4096))
 		if len(body) > 0 {
-			return 0, output.ErrNetwork("download failed: HTTP %d: %s", downloadResp.StatusCode, strings.TrimSpace(string(body)))
+			return "", 0, output.ErrNetwork("download failed: HTTP %d: %s", downloadResp.StatusCode, strings.TrimSpace(string(body)))
 		}
-		return 0, output.ErrNetwork("download failed: HTTP %d", downloadResp.StatusCode)
+		return "", 0, output.ErrNetwork("download failed: HTTP %d", downloadResp.StatusCode)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(safePath), 0700); err != nil {
-		return 0, output.Errorf(output.ExitInternal, "api_error", "cannot create parent directory: %s", err)
+		return "", 0, output.Errorf(output.ExitInternal, "api_error", "cannot create parent directory: %s", err)
 	}
-	sizeBytes, err := validate.AtomicWriteFromReader(safePath, downloadResp.Body, 0600)
+
+	// Auto-detect extension from Content-Type if missing
+	finalPath := safePath
+	if filepath.Ext(safePath) == "" {
+		contentType := downloadResp.Header.Get("Content-Type")
+		mimeType := strings.Split(contentType, ";")[0]
+		mimeType = strings.TrimSpace(mimeType)
+		if ext, ok := imMimeToExt[mimeType]; ok {
+			finalPath = safePath + ext
+		}
+	}
+
+	sizeBytes, err := validate.AtomicWriteFromReader(finalPath, downloadResp.Body, 0600)
 	if err != nil {
-		return 0, output.Errorf(output.ExitInternal, "api_error", "cannot create file: %s", err)
+		return "", 0, output.Errorf(output.ExitInternal, "api_error", "cannot create file: %s", err)
 	}
-	return sizeBytes, nil
+	return finalPath, sizeBytes, nil
 }


### PR DESCRIPTION
## Summary
Add automatic file extension detection for IM message resource downloads.

## Why
Downloaded IM resources currently default to the raw file key when no `--output` extension is provided, which makes the saved file harder to open and identify locally. This change makes the download result more usable by inferring a reasonable extension from the response `Content-Type`.

## What changed
Updated `im +messages-resources-download` to append a file extension when the target path has no suffix
Added MIME type to file extension mappings for common image, document, audio, video, and archive formats
Returned the final saved path in command output after extension resolution
Updated related helper tests for the new download helper return signature

## Scope
This PR only updates IM resource download filename handling and related tests. It does not change the underlying download API behavior or upload flows.