### PR TITLE
feat: add lark-backup workflow skill

### DIFF
--- a/skills/lark-backup/SKILL.md
+++ b/skills/lark-backup/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: lark-backup
+version: 0.1.0
+description: "飞书备份工作流：用 lark-cli 备份飞书云文档、云空间文件夹、电子表格、多维表格到本地目录。当用户提到 backup、备份、归档、导出全部、下载整个文件夹、备份知识库、备份云空间、备份多维表格时使用。"
+metadata:
+  requires:
+    bins: ["lark-cli", "jq", "bash"]
+---
+
+# lark-backup
+
+**CRITICAL — 开始前 MUST 先读取 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)**，确认认证、身份和权限处理规则。
+
+这个 skill 不替代 `lark-doc` / `lark-drive` / `lark-sheets` / `lark-base` / `lark-wiki`。它是在这些官方 skill 之上，加一层“备份工作流”和确定性的脚本入口。
+
+## 适用场景
+
+- “备份这个飞书文档 / wiki / 表格 / 多维表格”
+- “把这个云空间文件夹递归下载到本地”
+- “给我做一个可重复执行的飞书备份流程”
+- “导出一个 Base，保留结构和记录”
+
+## 默认原则
+
+1. **默认用 `--as user`**
+   - 备份用户自己的云空间、文档、知识库时，优先 `user` 身份。
+   - 只有用户明确说要备份 bot 可见资源，或当前环境只有 bot 权限时，才改成 `--as bot`。
+2. **优先用脚本，不手拼命令**
+   - 先用 `scripts/lark-backup.sh`，因为它把 wiki 解析、目录递归、分页导出串起来了。
+3. **wiki 不能直接当真实 token**
+   - 遇到 `/wiki/...` 或 `wiki_token`，必须先解析真实 `obj_type` / `obj_token`。
+4. **备份目录尽量独立**
+   - 脚本会优先写到独立目录，避免覆盖旧备份。
+
+## 前置权限
+
+最省事的方式：
+
+```bash
+lark-cli auth login --recommend
+```
+
+如果要最小权限，常见会涉及：
+
+```bash
+lark-cli auth login --scope "wiki:node:read"
+lark-cli auth login --scope "space:document:retrieve"
+lark-cli auth login --scope "docs:document:readonly"
+lark-cli auth login --scope "docs:document:export"
+lark-cli auth login --scope "sheets:spreadsheet:read"
+lark-cli auth login --scope "base:app:read"
+```
+
+## 推荐入口
+
+### 1. 自动识别单个目标
+
+支持文档 / wiki / sheet / bitable / file / folder URL 或 token。
+
+```bash
+bash scripts/lark-backup.sh auto \
+  --target "https://xxx.feishu.cn/wiki/xxxx" \
+  --output-dir ./backup/wiki-page
+```
+
+如果只是 token，且脚本无法推断类型，显式传 `--type`：
+
+```bash
+bash scripts/lark-backup.sh auto \
+  --target "app_xxx" \
+  --type bitable \
+  --output-dir ./backup/base
+```
+
+### 2. 递归备份云空间文件夹
+
+```bash
+bash scripts/lark-backup.sh folder \
+  --folder-token "fldxxxx" \
+  --output-dir ./backup/drive-folder
+```
+
+### 3. 结构化备份多维表格
+
+```bash
+bash scripts/lark-backup.sh base \
+  --base-token "app_xxx" \
+  --output-dir ./backup/base
+```
+
+## 脚本会做什么
+
+- `auto`
+  - 识别 URL / token 类型
+  - wiki 先解析真实对象
+  - 再路由到文档、表格、Base、文件、文件夹备份逻辑
+- `folder`
+  - 调 `drive files list --page-all`
+  - 递归子文件夹
+  - 普通文件走 `drive +download`
+  - 文档 / 表格 / Base 走导出逻辑
+- `base`
+  - 导出一个 `xlsx` 快照
+  - 保存 `+base-get`
+  - 保存 `+table-list`
+  - 对每张表保存 `+table-get`
+  - 对每张表按页保存 `+record-list`
+
+更细的输出目录和边界说明，见 [references/backup-layout.md](references/backup-layout.md)。
+
+## 遇到问题时的处理
+
+- 权限报错：回到 `lark-shared`，补 `auth login --scope ...`
+- wiki token 报错：先 `wiki spaces get_node`
+- 大型 Base 或大文件夹：接受脚本运行较久；不要把 `+record-list` 并发化
+- `slides` / `mindnote` / 其他不在脚本覆盖范围内的类型：保留元数据并提示用户改走单独导出策略
+
+## 资源
+
+- [references/backup-layout.md](references/backup-layout.md) — 输出结构、对象覆盖范围、已知边界
+- [scripts/lark-backup.sh](scripts/lark-backup.sh) — 备份脚本

--- a/skills/lark-backup/SKILL.md
+++ b/skills/lark-backup/SKILL.md
@@ -115,7 +115,15 @@ bash scripts/lark-backup.sh base \
 - 大型 Base 或大文件夹：接受脚本运行较久；不要把 `+record-list` 并发化
 - `slides` / `mindnote` / 其他不在脚本覆盖范围内的类型：保留元数据并提示用户改走单独导出策略
 
+## 本地自检
+
+```bash
+bash scripts/lark-backup.sh --help
+bash scripts/lark-backup-smoke-test.sh
+```
+
 ## 资源
 
 - [references/backup-layout.md](references/backup-layout.md) — 输出结构、对象覆盖范围、已知边界
 - [scripts/lark-backup.sh](scripts/lark-backup.sh) — 备份脚本
+- [scripts/lark-backup-smoke-test.sh](scripts/lark-backup-smoke-test.sh) — 编号宽度与排序 smoke test

--- a/skills/lark-backup/references/backup-layout.md
+++ b/skills/lark-backup/references/backup-layout.md
@@ -43,5 +43,5 @@
 
 1. `docx` 内嵌图片/附件 token 会保留在 `fetch.json` 和 `content.md` 中，但脚本当前**不自动下载每个内嵌素材**。
 2. `slides`、`mindnote`、未知对象类型目前只保存 `entry.json` 并写入 `SKIPPED.txt`。
-3. `base +record-list` 的返回形状在不同环境可能不同，脚本按较宽松规则分页并把**原始响应完整落盘**，不要假设只有一种 schema。
+3. `base +record-list` 当前兼容两种已知返回形状：`.data.records.rows` 和 `.data.data`。如果响应不匹配这两种 schema，脚本会直接报错，避免静默截断备份；同时原始响应仍会完整落盘到 `records-page-*.json` 便于排查。
 4. 文件夹递归时会跳过已访问过的 folder token，避免快捷方式或目录环导致无限循环。

--- a/skills/lark-backup/references/backup-layout.md
+++ b/skills/lark-backup/references/backup-layout.md
@@ -6,7 +6,7 @@
 
 - `meta.json` — Drive 元数据
 - `fetch.json` — `docs +fetch` 的完整 JSON
-- `content.md` — 从 `fetch.json` 提取出的 Markdown
+- `content.md` — 从 `fetch.json` 提取出的 Markdown；仅当 `fetch.json` 中存在非空 `data.markdown` 时生成
 - `export-markdown.json` — `drive +export --file-extension markdown` 的结果
 - `export-pdf.json` — `drive +export --file-extension pdf` 的结果
 - 实际导出的 `.md` / `.pdf` 文件

--- a/skills/lark-backup/references/backup-layout.md
+++ b/skills/lark-backup/references/backup-layout.md
@@ -1,0 +1,47 @@
+# 备份输出布局
+
+## 文档 `docx`
+
+目录下通常会有：
+
+- `meta.json` — Drive 元数据
+- `fetch.json` — `docs +fetch` 的完整 JSON
+- `content.md` — 从 `fetch.json` 提取出的 Markdown
+- `export-markdown.json` — `drive +export --file-extension markdown` 的结果
+- `export-pdf.json` — `drive +export --file-extension pdf` 的结果
+- 实际导出的 `.md` / `.pdf` 文件
+
+## 旧版文档 `doc`
+
+- `meta.json`
+- `export-docx.json`
+- `export-pdf.json`
+- 实际导出的 `.docx` / `.pdf`
+
+## 电子表格 `sheet`
+
+- `info.json` — `sheets +info`
+- `export-xlsx.json`
+- `workbook.xlsx`
+- `csv/` — 每个工作表一个 `.csv`
+- `csv-*.json` — 每个工作表 CSV 导出记录
+
+## 多维表格 `bitable`
+
+- `base.json` — `base +base-get`
+- `tables.json` — `base +table-list`
+- `snapshot-xlsx.json` — `drive +export` 结果
+- `tables/<table_id>/table.json` — `base +table-get`
+- `tables/<table_id>/records-page-*.json` — `base +record-list` 分页结果
+
+## 文件夹 `folder`
+
+- `folder-items.json` — 当前文件夹聚合后的清单
+- `items/<序号>-<名称>/` — 每个子项一个目录
+
+## 已知边界
+
+1. `docx` 内嵌图片/附件 token 会保留在 `fetch.json` 和 `content.md` 中，但脚本当前**不自动下载每个内嵌素材**。
+2. `slides`、`mindnote`、未知对象类型目前只保存 `entry.json` 并写入 `SKIPPED.txt`。
+3. `base +record-list` 的返回形状在不同环境可能不同，脚本按较宽松规则分页并把**原始响应完整落盘**，不要假设只有一种 schema。
+4. 文件夹递归时会跳过已访问过的 folder token，避免快捷方式或目录环导致无限循环。

--- a/skills/lark-backup/scripts/lark-backup-smoke-test.sh
+++ b/skills/lark-backup/scripts/lark-backup-smoke-test.sh
@@ -31,4 +31,35 @@ assert_eq "020" "$(format_index 20 100)" "intermediate indices share the same wi
 assert_eq "100" "$(format_index 100 100)" "last index keeps natural width"
 assert_eq "0007" "$(format_index 7 1000)" "four-digit totals pad to width four"
 
+known_rows_json="$(mktemp)"
+TMP_FILES+=("$known_rows_json")
+cat >"$known_rows_json" <<'EOF'
+{"data":{"records":{"rows":[["Alice"],["Bob"]]}}}
+EOF
+assert_eq $'2\tfalse\t0' "$(record_list_page_info "$known_rows_json")" "legacy nested record-list shape is supported"
+
+known_flat_json="$(mktemp)"
+TMP_FILES+=("$known_flat_json")
+cat >"$known_flat_json" <<'EOF'
+{"data":{"data":[["Alice"],["Bob"],["Carol"]]}}
+EOF
+assert_eq $'3\tfalse\t0' "$(record_list_page_info "$known_flat_json")" "flat record-list shape is supported"
+
+unknown_shape_json="$(mktemp)"
+TMP_FILES+=("$unknown_shape_json")
+cat >"$unknown_shape_json" <<'EOF'
+{"data":{"items":[{"name":"unexpected"}]}}
+EOF
+if ( record_list_page_info "$unknown_shape_json" >/dev/null 2>&1 ); then
+  echo "assertion failed: unknown record-list shape must fail fast" >&2
+  exit 1
+fi
+
+table_list_json="$(mktemp)"
+TMP_FILES+=("$table_list_json")
+cat >"$table_list_json" <<'EOF'
+{"data":{"items":[{"table_id":"tbl_1"},{"table_id":"tbl_2"}],"has_more":true,"total":12}}
+EOF
+assert_eq $'2\ttrue\t12' "$(table_list_page_info "$table_list_json")" "table-list pagination metadata is parsed in one pass"
+
 echo "lark-backup smoke test OK"

--- a/skills/lark-backup/scripts/lark-backup-smoke-test.sh
+++ b/skills/lark-backup/scripts/lark-backup-smoke-test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Source helpers without running the backup entrypoint.
+source "$SCRIPT_DIR/lark-backup.sh"
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+
+  if [[ "$expected" != "$actual" ]]; then
+    echo "assertion failed: $message" >&2
+    echo "expected: $expected" >&2
+    echo "actual:   $actual" >&2
+    exit 1
+  fi
+}
+
+assert_eq "2" "$(index_width 0)" "empty collections keep two-digit compatibility"
+assert_eq "2" "$(index_width 9)" "single-digit totals still render two digits"
+assert_eq "2" "$(index_width 99)" "double-digit totals stay two digits"
+assert_eq "3" "$(index_width 100)" "three-digit totals widen to three digits"
+assert_eq "4" "$(index_width 1000)" "four-digit totals widen to four digits"
+
+assert_eq "01" "$(format_index 1 9)" "single-digit totals stay zero-padded"
+assert_eq "99" "$(format_index 99 99)" "two-digit totals do not over-pad"
+assert_eq "001" "$(format_index 1 100)" "three-digit totals pad to width three"
+assert_eq "020" "$(format_index 20 100)" "intermediate indices share the same width"
+assert_eq "100" "$(format_index 100 100)" "last index keeps natural width"
+assert_eq "0007" "$(format_index 7 1000)" "four-digit totals pad to width four"
+
+echo "lark-backup smoke test OK"

--- a/skills/lark-backup/scripts/lark-backup.sh
+++ b/skills/lark-backup/scripts/lark-backup.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ -z "${BASH_VERSINFO:-}" || ${BASH_VERSINFO[0]} -lt 4 ]]; then
-  echo "error: lark-backup.sh requires Bash 4 or newer. Current bash version: ${BASH_VERSION:-unknown}" >&2
+if [[ "${BASH_VERSINFO[0]}" -lt 4 ]]; then
+  echo "error: lark-backup.sh requires Bash 4+ (found ${BASH_VERSION})" >&2
   exit 1
 fi
 

--- a/skills/lark-backup/scripts/lark-backup.sh
+++ b/skills/lark-backup/scripts/lark-backup.sh
@@ -1,0 +1,537 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IDENTITY="user"
+OUTPUT_DIR=""
+TARGET_TYPE=""
+
+declare -a TMP_FILES=()
+declare -A SEEN_FOLDERS=()
+
+cleanup() {
+  local f
+  for f in "${TMP_FILES[@]:-}"; do
+    if [[ -n "$f" && -e "$f" ]]; then
+      rm -f "$f"
+    fi
+  done
+}
+trap cleanup EXIT
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+log() {
+  echo "[lark-backup] $*" >&2
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+json_tmp() {
+  local f
+  f="$(mktemp)"
+  TMP_FILES+=("$f")
+  printf '%s\n' "$f"
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  lark-backup.sh auto   --target <url-or-token> [--type <kind>] [--output-dir <dir>] [--as user|bot]
+  lark-backup.sh folder --folder-token <token> [--output-dir <dir>] [--as user|bot]
+  lark-backup.sh base   --base-token <token> [--output-dir <dir>] [--as user|bot]
+  lark-backup.sh doc    --token <token> --doc-type <docx|doc> [--output-dir <dir>] [--as user|bot]
+  lark-backup.sh sheet  --token <token> [--output-dir <dir>] [--as user|bot]
+  lark-backup.sh file   --token <token> [--output-dir <dir>] [--as user|bot]
+
+Examples:
+  lark-backup.sh auto --target "https://xxx.feishu.cn/wiki/xxxx" --output-dir ./backup/wiki
+  lark-backup.sh folder --folder-token "fldxxxx" --output-dir ./backup/drive
+  lark-backup.sh base --base-token "app_xxx" --output-dir ./backup/base
+EOF
+}
+
+sanitize_name() {
+  local raw="${1:-}"
+  local cleaned
+  cleaned="$(printf '%s' "$raw" | tr '/\n\r\t' '____' | sed -E 's/[[:space:]]+/_/g; s/[^[:alnum:]_.-]+/_/g; s/_+/_/g; s/^[_ .-]+//; s/[_ .-]+$//')"
+  if [[ -z "$cleaned" ]]; then
+    cleaned="item"
+  fi
+  printf '%s\n' "$cleaned"
+}
+
+prepare_output_dir() {
+  local requested="${1:-}"
+  local dir
+  if [[ -z "$requested" ]]; then
+    dir="./lark-backup-$(date +%Y%m%d-%H%M%S)"
+  else
+    dir="$requested"
+    if [[ -d "$dir" ]] && [[ -n "$(find "$dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+      dir="${dir%/}-$(date +%Y%m%d-%H%M%S)"
+    fi
+  fi
+  mkdir -p "$dir"
+  printf '%s\n' "$dir"
+}
+
+run_shortcut_json() {
+  local out="$1"
+  shift
+  "$@" >"$out"
+  jq -e '.ok == true' "$out" >/dev/null || {
+    cat "$out" >&2
+    fail "shortcut command failed: $*"
+  }
+}
+
+run_service_json() {
+  local out="$1"
+  shift
+  "$@" >"$out"
+  jq -e '.code == 0' "$out" >/dev/null || {
+    cat "$out" >&2
+    fail "service command failed: $*"
+  }
+}
+
+extract_token() {
+  local target="$1"
+  local clean="${target%%\?*}"
+  clean="${clean%%#*}"
+  if [[ "$clean" == http://* || "$clean" == https://* ]]; then
+    printf '%s\n' "${clean##*/}"
+    return
+  fi
+  printf '%s\n' "$clean"
+}
+
+infer_type() {
+  local target="$1"
+  local explicit="${2:-}"
+  local clean
+  clean="${target%%\?*}"
+  clean="${clean%%#*}"
+
+  if [[ -n "$explicit" ]]; then
+    printf '%s\n' "$explicit"
+    return
+  fi
+
+  case "$clean" in
+    http://*|https://*)
+      case "$clean" in
+        */drive/folder/*) echo "folder" ;;
+        */drive/file/*) echo "file" ;;
+        */wiki/*) echo "wiki" ;;
+        */docx/*) echo "docx" ;;
+        */doc/*) echo "doc" ;;
+        */sheets/*) echo "sheet" ;;
+        */base/*) echo "bitable" ;;
+        *) fail "cannot infer target type from URL: $target; pass --type" ;;
+      esac
+      ;;
+    *)
+      case "$clean" in
+        fld*) echo "folder" ;;
+        wik*) echo "wiki" ;;
+        sht*) echo "sheet" ;;
+        dox*) echo "docx" ;;
+        doc*) echo "doc" ;;
+        app_*|bascn*|bas*) echo "bitable" ;;
+        box*|file_*) echo "file" ;;
+        *) fail "cannot infer target type from token: $target; pass --type" ;;
+      esac
+      ;;
+  esac
+}
+
+write_json_copy() {
+  local src="$1"
+  local dest="$2"
+  cp "$src" "$dest"
+}
+
+backup_doc() {
+  local token="$1"
+  local doc_type="$2"
+  local outdir="$3"
+  local meta_json fetch_json
+
+  mkdir -p "$outdir"
+  log "backup ${doc_type}: ${token}"
+
+  meta_json="$(json_tmp)"
+  run_service_json "$meta_json" \
+    lark-cli drive metas batch_query --as "$IDENTITY" \
+    --data "$(jq -cn --arg token "$token" --arg doc_type "$doc_type" '{request_docs:[{doc_token:$token,doc_type:$doc_type}],with_url:true}')"
+  write_json_copy "$meta_json" "$outdir/meta.json"
+
+  if [[ "$doc_type" == "docx" ]]; then
+    fetch_json="$(json_tmp)"
+    run_shortcut_json "$fetch_json" \
+      lark-cli docs +fetch --as "$IDENTITY" --doc "$token" --format json
+    write_json_copy "$fetch_json" "$outdir/fetch.json"
+    jq -r '.data.markdown // empty' "$fetch_json" >"$outdir/content.md"
+
+    run_shortcut_json "$outdir/export-markdown.json" \
+      lark-cli drive +export --as "$IDENTITY" \
+      --token "$token" --doc-type docx --file-extension markdown --output-dir "$outdir"
+    run_shortcut_json "$outdir/export-pdf.json" \
+      lark-cli drive +export --as "$IDENTITY" \
+      --token "$token" --doc-type docx --file-extension pdf --output-dir "$outdir"
+    return
+  fi
+
+  run_shortcut_json "$outdir/export-docx.json" \
+    lark-cli drive +export --as "$IDENTITY" \
+    --token "$token" --doc-type doc --file-extension docx --output-dir "$outdir"
+  run_shortcut_json "$outdir/export-pdf.json" \
+    lark-cli drive +export --as "$IDENTITY" \
+    --token "$token" --doc-type doc --file-extension pdf --output-dir "$outdir"
+}
+
+backup_sheet() {
+  local token="$1"
+  local outdir="$2"
+  local info_json
+  local idx=0
+
+  mkdir -p "$outdir/csv"
+  log "backup sheet: ${token}"
+
+  info_json="$(json_tmp)"
+  run_shortcut_json "$info_json" \
+    lark-cli sheets +info --as "$IDENTITY" --spreadsheet-token "$token"
+  write_json_copy "$info_json" "$outdir/info.json"
+
+  run_shortcut_json "$outdir/export-xlsx.json" \
+    lark-cli sheets +export --as "$IDENTITY" \
+    --spreadsheet-token "$token" --file-extension xlsx --output-path "$outdir/workbook.xlsx"
+
+  while IFS=$'\t' read -r sheet_id title; do
+    [[ -z "$sheet_id" ]] && continue
+    idx=$((idx + 1))
+    local safe_title
+    safe_title="$(sanitize_name "$title")"
+    run_shortcut_json "$outdir/csv-${idx}.json" \
+      lark-cli sheets +export --as "$IDENTITY" \
+      --spreadsheet-token "$token" \
+      --file-extension csv \
+      --sheet-id "$sheet_id" \
+      --output-path "$outdir/csv/$(printf '%02d' "$idx")-${safe_title}.csv"
+  done < <(jq -r '.data.sheets[]? | [.sheet_id, (.title // .sheet_id)] | @tsv' "$info_json")
+}
+
+backup_file() {
+  local token="$1"
+  local outdir="$2"
+
+  mkdir -p "$outdir"
+  log "backup file: ${token}"
+
+  (
+    cd "$outdir"
+    lark-cli drive +download --as "$IDENTITY" --file-token "$token" >download.json
+  )
+  jq -e '.ok == true' "$outdir/download.json" >/dev/null || {
+    cat "$outdir/download.json" >&2
+    fail "file download failed for ${token}"
+  }
+}
+
+backup_base() {
+  local token="$1"
+  local outdir="$2"
+  local tables_json
+
+  mkdir -p "$outdir/tables"
+  log "backup base: ${token}"
+
+  run_shortcut_json "$outdir/base.json" \
+    lark-cli base +base-get --as "$IDENTITY" --base-token "$token"
+
+  run_shortcut_json "$outdir/snapshot-xlsx.json" \
+    lark-cli drive +export --as "$IDENTITY" \
+    --token "$token" --doc-type bitable --file-extension xlsx --output-dir "$outdir"
+
+  tables_json="$(json_tmp)"
+  run_shortcut_json "$tables_json" \
+    lark-cli base +table-list --as "$IDENTITY" --base-token "$token" --offset 0 --limit 100
+  write_json_copy "$tables_json" "$outdir/tables.json"
+
+  while IFS=$'\t' read -r table_id table_name; do
+    [[ -z "$table_id" ]] && continue
+    local table_dir count has_more total offset page page_json
+    table_dir="$outdir/tables/${table_id}-$(sanitize_name "$table_name")"
+    mkdir -p "$table_dir"
+
+    run_shortcut_json "$table_dir/table.json" \
+      lark-cli base +table-get --as "$IDENTITY" --base-token "$token" --table-id "$table_id"
+
+    offset=0
+    page=1
+    while :; do
+      page_json="$table_dir/records-page-$(printf '%03d' "$page").json"
+      run_shortcut_json "$page_json" \
+        lark-cli base +record-list --as "$IDENTITY" \
+        --base-token "$token" --table-id "$table_id" --offset "$offset" --limit 200
+
+      count="$(jq -r '((.data.records.rows // .data.data // []) | length)' "$page_json")"
+      has_more="$(jq -r '.data.has_more // false' "$page_json")"
+      total="$(jq -r '.data.total // 0' "$page_json")"
+
+      if [[ "$count" -eq 0 ]]; then
+        break
+      fi
+
+      offset=$((offset + count))
+      page=$((page + 1))
+
+      if [[ "$has_more" == "true" ]]; then
+        continue
+      fi
+      if [[ "$total" =~ ^[0-9]+$ ]] && [[ "$total" -gt "$offset" ]]; then
+        continue
+      fi
+      if [[ "$count" -lt 200 ]]; then
+        break
+      fi
+    done
+  done < <(jq -r '.data.items[]? | [.table_id, (.table_name // .table_id)] | @tsv' "$tables_json")
+}
+
+resolve_wiki_to_object() {
+  local token="$1"
+  local out_json="$2"
+  run_service_json "$out_json" \
+    lark-cli wiki spaces get_node --as "$IDENTITY" \
+    --params "$(jq -cn --arg token "$token" '{token:$token}')"
+}
+
+backup_auto() {
+  local target="$1"
+  local outdir="$2"
+  local inferred_type token wiki_json obj_type obj_token
+
+  inferred_type="$(infer_type "$target" "$TARGET_TYPE")"
+  token="$(extract_token "$target")"
+
+  case "$inferred_type" in
+    docx|doc)
+      backup_doc "$token" "$inferred_type" "$outdir"
+      ;;
+    sheet)
+      backup_sheet "$token" "$outdir"
+      ;;
+    bitable)
+      backup_base "$token" "$outdir"
+      ;;
+    file)
+      backup_file "$token" "$outdir"
+      ;;
+    folder)
+      backup_folder "$token" "$outdir"
+      ;;
+    wiki)
+      wiki_json="$(json_tmp)"
+      resolve_wiki_to_object "$token" "$wiki_json"
+      write_json_copy "$wiki_json" "$outdir/wiki-node.json"
+      obj_type="$(jq -r '.data.node.obj_type // empty' "$wiki_json")"
+      obj_token="$(jq -r '.data.node.obj_token // empty' "$wiki_json")"
+      [[ -n "$obj_type" && -n "$obj_token" ]] || fail "failed to resolve wiki target: $target"
+      case "$obj_type" in
+        docx|doc)
+          backup_doc "$obj_token" "$obj_type" "$outdir"
+          ;;
+        sheet)
+          backup_sheet "$obj_token" "$outdir"
+          ;;
+        bitable)
+          backup_base "$obj_token" "$outdir"
+          ;;
+        file)
+          backup_file "$obj_token" "$outdir"
+          ;;
+        *)
+          fail "wiki target resolved to unsupported type: $obj_type"
+          ;;
+      esac
+      ;;
+    *)
+      fail "unsupported target type: $inferred_type"
+      ;;
+  esac
+}
+
+backup_folder() {
+  local folder_token="$1"
+  local outdir="$2"
+  local list_json idx=0
+
+  if [[ -n "${SEEN_FOLDERS[$folder_token]:-}" ]]; then
+    log "skip already visited folder: ${folder_token}"
+    return
+  fi
+  SEEN_FOLDERS["$folder_token"]=1
+
+  mkdir -p "$outdir/items"
+  log "backup folder: ${folder_token}"
+
+  list_json="$(json_tmp)"
+  run_service_json "$list_json" \
+    lark-cli drive files list --as "$IDENTITY" --format json --page-all \
+    --params "$(jq -cn --arg folder_token "$folder_token" '{folder_token:$folder_token,page_size:100}')"
+  write_json_copy "$list_json" "$outdir/folder-items.json"
+
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    idx=$((idx + 1))
+
+    local entry_name entry_type entry_token shortcut_type shortcut_token entry_dir safe_name
+    entry_name="$(jq -r '.name // "item"' <<<"$entry")"
+    entry_type="$(jq -r '.type // empty' <<<"$entry")"
+    entry_token="$(jq -r '.token // empty' <<<"$entry")"
+    shortcut_type="$(jq -r '.shortcut_info.target_type // empty' <<<"$entry")"
+    shortcut_token="$(jq -r '.shortcut_info.target_token // empty' <<<"$entry")"
+
+    if [[ -n "$shortcut_type" && -n "$shortcut_token" ]]; then
+      entry_type="$shortcut_type"
+      entry_token="$shortcut_token"
+    fi
+
+    safe_name="$(sanitize_name "$entry_name")"
+    entry_dir="$outdir/items/$(printf '%02d' "$idx")-${safe_name}"
+    mkdir -p "$entry_dir"
+    jq . <<<"$entry" >"$entry_dir/entry.json"
+
+    case "$entry_type" in
+      folder)
+        backup_folder "$entry_token" "$entry_dir"
+        ;;
+      docx|doc)
+        backup_doc "$entry_token" "$entry_type" "$entry_dir"
+        ;;
+      sheet)
+        backup_sheet "$entry_token" "$entry_dir"
+        ;;
+      bitable)
+        backup_base "$entry_token" "$entry_dir"
+        ;;
+      file)
+        backup_file "$entry_token" "$entry_dir"
+        ;;
+      *)
+        printf '%s\n' "unsupported type: ${entry_type:-unknown}" >"$entry_dir/SKIPPED.txt"
+        ;;
+    esac
+  done < <(jq -c '.data.files[]?' "$list_json")
+}
+
+main() {
+  need_cmd lark-cli
+  need_cmd jq
+
+  local command="${1:-}"
+  [[ -n "$command" ]] || {
+    usage
+    exit 1
+  }
+  if [[ "$command" == "-h" || "$command" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+  shift || true
+
+  local target="" token="" folder_token="" base_token="" doc_type=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --as)
+        IDENTITY="${2:-}"
+        shift 2
+        ;;
+      --output-dir)
+        OUTPUT_DIR="${2:-}"
+        shift 2
+        ;;
+      --type)
+        TARGET_TYPE="${2:-}"
+        shift 2
+        ;;
+      --target)
+        target="${2:-}"
+        shift 2
+        ;;
+      --token)
+        token="${2:-}"
+        shift 2
+        ;;
+      --folder-token)
+        folder_token="${2:-}"
+        shift 2
+        ;;
+      --base-token)
+        base_token="${2:-}"
+        shift 2
+        ;;
+      --doc-type)
+        doc_type="${2:-}"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        fail "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  OUTPUT_DIR="$(prepare_output_dir "$OUTPUT_DIR")"
+  log "identity=${IDENTITY}"
+  log "output_dir=${OUTPUT_DIR}"
+
+  case "$command" in
+    auto)
+      [[ -n "$target" ]] || fail "--target is required for auto"
+      backup_auto "$target" "$OUTPUT_DIR"
+      ;;
+    folder)
+      [[ -n "$folder_token" ]] || fail "--folder-token is required for folder"
+      backup_folder "$folder_token" "$OUTPUT_DIR"
+      ;;
+    base)
+      [[ -n "$base_token" ]] || fail "--base-token is required for base"
+      backup_base "$base_token" "$OUTPUT_DIR"
+      ;;
+    doc)
+      [[ -n "$token" ]] || fail "--token is required for doc"
+      [[ "$doc_type" == "docx" || "$doc_type" == "doc" ]] || fail "--doc-type must be docx or doc"
+      backup_doc "$token" "$doc_type" "$OUTPUT_DIR"
+      ;;
+    sheet)
+      [[ -n "$token" ]] || fail "--token is required for sheet"
+      backup_sheet "$token" "$OUTPUT_DIR"
+      ;;
+    file)
+      [[ -n "$token" ]] || fail "--token is required for file"
+      backup_file "$token" "$OUTPUT_DIR"
+      ;;
+    *)
+      usage
+      fail "unknown command: $command"
+      ;;
+  esac
+
+  log "done"
+  echo "$OUTPUT_DIR"
+}
+
+main "$@"

--- a/skills/lark-backup/scripts/lark-backup.sh
+++ b/skills/lark-backup/scripts/lark-backup.sh
@@ -38,6 +38,14 @@ json_tmp() {
   printf '%s\n' "$f"
 }
 
+require_flag_value() {
+  local flag="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    fail "${flag} requires a value"
+  fi
+}
+
 usage() {
   cat <<'EOF'
 Usage:
@@ -82,8 +90,14 @@ prepare_output_dir() {
 
 run_shortcut_json() {
   local out="$1"
+  local err_out
   shift
-  "$@" >"$out"
+  err_out="$(json_tmp)"
+  if ! "$@" >"$out" 2>"$err_out"; then
+    [[ -s "$out" ]] && cat "$out" >&2
+    [[ -s "$err_out" ]] && cat "$err_out" >&2
+    fail "shortcut command failed: $*"
+  fi
   jq -e '.ok == true' "$out" >/dev/null || {
     cat "$out" >&2
     fail "shortcut command failed: $*"
@@ -92,8 +106,14 @@ run_shortcut_json() {
 
 run_service_json() {
   local out="$1"
+  local err_out
   shift
-  "$@" >"$out"
+  err_out="$(json_tmp)"
+  if ! "$@" >"$out" 2>"$err_out"; then
+    [[ -s "$out" ]] && cat "$out" >&2
+    [[ -s "$err_out" ]] && cat "$err_out" >&2
+    fail "service command failed: $*"
+  fi
   jq -e '.code == 0' "$out" >/dev/null || {
     cat "$out" >&2
     fail "service command failed: $*"
@@ -103,12 +123,31 @@ run_service_json() {
 extract_token() {
   local target="$1"
   local clean="${target%%\?*}"
+  local result=""
   clean="${clean%%#*}"
   if [[ "$clean" == http://* || "$clean" == https://* ]]; then
-    printf '%s\n' "${clean##*/}"
-    return
+    if [[ "$clean" =~ /drive/folder/([^/]+)/?$ ]]; then
+      result="${BASH_REMATCH[1]}"
+    elif [[ "$clean" =~ /drive/file/([^/]+)/?$ ]]; then
+      result="${BASH_REMATCH[1]}"
+    elif [[ "$clean" =~ /wiki/([^/]+)/?$ ]]; then
+      result="${BASH_REMATCH[1]}"
+    elif [[ "$clean" =~ /docx/([^/]+)/?$ ]]; then
+      result="${BASH_REMATCH[1]}"
+    elif [[ "$clean" =~ /doc/([^/]+)/?$ ]]; then
+      result="${BASH_REMATCH[1]}"
+    elif [[ "$clean" =~ /sheets/([^/]+)/?$ ]]; then
+      result="${BASH_REMATCH[1]}"
+    elif [[ "$clean" =~ /base/([^/]+)/?$ ]]; then
+      result="${BASH_REMATCH[1]}"
+    else
+      fail "cannot extract token from URL: $target"
+    fi
+  else
+    result="${clean%/}"
   fi
-  printf '%s\n' "$clean"
+  [[ -n "$result" ]] || fail "cannot extract token from: $target"
+  printf '%s\n' "$result"
 }
 
 infer_type() {
@@ -139,12 +178,13 @@ infer_type() {
     *)
       case "$clean" in
         fld*) echo "folder" ;;
-        wik*) echo "wiki" ;;
+        wikcn*) echo "wiki" ;;
         sht*) echo "sheet" ;;
         dox*) echo "docx" ;;
-        doc*) echo "doc" ;;
-        app_*|bascn*|bas*) echo "bitable" ;;
-        box*|file_*) echo "file" ;;
+        doccn*) echo "doc" ;;
+        # Keep known token families, but require --type for ambiguous raw tokens.
+        app_*|bascn*) echo "bitable" ;;
+        box*) echo "file" ;;
         *) fail "cannot infer target type from token: $target; pass --type" ;;
       esac
       ;;
@@ -241,12 +281,9 @@ backup_file() {
 
   (
     cd "$outdir"
-    lark-cli drive +download --as "$IDENTITY" --file-token "$token" >download.json
+    run_shortcut_json "download.json" \
+      lark-cli drive +download --as "$IDENTITY" --file-token "$token"
   )
-  jq -e '.ok == true' "$outdir/download.json" >/dev/null || {
-    cat "$outdir/download.json" >&2
-    fail "file download failed for ${token}"
-  }
 }
 
 list_all_base_tables() {
@@ -362,9 +399,7 @@ backup_base() {
       if [[ "$total" =~ ^[0-9]+$ ]] && [[ "$total" -gt "$offset" ]]; then
         continue
       fi
-      if [[ "$count" -lt 200 ]]; then
-        break
-      fi
+      break
     done
   done < <(jq -r '.data.items[]? | [.table_id, (.table_name // .table_id)] | @tsv' "$tables_json")
 }
@@ -516,35 +551,43 @@ main() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --as)
-        IDENTITY="${2:-}"
+        require_flag_value "$1" "${2:-}"
+        IDENTITY="$2"
         shift 2
         ;;
       --output-dir)
-        OUTPUT_DIR="${2:-}"
+        require_flag_value "$1" "${2:-}"
+        OUTPUT_DIR="$2"
         shift 2
         ;;
       --type)
-        TARGET_TYPE="${2:-}"
+        require_flag_value "$1" "${2:-}"
+        TARGET_TYPE="$2"
         shift 2
         ;;
       --target)
-        target="${2:-}"
+        require_flag_value "$1" "${2:-}"
+        target="$2"
         shift 2
         ;;
       --token)
-        token="${2:-}"
+        require_flag_value "$1" "${2:-}"
+        token="$2"
         shift 2
         ;;
       --folder-token)
-        folder_token="${2:-}"
+        require_flag_value "$1" "${2:-}"
+        folder_token="$2"
         shift 2
         ;;
       --base-token)
-        base_token="${2:-}"
+        require_flag_value "$1" "${2:-}"
+        base_token="$2"
         shift 2
         ;;
       --doc-type)
-        doc_type="${2:-}"
+        require_flag_value "$1" "${2:-}"
+        doc_type="$2"
         shift 2
         ;;
       -h|--help)

--- a/skills/lark-backup/scripts/lark-backup.sh
+++ b/skills/lark-backup/scripts/lark-backup.sh
@@ -177,7 +177,11 @@ backup_doc() {
     run_shortcut_json "$fetch_json" \
       lark-cli docs +fetch --as "$IDENTITY" --doc "$token" --format json
     write_json_copy "$fetch_json" "$outdir/fetch.json"
-    jq -r '.data.markdown // empty' "$fetch_json" >"$outdir/content.md"
+    if jq -e '.data.markdown | type == "string" and length > 0' "$fetch_json" >/dev/null; then
+      jq -r '.data.markdown' "$fetch_json" >"$outdir/content.md"
+    else
+      log "docs +fetch returned no markdown; skipping content.md for ${token}"
+    fi
 
     run_shortcut_json "$outdir/export-markdown.json" \
       lark-cli drive +export --as "$IDENTITY" \

--- a/skills/lark-backup/scripts/lark-backup.sh
+++ b/skills/lark-backup/scripts/lark-backup.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ -z "${BASH_VERSINFO:-}" || ${BASH_VERSINFO[0]} -lt 4 ]]; then
+  echo "error: lark-backup.sh requires Bash 4 or newer. Current bash version: ${BASH_VERSION:-unknown}" >&2
+  exit 1
+fi
+
 IDENTITY="user"
 OUTPUT_DIR=""
 TARGET_TYPE=""
@@ -182,8 +187,10 @@ infer_type() {
         dox*) echo "docx" ;;    # doxcn... for new documents
         sht*) echo "sheet" ;;   # shtcn... for sheets
         box*) echo "file" ;;    # boxcn... for files
-        # Legacy/undocumented prefixes - require explicit --type
-        # Removed: wikcn*, doccn*, app_*, bascn* to avoid misclassification
+        # Exact known legacy/documented forms
+        doccn*) echo "doc" ;;   # doccn... for old docs
+        wikcn*) echo "wiki" ;;  # wikcn... for wiki tokens
+        # Other ambiguous prefixes require explicit --type
         *) fail "cannot infer target type from token: $target; pass --type" ;;
       esac
       ;;
@@ -310,6 +317,7 @@ list_all_base_tables() {
     mv "$next_merged_json" "$merged_json"
 
     count="$(jq -r '(.data.items // []) | length' "$page_json")"
+    has_more="$(jq -r '.data.has_more // false' "$page_json")"
     total="$(jq -r '.data.total // 0' "$page_json")"
 
     if [[ "$count" -eq 0 ]]; then
@@ -318,6 +326,9 @@ list_all_base_tables() {
 
     offset=$((offset + count))
 
+    if [[ "$has_more" == "true" ]]; then
+      continue
+    fi
     if [[ "$total" =~ ^[0-9]+$ ]] && [[ "$total" -gt 0 ]] && [[ "$offset" -lt "$total" ]]; then
       continue
     fi
@@ -599,34 +610,53 @@ main() {
     esac
   done
 
+  case "$command" in
+    auto)
+      [[ -n "$target" ]] || fail "--target is required for auto"
+      ;;
+    folder)
+      [[ -n "$folder_token" ]] || fail "--folder-token is required for folder"
+      ;;
+    base)
+      [[ -n "$base_token" ]] || fail "--base-token is required for base"
+      ;;
+    doc)
+      [[ -n "$token" ]] || fail "--token is required for doc"
+      [[ "$doc_type" == "docx" || "$doc_type" == "doc" ]] || fail "--doc-type must be docx or doc"
+      ;;
+    sheet)
+      [[ -n "$token" ]] || fail "--token is required for sheet"
+      ;;
+    file)
+      [[ -n "$token" ]] || fail "--token is required for file"
+      ;;
+    *)
+      usage
+      fail "unknown command: $command"
+      ;;
+  esac
+
   OUTPUT_DIR="$(prepare_output_dir "$OUTPUT_DIR")"
   log "identity=${IDENTITY}"
   log "output_dir=${OUTPUT_DIR}"
 
   case "$command" in
     auto)
-      [[ -n "$target" ]] || fail "--target is required for auto"
       backup_auto "$target" "$OUTPUT_DIR"
       ;;
     folder)
-      [[ -n "$folder_token" ]] || fail "--folder-token is required for folder"
       backup_folder "$folder_token" "$OUTPUT_DIR"
       ;;
     base)
-      [[ -n "$base_token" ]] || fail "--base-token is required for base"
       backup_base "$base_token" "$OUTPUT_DIR"
       ;;
     doc)
-      [[ -n "$token" ]] || fail "--token is required for doc"
-      [[ "$doc_type" == "docx" || "$doc_type" == "doc" ]] || fail "--doc-type must be docx or doc"
       backup_doc "$token" "$doc_type" "$OUTPUT_DIR"
       ;;
     sheet)
-      [[ -n "$token" ]] || fail "--token is required for sheet"
       backup_sheet "$token" "$OUTPUT_DIR"
       ;;
     file)
-      [[ -n "$token" ]] || fail "--token is required for file"
       backup_file "$token" "$OUTPUT_DIR"
       ;;
     *)

--- a/skills/lark-backup/scripts/lark-backup.sh
+++ b/skills/lark-backup/scripts/lark-backup.sh
@@ -245,6 +245,66 @@ backup_file() {
   }
 }
 
+list_all_base_tables() {
+  local token="$1"
+  local out_json="$2"
+  local offset=0
+  local limit=100
+  local total=0
+  local count=0
+  local merged_json page_json items_json next_merged_json
+
+  merged_json="$(json_tmp)"
+  printf '%s\n' '[]' >"$merged_json"
+
+  while :; do
+    page_json="$(json_tmp)"
+    run_shortcut_json "$page_json" \
+      lark-cli base +table-list --as "$IDENTITY" --base-token "$token" --offset "$offset" --limit "$limit"
+
+    items_json="$(json_tmp)"
+    jq -c '.data.items // []' "$page_json" >"$items_json"
+
+    next_merged_json="$(json_tmp)"
+    jq -s '.[0] + .[1]' "$merged_json" "$items_json" >"$next_merged_json"
+    mv "$next_merged_json" "$merged_json"
+
+    count="$(jq -r '(.data.items // []) | length' "$page_json")"
+    total="$(jq -r '.data.total // 0' "$page_json")"
+
+    if [[ "$count" -eq 0 ]]; then
+      break
+    fi
+
+    offset=$((offset + count))
+
+    if [[ "$total" =~ ^[0-9]+$ ]] && [[ "$total" -gt 0 ]] && [[ "$offset" -lt "$total" ]]; then
+      continue
+    fi
+    if [[ "$count" -lt "$limit" ]]; then
+      break
+    fi
+  done
+
+  jq -n \
+    --slurpfile items "$merged_json" \
+    --argjson total "$total" \
+    --argjson limit "$limit" \
+    '
+      ($items[0]) as $merged
+      | {
+          ok: true,
+          data: {
+            items: $merged,
+            offset: 0,
+            limit: $limit,
+            count: ($merged | length),
+            total: (if $total > 0 then $total else ($merged | length) end)
+          }
+        }
+    ' >"$out_json"
+}
+
 backup_base() {
   local token="$1"
   local outdir="$2"
@@ -261,8 +321,7 @@ backup_base() {
     --token "$token" --doc-type bitable --file-extension xlsx --output-dir "$outdir"
 
   tables_json="$(json_tmp)"
-  run_shortcut_json "$tables_json" \
-    lark-cli base +table-list --as "$IDENTITY" --base-token "$token" --offset 0 --limit 100
+  list_all_base_tables "$token" "$tables_json"
   write_json_copy "$tables_json" "$outdir/tables.json"
 
   while IFS=$'\t' read -r table_id table_name; do

--- a/skills/lark-backup/scripts/lark-backup.sh
+++ b/skills/lark-backup/scripts/lark-backup.sh
@@ -177,14 +177,13 @@ infer_type() {
       ;;
     *)
       case "$clean" in
-        fld*) echo "folder" ;;
-        wikcn*) echo "wiki" ;;
-        sht*) echo "sheet" ;;
-        dox*) echo "docx" ;;
-        doccn*) echo "doc" ;;
-        # Keep known token families, but require --type for ambiguous raw tokens.
-        app_*|bascn*) echo "bitable" ;;
-        box*) echo "file" ;;
+        # Documented token prefixes per Lark/Feishu API
+        fld*) echo "folder" ;;  # fldcn... for folders
+        dox*) echo "docx" ;;    # doxcn... for new documents
+        sht*) echo "sheet" ;;   # shtcn... for sheets
+        box*) echo "file" ;;    # boxcn... for files
+        # Legacy/undocumented prefixes - require explicit --type
+        # Removed: wikcn*, doccn*, app_*, bascn* to avoid misclassification
         *) fail "cannot infer target type from token: $target; pass --type" ;;
       esac
       ;;

--- a/skills/lark-backup/scripts/lark-backup.sh
+++ b/skills/lark-backup/scripts/lark-backup.sh
@@ -116,6 +116,46 @@ format_index() {
   printf "%0${width}d\n" "$index"
 }
 
+table_list_page_info() {
+  local page_json="$1"
+  local err_out info
+
+  err_out="$(json_tmp)"
+  if ! info="$(jq -er '
+    [
+      ((.data.items // []) | length),
+      (.data.has_more // false),
+      (.data.total // 0)
+    ] | @tsv
+  ' "$page_json" 2>"$err_out")"; then
+    [[ -s "$err_out" ]] && cat "$err_out" >&2
+    fail "failed to parse base +table-list pagination metadata from $page_json"
+  fi
+
+  printf '%s\n' "$info"
+}
+
+record_list_page_info() {
+  local page_json="$1"
+  local err_out info
+
+  err_out="$(json_tmp)"
+  if ! info="$(jq -er '
+    if (.data.records.rows? | type) == "array" then
+      [(.data.records.rows | length), (.data.has_more // false), (.data.total // 0)] | @tsv
+    elif (.data.data? | type) == "array" then
+      [(.data.data | length), (.data.has_more // false), (.data.total // 0)] | @tsv
+    else
+      error("expected .data.records.rows or .data.data array")
+    end
+  ' "$page_json" 2>"$err_out")"; then
+    [[ -s "$err_out" ]] && cat "$err_out" >&2
+    fail "unsupported base +record-list response shape in $page_json"
+  fi
+
+  printf '%s\n' "$info"
+}
+
 run_shortcut_json() {
   local out="$1"
   local err_out
@@ -341,9 +381,7 @@ list_all_base_tables() {
     jq -s '.[0] + .[1]' "$merged_json" "$items_json" >"$next_merged_json"
     mv "$next_merged_json" "$merged_json"
 
-    count="$(jq -r '(.data.items // []) | length' "$page_json")"
-    has_more="$(jq -r '.data.has_more // false' "$page_json")"
-    total="$(jq -r '.data.total // 0' "$page_json")"
+    IFS=$'\t' read -r count has_more total <<<"$(table_list_page_info "$page_json")"
 
     if [[ "$count" -eq 0 ]]; then
       break
@@ -417,9 +455,7 @@ backup_base() {
         lark-cli base +record-list --as "$IDENTITY" \
         --base-token "$token" --table-id "$table_id" --offset "$offset" --limit 200
 
-      count="$(jq -r '((.data.records.rows // .data.data // []) | length)' "$page_json")"
-      has_more="$(jq -r '.data.has_more // false' "$page_json")"
-      total="$(jq -r '.data.total // 0' "$page_json")"
+      IFS=$'\t' read -r count has_more total <<<"$(record_list_page_info "$page_json")"
 
       if [[ "$count" -eq 0 ]]; then
         break

--- a/skills/lark-backup/scripts/lark-backup.sh
+++ b/skills/lark-backup/scripts/lark-backup.sh
@@ -93,6 +93,29 @@ prepare_output_dir() {
   printf '%s\n' "$dir"
 }
 
+index_width() {
+  local total="${1:-0}"
+  local width=2
+
+  if [[ "$total" =~ ^[0-9]+$ ]] && (( total > 0 )); then
+    width="${#total}"
+    if (( width < 2 )); then
+      width=2
+    fi
+  fi
+
+  printf '%s\n' "$width"
+}
+
+format_index() {
+  local index="$1"
+  local total="${2:-0}"
+  local width
+
+  width="$(index_width "$total")"
+  printf "%0${width}d\n" "$index"
+}
+
 run_shortcut_json() {
   local out="$1"
   local err_out
@@ -249,7 +272,7 @@ backup_doc() {
 backup_sheet() {
   local token="$1"
   local outdir="$2"
-  local info_json
+  local info_json total_sheets
   local idx=0
 
   mkdir -p "$outdir/csv"
@@ -259,6 +282,7 @@ backup_sheet() {
   run_shortcut_json "$info_json" \
     lark-cli sheets +info --as "$IDENTITY" --spreadsheet-token "$token"
   write_json_copy "$info_json" "$outdir/info.json"
+  total_sheets="$(jq -r '(.data.sheets // []) | length' "$info_json")"
 
   run_shortcut_json "$outdir/export-xlsx.json" \
     lark-cli sheets +export --as "$IDENTITY" \
@@ -267,14 +291,15 @@ backup_sheet() {
   while IFS=$'\t' read -r sheet_id title; do
     [[ -z "$sheet_id" ]] && continue
     idx=$((idx + 1))
-    local safe_title
+    local safe_title sheet_prefix
     safe_title="$(sanitize_name "$title")"
+    sheet_prefix="$(format_index "$idx" "$total_sheets")"
     run_shortcut_json "$outdir/csv-${idx}.json" \
       lark-cli sheets +export --as "$IDENTITY" \
       --spreadsheet-token "$token" \
       --file-extension csv \
       --sheet-id "$sheet_id" \
-      --output-path "$outdir/csv/$(printf '%02d' "$idx")-${safe_title}.csv"
+      --output-path "$outdir/csv/${sheet_prefix}-${safe_title}.csv"
   done < <(jq -r '.data.sheets[]? | [.sheet_id, (.title // .sheet_id)] | @tsv' "$info_json")
 }
 
@@ -480,7 +505,8 @@ backup_auto() {
 backup_folder() {
   local folder_token="$1"
   local outdir="$2"
-  local list_json idx=0
+  local list_json total_entries
+  local idx=0
 
   if [[ -n "${SEEN_FOLDERS[$folder_token]:-}" ]]; then
     log "skip already visited folder: ${folder_token}"
@@ -496,12 +522,13 @@ backup_folder() {
     lark-cli drive files list --as "$IDENTITY" --format json --page-all \
     --params "$(jq -cn --arg folder_token "$folder_token" '{folder_token:$folder_token,page_size:100}')"
   write_json_copy "$list_json" "$outdir/folder-items.json"
+  total_entries="$(jq -r '(.data.files // []) | length' "$list_json")"
 
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue
     idx=$((idx + 1))
 
-    local entry_name entry_type entry_token shortcut_type shortcut_token entry_dir safe_name
+    local entry_name entry_type entry_token shortcut_type shortcut_token entry_dir safe_name entry_prefix
     entry_name="$(jq -r '.name // "item"' <<<"$entry")"
     entry_type="$(jq -r '.type // empty' <<<"$entry")"
     entry_token="$(jq -r '.token // empty' <<<"$entry")"
@@ -514,7 +541,8 @@ backup_folder() {
     fi
 
     safe_name="$(sanitize_name "$entry_name")"
-    entry_dir="$outdir/items/$(printf '%02d' "$idx")-${safe_name}"
+    entry_prefix="$(format_index "$idx" "$total_entries")"
+    entry_dir="$outdir/items/${entry_prefix}-${safe_name}"
     mkdir -p "$entry_dir"
     jq . <<<"$entry" >"$entry_dir/entry.json"
 
@@ -669,4 +697,6 @@ main() {
   echo "$OUTPUT_DIR"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Summary
Add a new official workflow skill, `lark-backup`, that turns existing docs/drive/sheets/base/wiki commands into a practical backup flow for Feishu resources.

## Changes
- Add `skills/lark-backup/SKILL.md` with the backup workflow, auth guidance, and script entrypoints.
- Add `skills/lark-backup/references/backup-layout.md` documenting output layout and current boundaries.
- Add `skills/lark-backup/scripts/lark-backup.sh` to back up docs, sheets, Base resources, files, folders, and wiki-resolved objects.

## Test Plan
- [ ] Unit tests pass
- [x] Manual local verification confirms the `lark xxx` command works as expected

Manual verification:
- `bash -n skills/lark-backup/scripts/lark-backup.sh`
- `find skills/lark-backup -maxdepth 3 -type f | sort`

## Related Issues
- Closes #323


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-mode Feishu/Lark backup CLI: automatic type detection plus folder, base, doc, sheet and file modes; recursive folder traversal with revisit protection; per-item exports (MD/XLSX/CSV/etc.), paginated record snapshots, and printed output directory on completion.

* **Documentation**
  * Added user guidance covering usage modes, recommended authentication, permission/type error handling, output layout/schema, unsupported-type behavior, and tips for large tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->