### PR TITLE
fix(cli): make completion command discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ lark-cli auth login --recommend
 lark-cli calendar +agenda
 ```
 
+#### Optional: Shell Completion
+
+`lark-cli completion` is available as a regular top-level command and does not require login. Generate a completion script for the shell you use most:
+
+```bash
+# Bash
+lark-cli completion bash > ~/.local/share/bash-completion/completions/lark-cli
+
+# Zsh
+mkdir -p ~/.zfunc
+lark-cli completion zsh > ~/.zfunc/_lark-cli
+```
+
 ## Quick Start (AI Agent)
 
 > The following steps are for AI Agents. Some steps require the user to complete actions in a browser.
@@ -124,6 +137,12 @@ lark-cli auth login --recommend
 
 ```bash
 lark-cli auth status
+```
+
+Shell completion is also available without authentication:
+
+```bash
+lark-cli completion fish > ~/.config/fish/completions/lark-cli.fish
 ```
 
 ## Agent Skills

--- a/README.zh.md
+++ b/README.zh.md
@@ -90,6 +90,19 @@ lark-cli auth login --recommend
 lark-cli calendar +agenda
 ```
 
+#### 可选：Shell Completion
+
+`lark-cli completion` 是一个普通的顶层命令，不需要先登录。可以为常用 shell 生成补全脚本：
+
+```bash
+# Bash
+lark-cli completion bash > ~/.local/share/bash-completion/completions/lark-cli
+
+# Zsh
+mkdir -p ~/.zfunc
+lark-cli completion zsh > ~/.zfunc/_lark-cli
+```
+
 ### 快速开始（AI Agent）
 
 > 以下步骤面向 AI Agent，部分步骤需要用户在浏览器中配合完成。
@@ -124,6 +137,12 @@ lark-cli auth login --recommend
 
 ```bash
 lark-cli auth status
+```
+
+Shell completion 也不依赖认证：
+
+```bash
+lark-cli completion fish > ~/.config/fish/completions/lark-cli.fish
 ```
 
 

--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -16,7 +16,6 @@ func NewCmdCompletion(f *cmdutil.Factory) *cobra.Command {
 		Use:       "completion <shell>",
 		Short:     "Generate shell completion scripts",
 		Long:      "Generate shell completion scripts for bash, zsh, fish, or powershell.",
-		Hidden:    true,
 		ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
 		Args:      cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/completion/completion_test.go
+++ b/cmd/completion/completion_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package completion
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+)
+
+func TestNewCmdCompletion_IsVisibleAndAuthFree(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+
+	cmd := NewCmdCompletion(f)
+	if cmd.Hidden {
+		t.Fatal("expected completion command to be visible")
+	}
+	if !cmdutil.IsAuthCheckDisabled(cmd) {
+		t.Fatal("expected completion command to skip auth checks")
+	}
+}
+


### PR DESCRIPTION
## Summary
Fixes #264.

`lark-cli completion` already works, but it is hidden from normal command discovery and is not documented in either README. This change makes the command visible and adds short shell completion setup examples in both English and Chinese docs.

## Changes
- remove `Hidden: true` from `cmd/completion/completion.go`
- add `cmd/completion/completion_test.go` to verify the command stays visible and auth-free
- document shell completion usage in `README.md`
- document shell completion usage in `README.zh.md`

## Why this change
- issue `#264` reports that the command is usable today but hidden from users
- `CHANGELOG.md` already describes completion support as a shipped feature
- keeping the command hidden makes `--help` discovery weaker than the actual product surface

## Validation
- `git diff --check`
- focused source review of `cmd/completion/completion.go`, `cmd/root.go`, `README.md`, and `README.zh.md`
- Go tests not run in this environment because `go` is not installed in the container


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell completion command is now visible and directly accessible in the CLI help output

* **Documentation**
  * Added comprehensive setup guides for shell completion with platform-specific installation instructions for Bash, Zsh, and Fish shells
  * Clarified that completion functionality operates independently without requiring user authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->