### PR TITLE
docs(im): Document critical Feishu Markdown silent drop limitations

### DIFF
--- a/skills/lark-im/references/lark-im-messages-send.md
+++ b/skills/lark-im/references/lark-im-messages-send.md
@@ -57,6 +57,9 @@ This means `--markdown` is convenient, but it is not a full-fidelity Markdown tr
 - It does **not** promise full CommonMark / GitHub Flavored Markdown support.
 - It always becomes a `post` payload with a single `zh_cn` locale.
 - It does **not** let you set a `post` title. If you need a title, use `--msg-type post --content ...`.
+- **Link parsing restrictions (Critical for silent drops):**
+    - Non-HTTP(S) URL schemes (e.g. `[query](from:user)`) are strictly forbidden and will cause the link (or sometimes the whole paragraph) to be silently dropped by the Feishu client.
+    - **No bold nested links**: Feishu's Markdown parser will silently destroy links if they are wrapped inside bold tags. Never write `**[Title](https://...)**`. Instead, place them outside like `**Item.** [Title](https://...)`.
 - Headings are rewritten:
     - `# Title` becomes `#### Title`
     - `##` to `######` are normalized to `#####` when the content contains H1-H3


### PR DESCRIPTION
This PR adds critical documentation to the `im +messages-send` shortcut regarding Feishu's Markdown parser limitations.

Specifically, it warns users about two silent message drop conditions:
1. Using non-HTTP(S) schemas in Markdown links (e.g. `[query](from:user)`) triggering client-side dropping.
2. Nesting links inside bold tags (`**[title](url)**`), which strips the link completely in the native Feishu Post renderer.

These additions will prevent other agents and CLI users from generating malformed markdown that quietly breaks rendering without raising an API error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated link formatting guidance for Lark IM messages with new parsing restrictions and caveats.
  * Documented that bold-wrapped links may be silently dropped and provided alternative formatting patterns.
  * Clarified supported URL schemes in Markdown links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->