### PR TITLE
fix(help): point root help Agent Skills link to README section

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,7 +78,7 @@ AI AGENT SKILLS:
         npx skills add larksuite/cli -s lark-calendar -y
         npx skills add larksuite/cli -s lark-im -y
 
-    Learn more: https://github.com/larksuite/cli#install-ai-agent-skills
+    Learn more: https://github.com/larksuite/cli#agent-skills
 
 COMMUNITY:
     GitHub:     https://github.com/larksuite/cli

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -187,3 +187,12 @@ func TestEnrichPermissionError_SpecialCharsEscaped(t *testing.T) {
 		})
 	}
 }
+
+func TestRootLong_AgentSkillsLinkTargetsReadmeSection(t *testing.T) {
+	if !strings.Contains(rootLong, "https://github.com/larksuite/cli#agent-skills") {
+		t.Fatalf("root help should link to the README Agent Skills section, got:\n%s", rootLong)
+	}
+	if strings.Contains(rootLong, "https://github.com/larksuite/cli#install-ai-agent-skills") {
+		t.Fatalf("root help should not reference the removed install-ai-agent-skills anchor, got:\n%s", rootLong)
+	}
+}


### PR DESCRIPTION
## Summary
Fix the root help text so the "Learn more" link points to an existing README section.

## Changes
- replace the broken `#install-ai-agent-skills` anchor with `#agent-skills`
- add a regression test to keep the root help link aligned with the README section

## Test Plan
- [x] `GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache /opt/homebrew/opt/go/bin/go test ./cmd/... ./internal/output`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Fixed the help text documentation link for "AI Agent Skills" to target the correct README section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->