### PR TITLE
fix(base): correct scope for record history list shortcut

### DIFF
--- a/shortcuts/base/record_history_list.go
+++ b/shortcuts/base/record_history_list.go
@@ -14,7 +14,7 @@ var BaseRecordHistoryList = common.Shortcut{
 	Command:     "+record-history-list",
 	Description: "List record change history",
 	Risk:        "read",
-	Scopes:      []string{"base:record:read"},
+	Scopes:      []string{"base:history:read"},
 	AuthTypes:   authTypes(),
 	Flags: []common.Flag{
 		baseTokenFlag(true),


### PR DESCRIPTION
## Summary
- change `shortcuts/base/record_history_list.go` scope from `base:record:read` to `base:history:read`
- align permission scope with record history API usage

## Testing
- not run (scope string change only)