### PR TITLE
feat(base): auto prune 5 empty rows upon base creation

### DIFF
--- a/shortcuts/base/base_create.go
+++ b/shortcuts/base/base_create.go
@@ -14,12 +14,13 @@ var BaseBaseCreate = common.Shortcut{
 	Command:     "+base-create",
 	Description: "Create a new base resource",
 	Risk:        "write",
-	Scopes:      []string{"base:app:create"},
+	Scopes:      []string{"base:app:create", "bitable:app.table:read", "bitable:app.table.record:delete"},
 	AuthTypes:   authTypes(),
 	Flags: []common.Flag{
 		{Name: "name", Desc: "base name", Required: true},
 		{Name: "folder-token", Desc: "folder token for destination"},
 		{Name: "time-zone", Desc: "time zone, e.g. Asia/Shanghai"},
+		{Name: "keep-empty-rows", Type: "bool", Default: "false", Desc: "retain the default 5 empty rows in the newly created base"},
 	},
 	DryRun: dryRunBaseCreate,
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {

--- a/shortcuts/base/base_ops.go
+++ b/shortcuts/base/base_ops.go
@@ -92,6 +92,47 @@ func executeBaseCreate(runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
-	runtime.Out(map[string]interface{}{"base": data, "created": true}, nil)
+
+	deletedTotal := 0
+	if !runtime.Bool("keep-empty-rows") {
+		var baseToken string
+		if m, ok := data["base"].(map[string]interface{}); ok {
+			baseToken, _ = m["base_token"].(string)
+		}
+		if baseToken == "" {
+			baseToken, _ = data["base_token"].(string)
+		}
+		if baseToken != "" {
+			tables, _, err := listAllTables(runtime, baseToken, 0, 10)
+			if err == nil && len(tables) > 0 {
+				defaultTableID := tableID(tables[0])
+				recordsData, err := baseV3Call(runtime, "GET", baseV3Path("bases", baseToken, "tables", defaultTableID, "records"), map[string]interface{}{"limit": 10}, nil)
+				if err == nil {
+					if rawItems, ok := recordsData["items"].([]interface{}); ok {
+						for _, item := range rawItems {
+							if recMap, ok := item.(map[string]interface{}); ok {
+								// Emptiness guard: only delete if 'fields' is strictly empty (no values filled yet)
+								fieldsMap, _ := recMap["fields"].(map[string]interface{})
+								if len(fieldsMap) == 0 {
+									if recID, ok := recMap["record_id"].(string); ok {
+										_, delErr := baseV3Call(runtime, "DELETE", baseV3Path("bases", baseToken, "tables", defaultTableID, "records", recID), nil, nil)
+										if delErr == nil {
+											deletedTotal++
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	result := map[string]interface{}{"base": data, "created": true}
+	if deletedTotal > 0 {
+		result["_pruned_records"] = deletedTotal
+	}
+	runtime.Out(result, nil)
 	return nil
 }


### PR DESCRIPTION
## Motivation / 背景动因

In scenarios where `lark-cli` is utilized within an automated pipeline (e.g., CI/CD, data scraping, syncing scripts), creating a new Base is explicitly intended for programmatic data ingestion. However, the Feishu OpenAPI inherently initializes 5 empty records in the default table of a newly created Base. 
While this is helpful for human users via the GUI to understand where to input data, it introduces significant side-effects and deterministic data order issues for scripts and developers writing to an unexpectedly "dirty" table.

在自动化的工作流场景中（如爬虫同步、数据自动化录入等），开发者通过 `lark-cli` 创建一个全新的多维表格（Base），其唯一目的就是提供一个结构化的、干净的数据底座以便后续程序化定点写入数据。然而，受限于飞书平台层的默认行为，新建的 Base 内部第一张默认表会自动生成 5 行空数据。这对机器脚本而言是非常破坏性的（会导致新插数据行号偏移或数据完整层面的错乱）。

## Proposed Solution / 解决方案

This PR implements an orchestrating "cleanup" phase internally attached to the `executeBaseCreate` workflow:
1. Adds a `--keep-empty-rows` boolean flag (defaults to `false`), maintaining zero-config convenience while pruning records by default.
2. Upon successful Base creation, the CLI will transparently retrieve the default table and purge up to 10 empty records initialization rows.
3. Added the corresponding required scopes (`bitable:app.table:read` & `bitable:app.table.record:delete`) into the base create command definitions to ensure seamless permissions.
4. Any errors encountered during the cleanup phase are gracefully swallowed to guarantee that the primary `create` command remains successful regardless of unexpected permission restrictions.

本 PR 包含以下优化，主要是在 `executeBaseCreate` 中挂载了尽力而为的静默后置清理操作：
1. 为 `lark-cli base +base-create` 命令追加 `--keep-empty-rows` 退出选项（默认 `false`，即遵循“机器建表必须干净”的潜规则）。
2. 在原先的创建 API (`POST`) 成功且返回 Token 后，利用已封装完成的底层方法，找到产生的首张表执行 `GET records` 后遍历 `DELETE` 以实现秒级“自清理”。
3. 补充了默认命令声明所需的读表/删记录的底层安全 Scope 集合。
4. 在该后处理逻辑中进行了极高容忍度的容错保护，任意异常均绝不会阻塞“建表成功”这一核心响应。

**Type:** `feat` (DX improvement)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `keep-empty-rows` flag (default: false) to control whether default placeholder rows are preserved after creating a new base.

* **Bug Fixes / Improvements**
  * By default, newly created bases now automatically prune placeholder empty rows.
  * Creation proceeds even if cleanup encounters errors.
  * Creation output now includes a count of pruned rows when any were removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->