### PR TITLE
fix(mail): add missing scopes for mail +watch

### DIFF
--- a/internal/registry/scope_overrides.json
+++ b/internal/registry/scope_overrides.json
@@ -25,6 +25,7 @@
       "calendar:calendar:update",
       "contact:user.basic_profile:readonly",
       "mail:event",
+      "mail:user_mailbox.event.mail_address:read",
       "mail:user_mailbox.mail_contact:read",
       "mail:user_mailbox.mail_contact:write",
       "mail:user_mailbox.message.address:read",

--- a/internal/registry/scope_overrides.json
+++ b/internal/registry/scope_overrides.json
@@ -25,7 +25,6 @@
       "calendar:calendar:update",
       "contact:user.basic_profile:readonly",
       "mail:event",
-      "mail:user_mailbox.event.mail_address:read",
       "mail:user_mailbox.mail_contact:read",
       "mail:user_mailbox.mail_contact:write",
       "mail:user_mailbox.message.address:read",

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -81,7 +81,7 @@ var MailWatch = common.Shortcut{
 	Command:     "+watch",
 	Description: "Watch for incoming mail events via WebSocket (requires scope mail:event and bot event mail.user_mailbox.event.message_received_v1 added). Run with --print-output-schema to see per-format field reference before parsing output.",
 	Risk:        "read",
-	Scopes:      []string{"mail:event", "mail:user_mailbox.event.mail_address:read", "mail:user_mailbox.message:readonly", "mail:user_mailbox.message.address:read", "mail:user_mailbox.message.subject:read", "mail:user_mailbox.message.body:read"},
+	Scopes:      []string{"mail:event", "mail:user_mailbox.event.mail_address:read", "mail:user_mailbox:readonly", "mail:user_mailbox.message:readonly", "mail:user_mailbox.message.address:read", "mail:user_mailbox.message.subject:read", "mail:user_mailbox.message.body:read"},
 	AuthTypes:   []string{"user"},
 	Flags: []common.Flag{
 		{Name: "format", Default: "data", Desc: "json: NDJSON stream with ok/data envelope; data: bare NDJSON stream"},

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -81,7 +81,7 @@ var MailWatch = common.Shortcut{
 	Command:     "+watch",
 	Description: "Watch for incoming mail events via WebSocket (requires scope mail:event and bot event mail.user_mailbox.event.message_received_v1 added). Run with --print-output-schema to see per-format field reference before parsing output.",
 	Risk:        "read",
-	Scopes:      []string{"mail:event", "mail:user_mailbox.message:readonly", "mail:user_mailbox.message.address:read", "mail:user_mailbox.message.subject:read", "mail:user_mailbox.message.body:read"},
+	Scopes:      []string{"mail:event", "mail:user_mailbox.event.mail_address:read", "mail:user_mailbox.message:readonly", "mail:user_mailbox.message.address:read", "mail:user_mailbox.message.subject:read", "mail:user_mailbox.message.body:read"},
 	AuthTypes:   []string{"user"},
 	Flags: []common.Flag{
 		{Name: "format", Default: "data", Desc: "json: NDJSON stream with ok/data envelope; data: bare NDJSON stream"},


### PR DESCRIPTION
## Summary

- Add `mail:user_mailbox.event.mail_address:read` and `mail:user_mailbox:readonly` to mail `+watch` shortcut's declared Scopes

## Problem

The `mail +watch` shortcut was missing two scopes:

1. **`mail:user_mailbox.event.mail_address:read`** — Without it, WebSocket event payloads arrive without the `mail_address` field, which breaks:
   - `--mailbox` filtering (cannot match events to the subscribed mailbox)
   - `fetchMailbox` resolution (falls back to the `--mailbox` flag value instead of the event's actual mailbox address)

2. **`mail:user_mailbox:readonly`** — Required by `fetchMailboxPrimaryEmail` (GET `user_mailboxes/me/profile`) to resolve the mailbox address for event filtering. All other mail shortcuts that call this API (send, reply, forward, draft-create, draft-edit) already declare this scope, but `+watch` did not.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./shortcuts/mail/... ./internal/registry/...` passes
- [ ] Manual: `mail +watch` events contain `mail_address` field after re-login with updated scopes