### PR TITLE
fix(darwin): accept wrapped go-keyring master keys

### DIFF
--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -11,9 +11,11 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,6 +26,8 @@ const keychainTimeout = 5 * time.Second
 const masterKeyBytes = 32
 const ivBytes = 12
 const tagBytes = 16
+const goKeyringEncodedPrefix = "go-keyring-encoded:"
+const goKeyringBase64Prefix = "go-keyring-base64:"
 
 // StorageDir returns the storage directory for a given service name on macOS.
 func StorageDir(service string) string {
@@ -40,6 +44,35 @@ func safeFileName(account string) string {
 	return safeFileNameRe.ReplaceAllString(account, "_") + ".enc"
 }
 
+func decodeMasterKeyValue(value string) ([]byte, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, false
+	}
+
+	candidates := []string{value}
+	switch {
+	case strings.HasPrefix(value, goKeyringBase64Prefix):
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(value, goKeyringBase64Prefix))
+		if err == nil {
+			candidates = append(candidates, strings.TrimSpace(string(decoded)))
+		}
+	case strings.HasPrefix(value, goKeyringEncodedPrefix):
+		decoded, err := hex.DecodeString(strings.TrimPrefix(value, goKeyringEncodedPrefix))
+		if err == nil {
+			candidates = append(candidates, strings.TrimSpace(string(decoded)))
+		}
+	}
+
+	for _, candidate := range candidates {
+		key, err := base64.StdEncoding.DecodeString(candidate)
+		if err == nil && len(key) == masterKeyBytes {
+			return key, true
+		}
+	}
+	return nil, false
+}
+
 func getMasterKey(service string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), keychainTimeout)
 	defer cancel()
@@ -54,8 +87,7 @@ func getMasterKey(service string) ([]byte, error) {
 
 		encodedKey, err := keyring.Get(service, "master.key")
 		if err == nil {
-			key, decodeErr := base64.StdEncoding.DecodeString(encodedKey)
-			if decodeErr == nil && len(key) == masterKeyBytes {
+			if key, ok := decodeMasterKeyValue(encodedKey); ok {
 				resCh <- result{key: key, err: nil}
 				return
 			}

--- a/internal/keychain/keychain_darwin_test.go
+++ b/internal/keychain/keychain_darwin_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build darwin
+
+package keychain
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+)
+
+func TestDecodeMasterKeyValue(t *testing.T) {
+	rawKey := bytes.Repeat([]byte{0x5a}, masterKeyBytes)
+	encodedKey := base64.StdEncoding.EncodeToString(rawKey)
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "plain base64",
+			input: encodedKey,
+		},
+		{
+			name:  "go-keyring base64 wrapper",
+			input: goKeyringBase64Prefix + base64.StdEncoding.EncodeToString([]byte(encodedKey)),
+		},
+		{
+			name:  "go-keyring hex wrapper",
+			input: goKeyringEncodedPrefix + hex.EncodeToString([]byte(encodedKey)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := decodeMasterKeyValue(tt.input)
+			if !ok {
+				t.Fatalf("decodeMasterKeyValue(%q) returned ok=false", tt.name)
+			}
+			if !bytes.Equal(got, rawKey) {
+				t.Fatalf("decodeMasterKeyValue(%q) returned unexpected key", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This patch makes the macOS keychain backend more tolerant when reading `master.key`.

On Darwin, `lark-cli` expects `master.key` to resolve to a base64-encoded 32-byte AES key. In practice, some environments can surface the stored value in a wrapped go-keyring format such as:

- `go-keyring-base64:<...>`
- `go-keyring-encoded:<...>`

When that happens, the current code only attempts a single direct base64 decode, fails to recover the 32-byte key, and silently falls back to generating a new key. That breaks decryption for previously stored secrets and tokens, which then shows up as config/auth failures like:

- `keychain entry not found: lark-cli/appsecret:<appId>`
- `auth status` reporting `no_token` even though the encrypted token file exists

## Root Cause

`getMasterKey()` currently assumes the value returned from keychain access is always a plain base64 string representing the raw 32-byte master key.

That assumption is too strict. If the value is still wrapped in a go-keyring prefix, it needs one extra normalization step before the final base64 decode.

## What Changed

- Added `decodeMasterKeyValue()` in `internal/keychain/keychain_darwin.go`
- Accepted all of these master key shapes:
  - plain base64
  - `go-keyring-base64:` wrapped values
  - `go-keyring-encoded:` wrapped values
- Switched `getMasterKey()` to use the new normalization helper
- Added a Darwin unit test covering the supported input formats

## Impact

This is a low-risk compatibility fix for macOS storage reads.

- It does not change the on-disk encrypted file format.
- It does not change how new keys are generated.
- It only broadens what existing `master.key` values can be decoded successfully.

## Validation

Validated logically against the current keychain/file storage flow and added a unit test for the decoding helper.

Note: Go tests were not run locally because the original environment had no Go toolchain.