### PR TITLE
docs: clarify lark task guid usage

### DIFF
--- a/skills/lark-task/references/lark-task-assign.md
+++ b/skills/lark-task/references/lark-task-assign.md
@@ -8,20 +8,20 @@ Assign or remove members (assignees) from a task.
 
 ```bash
 # Add an assignee
-lark-cli task +assign --task-id "t_xxx" --add "ou_aaa"
+lark-cli task +assign --task-id "<task_guid>" --add "ou_aaa"
 
 # Transfer an assignee (remove old, add new)
-lark-cli task +assign --task-id "t_xxx" --remove "ou_old" --add "ou_new"
+lark-cli task +assign --task-id "<task_guid>" --remove "ou_old" --add "ou_new"
 
 # Add multiple assignees
-lark-cli task +assign --task-id "t_xxx" --add "ou_aaa,ou_bbb"
+lark-cli task +assign --task-id "<task_guid>" --add "ou_aaa,ou_bbb"
 ```
 
 ## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--task-id <id>` | Yes | The ID of the task to modify. |
+| `--task-id <guid>` | Yes | The task GUID to modify. For Feishu task applinks, use the `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
 | `--add <ids>` | No | Comma-separated list of user `open_id`s to add as assignees. |
 | `--remove <ids>` | No | Comma-separated list of user `open_id`s to remove from assignees. |
 
@@ -33,4 +33,3 @@ lark-cli task +assign --task-id "t_xxx" --add "ou_aaa,ou_bbb"
 
 > [!CAUTION]
 > This is a **Write Operation** -- You must confirm the user's intent before executing.
-EOF~

--- a/skills/lark-task/references/lark-task-comment.md
+++ b/skills/lark-task/references/lark-task-comment.md
@@ -8,14 +8,14 @@ Add a comment to an existing task.
 
 ```bash
 # Add a comment
-lark-cli task +comment --task-id "t_xxx" --content "Looks good!"
+lark-cli task +comment --task-id "<task_guid>" --content "Looks good!"
 ```
 
 ## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--task-id <id>` | Yes | The ID of the task to comment on. |
+| `--task-id <guid>` | Yes | The task GUID to comment on. For Feishu task applinks, use the `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
 | `--content <text>` | Yes | The text content of the comment. |
 
 ## Workflow

--- a/skills/lark-task/references/lark-task-complete.md
+++ b/skills/lark-task/references/lark-task-complete.md
@@ -8,14 +8,14 @@ Mark a task as completed.
 
 ```bash
 # Complete a task
-lark-cli task +complete --task-id "t_xxx"
+lark-cli task +complete --task-id "<task_guid>"
 ```
 
 ## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--task-id <id>` | Yes | The ID of the task to complete. |
+| `--task-id <guid>` | Yes | The task GUID to complete. For Feishu task applinks, use the `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
 
 ## Workflow
 

--- a/skills/lark-task/references/lark-task-followers.md
+++ b/skills/lark-task/references/lark-task-followers.md
@@ -8,17 +8,17 @@ Manage task followers. Add or remove followers from an existing task.
 
 ```bash
 # Add a follower
-lark-cli task +followers --task-id "t_xxx" --add "ou_aaa"
+lark-cli task +followers --task-id "<task_guid>" --add "ou_aaa"
 
 # Remove a follower
-lark-cli task +followers --task-id "t_xxx" --remove "ou_aaa"
+lark-cli task +followers --task-id "<task_guid>" --remove "ou_aaa"
 ```
 
 ## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--task-id <id>` | Yes | The ID of the task to modify. |
+| `--task-id <guid>` | Yes | The task GUID to modify. For Feishu task applinks, use the `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
 | `--add <ids>` | No | Comma-separated list of user `open_id`s to add as followers. |
 | `--remove <ids>` | No | Comma-separated list of user `open_id`s to remove from followers. |
 

--- a/skills/lark-task/references/lark-task-reminder.md
+++ b/skills/lark-task/references/lark-task-reminder.md
@@ -9,20 +9,20 @@ Manage task reminders. Set new reminders or remove existing ones. Note that sett
 
 ```bash
 # Set a reminder (e.g., 30 minutes before due)
-lark-cli task +reminder --task-id "t_xxx" --set "30"
+lark-cli task +reminder --task-id "<task_guid>" --set "30"
 
 # Set a reminder (e.g., 1 hour before due)
-lark-cli task +reminder --task-id "t_xxx" --set "1h"
+lark-cli task +reminder --task-id "<task_guid>" --set "1h"
 
 # Remove all reminders
-lark-cli task +reminder --task-id "t_xxx" --remove "true"
+lark-cli task +reminder --task-id "<task_guid>" --remove "true"
 ```
 
 ## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--task-id <id>` | Yes | The ID of the task to modify. |
+| `--task-id <guid>` | Yes | The task GUID to modify. For Feishu task applinks, use the `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
 | `--set <val>` | No | Relative fire minutes before the due time. Supports numbers (e.g., `30`) or units (e.g., `15m`, `1h`, `1d`). |
 | `--remove <bool>` | No | If set to `true`, removes all existing reminders from the task. |
 

--- a/skills/lark-task/references/lark-task-reopen.md
+++ b/skills/lark-task/references/lark-task-reopen.md
@@ -8,14 +8,14 @@ Reopen a previously completed task.
 
 ```bash
 # Reopen a task
-lark-cli task +reopen --task-id "t_xxx"
+lark-cli task +reopen --task-id "<task_guid>"
 ```
 
 ## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--task-id <id>` | Yes | The ID of the task to reopen. |
+| `--task-id <guid>` | Yes | The task GUID to reopen. For Feishu task applinks, use the `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
 
 ## Workflow
 

--- a/skills/lark-task/references/lark-task-tasklist-task-add.md
+++ b/skills/lark-task/references/lark-task-tasklist-task-add.md
@@ -8,18 +8,18 @@ Add existing tasks to a tasklist.
 
 ```bash
 # Add a single task to a tasklist
-lark-cli task +tasklist-task-add --tasklist-id "tl_xxx" --task-id "t_aaa"
+lark-cli task +tasklist-task-add --tasklist-id "<tasklist_guid>" --task-id "<task_guid>"
 
 # Add multiple tasks to a tasklist
-lark-cli task +tasklist-task-add --tasklist-id "tl_xxx" --task-id "t_aaa,t_bbb,t_ccc"
+lark-cli task +tasklist-task-add --tasklist-id "<tasklist_guid>" --task-id "<task_guid>,<another_task_guid>,<third_task_guid>"
 ```
 
 ## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--tasklist-id <id>` | Yes | The GUID of the tasklist, or a full AppLink URL. |
-| `--task-id <ids>` | Yes | Comma-separated list of task IDs to add to the tasklist. |
+| `--tasklist-id <guid>` | Yes | The GUID of the tasklist, or a full AppLink URL. |
+| `--task-id <guids>` | Yes | Comma-separated list of task GUIDs to add to the tasklist. For Feishu task applinks, use each task's `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
 
 ## Workflow
 

--- a/skills/lark-task/references/lark-task-update.md
+++ b/skills/lark-task/references/lark-task-update.md
@@ -8,20 +8,20 @@ Update an existing task in Lark.
 
 ```bash
 # Update task summary
-lark-cli task +update --task-id "t_xxx" --summary "New Summary"
+lark-cli task +update --task-id "<task_guid>" --summary "New Summary"
 
 # Update multiple tasks' due dates
-lark-cli task +update --task-id "t_xxx,t_yyy" --due "+2d"
+lark-cli task +update --task-id "<task_guid>,<another_task_guid>" --due "+2d"
 
 # Update with JSON data
-lark-cli task +update --task-id "t_xxx" --data '{"description": "New description"}'
+lark-cli task +update --task-id "<task_guid>" --data '{"description": "New description"}'
 ```
 
 ## Parameters
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `--task-id <id>` | Yes | The ID of the task to update. Comma-separated list supported for multiple tasks. |
+| `--task-id <guid>` | Yes | The task GUID to update. Comma-separated task GUIDs are supported for multiple tasks. For Feishu task applinks, use the `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
 | `--summary <text>` | No | New summary/title for the task. |
 | `--description <text>` | No | New description for the task. |
 | `--due <time>` | No | New due date (supports relative time). |


### PR DESCRIPTION
## Summary
Clarify that the `lark-cli task` shortcut flag `--task-id` expects a task GUID, not the Feishu display task ID from `suite_entity_num`. This prevents agents and users from passing values like `t104121` to task shortcut commands.

## Changes
- Replace task ID examples with `<task_guid>` placeholders for `+assign`, `+comment`, `+followers`, `+complete`, `+reopen`, `+reminder`, `+update`, and `+tasklist-task-add`.
- Document that Feishu task applinks should use the `guid` query parameter instead of `suite_entity_num` / display task IDs like `t104121`.
- Keep tasklist examples on tasklist GUID terminology where appropriate.
- Remove a stray `EOF~` marker from the assign reference.

## Test Plan
- [x] `node scripts/skill-format-check/index.js`
- [x] `git diff --check`
- [x] `docker run --rm -v "$PWD":/workspace -v /tmp/larksuite-cli-go-cache/mod:/go/pkg/mod -v /tmp/larksuite-cli-go-cache/build:/root/.cache/go-build -w /workspace golang:1.23.9-bookworm go test -race -gcflags="all=-N -l" -count=1 ./shortcuts/task/...`
- [x] Dry-run checked `task +complete`, `task +reopen`, `task +reminder`, `task +update`, and `task +tasklist-task-add`; each command places `--task-id` in `/open-apis/task/v2/tasks/{task_guid}`.
- [ ] `make unit-test` (attempted in Docker; currently fails in unrelated `shortcuts/minutes` download URL tests with `blocked download URL: local/internal host is not allowed`)

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that task identifiers should be GUIDs (not display IDs) and updated examples across task commands (assign, comment, followers, complete, reminder, reopen, update, tasklist-task-add).
  * Updated tasklist-related examples to use GUIDs where applicable.
  * Added explicit note to use the Feishu applink "guid" query parameter for tasks.
  * Minor formatting/cleanup fixes to documentation examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->