### PR TITLE
[codex] Inject output helper error sink

### DIFF
--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -7,7 +7,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"os"
 )
 
 // FormatAsCSV formats data as CSV (with header) and writes it to w.
@@ -71,6 +70,6 @@ func writeCSVRows(w io.Writer, rows []map[string]string, cols []string, writeHea
 func flushCSV(cw *csv.Writer) {
 	cw.Flush()
 	if err := cw.Error(); err != nil {
-		fmt.Fprintf(os.Stderr, "csv write error: %v\n", err)
+		writeHelperError("csv write error: %v\n", err)
 	}
 }

--- a/internal/output/print.go
+++ b/internal/output/print.go
@@ -12,11 +12,30 @@ import (
 	"github.com/larksuite/cli/internal/validate"
 )
 
+var errorSink io.Writer = os.Stderr
+
+// SetErrorSink replaces the package-level sink used by output helpers for
+// internal formatting failures. It returns the previous sink so callers can
+// restore it after redirecting output.
+func SetErrorSink(w io.Writer) io.Writer {
+	prev := errorSink
+	if w == nil {
+		errorSink = io.Discard
+		return prev
+	}
+	errorSink = w
+	return prev
+}
+
+func writeHelperError(format string, args ...interface{}) {
+	fmt.Fprintf(errorSink, format, args...)
+}
+
 // PrintJson prints data as formatted JSON to w.
 func PrintJson(w io.Writer, data interface{}) {
 	b, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "json marshal error: %v\n", err)
+		writeHelperError("json marshal error: %v\n", err)
 		return
 	}
 	fmt.Fprintln(w, string(b))
@@ -27,7 +46,7 @@ func PrintNdjson(w io.Writer, data interface{}) {
 	emit := func(item interface{}) {
 		b, err := json.Marshal(item)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "ndjson marshal error: %v\n", err)
+			writeHelperError("ndjson marshal error: %v\n", err)
 			return
 		}
 		fmt.Fprintln(w, string(b))

--- a/internal/output/print_test.go
+++ b/internal/output/print_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package output
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+type failingWriter struct{}
+
+func (failingWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("boom")
+}
+
+func TestPrintJson_UsesInjectableErrorSink(t *testing.T) {
+	var sink bytes.Buffer
+	prev := SetErrorSink(&sink)
+	t.Cleanup(func() { SetErrorSink(prev) })
+
+	var out bytes.Buffer
+	PrintJson(&out, map[string]interface{}{"bad": make(chan int)})
+
+	if out.Len() != 0 {
+		t.Fatalf("expected no stdout output on marshal error, got %q", out.String())
+	}
+	if !strings.Contains(sink.String(), "json marshal error:") {
+		t.Fatalf("expected marshal failure in redirected sink, got %q", sink.String())
+	}
+}
+
+func TestPrintNdjson_UsesInjectableErrorSink(t *testing.T) {
+	var sink bytes.Buffer
+	prev := SetErrorSink(&sink)
+	t.Cleanup(func() { SetErrorSink(prev) })
+
+	var out bytes.Buffer
+	PrintNdjson(&out, []interface{}{map[string]interface{}{"bad": make(chan int)}})
+
+	if out.Len() != 0 {
+		t.Fatalf("expected no stdout output on marshal error, got %q", out.String())
+	}
+	if !strings.Contains(sink.String(), "ndjson marshal error:") {
+		t.Fatalf("expected ndjson failure in redirected sink, got %q", sink.String())
+	}
+}
+
+func TestFormatAsCSV_UsesInjectableErrorSink(t *testing.T) {
+	var sink bytes.Buffer
+	prev := SetErrorSink(&sink)
+	t.Cleanup(func() { SetErrorSink(prev) })
+
+	data := []interface{}{
+		map[string]interface{}{"name": "Alice"},
+	}
+
+	FormatAsCSV(failingWriter{}, data)
+
+	if !strings.Contains(sink.String(), "csv write error:") {
+		t.Fatalf("expected csv failure in redirected sink, got %q", sink.String())
+	}
+}


### PR DESCRIPTION
## Summary
- route output helper failures through an injectable package-level error sink instead of writing directly to `os.Stderr`
- update CSV and print helpers to share the same redirected error path
- add focused regression tests covering redirected JSON, NDJSON, and CSV failure output

## Root cause
Output helpers wrote marshal/flush failures directly to `os.Stderr`, which bypassed injected IO streams used by tests, embedding, and agent-side output capture.

## Testing
- `gofmt -w internal/output/print.go internal/output/csv.go internal/output/print_test.go`
- `go test ./internal/output`
