### PR TITLE
fix: align help examples and inject output error writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Call any Lark Open Platform endpoint directly, covering 2500+ APIs.
 
 ```bash
 lark-cli api GET /open-apis/calendar/v4/calendars
-lark-cli api POST /open-apis/im/v1/messages --params '{"receive_id_type":"chat_id"}' --body '{"receive_id":"oc_xxx","msg_type":"text","content":"{\"text\":\"Hello\"}"}'
+lark-cli api POST /open-apis/im/v1/messages --params '{"receive_id_type":"chat_id"}' --data '{"receive_id":"oc_xxx","msg_type":"text","content":"{\"text\":\"Hello\"}"}'
 ```
 
 ## Advanced Usage

--- a/README.zh.md
+++ b/README.zh.md
@@ -215,7 +215,7 @@ lark-cli calendar events instance_view --params '{"calendar_id":"primary","start
 
 ```bash
 lark-cli api GET /open-apis/calendar/v4/calendars
-lark-cli api POST /open-apis/im/v1/messages --params '{"receive_id_type":"chat_id"}' --body '{"receive_id":"oc_xxx","msg_type":"text","content":"{\"text\":\"Hello\"}"}'
+lark-cli api POST /open-apis/im/v1/messages --params '{"receive_id_type":"chat_id"}' --data '{"receive_id":"oc_xxx","msg_type":"text","content":"{\"text\":\"Hello\"}"}'
 ```
 
 ## 进阶用法

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,8 +39,8 @@ EXAMPLES:
     # View upcoming events
     lark-cli calendar +agenda
 
-    # List calendar events
-    lark-cli calendar events list --params '{"calendar_id":"primary"}'
+    # View calendar event instances
+    lark-cli calendar events instance_view --params '{"calendar_id":"primary","start_time":"1700000000","end_time":"1700086400"}'
 
     # Search users
     lark-cli contact +search-user --query "John"

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -7,7 +7,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"os"
 )
 
 // FormatAsCSV formats data as CSV (with header) and writes it to w.
@@ -71,6 +70,6 @@ func writeCSVRows(w io.Writer, rows []map[string]string, cols []string, writeHea
 func flushCSV(cw *csv.Writer) {
 	cw.Flush()
 	if err := cw.Error(); err != nil {
-		fmt.Fprintf(os.Stderr, "csv write error: %v\n", err)
+		writeErrorf("csv write error: %v\n", err)
 	}
 }

--- a/internal/output/print.go
+++ b/internal/output/print.go
@@ -12,11 +12,30 @@ import (
 	"github.com/larksuite/cli/internal/validate"
 )
 
+var errorWriter io.Writer = os.Stderr
+
+// SetErrorWriter overrides the package-level error sink used by output helpers.
+// It returns a restore function for callers that need temporary redirection.
+func SetErrorWriter(w io.Writer) func() {
+	prev := errorWriter
+	errorWriter = w
+	return func() {
+		errorWriter = prev
+	}
+}
+
+func writeErrorf(format string, args ...interface{}) {
+	if errorWriter == nil {
+		return
+	}
+	fmt.Fprintf(errorWriter, format, args...)
+}
+
 // PrintJson prints data as formatted JSON to w.
 func PrintJson(w io.Writer, data interface{}) {
 	b, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "json marshal error: %v\n", err)
+		writeErrorf("json marshal error: %v\n", err)
 		return
 	}
 	fmt.Fprintln(w, string(b))
@@ -27,7 +46,7 @@ func PrintNdjson(w io.Writer, data interface{}) {
 	emit := func(item interface{}) {
 		b, err := json.Marshal(item)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "ndjson marshal error: %v\n", err)
+			writeErrorf("ndjson marshal error: %v\n", err)
 			return
 		}
 		fmt.Fprintln(w, string(b))

--- a/internal/output/print_test.go
+++ b/internal/output/print_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package output
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type failingWriter struct{}
+
+func (failingWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("boom")
+}
+
+func TestPrintJson_UsesInjectedErrorWriter(t *testing.T) {
+	var stderr bytes.Buffer
+	restore := SetErrorWriter(&stderr)
+	t.Cleanup(restore)
+
+	var stdout bytes.Buffer
+	PrintJson(&stdout, map[string]interface{}{"bad": make(chan int)})
+
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout output on marshal error, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "json marshal error:") {
+		t.Fatalf("expected marshal error on injected stderr, got %q", stderr.String())
+	}
+}
+
+func TestPrintNdjson_UsesInjectedErrorWriter(t *testing.T) {
+	var stderr bytes.Buffer
+	restore := SetErrorWriter(&stderr)
+	t.Cleanup(restore)
+
+	var stdout bytes.Buffer
+	PrintNdjson(&stdout, []interface{}{make(chan int)})
+
+	if stdout.Len() != 0 {
+		t.Fatalf("expected no stdout output on marshal error, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "ndjson marshal error:") {
+		t.Fatalf("expected ndjson marshal error on injected stderr, got %q", stderr.String())
+	}
+}
+
+func TestFormatAsCSV_UsesInjectedErrorWriter(t *testing.T) {
+	var stderr bytes.Buffer
+	restore := SetErrorWriter(&stderr)
+	t.Cleanup(restore)
+
+	FormatAsCSV(failingWriter{}, []interface{}{
+		map[string]interface{}{"name": "Alice"},
+	})
+
+	if !strings.Contains(stderr.String(), "csv write error:") {
+		t.Fatalf("expected csv write error on injected stderr, got %q", stderr.String())
+	}
+}


### PR DESCRIPTION
## Summary
- align the root help example with the current calendar command surface by replacing the nonexistent `calendar events list` example
- update the English and Chinese README raw API examples to use the actual `--data` flag exposed by `cmd/api/api.go`
- route output helper failures through an injectable package-level error writer and add focused tests for JSON, NDJSON, and CSV error paths

## Why
The current compare includes two small but user-facing inconsistencies: copied examples can fail immediately, and `internal/output` still writes failures directly to `os.Stderr`, which bypasses injected IO streams and makes embedding and output capture harder than the rest of the CLI.

## Testing
- added targeted tests in `internal/output/print_test.go`
- local `go test` could not be completed in this environment because the temporary toolchain fails stdlib resolution before package compilation (`package strings is not in std`)
- static verification completed for the command example and `--data` flag usage

Closes #48
Closes #49