### PR TITLE
feat: add approve domain

### DIFF
--- a/internal/registry/service_descriptions.json
+++ b/internal/registry/service_descriptions.json
@@ -1,4 +1,8 @@
 {
+  "approval": {
+    "en": { "title": "Approval API", "description": "Approval instance, and task management" },
+    "zh": { "title": "审批 API", "description": "审批实例、审批任务管理" }
+  },
   "base": {
     "en": { "title": "Base", "description": "Table, field, record, view, dashboard, workflow, form, role & permission management" },
     "zh": { "title": "多维表格", "description": "数据表、字段、记录、视图、仪表盘、自动化流程、表单、角色权限管理" }

--- a/skills/lark-approval/SKILL.md
+++ b/skills/lark-approval/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: lark-approval
+version: 1.0.0
+description: "飞书审批 API：审批实例、审批任务管理。"
+metadata:
+  requires:
+    bins: ["lark-cli"]
+  cliHelp: "lark-cli approval --help"
+---
+
+# approval (v4)
+
+**CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，其中包含认证、权限处理**
+
+## API Resources
+
+```bash
+lark-cli schema approval.<resource>.<method>   # 调用 API 前必须先查看参数结构
+lark-cli approval <resource> <method> [flags] # 调用 API
+```
+
+> **重要**：使用原生 API 时，必须先运行 `schema` 查看 `--data` / `--params` 参数结构，不要猜测字段格式。
+
+### instances
+
+  - `get` — 获取单个审批实例详情
+  - `cancel` — 撤回审批实例
+  - `cc` — 抄送审批实例
+
+### tasks
+
+  - `approve` — 同意审批任务
+  - `reject` — 拒绝审批任务
+  - `transfer` — 转交审批任务
+  - `query` — 查询用户的任务列表
+
+## 权限表
+
+| 方法 | 所需 scope |
+|------|-----------|
+| `instances.get` | `approval:instance:read` |
+| `instances.cancel` | `approval:instance:write` |
+| `instances.cc` | `approval:instance:write` |
+| `tasks.approve` | `approval:task:write` |
+| `tasks.reject` | `approval:task:write` |
+| `tasks.transfer` | `approval:task:write` |
+| `tasks.query` | `approval:task:read` |
+


### PR DESCRIPTION
## Summary

Add the approval domain skill and register its service description

## Changes
- Add skills/lark-approval/SKILL.md with:                                                                                                  
    - Skill frontmatter (name, version, description, requires)
    - API resource documentation for instances (get, cancel, cc) and tasks (approve, reject, transfer, query)                                
    - Permission scope table mapping each method to its required scope                                                                       
  - Register approval service in internal/registry/service_descriptions.json with bilingual (en/zh) title and description

## Test Plan
  - Run lark-cli approval --help and verify the approval subcommand is recognized                                                            
  - Run lark-cli schema approval.instances.get and confirm the schema output is correct
  - Run lark-cli schema approval.tasks.query and confirm the schema output is correct   
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Approval API for managing approval instances and tasks, including instance actions (get, cancel, cc) and task actions (approve, reject, transfer, query).

* **Documentation**
  * Added end-user documentation covering CLI command patterns, how to inspect API schemas, and required permission scopes for each method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->