### PR TITLE
fix(config): save empty config before clearing keychain in config remove

### DIFF
--- a/cmd/config/remove.go
+++ b/cmd/config/remove.go
@@ -44,18 +44,18 @@ func configRemoveRun(opts *ConfigRemoveOptions) error {
 		return output.ErrValidation("not configured yet")
 	}
 
-	// Clean up keychain entries for all apps
+	// Save empty config first — if this fails, keychain is still intact and the user can retry
+	empty := &core.MultiAppConfig{Apps: []core.AppConfig{}}
+	if err := core.SaveMultiAppConfig(empty); err != nil {
+		return output.Errorf(output.ExitInternal, "internal", "failed to save config: %v", err)
+	}
+
+	// Clean up keychain entries — best-effort; orphaned entries are harmless
 	for _, app := range config.Apps {
 		core.RemoveSecretStore(app.AppSecret, f.Keychain)
 		for _, user := range app.Users {
 			auth.RemoveStoredToken(app.AppId, user.UserOpenId)
 		}
-	}
-
-	// Save empty config
-	empty := &core.MultiAppConfig{Apps: []core.AppConfig{}}
-	if err := core.SaveMultiAppConfig(empty); err != nil {
-		return output.Errorf(output.ExitInternal, "internal", "failed to save config: %v", err)
 	}
 	output.PrintSuccess(f.IOStreams.ErrOut, "Configuration removed")
 	userCount := 0


### PR DESCRIPTION
## Summary

Fixes the operation order in `config remove` to prevent an unrecoverable state when the config save fails.

## Problem

Previously the order was:
1. Clear keychain entries ← irreversible
2. Save empty config ← if this fails, keychain is already wiped

If step 2 failed (disk full, permission error, etc.), `config.json` still contained the old app data but the keychain secrets were gone. On the next run, `LoadMultiAppConfig` would succeed but `ResolveSecretInput` would fail to find the secret — leaving the user stuck with no way to recover without manually editing `config.json`.

## Fix

Swap the order:
1. Save empty config first — if this fails, keychain is intact and the user can retry
2. Clear keychain entries — best-effort; orphaned entries are harmless since `config.json` no longer references them

## Changes

`cmd/config/remove.go` — swap the two blocks, update comments

Fixes #114

## Test plan

- [ ] `config remove` with a valid config → works as before, prints "Configuration removed"
- [ ] `config remove` when config save fails → keychain entries remain intact
- [ ] `config remove` when keychain clear fails → config is already empty, no broken state

🤖 Generated with [Claude Code](https://claude.com/claude-code)