### PR TITLE
ci: add gitleaks scanning workflow and custom rules

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,28 @@
+name: Gitleaks
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    # Forked pull_request runs do not receive repository/org secrets except GITHUB_TOKEN.
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
+        env:
+          # GITHUB_TOKEN is provided automatically by GitHub Actions.
+          # GITLEAKS_KEY must be configured as a repository secret.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_KEY }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+title = "lark-cli gitleaks config"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "lark-bot-app-id"
+description = "Detect Lark bot app ids"
+regex = '''\bcli_[a-z0-9]{16}\b'''
+keywords = ["cli_"]
+
+[[rules]]
+id = "lark-session-token"
+description = "Detect Lark session tokens"
+regex = '''\bXN0YXJ0-[A-Za-z0-9_-]+-WVuZA\b'''
+keywords = ["XN0YXJ0-", "-WVuZA"]


### PR DESCRIPTION
  Summary

  - add a GitHub Actions Gitleaks workflow to run on pull requests targeting main
  - use the repository secret GITLEAKS_KEY as GITLEAKS_LICENSE, while relying on the default GitHub Actions GITHUB_TOKEN
  - add a repository-level .gitleaks.toml that extends the default ruleset with two Lark-specific detectors:
      - cli_... bot app IDs
      - XN0YXJ0-...-WVuZA session tokens

  Test Plan

  - verified the workflow can be triggered from the current branch by temporarily enabling a branch-specific push trigger during validation
  - verified the default Gitleaks workflow fails on a known secret-like fixture
  - verified the custom .gitleaks.toml rules detect both:
      - cli_a94094xxxedf5xxx
      - XN0YXJ0-a8eo8xxx-xxxx-47e2-b21b-077c68019xxx-WVuZA
  - verified GitHub Push Protection blocked the push after the custom rule matched
  - verified the blocked push could be explicitly unblocked through GitHub and then pushed successfully
  - removed all temporary test fixtures and the temporary branch-specific push trigger after validation

<img width="363" height="171" alt="image" src="https://github.com/user-attachments/assets/da57e391-02c7-440a-ba4f-7898483028c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented automated secret-detection scanning for pushes and pull requests to main, with optional manual triggering.
  * Scan skips contexts where repository secrets aren’t available (e.g., forked PRs), avoiding false positives.
  * Added custom detection rules to identify specific application IDs and session-token patterns, improving scanner accuracy for repo-relevant secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->