### PR TITLE
docs: fix root calendar example

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ EXAMPLES:
     lark-cli calendar +agenda
 
     # List calendar events
-    lark-cli calendar events list --params '{"calendar_id":"primary"}'
+    lark-cli calendar events instance_view --params '{"calendar_id":"primary","start_time":"1700000000","end_time":"1700086400"}'
 
     # Search users
     lark-cli contact +search-user --query "John"


### PR DESCRIPTION
## Summary
Fix the stale root help example for calendar events so the command shown in `lark-cli --help` matches the current CLI surface.

## Changes
- Replace the removed `calendar events list` example in `cmd/root.go`
- Use `calendar events instance_view` with the required time range parameters

## Test Plan
- [x] Unit tests pass
- [x] Manual local verification confirms the `lark xxx` command works as expected (`GOCACHE=/tmp/go-build go run . --help`)

## Related Issues
- Fixes #48


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation example for calendar events to demonstrate querying with time range parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->