### PR TITLE
feat: add --overwrite flag to sheets +export shortcut

### DIFF
--- a/shortcuts/sheets/sheet_export.go
+++ b/shortcuts/sheets/sheet_export.go
@@ -31,6 +31,7 @@ var SheetExport = common.Shortcut{
 		{Name: "file-extension", Desc: "export format: xlsx | csv", Required: true},
 		{Name: "output-path", Desc: "local save path"},
 		{Name: "sheet-id", Desc: "sheet ID (required for CSV)"},
+		{Name: "overwrite", Type: "bool", Desc: "overwrite existing output file"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token := runtime.Str("spreadsheet-token")
@@ -61,11 +62,18 @@ var SheetExport = common.Shortcut{
 		fileExt := runtime.Str("file-extension")
 		outputPath := runtime.Str("output-path")
 		sheetIdFlag := runtime.Str("sheet-id")
+		overwrite := runtime.Bool("overwrite")
 
 		// Early path validation before any API call
+		var safePath string
 		if outputPath != "" {
-			if _, err := validate.SafeOutputPath(outputPath); err != nil {
+			var err error
+			safePath, err = validate.SafeOutputPath(outputPath)
+			if err != nil {
 				return output.ErrValidation("unsafe output path: %s", err)
+			}
+			if err := common.EnsureWritableFile(safePath, overwrite); err != nil {
+				return err
 			}
 		}
 
@@ -117,6 +125,7 @@ var SheetExport = common.Shortcut{
 				"file_token": fileToken,
 				"ticket":     ticket,
 			}, nil)
+			return nil
 		}
 
 		// Download
@@ -129,10 +138,6 @@ var SheetExport = common.Shortcut{
 		}
 		defer resp.Body.Close()
 
-		safePath, pathErr := validate.SafeOutputPath(outputPath)
-		if pathErr != nil {
-			return output.ErrValidation("unsafe output path: %s", pathErr)
-		}
 		if err := vfs.MkdirAll(filepath.Dir(safePath), 0700); err != nil {
 			return output.Errorf(output.ExitInternal, "api_error", "cannot create parent directory: %s", err)
 		}

--- a/shortcuts/sheets/sheet_export_test.go
+++ b/shortcuts/sheets/sheet_export_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestSheetExportRejectsOverwriteWithoutFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, sheetsTestConfig())
+
+	tmpDir := t.TempDir()
+	cmdutil.TestChdir(t, tmpDir)
+
+	if err := os.WriteFile("report.xlsx", []byte("old"), 0644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	// The overwrite check happens before any API call, so no HTTP stubs needed.
+	err := mountAndRunSheets(t, SheetExport, []string{
+		"+export",
+		"--spreadsheet-token", "shtTOKEN",
+		"--file-extension", "xlsx",
+		"--output-path", "report.xlsx",
+		"--as", "user",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected overwrite protection error, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSheetExportAllowsOverwriteWithFlag(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, sheetsTestConfig())
+
+	// Register stubs for the export task creation API.
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/export_tasks",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"ticket": "tkt_123"},
+		},
+	})
+	// Register stub for the poll API (returns completed immediately).
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/drive/v1/export_tasks/tkt_123",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"result": map[string]interface{}{
+					"file_token": "box_export_123",
+					"file_name":  "report.xlsx",
+					"file_size":  100,
+				},
+			},
+		},
+	})
+	// Register stub for the download API.
+	reg.Register(&httpmock.Stub{
+		Method:  "GET",
+		URL:     "/open-apis/drive/v1/export_tasks/file/box_export_123/download",
+		RawBody: []byte("new-content"),
+		Headers: http.Header{
+			"Content-Type": []string{"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"},
+		},
+	})
+
+	tmpDir := t.TempDir()
+	cmdutil.TestChdir(t, tmpDir)
+
+	if err := os.WriteFile("report.xlsx", []byte("old"), 0644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	err := mountAndRunSheets(t, SheetExport, []string{
+		"+export",
+		"--spreadsheet-token", "shtTOKEN",
+		"--file-extension", "xlsx",
+		"--output-path", "report.xlsx",
+		"--overwrite",
+		"--as", "user",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile("report.xlsx")
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if string(data) != "new-content" {
+		t.Fatalf("file content = %q, want %q", string(data), "new-content")
+	}
+}
+
+func TestSheetExportNoOutputPathReturnsFileToken(t *testing.T) {
+	// When --output-path is not provided, Execute should return the
+	// file_token JSON without downloading.
+	f, stdout, _, reg := cmdutil.TestFactory(t, sheetsTestConfig())
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/export_tasks",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"ticket": "tkt_456"},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/drive/v1/export_tasks/tkt_456",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"result": map[string]interface{}{
+					"file_token": "box_export_456",
+				},
+			},
+		},
+	})
+
+	err := mountAndRunSheets(t, SheetExport, []string{
+		"+export",
+		"--spreadsheet-token", "shtTOKEN",
+		"--file-extension", "xlsx",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "box_export_456") {
+		t.Fatalf("stdout should contain file_token, got: %s", stdout.String())
+	}
+}

--- a/shortcuts/sheets/sheets_test_helpers_test.go
+++ b/shortcuts/sheets/sheets_test_helpers_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+func sheetsTestConfig() *core.CliConfig {
+	return &core.CliConfig{
+		AppID: "sheets-test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	}
+}
+
+func mountAndRunSheets(t *testing.T, s common.Shortcut, args []string, f *cmdutil.Factory, stdout *bytes.Buffer) error {
+	t.Helper()
+	parent := &cobra.Command{Use: "sheets"}
+	s.Mount(parent, f)
+	parent.SetArgs(args)
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	if stdout != nil {
+		stdout.Reset()
+	}
+	return parent.Execute()
+}


### PR DESCRIPTION
  ## Summary                                                

  Add an `--overwrite` flag to `sheets +export` that controls whether an existing                                                                                                            
  output file can be replaced. Without the flag, exporting to a path that already
  exists now returns a clear error before any API call is made.                                                                                                                              
                                                                                                                                                                                             
  ## Changes                                                                                                                                                                                 
                                                                                                                                                                                             
  - Add `--overwrite` boolean flag to `SheetExport` in `shortcuts/sheets/sheet_export.go`                                                                                                    
  - Validate output path writability via `common.EnsureWritableFile` before creating
    the export task, so conflicts are caught early                                                                                                                                           
  - Add `sheet_export_test.go` with three test cases:                                                                                                                                        
    - Rejects overwrite when flag is not set
    - Allows overwrite when flag is set (end-to-end with mocked export + download)                                                                                                           
    - Skips overwrite check when `--output-path` is omitted                                                                                                                                  
                                                                                                                                                                                             
  ## Test Plan                                                                                                                                                                               
                                                            
  - [x] `make unit-test` passed                                                                                                                                                              
  - [x] Added `TestSheetExport*` covering overwrite protection, flag acceptance,
    and no-output-path bypass                                                                                                                                                                
                                                            
  ## Related Issues                                                                                                                                                                          
                                                            
  N/A                                                                                                                                                                                        
                                                            
  Label: feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an --overwrite flag to sheet export to allow replacing existing files.

* **Behavior Changes / Bug Fixes**
  * Export uses a single safe output path validation and atomic, safe file writes; avoids accidental overwrites by default.
  * When no output path is given, the command prints the file token and exits.

* **Tests**
  * Added tests and test helpers covering overwrite behavior and token-only output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->