### PR TITLE
fix(docs): normalize capitalization in lark-approval skill description

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ lark-cli auth status
 | `lark-minutes`                  | Minutes metadata & AI artifacts (summary, todos, chapters)                                                     |
 | `lark-openapi-explorer`         | Explore underlying APIs from official docs                                                                     |
 | `lark-skill-maker`              | Custom skill creation framework                                                                                |
-| `lark-approval`                 | query Approval tasks, approve/reject/transfer tasks, cancel and CC instances                                   |
+| `lark-approval`                 | Query approval tasks, approve/reject/transfer tasks, cancel and CC instances                                   |
 | `lark-workflow-meeting-summary` | Workflow: meeting minutes aggregation & structured report                                                      |
 | `lark-workflow-standup-report`  | Workflow: agenda & todo summary                                                                                |
 


### PR DESCRIPTION
Lowercase "Approval" to "approval" and uppercase the leading "query" to "Query" so the description follows the same sentence-case convention.

## Summary
normalize capitalization in lark-approval skill description

## Changes
- Lowercase "Approval" to "approval" and uppercase the leading "query" to "Query" so the description follows the same sentence-case convention.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation formatting for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->