### PR TITLE
feat: add update notification to help users keep CLI and Skills in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A command-line tool for [Lark/Feishu](https://www.larksuite.com/) Open Platform — built for humans and AI Agents. Covers core business domains including Messenger, Docs, Base, Sheets, Calendar, Mail, Tasks, Meetings, and more, with 200+ commands and 19 AI Agent [Skills](./skills/).
 
-[Install](#installation--quick-start) · [AI Agent Skills](#agent-skills) · [Auth](#authentication) · [Commands](#three-layer-command-system) · [Advanced](#advanced-usage) · [Security](#security--risk-warnings-read-before-use) · [Contributing](#contributing)
+[Install](#installation--quick-start) · [Update](#updating) · [AI Agent Skills](#agent-skills) · [Auth](#authentication) · [Commands](#three-layer-command-system) · [Advanced](#advanced-usage) · [Security](#security--risk-warnings-read-before-use) · [Contributing](#contributing)
 
 ## Why lark-cli?
 
@@ -109,6 +109,41 @@ lark-cli auth login --recommend
 # 5. Verify
 lark-cli auth status
 ```
+
+## Updating
+
+When a new version of lark-cli is released, you need to update **both** the CLI binary and the Skills to stay in sync.
+
+### One-Liner (Recommended)
+
+```bash
+npm update -g @larksuite/cli && npx skills add larksuite/cli --all -y
+```
+
+### Step by Step
+
+```bash
+# 1. Update CLI binary
+npm update -g @larksuite/cli
+
+# 2. Update Skills (re-running the install command pulls the latest version)
+npx skills add larksuite/cli --all -y
+
+# 3. Verify
+lark-cli --version
+```
+
+### Check for Updates
+
+```bash
+# See your installed version
+lark-cli --version
+
+# See the latest version on npm
+npm view @larksuite/cli version
+```
+
+> **Tip for AI Agent users:** After updating, restart your AI Agent (e.g. Claude Code) to pick up the new Skills. The CLI binary is updated immediately, but Skills are loaded at Agent startup.
 
 ## Agent Skills
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,7 +7,7 @@
 
 飞书/Lark 开放平台命令行工具 — 让人类和 AI Agent 都能在终端中操作飞书。覆盖消息、文档、多维表格、电子表格、日历、邮箱、任务、会议等核心业务域，提供 200+ 命令及 19 个 AI Agent [Skills](./skills/)。
 
-[安装](#安装与快速开始) · [AI Agent Skills](#agent-skills) · [认证](#认证) · [命令](#三层命令调用) · [进阶用法](#进阶用法) · [安全](#安全与风险提示使用前必读) · [贡献](#贡献)
+[安装](#安装与快速开始) · [升级](#升级) · [AI Agent Skills](#agent-skills) · [认证](#认证) · [命令](#三层命令调用) · [进阶用法](#进阶用法) · [安全](#安全与风险提示使用前必读) · [贡献](#贡献)
 
 ## 为什么选 lark-cli？
 
@@ -110,6 +110,41 @@ lark-cli auth login --recommend
 lark-cli auth status
 ```
 
+
+## 升级
+
+当 lark-cli 发布新版本时，需要**同时**更新 CLI 二进制和 Skills 以保持同步。
+
+### 一行命令（推荐）
+
+```bash
+npm update -g @larksuite/cli && npx skills add larksuite/cli --all -y
+```
+
+### 分步操作
+
+```bash
+# 1. 更新 CLI 二进制
+npm update -g @larksuite/cli
+
+# 2. 更新 Skills（重新运行安装命令即可拉取最新版本）
+npx skills add larksuite/cli --all -y
+
+# 3. 验证
+lark-cli --version
+```
+
+### 检查更新
+
+```bash
+# 查看当前安装版本
+lark-cli --version
+
+# 查看 npm 上的最新版本
+npm view @larksuite/cli version
+```
+
+> **AI Agent 用户提示：** 更新完成后，请重启你的 AI Agent（如 Claude Code）以加载最新的 Skills。CLI 二进制会立即生效，但 Skills 在 Agent 启动时加载。
 
 ## Agent Skills
 

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -62,6 +62,10 @@ func fail(name, msg, hint string) checkResult {
 	return checkResult{Name: name, Status: "fail", Message: msg, Hint: hint}
 }
 
+func warn(name, msg, hint string) checkResult {
+	return checkResult{Name: name, Status: "warn", Message: msg, Hint: hint}
+}
+
 func skip(name, msg string) checkResult {
 	return checkResult{Name: name, Status: "skip", Message: msg}
 }
@@ -237,7 +241,7 @@ func versionCheck(opts *DoctorOptions) []checkResult {
 	if result == nil {
 		return []checkResult{pass("version_latest", fmt.Sprintf("up to date (%s)", current))}
 	}
-	return []checkResult{fail(
+	return []checkResult{warn(
 		"version_latest",
 		fmt.Sprintf("update available: %s → %s", result.Current, result.Latest),
 		"run: "+result.UpdateCommand(),

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -49,7 +49,7 @@ func NewCmdDoctor(f *cmdutil.Factory) *cobra.Command {
 // checkResult represents one diagnostic check.
 type checkResult struct {
 	Name    string `json:"name"`
-	Status  string `json:"status"` // "pass", "fail", "skip"
+	Status  string `json:"status"` // "pass", "fail", "warn", "skip"
 	Message string `json:"message"`
 	Hint    string `json:"hint,omitempty"`
 }

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -220,6 +220,7 @@ func mustHTTPClient(f *cmdutil.Factory) *http.Client {
 }
 
 // versionCheck queries GitHub for the latest release and compares.
+// Uses a 5s timeout to avoid blocking doctor longer than other network checks.
 func versionCheck(opts *DoctorOptions) []checkResult {
 	current := build.Version
 	if current == "DEV" || current == "" {
@@ -229,7 +230,10 @@ func versionCheck(opts *DoctorOptions) []checkResult {
 		return []checkResult{skip("version_latest", "skipped (--offline)")}
 	}
 
-	result := update.CheckForUpdate(opts.Ctx, &http.Client{Timeout: 5 * time.Second})
+	ctx, cancel := context.WithTimeout(opts.Ctx, 5*time.Second)
+	defer cancel()
+
+	result := update.CheckForUpdate(ctx, &http.Client{Timeout: 5 * time.Second})
 	if result == nil {
 		return []checkResult{pass("version_latest", fmt.Sprintf("up to date (%s)", current))}
 	}

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -219,7 +219,7 @@ func mustHTTPClient(f *cmdutil.Factory) *http.Client {
 	return c
 }
 
-// versionCheck queries GitHub for the latest release and compares.
+// versionCheck queries npm registry for the latest release and compares.
 // Uses a 5s timeout to avoid blocking doctor longer than other network checks.
 func versionCheck(opts *DoctorOptions) []checkResult {
 	current := build.Version

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -14,9 +14,11 @@ import (
 	"github.com/spf13/cobra"
 
 	larkauth "github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/build"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/update"
 )
 
 // DoctorOptions holds inputs for the doctor command.
@@ -67,6 +69,9 @@ func skip(name, msg string) checkResult {
 func doctorRun(opts *DoctorOptions) error {
 	f := opts.Factory
 	var checks []checkResult
+
+	// ── 0. Version check ──
+	checks = append(checks, versionCheck(opts)...)
 
 	// ── 1. Config file ──
 	_, err := core.LoadMultiAppConfig()
@@ -212,6 +217,27 @@ func mustHTTPClient(f *cmdutil.Factory) *http.Client {
 		return &http.Client{Timeout: 30 * time.Second}
 	}
 	return c
+}
+
+// versionCheck queries GitHub for the latest release and compares.
+func versionCheck(opts *DoctorOptions) []checkResult {
+	current := build.Version
+	if current == "DEV" || current == "" {
+		return []checkResult{skip("version_latest", "dev build, skipped")}
+	}
+	if opts.Offline {
+		return []checkResult{skip("version_latest", "skipped (--offline)")}
+	}
+
+	result := update.CheckForUpdate(opts.Ctx, &http.Client{Timeout: 5 * time.Second})
+	if result == nil {
+		return []checkResult{pass("version_latest", fmt.Sprintf("up to date (%s)", current))}
+	}
+	return []checkResult{fail(
+		"version_latest",
+		fmt.Sprintf("update available: %s → %s", result.Current, result.Latest),
+		"run: "+result.UpdateCommand(),
+	)}
 }
 
 func finishDoctor(f *cmdutil.Factory, checks []checkResult) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,8 +145,13 @@ func Execute() int {
 // shouldShowUpdateNotification returns false for commands whose output
 // must stay machine-parseable (e.g. shell completion scripts, --version).
 func shouldShowUpdateNotification(rootCmd *cobra.Command) bool {
-	// After Execute(), CalledAs() on the root returns "" when a subcommand ran.
-	// We need to walk the command tree to find what actually executed.
+	// --version is a root flag, not a subcommand — Find() won't catch it.
+	for _, arg := range os.Args[1:] {
+		if arg == "--version" || arg == "-v" {
+			return false
+		}
+	}
+	// Suppress for commands whose output must stay machine-parseable.
 	cmd, _, _ := rootCmd.Find(os.Args[1:])
 	if cmd == nil {
 		return true

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -126,7 +126,7 @@ func Execute() int {
 	// Print update notification after command output (non-blocking, best-effort).
 	select {
 	case result := <-updateResultCh:
-		if result.IsNewer() {
+		if result != nil && result.IsNewer() {
 			fmt.Fprintf(f.IOStreams.ErrOut,
 				"\nA new version of lark-cli is available: %s → %s\nRun: %s\n",
 				result.Current, result.Latest, result.UpdateCommand())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"time"
 
@@ -124,18 +125,34 @@ func Execute() int {
 	}
 
 	// Print update notification after command output (non-blocking, best-effort).
-	select {
-	case result := <-updateResultCh:
-		if result != nil && result.IsNewer() {
-			fmt.Fprintf(f.IOStreams.ErrOut,
-				"\nA new version of lark-cli is available: %s → %s\nRun: %s\n",
-				result.Current, result.Latest, result.UpdateCommand())
+	// Suppress for commands whose stdout/stderr must stay clean (e.g. shell completion).
+	if shouldShowUpdateNotification(rootCmd) {
+		select {
+		case result := <-updateResultCh:
+			if result != nil && result.IsNewer() {
+				fmt.Fprintf(f.IOStreams.ErrOut,
+					"\nA new version of lark-cli is available: %s → %s\nRun: %s\n",
+					result.Current, result.Latest, result.UpdateCommand())
+			}
+		default:
+			// Check hasn't finished yet — don't block.
 		}
-	default:
-		// Check hasn't finished yet — don't block.
 	}
 
 	return exitCode
+}
+
+// shouldShowUpdateNotification returns false for commands whose output
+// must stay machine-parseable (e.g. shell completion scripts, --version).
+func shouldShowUpdateNotification(rootCmd *cobra.Command) bool {
+	// After Execute(), CalledAs() on the root returns "" when a subcommand ran.
+	// We need to walk the command tree to find what actually executed.
+	cmd, _, _ := rootCmd.Find(os.Args[1:])
+	if cmd == nil {
+		return true
+	}
+	name := cmd.Name()
+	return name != "completion" && name != "__complete"
 }
 
 // handleRootError dispatches a command error to the appropriate handler

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,12 +4,15 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/larksuite/cli/cmd/api"
 	"github.com/larksuite/cli/cmd/auth"
@@ -24,6 +27,7 @@ import (
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/registry"
+	"github.com/larksuite/cli/internal/update"
 	"github.com/larksuite/cli/shortcuts"
 	"github.com/spf13/cobra"
 )
@@ -92,6 +96,15 @@ func Execute() int {
 	}
 	installTipsHelpFunc(rootCmd)
 	rootCmd.SilenceErrors = true
+
+	// Start async update check before command execution.
+	updateResultCh := make(chan *update.Result, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		updateResultCh <- update.CheckForUpdate(ctx, &http.Client{Timeout: 5 * time.Second})
+	}()
+
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		cmd.SilenceUsage = true
 	}
@@ -105,10 +118,24 @@ func Execute() int {
 	service.RegisterServiceCommands(rootCmd, f)
 	shortcuts.RegisterShortcuts(rootCmd, f)
 
+	exitCode := 0
 	if err := rootCmd.Execute(); err != nil {
-		return handleRootError(f, err)
+		exitCode = handleRootError(f, err)
 	}
-	return 0
+
+	// Print update notification after command output (non-blocking, best-effort).
+	select {
+	case result := <-updateResultCh:
+		if result.IsNewer() {
+			fmt.Fprintf(f.IOStreams.ErrOut,
+				"\nA new version of lark-cli is available: %s → %s\nRun: %s\n",
+				result.Current, result.Latest, result.UpdateCommand())
+		}
+	default:
+		// Check hasn't finished yet — don't block.
+	}
+
+	return exitCode
 }
 
 // handleRootError dispatches a command error to the appropriate handler

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -76,7 +76,7 @@ func CheckForUpdate(ctx context.Context, httpClient *http.Client) *Result {
 		}
 	}
 
-	// Fetch latest version from GitHub.
+	// Fetch latest version from npm registry.
 	latest, err := fetchLatestVersion(ctx, httpClient)
 	if err != nil {
 		return nil

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/larksuite/cli/internal/build"
+	"github.com/larksuite/cli/internal/core"
+)
+
+const (
+	// checkInterval is the minimum time between remote version checks.
+	checkInterval = 24 * time.Hour
+
+	// releaseURL is the GitHub API endpoint for the latest release.
+	releaseURL = "https://api.github.com/repos/larksuite/cli/releases/latest"
+
+	// stateFile is the file name for persisting last-check state.
+	stateFile = "update-state.json"
+)
+
+// state persists between CLI invocations to avoid checking on every run.
+type state struct {
+	CheckedAt     time.Time `json:"checked_at"`
+	LatestVersion string    `json:"latest_version"`
+}
+
+// Result holds the outcome of a version check.
+type Result struct {
+	Current string
+	Latest  string
+}
+
+// IsNewer returns true if the latest version is newer than current.
+func (r *Result) IsNewer() bool {
+	return r != nil && r.Latest != "" && r.Latest != r.Current && compareVersions(r.Latest, r.Current) > 0
+}
+
+// UpdateCommand returns the recommended update command string.
+func (r *Result) UpdateCommand() string {
+	return "npm update -g @larksuite/cli && npx skills add larksuite/cli --all -y"
+}
+
+// CheckForUpdate checks whether a newer version is available.
+// It reads cached state to avoid hitting the network on every invocation.
+// Returns nil if no update is available, the version is DEV, or checking is disabled.
+func CheckForUpdate(ctx context.Context, httpClient *http.Client) *Result {
+	if isDisabled() {
+		return nil
+	}
+	current := build.Version
+	if current == "DEV" || current == "" {
+		return nil
+	}
+
+	stPath := statePath()
+
+	// Try to use cached state first.
+	if s, err := readState(stPath); err == nil {
+		if time.Since(s.CheckedAt) < checkInterval {
+			r := &Result{Current: current, Latest: s.LatestVersion}
+			if r.IsNewer() {
+				return r
+			}
+			return nil
+		}
+	}
+
+	// Fetch latest version from GitHub.
+	latest, err := fetchLatestVersion(ctx, httpClient)
+	if err != nil {
+		return nil
+	}
+
+	// Persist state.
+	_ = writeState(stPath, &state{
+		CheckedAt:     time.Now(),
+		LatestVersion: latest,
+	})
+
+	r := &Result{Current: current, Latest: latest}
+	if r.IsNewer() {
+		return r
+	}
+	return nil
+}
+
+// isDisabled returns true if the user has opted out of update checks.
+func isDisabled() bool {
+	if v := os.Getenv("LARKSUITE_CLI_NO_UPDATE_NOTIFIER"); v != "" {
+		return true
+	}
+	// Suppress in common CI environments.
+	for _, key := range []string{"CI", "BUILD_NUMBER", "RUN_ID"} {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func statePath() string {
+	return filepath.Join(core.GetConfigDir(), stateFile)
+}
+
+func readState(path string) (*state, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var s state
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func writeState(path string, s *state) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// githubRelease is the subset of GitHub release JSON we care about.
+type githubRelease struct {
+	TagName string `json:"tag_name"`
+}
+
+func fetchLatestVersion(ctx context.Context, httpClient *http.Client) (string, error) {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("github: status %d", resp.StatusCode)
+	}
+
+	var rel githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(rel.TagName, "v"), nil
+}
+
+// compareVersions compares two semver strings (without "v" prefix).
+// Returns >0 if a > b, <0 if a < b, 0 if equal.
+func compareVersions(a, b string) int {
+	ap := parseVersion(a)
+	bp := parseVersion(b)
+	for i := 0; i < 3; i++ {
+		if ap[i] != bp[i] {
+			return ap[i] - bp[i]
+		}
+	}
+	return 0
+}
+
+func parseVersion(v string) [3]int {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	var result [3]int
+	for i := 0; i < len(parts) && i < 3; i++ {
+		// Strip pre-release suffix (e.g. "1-beta" → "1").
+		num := strings.SplitN(parts[i], "-", 2)[0]
+		result[i], _ = strconv.Atoi(num)
+	}
+	return result
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -22,8 +22,8 @@ const (
 	// checkInterval is the minimum time between remote version checks.
 	checkInterval = 24 * time.Hour
 
-	// releaseURL is the GitHub API endpoint for the latest release.
-	releaseURL = "https://api.github.com/repos/larksuite/cli/releases/latest"
+	// registryURL is the npm registry endpoint for the latest version.
+	registryURL = "https://registry.npmjs.org/@larksuite/cli/latest"
 
 	// stateFile is the file name for persisting last-check state.
 	stateFile = "update-state.json"
@@ -137,9 +137,9 @@ func writeState(path string, s *state) error {
 	return os.WriteFile(path, data, 0600)
 }
 
-// githubRelease is the subset of GitHub release JSON we care about.
-type githubRelease struct {
-	TagName string `json:"tag_name"`
+// npmPackage is the subset of npm registry JSON we care about.
+type npmPackage struct {
+	Version string `json:"version"`
 }
 
 func fetchLatestVersion(ctx context.Context, httpClient *http.Client) (string, error) {
@@ -149,11 +149,11 @@ func fetchLatestVersion(ctx context.Context, httpClient *http.Client) (string, e
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releaseURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, registryURL, nil)
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Accept", "application/json")
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
@@ -162,14 +162,14 @@ func fetchLatestVersion(ctx context.Context, httpClient *http.Client) (string, e
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("github: status %d", resp.StatusCode)
+		return "", fmt.Errorf("npm registry: status %d", resp.StatusCode)
 	}
 
-	var rel githubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+	var pkg npmPackage
+	if err := json.NewDecoder(resp.Body).Decode(&pkg); err != nil {
 		return "", err
 	}
-	return strings.TrimPrefix(rel.TagName, "v"), nil
+	return pkg.Version, nil
 }
 
 // compareVersions compares two semver strings (without "v" prefix).

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -106,7 +106,6 @@ func TestCheckForUpdate_CachedState(t *testing.T) {
 	build.Version = "1.0.0"
 	defer func() { build.Version = origVersion }()
 
-	// Set up temp config dir
 	tmpDir := t.TempDir()
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", tmpDir)
 
@@ -127,51 +126,24 @@ func TestCheckForUpdate_CachedState(t *testing.T) {
 	}
 }
 
-func TestCheckForUpdate_FetchesFromGitHub(t *testing.T) {
-	origVersion := build.Version
-	build.Version = "1.0.0"
-	defer func() { build.Version = origVersion }()
-
-	tmpDir := t.TempDir()
-	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", tmpDir)
-
-	// Mock GitHub API
+func TestFetchLatestVersion_NpmRegistry(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(githubRelease{TagName: "v1.2.0"})
+		json.NewEncoder(w).Encode(npmPackage{Version: "2.0.0"})
 	}))
 	defer server.Close()
 
-	// Override releaseURL by using a custom fetcher through the server
-	origURL := releaseURL
-	// We can't easily override the const, so test fetchLatestVersion directly
-	_ = origURL
-
-	latest, err := fetchLatestVersion(context.Background(), server.Client())
-	// This will fail because it hits the real URL, not our mock.
-	// Instead, test the mock server directly.
-	_ = latest
-	_ = err
-}
-
-func TestFetchLatestVersion(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(githubRelease{TagName: "v2.0.0"})
-	}))
-	defer server.Close()
-
-	// We test the JSON parsing by calling the server directly.
 	resp, err := server.Client().Get(server.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
 
-	var rel githubRelease
-	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+	var pkg npmPackage
+	if err := json.NewDecoder(resp.Body).Decode(&pkg); err != nil {
 		t.Fatal(err)
 	}
-	if rel.TagName != "v2.0.0" {
-		t.Errorf("expected v2.0.0, got %s", rel.TagName)
+	if pkg.Version != "2.0.0" {
+		t.Errorf("expected 2.0.0, got %s", pkg.Version)
 	}
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/build"
+)
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"1.0.1", "1.0.0", 1},
+		{"1.0.0", "1.0.1", -1},
+		{"2.0.0", "1.9.9", 1},
+		{"1.10.0", "1.9.0", 1},
+		{"0.1.0", "0.0.9", 1},
+	}
+	for _, tt := range tests {
+		got := compareVersions(tt.a, tt.b)
+		if (tt.want > 0 && got <= 0) || (tt.want < 0 && got >= 0) || (tt.want == 0 && got != 0) {
+			t.Errorf("compareVersions(%q, %q) = %d, want sign %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  [3]int
+	}{
+		{"1.2.3", [3]int{1, 2, 3}},
+		{"v1.2.3", [3]int{1, 2, 3}},
+		{"1.2.3-beta", [3]int{1, 2, 3}},
+		{"1.0", [3]int{1, 0, 0}},
+		{"1", [3]int{1, 0, 0}},
+	}
+	for _, tt := range tests {
+		got := parseVersion(tt.input)
+		if got != tt.want {
+			t.Errorf("parseVersion(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestResult_IsNewer(t *testing.T) {
+	tests := []struct {
+		name   string
+		result *Result
+		want   bool
+	}{
+		{"nil result", nil, false},
+		{"same version", &Result{Current: "1.0.0", Latest: "1.0.0"}, false},
+		{"newer available", &Result{Current: "1.0.0", Latest: "1.1.0"}, true},
+		{"older available", &Result{Current: "1.1.0", Latest: "1.0.0"}, false},
+		{"empty latest", &Result{Current: "1.0.0", Latest: ""}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.result.IsNewer()
+			if got != tt.want {
+				t.Errorf("IsNewer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCheckForUpdate_DEV(t *testing.T) {
+	origVersion := build.Version
+	build.Version = "DEV"
+	defer func() { build.Version = origVersion }()
+
+	result := CheckForUpdate(context.Background(), nil)
+	if result != nil {
+		t.Error("expected nil for DEV version")
+	}
+}
+
+func TestCheckForUpdate_Disabled(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_NO_UPDATE_NOTIFIER", "1")
+
+	origVersion := build.Version
+	build.Version = "1.0.0"
+	defer func() { build.Version = origVersion }()
+
+	result := CheckForUpdate(context.Background(), nil)
+	if result != nil {
+		t.Error("expected nil when disabled")
+	}
+}
+
+func TestCheckForUpdate_CachedState(t *testing.T) {
+	origVersion := build.Version
+	build.Version = "1.0.0"
+	defer func() { build.Version = origVersion }()
+
+	// Set up temp config dir
+	tmpDir := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", tmpDir)
+
+	// Write a fresh cached state
+	s := &state{
+		CheckedAt:     time.Now(),
+		LatestVersion: "1.1.0",
+	}
+	data, _ := json.Marshal(s)
+	os.WriteFile(filepath.Join(tmpDir, stateFile), data, 0600)
+
+	result := CheckForUpdate(context.Background(), nil)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Latest != "1.1.0" {
+		t.Errorf("expected latest 1.1.0, got %s", result.Latest)
+	}
+}
+
+func TestCheckForUpdate_FetchesFromGitHub(t *testing.T) {
+	origVersion := build.Version
+	build.Version = "1.0.0"
+	defer func() { build.Version = origVersion }()
+
+	tmpDir := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", tmpDir)
+
+	// Mock GitHub API
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(githubRelease{TagName: "v1.2.0"})
+	}))
+	defer server.Close()
+
+	// Override releaseURL by using a custom fetcher through the server
+	origURL := releaseURL
+	// We can't easily override the const, so test fetchLatestVersion directly
+	_ = origURL
+
+	latest, err := fetchLatestVersion(context.Background(), server.Client())
+	// This will fail because it hits the real URL, not our mock.
+	// Instead, test the mock server directly.
+	_ = latest
+	_ = err
+}
+
+func TestFetchLatestVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(githubRelease{TagName: "v2.0.0"})
+	}))
+	defer server.Close()
+
+	// We test the JSON parsing by calling the server directly.
+	resp, err := server.Client().Get(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var rel githubRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		t.Fatal(err)
+	}
+	if rel.TagName != "v2.0.0" {
+		t.Errorf("expected v2.0.0, got %s", rel.TagName)
+	}
+}
+
+func TestStateReadWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "state.json")
+
+	s := &state{
+		CheckedAt:     time.Now().Truncate(time.Second),
+		LatestVersion: "1.5.0",
+	}
+
+	if err := writeState(path, s); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readState(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.LatestVersion != s.LatestVersion {
+		t.Errorf("got %s, want %s", got.LatestVersion, s.LatestVersion)
+	}
+}

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -73,6 +73,25 @@ lark-cli auth login --scope "calendar:calendar:readonly"
 ```
 
 
+## 更新检查
+
+lark-cli 命令执行后，如果检测到新版本，会在 stderr 输出类似如下提示：
+
+```
+A new version of lark-cli is available: 1.0.0 → 1.1.0
+Run: npm update -g @larksuite/cli && npx skills add larksuite/cli --all -y
+```
+
+**当你在 stderr 中看到此提示时，必须主动告知用户**，包含以下信息：
+1. 当前版本和最新版本号
+2. 更新命令（CLI 和 Skills 需要同时更新）：
+   ```bash
+   npm update -g @larksuite/cli && npx skills add larksuite/cli --all -y
+   ```
+3. 提醒用户：更新 Skills 后需要**重启 AI Agent**（如 Claude Code）才能生效
+
+**规则**：不要静默忽略更新提示。即使当前任务与更新无关，也应在完成用户请求后补充告知。
+
 ## 安全规则
 
 - **禁止输出密钥**（appSecret、accessToken）到终端明文。


### PR DESCRIPTION
## 用户痛点

很多用户反馈同一个问题：**"我怎么知道 lark-cli 更新了？更新之后怎么让我的 Claude Code 也跟着更新？"**

lark-cli 此前没有任何版本更新感知机制。用户安装后就进入了"信息黑洞"——不知道何时有新版本，也不知道更新 CLI 后还需要同步更新 Skills 才能让 AI Agent 用上最新能力。这导致大量用户长期停留在旧版本上。

## 用户视角分析：光改 CLI 不够

我们从用户视角走查了完整链路，发现**只在 CLI 加 stderr 提示是不够的**：

### 人类用户直接用终端 → 体验完整 ✅

```
$ lark-cli calendar +agenda
{ ... 正常输出 ... }

A new version of lark-cli is available: 1.0.0 → 1.1.0
Run: npm update -g @larksuite/cli && npx skills add larksuite/cli --all -y
```

用户看到提示，复制命令更新。没问题。

### AI Agent 用户（如 Claude Code）→ 如果只改 CLI，体验是断的 ❌

```
Agent 执行: lark-cli calendar +agenda
├── stdout: JSON 数据 → Agent 正常处理
└── stderr: "A new version available..." → Agent 大概率忽略
```

问题在于：
- Agent 的核心任务是处理用户请求，**stderr 里的更新提示不在它的"职责范围"内**
- 即使 Agent 注意到了，它**没有指令告诉它该怎么做** — 是忽略？是告知用户？是自动更新？
- 用户完全不知道有新版本，因为 Agent 什么都没说

这就是为什么大量用户反馈这个问题 — **他们的 Agent 每天都在调用 lark-cli，但从来没告诉过他们有新版本。**

## 参考 OpenClaw 的做法

调研了 [OpenClaw](https://github.com/openclaw/openclaw) 和 [GitHub CLI (gh)](https://github.com/cli/cli) 的更新机制。

OpenClaw 的 CLI 层版本检查和其他工具差不多（Gateway 日志 + status 命令），但真正解决 Agent 用户问题的是 **auto-updater Skill** — 用 Skill 教 Agent 理解更新流程并主动行动。这个思路是对的：**Agent 的行为由 Skill 定义，不是由 stderr 输出定义。**

| 设计决策 | OpenClaw | gh CLI | 本 PR |
|----------|----------|--------|-------|
| 检查数据源 | npm / GitHub releases | GitHub releases API | **npm registry** — 分发渠道是 npm，无限流问题 |
| 避免频繁请求 | 按 channel 配置间隔 | 24h YAML state 文件 | **24h JSON state 文件** |
| 不阻塞命令执行 | 网关异步 | 后台 goroutine | **goroutine + select default** — 没完成就跳过 |
| CI 环境静默 | — | 检测 `CI` 等环境变量 | **同样检测** + `LARKSUITE_CLI_NO_UPDATE_NOTIFIER` |
| health check 集成 | `openclaw doctor` | — | **`lark-cli doctor` 新增 `version_latest`（warn，不影响 exit code）** |
| **Skill 引导 Agent** | auto-updater Skill | — | **`lark-shared` Skill 指令：看到更新提示必须主动告知用户** |

## 解决方案：CLI 检测 + Skill 引导

采用三层联动，确保人类用户和 AI Agent 用户的体验都完整：

```
┌─────────────────────────────────────────────────────────┐
│  CLI 层 (internal/update/)                              │
│  检测新版本 → stderr 输出提示                            │
└──────────────────────┬──────────────────────────────────┘
                       │
          ┌────────────┴────────────┐
          ▼                         ▼
┌──────────────────┐    ┌───────────────────────────────┐
│ 人类用户          │    │ AI Agent                      │
│ 直接看到 stderr  │    │ Skill 指令要求必须告知用户      │
│ 复制命令更新     │    │ → 完成用户请求后补充告知版本号、 │
│                  │    │   更新命令、需重启 Agent        │
│ ✅ 完整          │    │ ✅ 完整                        │
└──────────────────┘    └───────────────────────────────┘
```

### AI Agent 用户的最终体验

```
用户: 帮我看看今天的日程

Agent 执行: lark-cli calendar +agenda
├── stdout: 日程数据
└── stderr: "A new version of lark-cli is available: 1.0.0 → 1.1.0 ..."

Agent 回复:
  今天有 3 个会议：
  - 09:00 周会
  - 14:00 评审
  - 16:00 1:1

  💡 lark-cli 有新版本可用（1.0.0 → 1.1.0），建议运行以下命令更新：
  npm update -g @larksuite/cli && npx skills add larksuite/cli --all -y
  更新后需要重启 Claude Code 以加载最新 Skills。
```

## 改动内容

### 1. 新增 `internal/update/` 包 — 版本检查引擎

- 查询 npm registry (`registry.npmjs.org/@larksuite/cli/latest`) 获取最新版本
- 结果缓存到 `~/.lark-cli/update-state.json`，24 小时内不重复请求
- DEV 构建自动跳过；CI 环境自动静默；支持环境变量完全关闭
- 内置 semver 比较，正确处理 `v` 前缀和 pre-release 后缀

### 2. 修改 `cmd/root.go` — 异步更新提示

- 进程启动时 goroutine 异步发起检查，命令完成后 `select` 读取，**绝不阻塞**
- 对 `completion` 和 `__complete` 命令静默，避免污染 shell 补全脚本

### 3. 修改 `cmd/doctor/doctor.go` — 新增 `version_latest` 检查项

- 有更新时使用 **`warn` 状态**（非 `fail`），不影响 exit code
- 确保 CI 健康检查门控不会因为可选更新误报失败

### 4. 修改 `skills/lark-shared/SKILL.md` — 教 Agent 处理更新提示

- 新增"更新检查"章节，指导 Agent 看到 stderr 更新提示时**必须主动告知用户**
- 明确告知内容：版本号、更新命令、需要重启 Agent
- 规则：不得静默忽略，完成当前任务后补充告知
- `lark-shared` 被所有其他 Skill 自动加载，全局生效

### 5. 更新 README（中英文）— 新增 Updating 章节

- 一行命令同时更新 CLI + Skills
- 分步说明 + 版本检查命令
- 提示 AI Agent 用户更新后需重启 Agent

## 设计取舍

| 取舍 | 决策 | 理由 |
|------|------|------|
| state 文件写入非原子 | 接受 | 写坏了下次重新 fetch，不崩不误报 |
| npm 响应体未限 size | 接受 | 5s 超时兜底，`/latest` 返回量可控 |
| doctor 版本检查同步阻塞 | 接受 | doctor 本身就做网络检查，已加独立 5s timeout |
| warn 不影响 exit code | 刻意为之 | 可选更新不应破坏 `doctor` 作为健康检查的语义 |

## Test plan
- [x] `go test ./internal/update/` — 8 tests pass
- [x] `go test ./cmd/doctor/` — 4 tests pass
- [x] `go build ./...` — 编译通过
- [ ] 手动验证：设置旧版本号，确认 stderr 提示出现
- [ ] 手动验证：`lark-cli doctor` 显示 `version_latest` 为 `warn`，exit code 为 0
- [ ] 手动验证：`LARKSUITE_CLI_NO_UPDATE_NOTIFIER=1` 时无检查
- [ ] 手动验证：`lark-cli completion bash` 时无更新提示
- [ ] 手动验证：AI Agent 调用 lark-cli 后看到 stderr 更新提示，按 Skill 指令主动告知用户

🤖 Generated with [Claude Code](https://claude.com/claude-code)