### PR TITLE
fix(im): add im:message scope for user identity send/reply

### DIFF
--- a/shortcuts/im/im_messages_reply.go
+++ b/shortcuts/im/im_messages_reply.go
@@ -20,7 +20,7 @@ var ImMessagesReply = common.Shortcut{
 	Description: "Reply to a message (supports thread replies); user/bot; supports text/markdown/post/media replies, reply-in-thread, idempotency key",
 	Risk:        "write",
 	Scopes:      []string{"im:message:send_as_bot"},
-	UserScopes:  []string{"im:message.send_as_user"},
+	UserScopes:  []string{"im:message.send_as_user", "im:message"},
 	BotScopes:   []string{"im:message:send_as_bot"},
 	AuthTypes:   []string{"bot", "user"},
 	Flags: []common.Flag{

--- a/shortcuts/im/im_messages_send.go
+++ b/shortcuts/im/im_messages_send.go
@@ -21,7 +21,7 @@ var ImMessagesSend = common.Shortcut{
 	Description: "Send a message to a chat or direct message; user/bot; sends to chat-id or user-id with text/markdown/post/media, supports idempotency key",
 	Risk:        "write",
 	Scopes:      []string{"im:message:send_as_bot"},
-	UserScopes:  []string{"im:message.send_as_user"},
+	UserScopes:  []string{"im:message.send_as_user", "im:message"},
 	BotScopes:   []string{"im:message:send_as_bot"},
 	AuthTypes:   []string{"bot", "user"},
 	Flags: []common.Flag{

--- a/skills/lark-im/references/lark-im-messages-reply.md
+++ b/skills/lark-im/references/lark-im-messages-reply.md
@@ -18,7 +18,7 @@ Replies sent by this tool are visible to other people. Before calling it, you **
 
 When using `--as bot`, the reply is sent in the app's name, so make sure the app has already been added to the target chat.
 
-When using `--as user`, the reply is sent as the authorized end user and requires the `im:message.send_as_user` scope.
+When using `--as user`, the reply is sent as the authorized end user and requires the `im:message.send_as_user` and `im:message` scopes.
 
 ## Choose The Right Content Flag
 
@@ -218,5 +218,5 @@ The reply appears in the target message's thread and does not show up in the mai
 - When using `--video`, `--video-cover` is required as the video cover
 - `--dry-run` uses placeholder image keys for remote Markdown images and placeholder media keys for local uploads
 - Failures return error codes and messages
-- `--as user` uses a user access token (UAT) and requires the `im:message.send_as_user` scope; the reply is sent as the authorized end user
+- `--as user` uses a user access token (UAT) and requires the `im:message.send_as_user` and `im:message` scopes; the reply is sent as the authorized end user
 - `--as bot` uses a tenant access token (TAT), and requires the `im:message:send_as_bot` scope

--- a/skills/lark-im/references/lark-im-messages-send.md
+++ b/skills/lark-im/references/lark-im-messages-send.md
@@ -18,7 +18,7 @@ Messages sent by this tool are visible to other people. Before calling it, you *
 
 When using `--as bot`, the message is sent in the app's name, so make sure the app has already been added to the target chat.
 
-When using `--as user`, the message is sent as the authorized end user and requires the `im:message.send_as_user` scope.
+When using `--as user`, the message is sent as the authorized end user and requires the `im:message.send_as_user` and `im:message` scopes.
 
 ## Choose The Right Content Flag
 
@@ -218,6 +218,6 @@ lark-cli im +messages-send --chat-id oc_xxx --markdown $'## Test\n\nhello' --dry
 - When using `--video`, `--video-cover` is required as the video cover
 - `--dry-run` uses placeholder image keys for remote Markdown images and placeholder media keys for local uploads
 - Failures return an error code and message
-- `--as user` uses a user access token (UAT) and requires the `im:message.send_as_user` scope; the message is sent as the authorized end user
+- `--as user` uses a user access token (UAT) and requires the `im:message.send_as_user` and `im:message` scopes; the message is sent as the authorized end user
 - `--as bot` uses a tenant access token (TAT) and requires the `im:message:send_as_bot` scope
 - When sending as a bot, the app must already be in the target group or already have a direct-message relationship with the target user


### PR DESCRIPTION
## Summary

- Add `im:message` as a required scope for user identity (`--as user`) in `+messages-send` and `+messages-reply` shortcuts
- Update skill reference docs to document both `im:message.send_as_user` and `im:message` scopes for user identity

## Changes

- `shortcuts/im/im_messages_send.go`: add `im:message` to `UserScopes`
- `shortcuts/im/im_messages_reply.go`: add `im:message` to `UserScopes`
- `skills/lark-im/references/lark-im-messages-send.md`: document `im:message` requirement for `--as user`
- `skills/lark-im/references/lark-im-messages-reply.md`: document `im:message` requirement for `--as user`

## Test Plan

- [x] Run `lark-cli im +messages-send --user-id <ou_xxx> --text "test" --as user` and verify the scope prompt includes `im:message`
- [x] Run `lark-cli im +messages-reply --message-id <om_xxx> --text "test" --as user` and verify the scope prompt includes `im:message`

🤖 Generated with [Claude Code](https://claude.com/claude-code)