### PR TITLE
docs: add im chat member delete notes

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -87,6 +87,7 @@ lark-cli im <resource> <method> [flags] # 调用 API
 ### chat.members
 
   - `create` — 将用户或机器人拉入群聊。Identity: supports `user` and `bot`; the caller must be in the target chat; for `bot` calls, added users must be within the app's availability; for internal chats the operator must belong to the same tenant; if only owners/admins can add members, the caller must be an owner/admin, or a chat-creator bot with `im:chat:operate_as_owner`.
+  - `delete` — 将用户或机器人移出群聊。Identity: supports `user` and `bot`; only group owner, admin, or creator bot can remove others; max 50 users or 5 bots per request.
   - `get` — 获取群成员列表。Identity: supports `user` and `bot`; the caller must be in the target chat and must belong to the same tenant for internal chats.
 
 ### messages
@@ -123,6 +124,7 @@ lark-cli im <resource> <method> [flags] # 调用 API
 | `chats.list` | `im:chat:read` |
 | `chats.update` | `im:chat:update` |
 | `chat.members.create` | `im:chat.members:write_only` |
+| `chat.members.delete` | `im:chat.members:write_only` |
 | `chat.members.get` | `im:chat.members:read` |
 | `messages.delete` | `im:message:recall` |
 | `messages.forward` | `im:message` |


### PR DESCRIPTION
## Summary
- document the IM chat member delete API in the IM skill reference
- add the required scope entry for `chat.members.delete`

## Test plan
- [x] reviewed diff to ensure only `skills/lark-im/SKILL.md` is included
- [ ] no runtime tests needed for this docs-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a chat members deletion API method
  * Documented supported identities: users and bots
  * Specified allowed callers: group owner, admin, and creator bot
  * Documented batch limits: up to 50 users or 5 bots per request
  * Updated permissions table with the required API scope
<!-- end of auto-generated comment: release notes by coderabbit.ai -->