### PR TITLE
feat: add private deployment support and fix cache read in restricted environments

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -25,8 +25,13 @@ func NewCmdConfig(f *cmdutil.Factory) *cobra.Command {
 }
 
 func parseBrand(value string) core.LarkBrand {
-	if value == "lark" {
+	switch value {
+	case "lark":
 		return core.BrandLark
+	case "feishu", "":
+		return core.BrandFeishu
+	default:
+		// Custom base URL for private deployments (e.g. "https://your-company.feishu.cn")
+		return core.LarkBrand(value)
 	}
-	return core.BrandFeishu
 }

--- a/cmd/config/init.go
+++ b/cmd/config/init.go
@@ -57,7 +57,7 @@ verification URL from its output.`,
 	cmd.Flags().BoolVar(&opts.New, "new", false, "create a new app directly (skip mode selection)")
 	cmd.Flags().StringVar(&opts.AppID, "app-id", "", "App ID (non-interactive)")
 	cmd.Flags().BoolVar(&opts.AppSecretStdin, "app-secret-stdin", false, "Read App Secret from stdin to avoid process list exposure")
-	cmd.Flags().StringVar(&opts.Brand, "brand", "feishu", "feishu or lark (non-interactive, default feishu)")
+	cmd.Flags().StringVar(&opts.Brand, "brand", "feishu", `brand: "feishu", "lark", or a custom base URL for private deployments (e.g. "https://your-company.feishu.cn")`)
 	cmd.Flags().StringVar(&opts.Lang, "lang", "zh", "language for interactive prompts (zh or en)")
 
 	return cmd

--- a/cmd/config/init_interactive.go
+++ b/cmd/config/init_interactive.go
@@ -86,9 +86,15 @@ func runExistingAppForm(f *cmdutil.Factory, msg *initMsg) (*configInitResult, er
 		appSecretInput = appSecretInput.Placeholder("xxxx")
 	}
 
-	brand = "feishu"
+	// Determine initial brand select value
+	brandSelect := "feishu"
 	if firstApp != nil && firstApp.Brand != "" {
-		brand = string(firstApp.Brand)
+		switch firstApp.Brand {
+		case core.BrandFeishu, core.BrandLark:
+			brandSelect = string(firstApp.Brand)
+		default:
+			brandSelect = "custom"
+		}
 	}
 
 	form := huh.NewForm(
@@ -100,8 +106,9 @@ func runExistingAppForm(f *cmdutil.Factory, msg *initMsg) (*configInitResult, er
 				Options(
 					huh.NewOption(msg.Feishu, "feishu"),
 					huh.NewOption("Lark", "lark"),
+					huh.NewOption(msg.PrivateDeployment, "custom"),
 				).
-				Value(&brand),
+				Value(&brandSelect),
 		),
 	).WithTheme(cmdutil.ThemeFeishu())
 
@@ -110,6 +117,31 @@ func runExistingAppForm(f *cmdutil.Factory, msg *initMsg) (*configInitResult, er
 			return nil, output.ErrBare(1)
 		}
 		return nil, err
+	}
+
+	// If private deployment selected, prompt for base URL
+	if brandSelect == "custom" {
+		customURL := ""
+		if firstApp != nil && firstApp.Brand != core.BrandFeishu && firstApp.Brand != core.BrandLark {
+			customURL = string(firstApp.Brand)
+		}
+		urlForm := huh.NewForm(
+			huh.NewGroup(
+				huh.NewInput().
+					Title(msg.PrivateBaseURL).
+					Placeholder("https://your-company.feishu.cn").
+					Value(&customURL),
+			),
+		).WithTheme(cmdutil.ThemeFeishu())
+		if err := urlForm.Run(); err != nil {
+			if err == huh.ErrUserAborted {
+				return nil, output.ErrBare(1)
+			}
+			return nil, err
+		}
+		brand = customURL
+	} else {
+		brand = brandSelect
 	}
 
 	// Resolve defaults

--- a/cmd/config/init_messages.go
+++ b/cmd/config/init_messages.go
@@ -16,6 +16,8 @@ type initMsg struct {
 	Platform           string
 	SelectPlatform     string
 	Feishu             string
+	PrivateDeployment  string
+	PrivateBaseURL     string
 	ScanOrOpenLink     string
 	WaitingForScan     string
 	DetectedLarkTenant string
@@ -30,6 +32,8 @@ var initMsgZh = &initMsg{
 	Platform:           "平台",
 	SelectPlatform:     "选择平台",
 	Feishu:             "飞书",
+	PrivateDeployment:  "私有化部署",
+	PrivateBaseURL:     "私有化部署 Base URL（如 https://your-company.feishu.cn）",
 	ScanOrOpenLink:     "\n打开以下链接配置应用:\n\n",
 	WaitingForScan:     "等待配置应用...",
 	DetectedLarkTenant: "[lark-cli] 检测到 Lark 租户，切换端点重试...",
@@ -44,6 +48,8 @@ var initMsgEn = &initMsg{
 	Platform:           "Platform",
 	SelectPlatform:     "Select platform",
 	Feishu:             "Feishu",
+	PrivateDeployment:  "Private deployment",
+	PrivateBaseURL:     "Private deployment base URL (e.g. https://your-company.feishu.cn)",
 	ScanOrOpenLink:     "\nOpen the link below to configure app:\n\n",
 	WaitingForScan:     "Waiting for app configuration...",
 	DetectedLarkTenant: "[lark-cli] Detected Lark tenant, switching endpoint...",

--- a/internal/cmdutil/factory_default.go
+++ b/internal/cmdutil/factory_default.go
@@ -4,6 +4,7 @@
 package cmdutil
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"os"
@@ -73,7 +74,9 @@ func safeRedirectPolicy(req *http.Request, via []*http.Request) error {
 
 func cachedHttpClientFunc() func() (*http.Client, error) {
 	return sync.OnceValues(func() (*http.Client, error) {
-		var transport = http.DefaultTransport
+		var transport http.RoundTripper = &http.Transport{
+			TLSClientConfig: tlsConfig(),
+		}
 		transport = &RetryTransport{Base: transport}
 		transport = &SecurityHeaderTransport{Base: transport}
 
@@ -98,7 +101,9 @@ func cachedLarkClientFunc(f *Factory) func() (*lark.Client, error) {
 			lark.WithHeaders(BaseSecurityHeaders()),
 		}
 		// Build SDK transport chain
-		var sdkTransport = http.DefaultTransport
+		var sdkTransport http.RoundTripper = &http.Transport{
+			TLSClientConfig: tlsConfig(),
+		}
 		sdkTransport = &UserAgentTransport{Base: sdkTransport}
 		sdkTransport = &auth.SecurityPolicyTransport{Base: sdkTransport}
 		opts = append(opts, lark.WithHttpClient(&http.Client{
@@ -110,4 +115,15 @@ func cachedLarkClientFunc(f *Factory) func() (*lark.Client, error) {
 		client := lark.NewClient(cfg.AppID, cfg.AppSecret, opts...)
 		return client, nil
 	})
+}
+
+// tlsConfig returns a TLS config.
+// When LARK_TLS_INSECURE=1 is set, TLS verification is disabled.
+// This is intended for corporate proxy environments where the platform
+// TLS verifier (macOS Security framework) rejects valid proxy certificates.
+func tlsConfig() *tls.Config {
+	if os.Getenv("LARK_TLS_INSECURE") == "1" {
+		return &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+	}
+	return nil
 }

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -3,6 +3,8 @@
 
 package core
 
+import "strings"
+
 // LarkBrand represents the Lark platform brand.
 // "feishu" targets China-mainland, "lark" targets international.
 // Any other string is treated as a custom base URL.
@@ -21,6 +23,9 @@ type Endpoints struct {
 }
 
 // ResolveEndpoints resolves endpoint URLs based on brand.
+// "feishu" targets China-mainland, "lark" targets international.
+// Any other string starting with "http" is treated as a custom base URL
+// for private deployments (e.g. "https://your-company.feishu.cn").
 func ResolveEndpoints(brand LarkBrand) Endpoints {
 	switch brand {
 	case BrandLark:
@@ -29,11 +34,20 @@ func ResolveEndpoints(brand LarkBrand) Endpoints {
 			Accounts: "https://accounts.larksuite.com",
 			MCP:      "https://mcp.larksuite.com",
 		}
-	default:
+	case BrandFeishu, "":
 		return Endpoints{
 			Open:     "https://open.feishu.cn",
 			Accounts: "https://accounts.feishu.cn",
 			MCP:      "https://mcp.feishu.cn",
+		}
+	default:
+		// Custom base URL for private deployments.
+		// All services share the same domain; paths differ per API.
+		base := strings.TrimRight(string(brand), "/")
+		return Endpoints{
+			Open:     base,
+			Accounts: base,
+			MCP:      base,
 		}
 	}
 }

--- a/internal/core/types_test.go
+++ b/internal/core/types_test.go
@@ -38,6 +38,26 @@ func TestResolveEndpoints_EmptyDefaultsToFeishu(t *testing.T) {
 	}
 }
 
+func TestResolveEndpoints_CustomURL(t *testing.T) {
+	ep := ResolveEndpoints("https://your-company.feishu.cn")
+	if ep.Open != "https://your-company.feishu.cn" {
+		t.Errorf("Open = %q, want custom URL", ep.Open)
+	}
+	if ep.Accounts != "https://your-company.feishu.cn" {
+		t.Errorf("Accounts = %q, want custom URL", ep.Accounts)
+	}
+	if ep.MCP != "https://your-company.feishu.cn" {
+		t.Errorf("MCP = %q, want custom URL", ep.MCP)
+	}
+}
+
+func TestResolveEndpoints_CustomURLTrailingSlash(t *testing.T) {
+	ep := ResolveEndpoints("https://your-company.feishu.cn/")
+	if ep.Open != "https://your-company.feishu.cn" {
+		t.Errorf("Open = %q, trailing slash should be stripped", ep.Open)
+	}
+}
+
 func TestResolveOpenBaseURL(t *testing.T) {
 	if got := ResolveOpenBaseURL(BrandFeishu); got != "https://open.feishu.cn" {
 		t.Errorf("ResolveOpenBaseURL(feishu) = %q", got)

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -45,9 +45,8 @@ func InitWithBrand(brand core.LarkBrand) {
 		configuredBrand = brand
 		// 1. Load embedded meta_data.json as baseline (no-op if not compiled in)
 		loadEmbeddedIntoMerged()
-		// 2. Remote overlay
-		if remoteEnabled() && cacheWritable() {
-			// Check if brand changed since last cache
+		// 2. Always attempt to read from cache (read-only, no write required)
+		if remoteEnabled() {
 			meta, metaErr := loadCacheMeta()
 			brandChanged := metaErr == nil && meta.Brand != "" && meta.Brand != string(brand)
 
@@ -56,15 +55,18 @@ func InitWithBrand(brand core.LarkBrand) {
 					overlayMergedServices(cached)
 				}
 			}
-			if len(mergedServices) == 0 || brandChanged {
-				// No data at all or brand changed — must sync fetch
-				doSyncFetch()
-			} else if shouldRefresh(meta) || metaErr != nil {
-				// Have embedded/cached data; refresh in background if TTL expired or first run
-				triggerBackgroundRefresh()
+			// 3. Refresh/fetch only when we can write to cache
+			if cacheWritable() {
+				if len(mergedServices) == 0 || brandChanged {
+					// No data at all or brand changed — must sync fetch
+					doSyncFetch()
+				} else if shouldRefresh(meta) || metaErr != nil {
+					// Have embedded/cached data; refresh in background if TTL expired or first run
+					triggerBackgroundRefresh()
+				}
 			}
 		}
-		// 3. Build sorted project list
+		// 4. Build sorted project list
 		rebuildProjectList()
 	})
 }

--- a/internal/registry/remote.go
+++ b/internal/registry/remote.go
@@ -72,7 +72,10 @@ func remoteMetaURL(version string) string {
 	switch configuredBrand {
 	case core.BrandLark:
 		base = "https://open.larksuite.com/api/tools/open/api_definition"
+	case core.BrandFeishu, "":
+		base = "https://open.feishu.cn/api/tools/open/api_definition"
 	default:
+		// Private deployments don't host the CLI schema registry; fall back to feishu.
 		base = "https://open.feishu.cn/api/tools/open/api_definition"
 	}
 	q := "protocol=meta&client_version=" + url.QueryEscape(build.Version)


### PR DESCRIPTION
Closes #97

## Summary

- **Private deployment support**: `brand` now accepts a custom base URL (e.g. `https://your-company.feishu.cn`) in addition to `feishu`/`lark`, enabling on-premise Lark deployments. Both the CLI flag and the interactive TUI support this.
- **`LARK_TLS_INSECURE=1` env var**: disables TLS certificate verification to work around corporate proxy environments where Go's macOS Security framework rejects valid proxy certificates (`OSStatus -26276`).
- **Fix: service commands disappear in read-only environments**: `InitWithBrand` previously used `cacheWritable()` to gate both reading and refreshing the service registry cache. In sandboxed or read-only environments this caused the entire cached registry (wiki, calendar, etc.) to be silently skipped, making dynamic commands vanish from the CLI. Reading existing cache no longer requires write permission.

## Changes

| File | Change |
|---|---|
| `internal/core/types.go` | `ResolveEndpoints`: custom URL support in `default` branch |
| `cmd/config/config.go` | `parseBrand`: pass through arbitrary URL as `LarkBrand` |
| `cmd/config/init.go` | Update `--brand` flag help text |
| `cmd/config/init_interactive.go` | TUI: add "Private deployment" option with URL input step |
| `cmd/config/init_messages.go` | Add `PrivateDeployment` / `PrivateBaseURL` message fields (zh + en) |
| `internal/cmdutil/factory_default.go` | Add `tlsConfig()` + `LARK_TLS_INSECURE=1` support |
| `internal/registry/loader.go` | Decouple cache read from cache write in `InitWithBrand` |
| `internal/registry/remote.go` | Fallback to feishu schema registry for private brands |
| `internal/core/types_test.go` | Add tests for custom URL and trailing slash stripping |

## Test plan

- [ ] `go test ./internal/core/... ./cmd/config/... ./internal/registry/...` passes
- [ ] `lark-cli config init` TUI shows "Private deployment" option
- [ ] `lark-cli config init --brand https://your-company.feishu.cn --app-id ... --app-secret-stdin` saves custom brand correctly
- [ ] `LARK_TLS_INSECURE=1 lark-cli ...` skips TLS verification
- [ ] In a read-only `~/.lark-cli/cache` environment, `lark-cli wiki spaces get_node` still works when cache exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)