### PR TITLE
feat: add jq output filtering support

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -40,6 +40,7 @@ type APIOptions struct {
 	PageLimit int
 	PageDelay int
 	Format    string
+	JQ        string
 	DryRun    bool
 }
 
@@ -96,6 +97,7 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*APIOptions) error) *cobra.Command 
 	cmd.Flags().IntVar(&opts.PageLimit, "page-limit", 10, "max pages to fetch with --page-all (0 = unlimited)")
 	cmd.Flags().IntVar(&opts.PageDelay, "page-delay", 200, "delay in ms between pages")
 	cmd.Flags().StringVar(&opts.Format, "format", "json", "output format: json|ndjson|table|csv")
+	cmd.Flags().StringVar(&opts.JQ, "jq", "", "jq expression to filter JSON output")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "print request without executing")
 
 	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
@@ -155,6 +157,14 @@ func apiRun(opts *APIOptions) error {
 	if opts.PageAll && opts.Output != "" {
 		return output.ErrValidation("--output and --page-all are mutually exclusive")
 	}
+	if opts.JQ != "" {
+		if opts.Output != "" {
+			return output.ErrValidation("--jq and --output are mutually exclusive")
+		}
+		if format, _ := output.ParseFormat(opts.Format); format != output.FormatJSON || opts.Format == "ndjson" {
+			return output.ErrValidation("--jq is only supported with JSON output")
+		}
+	}
 
 	request, err := buildAPIRequest(opts)
 	if err != nil {
@@ -184,7 +194,7 @@ func apiRun(opts *APIOptions) error {
 	}
 
 	if opts.PageAll {
-		return apiPaginate(opts.Ctx, ac, request, format, out, f.IOStreams.ErrOut,
+		return apiPaginate(opts.Ctx, ac, request, format, opts.JQ, out, f.IOStreams.ErrOut,
 			client.PaginationOptions{PageLimit: opts.PageLimit, PageDelay: opts.PageDelay})
 	}
 
@@ -195,6 +205,7 @@ func apiRun(opts *APIOptions) error {
 	err = client.HandleResponse(resp, client.ResponseOptions{
 		OutputPath: opts.Output,
 		Format:     format,
+		JQ:         opts.JQ,
 		Out:        out,
 		ErrOut:     f.IOStreams.ErrOut,
 	})
@@ -210,7 +221,7 @@ func apiDryRun(f *cmdutil.Factory, request client.RawApiRequest, config *core.Cl
 	return cmdutil.PrintDryRun(f.IOStreams.Out, request, config, format)
 }
 
-func apiPaginate(ctx context.Context, ac *client.APIClient, request client.RawApiRequest, format output.Format, out, errOut io.Writer, pagOpts client.PaginationOptions) error {
+func apiPaginate(ctx context.Context, ac *client.APIClient, request client.RawApiRequest, format output.Format, jq string, out, errOut io.Writer, pagOpts client.PaginationOptions) error {
 	switch format {
 	case output.FormatNDJSON, output.FormatTable, output.FormatCSV:
 		pf := output.NewPaginatedFormatter(out, format)
@@ -221,12 +232,12 @@ func apiPaginate(ctx context.Context, ac *client.APIClient, request client.RawAp
 			return output.MarkRaw(output.ErrNetwork("API call failed: %v", err))
 		}
 		if apiErr := client.CheckLarkResponse(result); apiErr != nil {
-			output.FormatValue(out, result, output.FormatJSON)
+			_ = output.FormatValueWithOptions(out, result, output.FormatOptions{Format: output.FormatJSON})
 			return output.MarkRaw(apiErr)
 		}
 		if !hasItems {
 			fmt.Fprintf(errOut, "warning: this API does not return a list, format %q is not supported, falling back to json\n", format)
-			output.FormatValue(out, result, output.FormatJSON)
+			_ = output.FormatValueWithOptions(out, result, output.FormatOptions{Format: output.FormatJSON})
 		}
 		return nil
 	default:
@@ -235,10 +246,9 @@ func apiPaginate(ctx context.Context, ac *client.APIClient, request client.RawAp
 			return output.MarkRaw(output.ErrNetwork("API call failed: %v", err))
 		}
 		if apiErr := client.CheckLarkResponse(result); apiErr != nil {
-			output.FormatValue(out, result, output.FormatJSON)
+			_ = output.FormatValueWithOptions(out, result, output.FormatOptions{Format: output.FormatJSON})
 			return output.MarkRaw(apiErr)
 		}
-		output.FormatValue(out, result, format)
-		return nil
+		return output.FormatValueWithOptions(out, result, output.FormatOptions{Format: format, JQ: jq})
 	}
 }

--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -45,6 +45,23 @@ func TestApiCmd_FlagParsing(t *testing.T) {
 	}
 }
 
+func TestApiCmd_JQFlagParsing(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu})
+
+	var gotOpts *APIOptions
+	cmd := NewCmdApi(f, func(opts *APIOptions) error {
+		gotOpts = opts
+		return nil
+	})
+	cmd.SetArgs([]string{"GET", "/open-apis/test", "--jq", ".data.result"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotOpts == nil || gotOpts.JQ != ".data.result" {
+		t.Fatalf("expected jq flag to be captured, got %#v", gotOpts)
+	}
+}
+
 func TestApiCmd_DryRun(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
 		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,
@@ -206,6 +223,22 @@ func TestApiCmd_PageLimitDefault(t *testing.T) {
 	}
 	if gotOpts.PageLimit != 10 {
 		t.Errorf("expected default PageLimit=10, got %d", gotOpts.PageLimit)
+	}
+}
+
+func TestApiCmd_JQValidation(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu})
+
+	cmd := NewCmdApi(f, nil)
+	cmd.SetArgs([]string{"GET", "/open-apis/test", "--jq", ".data", "--output", "file.bin"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--jq and --output") {
+		t.Fatalf("expected jq/output conflict, got %v", err)
+	}
+
+	cmd = NewCmdApi(f, nil)
+	cmd.SetArgs([]string{"GET", "/open-apis/test", "--jq", ".data", "--format", "table"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "only supported with JSON") {
+		t.Fatalf("expected jq/json validation, got %v", err)
 	}
 }
 
@@ -533,6 +566,21 @@ func TestApiCmd_PageAll_APIError_IsRaw(t *testing.T) {
 	}
 	if !exitErr.Raw {
 		t.Error("expected paginated API error to be marked Raw")
+	}
+}
+
+func TestApiCmd_JQOutput(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app-jq", AppSecret: "test-secret-jq", Brand: core.BrandFeishu})
+	reg.Register(&httpmock.Stub{URL: "/open-apis/auth/v3/tenant_access_token/internal", Body: map[string]interface{}{"code": 0, "msg": "ok", "tenant_access_token": "t-test-token-jq", "expire": 7200}})
+	reg.Register(&httpmock.Stub{URL: "/open-apis/test/jq", Body: map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"result": "success", "items": []interface{}{map[string]interface{}{"id": "1"}}}}})
+
+	cmd := NewCmdApi(f, nil)
+	cmd.SetArgs([]string{"GET", "/open-apis/test/jq", "--as", "bot", "--jq", ".data.result"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "success") || strings.Contains(got, "items") {
+		t.Fatalf("unexpected jq output: %s", got)
 	}
 }
 

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -109,6 +109,7 @@ type ServiceMethodOptions struct {
 	PageLimit int
 	PageDelay int
 	Format    string
+	JQ        string
 	DryRun    bool
 }
 
@@ -157,6 +158,7 @@ func NewCmdServiceMethod(f *cmdutil.Factory, spec, method map[string]interface{}
 	cmd.Flags().IntVar(&opts.PageLimit, "page-limit", 10, "max pages to fetch with --page-all (0 = unlimited)")
 	cmd.Flags().IntVar(&opts.PageDelay, "page-delay", 200, "delay in ms between pages")
 	cmd.Flags().StringVar(&opts.Format, "format", "json", "output format: json|ndjson|table|csv")
+	cmd.Flags().StringVar(&opts.JQ, "jq", "", "jq expression to filter JSON output")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "print request without executing")
 
 	_ = cmd.RegisterFlagCompletionFunc("as", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
@@ -184,6 +186,14 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 
 	if opts.PageAll && opts.Output != "" {
 		return output.ErrValidation("--output and --page-all are mutually exclusive")
+	}
+	if opts.JQ != "" {
+		if opts.Output != "" {
+			return output.ErrValidation("--jq and --output are mutually exclusive")
+		}
+		if format, _ := output.ParseFormat(opts.Format); format != output.FormatJSON || opts.Format == "ndjson" {
+			return output.ErrValidation("--jq is only supported with JSON output")
+		}
 	}
 
 	config, err := f.ResolveConfig(opts.As)
@@ -223,7 +233,7 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	checkErr := scopeAwareChecker(scopes, opts.As.IsBot())
 
 	if opts.PageAll {
-		return servicePaginate(opts.Ctx, ac, request, format, out, f.IOStreams.ErrOut,
+		return servicePaginate(opts.Ctx, ac, request, format, opts.JQ, out, f.IOStreams.ErrOut,
 			client.PaginationOptions{PageLimit: opts.PageLimit, PageDelay: opts.PageDelay}, checkErr)
 	}
 
@@ -234,6 +244,7 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	return client.HandleResponse(resp, client.ResponseOptions{
 		OutputPath: opts.Output,
 		Format:     format,
+		JQ:         opts.JQ,
 		Out:        out,
 		ErrOut:     f.IOStreams.ErrOut,
 		CheckError: checkErr,
@@ -400,7 +411,7 @@ func scopeAwareChecker(scopes []interface{}, isBotMode bool) func(interface{}) e
 	}
 }
 
-func servicePaginate(ctx context.Context, ac *client.APIClient, request client.RawApiRequest, format output.Format, out, errOut io.Writer, pagOpts client.PaginationOptions, checkErr func(interface{}) error) error {
+func servicePaginate(ctx context.Context, ac *client.APIClient, request client.RawApiRequest, format output.Format, jq string, out, errOut io.Writer, pagOpts client.PaginationOptions, checkErr func(interface{}) error) error {
 	switch format {
 	case output.FormatNDJSON, output.FormatTable, output.FormatCSV:
 		pf := output.NewPaginatedFormatter(out, format)
@@ -415,7 +426,7 @@ func servicePaginate(ctx context.Context, ac *client.APIClient, request client.R
 		}
 		if !hasItems {
 			fmt.Fprintf(errOut, "warning: this API does not return a list, format %q is not supported, falling back to json\n", format)
-			output.FormatValue(out, result, output.FormatJSON)
+			_ = output.FormatValueWithOptions(out, result, output.FormatOptions{Format: output.FormatJSON})
 		}
 		return nil
 	default:
@@ -426,7 +437,6 @@ func servicePaginate(ctx context.Context, ac *client.APIClient, request client.R
 		if apiErr := checkErr(result); apiErr != nil {
 			return apiErr
 		}
-		output.FormatValue(out, result, format)
-		return nil
+		return output.FormatValueWithOptions(out, result, output.FormatOptions{Format: format, JQ: jq})
 	}
 }

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -158,6 +158,23 @@ func TestNewCmdServiceMethod_POSTHasDataFlag(t *testing.T) {
 	}
 }
 
+func TestNewCmdServiceMethod_JQFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+
+	var captured *ServiceMethodOptions
+	cmd := NewCmdServiceMethod(f, driveSpec(), map[string]interface{}{"description": "desc", "httpMethod": "GET"}, "list", "files", func(opts *ServiceMethodOptions) error {
+		captured = opts
+		return nil
+	})
+	cmd.SetArgs([]string{"--jq", ".data.result"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured == nil || captured.JQ != ".data.result" {
+		t.Fatalf("expected jq flag to be captured, got %#v", captured)
+	}
+}
+
 func TestNewCmdServiceMethod_RunFCallback(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
 
@@ -341,6 +358,24 @@ func TestServiceMethod_InvalidDataJSON(t *testing.T) {
 	}
 }
 
+func TestServiceMethod_JQValidation(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	spec := map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"}
+	method := map[string]interface{}{"path": "items", "httpMethod": "GET"}
+
+	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
+	cmd.SetArgs([]string{"--jq", ".data", "--output", "file.bin", "--as", "bot"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--jq and --output") {
+		t.Fatalf("expected jq/output conflict, got %v", err)
+	}
+
+	cmd = NewCmdServiceMethod(f, spec, method, "list", "items", nil)
+	cmd.SetArgs([]string{"--jq", ".data", "--format", "csv", "--as", "bot"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "only supported with JSON") {
+		t.Fatalf("expected jq/json validation, got %v", err)
+	}
+}
+
 func TestServiceMethod_OutputAndPageAllConflict(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
 	spec := map[string]interface{}{
@@ -447,6 +482,23 @@ func TestServiceMethod_BotMode_PageAll_JSON(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `"id"`) {
 		t.Errorf("expected items in output, got:\n%s", stdout.String())
+	}
+}
+
+func TestServiceMethod_JQOutput(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test-app-svc-jq", AppSecret: "test-secret-svc-jq", Brand: core.BrandFeishu})
+	reg.Register(tokenStub())
+	reg.Register(&httpmock.Stub{URL: "/open-apis/svc/v1/items", Body: map[string]interface{}{"code": 0, "msg": "ok", "data": map[string]interface{}{"result": "success", "items": []interface{}{map[string]interface{}{"id": "1"}}}}})
+
+	spec := map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"}
+	method := map[string]interface{}{"path": "items", "httpMethod": "GET", "parameters": map[string]interface{}{}}
+	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
+	cmd.SetArgs([]string{"--as", "bot", "--jq", ".data.result"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "success") || strings.Contains(got, "items") {
+		t.Fatalf("unexpected jq output: %s", got)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,22 @@
 module github.com/larksuite/cli
 
-go 1.23.0
+go 1.24.0
+
+toolchain go1.24.2
 
 require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/gofrs/flock v0.8.1
 	github.com/google/uuid v1.6.0
+	github.com/itchyny/gojq v0.12.18
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/spf13/cobra v1.10.2
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/net v0.33.0
-	golang.org/x/sys v0.33.0
+	golang.org/x/sys v0.38.0
 	golang.org/x/term v0.27.0
 	golang.org/x/text v0.23.0
 )
@@ -29,6 +32,8 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240722160745-212f7b056ed0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
+	github.com/clipperhouse/stringish v0.1.1 // indirect
+	github.com/clipperhouse/uax29/v2 v2.3.0 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -37,11 +42,12 @@ require (
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/itchyny/timefmt-go v0.1.7 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,10 @@ github.com/charmbracelet/x/termios v0.1.1 h1:o3Q2bT8eqzGnGPOYheoYS8eEleT5ZVNYNy8
 github.com/charmbracelet/x/termios v0.1.1/go.mod h1:rB7fnv1TgOPOyyKRJ9o+AsTU/vK5WHJ2ivHeut/Pcwo=
 github.com/charmbracelet/x/xpty v0.1.2 h1:Pqmu4TEJ8KeA9uSkISKMU3f+C1F6OGBn8ABuGlqCbtI=
 github.com/charmbracelet/x/xpty v0.1.2/go.mod h1:XK2Z0id5rtLWcpeNiMYBccNNBrP2IJnzHI0Lq13Xzq4=
+github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=
+github.com/clipperhouse/stringish v0.1.1/go.mod h1:v/WhFtE1q0ovMta2+m+UbpZ+2/HEXNWYXQgCt4hdOzA=
+github.com/clipperhouse/uax29/v2 v2.3.0 h1:SNdx9DVUqMoBuBoW3iLOj4FQv3dN5mDtuqwuhIGpJy4=
+github.com/clipperhouse/uax29/v2 v2.3.0/go.mod h1:Wn1g7MK6OoeDT0vL+Q0SQLDz/KpfsVRgg6W7ihQeh4g=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
@@ -61,6 +65,10 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/itchyny/gojq v0.12.18 h1:gFGHyt/MLbG9n6dqnvlliiya2TaMMh6FFaR2b1H6Drc=
+github.com/itchyny/gojq v0.12.18/go.mod h1:4hPoZ/3lN9fDL1D+aK7DY1f39XZpY9+1Xpjz8atrEkg=
+github.com/itchyny/timefmt-go v0.1.7 h1:xyftit9Tbw+Dc/huSSPJaEmX1TVL8lw5vxjJLK4GMMA=
+github.com/itchyny/timefmt-go v0.1.7/go.mod h1:5E46Q+zj7vbTgWY8o5YkMeYb4I6GeWLFnetPy5oBrAI=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -73,8 +81,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
-github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
-github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
+github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
@@ -85,7 +93,6 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -133,8 +140,8 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
-golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/term v0.27.0 h1:WP60Sv1nlK1T6SupCHbXzSaN0b9wUmsPoRS9b61A23Q=
 golang.org/x/term v0.27.0/go.mod h1:iMsnZpn0cago0GOrHO2+Y7u7JPn5AylBrcoWkElMTSM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/client/response.go
+++ b/internal/client/response.go
@@ -26,8 +26,9 @@ import (
 type ResponseOptions struct {
 	OutputPath string        // --output flag; "" = auto-detect
 	Format     output.Format // output format for JSON responses
-	Out        io.Writer     // stdout
-	ErrOut     io.Writer     // stderr
+	JQ         string
+	Out        io.Writer // stdout
+	ErrOut     io.Writer // stderr
 	// CheckError is called on parsed JSON results. Nil defaults to CheckLarkResponse.
 	CheckError func(interface{}) error
 }
@@ -62,8 +63,7 @@ func HandleResponse(resp *larkcore.ApiResp, opts ResponseOptions) error {
 		if opts.OutputPath != "" {
 			return saveAndPrint(resp, opts.OutputPath, opts.Out)
 		}
-		output.FormatValue(opts.Out, result, opts.Format)
-		return nil
+		return output.FormatValueWithOptions(opts.Out, result, output.FormatOptions{Format: opts.Format, JQ: opts.JQ})
 	}
 
 	// Non-JSON (binary) responses.

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io"
 	"sort"
+
+	"github.com/itchyny/gojq"
 )
 
 // Known array field names for pagination.
@@ -98,10 +100,48 @@ func ExtractItems(data interface{}) []interface{} {
 	return nil
 }
 
-// FormatValue formats a single response and writes it to w.
-func FormatValue(w io.Writer, data interface{}, format Format) {
+type FormatOptions struct {
+	Format Format
+	JQ     string
+}
+
+func ApplyJQ(data interface{}, expr string) (interface{}, error) {
 	data = toGeneric(data)
-	switch format {
+	query, err := gojq.Parse(expr)
+	if err != nil {
+		return nil, ErrValidation("invalid jq expression: %v", err)
+	}
+	iter := query.Run(data)
+	results := make([]interface{}, 0, 1)
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, ok := v.(error); ok {
+			return nil, ErrValidation("invalid jq expression: %v", err)
+		}
+		results = append(results, v)
+	}
+	if len(results) == 0 {
+		return []interface{}{}, nil
+	}
+	if len(results) == 1 {
+		return toGeneric(results[0]), nil
+	}
+		return toGeneric(results), nil
+}
+
+func FormatValueWithOptions(w io.Writer, data interface{}, opts FormatOptions) error {
+	data = toGeneric(data)
+	if opts.JQ != "" {
+		var err error
+		data, err = ApplyJQ(data, opts.JQ)
+		if err != nil {
+			return err
+		}
+	}
+	switch opts.Format {
 	case FormatNDJSON:
 		items := ExtractItems(data)
 		if items != nil {
@@ -129,6 +169,12 @@ func FormatValue(w io.Writer, data interface{}, format Format) {
 	default: // FormatJSON
 		PrintJson(w, data)
 	}
+	return nil
+}
+
+// FormatValue formats a single response and writes it to w.
+func FormatValue(w io.Writer, data interface{}, format Format) {
+	_ = FormatValueWithOptions(w, data, FormatOptions{Format: format})
 }
 
 // PaginatedFormatter holds state across paginated calls to ensure

--- a/internal/output/format_test.go
+++ b/internal/output/format_test.go
@@ -10,6 +10,55 @@ import (
 	"testing"
 )
 
+func TestApplyJQ(t *testing.T) {
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"items": []interface{}{
+				map[string]interface{}{"id": 1, "name": "Alice"},
+				map[string]interface{}{"id": 2, "name": "Bob"},
+			},
+		},
+	}
+
+	t.Run("single result", func(t *testing.T) {
+		result, err := ApplyJQ(data, ".data.items[0].name")
+		if err != nil {
+			t.Fatalf("ApplyJQ error: %v", err)
+		}
+		if result != "Alice" {
+			t.Fatalf("expected Alice, got %#v", result)
+		}
+	})
+
+	t.Run("multiple results", func(t *testing.T) {
+		result, err := ApplyJQ(data, ".data.items[].id")
+		if err != nil {
+			t.Fatalf("ApplyJQ error: %v", err)
+		}
+		items, ok := result.([]interface{})
+		if !ok || len(items) != 2 {
+			t.Fatalf("expected 2 jq results, got %#v", result)
+		}
+	})
+
+	t.Run("no results", func(t *testing.T) {
+		result, err := ApplyJQ(data, ".data.missing[]?")
+		if err != nil {
+			t.Fatalf("ApplyJQ error: %v", err)
+		}
+		items, ok := result.([]interface{})
+		if !ok || len(items) != 0 {
+			t.Fatalf("expected empty result slice, got %#v", result)
+		}
+	})
+
+	t.Run("invalid expression", func(t *testing.T) {
+		if _, err := ApplyJQ(data, ".data["); err == nil {
+			t.Fatal("expected invalid jq expression error")
+		}
+	})
+}
+
 func TestFormatValue_JSON(t *testing.T) {
 	data := map[string]interface{}{"name": "Alice"}
 
@@ -263,6 +312,24 @@ func TestExtractItems(t *testing.T) {
 	items7 := ExtractItems(plainArr)
 	if len(items7) != 1 {
 		t.Fatalf("expected 1 item from plain array, got %d", len(items7))
+	}
+}
+
+func TestFormatValueWithOptions_JQ(t *testing.T) {
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"items": []interface{}{
+				map[string]interface{}{"name": "Alice"},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := FormatValueWithOptions(&buf, data, FormatOptions{Format: FormatJSON, JQ: ".data.items[0].name"}); err != nil {
+		t.Fatalf("FormatValueWithOptions error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Alice") || strings.Contains(buf.String(), "items") {
+		t.Fatalf("unexpected jq-filtered output: %s", buf.String())
 	}
 }
 

--- a/shortcuts/base/base_execute_test.go
+++ b/shortcuts/base/base_execute_test.go
@@ -70,6 +70,33 @@ func runShortcut(t *testing.T, shortcut common.Shortcut, args []string, factory 
 	return parent.ExecuteContext(context.Background())
 }
 
+func TestBaseShortcut_JQOutput(t *testing.T) {
+	factory, stdout, reg := newExecuteFactory(t)
+	registerTokenStub(reg)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/base/v3/bases/app_x/tables/tbl_x/forms/frm_x",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"id": "frm_x", "name": "Demo Form", "description": "Example"},
+		},
+	})
+	if err := runShortcut(t, BaseFormGet, []string{"+form-get", "--base-token", "app_x", "--table-id", "tbl_x", "--form-id", "frm_x", "--jq", ".name"}, factory, stdout); err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "Demo Form") || strings.Contains(got, "description") {
+		t.Fatalf("stdout=%s", got)
+	}
+}
+
+func TestBaseShortcut_JQValidation(t *testing.T) {
+	factory, stdout, _ := newExecuteFactory(t)
+	stdout.Reset()
+	if err := runShortcut(t, BaseFormGet, []string{"+form-get", "--base-token", "app_x", "--table-id", "tbl_x", "--form-id", "frm_x", "--format", "table", "--jq", ".name"}, factory, stdout); err == nil || !strings.Contains(err.Error(), "only supported with JSON") {
+		t.Fatalf("expected jq/json validation, got %v", err)
+	}
+}
+
 func TestBaseWorkspaceExecuteCreate(t *testing.T) {
 	factory, stdout, reg := newExecuteFactory(t)
 	registerTokenStub(reg)

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -33,6 +33,7 @@ type RuntimeContext struct {
 	Config     *core.CliConfig
 	Cmd        *cobra.Command
 	Format     string
+	JQ         string
 	botOnly    bool              // set by framework for bot-only shortcuts
 	resolvedAs core.Identity     // effective identity resolved by framework
 	Factory    *cmdutil.Factory  // injected by framework
@@ -434,7 +435,16 @@ func (ctx *RuntimeContext) OutFormat(data interface{}, meta *output.Meta, pretty
 			ctx.Out(data, meta)
 		}
 	case "json", "":
-		ctx.Out(data, meta)
+		if ctx.JQ == "" {
+			ctx.Out(data, meta)
+		} else {
+			filtered, err := output.ApplyJQ(data, ctx.JQ)
+			if err != nil {
+				fmt.Fprintln(ctx.IO().ErrOut, err)
+				return
+			}
+			output.PrintJson(ctx.IO().Out, filtered)
+		}
 	default:
 		// table, csv, ndjson — pass data directly; FormatValue handles both
 		// plain arrays and maps with array fields (e.g. {"members":[…]})
@@ -603,6 +613,10 @@ func newRuntimeContext(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, conf
 
 	if s.HasFormat {
 		rctx.Format = rctx.Str("format")
+		rctx.JQ = rctx.Str("jq")
+		if rctx.JQ != "" && rctx.Format != "" && rctx.Format != "json" {
+			return nil, output.ErrValidation("--jq is only supported with JSON output")
+		}
 	}
 	return rctx, nil
 }
@@ -680,6 +694,7 @@ func registerShortcutFlags(cmd *cobra.Command, s *Shortcut) {
 	cmd.Flags().Bool("dry-run", false, "print request without executing")
 	if s.HasFormat {
 		cmd.Flags().String("format", "json", "output format: json (default) | pretty | table | ndjson | csv")
+		cmd.Flags().String("jq", "", "jq expression to filter JSON output")
 	}
 	if s.Risk == "high-risk-write" {
 		cmd.Flags().Bool("yes", false, "confirm high-risk operation")


### PR DESCRIPTION
## Summary
- add `--jq` filtering support for `api`, service commands, and format-enabled shortcuts
- apply jq filtering through the shared JSON output pipeline, including page-all aggregation paths
- add tests for jq output behavior and validation rules

## Test plan
- [x] `go test ./internal/output ./cmd/api ./cmd/service ./shortcuts/base`