### PR TITLE
feat(auth): support multiple users by upserting on login

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -303,16 +303,11 @@ func authLoginRun(opts *LoginOptions) error {
 		return output.Errorf(output.ExitInternal, "internal", "failed to save token: %v", err)
 	}
 
-	// Step 8: Update config — overwrite Users to single user, clean old tokens
+	// Step 8: Update config — upsert user, keep existing users
 	multi, _ := core.LoadMultiAppConfig()
 	if multi != nil && len(multi.Apps) > 0 {
 		app := &multi.Apps[0]
-		for _, oldUser := range app.Users {
-			if oldUser.UserOpenId != openId {
-				larkauth.RemoveStoredToken(config.AppID, oldUser.UserOpenId)
-			}
-		}
-		app.Users = []core.AppUser{{UserOpenId: openId, UserName: userName}}
+		app.Users = upsertUser(app.Users, core.AppUser{UserOpenId: openId, UserName: userName})
 		if err := core.SaveMultiAppConfig(multi); err != nil {
 			return output.Errorf(output.ExitInternal, "internal", "failed to save config: %v", err)
 		}
@@ -383,16 +378,11 @@ func authLoginPollDeviceCode(opts *LoginOptions, config *core.CliConfig, msg *lo
 		return output.Errorf(output.ExitInternal, "internal", "failed to save token: %v", err)
 	}
 
-	// Update config — overwrite Users to single user, clean old tokens
+	// Update config — upsert user, keep existing users
 	multi, _ := core.LoadMultiAppConfig()
 	if multi != nil && len(multi.Apps) > 0 {
 		app := &multi.Apps[0]
-		for _, oldUser := range app.Users {
-			if oldUser.UserOpenId != openId {
-				larkauth.RemoveStoredToken(config.AppID, oldUser.UserOpenId)
-			}
-		}
-		app.Users = []core.AppUser{{UserOpenId: openId, UserName: userName}}
+		app.Users = upsertUser(app.Users, core.AppUser{UserOpenId: openId, UserName: userName})
 		if err := core.SaveMultiAppConfig(multi); err != nil {
 			return output.Errorf(output.ExitInternal, "internal", "failed to save config: %v", err)
 		}
@@ -470,6 +460,19 @@ func shortcutSupportsIdentity(sc common.Shortcut, identity string) bool {
 		}
 	}
 	return false
+}
+
+// upsertUser inserts or updates a user in the users slice.
+// If a user with the same UserOpenId already exists, it is updated in place.
+// Otherwise the new user is appended.
+func upsertUser(users []core.AppUser, u core.AppUser) []core.AppUser {
+	for i, existing := range users {
+		if existing.UserOpenId == u.UserOpenId {
+			users[i] = u
+			return users
+		}
+	}
+	return append(users, u)
 }
 
 // suggestDomain finds the best "did you mean" match for an unknown domain.

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -52,12 +52,16 @@ func authLogoutRun(opts *LogoutOptions) error {
 		return nil
 	}
 
-	for _, user := range app.Users {
-		if err := larkauth.RemoveStoredToken(app.AppId, user.UserOpenId); err != nil {
-			fmt.Fprintf(f.IOStreams.ErrOut, "Warning: failed to remove token for %s: %v\n", user.UserOpenId, err)
-		}
+	active := core.ResolveActiveUser(app.Users)
+	if active == nil {
+		fmt.Fprintln(f.IOStreams.ErrOut, "Not logged in.")
+		return nil
 	}
-	app.Users = []core.AppUser{}
+
+	if err := larkauth.RemoveStoredToken(app.AppId, active.UserOpenId); err != nil {
+		fmt.Fprintf(f.IOStreams.ErrOut, "Warning: failed to remove token for %s: %v\n", active.UserOpenId, err)
+	}
+	app.Users = core.RemoveUser(app.Users, active.UserOpenId)
 	if err := core.SaveMultiAppConfig(multi); err != nil {
 		return output.Errorf(output.ExitInternal, "internal", "failed to save config: %v", err)
 	}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -129,11 +129,30 @@ func RequireConfig(kc keychain.KeychainAccess) (*CliConfig, error) {
 		Brand:     app.Brand,
 		DefaultAs: app.DefaultAs,
 	}
-	if len(app.Users) > 0 {
-		cfg.UserOpenId = app.Users[0].UserOpenId
-		cfg.UserName = app.Users[0].UserName
+	if u := resolveActiveUser(app.Users); u != nil {
+		cfg.UserOpenId = u.UserOpenId
+		cfg.UserName = u.UserName
 	}
 	return cfg, nil
+}
+
+// resolveActiveUser picks the active user from the list.
+// If LARKSUITE_CLI_USER_OPEN_ID is set, the matching user is returned;
+// if not found, nil is returned (caller will see "no user logged in").
+// If unset, the first user is returned.
+func resolveActiveUser(users []AppUser) *AppUser {
+	if len(users) == 0 {
+		return nil
+	}
+	if id := os.Getenv("LARKSUITE_CLI_USER_OPEN_ID"); id != "" {
+		for i := range users {
+			if users[i].UserOpenId == id {
+				return &users[i]
+			}
+		}
+		return nil // env var set but user not found — do not fall back
+	}
+	return &users[0]
 }
 
 // RequireAuth loads config and ensures a user is logged in.

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -136,10 +136,25 @@ func RequireConfig(kc keychain.KeychainAccess) (*CliConfig, error) {
 	return cfg, nil
 }
 
-// resolveActiveUser picks the active user from the list.
+// ResolveActiveUser picks the active user from the list.
 // If LARKSUITE_CLI_USER_OPEN_ID is set, the matching user is returned;
 // if not found, nil is returned (caller will see "no user logged in").
 // If unset, the first user is returned.
+func ResolveActiveUser(users []AppUser) *AppUser {
+	return resolveActiveUser(users)
+}
+
+// RemoveUser returns a new slice with the user matching openId removed.
+func RemoveUser(users []AppUser, openId string) []AppUser {
+	out := users[:0:0]
+	for _, u := range users {
+		if u.UserOpenId != openId {
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
 func resolveActiveUser(users []AppUser) *AppUser {
 	if len(users) == 0 {
 		return nil


### PR DESCRIPTION
#204 
- Replace overwrite logic with upsertUser helper: existing users with the same UserOpenId are updated in place, others are preserved.
- Add resolveActiveUser in config: respects LARKSUITE_CLI_USER_OPEN_ID env var to select the active user; falls back to first user if unset.

## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [x] Unit tests pass
- [x] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage multiple authenticated user accounts with persistent credentials.
  * Environment variable to select the active user account.

* **Changes**
  * Login now preserves existing sessions when adding or updating an account instead of replacing them.
  * Logout removes only the active account’s credentials rather than clearing all stored sessions.
  * Active-user resolution now governs authentication checks and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->