### PR TITLE
fix(registry): don't fallback embeddedMetaJSON to default empty JSON

### DIFF
--- a/internal/registry/loader_embedded.go
+++ b/internal/registry/loader_embedded.go
@@ -14,7 +14,8 @@ var embeddedMetaDataDefaultJSON []byte
 func init() {
 	if data, err := metaFS.ReadFile("meta_data.json"); err == nil && len(data) > 0 {
 		embeddedMetaJSON = data
-	} else {
-		embeddedMetaJSON = embeddedMetaDataDefaultJSON
 	}
+	// When meta_data.json is not compiled in, embeddedMetaJSON remains nil,
+	// so hasEmbeddedData() correctly returns false and tests that depend on
+	// real embedded services will be skipped rather than failing.
 }


### PR DESCRIPTION
## Summary

- `loader_embedded.go` was setting `embeddedMetaJSON` to the default empty JSON (`{"version":"0.0.0","services":[]}`) when `meta_data.json` is not compiled in
- This caused `hasEmbeddedData()` to return `true` (34 bytes > 0), even though there were no real services
- As a result, two tests failed instead of being correctly skipped:
  - `TestColdStart_UsesEmbedded`: failed with "expected embedded projects, got none"
  - `TestCacheHit_WithinTTL`: failed with "expected calendar from embedded data"

## Fix

Remove the `else` fallback so `embeddedMetaJSON` remains `nil` when no real `meta_data.json` is present. `hasEmbeddedData()` then correctly returns `false` and dependent tests skip as intended.

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./...` — no warnings
- [x] `TestColdStart_UsesEmbedded` — now correctly SKIP (was FAIL)
- [x] `TestCacheHit_WithinTTL` — now PASS (was FAIL)
- [x] All other tests — still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing embedded metadata. The system now properly detects when metadata is unavailable instead of applying default fallback values, enabling more accurate downstream behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->