### PR TITLE
feat: add lark-scan-report skill

### DIFF
--- a/skills/lark-scan-report/README.md
+++ b/skills/lark-scan-report/README.md
@@ -1,0 +1,217 @@
+# Scan Report Skill
+
+An AI agent skill that generates structured Lark/Feishu work reports as message cards — built from your task list and chat messages.
+
+All logic runs through `lark-cli` commands. No code execution, no SDK dependency — any AI agent that can run shell commands can operate this skill.
+
+**Five report types:** morning briefing · evening wrap-up · quick scan · full snapshot · weekly summary
+
+---
+
+## For Humans
+
+### What You Get
+
+| Report | Default Schedule (UTC+8) | What it answers |
+|--------|--------------------------|-----------------|
+| Morning | 10:30 Mon–Fri | Top tasks today + overnight messages requiring action |
+| Evening | 22:00 Mon–Fri | What shipped today + what to push tomorrow |
+| Quick scan | On demand | Anything new since last check — @mentions + task updates |
+| Full | On demand | Comprehensive snapshot across all sources |
+| Weekly | Sun 15:00 | What I accomplished this week + what's next |
+
+Morning and evening reports accumulate into a rolling weekly log. The weekly summary reads that log — no redundant API calls.
+
+All output is formatted as a Lark message card, sent directly to your configured chat.
+
+---
+
+### Installation
+
+**Prerequisites:** [lark-cli](../../README.md) installed and authenticated.
+
+Tell your AI agent:
+
+```
+install scan report skill
+```
+
+The agent will scan your groups, let you pick which ones to monitor, and write your config. No manual YAML editing required.
+
+> **Claude Code users:** The setup flow generates an interactive HTML config page for group selection — a smoother experience than inline Q&A.
+
+---
+
+### Triggering Reports
+
+Tell your AI agent:
+
+| Say this | Report |
+|----------|--------|
+| `morning report` | Morning briefing |
+| `evening report` | Evening wrap-up |
+| `weekly report` | Weekly summary |
+| `quick scan` | Quick scan |
+| `full report` | Full snapshot |
+
+Chinese triggers also work: `日报` · `晚报` · `周报`
+
+---
+
+### Required Permissions
+
+In your Lark app console at [open.larksuite.com](https://open.larksuite.com) (Feishu: [open.feishu.cn](https://open.feishu.cn)), add the following under **Permissions & Scopes**. Copy and paste directly into the permission configuration:
+
+```json
+{
+  "scopes": {
+    "tenant": [
+      "im:message",
+      "im:message:send_as_bot",
+      "task:task:readonly",
+      "task:tasklist:readonly"
+    ],
+    "user": [
+      "im:message:readonly",
+      "task:task:readonly",
+      "task:tasklist:readonly",
+      "offline_access"
+    ]
+  }
+}
+```
+
+> **Why both tenant and user scopes?** Message cards are sent as the bot (tenant token). Task and message history APIs require user identity to access personal data.
+
+After adding permissions, re-authenticate:
+
+```bash
+lark auth login --add --scopes messages
+```
+
+---
+
+## For AI Agents
+
+This skill orchestrates two data sources via `lark-cli` commands — no code execution needed:
+
+```
+lark-cli task *  +  lark-cli im *  →  Message card report
+```
+
+### What You Need
+
+The only hard dependency is `lark-cli` in PATH with valid auth. Everything in this skill is a sequence of CLI calls, JSON parsing, and text generation. No Python, no SDKs, no build steps.
+
+### Core Flow
+
+1. **Task collection** — `tasks list` discovers tasklist GUIDs from response; `tasklists tasks` per GUID fetches all tasks including follower tasks. (`tasklists list` returns error 1470500 — skip it entirely.)
+2. **Message scanning** — Delta scan from `.last-scan-ts`. Whitelist groups get full pull; other active groups are discovered via `messages-search`. `@me` search as catchall backstop.
+3. **Intelligence layer** — Match messages against open tasks by keyword and sender; extract action items; classify urgency; identify blockers.
+4. **Card output** — Render Lark interactive card JSON per template; send via `messages-send --msg-type interactive --as bot`.
+
+### Templates
+
+Five templates in `templates/` — each defines card structure, extraction logic, and output rules:
+
+| File | Report |
+|------|--------|
+| `morning-report.md` | TOP 3 tasks (DDL today > P0 > overdue) + message-driven action items |
+| `evening-report.md` | Completed tasks + tomorrow push list + conversation highlights |
+| `quick-scan.md` | @mentions → task-matched updates → group digest. Plain text if no updates. |
+| `full-report.md` | Full task hierarchy by section + all active message groups |
+| `weekly-summary.md` | Exec-facing (module-grouped, narrative) + internal (task list + tracking) |
+
+Templates are the source of truth for card format and report logic — edit them to change structure, card theme, or extraction behavior.
+
+### What's Configurable in `config.yaml`
+
+| Field | What it controls |
+|-------|-----------------|
+| `tasks.section_names` | Map section GUIDs to display names (TODO / Ongoing Project / Tracking) |
+| `messages.group_filter.whitelist` | Groups to always scan in full |
+| `messages.group_filter.blacklist` | Groups to never scan |
+| `scope.areas` | Keyword sets used for weekly report topic extraction |
+| `report_types.*.schedule` | Cron schedule per report type |
+| `output.send_to` | Auto-send destination (user or chat) |
+
+### Full Skill Documentation
+
+See [SKILL.md](SKILL.md) for complete execution flow, API workarounds, section GUID discovery, card formatting rules, and weekly log accumulation logic.
+
+---
+
+## 中文说明
+
+### 这是什么
+
+一个 AI Agent Skill，自动从飞书任务和群消息中生成结构化工作报告，以消息卡片形式直接发送。
+
+所有逻辑通过 `lark-cli` 命令执行，无需代码运行、无 SDK 依赖——任何能执行 shell 命令的 AI Agent 均可使用。
+
+**五种报告类型：** 日报 · 晚报 · 快速扫描 · 全量报告 · 周报
+
+日报和晚报会累积到周日志，周报直接读取该日志，不重复拉取数据。所有报告以飞书消息卡片形式输出。
+
+---
+
+### 安装
+
+**前置条件：** 已安装并完成认证的 [lark-cli](../../README.md)。
+
+对你的 AI Agent 说：
+
+```
+install scan report skill
+```
+
+Agent 会自动扫描你的群组，引导你选择要监控的群，生成配置文件。无需手动编辑 YAML。
+
+> **Claude Code 用户：** 配置流程会生成一个交互式 HTML 页面来选择群组，体验更好。
+
+---
+
+### 触发方式
+
+直接告诉你的 AI Agent：
+
+| 说这个 | 生成的报告 |
+|--------|-----------|
+| `日报` / `morning report` | 早间日报 |
+| `晚报` / `evening report` | 晚间总结 |
+| `周报` / `weekly report` | 周报草稿 |
+| `quick scan` | 快速扫描 |
+| `full report` | 全量报告 |
+
+---
+
+### 必要权限
+
+在飞书开放平台 [open.feishu.cn](https://open.feishu.cn)（Lark: [open.larksuite.com](https://open.larksuite.com)）的「权限管理」中添加以下权限。可直接复制粘贴到权限配置：
+
+```json
+{
+  "scopes": {
+    "tenant": [
+      "im:message",
+      "im:message:send_as_bot",
+      "task:task:readonly",
+      "task:tasklist:readonly"
+    ],
+    "user": [
+      "im:message:readonly",
+      "task:task:readonly",
+      "task:tasklist:readonly",
+      "offline_access"
+    ]
+  }
+}
+```
+
+> **为什么需要两类权限？** 消息卡片以 bot 身份发送（tenant token）；任务和消息历史需要用户身份才能读取个人数据。
+
+添加权限后重新授权：
+
+```bash
+lark auth login --add --scopes messages
+```

--- a/skills/lark-scan-report/SKILL.md
+++ b/skills/lark-scan-report/SKILL.md
@@ -1,0 +1,409 @@
+---
+name: lark-scan-report
+version: 3.1.0
+description: "Generate structured work reports from Feishu tasks and messages. Five report types: morning briefing, evening wrap-up, quick scan, full snapshot, weekly summary. Uses weekly log accumulation — no redundant re-fetching. All logic runs through lark-cli commands — no special runtime requirements. Triggers on: 'daily report', 'morning report', 'evening report', 'weekly summary', '日报', '晚报', '周报'."
+metadata:
+  requires:
+    bins: ["lark-cli"]
+    skills: ["lark-task", "lark-im", "lark-shared"]
+---
+
+# Lark Scan Report
+
+Modular Feishu report system with **weekly log accumulation**. Morning and evening reports fetch data and append to a rolling weekly log. The weekly summary reads that log — no re-fetching.
+
+All data collection and delivery runs through `lark-cli` commands. No code execution, no SDK dependency — any agent that can run shell commands can operate this skill.
+
+**CRITICAL — Before starting, read [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md) for auth and permission handling.**
+
+## First-Time Setup
+
+If `config.yaml` has empty whitelist/blacklist (or user says "setup daily report", "configure report"), run the interactive setup flow:
+
+### Setup Flow
+
+1. **Check auth**: Verify `lark-cli auth` is configured. If not, guide user through `lark-cli config init` + `lark-cli auth login --recommend`.
+
+2. **Ask basic preferences**:
+   - Language: zh or en? (default: en)
+   - Timezone: (default: Asia/Shanghai)
+   - Output format: text or card? (default: text)
+
+3. **Scan all groups**: Run `lark-cli im +chat-search --member-ids "<user_open_id>" --page-size 100 --sort-by update_time_desc` to get the full list of groups the user is in.
+
+4. **Generate interactive config page**: Create a local HTML file (like `lark-chat-config.html`) listing all groups with:
+   - Dropdown: Auto / Whitelist / Blacklist
+   - Note field for each group
+   - Pre-fill suggestions: system groups (On Call, Help Desk, Assistant) as Blacklist
+   - Open in browser for the user to configure
+
+5. **Read user selections**: After user submits, read the JSON result and update `config.yaml` whitelist/blacklist accordingly.
+
+6. **Check required scopes**: Test `+messages-search` and `+get-my-tasks`. If scope missing, guide user to run `lark-cli auth login --scope "<missing_scope>"`.
+
+7. **Create report directories**: `mkdir -p reports/weekly-logs`
+
+8. **Confirm**: Print summary of config — N whitelist, N blacklist, N auto groups. Ready to run.
+
+### Re-configuration
+
+User can say "reconfigure daily report" or "update report config" at any time to re-run steps 3-5 (group scan + selection). This is useful when the user joins new groups or wants to change whitelist/blacklist.
+
+## Architecture
+
+```
+Mon-Fri morning/evening reports
+  ├── 1. Fetch tasks (tasklists + subtasks)
+  ├── 2. Scan messages (per config rules)
+  ├── 3. Generate report → output to user
+  └── 4. Append structured entry to weekly log
+
+Sunday weekly summary
+  ├── 1. Read weekly log (already accumulated)
+  ├── 2. Scan weekend delta only (Sat 00:00 → Sun 15:00)
+  └── 3. Generate weekly summary → output to user
+```
+
+### File Layout
+
+```
+{workspace}/reports/
+├── morning_YYYY-MM-DD.md              # Archived morning reports
+├── evening_YYYY-MM-DD.md              # Archived evening reports
+├── weekly_YYYY-WNN.md                 # Archived weekly summaries
+└── weekly-logs/
+    └── week-YYYY-WNN.md              # Rolling weekly log (append-only)
+```
+
+## Report Types
+
+| Type | Schedule (UTC+8) | Trigger | Template |
+|------|-------------------|---------|----------|
+| `morning` | 10:30 Mon-Fri | cron | [morning-report.md](templates/morning-report.md) |
+| `evening` | 22:00 Mon-Fri | cron | [evening-report.md](templates/evening-report.md) |
+| `weekly` | Sun 15:00 | cron | [weekly-summary.md](templates/weekly-summary.md) |
+| `quick` | — | user | [quick-scan.md](templates/quick-scan.md) |
+| `full` | — | user | [full-report.md](templates/full-report.md) |
+
+### User-Triggered Reports
+
+**Quick Scan** (`quick`): Lightweight delta check. Finds the last archived report timestamp, scans only messages since then, checks task changes. Minimal API calls — typically 2-3. Output is compact, ≤15 lines. Does not archive or append to weekly log.
+
+**Full Report** (`full`): Comprehensive on-demand snapshot. Runs all scan rules, full task hierarchy, completion detection from both sources, conversation extraction. Archives to `reports/full_YYYY-MM-DD_HH-MM.md`. Appends to weekly log.
+
+## Execution Flow
+
+### Phase 0: Delta Timestamp
+
+Before any data collection, resolve the scan time window:
+
+```bash
+# Read last scan timestamp
+cat reports/.last-scan-ts
+# → "2026-03-28T10:30:00+08:00"  (or empty if first run)
+```
+
+- If `.last-scan-ts` exists → use it as `--start`, current time as `--end`
+- If missing → fall back to `delta.fallback_range` from config (default: last_24h)
+- After report completes → write current time to `.last-scan-ts`
+
+This ensures every message is fetched exactly once across runs. No duplication, no gaps.
+
+### Phase 1: Data Collection
+
+#### 1A. Task Collection
+
+**Known API issue**: `tasklists list` returns error 1470500. `tasks list` and `+get-my-tasks` only return tasks where user is **assignee** — they miss tasks where user is **follower**. The workaround is a 3-step approach:
+
+```bash
+# Step 1: Get all "my tasks" (assignee role) with full detail
+# This returns complete task objects with tasklists[].tasklist_guid
+lark-cli task tasks list --page-all --format json
+# → Extract unique tasklist_guid values from each task's `tasklists` array
+
+# Step 2: For EACH discovered tasklist_guid, get ALL tasks (assignee + follower)
+# This is the ONLY way to get follower tasks
+lark-cli task tasklists tasks \
+  --params '{"tasklist_guid":"<GUID>","completed":"false"}' \
+  --page-all --format json
+# → Open tasks (completed_at == "0")
+
+lark-cli task tasklists tasks \
+  --params '{"tasklist_guid":"<GUID>","completed":"true"}' \
+  --page-all --format json
+# → Completed tasks — filter by completed_at timestamp for "today" or "this week"
+
+# Step 3: Get tasklist name for display
+lark-cli task tasklists get \
+  --params '{"tasklist_guid":"<GUID>"}' --format json
+# → Returns { tasklist: { name: "TODO", ... } }
+
+# Step 4: For tasks with subtask_count > 0, expand subtasks
+lark-cli task subtasks list \
+  --params '{"task_guid":"<TASK_GUID>"}' \
+  --page-all --format json
+```
+
+**Merging logic**: Step 1 gives detailed task objects (custom_fields, description, origin). Step 2 gives section_guid grouping. Merge by task GUID — use Step 1 data for rich fields, Step 2 for section placement.
+
+**Section (Guild) classification**: Each task belongs to a section (guild) within the tasklist. Section names are mapped in `config.yaml → tasks.section_names` (sections API returns 404, so hardcoded). To get a task's section_guid, use `tasks get` → `tasklists[].section_guid`.
+
+Classification rules:
+- **TODO**: Active work items the user is responsible for
+- **Ongoing Project**: Multi-day/week projects the user is driving
+- **Tracking**: Items owned by others that the user monitors — show separately, lower priority
+- **Content Topic**: Personal notes/memos — **skip in reports entirely**
+
+The `members[].role` field (assignee/follower) is less important than the section classification for this user. All tasks in TODO and Ongoing are "responsible" regardless of role.
+
+#### 1B. Message Scanning (Delta-Based)
+
+Execute scan phases from config. All phases use `--start` / `--end` from Phase 0.
+
+```bash
+# Phase 0: Discover ALL active conversations in delta window
+# This single call finds every chat with activity — including new groups you were added to
+lark-cli im +messages-search \
+  --start "<last_scan_ts>" \
+  --end "<now>" \
+  --page-size 50 --page-all --format json
+# → Returns messages with chat_id, sender, content. Extract unique chat_ids.
+
+# Phase 1: Whitelist groups — full message pull (paginate all)
+lark-cli im +chat-messages-list \
+  --chat-id "oc_xxx" \
+  --start "<last_scan_ts>" --end "<now>" \
+  --page-size 50 --page-all --format json
+
+# Phase 2: All discovered P2P chats — iterate each
+lark-cli im +chat-messages-list \
+  --user-id "ou_xxx" \
+  --start "<last_scan_ts>" --end "<now>" \
+  --page-size 50 --page-all --format json
+
+# Phase 3: All other discovered groups — full pull
+# (groups found in Phase 0 that are not in whitelist or blacklist)
+lark-cli im +chat-messages-list \
+  --chat-id "oc_yyy" \
+  --start "<last_scan_ts>" --end "<now>" \
+  --page-size 50 --page-all --format json
+
+# Phase 4: @me catch-all (belt-and-suspenders)
+lark-cli im +messages-search \
+  --is-at-me \
+  --start "<last_scan_ts>" --end "<now>" \
+  --page-size 30 --format json
+
+# Phase 5: Thread follow-up in whitelist groups
+lark-cli im +threads-messages-list \
+  --params '{"thread_id":"omt_xxx"}' \
+  --format json
+```
+
+**Key**: `--page-all` ensures we get ALL messages in the delta window, not just the first page. Since we're only fetching the delta (not 24h), the volume per call is manageable.
+
+#### 1C. Completion Detection
+
+Completions from TWO sources — always check both:
+
+1. **Task API**: `tasklists tasks` with `completed=true`, filter by `completed_at` timestamp within report window
+2. **Chat messages**: Scan for completion signals in conversations:
+   - User said: "done", "搞定", "已发", "finished", "deployed", "merged", "shipped"
+   - User shared a deliverable (file, link, screenshot)
+   - Counterpart acknowledged: "收到", "looks good", "approved", "thanks"
+
+Cross-reference: if a chat message indicates completion but the task is still open, note it. If a task is marked complete but no chat evidence, still include it.
+
+#### 1D. Group Discussion Digest
+
+For morning/evening/full reports, generate a **group discussion overview** from ALL scanned group messages (including groups where user wasn't @'d):
+
+- Per active group: summarize the main topic(s) being discussed in 1-2 lines
+- If a specific message is noteworthy, quote it with attribution: `@person: "exact quote"`
+- Flag discussions that may relate to user's scope even if user wasn't involved
+- This section captures the "ambient awareness" that would otherwise be missed
+
+This becomes the "各群动态" / "Group Activity" section in the report output.
+
+### Phase 2: Intelligence Layer (Message → Action Extraction)
+
+**This is the core value of the report.** Raw data from Phase 1 is useless without intelligence extraction. The report is NOT a message log — it is an actionable briefing.
+
+#### 2A. Temporal Reasoning
+
+All timestamps must be interpreted relative to the **report generation time**, not the message send time.
+
+Rules:
+- If someone said "明天开放" at 23:00 on 3/27, and the report runs at 10:30 on 3/28, that means "今天已开放" — NOT "明天开放"
+- "下周" in a Monday message means this current week if the report runs on Tuesday
+- "刚刚部署了" in a message 12 hours ago = already deployed, verify current status
+- Always convert relative time references to absolute dates, then re-relativize to report time
+
+#### 2B. Message → Task Mapping
+
+For each message thread/conversation, attempt to match it to an existing task:
+
+1. **Keyword match**: task summary ↔ message content (fuzzy match on project names, feature names, people names)
+2. **People match**: task assignee/follower ↔ message sender
+3. **Context match**: same topic group + similar domain language
+
+When matched:
+- Update the task's status description with chat evidence (e.g., "消息中确认已部署")
+- Merge chat progress into the task row — don't show it separately
+- If chat indicates completion but task is still open, flag as "疑似完成，任务未关闭"
+
+When NOT matched:
+- Extract as a standalone action item if it requires user response
+- Classify as FYI/signal if no action needed
+
+#### 2C. Action Item Extraction
+
+From every message, extract one of:
+- **Action required by user**: "你需要..." — becomes a TODO item
+- **Decision needed from user**: "需要你定..." — becomes a decision item
+- **Progress update**: "XXX 已完成" — becomes evidence for task progress
+- **Blocker reported**: "被 XXX 阻塞" — becomes a blocker item
+- **FYI / signal**: no action needed — goes to signals section only if notable
+
+#### 2D. Report Organization Principle
+
+The report answers: **"你现在需要做什么？"**
+
+Structure priority (top to bottom):
+1. **What you finished** (completed tasks + chat evidence) — positive momentum first
+2. **What needs your action NOW** (decision items, review requests, replies needed)
+3. **What's in progress** (tasks with recent activity, grouped by tasklist)
+4. **What's blocked** (waiting on others, with duration and escalation plan)
+5. **Key conversations** (topic → conclusion → your action, NOT raw messages)
+6. **Signals** (ambient awareness, org changes, competitor moves)
+
+**Anti-patterns to avoid:**
+- ❌ "群里讨论了XXX" → ✅ "XXX 已定方案：令牌桶 → 你需要更新设计文档"
+- ❌ "收到 3 条消息" → ✅ "3 条消息均为 FYI，无需回复"
+- ❌ "吴郕说明天开放" → ✅ "飞书 CLI 今天已开放（吴郕 3/27 晚确认）"
+
+### Phase 2.5: Report Generation
+
+Apply the appropriate template (see `templates/` directory). Each template defines the exact output structure.
+
+**Output format** — check `config.yaml → output.default_format`:
+- `text`: Plain text with tab-aligned columns and Unicode box chars for structure. Suitable for direct Feishu message.
+- `card`: Feishu interactive card JSON via `--msg-type interactive`.
+
+### Phase 3: Weekly Log Append (morning & evening only)
+
+After generating the report, append a structured entry to the weekly log. This is the key mechanism that makes weekly summaries efficient.
+
+```markdown
+<!-- Append to reports/weekly-logs/week-YYYY-WNN.md -->
+
+## YYYY-MM-DD evening
+
+### Completed
+- [task] Finished API migration for user service
+- [chat] Sent final design spec to @designer (confirmed received)
+
+### In Progress
+- [task] Payment integration — waiting for sandbox credentials
+- [chat] Discussing rate limit strategy in #arch-group
+
+### Discussions & Decisions
+- #core-team: Agreed to delay launch by 1 week for QA
+- @PM: Changed priority of onboarding flow to P0
+
+### Blockers
+- Sandbox credentials from payment provider (3 days waiting)
+
+### Signals & Notes
+- @CTO mentioned potential org restructure in #leadership
+- New competitor feature spotted in #market-watch discussion
+```
+
+**Log rules**:
+- One `## YYYY-MM-DD morning/evening` section per report run
+- Use `[task]` or `[chat]` prefix to indicate the source
+- Keep entries atomic and factual — no commentary
+- Deduplicate across morning/evening for the same day
+- This file is append-only during the week; never rewrite earlier entries
+
+### Phase 4: Delivery
+
+```bash
+# Text format
+lark-cli im +messages-send \
+  --user-id "ou_xxx" \
+  --text "<report_content>"
+
+# Card format
+lark-cli im +messages-send \
+  --user-id "ou_xxx" \
+  --msg-type interactive \
+  --content '<card_json>'
+```
+
+## Weekly Summary: Diff-Based Approach
+
+The Sunday weekly summary does NOT re-scan the entire week. Instead:
+
+1. **Read the weekly log** (`reports/weekly-logs/week-YYYY-WNN.md`) — this already contains all Mon-Fri data
+2. **Scan weekend delta only** — messages from Friday 22:00 → Sunday 15:00
+3. **Synthesize** — merge the log entries into a cohesive weekly narrative
+
+This means the weekly summary is fast and never makes redundant API calls.
+
+## Classification Logic
+
+When categorizing items from tasks and messages:
+
+| Signal | Category |
+|--------|----------|
+| User is the owner/assignee | TODO / In Progress |
+| Someone else owns it, user is waiting | Tracking |
+| User-led, multi-day/week effort | Ongoing Project |
+| Explicitly completed (task API or chat signal) | Completed |
+| Mentioned but no action required | FYI / Signal |
+
+## Formatting Rules
+
+- `**bold**` for key items and names
+- `*italic*` for next steps and notes
+- **Attribution rule**: When mentioning someone's words/actions, the reader must know WHERE it was said. Rules:
+  - If the item is already under a group heading (e.g. `**[增长&留存](link)** · 3/27`), do NOT repeat the group name on each bullet — just write `某人 时间：内容`
+  - If the item appears OUTSIDE its group context (e.g. in 🔴需要关注 or 📡信号), MUST include `[群名](deeplink)` so reader knows the source
+  - Never redundantly repeat `[群名]` when already scoped under that group's heading
+- Group links as deeplinks: `[group-name](https://applink.feishu.cn/client/chat/open?openChatId=oc_xxx)`
+- Task links from API `url` field
+- Completed subtasks: `~~*subtask name*~~ ✅` (strikethrough + italic + checkmark)
+- In-progress subtasks: `🔄 subtask name`, indented with `\u2003\u2003`
+- Status indicators: done / in-progress / blocked / waiting
+
+## Cron Configuration Examples
+
+```json
+[
+  {
+    "name": "lark-morning-report",
+    "schedule": { "kind": "cron", "expr": "30 2 * * 1-5", "tz": "UTC" },
+    "payload": {
+      "kind": "systemEvent",
+      "text": "Generate morning report. Read lark-scan-report skill, load config.yaml, execute report_type=morning."
+    }
+  },
+  {
+    "name": "lark-evening-report",
+    "schedule": { "kind": "cron", "expr": "0 14 * * 1-5", "tz": "UTC" },
+    "payload": {
+      "kind": "systemEvent",
+      "text": "Generate evening report. Read lark-scan-report skill, load config.yaml, execute report_type=evening."
+    }
+  },
+  {
+    "name": "lark-weekly-summary",
+    "schedule": { "kind": "cron", "expr": "0 7 * * 0", "tz": "UTC" },
+    "payload": {
+      "kind": "systemEvent",
+      "text": "Generate weekly summary. Read lark-scan-report skill, load config.yaml, execute report_type=weekly."
+    }
+  }
+]
+```

--- a/skills/lark-scan-report/config.example.yaml
+++ b/skills/lark-scan-report/config.example.yaml
@@ -1,0 +1,186 @@
+# ============================================================
+# Lark Daily Report — User Configuration
+# ============================================================
+# Copy this file to config.yaml and fill in your values.
+# Never commit config.yaml — it contains personal data.
+# ============================================================
+
+# ----------------------------------------------------------
+# General
+# ----------------------------------------------------------
+general:
+  timezone: "Asia/Shanghai"
+  language: "zh"                       # zh | en
+  archive_dir: "reports"
+  weekly_log_dir: "reports/weekly-logs"
+  last_scan_file: "reports/.last-scan-ts"
+
+# ----------------------------------------------------------
+# Task Fetching
+# ----------------------------------------------------------
+tasks:
+  enabled: true
+  include_tasklists: true
+  include_subtasks: true
+  extra_fields:
+    - due
+    - assignee
+    - priority
+    - description
+  tasklist_filter: []
+
+  # --- Section (Guild) name mapping ---
+  # Sections API is unavailable (404), so we hardcode the mapping.
+  # To find your section GUIDs: run `lark-cli tasks get <task_id>`
+  # and look at the `tasklists[].section_guid` field for any task
+  # in each section. Then map them here.
+  section_names:
+    # "<your-section-guid>": "TODO"
+    # "<your-section-guid>": "Ongoing Project"
+    # "<your-section-guid>": "Tracking"
+    # "<your-section-guid>": "Content Topic"
+
+  # Classification rules based on section:
+  # - TODO + Ongoing Project = active work (show as primary)
+  # - Tracking             = tracking (show separately, lower priority)
+  # - Content Topic        = memo, hidden from reports
+
+# ----------------------------------------------------------
+# User Scope (for weekly report extraction)
+# ----------------------------------------------------------
+scope:
+  description: "周报只提取 scope 范围内的事项"
+  areas:
+    - name: "Area 1"
+      keywords: ["keyword1", "keyword2"]
+    # Add more areas that match your role/responsibilities
+
+# ----------------------------------------------------------
+# Message Scanning
+# ----------------------------------------------------------
+messages:
+  enabled: true
+
+  # --- Source toggles ---
+  sources:
+    p2p: true
+    group: true
+    topic: true
+    bot: false
+
+  # --- Delta mode ---
+  # Every scan reads .last-scan-ts as --start, writes current time after completion.
+  # First run (no timestamp file): falls back to time_range below.
+  delta:
+    enabled: true
+    fallback_range: "last_24h"
+
+  # --- Group filtering ---
+  group_filter:
+    max_member_count: 0                # 0 = no limit
+
+    # Tier 1: full scan, every message
+    whitelist:
+      # - chat_id: "oc_xxxx"
+      #   name: "Your Key Group Name"
+
+    # Never scan these groups
+    blacklist:
+      # - chat_id: "oc_xxxx"
+      #   name: "Noisy Group"
+      #   reason: "why excluded"
+
+  # --- Scan phases ---
+  scan_phases:
+
+    - name: "discover-active"
+      description: "Find all chats with activity since last scan"
+      action: "messages-search"
+      params:
+        page_size: 50
+        page_all: true
+      report_types: ["morning", "evening", "full"]
+
+    - name: "whitelist-full"
+      description: "Full messages from key groups"
+      action: "chat-messages-list"
+      target: "whitelist"
+      params:
+        page_size: 50
+        page_all: true
+      report_types: ["morning", "evening", "full", "quick"]
+
+    - name: "p2p-discovered"
+      description: "Full messages from all active private chats"
+      action: "chat-messages-list"
+      target: "discovered_p2p"
+      params:
+        page_size: 50
+        page_all: true
+      report_types: ["morning", "evening", "full"]
+
+    - name: "groups-discovered"
+      description: "Full messages from all other active groups"
+      action: "chat-messages-list"
+      target: "discovered_groups"
+      params:
+        page_size: 50
+        page_all: true
+      report_types: ["morning", "evening", "full"]
+
+    - name: "at-me-catchall"
+      description: "Catch any @mentions not already covered"
+      action: "messages-search"
+      params:
+        is_at_me: true
+        page_size: 30
+      report_types: ["morning", "evening", "full", "quick"]
+
+    - name: "thread-tracking"
+      description: "Follow up on active threads"
+      action: "threads-messages-list"
+      target: "whitelist"
+      params:
+        page_size: 20
+      report_types: ["morning", "evening", "full"]
+
+# ----------------------------------------------------------
+# Report Types
+# ----------------------------------------------------------
+report_types:
+  morning:
+    description: "Morning briefing — today's plan + overnight catch-up"
+    archive: true
+    schedule: "30 2 * * 1-5"          # 10:30 UTC+8, Mon-Fri
+
+  evening:
+    description: "Evening wrap-up — today's completions + status"
+    archive: true
+    schedule: "0 14 * * 1-5"          # 22:00 UTC+8, Mon-Fri
+
+  weekly:
+    description: "Weekly summary — accumulated from weekday logs"
+    archive: true
+    schedule: "0 7 * * 0"             # Sun 15:00 UTC+8
+
+  quick:
+    description: "Quick scan — delta since last report, minimal"
+    archive: false
+    trigger: "manual"
+
+  full:
+    description: "Full report — comprehensive snapshot"
+    archive: true
+    trigger: "manual"
+
+# ----------------------------------------------------------
+# Output
+# ----------------------------------------------------------
+output:
+  default_format: "card"              # text | card
+
+  # send_to:
+  #   type: "user"
+  #   id: "ou_xxx"                    # Your Lark open_id
+
+  card_theme: "blue"

--- a/skills/lark-scan-report/templates/evening-report.md
+++ b/skills/lark-scan-report/templates/evening-report.md
@@ -1,0 +1,99 @@
+# Evening Report Template
+
+**Purpose**: Daily wrap-up — answers "今天做了什么？还有什么没收尾？"
+**Schedule**: Mon-Fri 22:00 UTC+8
+**Archive**: `reports/evening_YYYY-MM-DD.md`
+
+## Core Question
+
+> "今天完成了什么？有什么阻塞需要明天升级？群里有什么重要决策？"
+
+## Scan Window
+
+- Full day messages: morning report time (10:30) → now (22:00), or 00:00 → 22:00
+- Tasks: all tasks + today's completed tasks (filter `completed_at` to today)
+- Today's morning report: read for continuity — check if TOP 3 was achieved
+
+## Completion Detection
+
+From TWO sources:
+1. **Task API**: `tasklists tasks` with `completed=true`, filter `completed_at` to today's timestamp range
+2. **Chat signals**: "done", "搞定", "已发", "deployed", "merged" + deliverable shared + counterpart acknowledged
+
+Cross-reference both. A task marked done + chat evidence = `[双]` source tag.
+
+## Output Structure (Card Format)
+
+```json
+{
+  "config": { "wide_screen_mode": true },
+  "header": {
+    "template": "indigo",
+    "title": { "tag": "plain_text", "content": "🌙 晚报 — YYYY-MM-DD 周X" }
+  },
+  "elements": [
+    {
+      "tag": "markdown",
+      "content": "**✅ 今日完成**\n• [任务] **Schema 更新** — 已合并到 main\n• [消息] 发终稿给 @设计师 — 对方确认收到\n• [双] **支付 bugfix** — 已部署 staging + 任务已关\n\n— 或：今天没有完成项（说明原因）"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**📌 需要你明天推动**\n• **回复 @PM 关于优先级** — 今天在 [#核心团队](deeplink) 讨论了但没定\n• **Review PR #42** — @张三 今天提交，等你 review\n\n— 或：无待推动事项"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**🔄 进行中**\n*清单: TODO*\n• **限流模块** [负责] — 70% · 下一步: 跑测试\n  ├ Redis 部署 ✅\n  └ 配置迁移 🔄\n• **AI Reddit** [跟进] — @某人 在推进 · 2 个子任务未完成"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**🚫 阻塞项**\n• **沙盒凭证** — 等 @供应商 · 已 3 天 · *明天再催，后天升级到 VP*"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**💬 重要对话**\n• [#核心团队](deeplink): 上线时间 → **延后一周做 QA** — 全员同意 · *你需要更新排期表*\n• 私聊 @PM: 入职流程 → **优先级改 P0** · *你需要重排 sprint*\n• [#架构组](deeplink): 限流方案 → **确定令牌桶** · *FYI，与你任务一致*"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**📡 信号**\n• @CTO 在 #leadership 提到组织架构调整可能\n• 竞品发布了类似功能（#market-watch 讨论）"
+    },
+    {
+      "tag": "note",
+      "elements": [{ "tag": "plain_text", "content": "22:00 UTC+8 · 扫描窗口 10:30→22:00" }]
+    }
+  ]
+}
+```
+
+## Section Rules
+
+| Section | Show when | Skip when |
+|---------|-----------|-----------|
+| ✅ 今日完成 | Always — lead with wins | Say "无完成项" if empty |
+| 📌 需要明天推动 | Extracted actions from messages/tasks | Nothing pending |
+| 🔄 进行中 | Has open tasks | — |
+| 🚫 阻塞项 | Something blocked > 1 day | No blockers |
+| 💬 重要对话 | Has discussions with decisions/actions | No notable conversations |
+| 📡 信号 | Org/competitor/strategic signals found | Nothing notable |
+
+## Attribution Rule
+
+When mentioning someone's words/actions:
+- Under a group heading (e.g. `**[增长&留存](link)** · 3/27`): do NOT repeat group name on each bullet — just `某人 时间：内容`
+- Outside group context (🔴需要关注, 📡信号): MUST include `[群名](deeplink)` for source context
+- Never redundantly repeat group name when already under that group's heading
+
+## Morning Report Reconciliation
+
+Compare with this morning's TOP 3:
+- If completed: show in ✅ section with "✓ 早报 TOP1"
+- If not completed: show in 🔄 with reason
+- If new urgent item displaced TOP 3: note what changed and why
+
+## After Generation
+
+Append structured entry to weekly log (see skill.md Phase 3).

--- a/skills/lark-scan-report/templates/full-report.md
+++ b/skills/lark-scan-report/templates/full-report.md
@@ -1,0 +1,102 @@
+# Full Report Template
+
+**Purpose**: Comprehensive on-demand snapshot — answers "全面了解一下现在的状态"
+**Archive**: `reports/full_YYYY-MM-DD_HH-MM.md`
+**Weekly log**: Yes — append after generation
+
+## Core Question
+
+> "你现在的全部工作是什么状态？有哪些需要立刻行动的？"
+
+## Execution
+
+1. Full task fetch: `tasks list` → extract tasklist GUIDs → `tasklists tasks` per GUID (both open + today's completed)
+2. All scan phases from config (discover-active, whitelist, P2P, groups, @me, threads)
+3. Completion detection: task API + chat signals (dual source)
+4. Intelligence extraction: message → action items, message → task mapping
+5. Calendar: today's remaining events
+6. Archive + append to weekly log
+
+## Output Structure (Card Format)
+
+```json
+{
+  "config": { "wide_screen_mode": true },
+  "header": {
+    "template": "blue",
+    "title": { "tag": "plain_text", "content": "📊 全量报告 — YYYY-MM-DD HH:MM" }
+  },
+  "elements": [
+    {
+      "tag": "markdown",
+      "content": "**✅ 已完成（今日）**\n• [任务] **Schema 更新** — 已合并\n• [消息] 发终稿给 @设计师 — 确认收到\n• [双] **支付 bugfix** — 已部署 + 任务已关"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**🔴 需要你立刻行动**\n• **回复 @PM** — 在 #核心团队 等你定优先级\n• **Review PR #42** — @张三 3小时前提交\n• **确认设计稿** — @设计师 私聊发了终版"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**📋 全部任务**\n\n*清单: TODO (12 open / 23 done)*\n\n**[负责] 我的任务:**\n• **限流模块** — 70% · 下一步: 跑测试 · 截止 3/30\n  ├ Redis 部署 ✅\n  └ 配置迁移 🔄\n• **API 迁移** — 进行中 · 等 PR review\n\n**[跟进] 关注的任务:**\n• **AI Reddit** — @某人 负责 · 2 子任务未完成\n• **视频翻译多国内容** — @某人 负责 · 无进展更新\n• **webapp builder 调研** — @某人 负责 · 待启动"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**🚫 阻塞项**\n• **沙盒凭证** — 等 @供应商 · 3天 · 明天再催\n• **CI 不稳定** — 等 @基础设施 · 2天 · 周二 pair-debug"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**💬 重要对话摘要**\n• [#核心团队](deeplink): 上线时间 → **延后一周** · *你需要更新排期*\n• 私聊 @PM: 入职流程 → **P0** · *你需要重排 sprint*\n• [#架构组](deeplink): 限流方案 → **令牌桶** · *与你任务一致*"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**⏳ 等待他人**\n• 设计评审 — 等 @设计师 · 预计明天\n• 沙盒权限 — 等 @供应商 · 预计今天"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**📡 信号**\n• CTO 提到组织架构调整可能\n• 竞品上了类似功能"
+    },
+    {
+      "tag": "note",
+      "elements": [{ "tag": "plain_text", "content": "HH:MM UTC+8 · 全量扫描" }]
+    }
+  ]
+}
+```
+
+## Section Priority
+
+Sections appear in this exact order (skip empty ones):
+1. ✅ 已完成 — lead with wins
+2. 🔴 需要立刻行动 — extracted from messages, highest urgency
+3. 📋 全部任务 — split by role (负责 vs 跟进), grouped by tasklist
+4. 🚫 阻塞项 — with age and escalation plan
+5. 💬 重要对话 — topic → decision → your action (NOT raw messages)
+6. ⏳ 等待他人 — who, what, when
+7. 📡 信号 — only if notable, skip if nothing
+
+## Task Display Rules
+
+- Group by **section (guild)** from `config.yaml → tasks.section_names`:
+  - **📋 TODO** — active work items, show first
+  - **🏗️ Ongoing Project** — multi-day projects, show second
+  - **👀 Tracking** — monitoring others' work, show third
+  - **Content Topic** — personal memos, **skip entirely**
+- To get section_guid: `tasks get` → `tasklists[].section_guid`, then map via config
+- Subtask display:
+  - Completed: `~~*subtask name*~~ ✅` (strikethrough + italic + checkmark)
+  - In progress: `🔄 subtask name`
+  - Indent subtasks with `\u2003\u2003` (em space x2) for card rendering
+- Show `due` date if set, highlight if overdue
+- Show custom_fields if available (priority, type, brief)
+
+## Anti-Patterns
+
+- ❌ "AnyGen-垂类群有 5 条消息" → ✅ extract what those messages mean for the user
+- ❌ listing every message → ✅ one line per conversation thread: topic → conclusion → action
+- ❌ "某人说了..." → ✅ "某人确认了X / 某人需要你做Y"

--- a/skills/lark-scan-report/templates/morning-report.md
+++ b/skills/lark-scan-report/templates/morning-report.md
@@ -1,0 +1,97 @@
+# Morning Report Template
+
+**Purpose**: Daily planning + overnight catch-up — answers "你今天要做什么？"
+**Schedule**: Mon-Fri 10:30 UTC+8
+**Archive**: `reports/morning_YYYY-MM-DD.md`
+
+## Core Question
+
+> "今天最重要的 3 件事是什么？有什么需要立刻回复或推动的？"
+
+## Scan Window
+
+- Overnight messages: previous evening report time (22:00) → now (10:30)
+- Tasks: all open tasks from tasklists (assignee + follower)
+- Previous evening report: read for continuity
+- Calendar: today's agenda via `lark-cli calendar +agenda`
+
+## Intelligence Rules
+
+- **TOP 3** = highest priority TASKS only: today's deadline tasks first > P0 tasks > overdue tasks. These are things you must ship/close today.
+- **今日关注** = action items extracted from messages (需要回复、需要定方案、需要确认), NOT tasks. These are conversation-driven actions.
+- Overnight messages: extract action items, don't just list "谁说了什么"
+- If a message says "明天做X", check if "明天" is today — if so, report as "今天需要做X"
+- Distinguish "需要你回复" vs "FYI" — only surface FYI if truly notable
+
+## Output Structure (Card Format)
+
+Card JSON template — use `--msg-type interactive`:
+
+```json
+{
+  "config": { "wide_screen_mode": true },
+  "header": {
+    "template": "blue",
+    "title": { "tag": "plain_text", "content": "☀️ 早报 — YYYY-MM-DD 周X" }
+  },
+  "elements": [
+    {
+      "tag": "markdown",
+      "content": "**🎯 今日 TOP 3**\n1. **[最重要]** — 原因/截止\n2. **[第二]** — 背景\n3. **[第三]** — 背景"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**📬 需要你回复/处理**\n• @某人 在 [群名](deeplink): 问了XXX → *你需要回复XXX*\n• @某人 私聊: 发了文件 → *你需要确认*\n\n— 或：无需立即回复的事项"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**📋 待办任务** *(清单: TODO)*\n• **任务名** — 状态 · 下一步\n  ├ 子任务1 ✅\n  └ 子任务2 🔄 进行中\n• **任务名** [跟进] — 等 @某人 回复"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**⏳ 等待他人**\n• 事项 — 等 @谁 · 已等N天 · 预计XX"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**📅 今日日程**\n• 14:00 Sprint 规划 — 团队\n• 16:00 1:1 with PM"
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**💬 隔夜群动态**\n• [#核心团队](deeplink): 讨论了X → 结论Y → *与你无关 / 你需要跟进Z*\n• [#架构组](deeplink): @张三 提了新方案 → *FYI*"
+    },
+    {
+      "tag": "note",
+      "elements": [{ "tag": "plain_text", "content": "10:30 UTC+8 · 扫描窗口 22:00→10:30" }]
+    }
+  ]
+}
+```
+
+## Section Rules
+
+| Section | Show when | Skip when |
+|---------|-----------|-----------|
+| 🎯 TOP 3 | Always | Never |
+| 📬 需要回复 | Has action items | No messages or all FYI |
+| 📋 待办任务 | Has open tasks | — |
+| ⏳ 等待他人 | Waiting on someone | Nothing pending |
+| 📅 今日日程 | Has calendar events | No events |
+| 💬 群动态 | Groups had activity | No activity |
+
+## Task Display
+
+- Group by **section (guild)** — TODO first, Ongoing second, Tracking third, Content Topic hidden
+- Subtask formatting:
+  - Completed: `~~*subtask name*~~ ✅` (strikethrough + italic + checkmark)
+  - In progress: `🔄 subtask name`
+  - Indent subtasks with `\u2003\u2003` (em space x2)
+- If task has `custom_fields` with priority, show it
+
+## Text Fallback
+
+If `output.default_format == "text"`, use the card content as markdown-like plain text (no JSON wrapper).

--- a/skills/lark-scan-report/templates/quick-scan.md
+++ b/skills/lark-scan-report/templates/quick-scan.md
@@ -1,0 +1,78 @@
+# Quick Scan Template
+
+**Purpose**: Attention recap after a break — answers "我关注的事有进展吗？"
+**Archive**: No
+**Weekly log**: No
+
+## Core Logic
+
+Quick scan refreshes the user's **active attention** — not a generic message dump. Three layers:
+
+1. **Task focus refresh**: Show TODO (today DDL + P0) and Tracking tasks — are there chat updates that move these forward?
+2. **@你 + 需回复**: Anything requiring action since last scan
+3. **Overall digest**: If messages exist but none need action, one-line summary per active group
+
+## Execution
+
+1. Read `.last-scan-ts` for delta window
+2. Pull latest 10 messages from each whitelist group (2-4 API calls)
+3. Filter to messages AFTER last scan
+4. Match new messages against TODO + Tracking tasks (keyword/people match)
+5. No full task re-fetch — use cached task list from morning/last report
+
+## Output Structure (Card Format)
+
+**Has actionable updates:**
+```json
+{
+  "config": { "wide_screen_mode": true },
+  "header": {
+    "template": "turquoise",
+    "title": { "tag": "plain_text", "content": "⚡ N 条新 · Xh 前" }
+  },
+  "elements": [
+    {
+      "tag": "markdown",
+      "content": "**@你:**\n• [群名](link) 某人：内容 → *需回复*\n\n**任务进展:**\n• **订阅弹窗** — [群名](link) 某人确认了视觉稿 → 可进下一步\n• **任务机制改版** — [群名](link) AA实验结果出了 → 查看\n\n→ **需处理 N / FYI N**"
+    }
+  ]
+}
+```
+
+**Has messages but nothing actionable:**
+```json
+{
+  "config": { "wide_screen_mode": true },
+  "header": {
+    "template": "turquoise",
+    "title": { "tag": "plain_text", "content": "⚡ N 条新 · 无需处理 · Xh 前" }
+  },
+  "elements": [
+    {
+      "tag": "markdown",
+      "content": "[群名](link) 在聊X · [群名](link) 在聊Y"
+    }
+  ]
+}
+```
+
+**No updates:**
+```json
+{
+  "config": { "wide_screen_mode": true },
+  "header": {
+    "template": "turquoise",
+    "title": { "tag": "plain_text", "content": "⚡ 无新消息 · 距上次 Xh" }
+  },
+  "elements": []
+}
+```
+
+## Rules
+
+- **@你 first** — if someone @'d you, that's #1
+- **Task match second** — scan new messages for keywords matching TODO/Tracking task names. If a message updates a task's status, show it as `**任务名** — [群](link) 进展摘要`
+- **One-line overall last** — if messages exist but don't match any task or @you, compress to `[群](link) 在聊X` per group, all on one line
+- **Never repeat task list** — user already knows their tasks from morning report. Only show tasks that had NEW activity.
+- Target: ≤8 lines. Header carries the verdict (需处理/无需处理/无新消息)
+- Do NOT include signals/analysis — just delta facts

--- a/skills/lark-scan-report/templates/weekly-summary.md
+++ b/skills/lark-scan-report/templates/weekly-summary.md
@@ -1,0 +1,77 @@
+# Weekly Summary Template
+
+**Purpose**: Generate weekly report draft — answers "这周做了什么？下周做什么？"
+**Schedule**: Sunday 15:00 UTC+8
+**Archive**: `reports/weekly_YYYY-WNN.md`
+
+## Core Scenario
+
+User needs to write a weekly report (周报). The output should be a **draft they can directly paste**, structured by business module, with concrete deliverables and data points. NOT a message recap.
+
+## Data Sources
+
+1. **Weekly log** (`reports/weekly-logs/week-YYYY-WNN.md`) — accumulated daily entries
+2. **Weekend delta** — Fri 22:00 → Sun 15:00
+3. **Fresh task pull** — current open tasks for next-week plan
+4. **Chat messages** — mine for data points, decisions, deliverables mentioned in conversations
+
+## Output Structure (Card Format)
+
+```json
+{
+  "config": { "wide_screen_mode": true },
+  "header": {
+    "template": "violet",
+    "title": { "tag": "plain_text", "content": "📅 周报草稿 — W13 (3/24→3/28)" }
+  },
+  "elements": [
+    {
+      "tag": "markdown",
+      "content": "**本周进展**\n\n**[模块名]** @负责人\n• 具体完成项，带数据/链接\n• 具体完成项\n  - 细节补充\n\n**[模块名]** @负责人\n• ..."
+    },
+    { "tag": "hr" },
+    {
+      "tag": "markdown",
+      "content": "**下周计划**\n\n**[模块名]**\n1. 计划项\n2. 计划项\n\n**[模块名]**\n1. 计划项"
+    }
+  ]
+}
+```
+
+## Intelligence Rules
+
+### 本周进展 — Extraction Logic
+
+Group by **business module** (not by day/group/task). Derive modules from:
+- Task section names (TODO, Ongoing Project items)
+- Chat group topics (增长&留存 → 增长策略, 裂变/积分 → 裂变与积分体系, etc.)
+- Cluster related items into the same module
+
+For each module:
+- **Lead with deliverables**: what shipped, what launched, what decision was made
+- **Include data points**: any numbers mentioned in chat (DAU, 转化率, 积分消耗, etc.)
+- **Include experiment status**: if an A/B test or experiment was discussed, state: launched/观测中/结论
+- **Include blockers resolved / remaining**
+- **Attribute to people**: `@某人` for accountability
+
+### 下周计划 — Derivation Logic
+
+Derive from:
+1. **Open TODO tasks** — things that must ship next week
+2. **Unresolved discussion threads** — decisions pending from this week's conversations
+3. **Experiment observation** — things in "再观察一周" state
+4. **Tracking tasks with upcoming milestones**
+
+Keep it brief: 2-4 items per module, one line each.
+
+### Format Rules
+
+- Mirror the user's actual 周报 style: module headers with @owner, bullet + sub-bullet, data inline
+- Chinese language, concise professional tone
+- No emoji in the report body (this is for pasting into formal docs)
+- Data first, narrative second: "付费率 US/SG 正向，BR 持平" not "我们观察到一些积极的信号"
+- Link to relevant docs/dashboards if URLs appeared in messages
+
+## After Generation
+
+Freeze weekly log. Update `.last-scan-ts`.


### PR DESCRIPTION
## Summary

Adds `skills/lark-scan-report` — a skill that generates structured Lark/Feishu work reports as message cards by combining task data and chat messages.

**Five report types:**
- morning: TOP 3 tasks (DDL today > P0 > overdue) + overnight action items
- evening: Completed tasks + tomorrow push list + conversation highlights
- quick-scan: Delta @mentions + task updates since last scan; plain text if nothing new
- full: Comprehensive snapshot across all sources
- weekly: Two output blocks — exec-facing narrative + internal task list

## Implementation notes

- tasklists list returns error 1470500 — skill discovers tasklist GUIDs from tasks list response, then fetches per GUID via tasklists tasks
- Sections API returns 404 — section GUID to name mapping is hardcoded in config.yaml
- .last-scan-ts tracks last scan time to avoid re-processing messages on every run
- Output sent via messages-send --msg-type interactive --as bot

## What is included

- SKILL.md — Full execution flow, API workarounds, formatting rules
- README.md — Bilingual EN/ZH: installation, triggers, required permissions with copy-paste JSON
- config.example.yaml — Clean template with no personal data
- templates/ — Five report templates (card structure + extraction logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)