### PR TITLE
feat(im): add +bot-receive-diagnose for IM bot receive diagnostics (read-only)

### DIFF
--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -74,7 +74,9 @@ func getFileMasterKey(service string, allowCreate bool) ([]byte, error) {
 	path := fileMasterKeyPath(service)
 	if key, err := readFileMasterKey(path); err == nil {
 		return key, nil
-	} else if err != nil && !os.IsNotExist(err) && !errors.Is(err, errInvalidMasterKey) {
+	} else if errors.Is(err, errInvalidMasterKey) {
+		return nil, fmt.Errorf("master key file %s exists but is corrupt; remove it manually to reset", path)
+	} else if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -6,12 +6,14 @@
 package keychain
 
 import (
+	"bytes"
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -30,21 +32,92 @@ const tagBytes = 16
 func StorageDir(service string) string {
 	home, err := os.UserHomeDir()
 	if err != nil || home == "" {
+		fmt.Fprintln(os.Stderr, "warning: unable to determine home directory; using relative keychain path .lark-cli/keychain/"+service)
 		return filepath.Join(".lark-cli", "keychain", service)
 	}
 	return filepath.Join(home, "Library", "Application Support", service)
 }
 
 var safeFileNameRe = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+var errInvalidMasterKey = errors.New("invalid master key")
 
 // safeFileName sanitizes an account name to be used as a safe file name.
 func safeFileName(account string) string {
 	return safeFileNameRe.ReplaceAllString(account, "_") + ".enc"
 }
 
+func fileMasterKeyPath(service string) string {
+	return filepath.Join(StorageDir(service), "master.key")
+}
+
+func readFileMasterKey(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	key, err := base64.StdEncoding.DecodeString(string(data))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", errInvalidMasterKey, err)
+	}
+	if len(key) != masterKeyBytes {
+		return nil, fmt.Errorf("%w: invalid length %d", errInvalidMasterKey, len(key))
+	}
+	return key, nil
+}
+
+func getFileMasterKey(service string, allowCreate bool) ([]byte, error) {
+	dir := StorageDir(service)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, err
+	}
+
+	path := fileMasterKeyPath(service)
+	if key, err := readFileMasterKey(path); err == nil {
+		return key, nil
+	} else if err != nil && !os.IsNotExist(err) && !errors.Is(err, errInvalidMasterKey) {
+		return nil, err
+	}
+
+	if !allowCreate {
+		return nil, errNotInitialized
+	}
+
+	key := make([]byte, masterKeyBytes)
+	if _, randErr := rand.Read(key); randErr != nil {
+		return nil, randErr
+	}
+
+	encodedKey := base64.StdEncoding.EncodeToString(key)
+	tmpPath := path + "." + uuid.New().String() + ".tmp"
+	defer os.Remove(tmpPath)
+
+	if err := os.WriteFile(tmpPath, []byte(encodedKey), 0600); err != nil {
+		return nil, err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		existingKey, readErr := readFileMasterKey(path)
+		if readErr == nil {
+			return existingKey, nil
+		}
+		return nil, err
+	}
+
+	writtenKey, err := readFileMasterKey(path)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(writtenKey, key) {
+		return writtenKey, nil
+	}
+	return key, nil
+}
+
 // getMasterKey retrieves the master key from the system keychain.
 // If allowCreate is true, it generates and stores a new master key if one doesn't exist.
 func getMasterKey(service string, allowCreate bool) ([]byte, error) {
+	if os.Getenv("LARKSUITE_CLI_KEYCHAIN_MASTER_KEY") == "file" {
+		return getFileMasterKey(service, allowCreate)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), keychainTimeout)
 	defer cancel()
 
@@ -99,7 +172,9 @@ func getMasterKey(service string, allowCreate bool) ([]byte, error) {
 	case res := <-resCh:
 		return res.key, res.err
 	case <-ctx.Done():
-		// Timeout is usually caused by ignored/blocked permission prompts
+		if os.Getenv("LARKSUITE_CLI_KEYCHAIN_MASTER_KEY") == "file_fallback" {
+			return getFileMasterKey(service, allowCreate)
+		}
 		return nil, errors.New("keychain access blocked")
 	}
 }

--- a/internal/keychain/keychain_darwin_test.go
+++ b/internal/keychain/keychain_darwin_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build darwin
+
+package keychain
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetFileMasterKeyCorruptExistingReturnsError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	dir := StorageDir(LarkCliService)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, "master.key")
+	if err := os.WriteFile(path, []byte("not-base64"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := getFileMasterKey(LarkCliService, true)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "is corrupt") {
+		t.Fatalf("expected corrupt error, got %v", err)
+	}
+}

--- a/internal/keychain/keychain_darwin_test.go
+++ b/internal/keychain/keychain_darwin_test.go
@@ -7,7 +7,6 @@ package keychain
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -20,7 +19,7 @@ func TestGetFileMasterKeyCorruptExistingReturnsError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	path := filepath.Join(dir, "master.key")
+	path := fileMasterKeyPath(LarkCliService)
 	if err := os.WriteFile(path, []byte("not-base64"), 0600); err != nil {
 		t.Fatal(err)
 	}

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -88,12 +88,22 @@ func (ctx *RuntimeContext) getAPIClient() (*client.APIClient, error) {
 // For user: returns user access token (with auto-refresh).
 // For bot: returns tenant access token.
 func (ctx *RuntimeContext) AccessToken() (string, error) {
+	return ctx.AccessTokenWithContext(ctx.ctx)
+}
+
+func (ctx *RuntimeContext) AccessTokenWithContext(callCtx context.Context) (string, error) {
+	if callCtx == nil {
+		callCtx = ctx.ctx
+	}
+	if callCtx == nil {
+		callCtx = context.Background()
+	}
 	if ctx.IsBot() {
 		ac, err := ctx.getAPIClient()
 		if err != nil {
 			return "", output.ErrAuth("failed to get SDK: %s", err)
 		}
-		tatResp, err := ac.SDK.GetTenantAccessTokenBySelfBuiltApp(ctx.ctx, &larkcore.SelfBuiltTenantAccessTokenReq{
+		tatResp, err := ac.SDK.GetTenantAccessTokenBySelfBuiltApp(callCtx, &larkcore.SelfBuiltTenantAccessTokenReq{
 			AppID:     ctx.Config.AppID,
 			AppSecret: ctx.Config.AppSecret,
 		})

--- a/shortcuts/im/helpers_test.go
+++ b/shortcuts/im/helpers_test.go
@@ -496,6 +496,7 @@ func TestShortcuts(t *testing.T) {
 	}
 
 	want := []string{
+		"+bot-receive-diagnose",
 		"+chat-create",
 		"+chat-messages-list",
 		"+chat-search",

--- a/shortcuts/im/im_bot_receive_diagnose.go
+++ b/shortcuts/im/im_bot_receive_diagnose.go
@@ -100,7 +100,18 @@ var ImBotReceiveDiagnose = common.Shortcut{
 
 		checks = append(checks, diagnoseBotApp(runtime))
 
-		if strings.TrimSpace(runtime.Config.AppSecret) == "" {
+		if runtime.Config == nil {
+			checks = append(checks,
+				failBotReceiveCheck(
+					"app_credential",
+					"app configuration is unavailable; cannot inspect app secret",
+					"run `lark-cli config init --new` to configure the app before diagnosing bot receive events",
+				),
+				skipBotReceiveCheck("token_bot", "skipped because app configuration is unavailable"),
+				skipBotReceiveCheck("endpoint_open", "skipped because app configuration is unavailable"),
+				skipBotReceiveCheck("endpoint_ws", "skipped because app configuration is unavailable"),
+			)
+		} else if strings.TrimSpace(runtime.Config.AppSecret) == "" {
 			checks = append(checks, failBotReceiveCheck(
 				"app_credential",
 				"app secret is empty",
@@ -110,24 +121,39 @@ var ImBotReceiveDiagnose = common.Shortcut{
 			checks = append(checks, passBotReceiveCheck("app_credential", "app credentials are configured"))
 		}
 
-		token, err := runtime.AccessToken()
-		if err != nil {
+		token := ""
+		switch {
+		case runtime.Config == nil:
+		case offline:
+			checks = append(checks, skipBotReceiveCheck("token_bot", "skipped (--offline); local app configuration readiness only"))
+		case strings.TrimSpace(runtime.Config.AppSecret) == "":
 			checks = append(checks, failBotReceiveCheck(
 				"token_bot",
-				fmt.Sprintf("failed to get bot tenant access token: %v", err),
-				"check app id/app secret, app status, and bot-related permissions in the developer console",
+				"cannot acquire bot tenant access token because app secret is empty",
+				"run `lark-cli config init --new` or update the configured app secret before diagnosing bot receive events",
 			))
-		} else if strings.TrimSpace(token) == "" {
-			checks = append(checks, failBotReceiveCheck(
-				"token_bot",
-				"tenant access token is empty",
-				"check app id/app secret and retry",
-			))
-		} else {
-			checks = append(checks, passBotReceiveCheck("token_bot", "bot tenant access token acquired successfully"))
+		default:
+			var err error
+			token, err = runtime.AccessToken()
+			if err != nil {
+				checks = append(checks, failBotReceiveCheck(
+					"token_bot",
+					fmt.Sprintf("failed to get bot tenant access token: %v", err),
+					"check app id/app secret, app status, and bot-related permissions in the developer console",
+				))
+			} else if strings.TrimSpace(token) == "" {
+				checks = append(checks, failBotReceiveCheck(
+					"token_bot",
+					"tenant access token is empty",
+					"check app id/app secret and retry",
+				))
+			} else {
+				checks = append(checks, passBotReceiveCheck("token_bot", "bot tenant access token acquired successfully"))
+			}
 		}
 
-		if offline {
+		if runtime.Config == nil {
+		} else if offline {
 			checks = append(checks,
 				skipBotReceiveCheck("endpoint_open", "skipped (--offline)"),
 				skipBotReceiveCheck("endpoint_ws", "skipped (--offline)"),
@@ -248,7 +274,7 @@ func collectBotReceiveNextSteps(checks []botReceiveCheck) []string {
 func probeBotReceiveEndpoint(ctx context.Context, runtime *common.RuntimeContext, url string, timeout time.Duration) error {
 	httpClient, err := runtime.Factory.HttpClient()
 	if err != nil {
-		httpClient = &http.Client{}
+		return fmt.Errorf("failed to obtain runtime HTTP client: %w", err)
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -265,6 +291,10 @@ func probeBotReceiveEndpoint(ctx context.Context, runtime *common.RuntimeContext
 }
 
 func diagnoseBotReceiveWebsocket(ctx context.Context, runtime *common.RuntimeContext, eventType string, timeout time.Duration) botReceiveCheck {
+	if runtime.Config == nil || strings.TrimSpace(runtime.Config.AppID) == "" || strings.TrimSpace(runtime.Config.AppSecret) == "" {
+		return skipBotReceiveCheck("endpoint_ws", "skipped because app configuration is unavailable")
+	}
+
 	domain := lark.FeishuBaseUrl
 	if runtime.Config.Brand == core.BrandLark {
 		domain = lark.LarkBaseUrl

--- a/shortcuts/im/im_bot_receive_diagnose.go
+++ b/shortcuts/im/im_bot_receive_diagnose.go
@@ -71,7 +71,7 @@ var ImBotReceiveDiagnose = common.Shortcut{
 	AuthTypes:   []string{"bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
-		{Name: "offline", Type: "bool", Desc: "skip network and WebSocket checks; only verify local bot configuration and token readiness"},
+		{Name: "offline", Type: "bool", Desc: "skip network and WebSocket checks; only verify local bot configuration and credential presence"},
 		{Name: "timeout", Type: "int", Default: "5", Desc: "timeout in seconds for network and WebSocket checks (1-60)"},
 		{Name: "event-type", Default: defaultIMReceiveEventType, Desc: "event type to diagnose (default im.message.receive_v1)"},
 	},
@@ -133,8 +133,10 @@ var ImBotReceiveDiagnose = common.Shortcut{
 				"run `lark-cli config init --new` or update the configured app secret before diagnosing bot receive events",
 			))
 		default:
+			tokenCtx, tokenCancel := context.WithTimeout(ctx, timeout)
+			defer tokenCancel()
 			var err error
-			token, err = runtime.AccessToken()
+			token, err = runtime.AccessTokenWithContext(tokenCtx)
 			if err != nil {
 				checks = append(checks, failBotReceiveCheck(
 					"token_bot",

--- a/shortcuts/im/im_bot_receive_diagnose.go
+++ b/shortcuts/im/im_bot_receive_diagnose.go
@@ -1,0 +1,321 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+package im
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	larkevent "github.com/larksuite/oapi-sdk-go/v3/event"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
+	larkws "github.com/larksuite/oapi-sdk-go/v3/ws"
+)
+
+const defaultIMReceiveEventType = "im.message.receive_v1"
+
+var (
+	botReceiveProbeEndpoint  = probeBotReceiveEndpoint
+	botReceiveProbeWebsocket = diagnoseBotReceiveWebsocket
+)
+
+type botReceiveCheck struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Hint    string `json:"hint,omitempty"`
+}
+
+type botReceiveSummary struct {
+	OK    bool `json:"ok"`
+	Pass  int  `json:"pass"`
+	Warn  int  `json:"warn"`
+	Fail  int  `json:"fail"`
+	Skip  int  `json:"skip"`
+	Total int  `json:"total"`
+}
+
+type botReceivePayload struct {
+	EventType string            `json:"event_type"`
+	Summary   botReceiveSummary `json:"summary"`
+	Checks    []botReceiveCheck `json:"checks"`
+	NextSteps []string          `json:"next_steps,omitempty"`
+}
+
+type silentSDKLogger struct{}
+
+func (l *silentSDKLogger) Debug(_ context.Context, _ ...interface{}) {}
+func (l *silentSDKLogger) Info(_ context.Context, _ ...interface{})  {}
+func (l *silentSDKLogger) Warn(_ context.Context, _ ...interface{})  {}
+func (l *silentSDKLogger) Error(_ context.Context, _ ...interface{}) {}
+
+var _ larkcore.Logger = (*silentSDKLogger)(nil)
+
+var ImBotReceiveDiagnose = common.Shortcut{
+	Service:     "im",
+	Command:     "+bot-receive-diagnose",
+	Description: "Diagnose why a bot does not receive IM message events (bot-only, read-only)",
+	Risk:        "read",
+	Scopes:      []string{"im:message:receive_as_bot"},
+	AuthTypes:   []string{"bot"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "offline", Type: "bool", Desc: "skip network and WebSocket checks; only verify local bot configuration and token readiness"},
+		{Name: "timeout", Type: "int", Default: "5", Desc: "timeout in seconds for network and WebSocket checks (1-60)"},
+		{Name: "event-type", Default: defaultIMReceiveEventType, Desc: "event type to diagnose (default im.message.receive_v1)"},
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		return common.NewDryRunAPI().
+			Desc("Diagnose IM bot receive readiness without changing remote state").
+			Set("command", "im +bot-receive-diagnose").
+			Set("event_type", runtime.Str("event-type")).
+			Set("offline", runtime.Bool("offline")).
+			Set("timeout_sec", runtime.Int("timeout"))
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if runtime.Int("timeout") < 1 || runtime.Int("timeout") > 60 {
+			return output.ErrValidation("--timeout must be an integer between 1 and 60")
+		}
+		if strings.TrimSpace(runtime.Str("event-type")) == "" {
+			return output.ErrValidation("--event-type cannot be empty")
+		}
+		return nil
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		offline := runtime.Bool("offline")
+		eventType := strings.TrimSpace(runtime.Str("event-type"))
+		timeout := time.Duration(runtime.Int("timeout")) * time.Second
+		checks := make([]botReceiveCheck, 0, 8)
+
+		checks = append(checks, diagnoseBotApp(runtime))
+
+		if strings.TrimSpace(runtime.Config.AppSecret) == "" {
+			checks = append(checks, failBotReceiveCheck(
+				"app_credential",
+				"app secret is empty",
+				"run `lark-cli config init --new` or update the configured app secret before diagnosing bot receive events",
+			))
+		} else {
+			checks = append(checks, passBotReceiveCheck("app_credential", "app credentials are configured"))
+		}
+
+		token, err := runtime.AccessToken()
+		if err != nil {
+			checks = append(checks, failBotReceiveCheck(
+				"token_bot",
+				fmt.Sprintf("failed to get bot tenant access token: %v", err),
+				"check app id/app secret, app status, and bot-related permissions in the developer console",
+			))
+		} else if strings.TrimSpace(token) == "" {
+			checks = append(checks, failBotReceiveCheck(
+				"token_bot",
+				"tenant access token is empty",
+				"check app id/app secret and retry",
+			))
+		} else {
+			checks = append(checks, passBotReceiveCheck("token_bot", "bot tenant access token acquired successfully"))
+		}
+
+		if offline {
+			checks = append(checks,
+				skipBotReceiveCheck("endpoint_open", "skipped (--offline)"),
+				skipBotReceiveCheck("endpoint_ws", "skipped (--offline)"),
+			)
+		} else {
+			openURL := core.ResolveEndpoints(runtime.Config.Brand).Open
+			if err := botReceiveProbeEndpoint(ctx, runtime, openURL, timeout); err != nil {
+				checks = append(checks, failBotReceiveCheck(
+					"endpoint_open",
+					fmt.Sprintf("%s unreachable: %v", openURL, err),
+					"check network, proxy, or firewall settings before diagnosing IM event delivery",
+				))
+			} else {
+				checks = append(checks, passBotReceiveCheck("endpoint_open", openURL+" reachable"))
+			}
+
+			if strings.TrimSpace(token) == "" {
+				checks = append(checks, skipBotReceiveCheck("endpoint_ws", "skipped because bot token is unavailable"))
+			} else {
+				checks = append(checks, botReceiveProbeWebsocket(ctx, runtime, eventType, timeout))
+			}
+		}
+
+		checks = append(checks,
+			warnBotReceiveCheck(
+				"event_subscription",
+				fmt.Sprintf("CLI cannot verify whether %s is subscribed in the developer console", eventType),
+				fmt.Sprintf("verify that event `%s` is added in the app's event subscriptions", eventType),
+			),
+			warnBotReceiveCheck(
+				"receive_scope",
+				"message receive permission cannot be fully pre-verified for bot identity",
+				"confirm the app has `im:message:receive_as_bot` enabled and approved in the developer console",
+			),
+			warnBotReceiveCheck(
+				"bot_availability",
+				"bot availability and target chat visibility cannot be inferred locally",
+				"confirm the bot is enabled, visible to the target users, and already added to the target chat",
+			),
+		)
+
+		payload := botReceivePayload{
+			EventType: eventType,
+			Summary:   summarizeBotReceiveChecks(checks),
+			Checks:    checks,
+			NextSteps: collectBotReceiveNextSteps(checks),
+		}
+
+		runtime.OutFormat(payload, nil, func(w io.Writer) {
+			rows := make([]map[string]interface{}, 0, len(checks))
+			for _, check := range checks {
+				row := map[string]interface{}{
+					"check":   check.Name,
+					"status":  check.Status,
+					"message": check.Message,
+				}
+				if check.Hint != "" {
+					row["hint"] = check.Hint
+				}
+				rows = append(rows, row)
+			}
+			output.PrintTable(w, rows)
+			fmt.Fprintf(w, "\nSummary: ok=%t pass=%d warn=%d fail=%d skip=%d total=%d\n",
+				payload.Summary.OK, payload.Summary.Pass, payload.Summary.Warn, payload.Summary.Fail, payload.Summary.Skip, payload.Summary.Total)
+			if len(payload.NextSteps) > 0 {
+				fmt.Fprintln(w, "\nNext steps:")
+				for _, step := range payload.NextSteps {
+					fmt.Fprintf(w, "- %s\n", step)
+				}
+			}
+		})
+		return nil
+	},
+}
+
+func diagnoseBotApp(runtime *common.RuntimeContext) botReceiveCheck {
+	if runtime.Config == nil || strings.TrimSpace(runtime.Config.AppID) == "" {
+		return failBotReceiveCheck("app_resolved", "bot app configuration is unavailable", "run `lark-cli config init --new` to configure the app before diagnosing IM bot receive issues")
+	}
+	return passBotReceiveCheck("app_resolved", fmt.Sprintf("app resolved: %s (%s)", runtime.Config.AppID, runtime.Config.Brand))
+}
+
+func summarizeBotReceiveChecks(checks []botReceiveCheck) botReceiveSummary {
+	summary := botReceiveSummary{OK: true, Total: len(checks)}
+	for _, check := range checks {
+		switch check.Status {
+		case "pass":
+			summary.Pass++
+		case "warn":
+			summary.Warn++
+		case "fail":
+			summary.Fail++
+			summary.OK = false
+		case "skip":
+			summary.Skip++
+		}
+	}
+	return summary
+}
+
+func collectBotReceiveNextSteps(checks []botReceiveCheck) []string {
+	seen := make(map[string]struct{})
+	var steps []string
+	for _, check := range checks {
+		if check.Hint == "" || (check.Status != "fail" && check.Status != "warn") {
+			continue
+		}
+		if _, ok := seen[check.Hint]; ok {
+			continue
+		}
+		seen[check.Hint] = struct{}{}
+		steps = append(steps, check.Hint)
+	}
+	sort.Strings(steps)
+	return steps
+}
+
+func probeBotReceiveEndpoint(ctx context.Context, runtime *common.RuntimeContext, url string, timeout time.Duration) error {
+	httpClient, err := runtime.Factory.HttpClient()
+	if err != nil {
+		httpClient = &http.Client{}
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
+}
+
+func diagnoseBotReceiveWebsocket(ctx context.Context, runtime *common.RuntimeContext, eventType string, timeout time.Duration) botReceiveCheck {
+	domain := lark.FeishuBaseUrl
+	if runtime.Config.Brand == core.BrandLark {
+		domain = lark.LarkBaseUrl
+	}
+
+	sdkLogger := &silentSDKLogger{}
+	eventDispatcher := dispatcher.NewEventDispatcher("", "")
+	eventDispatcher.InitConfig(larkevent.WithLogger(sdkLogger))
+	eventDispatcher.OnCustomizedEvent(eventType, func(context.Context, *larkevent.EventReq) error { return nil })
+
+	wsCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cli := larkws.NewClient(runtime.Config.AppID, runtime.Config.AppSecret,
+		larkws.WithEventHandler(eventDispatcher),
+		larkws.WithDomain(domain),
+		larkws.WithLogger(sdkLogger),
+	)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- cli.Start(wsCtx)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return passBotReceiveCheck("endpoint_ws", fmt.Sprintf("event WebSocket for %s did not fail within %s", eventType, timeout))
+		}
+		return failBotReceiveCheck(
+			"endpoint_ws",
+			fmt.Sprintf("event WebSocket startup failed for %s: %v", eventType, err),
+			"check event subscription settings, bot receive permission, and network/proxy settings for long connections",
+		)
+	case <-wsCtx.Done():
+		return passBotReceiveCheck("endpoint_ws", fmt.Sprintf("event WebSocket for %s did not fail within %s", eventType, timeout))
+	}
+}
+
+func passBotReceiveCheck(name, msg string) botReceiveCheck {
+	return botReceiveCheck{Name: name, Status: "pass", Message: msg}
+}
+
+func warnBotReceiveCheck(name, msg, hint string) botReceiveCheck {
+	return botReceiveCheck{Name: name, Status: "warn", Message: msg, Hint: hint}
+}
+
+func failBotReceiveCheck(name, msg, hint string) botReceiveCheck {
+	return botReceiveCheck{Name: name, Status: "fail", Message: msg, Hint: hint}
+}
+
+func skipBotReceiveCheck(name, msg string) botReceiveCheck {
+	return botReceiveCheck{Name: name, Status: "skip", Message: msg}
+}

--- a/shortcuts/im/im_bot_receive_diagnose.go
+++ b/shortcuts/im/im_bot_receive_diagnose.go
@@ -321,8 +321,15 @@ func diagnoseBotReceiveWebsocket(ctx context.Context, runtime *common.RuntimeCon
 
 	select {
 	case err := <-errCh:
-		if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if err == nil {
 			return passBotReceiveCheck("endpoint_ws", fmt.Sprintf("event WebSocket for %s did not fail within %s", eventType, timeout))
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return warnBotReceiveCheck(
+				"endpoint_ws",
+				fmt.Sprintf("event WebSocket for %s did not fail within %s, but readiness was not confirmed", eventType, timeout),
+				"retry with a larger --timeout or verify that long-lived WebSocket connections are allowed by the network/proxy",
+			)
 		}
 		return failBotReceiveCheck(
 			"endpoint_ws",
@@ -330,7 +337,11 @@ func diagnoseBotReceiveWebsocket(ctx context.Context, runtime *common.RuntimeCon
 			"check event subscription settings, bot receive permission, and network/proxy settings for long connections",
 		)
 	case <-wsCtx.Done():
-		return passBotReceiveCheck("endpoint_ws", fmt.Sprintf("event WebSocket for %s did not fail within %s", eventType, timeout))
+		return warnBotReceiveCheck(
+			"endpoint_ws",
+			fmt.Sprintf("event WebSocket for %s did not fail within %s, but readiness was not confirmed", eventType, timeout),
+			"retry with a larger --timeout or verify that long-lived WebSocket connections are allowed by the network/proxy",
+		)
 	}
 }
 

--- a/shortcuts/im/im_bot_receive_diagnose_test.go
+++ b/shortcuts/im/im_bot_receive_diagnose_test.go
@@ -66,10 +66,12 @@ func TestImBotReceiveDiagnose_OfflineSuccess(t *testing.T) {
 	}))
 	restoreProbe := stubBotReceiveProbes(
 		func(ctx context.Context, runtime *common.RuntimeContext, url string, timeout time.Duration) error {
+			t.Fatal("endpoint probe should not run in offline mode")
 			return nil
 		},
 		func(ctx context.Context, runtime *common.RuntimeContext, eventType string, timeout time.Duration) botReceiveCheck {
-			return passBotReceiveCheck("endpoint_ws", "stubbed")
+			t.Fatal("websocket probe should not run in offline mode")
+			return botReceiveCheck{}
 		},
 	)
 	defer restoreProbe()
@@ -99,6 +101,9 @@ func TestImBotReceiveDiagnose_OfflineSuccess(t *testing.T) {
 	}
 	if !containsString(checks, "endpoint_open:skip") {
 		t.Fatalf("expected endpoint_open skip, got: %v", checks)
+	}
+	if !containsString(checks, "endpoint_ws:skip") {
+		t.Fatalf("expected endpoint_ws skip, got: %v", checks)
 	}
 	if !containsString(checks, "event_subscription:warn") {
 		t.Fatalf("expected event_subscription warn, got: %v", checks)
@@ -180,6 +185,55 @@ func TestImBotReceiveDiagnose_OnlineProbeFailure(t *testing.T) {
 	}
 	if !containsString(checks, "endpoint_ws:fail") {
 		t.Fatalf("expected endpoint_ws fail, got: %v", checks)
+	}
+}
+
+func TestImBotReceiveDiagnose_WebsocketTimeoutWarns(t *testing.T) {
+	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case strings.Contains(req.URL.Path, "tenant_access_token"):
+			return shortcutJSONResponse(200, map[string]interface{}{
+				"code":                0,
+				"tenant_access_token": "tenant-token",
+				"expire":              7200,
+			}), nil
+		default:
+			return shortcutJSONResponse(200, map[string]interface{}{"code": 0}), nil
+		}
+	}))
+	restoreProbe := stubBotReceiveProbes(
+		func(ctx context.Context, runtime *common.RuntimeContext, url string, timeout time.Duration) error {
+			return nil
+		},
+		func(ctx context.Context, runtime *common.RuntimeContext, eventType string, timeout time.Duration) botReceiveCheck {
+			wsCtx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			<-wsCtx.Done()
+			return warnBotReceiveCheck(
+				"endpoint_ws",
+				"event WebSocket for "+eventType+" did not fail within "+timeout.String()+", but readiness was not confirmed",
+				"retry with a larger --timeout or verify that long-lived WebSocket connections are allowed by the network/proxy",
+			)
+		},
+	)
+	defer restoreProbe()
+
+	root := mountedBotReceiveDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose", "--timeout", "1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	env := decodeBotReceiveEnvelope(t, rt)
+	if !env.Data.Summary.OK {
+		t.Fatalf("expected summary ok=true for warn-only timeout path, got false")
+	}
+	checks := stringifyChecks(env.Data.Checks)
+	if !containsString(checks, "endpoint_open:pass") {
+		t.Fatalf("expected endpoint_open pass, got: %v", checks)
+	}
+	if !containsString(checks, "endpoint_ws:warn") {
+		t.Fatalf("expected endpoint_ws warn, got: %v", checks)
 	}
 }
 

--- a/shortcuts/im/im_bot_receive_diagnose_test.go
+++ b/shortcuts/im/im_bot_receive_diagnose_test.go
@@ -62,16 +62,7 @@ func TestImBotReceiveDiagnose_ValidateTimeout(t *testing.T) {
 
 func TestImBotReceiveDiagnose_OfflineSuccess(t *testing.T) {
 	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-		switch {
-		case strings.Contains(req.URL.Path, "tenant_access_token"):
-			return shortcutJSONResponse(200, map[string]interface{}{
-				"code":                0,
-				"tenant_access_token": "tenant-token",
-				"expire":              7200,
-			}), nil
-		default:
-			return shortcutJSONResponse(200, map[string]interface{}{"code": 0}), nil
-		}
+		return nil, errors.New("offline diagnose should not make HTTP requests")
 	}))
 	restoreProbe := stubBotReceiveProbes(
 		func(ctx context.Context, runtime *common.RuntimeContext, url string, timeout time.Duration) error {
@@ -103,8 +94,8 @@ func TestImBotReceiveDiagnose_OfflineSuccess(t *testing.T) {
 		t.Fatalf("expected summary ok=true, got false")
 	}
 	checks := stringifyChecks(env.Data.Checks)
-	if !containsString(checks, "token_bot:pass") {
-		t.Fatalf("expected token_bot pass, got: %v", checks)
+	if !containsString(checks, "token_bot:skip") {
+		t.Fatalf("expected token_bot skip, got: %v", checks)
 	}
 	if !containsString(checks, "endpoint_open:skip") {
 		t.Fatalf("expected endpoint_open skip, got: %v", checks)
@@ -189,6 +180,57 @@ func TestImBotReceiveDiagnose_OnlineProbeFailure(t *testing.T) {
 	}
 	if !containsString(checks, "endpoint_ws:fail") {
 		t.Fatalf("expected endpoint_ws fail, got: %v", checks)
+	}
+}
+
+func TestImBotReceiveDiagnose_NilConfigDoesNotPanic(t *testing.T) {
+	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("nil config diagnose should not make HTTP requests")
+	}))
+	rt.Config = nil
+
+	restoreProbe := stubBotReceiveProbes(
+		func(ctx context.Context, runtime *common.RuntimeContext, url string, timeout time.Duration) error {
+			t.Fatal("endpoint probe should not run when config is nil")
+			return nil
+		},
+		func(ctx context.Context, runtime *common.RuntimeContext, eventType string, timeout time.Duration) botReceiveCheck {
+			t.Fatal("websocket probe should not run when config is nil")
+			return botReceiveCheck{}
+		},
+	)
+	defer restoreProbe()
+
+	parent := &cobra.Command{Use: "im"}
+	ImBotReceiveDiagnose.Mount(parent, rt.Factory)
+	cmd := parent.Commands()[0]
+	rt.Cmd = cmd
+	if err := cmd.Flags().Set("offline", "false"); err != nil {
+		t.Fatalf("failed to set offline flag: %v", err)
+	}
+	if err := cmd.Flags().Set("event-type", defaultIMReceiveEventType); err != nil {
+		t.Fatalf("failed to set event-type flag: %v", err)
+	}
+	if err := cmd.Flags().Set("timeout", "5"); err != nil {
+		t.Fatalf("failed to set timeout flag: %v", err)
+	}
+	if err := ImBotReceiveDiagnose.Execute(context.Background(), rt); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	env := decodeBotReceiveEnvelope(t, rt)
+	checks := stringifyChecks(env.Data.Checks)
+	if !containsString(checks, "app_resolved:fail") {
+		t.Fatalf("expected app_resolved fail, got: %v", checks)
+	}
+	if !containsString(checks, "token_bot:skip") {
+		t.Fatalf("expected token_bot skip, got: %v", checks)
+	}
+	if !containsString(checks, "endpoint_open:skip") {
+		t.Fatalf("expected endpoint_open skip, got: %v", checks)
+	}
+	if !containsString(checks, "endpoint_ws:skip") {
+		t.Fatalf("expected endpoint_ws skip, got: %v", checks)
 	}
 }
 

--- a/shortcuts/im/im_bot_receive_diagnose_test.go
+++ b/shortcuts/im/im_bot_receive_diagnose_test.go
@@ -1,0 +1,244 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+type botReceiveEnvelope struct {
+	OK       bool              `json:"ok"`
+	Identity string            `json:"identity"`
+	Data     botReceivePayload `json:"data"`
+}
+
+func TestImBotReceiveDiagnose_Registers(t *testing.T) {
+	rt := newBotShortcutRuntime(t, nil)
+	parent := &cobra.Command{Use: "im"}
+	ImBotReceiveDiagnose.Mount(parent, rt.Factory)
+	if got := len(parent.Commands()); got != 1 {
+		t.Fatalf("expected 1 command, got %d", got)
+	}
+	if got, want := parent.Commands()[0].Use, "+bot-receive-diagnose"; got != want {
+		t.Fatalf("command use: got %q, want %q", got, want)
+	}
+}
+
+func TestImBotReceiveDiagnose_ValidateTimeout(t *testing.T) {
+	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case strings.Contains(req.URL.Path, "tenant_access_token"):
+			return shortcutJSONResponse(200, map[string]interface{}{
+				"code":                0,
+				"tenant_access_token": "tenant-token",
+				"expire":              7200,
+			}), nil
+		default:
+			return shortcutJSONResponse(200, map[string]interface{}{"code": 0}), nil
+		}
+	}))
+	root := mountedBotReceiveDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose", "--timeout", "0"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--timeout must be an integer between 1 and 60") {
+		t.Fatalf("expected error to contain timeout validation message, got: %v", err)
+	}
+}
+
+func TestImBotReceiveDiagnose_OfflineSuccess(t *testing.T) {
+	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case strings.Contains(req.URL.Path, "tenant_access_token"):
+			return shortcutJSONResponse(200, map[string]interface{}{
+				"code":                0,
+				"tenant_access_token": "tenant-token",
+				"expire":              7200,
+			}), nil
+		default:
+			return shortcutJSONResponse(200, map[string]interface{}{"code": 0}), nil
+		}
+	}))
+	restoreProbe := stubBotReceiveProbes(
+		func(ctx context.Context, runtime *common.RuntimeContext, url string, timeout time.Duration) error {
+			return nil
+		},
+		func(ctx context.Context, runtime *common.RuntimeContext, eventType string, timeout time.Duration) botReceiveCheck {
+			return passBotReceiveCheck("endpoint_ws", "stubbed")
+		},
+	)
+	defer restoreProbe()
+
+	root := mountedBotReceiveDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose", "--offline"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	env := decodeBotReceiveEnvelope(t, rt)
+	if !env.OK {
+		t.Fatalf("expected envelope ok=true, got false")
+	}
+	if got, want := env.Identity, "bot"; got != want {
+		t.Fatalf("identity: got %q, want %q", got, want)
+	}
+	if got, want := env.Data.EventType, defaultIMReceiveEventType; got != want {
+		t.Fatalf("event_type: got %q, want %q", got, want)
+	}
+	if !env.Data.Summary.OK {
+		t.Fatalf("expected summary ok=true, got false")
+	}
+	checks := stringifyChecks(env.Data.Checks)
+	if !containsString(checks, "token_bot:pass") {
+		t.Fatalf("expected token_bot pass, got: %v", checks)
+	}
+	if !containsString(checks, "endpoint_open:skip") {
+		t.Fatalf("expected endpoint_open skip, got: %v", checks)
+	}
+	if !containsString(checks, "event_subscription:warn") {
+		t.Fatalf("expected event_subscription warn, got: %v", checks)
+	}
+}
+
+func TestImBotReceiveDiagnose_TokenFailureMarksResultNotOK(t *testing.T) {
+	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("tenant token down")
+	}))
+	restoreProbe := stubBotReceiveProbes(
+		func(ctx context.Context, runtime *common.RuntimeContext, url string, timeout time.Duration) error {
+			return nil
+		},
+		func(ctx context.Context, runtime *common.RuntimeContext, eventType string, timeout time.Duration) botReceiveCheck {
+			return passBotReceiveCheck("endpoint_ws", "stubbed")
+		},
+	)
+	defer restoreProbe()
+
+	root := mountedBotReceiveDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	env := decodeBotReceiveEnvelope(t, rt)
+	if !env.OK {
+		t.Fatalf("expected envelope ok=true, got false")
+	}
+	if env.Data.Summary.OK {
+		t.Fatalf("expected summary ok=false, got true")
+	}
+	checks := stringifyChecks(env.Data.Checks)
+	if !containsString(checks, "token_bot:fail") {
+		t.Fatalf("expected token_bot fail, got: %v", checks)
+	}
+	if !containsString(env.Data.NextSteps, "check app id/app secret, app status, and bot-related permissions in the developer console") {
+		t.Fatalf("expected next_steps to contain token failure hint, got: %v", env.Data.NextSteps)
+	}
+}
+
+func TestImBotReceiveDiagnose_OnlineProbeFailure(t *testing.T) {
+	rt := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case strings.Contains(req.URL.Path, "tenant_access_token"):
+			return shortcutJSONResponse(200, map[string]interface{}{
+				"code":                0,
+				"tenant_access_token": "tenant-token",
+				"expire":              7200,
+			}), nil
+		default:
+			return shortcutJSONResponse(200, map[string]interface{}{"code": 0}), nil
+		}
+	}))
+	restoreProbe := stubBotReceiveProbes(
+		func(ctx context.Context, runtime *common.RuntimeContext, url string, timeout time.Duration) error {
+			return errors.New("dial tcp timeout")
+		},
+		func(ctx context.Context, runtime *common.RuntimeContext, eventType string, timeout time.Duration) botReceiveCheck {
+			return failBotReceiveCheck("endpoint_ws", "ws failed", "check event subscription settings, bot receive permission, and network/proxy settings for long connections")
+		},
+	)
+	defer restoreProbe()
+
+	root := mountedBotReceiveDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	env := decodeBotReceiveEnvelope(t, rt)
+	if env.Data.Summary.OK {
+		t.Fatalf("expected summary ok=false, got true")
+	}
+	checks := stringifyChecks(env.Data.Checks)
+	if !containsString(checks, "endpoint_open:fail") {
+		t.Fatalf("expected endpoint_open fail, got: %v", checks)
+	}
+	if !containsString(checks, "endpoint_ws:fail") {
+		t.Fatalf("expected endpoint_ws fail, got: %v", checks)
+	}
+}
+
+func mountedBotReceiveDiagnoseRoot(t *testing.T, rt *common.RuntimeContext) *cobra.Command {
+	t.Helper()
+	parent := &cobra.Command{Use: "im"}
+	ImBotReceiveDiagnose.Mount(parent, rt.Factory)
+	return parent
+}
+
+func decodeBotReceiveEnvelope(t *testing.T, rt *common.RuntimeContext) botReceiveEnvelope {
+	t.Helper()
+	buf, ok := rt.Factory.IOStreams.Out.(*bytes.Buffer)
+	if !ok {
+		t.Fatalf("expected stdout to be *bytes.Buffer, got %T", rt.Factory.IOStreams.Out)
+	}
+	var env botReceiveEnvelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("failed to unmarshal output: %v, output=%s", err, buf.String())
+	}
+	return env
+}
+
+func stringifyChecks(checks []botReceiveCheck) []string {
+	out := make([]string, 0, len(checks))
+	for _, check := range checks {
+		out = append(out, check.Name+":"+check.Status)
+	}
+	return out
+}
+
+func containsString[T ~string](items []T, needle string) bool {
+	for _, item := range items {
+		if string(item) == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func stubBotReceiveProbes(
+	endpoint func(ctx context.Context, runtime *common.RuntimeContext, url string, timeout time.Duration) error,
+	websocket func(ctx context.Context, runtime *common.RuntimeContext, eventType string, timeout time.Duration) botReceiveCheck,
+) func() {
+	prevEndpoint := botReceiveProbeEndpoint
+	prevWebsocket := botReceiveProbeWebsocket
+	botReceiveProbeEndpoint = endpoint
+	botReceiveProbeWebsocket = websocket
+	return func() {
+		botReceiveProbeEndpoint = prevEndpoint
+		botReceiveProbeWebsocket = prevWebsocket
+	}
+}

--- a/shortcuts/im/shortcuts.go
+++ b/shortcuts/im/shortcuts.go
@@ -8,6 +8,7 @@ import "github.com/larksuite/cli/shortcuts/common"
 // Shortcuts returns all im shortcuts.
 func Shortcuts() []common.Shortcut {
 	return []common.Shortcut{
+		ImBotReceiveDiagnose,
 		ImChatCreate,
 		ImChatMessageList,
 		ImChatSearch,

--- a/shortcuts/mail/mail_shortcut_test.go
+++ b/shortcuts/mail/mail_shortcut_test.go
@@ -33,6 +33,7 @@ func mailTestConfig() *core.CliConfig {
 func mailShortcutTestFactory(t *testing.T) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer, *httpmock.Registry) {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_KEYCHAIN_MASTER_KEY", "file")
 
 	cfg := mailTestConfig()
 	token := &auth.StoredUAToken{

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -57,6 +57,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli im +<verb> [flags]`）。
 | Shortcut | 说明 |
 |----------|------|
 | [`+chat-create`](references/lark-im-chat-create.md) | Create a group chat with bot identity; bot-only; creates private/public chats, invites users/bots, optionally sets bot manager |
+| [`+bot-receive-diagnose`](references/lark-im-bot-receive-diagnose.md) | Diagnose why a bot does not receive IM message events; bot-only; checks app credentials, tenant token, OpenAPI reachability, event WebSocket startup, and outputs next-step hints for subscription/scope/availability |
 | [`+chat-messages-list`](references/lark-im-chat-messages-list.md) | List messages in a chat or P2P conversation; user/bot; accepts --chat-id or --user-id, resolves P2P chat_id, supports time range/sort/pagination |
 | [`+chat-search`](references/lark-im-chat-search.md) | Search visible group chats by keyword and/or member open_ids (e.g. look up chat_id by group name); user/bot; supports member/type filters, sorting, and pagination |
 | [`+chat-update`](references/lark-im-chat-update.md) | Update group chat name or description; user/bot; updates a chat's name or description |

--- a/skills/lark-im/references/lark-im-bot-receive-diagnose.md
+++ b/skills/lark-im/references/lark-im-bot-receive-diagnose.md
@@ -1,0 +1,53 @@
+# `lark-cli im +bot-receive-diagnose`
+
+Diagnose why a bot is not receiving IM message events such as `im.message.receive_v1`.
+
+## What it checks
+
+- app configuration can be resolved
+- app credentials exist
+- bot tenant access token can be acquired
+- OpenAPI endpoint is reachable
+- event WebSocket startup does not fail immediately
+- next-step hints for event subscription, receive scope, and bot availability
+
+## Usage
+
+```bash
+lark-cli im +bot-receive-diagnose --as bot
+```
+
+## Common flags
+
+```bash
+# local-only checks
+lark-cli im +bot-receive-diagnose --as bot --offline
+
+# longer timeout for network / websocket startup
+lark-cli im +bot-receive-diagnose --as bot --timeout 10
+
+# diagnose a different event type
+lark-cli im +bot-receive-diagnose --as bot --event-type "im.message.message_read_v1"
+```
+
+## Output
+
+The command returns structured data with:
+
+- `event_type`
+- `summary`
+- `checks`
+- `next_steps`
+
+Each check includes:
+
+- `name`
+- `status` (`pass` / `warn` / `fail` / `skip`)
+- `message`
+- `hint`
+
+## Notes
+
+- This command is read-only and does not send probe messages.
+- It cannot directly read your developer-console event subscription settings, so subscription and availability checks are reported as actionable hints.
+- A passing result means the bot receive chain does not fail immediately from the CLI side; it does not guarantee that a target chat or business handler is already configured correctly.


### PR DESCRIPTION
## What
- Add lark-cli im +bot-receive-diagnose (read-only) with --offline/--timeout/--event-type (default im.message.receive_v1 )
- Structured output: ok/summary/checks/next_steps to diagnose credentials, OpenAPI reachability, and event WebSocket startup
- Fix: WebSocket probe now returns deterministically within --timeout (no hanging)
## Why
- Addresses frequent “bot not responding / not receiving messages” troubleshooting need; aligns with #33 (bot doctor/probe request)
## Tests
- go test -v -race -count=1 -timeout=5m ./cmd/... ./internal/... ./shortcuts/... (pass)
## Docs
- Update skills/lark-im/SKILL.md
- Add skills/lark-im/references/lark-im-bot-receive-diagnose.md
## Limitations
- Cannot read console subscription/scope/availability directly; reported as actionable hints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added im +bot-receive-diagnose CLI shortcut for bot receive diagnostics with timeout, offline, and event-type options; it's exposed in the IM shortcuts list.

* **Documentation**
  * Added command reference and skill docs describing usage, flags, structured output, and troubleshooting hints.

* **Tests**
  * Added tests covering command registration, validation, offline/online probe behaviors, and corrupted key-file handling.

* **Chores**
  * Improved keychain handling with optional file-based master-key selection via env var and made token acquisition context-aware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->