### PR TITLE
docs: clarify --complete flag behavior in get-my-tasks reference

### DIFF
--- a/skills/lark-task/references/lark-task-get-my-tasks.md
+++ b/skills/lark-task/references/lark-task-get-my-tasks.md
@@ -19,10 +19,13 @@ By default, the command will automatically paginate up to 20 times. Use `--page-
 # Search for a specific task by name
 lark-cli task +get-my-tasks --query "Lobster No. 1"
 
-# Get my incomplete tasks (fetches up to 20 pages by default)
+# Get all my tasks (fetches up to 20 pages by default)
 lark-cli task +get-my-tasks
 
-# Fetch all tasks (up to 40 pages)
+# Get my incomplete tasks (fetches up to 20 pages by default)
+lark-cli task +get-my-tasks --complete=false
+
+# Fetch all my tasks (up to 40 pages)
 lark-cli task +get-my-tasks --page-all
 
 # Fetch up to 10 pages


### PR DESCRIPTION
## Summary
Clarified the behavior of the `--complete` flag in the `lark-task-get-my-tasks` skill reference and fixed minor grammar issues.

## Changes
- Added an explicit example demonstrating how to fetch incomplete tasks using `--complete=false`.
- Corrected comments to accurately reflect that calling the command without the flag fetches *all* tasks, not just incomplete ones.
- Fixed a minor grammar issue in the example comments.

## Test Plan
- [x] N/A (Documentation only)

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command examples in the task management reference guide with improved clarity and detailed descriptions
  * Added a new explicit example demonstrating how to fetch incomplete tasks using the `--complete=false` parameter option
  * Enhanced guidance on available task retrieval methods to help users better understand different command variations and their intended purposes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->