### PR TITLE
fix: reject positional arguments in shortcuts

### DIFF
--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -540,7 +540,7 @@ func (s Shortcut) mountDeclarative(parent *cobra.Command, f *cmdutil.Factory) {
 	cmd := &cobra.Command{
 		Use:   shortcut.Command,
 		Short: shortcut.Description,
-		Args:  rejectPositionalArgs(&shortcut),
+		Args:  rejectPositionalArgs(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runShortcut(cmd, f, &shortcut, botOnly)
 		},
@@ -686,12 +686,12 @@ func handleShortcutDryRun(f *cmdutil.Factory, rctx *RuntimeContext, s *Shortcut)
 // positional arguments. The error is intentionally a plain error (not
 // ExitError) so that cobra prints usage and the root handler prints a
 // simple "Error:" line instead of a JSON envelope.
-func rejectPositionalArgs(_ *Shortcut) cobra.PositionalArgs {
+func rejectPositionalArgs() cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			return nil
 		}
-		return fmt.Errorf("positional arguments are not supported (got %q); pass values via flags", args[0])
+		return fmt.Errorf("positional arguments are not supported (got %q); pass values via flags", args)
 	}
 }
 

--- a/shortcuts/common/runner_args_test.go
+++ b/shortcuts/common/runner_args_test.go
@@ -13,12 +13,7 @@ import (
 func TestRejectPositionalArgs_WithArgs(t *testing.T) {
 	t.Parallel()
 
-	s := &Shortcut{
-		Flags: []Flag{
-			{Name: "query", Desc: "search keyword"},
-		},
-	}
-	validator := rejectPositionalArgs(s)
+	validator := rejectPositionalArgs()
 
 	err := validator(&cobra.Command{}, []string{"hello"})
 	if err == nil {
@@ -32,11 +27,27 @@ func TestRejectPositionalArgs_WithArgs(t *testing.T) {
 	}
 }
 
+func TestRejectPositionalArgs_MultipleArgs(t *testing.T) {
+	t.Parallel()
+
+	validator := rejectPositionalArgs()
+
+	err := validator(&cobra.Command{}, []string{"hello", "world"})
+	if err == nil {
+		t.Fatal("expected error for multiple positional args, got nil")
+	}
+	if !strings.Contains(err.Error(), "positional arguments are not supported") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+	if !strings.Contains(err.Error(), "hello") || !strings.Contains(err.Error(), "world") {
+		t.Errorf("expected all positional args in error, got: %v", err)
+	}
+}
+
 func TestRejectPositionalArgs_NoArgs(t *testing.T) {
 	t.Parallel()
 
-	s := &Shortcut{}
-	validator := rejectPositionalArgs(s)
+	validator := rejectPositionalArgs()
 
 	if err := validator(&cobra.Command{}, nil); err != nil {
 		t.Fatalf("expected no error for nil args, got: %v", err)


### PR DESCRIPTION
## Summary
- Shortcuts 之前会静默忽略位置参数（如 `lark-cli docs +search "hello"`），导致空搜索结果
- 在所有声明式 shortcut 的 cobra 命令上添加 `Args` 校验器，传入位置参数时打印 usage 并报错：`positional arguments are not supported (got "hello"); pass values via flags`
- 错误使用普通 error 而非 ExitError，避免输出 JSON 信封，保持 CLI 原生体验

## Test plan
- [x] `go test ./shortcuts/common/... -run TestRejectPositionalArgs` 通过
- [x] `go test ./shortcuts/common/...` 全量通过
- [x] `go build ./...` 编译通过
- [x] 手动验证 `lark-cli docs +search "hello"` 输出 usage + 错误提示
- [x] 手动验证 `lark-cli docs +search --query "hello"` 正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shortcut commands now reject positional arguments; values must be supplied via flags. Error messages clearly state positional arguments are unsupported and display the offending values, and CLI usage is shown to guide correct input.
* **Tests**
  * Added unit tests covering no args, single arg, and multiple args to ensure consistent rejection messaging and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->