### PR TITLE
fix(im): reject --user-id under bot identity for chat-messages-list

### DIFF
--- a/shortcuts/im/builders_test.go
+++ b/shortcuts/im/builders_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
 )
@@ -392,6 +393,28 @@ func TestShortcutValidateBranches(t *testing.T) {
 		}, nil)
 		if err := ImChatMessageList.Validate(context.Background(), runtime); err != nil {
 			t.Fatalf("ImChatMessageList.Validate() unexpected error = %v", err)
+		}
+	})
+
+	t.Run("ImChatMessageList rejects both targets", func(t *testing.T) {
+		runtime := newTestRuntimeContext(t, map[string]string{
+			"chat-id": "oc_abc",
+			"user-id": "ou_123",
+		}, nil)
+		err := ImChatMessageList.Validate(context.Background(), runtime)
+		if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Fatalf("ImChatMessageList.Validate() error = %v, want mutually exclusive", err)
+		}
+	})
+
+	t.Run("ImChatMessageList rejects user target for bot identity", func(t *testing.T) {
+		runtime := newTestRuntimeContext(t, map[string]string{
+			"user-id": "ou_123",
+		}, nil)
+		setRuntimeField(t, runtime, "resolvedAs", core.AsBot)
+		err := ImChatMessageList.Validate(context.Background(), runtime)
+		if err == nil || !strings.Contains(err.Error(), "requires user identity") {
+			t.Fatalf("ImChatMessageList.Validate() error = %v, want requires user identity", err)
 		}
 	})
 

--- a/shortcuts/im/coverage_additional_test.go
+++ b/shortcuts/im/coverage_additional_test.go
@@ -273,7 +273,7 @@ func TestResolveChatIDForMessagesList(t *testing.T) {
 	})
 
 	t.Run("user resolved through p2p lookup", func(t *testing.T) {
-		runtime := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 			switch {
 			case strings.Contains(req.URL.Path, "/open-apis/im/v1/chat_p2p/batch_query"):
 				return shortcutJSONResponse(200, map[string]interface{}{
@@ -301,6 +301,23 @@ func TestResolveChatIDForMessagesList(t *testing.T) {
 		}
 		if got != "oc_resolved" {
 			t.Fatalf("resolveChatIDForMessagesList() = %q, want %q", got, "oc_resolved")
+		}
+	})
+
+	t.Run("user target rejected for bot identity", func(t *testing.T) {
+		runtime := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, fmt.Errorf("unexpected request: %s", req.URL.String())
+		}))
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().String("user-id", "", "")
+		if err := cmd.Flags().Set("user-id", "ou_123"); err != nil {
+			t.Fatalf("Flags().Set() error = %v", err)
+		}
+		runtime.Cmd = cmd
+
+		_, err := resolveChatIDForMessagesList(runtime, false)
+		if err == nil || !strings.Contains(err.Error(), "requires user identity") {
+			t.Fatalf("resolveChatIDForMessagesList() error = %v, want requires user identity", err)
 		}
 	})
 }

--- a/shortcuts/im/helpers.go
+++ b/shortcuts/im/helpers.go
@@ -377,6 +377,9 @@ func mediaFallbackOrError(originalValue, mediaType string, uploadErr error) (str
 
 // resolveP2PChatID resolves user open_id to P2P chat_id.
 func resolveP2PChatID(runtime *common.RuntimeContext, openID string) (string, error) {
+	if runtime.IsBot() {
+		return "", output.Errorf(output.ExitValidation, "validation", "--user-id requires user identity (--as user); use --chat-id when calling with bot identity")
+	}
 	apiResp, err := runtime.DoAPI(&larkcore.ApiReq{
 		HttpMethod: http.MethodPost,
 		ApiPath:    "/open-apis/im/v1/chat_p2p/batch_query",

--- a/shortcuts/im/helpers_network_test.go
+++ b/shortcuts/im/helpers_network_test.go
@@ -107,12 +107,17 @@ func newBotShortcutRuntime(t *testing.T, rt http.RoundTripper) *common.RuntimeCo
 	return runtime
 }
 
+func newUserShortcutRuntime(t *testing.T, rt http.RoundTripper) *common.RuntimeContext {
+	t.Helper()
+	runtime := newBotShortcutRuntime(t, rt)
+	setRuntimeField(t, runtime, "resolvedAs", core.AsUser)
+	return runtime
+}
+
 func TestResolveP2PChatID(t *testing.T) {
-	var gotAuth string
-	runtime := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case strings.Contains(req.URL.Path, "/open-apis/im/v1/chat_p2p/batch_query"):
-			gotAuth = req.Header.Get("Authorization")
 			return shortcutJSONResponse(200, map[string]interface{}{
 				"code": 0,
 				"data": map[string]interface{}{
@@ -133,13 +138,10 @@ func TestResolveP2PChatID(t *testing.T) {
 	if got != "oc_123" {
 		t.Fatalf("resolveP2PChatID() = %q, want %q", got, "oc_123")
 	}
-	if gotAuth != "Bearer tenant-token" {
-		t.Fatalf("Authorization header = %q, want %q", gotAuth, "Bearer tenant-token")
-	}
 }
 
 func TestResolveP2PChatIDNotFound(t *testing.T) {
-	runtime := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+	runtime := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {
 		case strings.Contains(req.URL.Path, "/open-apis/im/v1/chat_p2p/batch_query"):
 			return shortcutJSONResponse(200, map[string]interface{}{
@@ -156,6 +158,17 @@ func TestResolveP2PChatIDNotFound(t *testing.T) {
 	_, err := resolveP2PChatID(runtime, "ou_404")
 	if err == nil || !strings.Contains(err.Error(), "P2P chat not found") {
 		t.Fatalf("resolveP2PChatID() error = %v", err)
+	}
+}
+
+func TestResolveP2PChatIDRejectsBot(t *testing.T) {
+	runtime := newBotShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("unexpected request: %s", req.URL.String())
+	}))
+
+	_, err := resolveP2PChatID(runtime, "ou_123")
+	if err == nil || !strings.Contains(err.Error(), "requires user identity") {
+		t.Fatalf("resolveP2PChatID() error = %v, want requires user identity", err)
 	}
 }
 

--- a/shortcuts/im/im_chat_messages_list.go
+++ b/shortcuts/im/im_chat_messages_list.go
@@ -28,7 +28,7 @@ var ImChatMessageList = common.Shortcut{
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "chat-id", Desc: "(required, mutually exclusive with --user-id) chat ID (oc_xxx)"},
-		{Name: "user-id", Desc: "(required, mutually exclusive with --chat-id) user open_id (ou_xxx)"},
+		{Name: "user-id", Desc: "(required, mutually exclusive with --chat-id; user identity only) user open_id (ou_xxx)"},
 		{Name: "start", Desc: "start time (ISO 8601)"},
 		{Name: "end", Desc: "end time (ISO 8601)"},
 		{Name: "sort", Default: "desc", Desc: "sort order", Enum: []string{"asc", "desc"}},
@@ -57,11 +57,21 @@ var ImChatMessageList = common.Shortcut{
 		return d.GET("/open-apis/im/v1/messages").Params(dryParams)
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if err := common.ExactlyOne(runtime, "chat-id", "user-id"); err != nil {
-			if runtime.Str("chat-id") == "" && runtime.Str("user-id") == "" {
-				return common.FlagErrorf("specify at least one of --chat-id or --user-id")
+		// Under bot identity, --user-id is not supported; require --chat-id only.
+		if runtime.IsBot() {
+			if runtime.Str("user-id") != "" {
+				return common.FlagErrorf("--user-id requires user identity (--as user); use --chat-id when calling with bot identity")
 			}
-			return err
+			if runtime.Str("chat-id") == "" {
+				return common.FlagErrorf("specify --chat-id (bot identity does not support --user-id)")
+			}
+		} else {
+			if err := common.ExactlyOne(runtime, "chat-id", "user-id"); err != nil {
+				if runtime.Str("chat-id") == "" && runtime.Str("user-id") == "" {
+					return common.FlagErrorf("specify at least one of --chat-id or --user-id")
+				}
+				return err
+			}
 		}
 
 		// Validate ID formats

--- a/skills/lark-im/references/lark-im-chat-messages-list.md
+++ b/skills/lark-im/references/lark-im-chat-messages-list.md
@@ -36,7 +36,7 @@ lark-cli im +chat-messages-list --chat-id oc_xxx --format json
 | Parameter | Required | Description |
 |------|------|------|
 | `--chat-id <id>` | One of two | Specify the conversation by its chat_id directly (e.g., group chat `oc_xxx`) |
-| `--user-id <id>` | One of two | Specify a DM conversation by the other user's open_id (`ou_xxx`); p2p chat_id is resolved automatically |
+| `--user-id <id>` | One of two | Specify a DM conversation by the other user's open_id (`ou_xxx`); p2p chat_id is resolved automatically. Requires user identity (`--as user`); not supported with bot identity |
 | `--start <time>` | No | Start time (ISO 8601 or date only) |
 | `--end <time>` | No | End time (ISO 8601 or date only) |
 | `--sort <order>` | No | Sort order: `asc` / `desc` (default `desc`) |
@@ -116,6 +116,7 @@ lark-cli api GET /open-apis/im/v1/messages \
 |---------|---------|---------|
 | `specify --chat-id <chat_id> or --user-id <open_id>` | Neither `--chat-id` nor `--user-id` was provided | You must provide exactly one |
 | `--chat-id and --user-id cannot be specified together` | Both parameters were provided | Use only one |
+| `--user-id requires user identity (--as user); use --chat-id when calling with bot identity` | `--user-id` was used with bot identity | The p2p resolution endpoint requires user identity. Either pass `--as user` or look up the p2p `chat_id` separately and pass it via `--chat-id` |
 | `P2P chat not found for this user` | `--user-id` was used but no p2p chat exists for the current identity and that user | Confirm the target direct-message relationship exists for the current identity |
 | `--start: invalid time format` | Invalid time format | Use ISO 8601 or date-only format such as `2026-03-10` |
 | Permission denied | Message read permissions are missing | Ensure the app has `im:message:readonly` and `im:chat:read` enabled |
@@ -130,7 +131,7 @@ lark-cli api GET /open-apis/im/v1/messages \
    ```
    **Do not use `im chats search` or `im chats list` — always use the `+chat-search` shortcut.**
 2. **Prefer `--chat-id` when available:** if the chat_id is already known, use it directly to avoid extra API calls.
-3. **For direct messages:** use `--user-id` to resolve the p2p chat automatically instead of looking it up manually.
+3. **For direct messages:** use `--user-id` to resolve the p2p chat automatically instead of looking it up manually. This requires user identity (`--as user`); with bot identity, resolve the p2p `chat_id` yourself and pass it via `--chat-id`.
 4. **For time ranges:** both ISO 8601 and date-only inputs are supported. Date-only is usually simpler.
 5. **For full content:** table output truncates content. Use `--format json` when you need the complete message body.
 6. **For sender info:** the command already resolves sender names, so you do not need a separate lookup.


### PR DESCRIPTION
## Summary
`lark-cli im +chat-messages-list --user-id ou_xxx` resolves the target user's p2p `chat_id` through `POST /open-apis/im/v1/chat_p2p/batch_query`, which requires **user identity**. Invoking it under bot identity previously failed silently or returned wrong results. This PR rejects the combination at the entry point with a clear error.

## Changes
- `shortcuts/im/im_chat_messages_list.go`: `Validate` now rejects `--user-id` when `runtime.IsBot()`, pointing users to `--as user` or `--chat-id`. Flag description updated to note "user identity only".
- `shortcuts/im/helpers.go`: `resolveP2PChatID` gains a defensive guard returning the same validation error, in case the helper is reached via another path.
- `skills/lark-im/references/lark-im-chat-messages-list.md`: document the user-identity requirement on `--user-id`, add the new error row to the troubleshooting table, and update the AI usage guidance.
- Tests:
  - `builders_test.go`: add subtests for mutual-exclusion and bot-identity rejection of `--user-id`.
  - `helpers_network_test.go`: introduce `newUserShortcutRuntime` helper; keep the p2p happy-path / not-found tests on user identity; add `TestResolveP2PChatIDRejectsBot`.
  - `coverage_additional_test.go`: `TestResolveChatIDForMessagesList` keeps the user-identity happy path and adds a bot-rejection subtest.

## Test Plan
- [x] Unit tests pass: `go test ./shortcuts/im/...`
- [x] `go build ./...` clean
- [x] Manual verification with a real tenant:
  - `lark-cli im +chat-messages-list --as bot --user-id ou_xxx` → rejected at Validate with `requires user identity`
  - `lark-cli im +chat-messages-list --as bot --chat-id oc_xxx` → returns messages normally
  - `lark-cli im +chat-messages-list --as user --user-id ou_xxx` → resolves p2p chat and returns DM messages
  - `lark-cli im +chat-messages-list --chat-id oc_xxx --user-id ou_xxx` → mutual-exclusion error

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commands now reject using --user-id when authenticated as a bot, return a clear error directing users to use --chat-id or run as user, and avoid attempting p2p resolution under bot identity.
* **Documentation**
  * Clarified docs/troubleshooting: automatic p2p chat resolution requires user identity; guidance to pass --as user or supply --chat-id.
* **Tests**
  * Added/updated tests covering validation and p2p resolution behaviors for user vs. bot identities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->