### PR TITLE
fix(config): distinguish ENOENT from other config load errors in show/remove

### DIFF
--- a/cmd/config/remove.go
+++ b/cmd/config/remove.go
@@ -4,7 +4,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 
 	"github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/cmdutil"
@@ -40,8 +42,11 @@ func configRemoveRun(opts *ConfigRemoveOptions) error {
 	f := opts.Factory
 
 	config, err := core.LoadMultiAppConfig()
-	if err != nil || config == nil || len(config.Apps) == 0 {
-		return output.ErrValidation("not configured yet")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return output.ErrValidation("not configured yet")
+		}
+		return fmt.Errorf("failed to load config: %w", err)
 	}
 
 	// Clean up keychain entries for all apps

--- a/cmd/config/show.go
+++ b/cmd/config/show.go
@@ -4,7 +4,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"strings"
 
 	"github.com/larksuite/cli/internal/cmdutil"
@@ -40,10 +42,13 @@ func configShowRun(opts *ConfigShowOptions) error {
 	f := opts.Factory
 
 	config, err := core.LoadMultiAppConfig()
-	if err != nil || config == nil || len(config.Apps) == 0 {
-		fmt.Fprintf(f.IOStreams.ErrOut, "Not configured yet. Config file path: %s\n", core.GetConfigPath())
-		fmt.Fprintln(f.IOStreams.ErrOut, "Run `lark-cli config init` to initialize.")
-		return nil
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			fmt.Fprintf(f.IOStreams.ErrOut, "Not configured yet. Config file path: %s\n", core.GetConfigPath())
+			fmt.Fprintln(f.IOStreams.ErrOut, "Run `lark-cli config init` to initialize.")
+			return nil
+		}
+		return fmt.Errorf("failed to load config: %w", err)
 	}
 	app := config.Apps[0]
 	users := "(no logged-in users)"


### PR DESCRIPTION
## Summary

- `config show` and `config remove` previously treated all `LoadMultiAppConfig` failures (including permission denied and JSON parse errors) as "not configured yet"
- `config show` returned exit code 0 on a permission/parse error, making it impossible for scripts to detect the real problem
- Users could be misled into running `config init` and overwriting a valid but temporarily unreadable config

## Changes

Use `errors.Is(err, fs.ErrNotExist)` to distinguish "file not found" from other failures:
- `fs.ErrNotExist` → show "Not configured yet" guidance (existing behavior)
- All other errors → surface the actual error message with non-zero exit

Also removes the redundant `config == nil` and `len(config.Apps) == 0` guard conditions — `LoadMultiAppConfig` never returns a non-nil config with a nil error when apps are empty.

Fixes #110

## Test plan

- [ ] `config show` with no config file → "Not configured yet" (unchanged)
- [ ] `config show` with unreadable config file (`chmod 000`) → actual permission error
- [ ] `config show` with corrupt JSON config → actual parse error
- [ ] `config remove` with no config file → "not configured yet" validation error (unchanged)
- [ ] `config remove` with unreadable config file → actual permission error

🤖 Generated with [Claude Code](https://claude.com/claude-code)