### PR TITLE
Fix base table-create dry-run follow-ups (#7)

### DIFF
--- a/shortcuts/base/base_dryrun_ops_test.go
+++ b/shortcuts/base/base_dryrun_ops_test.go
@@ -32,6 +32,52 @@ func TestDryRunTableOps(t *testing.T) {
 	assertDryRunContains(t, dryRunTableDelete(ctx, rt), "DELETE /open-apis/base/v3/bases/app_x/tables/tbl_1")
 }
 
+func TestDryRunTableCreateIncludesFieldAndViewFollowUps(t *testing.T) {
+	ctx := context.Background()
+	rt := newBaseTestRuntime(
+		map[string]string{
+			"base-token": "app_x",
+			"name":       "Orders",
+			"fields":     `[{"name":"Order ID","type":"text"},{"name":"Amount","type":"number"}]`,
+			"view":       `[{"name":"Main","type":"grid"}]`,
+		},
+		nil,
+		nil,
+	)
+
+	assertDryRunContains(t,
+		dryRunTableCreate(ctx, rt),
+		"# create table",
+		`{"name":"Orders"}`,
+		"PUT /open-apis/base/v3/bases/app_x/tables/%3Ccreated-table-id%3E/fields/%3Cprimary-field-id%3E",
+		`{"name":"Order ID","type":"text"}`,
+		"POST /open-apis/base/v3/bases/app_x/tables/%3Ccreated-table-id%3E/fields",
+		`{"name":"Amount","type":"number"}`,
+		"POST /open-apis/base/v3/bases/app_x/tables/%3Ccreated-table-id%3E/views",
+		`{"name":"Main","type":"grid"}`,
+	)
+}
+
+func TestDryRunTableCreateKeepsPrimaryCallWhenFieldsPreviewFails(t *testing.T) {
+	ctx := context.Background()
+	rt := newBaseTestRuntime(
+		map[string]string{
+			"base-token": "app_x",
+			"name":       "Orders",
+			"fields":     "{",
+		},
+		nil,
+		nil,
+	)
+
+	assertDryRunContains(t,
+		dryRunTableCreate(ctx, rt),
+		"# create table (follow-up --fields preview unavailable:",
+		"POST /open-apis/base/v3/bases/app_x/tables",
+		`{"name":"Orders"}`,
+	)
+}
+
 func TestDryRunFieldOps(t *testing.T) {
 	ctx := context.Background()
 

--- a/shortcuts/base/table_ops.go
+++ b/shortcuts/base/table_ops.go
@@ -30,10 +30,52 @@ func dryRunTableGet(_ context.Context, runtime *common.RuntimeContext) *common.D
 }
 
 func dryRunTableCreate(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
-	return common.NewDryRunAPI().
+	dry := common.NewDryRunAPI().
 		POST("/open-apis/base/v3/bases/:base_token/tables").
+		Desc("create table").
 		Body(map[string]interface{}{"name": runtime.Str("name")}).
-		Set("base_token", runtime.Str("base-token"))
+		Set("base_token", runtime.Str("base-token")).
+		Set("table_id", "<created-table-id>").
+		Set("field_id", "<primary-field-id>")
+
+	if rawFields := runtime.Str("fields"); rawFields != "" {
+		fieldItems, err := parseJSONArray(rawFields, "fields")
+		if err != nil {
+			dry.Desc("create table (follow-up --fields preview unavailable: " + err.Error() + ")")
+			return dry
+		}
+		for idx, item := range fieldItems {
+			body, ok := item.(map[string]interface{})
+			if !ok {
+				dry.Desc(fmt.Sprintf("create table (follow-up --fields preview unavailable: --fields item %d must be an object)", idx+1))
+				return dry
+			}
+			if idx == 0 {
+				dry.PUT("/open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id").
+					Desc("update the default primary field from the first --fields item").
+					Body(body)
+				continue
+			}
+			dry.POST("/open-apis/base/v3/bases/:base_token/tables/:table_id/fields").
+				Desc(fmt.Sprintf("create field %d from --fields", idx+1)).
+				Body(body)
+		}
+	}
+
+	if rawView := runtime.Str("view"); rawView != "" {
+		viewItems, err := parseObjectList(rawView, "view")
+		if err != nil {
+			dry.Desc("create table (follow-up --view preview unavailable: " + err.Error() + ")")
+			return dry
+		}
+		for idx, body := range viewItems {
+			dry.POST("/open-apis/base/v3/bases/:base_token/tables/:table_id/views").
+				Desc(fmt.Sprintf("create view %d from --view", idx+1)).
+				Body(body)
+		}
+	}
+
+	return dry
 }
 
 func dryRunTableUpdate(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {


### PR DESCRIPTION
## Summary
- expand `+table-create --dry-run` so it previews follow-up `--fields` operations
- preview `--view` follow-up calls in the same dry-run chain
- keep the primary table-create preview visible even when follow-up preview parsing fails

Fixes #7.