### PR TITLE
fix(mail): avoid real keychain access in mail scope tests

### DIFF
--- a/shortcuts/mail/mail_shortcut_test.go
+++ b/shortcuts/mail/mail_shortcut_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/zalando/go-keyring"
 
 	"github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/cmdutil"
@@ -32,6 +33,7 @@ func mailTestConfig() *core.CliConfig {
 
 func mailShortcutTestFactory(t *testing.T) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer, *httpmock.Registry) {
 	t.Helper()
+	keyring.MockInit() // use in-memory keyring to avoid macOS keychain popups
 	t.Setenv("HOME", t.TempDir())
 
 	cfg := mailTestConfig()


### PR DESCRIPTION
## Summary
- Mail scope tests (`TestConfirmSendMissingScopeReply/ReplyAll/Forward`) were calling `auth.SetStoredToken`/`RemoveStoredToken` which accessed the real macOS keychain via `go-keyring`, causing persistent popup dialogs when the master key was missing
- Add `keyring.MockInit()` in `mailShortcutTestFactory` to swap the keyring backend to an in-memory implementation during tests, completely avoiding real keychain access
- Only one file changed: `shortcuts/mail/mail_shortcut_test.go` (added 1 import + 1 line)

## Test plan
- [x] `TestConfirmSendMissingScopeReply`, `TestConfirmSendMissingScopeReplyAll`, `TestConfirmSendMissingScopeForward` pass without keychain popups
- [x] All 131 mail package tests pass
- [x] No changes to public/shared code (`factory.go`, `runner.go`, `helpers.go` are untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)