### PR TITLE
ci: improve pkg.pr.new install comment clarity

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -43,9 +43,23 @@ jobs:
             }
             const sourceRepo = context.payload.pull_request?.head?.repo?.full_name;
             const sourceBranch = context.payload.pull_request?.head?.ref;
-            if (!sourceRepo || !sourceBranch) {
-              throw new Error("No pull request source repo/branch found in event payload");
-            }
+            const hasSkillSource = Boolean(sourceRepo && sourceBranch);
+
+            const skillSection = hasSkillSource
+              ? [
+                  "",
+                  "### 🧩 Skill update",
+                  "",
+                  "```bash",
+                  `npx skills add ${sourceRepo}#${sourceBranch} -y -g`,
+                  "```",
+                ]
+              : [
+                  "",
+                  "### 🧩 Skill update",
+                  "",
+                  "_Unavailable for this PR because source repo/branch metadata is missing._",
+                ];
 
             const body = [
               "<!-- pkg-pr-new-install-guide -->",
@@ -56,12 +70,7 @@ jobs:
               "```bash",
               `npm i -g ${url}`,
               "```",
-              "",
-              "### 🧩 Skill update",
-              "",
-              "```bash",
-              `npx skills add ${sourceRepo}#${sourceBranch} -y -g`,
-              "```",
+              ...skillSection,
             ].join("\n");
             const issueNumber = context.issue.number;
 


### PR DESCRIPTION
## Summary
Improve the pkg.pr.new PR comment so the install guidance is clearer and harder to miss.

## Changes
- Add a clear top-level header in the bot comment.
- Split install instructions into two markdown sections: `CLI update` and `Skill update`.
- Add `npx skills add <source_repo>#<source_branch> -y -g` based on PR source repo/branch.
- Use a stable HTML marker to find/update the existing bot comment reliably.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR comments now include a structured "PR Preview Install Guide" with a CLI install snippet and, when available, an additional "Skill update" section.

* **Chores**
  * Improved bot comment handling to reliably update prior comments.
  * Shows a clear "Unavailable…metadata is missing" placeholder when PR metadata needed for the CLI/skill snippet is not present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->