### PR TITLE
fix(auth): return validation error when --scope is empty in auth check

### DIFF
--- a/cmd/auth/check.go
+++ b/cmd/auth/check.go
@@ -46,8 +46,7 @@ func authCheckRun(opts *CheckOptions) error {
 
 	required := strings.Fields(opts.Scope)
 	if len(required) == 0 {
-		output.PrintJson(f.IOStreams.Out, map[string]interface{}{"ok": true, "granted": []string{}, "missing": []string{}})
-		return nil
+		return output.ErrValidation("--scope cannot be empty")
 	}
 
 	config, err := f.Config()


### PR DESCRIPTION
## Summary

Fixes larksuite/cli#116

MarkFlagRequired only prevents omitting --scope entirely. Passing --scope "" bypassed the check and returned {"ok":true} with exit 0, silently misleading scripts that build scope strings dynamically.

## Fix

Replace the silent ok:true early return with a validation error when the resolved scope list is empty.

## Changes

cmd/auth/check.go — 1 insertion, 2 deletions

## Test plan

- [ ] auth check --scope "contact:readonly" works as before
- [ ] auth check --scope "" returns validation error with non-zero exit
- [ ] auth check --scope "  " (whitespace only) returns validation error

Generated with Claude Code