### PR TITLE
feat: add claude plugin manifests and repo install docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "larksuite-cli-marketplace",
+  "owner": {
+    "name": "larksuite"
+  },
+  "metadata": {
+    "description": "Official Claude Code marketplace for the Lark CLI skill bundle."
+  },
+  "plugins": [
+    {
+      "name": "larksuite/cli",
+      "source": "./",
+      "description": "Official Claude Code plugin bundle for Lark CLI skills."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "larksuite/cli",
+  "version": "1.0.4",
+  "description": "The official CLI for Lark/Feishu open platform",
+  "author": "Lark Open Platform",
+  "homepage": "https://github.com/larksuite/cli",
+  "repository": "git+https://github.com/larksuite/cli.git",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "lark",
+    "feishu",
+    "skills"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ Before you start, make sure you have:
 
 #### Install
 
-Choose **one** CLI installation method, then install the Claude Code plugin.
+Install the CLI first. If you use Claude Code, then install the plugin.
+
+**Step 1 — Install the CLI (choose one):**
 
 **Option 1 — From npm (recommended):**
 
@@ -60,14 +62,7 @@ Choose **one** CLI installation method, then install the Claude Code plugin.
 npm install -g @larksuite/cli
 ```
 
-**Option 2 — Install the Claude Code plugin (repo-first, recommended)**
-
-```bash
-claude plugin marketplace add larksuite/cli
-claude plugin install larksuite/cli@larksuite-cli-marketplace
-```
-
-**Option 3 — From source:**
+**Option 2 — From source:**
 
 Requires Go `v1.23`+ and Python 3.
 
@@ -75,6 +70,13 @@ Requires Go `v1.23`+ and Python 3.
 git clone https://github.com/larksuite/cli.git
 cd cli
 make install
+```
+
+**Step 2 — Install the Claude Code plugin (recommended for Claude Code users):**
+
+```bash
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```
 
 **Compatibility / fallback — install legacy standalone skills**
@@ -143,7 +145,7 @@ lark-cli auth login --recommend
 
 ```bash
 lark-cli auth status
-claude plugin validate .
+claude plugin list
 ```
 
 ## Agent Skills

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ npm install -g @larksuite/cli
 
 # Install CLI SKILL (required)
 npx skills add larksuite/cli -y -g
+
+# Another option, install Claude Code SKILL
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```
 
 **Option 2 — From source:**
@@ -75,6 +79,10 @@ make install
 
 # Install CLI SKILL (required)
 npx skills add larksuite/cli -y -g
+
+# Another option, install Claude Code SKILL
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```
 
 #### Configure & Use
@@ -102,6 +110,10 @@ npm install -g @larksuite/cli
 
 # Install CLI SKILL (required)
 npx skills add larksuite/cli -y -g
+
+# If you are Claude Code, you can install it directly
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```
 
 **Step 2 — Configure app credentials**

--- a/README.md
+++ b/README.md
@@ -52,19 +52,22 @@ Before you start, make sure you have:
 
 #### Install
 
-Choose **one** of the following methods:
+Choose **one** CLI installation method, then install the Claude Code plugin.
 
 **Option 1 — From npm (recommended):**
 
 ```bash
-# Install CLI
 npm install -g @larksuite/cli
-
-# Install CLI SKILL (required)
-npx skills add larksuite/cli -y -g
 ```
 
-**Option 2 — From source:**
+**Option 2 — Install the Claude Code plugin (repo-first, recommended)**
+
+```bash
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
+```
+
+**Option 3 — From source:**
 
 Requires Go `v1.23`+ and Python 3.
 
@@ -72,9 +75,14 @@ Requires Go `v1.23`+ and Python 3.
 git clone https://github.com/larksuite/cli.git
 cd cli
 make install
+```
 
-# Install CLI SKILL (required)
-npx skills add larksuite/cli -y -g
+**Compatibility / fallback — install legacy standalone skills**
+
+Use this only if you cannot use the Claude plugin workflow yet.
+
+```bash
+npx skills add larksuite/cli -g -y
 ```
 
 #### Configure & Use
@@ -94,17 +102,28 @@ lark-cli calendar +agenda
 
 > The following steps are for AI Agents. Some steps require the user to complete actions in a browser.
 
-**Step 1 — Install**
+**Step 1 — Install the Claude Code plugin (repo-first, recommended)**
 
 ```bash
-# Install CLI
-npm install -g @larksuite/cli
-
-# Install CLI SKILL (required)
-npx skills add larksuite/cli -y -g
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```
 
-**Step 2 — Configure app credentials**
+**Step 2 — Install the CLI binary**
+
+```bash
+npm install -g @larksuite/cli
+```
+
+**Compatibility / fallback — install legacy standalone skills**
+
+Use this only if the Claude plugin workflow is not available yet.
+
+```bash
+npx skills add larksuite/cli -g -y
+```
+
+**Step 3 — Configure app credentials**
 
 > Run this command in the background. It will output an authorization URL — extract it and send it to the user. The command exits automatically after the user completes the setup in the browser.
 
@@ -112,7 +131,7 @@ npx skills add larksuite/cli -y -g
 lark-cli config init --new
 ```
 
-**Step 3 — Login**
+**Step 4 — Login**
 
 > Same as above: run in the background, extract the authorization URL and send it to the user.
 
@@ -120,10 +139,11 @@ lark-cli config init --new
 lark-cli auth login --recommend
 ```
 
-**Step 4 — Verify**
+**Step 5 — Verify**
 
 ```bash
 lark-cli auth status
+claude plugin validate .
 ```
 
 ## Agent Skills

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ npm install -g @larksuite/cli
 # Install CLI SKILL (required)
 npx skills add larksuite/cli -y -g
 
-# If you are Claude Code, you can install it directly
+# If you are using Claude Code, you can install the plugin with the following commands:
 claude plugin marketplace add larksuite/cli
 claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```

--- a/README.md
+++ b/README.md
@@ -52,14 +52,16 @@ Before you start, make sure you have:
 
 #### Install
 
-Install the CLI first. If you use Claude Code, then install the plugin.
-
-**Step 1 — Install the CLI (choose one):**
+Choose **one** of the following methods:
 
 **Option 1 — From npm (recommended):**
 
 ```bash
+# Install CLI
 npm install -g @larksuite/cli
+
+# Install CLI SKILL (required)
+npx skills add larksuite/cli -y -g
 ```
 
 **Option 2 — From source:**
@@ -70,21 +72,9 @@ Requires Go `v1.23`+ and Python 3.
 git clone https://github.com/larksuite/cli.git
 cd cli
 make install
-```
 
-**Step 2 — Install the Claude Code plugin (recommended for Claude Code users):**
-
-```bash
-claude plugin marketplace add larksuite/cli
-claude plugin install larksuite/cli@larksuite-cli-marketplace
-```
-
-**Compatibility / fallback — install legacy standalone skills**
-
-Use this only if you cannot use the Claude plugin workflow yet.
-
-```bash
-npx skills add larksuite/cli -g -y
+# Install CLI SKILL (required)
+npx skills add larksuite/cli -y -g
 ```
 
 #### Configure & Use
@@ -104,28 +94,17 @@ lark-cli calendar +agenda
 
 > The following steps are for AI Agents. Some steps require the user to complete actions in a browser.
 
-**Step 1 — Install the Claude Code plugin (repo-first, recommended)**
+**Step 1 — Install**
 
 ```bash
-claude plugin marketplace add larksuite/cli
-claude plugin install larksuite/cli@larksuite-cli-marketplace
-```
-
-**Step 2 — Install the CLI binary**
-
-```bash
+# Install CLI
 npm install -g @larksuite/cli
+
+# Install CLI SKILL (required)
+npx skills add larksuite/cli -y -g
 ```
 
-**Compatibility / fallback — install legacy standalone skills**
-
-Use this only if the Claude plugin workflow is not available yet.
-
-```bash
-npx skills add larksuite/cli -g -y
-```
-
-**Step 3 — Configure app credentials**
+**Step 2 — Configure app credentials**
 
 > Run this command in the background. It will output an authorization URL — extract it and send it to the user. The command exits automatically after the user completes the setup in the browser.
 
@@ -133,7 +112,7 @@ npx skills add larksuite/cli -g -y
 lark-cli config init --new
 ```
 
-**Step 4 — Login**
+**Step 3 — Login**
 
 > Same as above: run in the background, extract the authorization URL and send it to the user.
 
@@ -141,11 +120,10 @@ lark-cli config init --new
 lark-cli auth login --recommend
 ```
 
-**Step 5 — Verify**
+**Step 4 — Verify**
 
 ```bash
 lark-cli auth status
-claude plugin list
 ```
 
 ## Agent Skills

--- a/README.zh.md
+++ b/README.zh.md
@@ -52,7 +52,9 @@
 
 #### 安装
 
-选择 **一种** CLI 安装方式，然后安装 Claude Code 插件。
+先安装 CLI。如果你使用 Claude Code，再安装插件。
+
+**第 1 步 — 安装 CLI（任选一种）：**
 
 **方式一 — 从 npm 安装（推荐）：**
 
@@ -60,14 +62,7 @@
 npm install -g @larksuite/cli
 ```
 
-**方式二 — 安装 Claude Code 插件（repo-first，推荐）**
-
-```bash
-claude plugin marketplace add larksuite/cli
-claude plugin install larksuite/cli@larksuite-cli-marketplace
-```
-
-**方式三 — 从源码安装：**
+**方式二 — 从源码安装：**
 
 需要 Go `v1.23`+ 和 Python 3。
 
@@ -75,6 +70,13 @@ claude plugin install larksuite/cli@larksuite-cli-marketplace
 git clone https://github.com/larksuite/cli.git
 cd cli
 make install
+```
+
+**第 2 步 — 安装 Claude Code 插件（Claude Code 用户推荐）：**
+
+```bash
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```
 
 **兼容 / 回退方案 — 安装旧版 standalone skills**
@@ -143,7 +145,7 @@ lark-cli auth login --recommend
 
 ```bash
 lark-cli auth status
-claude plugin validate .
+claude plugin list
 ```
 
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -111,7 +111,7 @@ npm install -g @larksuite/cli
 # 安装 CLI SKILL（必需）
 npx skills add larksuite/cli -y -g
 
-# 如果你使用的是 Claude Code，可以直接安装
+# 如果你使用的是 Claude Code，可以通过以下命令安装插件：
 claude plugin marketplace add larksuite/cli
 claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -62,6 +62,10 @@ npm install -g @larksuite/cli
 
 # 安装 CLI SKILL（必需）
 npx skills add larksuite/cli -y -g
+
+# 或者，安装 Claude Code SKILL
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```
 
 **方式二 — 从源码安装：**
@@ -75,6 +79,10 @@ make install
 
 # 安装 CLI SKILL（必需）
 npx skills add larksuite/cli -y -g
+
+# 或者，安装 Claude Code SKILL
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```
 
 #### 配置与使用
@@ -102,6 +110,10 @@ npm install -g @larksuite/cli
 
 # 安装 CLI SKILL（必需）
 npx skills add larksuite/cli -y -g
+
+# 如果你使用的是 Claude Code，可以直接安装
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```
 
 **第 2 步 — 配置应用凭证**

--- a/README.zh.md
+++ b/README.zh.md
@@ -52,14 +52,16 @@
 
 #### 安装
 
-先安装 CLI。如果你使用 Claude Code，再安装插件。
-
-**第 1 步 — 安装 CLI（任选一种）：**
+以下两种方式**任选其一**：
 
 **方式一 — 从 npm 安装（推荐）：**
 
 ```bash
+# 安装 CLI
 npm install -g @larksuite/cli
+
+# 安装 CLI SKILL（必需）
+npx skills add larksuite/cli -y -g
 ```
 
 **方式二 — 从源码安装：**
@@ -70,21 +72,9 @@ npm install -g @larksuite/cli
 git clone https://github.com/larksuite/cli.git
 cd cli
 make install
-```
 
-**第 2 步 — 安装 Claude Code 插件（Claude Code 用户推荐）：**
-
-```bash
-claude plugin marketplace add larksuite/cli
-claude plugin install larksuite/cli@larksuite-cli-marketplace
-```
-
-**兼容 / 回退方案 — 安装旧版 standalone skills**
-
-仅当暂时无法使用 Claude 插件工作流时再使用：
-
-```bash
-npx skills add larksuite/cli -g -y
+# 安装 CLI SKILL（必需）
+npx skills add larksuite/cli -y -g
 ```
 
 #### 配置与使用
@@ -100,32 +90,21 @@ lark-cli auth login --recommend
 lark-cli calendar +agenda
 ```
 
-## 快速开始（AI Agent）
+### 快速开始（AI Agent）
 
 > 以下步骤面向 AI Agent，部分步骤需要用户在浏览器中配合完成。
 
-**第 1 步 — 安装 Claude Code 插件（repo-first，推荐）**
+**第 1 步 — 安装**
 
 ```bash
-claude plugin marketplace add larksuite/cli
-claude plugin install larksuite/cli@larksuite-cli-marketplace
-```
-
-**第 2 步 — 安装 CLI 二进制**
-
-```bash
+# 安装 CLI
 npm install -g @larksuite/cli
+
+# 安装 CLI SKILL（必需）
+npx skills add larksuite/cli -y -g
 ```
 
-**兼容 / 回退方案 — 安装旧版 standalone skills**
-
-仅当 Claude 插件工作流暂不可用时再使用：
-
-```bash
-npx skills add larksuite/cli -g -y
-```
-
-**第 3 步 — 配置应用凭证**
+**第 2 步 — 配置应用凭证**
 
 > 在后台运行此命令，命令会输出一个授权链接，提取该链接并发送给用户，用户在浏览器中完成配置后命令会自动退出。
 
@@ -133,7 +112,7 @@ npx skills add larksuite/cli -g -y
 lark-cli config init --new
 ```
 
-**第 4 步 — 登录**
+**第 3 步 — 登录**
 
 > 同上，后台运行，提取授权链接发给用户。
 
@@ -141,11 +120,10 @@ lark-cli config init --new
 lark-cli auth login --recommend
 ```
 
-**第 5 步 — 验证**
+**第 4 步 — 验证**
 
 ```bash
 lark-cli auth status
-claude plugin list
 ```
 
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -52,19 +52,22 @@
 
 #### 安装
 
-以下两种方式**任选其一**：
+选择 **一种** CLI 安装方式，然后安装 Claude Code 插件。
 
 **方式一 — 从 npm 安装（推荐）：**
 
 ```bash
-# 安装 CLI
 npm install -g @larksuite/cli
-
-# 安装 CLI SKILL（必需）
-npx skills add larksuite/cli -y -g
 ```
 
-**方式二 — 从源码安装：**
+**方式二 — 安装 Claude Code 插件（repo-first，推荐）**
+
+```bash
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
+```
+
+**方式三 — 从源码安装：**
 
 需要 Go `v1.23`+ 和 Python 3。
 
@@ -72,9 +75,14 @@ npx skills add larksuite/cli -y -g
 git clone https://github.com/larksuite/cli.git
 cd cli
 make install
+```
 
-# 安装 CLI SKILL（必需）
-npx skills add larksuite/cli -y -g
+**兼容 / 回退方案 — 安装旧版 standalone skills**
+
+仅当暂时无法使用 Claude 插件工作流时再使用：
+
+```bash
+npx skills add larksuite/cli -g -y
 ```
 
 #### 配置与使用
@@ -90,21 +98,32 @@ lark-cli auth login --recommend
 lark-cli calendar +agenda
 ```
 
-### 快速开始（AI Agent）
+## 快速开始（AI Agent）
 
 > 以下步骤面向 AI Agent，部分步骤需要用户在浏览器中配合完成。
 
-**第 1 步 — 安装**
+**第 1 步 — 安装 Claude Code 插件（repo-first，推荐）**
 
 ```bash
-# 安装 CLI
-npm install -g @larksuite/cli
-
-# 安装 CLI SKILL（必需）
-npx skills add larksuite/cli -y -g
+claude plugin marketplace add larksuite/cli
+claude plugin install larksuite/cli@larksuite-cli-marketplace
 ```
 
-**第 2 步 — 配置应用凭证**
+**第 2 步 — 安装 CLI 二进制**
+
+```bash
+npm install -g @larksuite/cli
+```
+
+**兼容 / 回退方案 — 安装旧版 standalone skills**
+
+仅当 Claude 插件工作流暂不可用时再使用：
+
+```bash
+npx skills add larksuite/cli -g -y
+```
+
+**第 3 步 — 配置应用凭证**
 
 > 在后台运行此命令，命令会输出一个授权链接，提取该链接并发送给用户，用户在浏览器中完成配置后命令会自动退出。
 
@@ -112,7 +131,7 @@ npx skills add larksuite/cli -y -g
 lark-cli config init --new
 ```
 
-**第 3 步 — 登录**
+**第 4 步 — 登录**
 
 > 同上，后台运行，提取授权链接发给用户。
 
@@ -120,10 +139,11 @@ lark-cli config init --new
 lark-cli auth login --recommend
 ```
 
-**第 4 步 — 验证**
+**第 5 步 — 验证**
 
 ```bash
 lark-cli auth status
+claude plugin validate .
 ```
 
 


### PR DESCRIPTION
## Summary
- add root `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` so the repository exposes a Claude Code plugin bundle
- update English and Chinese README install docs to clarify CLI vs plugin setup and use `claude plugin list` for agent verification
- keep the change set focused on plugin manifests and install documentation

## Test plan
- [x] Review `.claude-plugin/plugin.json`
- [x] Review `.claude-plugin/marketplace.json`
- [x] Verify install instructions in `README.md` and `README.zh.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude Code marketplace registration for the Lark CLI plugin (v1.0.4), enabling marketplace discovery and installation.

* **Documentation**
  * Added Claude Code install steps to installation and quick-start guides for both human and AI-agent workflows.
  * Clarified standalone installation fallback and updated privacy link/ending newline in README files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->