### PR TITLE
fix(base): clarify table-id tbl prefix requirement

### DIFF
--- a/shortcuts/base/base_command_common.go
+++ b/shortcuts/base/base_command_common.go
@@ -14,7 +14,7 @@ func baseTokenFlag(required bool) common.Flag {
 }
 
 func tableRefFlag(required bool) common.Flag {
-	return common.Flag{Name: "table-id", Desc: "table ID or name", Required: required}
+	return common.Flag{Name: "table-id", Desc: "table ID (must start with tbl if ID) or name", Required: required}
 }
 
 func fieldRefFlag(required bool) common.Flag {

--- a/skills/lark-base/references/lark-base-table-get.md
+++ b/skills/lark-base/references/lark-base-table-get.md
@@ -17,7 +17,7 @@ lark-cli base +table-get \
 | 参数 | 必填 | 说明 |
 |------|------|------|
 | `--base-token <token>` | 是 | Base Token |
-| `--table-id <id_or_name>` | 是 | 表 ID 或表名 |
+| `--table-id <id_or_name>` | 是 | 表 ID（`id` 必须以 `tbl` 开头）或表名 |
 
 ## API 入参详情
 
@@ -36,6 +36,7 @@ GET /open-apis/base/v3/bases/:base_token/tables/:table_id
 
 ## 坑点
 
+- ⚠️ 如果 `--table-id` 传的是 `id`，必须是 `tbl` 开头；不是的话先询问用户具体是哪张表，或先用 `+table-list` 查表列表再确认。
 - ⚠️ `--table-id` 支持传表名，但重名场景下建议优先传 `tbl_xxx`。
 
 ## 参考


### PR DESCRIPTION
## Summary
Clarifies `--table-id` usage for Base table operations by explicitly stating that when an ID is provided, it must start with `tbl`, while table names are still supported.

## Changes
- Updated shared Base shortcut flag description in `shortcuts/base/base_command_common.go` to: `table ID (must start with tbl if ID) or name`.
- Updated `skills/lark-base/references/lark-base-table-get.md` parameter docs to emphasize the `tbl` prefix rule for IDs.
- Added a pitfall note in `skills/lark-base/references/lark-base-table-get.md` to guide users to ask for the target table or run `+table-list` when input is not a valid `tbl_*` ID.

## Test Plan
- [x] Unit tests pass
- [x] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
- None
