### PR TITLE
docs(mail): clarify JSON output is directly usable without extra encoding

### DIFF
--- a/skill-template/domains/mail.md
+++ b/skill-template/domains/mail.md
@@ -92,6 +92,8 @@ lark-cli mail +reply --message-id <id> --body '收到，谢谢'
 
 `+message`、`+messages`、`+thread` 默认返回 HTML 正文（`--html=true`）。仅需确认操作结果（如验证标记已读、移动文件夹是否成功）时，用 `--html=false` 跳过 HTML 正文，只返回纯文本，显著减少 token 消耗。
 
+输出默认为结构化 JSON，可直接读取，无需额外编码转换。
+
 ```bash
 # ✅ 验证操作结果：不需要 HTML
 lark-cli mail +message --message-id <id> --html=false

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -106,6 +106,8 @@ lark-cli mail +reply --message-id <id> --body '收到，谢谢'
 
 `+message`、`+messages`、`+thread` 默认返回 HTML 正文（`--html=true`）。仅需确认操作结果（如验证标记已读、移动文件夹是否成功）时，用 `--html=false` 跳过 HTML 正文，只返回纯文本，显著减少 token 消耗。
 
+输出默认为结构化 JSON，可直接读取，无需额外编码转换。
+
 ```bash
 # ✅ 验证操作结果：不需要 HTML
 lark-cli mail +message --message-id <id> --html=false

--- a/skills/lark-mail/references/lark-mail-message.md
+++ b/skills/lark-mail/references/lark-mail-message.md
@@ -154,11 +154,13 @@ lark-cli mail +message --message-id <message-id> --dry-run
 
 ## 注意事项
 
-- JSON 输出中 `body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变）。
+- **JSON 输出可直接使用** — 默认输出合法 UTF-8 JSON，可直接读取，无需额外编码转换。
+- JSON 输出中 `body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变，`jq -r` 可还原）。
 - `mail +message` 默认不再获取附件/图片下载 URL。这样可以保持邮件详情读取更轻量，调用方可按需单独请求 URL。
 - 查看原始 HTML：
 
 ```bash
+# jq -r 自动处理 JSON 转义，输出原始 HTML
 lark-cli mail +message --message-id <id> --format json | jq -r '.data.body_html'
 ```
 

--- a/skills/lark-mail/references/lark-mail-messages.md
+++ b/skills/lark-mail/references/lark-mail-messages.md
@@ -72,9 +72,10 @@ lark-cli mail +messages --message-ids <id1>,<id2> --dry-run
 
 ## 注意事项
 
+- **JSON 输出可直接使用**，可直接读取，无需额外编码转换。
 - 只需读取一封邮件时请使用 `+message`。
 - `--message-ids` 无硬性上限；shortcut 内部会自动将大列表拆分为多次批量 API 调用。
-- JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变）。
+- JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变，`jq -r` 可还原）。
 - `mail +messages` 仅返回附件元数据。如后续步骤需要下载 URL，请针对特定的 `message_id` 和 `attachment_ids` 调用原生附件 URL API。
 - 与 `+message` 一样，普通附件和内嵌图片都出现在 `messages[].attachments[]` 中，使用同一个 `user_mailbox.message.attachments download_url` API。
 

--- a/skills/lark-mail/references/lark-mail-thread.md
+++ b/skills/lark-mail/references/lark-mail-thread.md
@@ -67,7 +67,8 @@ lark-cli mail +thread --thread-id <thread-id> --dry-run
 
 ## 注意事项
 
-- JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变）。
+- **JSON 输出可直接使用**，可直接读取，无需额外编码转换。
+- JSON 输出中 `messages[].body_html` 里的 `<` / `>` 可能显示为 `\u003c` / `\u003e`（JSON 安全转义，内容不变，`jq -r` 可还原）。
 - `mail +thread` 不再在读取会话时获取附件/图片下载 URL。如后续步骤需要 URL，请针对特定的 `message_id` 和 `attachment_ids` 调用原生附件 URL API。
 - 与 `+message` 一样，普通附件和内嵌图片都出现在 `messages[].attachments[]` 中，使用同一个 `user_mailbox.message.attachments download_url` API。
 - 查看某条邮件的原始 HTML：


### PR DESCRIPTION
## Summary

Users reported that AI agents sometimes wrote shell scripts to manually extract and re-decode JSON string fields (e.g. `unicode_escape`), causing Chinese character corruption. Add notes to mail skill docs clarifying that JSON output can be read directly without additional encoding conversion.

## Changes

- `skill-template/domains/mail.md` + `SKILL.md`: add one-liner in "读取邮件" section noting JSON output is directly usable
- `references/lark-mail-message.md`: add "JSON 输出可直接使用" as first note, add `jq -r` hint for `\u003c`/`\u003e`
- `references/lark-mail-messages.md` and `lark-mail-thread.md`: add same "JSON 输出可直接使用" note

## Test Plan

- [x] Verified JSON output contains correct UTF-8 Chinese via `+message --format json`
- [x] Verified AI agent can directly read and understand JSON output without extra decoding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Clarified that JSON output from mail reading commands is directly consumable without requiring additional encoding conversions or transformation steps
* Added clear guidance on plain text output options available when verifying operation results
* Enhanced documentation explaining how special characters in mail content are represented in JSON format and how they can be processed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->