### PR TITLE
feat(im): recommend user identity for message fetch, add bot-not-in-group fallback guidance

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -46,6 +46,18 @@ When using bot identity (`--as bot`) to fetch messages (e.g. `+chat-messages-lis
 
 **Solution**: Check the app's visibility settings in the Lark Developer Console — ensure the app's visible range covers the users whose names need to be resolved. Alternatively, use `--as user` to fetch messages with user identity, which typically has broader contact access.
 
+### Fetching Messages: Prefer User Identity
+
+When reading/listing messages (`+chat-messages-list`, `+threads-messages-list`, `+messages-mget`), **prefer `--as user`** over bot identity. Bot identity requires the bot to be a member of the target chat; if it is not, the API will return a "not in group" or permission error.
+
+Note: `+messages-search` is **user-only** and does not support `--as bot`.
+
+**Recommended strategy (reason-based, no circular retries):**
+
+1. **Start with `--as user`** — broader chat access, correct sender name resolution.
+2. **If `--as user` fails due to missing scope** → try `--as bot` instead. Do not retry user until the scope is granted.
+3. **If `--as bot` fails due to "bot not in group"** → retry with `--as user` **only if** user scope is confirmed available; otherwise surface an actionable error: _"Bot is not in the chat and user scope is missing — grant `im:message:readonly` or add the bot to the chat."_
+
 ### Card Messages (Interactive)
 
 Card messages (`interactive` type) are not yet supported for compact conversion in event subscriptions. The raw event data will be returned instead, with a hint printed to stderr.


### PR DESCRIPTION
## Summary

When the bot is not a member of a target chat, message-fetch commands fail with a "not in group" error. This PR documents the recommended identity strategy so agents always pick the right identity without manual intervention.

## Changes

- Add `Fetching Messages: Prefer User Identity` section to `skills/lark-im/SKILL.md`
- Document the recommended strategy: prefer `--as user` first; fall back to `--as bot` if user scope is missing; retry with `--as user` if bot fails due to "not in group"

## Test Plan

- [ ] Manual verification: skill guidance is visible in `SKILL.md`
- [ ] Documentation-only change, no runtime behavior affected

## Related Issues

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for message-reading and listing commands: prefer acting as the user when possible; some search operations are user-only. Describes a clear fallback flow for permission errors — try user first, switch to bot when user scope is missing, and retry user only when bot membership is the blocker. Provides actionable errors for missing read scope or when the bot must be added to a chat.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->