### PR TITLE
docs: fix README auth scope and api data flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ lark-cli auth login --domain calendar,task
 lark-cli auth login --recommend
 
 # Exact scope
-lark-cli auth login --scope "calendar:calendar:readonly"
+lark-cli auth login --scope "calendar:calendar:read"
 
 # Agent mode: return verification URL immediately, non-blocking
 lark-cli auth login --domain calendar --no-wait
@@ -216,7 +216,7 @@ Call any Lark Open Platform endpoint directly, covering 2500+ APIs.
 
 ```bash
 lark-cli api GET /open-apis/calendar/v4/calendars
-lark-cli api POST /open-apis/im/v1/messages --params '{"receive_id_type":"chat_id"}' --body '{"receive_id":"oc_xxx","msg_type":"text","content":"{\"text\":\"Hello\"}"}'
+lark-cli api POST /open-apis/im/v1/messages --params '{"receive_id_type":"chat_id"}' --data '{"receive_id":"oc_xxx","msg_type":"text","content":"{\"text\":\"Hello\"}"}'
 ```
 
 ## Advanced Usage

--- a/README.zh.md
+++ b/README.zh.md
@@ -174,7 +174,7 @@ lark-cli auth login --domain calendar,task
 lark-cli auth login --recommend
 
 # 精确 scope
-lark-cli auth login --scope "calendar:calendar:readonly"
+lark-cli auth login --scope "calendar:calendar:read"
 
 # Agent 模式：立即返回验证 URL，不阻塞
 lark-cli auth login --domain calendar --no-wait
@@ -217,7 +217,7 @@ lark-cli calendar events instance_view --params '{"calendar_id":"primary","start
 
 ```bash
 lark-cli api GET /open-apis/calendar/v4/calendars
-lark-cli api POST /open-apis/im/v1/messages --params '{"receive_id_type":"chat_id"}' --body '{"receive_id":"oc_xxx","msg_type":"text","content":"{\"text\":\"Hello\"}"}'
+lark-cli api POST /open-apis/im/v1/messages --params '{"receive_id_type":"chat_id"}' --data '{"receive_id":"oc_xxx","msg_type":"text","content":"{\"text\":\"Hello\"}"}'
 ```
 
 ## 进阶用法


### PR DESCRIPTION
## Summary
Fix incorrect README examples for auth scope and raw IM API payload flag in both English and Chinese docs.

## Changes
- Update `calendar:calendar:readonly` to `calendar:calendar:read` in `README.md` and `README.zh.md`
- Replace `--body` with `--data` in the raw `lark-cli api POST /open-apis/im/v1/messages` examples

## Test Plan
- [x] `make unit-test`
- [x] `go mod tidy` leaves `go.mod` and `go.sum` unchanged
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main`
- [x] Manual local verification confirms both README files contain the corrected commands

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OAuth scope documentation for calendar permissions to reflect the correct current API specification
  * Corrected API request parameter format in IM messaging endpoint examples to match implementation standards
  * Applied updates to both English and Chinese documentation versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->