### PR TITLE
fix(mail): restore CID validation and stale PartID lookup lost in revert

### DIFF
--- a/shortcuts/mail/draft/patch.go
+++ b/shortcuts/mail/draft/patch.go
@@ -609,6 +609,9 @@ func replaceInline(snapshot *DraftSnapshot, partID, path, cid, fileName, content
 	if err := validate.RejectCRLF(finalCID, "inline cid"); err != nil {
 		return err
 	}
+	if strings.ContainsAny(finalCID, " \t<>()") {
+		return fmt.Errorf("inline cid %q contains invalid characters (spaces, tabs, angle brackets, or parentheses are not allowed)", finalCID)
+	}
 	if err := validate.RejectCRLF(fileName, "inline filename"); err != nil {
 		return err
 	}

--- a/shortcuts/mail/draft/patch_test.go
+++ b/shortcuts/mail/draft/patch_test.go
@@ -645,8 +645,8 @@ Content-Type: text/html; charset=UTF-8
 	err = Apply(snapshot, Patch{
 		Ops: []PatchOp{{Op: "set_body", Value: `<div>no image here</div>`}},
 	})
-	if err == nil {
-		t.Fatal("expected orphaned inline error after set_body dropped CID reference, got nil")
+	if err == nil || !strings.Contains(err.Error(), "orphaned cids") {
+		t.Fatalf("expected orphaned cid error, got: %v", err)
 	}
 }
 
@@ -692,6 +692,25 @@ Content-Type: text/html; charset=UTF-8
 		})
 		if err == nil {
 			t.Errorf("expected error for filename %q, got nil", bad)
+		}
+	}
+}
+
+func TestReplaceInlineRejectsInvalidCharactersInCID(t *testing.T) {
+	fixtureData := mustReadFixture(t, "testdata/html_inline_draft.eml")
+	chdirTemp(t)
+	if err := os.WriteFile("updated.png", []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	snapshot := mustParseFixtureDraft(t, fixtureData)
+	for _, bad := range []string{"my logo", "cid\there", "lo<go>id", "img(1)"} {
+		err := Apply(snapshot, Patch{
+			Ops: []PatchOp{{Op: "replace_inline", Target: AttachmentTarget{PartID: "1.2"}, Path: "updated.png", CID: bad}},
+		})
+		if err == nil {
+			t.Errorf("expected error for CID %q, got nil", bad)
+		} else if !strings.Contains(err.Error(), "invalid characters") {
+			t.Errorf("CID %q: expected 'invalid characters' error, got: %v", bad, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

The revert of PR #81 (`eda2b9c`, #199) removed the entire auto-resolve feature but also rolled back two independent bugfixes. This PR restores only those bugfixes:

- **CID character validation**: restore `strings.ContainsAny(cid, " \t<>()")` check in `newInlinePart` to reject invalid CID characters that produce malformed MIME output
- **Stale PartID lookup**: replace `findPart(snapshot.Body, snapshot.PrimaryHTMLPartID)` with `findPrimaryBodyPart(snapshot.Body, "text/html")` in `validateInlineCIDAfterApply` and `validateOrphanedInlineCIDAfterApply` to avoid stale PartID after ops restructure the MIME tree

## Test plan

- [x] `go build ./shortcuts/mail/draft/...` passes
- [x] `go test ./shortcuts/mail/draft/...` passes
- [x] Verify `add_inline` with CID containing spaces/angle brackets is correctly rejected
- [x] Verify inline CID validation still works after MIME tree restructuring ops (e.g. set_body after add_inline)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inline content identifiers (CIDs) now reject additional invalid characters (spaces, tabs, angle brackets, parentheses) and trim surrounding markers.
  * CID validation now scans the appropriate HTML section so referenced and orphaned inline resources are detected correctly after body/HTML changes.

* **Tests**
  * Added tests covering invalid CID rejection and CID validation across multipart/body updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->