### PR TITLE
feat(approval): add tenant-aware guidance when approval scope is missing

### DIFF
--- a/skills/lark-approval/SKILL.md
+++ b/skills/lark-approval/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 ## 审批权限不足时的租户兼容性分流
 
-当以 **user 身份**调用审批 API 失败，且错误原因为缺少 `approval:` 开头的 scope（如 `approval:task:read`、`approval:instance:write` 等）时，**必须先检查当前用户的 `tenant_key`** 再决定如何引导：
+当以 **user 身份**调用审批 API 失败，且错误响应的 `permission_violations` 中包含 `approval:` 开头的 scope（如 `approval:task:read`、`approval:instance:write` 等）时，**必须先检查当前用户的 `tenant_key`** 再决定如何引导：
 
 ```bash
 lark-cli contact +get-user
@@ -28,6 +28,8 @@ lark-cli contact +get-user
   不要引导用户去开发者后台添加权限，不要建议绕过方案。
 
 - **其他 `tenant_key`** → 按 `lark-shared/SKILL.md` 中的标准权限不足处理流程引导用户添加对应 scope。
+
+- **若 `lark-cli contact +get-user` 调用失败**（网络错误、缺少 `contact` 权限、返回中无 `tenant_key` 字段等）→ 按 `lark-shared/SKILL.md` 中的标准权限不足处理流程继续，不做租户分流。
 
 ---
 


### PR DESCRIPTION
## Summary
- When a user-identity approval API call fails due to a missing `approval:*` scope, the agent now checks the user's `tenant_key` via `lark-cli contact +get-user` before deciding how to guide the user.
- For a specific tenant (`736588c9260f175d`): displays a friendly "not yet supported" message instead of the standard permission-fix flow.
- For all other tenants: follows the existing `lark-shared` permission-handling logic as before.

## Motivation
Certain tenants do not yet have the approval feature enabled on the platform side. Without this change, the agent would misleadingly guide users through the standard scope-authorization flow, which would still fail. This provides a clear, actionable message instead.

## Test Plan
- [ ] Trigger an `approval:task:read` permission error as a user with `tenant_key=736588c9260f175d` → should see the "not yet supported" message
- [ ] Trigger the same error as a user with a different `tenant_key` → should see the standard permission-fix guidance
- [ ] Bot identity calls are unaffected by this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added step-by-step guidance for handling approval-API permission errors when requests use user identity, including running a user lookup and branching based on tenant support.
  * For tenants that do not support the approval skill, documentation explicitly forbids advising permission additions or bypasses.
  * For other tenants, directs users to the standard permission-scope remediation flow, with a fallback to that flow if user lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->