### PR TITLE
fix: use open_id instead of user_id in batchResolveByBasicContact

### DIFF
--- a/shortcuts/im/convert_lib/helpers.go
+++ b/shortcuts/im/convert_lib/helpers.go
@@ -151,7 +151,7 @@ func ResolveSenderNames(runtime *common.RuntimeContext, messages []map[string]in
 // batchResolveByBasicContact resolves user names via POST /contact/v3/users/basic_batch.
 // This API has lighter permission requirements and works with user identity
 // even when the target user is not in the app's visible range.
-// Response uses "users" (not "items") and "user_id" (not "open_id").
+// Response uses "users" (not "items") and "open_id" as the user identifier.
 func batchResolveByBasicContact(runtime *common.RuntimeContext, missingIDs []string, nameMap map[string]string) {
 	const batchSize = 50
 	for i := 0; i < len(missingIDs); i += batchSize {
@@ -173,10 +173,10 @@ func batchResolveByBasicContact(runtime *common.RuntimeContext, missingIDs []str
 		users, _ := data["users"].([]interface{})
 		for _, item := range users {
 			user, _ := item.(map[string]interface{})
-			userID, _ := user["user_id"].(string)
+			openID, _ := user["open_id"].(string)
 			name, _ := user["name"].(string)
-			if userID != "" && name != "" {
-				nameMap[userID] = name
+			if openID != "" && name != "" {
+				nameMap[openID] = name
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Fix sender name resolution when using user identity (`--as user`)
- `batchResolveByBasicContact()` reads `user["user_id"]` from the `/contact/v3/users/basic_batch` response, but the API returns `open_id` as the identifier field when `user_id_type=open_id` is specified
- This causes all API-resolved sender names to be silently dropped (only mention-resolved names work)
- Changed to read `user["open_id"]`, consistent with the bot path (`batchResolveUsers`)

## Root Cause

In `shortcuts/im/convert_lib/helpers.go:176`:

```go
// Before (bug): field doesn't exist in response → always empty
userID, _ := user["user_id"].(string)

// After (fix): matches actual API response field
openID, _ := user["open_id"].(string)
```

## Reproduction

1. `lark-cli im +chat-messages-list --chat-id oc_xxx --as user`
2. Messages from senders who are NOT @mentioned show empty sender names
3. Messages from senders who ARE @mentioned show names correctly (resolved via mentions, not API)

## Test plan

- [x] Existing `TestResolveSenderNames` and `TestResolveSenderNamesAPIFailure` pass
- [ ] Manual test: `im +chat-messages-list --as user` now resolves all sender names in the same tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)