### PR TITLE
fix(task): always send completed filter in +get-my-tasks

### DIFF
--- a/shortcuts/task/task_get_my_tasks.go
+++ b/shortcuts/task/task_get_my_tasks.go
@@ -44,9 +44,7 @@ var GetMyTasks = common.Shortcut{
 			"user_id_type": "open_id",
 			"page_size":    50,
 		}
-		if runtime.Cmd.Flags().Changed("complete") {
-			params["completed"] = runtime.Bool("complete")
-		}
+		params["completed"] = runtime.Bool("complete")
 
 		return d.GET("/open-apis/task/v2/tasks").Params(params)
 	},
@@ -58,13 +56,7 @@ var GetMyTasks = common.Shortcut{
 		queryParams.Set("type", "my_tasks")
 		queryParams.Set("user_id_type", "open_id")
 		queryParams.Set("page_size", "50")
-		if runtime.Cmd.Flags().Changed("complete") {
-			if runtime.Bool("complete") {
-				queryParams.Set("completed", "true")
-			} else {
-				queryParams.Set("completed", "false")
-			}
-		}
+		queryParams.Set("completed", strconv.FormatBool(runtime.Bool("complete")))
 
 		// parse time flags to ms timestamp if provided
 		var createdAfterMs, dueStartMs, dueEndMs int64


### PR DESCRIPTION
Fixes #164

## Problem

`lark-cli task +get-my-tasks` returns both completed and incomplete tasks when `--complete` is omitted. The help text says `default is false`, but the code only sends the `completed` query parameter when `--complete` is explicitly passed. When omitted, no filter is sent and the API returns everything.

## Fix

Always send the `completed` parameter using the flag's value. Since Go's bool zero value is `false`, omitting `--complete` now sends `completed=false` to the API, matching the documented behavior.

**Before** (11 lines):
```go
if runtime.Cmd.Flags().Changed("complete") {
    if runtime.Bool("complete") {
        queryParams.Set("completed", "true")
    } else {
        queryParams.Set("completed", "false")
    }
}
```

**After** (1 line):
```go
queryParams.Set("completed", strconv.FormatBool(runtime.Bool("complete")))
```

Same fix applied to both `Execute` and `DryRun` functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task completion status filtering to ensure consistent application across all task retrieval and query scenarios. The completion filter now reliably applies in all cases, resolving previous inconsistencies and improving the reliability and accuracy of task query results.

* **Refactor**
  * Simplified task parameter handling by removing redundant conditional logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->