### PR TITLE
fix(task): default +get-my-tasks to incomplete results

### DIFF
--- a/shortcuts/task/task_get_my_tasks.go
+++ b/shortcuts/task/task_get_my_tasks.go
@@ -29,7 +29,7 @@ var GetMyTasks = common.Shortcut{
 
 	Flags: []common.Flag{
 		{Name: "query", Desc: "search for tasks by summary (exact match first, then partial match)"},
-		{Name: "complete", Type: "bool", Desc: "if true, query completed tasks; default is false"},
+		{Name: "complete", Type: "bool", Desc: "if true, query completed tasks; if false or omitted, query incomplete tasks"},
 		{Name: "created_at", Desc: "query tasks created after this time (date/relative/ms)"},
 		{Name: "due-start", Desc: "query tasks with due date after this time (date/relative/ms)"},
 		{Name: "due-end", Desc: "query tasks with due date before this time (date/relative/ms)"},
@@ -44,9 +44,7 @@ var GetMyTasks = common.Shortcut{
 			"type":         "my_tasks",
 			"user_id_type": "open_id",
 			"page_size":    50,
-		}
-		if runtime.Cmd.Flags().Changed("complete") {
-			params["completed"] = runtime.Bool("complete")
+			"completed":    runtime.Bool("complete"),
 		}
 
 		return d.GET("/open-apis/task/v2/tasks").Params(params)
@@ -59,13 +57,7 @@ var GetMyTasks = common.Shortcut{
 		queryParams.Set("type", "my_tasks")
 		queryParams.Set("user_id_type", "open_id")
 		queryParams.Set("page_size", "50")
-		if runtime.Cmd.Flags().Changed("complete") {
-			if runtime.Bool("complete") {
-				queryParams.Set("completed", "true")
-			} else {
-				queryParams.Set("completed", "false")
-			}
-		}
+		queryParams.Set("completed", strconv.FormatBool(runtime.Bool("complete")))
 
 		// parse time flags to ms timestamp if provided
 		var createdAfterMs, dueStartMs, dueEndMs int64

--- a/shortcuts/task/task_get_my_tasks_test.go
+++ b/shortcuts/task/task_get_my_tasks_test.go
@@ -89,3 +89,54 @@ func TestGetMyTasks_LocalTimeFormatting(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMyTasks_CompletionFilterDefaultsToIncomplete(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantQueryURL string
+	}{
+		{
+			name:         "omitted flag defaults to incomplete",
+			args:         []string{"+get-my-tasks", "--format", "json", "--as", "bot"},
+			wantQueryURL: "completed=false",
+		},
+		{
+			name:         "explicit false remains incomplete",
+			args:         []string{"+get-my-tasks", "--complete=false", "--format", "json", "--as", "bot"},
+			wantQueryURL: "completed=false",
+		},
+		{
+			name:         "explicit true requests completed tasks",
+			args:         []string{"+get-my-tasks", "--complete=true", "--format", "json", "--as", "bot"},
+			wantQueryURL: "completed=true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, reg := taskShortcutTestFactory(t)
+			warmTenantToken(t, f, reg)
+
+			reg.Register(&httpmock.Stub{
+				Method: "GET",
+				URL:    tt.wantQueryURL,
+				Body: map[string]interface{}{
+					"code": 0, "msg": "success",
+					"data": map[string]interface{}{
+						"items":      []interface{}{},
+						"has_more":   false,
+						"page_token": "",
+					},
+				},
+			})
+
+			s := GetMyTasks
+			s.AuthTypes = []string{"bot", "user"}
+
+			if err := runMountedTaskShortcut(t, s, tt.args, f, stdout); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/skills/lark-task/references/lark-task-get-my-tasks.md
+++ b/skills/lark-task/references/lark-task-get-my-tasks.md
@@ -34,7 +34,7 @@ lark-cli task +get-my-tasks --page-limit 10
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `--query <string>` | No | Search for tasks by summary. Returns exact matches if any; otherwise returns partial matches. |
-| `--complete=<bool>` | No | Optional. If not provided, it fetches all tasks (both incomplete and completed). Set to `true` to fetch only completed tasks, or `false` for incomplete tasks. |
+| `--complete=<bool>` | No | Optional. If omitted, it defaults to incomplete tasks (`false`). Set to `true` to fetch only completed tasks, or `false` for incomplete tasks. |
 | `--created_at <string>` | No | Query tasks created after this time. Supports date: `YYYY-MM-DD`, relative: `-2d`, or ms timestamp. |
 | `--due-start <string>` | No | Query tasks with a due date after this time. Supports date: `YYYY-MM-DD`, relative: `-2d`, or ms timestamp. |
 | `--due-end <string>` | No | Query tasks with a due date before this time. Supports date: `YYYY-MM-DD`, relative: `-2d`, or ms timestamp. |


### PR DESCRIPTION
## Summary
Make `task +get-my-tasks` default to incomplete tasks when `--complete` is omitted, matching the command help and issue expectation.

## Changes
- always send the `completed` filter, defaulting to `false` when `--complete` is omitted
- keep `--complete=true` and `--complete=false` as explicit overrides
- add regression tests covering omitted, `true`, and `false` completion filters
- update the task skill reference to document the corrected default behavior

## Related Issues
- closes #164

## Test Plan
- [x] `GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache /opt/homebrew/opt/go/bin/go test ./shortcuts/task -run 'TestGetMyTasks_CompletionFilterDefaultsToIncomplete|TestGetMyTasks_LocalTimeFormatting'`
- [x] `GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache /opt/homebrew/opt/go/bin/go test ./shortcuts/task`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Modified `--complete` flag behavior: the API request now always includes the completion filter instead of omitting it when the flag is not provided.
  * Default behavior updated: omitting `--complete` now queries incomplete tasks only (previously returned all tasks).

* **Documentation**
  * Clarified `--complete` flag documentation to reflect the new default filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->