### PR TITLE
fix: replace os.Exit with graceful shutdown in mail watch

### DIFF
--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -259,13 +259,24 @@ var MailWatch = common.Shortcut{
 			})
 			return unsubErr
 		}
+		var unsubscribeLogOnce sync.Once
+		unsubscribeWithLog := func() {
+			unsubscribeLogOnce.Do(func() {
+				info("Unsubscribing mailbox events...")
+				if err := unsubscribe(); err != nil {
+					fmt.Fprintf(errOut, "Warning: unsubscribe failed: %v\n", err)
+				} else {
+					info("Mailbox unsubscribed.")
+				}
+			})
+		}
+		defer unsubscribeWithLog()
 
 		// Resolve "me" to the actual email address so we can filter events.
 		mailboxFilter := mailbox
 		if mailbox == "me" {
 			resolved, profileErr := fetchMailboxPrimaryEmail(runtime, "me")
 			if profileErr != nil {
-				unsubscribe() //nolint:errcheck // best-effort cleanup; primary error is profileErr
 				return enhanceProfileError(profileErr)
 			}
 			mailboxFilter = resolved
@@ -452,25 +463,12 @@ var MailWatch = common.Shortcut{
 		if err := cli.Start(watchCtx); err != nil {
 			select {
 			case <-shutdownBySignal:
-				info("Unsubscribing mailbox events...")
-				if unsubErr := unsubscribe(); unsubErr != nil {
-					fmt.Fprintf(errOut, "Warning: unsubscribe failed: %v\n", unsubErr)
-				} else {
-					info("Mailbox unsubscribed.")
-				}
 				return nil
 			default:
 			}
 			if errors.Is(err, context.Canceled) {
-				info("Unsubscribing mailbox events...")
-				if unsubErr := unsubscribe(); unsubErr != nil {
-					fmt.Fprintf(errOut, "Warning: unsubscribe failed: %v\n", unsubErr)
-				} else {
-					info("Mailbox unsubscribed.")
-				}
 				return nil
 			}
-			unsubscribe() //nolint:errcheck // best-effort cleanup
 			return output.ErrNetwork("WebSocket connection failed: %v", err)
 		}
 		return nil

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -94,6 +94,16 @@ func waitForMailWatchShutdown(startErrCh <-chan error, shutdownBySignal <-chan s
 	}
 }
 
+func finalizeMailWatchCleanup(runErr, cleanupErr error) error {
+	if cleanupErr == nil {
+		return runErr
+	}
+	if runErr != nil {
+		return runErr
+	}
+	return cleanupErr
+}
+
 var MailWatch = common.Shortcut{
 	Service:     "mail",
 	Command:     "+watch",
@@ -180,7 +190,7 @@ var MailWatch = common.Shortcut{
 		}
 		return d
 	},
-	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) (retErr error) {
 		if runtime.Bool("print-output-schema") {
 			printWatchOutputSchema(runtime)
 			return nil
@@ -278,17 +288,22 @@ var MailWatch = common.Shortcut{
 			return unsubErr
 		}
 		var unsubscribeLogOnce sync.Once
-		unsubscribeWithLog := func() error {
+		unsubscribeWithLog := func(primaryErr error) error {
 			unsubscribeLogOnce.Do(func() {
 				info("Unsubscribing mailbox events...")
 				if err := unsubscribe(); err != nil {
-					fmt.Fprintf(errOut, "Warning: unsubscribe failed: %v\n", err)
+					if primaryErr != nil {
+						fmt.Fprintf(errOut, "Warning: unsubscribe failed during cleanup: %v\n", err)
+					}
 				} else {
 					info("Mailbox unsubscribed.")
 				}
 			})
 			return unsubErr
 		}
+		defer func() {
+			retErr = finalizeMailWatchCleanup(retErr, unsubscribeWithLog(retErr))
+		}()
 		// Resolve "me" to the actual email address so we can filter events.
 		mailboxFilter := mailbox
 		if mailbox == "me" {
@@ -486,12 +501,6 @@ var MailWatch = common.Shortcut{
 		}()
 		if err := waitForMailWatchShutdown(startErrCh, shutdownBySignal); err != nil {
 			return output.ErrNetwork("WebSocket connection failed: %v", err)
-		}
-
-		// Ensure cleanup happens before returning
-		unsubErr = unsubscribeWithLog()
-		if unsubErr != nil {
-			return output.ErrSystem("Failed to unsubscribe mailbox events: %v", unsubErr)
 		}
 		return nil
 	},

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -77,6 +77,23 @@ func detectPromptInjection(content string) bool {
 	return false
 }
 
+func waitForMailWatchShutdown(startErrCh <-chan error, shutdownBySignal <-chan struct{}) error {
+	select {
+	case <-shutdownBySignal:
+		return nil
+	case err := <-startErrCh:
+		select {
+		case <-shutdownBySignal:
+			return nil
+		default:
+		}
+		if err == nil || errors.Is(err, context.Canceled) {
+			return nil
+		}
+		return err
+	}
+}
+
 var MailWatch = common.Shortcut{
 	Service:     "mail",
 	Command:     "+watch",
@@ -464,15 +481,11 @@ var MailWatch = common.Shortcut{
 		}()
 
 		info("Connected. Waiting for mail events... (Ctrl+C to stop)")
-		if err := cli.Start(watchCtx); err != nil {
-			select {
-			case <-shutdownBySignal:
-				return nil
-			default:
-			}
-			if errors.Is(err, context.Canceled) {
-				return nil
-			}
+		startErrCh := make(chan error, 1)
+		go func() {
+			startErrCh <- cli.Start(watchCtx)
+		}()
+		if err := waitForMailWatchShutdown(startErrCh, shutdownBySignal); err != nil {
 			return output.ErrNetwork("WebSocket connection failed: %v", err)
 		}
 		return nil

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -426,6 +426,12 @@ var MailWatch = common.Shortcut{
 
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		defer signal.Stop(sigCh)
+
+		watchCtx, cancelWatch := context.WithCancel(ctx)
+		defer cancelWatch()
+
+		shutdownBySignal := make(chan struct{})
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -440,12 +446,21 @@ var MailWatch = common.Shortcut{
 			} else {
 				info("Mailbox unsubscribed.")
 			}
-			signal.Stop(sigCh)
-			os.Exit(0)
+			cancelWatch()
+			close(shutdownBySignal)
 		}()
 
 		info("Connected. Waiting for mail events... (Ctrl+C to stop)")
-		if err := cli.Start(ctx); err != nil {
+		if err := cli.Start(watchCtx); err != nil {
+			select {
+			case <-shutdownBySignal:
+				return nil
+			default:
+			}
+			if errors.Is(err, context.Canceled) {
+				unsubscribe() //nolint:errcheck // best-effort cleanup
+				return nil
+			}
 			unsubscribe() //nolint:errcheck // best-effort cleanup
 			return output.ErrNetwork("WebSocket connection failed: %v", err)
 		}

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -278,7 +278,7 @@ var MailWatch = common.Shortcut{
 			return unsubErr
 		}
 		var unsubscribeLogOnce sync.Once
-		unsubscribeWithLog := func() {
+		unsubscribeWithLog := func() error {
 			unsubscribeLogOnce.Do(func() {
 				info("Unsubscribing mailbox events...")
 				if err := unsubscribe(); err != nil {
@@ -287,9 +287,8 @@ var MailWatch = common.Shortcut{
 					info("Mailbox unsubscribed.")
 				}
 			})
+			return unsubErr
 		}
-		defer unsubscribeWithLog()
-
 		// Resolve "me" to the actual email address so we can filter events.
 		mailboxFilter := mailbox
 		if mailbox == "me" {
@@ -487,6 +486,12 @@ var MailWatch = common.Shortcut{
 		}()
 		if err := waitForMailWatchShutdown(startErrCh, shutdownBySignal); err != nil {
 			return output.ErrNetwork("WebSocket connection failed: %v", err)
+		}
+
+		// Ensure cleanup happens before returning
+		unsubErr = unsubscribeWithLog()
+		if unsubErr != nil {
+			return output.ErrSystem("Failed to unsubscribe mailbox events: %v", unsubErr)
 		}
 		return nil
 	},

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -282,7 +283,7 @@ var MailWatch = common.Shortcut{
 			mailboxFilter = resolved
 		}
 
-		eventCount := 0
+		var eventCount int64
 
 		handleEvent := func(data map[string]interface{}) {
 			// Extract event body
@@ -348,7 +349,7 @@ var MailWatch = common.Shortcut{
 				}
 			}
 
-			eventCount++
+			atomic.AddInt64(&eventCount, 1)
 
 			// Prompt injection detection: warn when email body contains known injection patterns.
 			// Body fields may be base64url-encoded; decode before scanning.
@@ -451,7 +452,10 @@ var MailWatch = common.Shortcut{
 			}()
 			select {
 			case <-sigCh:
-				info(fmt.Sprintf("\nShutting down... (received %d events)", eventCount))
+				// Restore default signal behavior so a second Ctrl+C can force terminate.
+				signal.Stop(sigCh)
+				signal.Reset(os.Interrupt, syscall.SIGTERM)
+				info(fmt.Sprintf("\nShutting down... (received %d events)", atomic.LoadInt64(&eventCount)))
 				close(shutdownBySignal)
 				cancelWatch()
 			case <-watchCtx.Done():

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -446,8 +446,8 @@ var MailWatch = common.Shortcut{
 			} else {
 				info("Mailbox unsubscribed.")
 			}
-			cancelWatch()
 			close(shutdownBySignal)
+			cancelWatch()
 		}()
 
 		info("Connected. Waiting for mail events... (Ctrl+C to stop)")

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -438,27 +438,36 @@ var MailWatch = common.Shortcut{
 					fmt.Fprintf(errOut, "panic in signal handler: %v\n", r)
 				}
 			}()
-			<-sigCh
-			info(fmt.Sprintf("\nShutting down... (received %d events)", eventCount))
-			info("Unsubscribing mailbox events...")
-			if unsubErr := unsubscribe(); unsubErr != nil {
-				fmt.Fprintf(errOut, "Warning: unsubscribe failed: %v\n", unsubErr)
-			} else {
-				info("Mailbox unsubscribed.")
+			select {
+			case <-sigCh:
+				info(fmt.Sprintf("\nShutting down... (received %d events)", eventCount))
+				close(shutdownBySignal)
+				cancelWatch()
+			case <-watchCtx.Done():
+				return
 			}
-			close(shutdownBySignal)
-			cancelWatch()
 		}()
 
 		info("Connected. Waiting for mail events... (Ctrl+C to stop)")
 		if err := cli.Start(watchCtx); err != nil {
 			select {
 			case <-shutdownBySignal:
+				info("Unsubscribing mailbox events...")
+				if unsubErr := unsubscribe(); unsubErr != nil {
+					fmt.Fprintf(errOut, "Warning: unsubscribe failed: %v\n", unsubErr)
+				} else {
+					info("Mailbox unsubscribed.")
+				}
 				return nil
 			default:
 			}
 			if errors.Is(err, context.Canceled) {
-				unsubscribe() //nolint:errcheck // best-effort cleanup
+				info("Unsubscribing mailbox events...")
+				if unsubErr := unsubscribe(); unsubErr != nil {
+					fmt.Fprintf(errOut, "Warning: unsubscribe failed: %v\n", unsubErr)
+				} else {
+					info("Mailbox unsubscribed.")
+				}
 				return nil
 			}
 			unsubscribe() //nolint:errcheck // best-effort cleanup

--- a/shortcuts/mail/mail_watch_test.go
+++ b/shortcuts/mail/mail_watch_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
@@ -261,6 +262,47 @@ func TestMailWatchLoggerSuppressesDebugAlways(t *testing.T) {
 	logger.Debug(context.Background(), "debug message")
 	if got := buf.String(); got != "" {
 		t.Fatalf("expected debug suppressed, got: %q", got)
+	}
+}
+
+func TestWaitForMailWatchShutdownReturnsOnSignalWithoutStartResult(t *testing.T) {
+	startErrCh := make(chan error)
+	shutdownBySignal := make(chan struct{})
+	close(shutdownBySignal)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- waitForMailWatchShutdown(startErrCh, shutdownBySignal)
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected nil on signal shutdown, got %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("waitForMailWatchShutdown blocked after signal shutdown")
+	}
+}
+
+func TestWaitForMailWatchShutdownReturnsNilOnContextCanceled(t *testing.T) {
+	startErrCh := make(chan error, 1)
+	shutdownBySignal := make(chan struct{})
+	startErrCh <- context.Canceled
+
+	if err := waitForMailWatchShutdown(startErrCh, shutdownBySignal); err != nil {
+		t.Fatalf("expected nil for context.Canceled, got %v", err)
+	}
+}
+
+func TestWaitForMailWatchShutdownReturnsStartError(t *testing.T) {
+	startErrCh := make(chan error, 1)
+	shutdownBySignal := make(chan struct{})
+	want := assertErr("boom")
+	startErrCh <- want
+
+	if err := waitForMailWatchShutdown(startErrCh, shutdownBySignal); err != want {
+		t.Fatalf("expected original error, got %v", err)
 	}
 }
 

--- a/shortcuts/mail/mail_watch_test.go
+++ b/shortcuts/mail/mail_watch_test.go
@@ -306,6 +306,24 @@ func TestWaitForMailWatchShutdownReturnsStartError(t *testing.T) {
 	}
 }
 
+func TestFinalizeMailWatchCleanup(t *testing.T) {
+	runErr := assertErr("run failed")
+	cleanupErr := assertErr("cleanup failed")
+
+	if err := finalizeMailWatchCleanup(nil, nil); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if err := finalizeMailWatchCleanup(runErr, nil); err != runErr {
+		t.Fatalf("expected runErr when cleanup succeeds, got %v", err)
+	}
+	if err := finalizeMailWatchCleanup(nil, cleanupErr); err != cleanupErr {
+		t.Fatalf("expected cleanupErr when run succeeds, got %v", err)
+	}
+	if err := finalizeMailWatchCleanup(runErr, cleanupErr); err != runErr {
+		t.Fatalf("expected primary runErr to win, got %v", err)
+	}
+}
+
 func TestDecodeBodyFieldsForFileDecodesMessageWrapper(t *testing.T) {
 	htmlEncoded := base64.URLEncoding.EncodeToString([]byte("<h1>Hello</h1>"))
 	plainEncoded := base64.URLEncoding.EncodeToString([]byte("Hello plain"))


### PR DESCRIPTION
## Summary

- Remove `os.Exit(0)` from signal handler in `mail watch` command
- Implement graceful shutdown using `context.WithCancel` and channel signaling
- Move `signal.Stop(sigCh)` to defer for proper resource cleanup

## Problem

The `os.Exit(0)` call in the signal handler:
- Makes the code untestable (process terminates immediately)
- Bypasses deferred cleanup functions in the call stack
- Is not idiomatic for Go CLI tools

## Solution

Use a `shutdownBySignal` channel to coordinate shutdown between the signal handler and the main goroutine. The signal handler now:
1. Closes the `shutdownBySignal` channel
2. Calls `cancelWatch()` to cancel the WebSocket context

The main goroutine checks `shutdownBySignal` to distinguish between signal-triggered shutdown and actual connection errors.

## Test plan

- [x] Code review
- [x] Manual testing of `mail watch` command with Ctrl+C
- [ ] Add unit test for shutdown behavior (future work)

Closes #268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Mailbox watch now performs coordinated, cancellable shutdown: interrupt signals trigger graceful termination that cancels the watch and switches the client to a cancellable mode.
  * Unsubscribe is now idempotent and emits a single status message to avoid duplicate logs.
  * Event counting and shutdown reporting are made reliable.
  * Spurious error reports are suppressed when shutdown is user-initiated or cancelled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->