### PR TITLE
[codex] fix table truncation width accounting

### DIFF
--- a/internal/output/flatten.go
+++ b/internal/output/flatten.go
@@ -9,6 +9,7 @@ import (
 )
 
 const maxFlattenDepth = 3
+const ellipsis = "…"
 
 type flatEntry struct {
 	Key   string
@@ -113,15 +114,29 @@ func truncateToWidth(s string, maxWidth int) string {
 	if maxWidth <= 0 {
 		return ""
 	}
+	if stringWidth(s) <= maxWidth {
+		return s
+	}
+
+	ellipsisWidth := stringWidth(ellipsis)
+	if ellipsisWidth > maxWidth {
+		return ""
+	}
+
 	w := 0
+	cut := 0
 	for i, r := range s {
 		rw := runeWidth(r)
-		if w+rw > maxWidth {
-			return s[:i] + "…"
+		if w+rw+ellipsisWidth > maxWidth {
+			break
 		}
 		w += rw
+		cut = i + utf8.RuneLen(r)
 	}
-	return s
+	if cut == 0 {
+		return ellipsis
+	}
+	return s[:cut] + ellipsis
 }
 
 // flattenItem flattens a single item (object or other) into flatEntry pairs.

--- a/internal/output/flatten_test.go
+++ b/internal/output/flatten_test.go
@@ -119,15 +119,16 @@ func TestTruncateToWidth(t *testing.T) {
 	}{
 		{"hello", 10, "hello"},
 		{"hello", 5, "hello"},
-		{"hello", 4, "hell…"},
-		{"hello", 3, "hel…"},
-		{"hello", 1, "h…"},
+		{"hello", 4, "hel…"},
+		{"hello", 3, "he…"},
+		{"hello", 1, "…"},
 		{"hello", 0, ""},
 		// CJK: each char is width 2
 		{"你好世界", 8, "你好世界"},
-		{"你好世界", 6, "你好世…"},
-		{"你好世界", 4, "你好…"},
+		{"你好世界", 6, "你好…"},
+		{"你好世界", 4, "你…"},
 		{"你好世界", 3, "你…"},
+		{"你好世界", 2, "…"},
 	}
 
 	for _, tt := range tests {
@@ -135,6 +136,9 @@ func TestTruncateToWidth(t *testing.T) {
 			got := truncateToWidth(tt.input, tt.maxWidth)
 			if got != tt.want {
 				t.Errorf("truncateToWidth(%q, %d) = %q, want %q", tt.input, tt.maxWidth, got, tt.want)
+			}
+			if width := stringWidth(got); width > tt.maxWidth {
+				t.Errorf("truncateToWidth(%q, %d) width = %d, want <= %d", tt.input, tt.maxWidth, width, tt.maxWidth)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

This change fixes table-cell truncation so the rendered display width never exceeds the configured column width.

## What Changed

- reserve display width for the ellipsis before truncating
- return the original string unchanged when it already fits
- add regression coverage for ASCII and CJK truncation cases
- assert that truncated output width never exceeds the requested limit

## Why

truncateToWidth previously appended an ellipsis after cutting at the first rune that crossed the width limit. That meant the final rendered value could still be wider than the column budget, especially for wide characters, which can break table alignment.

## Impact

Table output stays aligned when values are truncated, including rows containing CJK text.

## Validation

- GOCACHE=/tmp/go-build GOMODCACHE=/tmp/gomodcache GOPATH=/tmp/gopath GOTMPDIR=/tmp go test ./internal/output ./internal/util ./internal/validate

## Notes

Full-repo tests were not run in this environment because the checkout resolves Go modules through https://goproxy.cn, which currently fails DNS resolution here.