### PR TITLE
feat: add jsonfile credential provider for JSON file credential injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ The official [Lark/Feishu](https://www.larksuite.com/) CLI tool, maintained by t
 
 ## Features
 
-| Category      | Capabilities                                                                                                                      |
-| ------------- |-----------------------------------------------------------------------------------------------------------------------------------|
-| 📅 Calendar   | View agenda, create events, invite attendees, check free/busy status, time suggestions                                            |
-| 💬 Messenger  | Send/reply messages, create and manage group chats, view chat history & threads, search messages, download media                  |
-| 📄 Docs       | Create, read, update, and search documents, read/write media & whiteboards                                                        |
-| 📁 Drive      | Upload and download files, search docs & wiki, manage comments                                                                    |
-| 📊 Base       | Create and manage tables, fields, records, views, dashboards, workflows, forms, roles & permissions, data aggregation & analytics |
-| 📈 Sheets     | Create, read, write, append, find, and export spreadsheet data                                                                    |
+| Category     | Capabilities                                                                                                                      |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| 📅 Calendar  | View agenda, create events, invite attendees, check free/busy status, time suggestions                                            |
+| 💬 Messenger | Send/reply messages, create and manage group chats, view chat history & threads, search messages, download media                  |
+| 📄 Docs      | Create, read, update, and search documents, read/write media & whiteboards                                                        |
+| 📁 Drive     | Upload and download files, search docs & wiki, manage comments                                                                    |
+| 📊 Base      | Create and manage tables, fields, records, views, dashboards, workflows, forms, roles & permissions, data aggregation & analytics |
+| 📈 Sheets    | Create, read, write, append, find, and export spreadsheet data                                                                    |
 | ✅ Tasks      | Create, query, update, and complete tasks; manage task lists, subtasks, comments & reminders                                      |
-| 📚 Wiki       | Create and manage knowledge spaces, nodes, and documents                                                                          |
-| 👤 Contact    | Search users by name/email/phone, get user profiles                                                                               |
-| 📧 Mail       | Browse, search, read emails, send, reply, forward, manage drafts, watch new mail                                                  |
-| 🎥 Meetings   | Search meeting records, query meeting minutes & recordings                                                                        |
-| ✍️ Approval   | Query approval tasks, approve/reject/transfer tasks, cancel and CC instances                                                      |
+| 📚 Wiki      | Create and manage knowledge spaces, nodes, and documents                                                                          |
+| 👤 Contact   | Search users by name/email/phone, get user profiles                                                                               |
+| 📧 Mail      | Browse, search, read emails, send, reply, forward, manage drafts, watch new mail                                                  |
+| 🎥 Meetings  | Search meeting records, query meeting minutes & recordings                                                                        |
+| ✍️ Approval  | Query approval tasks, approve/reject/transfer tasks, cancel and CC instances                                                      |
 
 ## Installation & Quick Start
 
@@ -129,7 +129,7 @@ lark-cli auth status
 ## Agent Skills
 
 | Skill                           | Description                                                                                                    |
-| ------------------------------- |----------------------------------------------------------------------------------------------------------------|
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `lark-shared`                   | App config, auth login, identity switching, scope management, security rules (auto-loaded by all other skills) |
 | `lark-calendar`                 | Calendar events, agenda view, free/busy queries, time suggestions                                              |
 | `lark-im`                       | Send/reply messages, group chat management, message search, upload/download images & files, reactions          |
@@ -158,7 +158,7 @@ lark-cli auth status
 | `auth login`  | OAuth login with interactive selection or CLI flags for scopes |
 | `auth logout` | Sign out and remove stored credentials                         |
 | `auth status` | Show current login status and granted scopes                   |
-| `auth check`  | Verify a specific scope (exit 0 = ok, 1 = missing)            |
+| `auth check`  | Verify a specific scope (exit 0 = ok, 1 = missing)             |
 | `auth scopes` | List all available scopes for the app                          |
 | `auth list`   | List all authenticated users                                   |
 
@@ -184,6 +184,38 @@ lark-cli auth login --device-code <DEVICE_CODE>
 lark-cli calendar +agenda --as user
 lark-cli im +messages-send --as bot --chat-id "oc_xxx" --text "Hello"
 ```
+
+### Credential File
+
+If you already have app credentials, you can skip the interactive `config init` by injecting them from a JSON file via environment variable:
+
+```bash
+export LARKSUITE_CLI_CREDENTIAL_FILE=/path/to/credentials.json
+```
+
+The JSON file format:
+
+```json
+{
+  "app_id": "cli_xxxx",
+  "app_secret": "your_app_secret",
+  "brand": "feishu",
+  "user_access_token": "u-xxxx",
+  "tenant_access_token": "t-xxxx",
+  "refresh_token": "r-xxxx"
+}
+```
+
+| Field                 | Required | Description                                                   |
+| --------------------- | -------- | ------------------------------------------------------------- |
+| `app_id`              | Yes      | Feishu/Lark App ID                                            |
+| `app_secret`          | No       | App Secret (not needed if tokens are provided)                |
+| `brand`               | No       | `feishu` (default) or `lark`                                  |
+| `user_access_token`   | No       | Pre-obtained User Access Token                                |
+| `tenant_access_token` | No       | Pre-obtained Tenant Access Token                              |
+| `refresh_token`       | No       | Refresh Token for auto-refreshing UAT (requires `app_secret`) |
+
+> **Note:** The file path must be an absolute path. When a credential file is set, it takes priority over the default config (`config init`) but lower than environment variables (`LARKSUITE_CLI_APP_ID`, etc.).
 
 ## Three-Layer Command System
 
@@ -269,7 +301,7 @@ Please fully understand all usage risks. By using this tool, you are deemed to v
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=larksuite/cli&type=Date)](https://star-history.com/#larksuite/cli&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=larksuite/cli\&type=Date)](https://star-history.com/#larksuite/cli\&Date)
 
 ## Contributing
 
@@ -287,3 +319,4 @@ When running, it calls Lark/Feishu Open Platform APIs. To use these APIs, you mu
 - [Feishu Open Platform App Service Provider Security Management Specifications](https://open.feishu.cn/document/uAjLw4CM/uMzNwEjLzcDMx4yM3ATM/management-practice/app-service-provider-security-management-specifications)
 - [Lark User Terms of Service](https://www.larksuite.com/user-terms-of-service)
 - [Lark Privacy Policy](https://www.larksuite.com/privacy-policy)
+

--- a/README.zh.md
+++ b/README.zh.md
@@ -186,6 +186,38 @@ lark-cli calendar +agenda --as user
 lark-cli im +messages-send --as bot --chat-id "oc_xxx" --text "Hello"
 ```
 
+### 凭证文件
+
+如果你已有应用凭证，可以跳过交互式 `config init`，通过环境变量指定 JSON 文件直接注入：
+
+```bash
+export LARKSUITE_CLI_CREDENTIAL_FILE=/path/to/credentials.json
+```
+
+JSON 文件格式：
+
+```json
+{
+  "app_id": "cli_xxxx",
+  "app_secret": "你的app_secret",
+  "brand": "feishu",
+  "user_access_token": "u-xxxx",
+  "tenant_access_token": "t-xxxx",
+  "refresh_token": "r-xxxx"
+}
+```
+
+| 字段                  | 必填 | 说明                                           |
+| -------------------- | ---- | ---------------------------------------------- |
+| `app_id`             | 是   | 飞书/Lark 应用 ID                               |
+| `app_secret`         | 否   | 应用密钥（如已提供 token 则可省略）                |
+| `brand`              | 否   | `feishu`（默认）或 `lark`                        |
+| `user_access_token`  | 否   | 预先获取的用户访问令牌                            |
+| `tenant_access_token`| 否   | 预先获取的租户访问令牌                            |
+| `refresh_token`      | 否   | 用于自动刷新用户令牌的 Refresh Token（需配合 `app_secret`）|
+
+> **注意：** 文件路径必须为绝对路径。凭证文件的优先级高于默认配置（`config init`），但低于环境变量（`LARKSUITE_CLI_APP_ID` 等）。
+
 ## 三层命令调用
 
 CLI 提供三种粒度的调用方式，覆盖从快速操作到完全自定义的全部场景：

--- a/extension/credential/jsonfile/jsonfile.go
+++ b/extension/credential/jsonfile/jsonfile.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package jsonfile
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/larksuite/cli/extension/credential"
+	larkauth "github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/charcheck"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/envvars"
+)
+
+type credFile struct {
+	AppID             string `json:"app_id"`
+	AppSecret         string `json:"app_secret"`
+	Brand             string `json:"brand"`
+	DefaultAs         string `json:"default_as"`
+	UserAccessToken   string `json:"user_access_token"`
+	TenantAccessToken string `json:"tenant_access_token"`
+	RefreshToken      string `json:"refresh_token"`
+}
+
+type cachedToken struct {
+	value     string
+	expiresAt time.Time
+}
+
+var (
+	refreshMu    sync.Mutex
+	refreshCache *cachedToken
+
+	tokenEndpointFunc = defaultTokenEndpoint
+)
+
+type Provider struct{}
+
+func (p *Provider) Name() string { return "jsonfile" }
+
+func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, error) {
+	filePath := os.Getenv(envvars.CliCredentialFile)
+	if filePath == "" {
+		return nil, nil
+	}
+
+	cf, err := readCredFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	appID := cf.AppID
+	appSecret := cf.AppSecret
+	hasUAT := cf.UserAccessToken != ""
+	hasTAT := cf.TenantAccessToken != ""
+	hasRefresh := cf.RefreshToken != ""
+
+	if appID == "" && appSecret == "" {
+		switch {
+		case hasUAT:
+			return nil, &credential.BlockError{Provider: "jsonfile", Reason: "user_access_token is set but app_id is missing in " + filePath}
+		case hasTAT:
+			return nil, &credential.BlockError{Provider: "jsonfile", Reason: "tenant_access_token is set but app_id is missing in " + filePath}
+		case hasRefresh:
+			return nil, &credential.BlockError{Provider: "jsonfile", Reason: "refresh_token is set but app_id is missing in " + filePath}
+		default:
+			return nil, nil
+		}
+	}
+	if appID == "" {
+		return nil, &credential.BlockError{Provider: "jsonfile", Reason: "app_secret is set but app_id is missing in " + filePath}
+	}
+	if appSecret == "" && !hasUAT && !hasTAT && !hasRefresh {
+		return nil, &credential.BlockError{
+			Provider: "jsonfile",
+			Reason:   "app_id is set but no app secret or access token is available in " + filePath,
+		}
+	}
+	if hasRefresh && appSecret == "" {
+		return nil, &credential.BlockError{
+			Provider: "jsonfile",
+			Reason:   "refresh_token requires app_secret in " + filePath,
+		}
+	}
+
+	brand := credential.Brand(cf.Brand)
+	if brand == "" {
+		brand = credential.BrandFeishu
+	}
+	acct := &credential.Account{AppID: appID, AppSecret: appSecret, Brand: brand}
+
+	switch id := credential.Identity(cf.DefaultAs); id {
+	case "", credential.IdentityAuto:
+		acct.DefaultAs = id
+	case credential.IdentityUser, credential.IdentityBot:
+		acct.DefaultAs = id
+	default:
+		return nil, &credential.BlockError{
+			Provider: "jsonfile",
+			Reason:   fmt.Sprintf("invalid default_as %q (want user, bot, or auto) in %s", id, filePath),
+		}
+	}
+
+	if hasUAT || hasRefresh {
+		acct.SupportedIdentities |= credential.SupportsUser
+	}
+	if hasTAT {
+		acct.SupportedIdentities |= credential.SupportsBot
+	}
+
+	if acct.DefaultAs == "" {
+		switch {
+		case hasUAT, hasRefresh:
+			acct.DefaultAs = credential.IdentityUser
+		case hasTAT:
+			acct.DefaultAs = credential.IdentityBot
+		}
+	}
+
+	return acct, nil
+}
+
+func (p *Provider) ResolveToken(ctx context.Context, req credential.TokenSpec) (*credential.Token, error) {
+	filePath := os.Getenv(envvars.CliCredentialFile)
+	if filePath == "" {
+		return nil, nil
+	}
+
+	cf, err := readCredFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	switch req.Type {
+	case credential.TokenTypeUAT:
+		return p.resolveUAT(cf, filePath)
+	case credential.TokenTypeTAT:
+		if cf.TenantAccessToken == "" {
+			return nil, nil
+		}
+		return &credential.Token{Value: cf.TenantAccessToken, Source: "jsonfile:" + filePath}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func (p *Provider) resolveUAT(cf *credFile, filePath string) (*credential.Token, error) {
+	if cf.UserAccessToken != "" {
+		return &credential.Token{Value: cf.UserAccessToken, Source: "jsonfile:" + filePath}, nil
+	}
+	if cf.RefreshToken == "" {
+		return nil, nil
+	}
+	token, err := refreshUAT(cf)
+	if err != nil {
+		return nil, err
+	}
+	return &credential.Token{Value: token, Source: "jsonfile:" + filePath + ":refreshed"}, nil
+}
+
+const refreshAheadDuration = 30 * time.Second
+
+func defaultTokenEndpoint(brand string) string {
+	b := core.LarkBrand(brand)
+	if b == "" {
+		b = core.BrandFeishu
+	}
+	return core.ResolveEndpoints(b).Open + larkauth.PathOAuthTokenV2
+}
+
+func refreshUAT(cf *credFile) (string, error) {
+	refreshMu.Lock()
+	defer refreshMu.Unlock()
+
+	if refreshCache != nil && time.Now().Before(refreshCache.expiresAt.Add(-refreshAheadDuration)) {
+		return refreshCache.value, nil
+	}
+
+	tokenURL := tokenEndpointFunc(cf.Brand)
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", cf.RefreshToken)
+	form.Set("client_id", cf.AppID)
+	form.Set("client_secret", cf.AppSecret)
+
+	req, err := http.NewRequest("POST", tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", &credential.BlockError{Provider: "jsonfile", Reason: fmt.Sprintf("failed to create refresh request: %v", err)}
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", &credential.BlockError{Provider: "jsonfile", Reason: fmt.Sprintf("refresh token request failed: %v", err)}
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", &credential.BlockError{Provider: "jsonfile", Reason: fmt.Sprintf("failed to read refresh response: %v", err)}
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(body, &data); err != nil {
+		return "", &credential.BlockError{Provider: "jsonfile", Reason: fmt.Sprintf("failed to parse refresh response: %v", err)}
+	}
+
+	if errStr, _ := data["error"].(string); errStr != "" {
+		desc, _ := data["error_description"].(string)
+		return "", &credential.BlockError{Provider: "jsonfile", Reason: fmt.Sprintf("refresh token failed: %s: %s", errStr, desc)}
+	}
+	if code, _ := data["code"].(float64); code != 0 {
+		msg, _ := data["message"].(string)
+		return "", &credential.BlockError{Provider: "jsonfile", Reason: fmt.Sprintf("refresh token failed (code=%d): %s", int(code), msg)}
+	}
+
+	accessToken, _ := data["access_token"].(string)
+	if accessToken == "" {
+		return "", &credential.BlockError{Provider: "jsonfile", Reason: "refresh response contains no access_token"}
+	}
+
+	expiresIn := 7200.0
+	if v, ok := data["expires_in"].(float64); ok && v > 0 {
+		expiresIn = v
+	}
+	refreshCache = &cachedToken{
+		value:     accessToken,
+		expiresAt: time.Now().Add(time.Duration(expiresIn) * time.Second),
+	}
+
+	return accessToken, nil
+}
+
+func readCredFile(filePath string) (*credFile, error) {
+	if err := charcheck.RejectControlChars(filePath, envvars.CliCredentialFile); err != nil {
+		return nil, &credential.BlockError{Provider: "jsonfile", Reason: fmt.Sprintf("invalid credential file path: %v", err)}
+	}
+
+	cleaned := filepath.Clean(filePath)
+	if !filepath.IsAbs(cleaned) {
+		return nil, &credential.BlockError{
+			Provider: "jsonfile",
+			Reason:   fmt.Sprintf("%s must be an absolute path, got %q", envvars.CliCredentialFile, filePath),
+		}
+	}
+
+	data, err := os.ReadFile(cleaned)
+	if err != nil {
+		return nil, &credential.BlockError{Provider: "jsonfile", Reason: fmt.Sprintf("cannot read credential file %s: %v", cleaned, err)}
+	}
+
+	var cf credFile
+	if err := json.Unmarshal(data, &cf); err != nil {
+		return nil, &credential.BlockError{Provider: "jsonfile", Reason: fmt.Sprintf("cannot parse credential file %s: %v", cleaned, err)}
+	}
+
+	return &cf, nil
+}
+
+func init() {
+	credential.Register(&Provider{})
+}

--- a/extension/credential/jsonfile/jsonfile_test.go
+++ b/extension/credential/jsonfile/jsonfile_test.go
@@ -1,0 +1,479 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package jsonfile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/extension/credential"
+	"github.com/larksuite/cli/internal/envvars"
+)
+
+func writeTempJSON(t *testing.T, data map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cred.json")
+	b, _ := json.Marshal(data)
+	os.WriteFile(path, b, 0o600)
+	return path
+}
+
+func TestProvider_Name(t *testing.T) {
+	if (&Provider{}).Name() != "jsonfile" {
+		t.Fail()
+	}
+}
+
+func TestResolveAccount_BothSet(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id":     "cli_test",
+		"app_secret": "secret_test",
+		"brand":      "feishu",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	acct, err := (&Provider{}).ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acct.AppID != "cli_test" || acct.AppSecret != "secret_test" || acct.Brand != "feishu" {
+		t.Errorf("unexpected: %+v", acct)
+	}
+}
+
+func TestResolveAccount_EnvNotSet(t *testing.T) {
+	acct, err := (&Provider{}).ResolveAccount(context.Background())
+	if err != nil || acct != nil {
+		t.Errorf("expected nil, nil; got %+v, %v", acct, err)
+	}
+}
+
+func TestResolveAccount_OnlyIDSet(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id": "cli_test",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	_, err := (&Provider{}).ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+}
+
+func TestResolveAccount_OnlySecretSet(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_secret": "secret_test",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	_, err := (&Provider{}).ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+}
+
+func TestResolveAccount_AppIDAndUserTokenWithoutSecret(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id":            "cli_test",
+		"user_access_token": "uat_test",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	acct, err := (&Provider{}).ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acct == nil {
+		t.Fatal("expected account, got nil")
+	}
+	if acct.AppSecret != credential.NoAppSecret {
+		t.Fatalf("AppSecret = %q, want credential.NoAppSecret", acct.AppSecret)
+	}
+	if acct.AppID != "cli_test" {
+		t.Fatalf("AppID = %q, want cli_test", acct.AppID)
+	}
+}
+
+func TestResolveAccount_DefaultBrand(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id":     "cli_test",
+		"app_secret": "secret_test",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	acct, _ := (&Provider{}).ResolveAccount(context.Background())
+	if acct.Brand != "feishu" {
+		t.Errorf("expected 'feishu', got %q", acct.Brand)
+	}
+}
+
+func TestResolveAccount_DefaultAsFromFile(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id":     "cli_test",
+		"app_secret": "secret_test",
+		"default_as": "user",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	acct, err := (&Provider{}).ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acct.DefaultAs != "user" {
+		t.Errorf("expected default-as user, got %q", acct.DefaultAs)
+	}
+}
+
+func TestResolveAccount_InvalidDefaultAsRejected(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id":     "app",
+		"app_secret": "secret",
+		"default_as": "invalid",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	_, err := (&Provider{}).ResolveAccount(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid default-as")
+	}
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %T", err)
+	}
+}
+
+func TestResolveAccount_InferFromUATOnly(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id":            "app",
+		"app_secret":        "secret",
+		"user_access_token": "u-tok",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	acct, err := (&Provider{}).ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acct.SupportedIdentities.UserOnly() {
+		t.Errorf("expected user-only from UAT inference, got %d", acct.SupportedIdentities)
+	}
+	if acct.DefaultAs != "user" {
+		t.Errorf("expected default-as user from UAT inference, got %q", acct.DefaultAs)
+	}
+}
+
+func TestResolveAccount_InferFromTATOnly(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id":              "app",
+		"app_secret":          "secret",
+		"tenant_access_token": "t-tok",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	acct, err := (&Provider{}).ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acct.SupportedIdentities.BotOnly() {
+		t.Errorf("expected bot-only from TAT inference, got %d", acct.SupportedIdentities)
+	}
+	if acct.DefaultAs != "bot" {
+		t.Errorf("expected default-as bot from TAT inference, got %q", acct.DefaultAs)
+	}
+}
+
+func TestResolveAccount_InferBothTokens(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id":              "app",
+		"app_secret":          "secret",
+		"user_access_token":   "u-tok",
+		"tenant_access_token": "t-tok",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	acct, err := (&Provider{}).ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acct.SupportedIdentities != credential.SupportsAll {
+		t.Errorf("expected SupportsAll, got %d", acct.SupportedIdentities)
+	}
+	if acct.DefaultAs != "user" {
+		t.Errorf("expected default-as user when both tokens are present, got %q", acct.DefaultAs)
+	}
+}
+
+func TestResolveToken_UATSet(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"user_access_token": "u-file",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Value != "u-file" || tok.Source != "jsonfile:"+path {
+		t.Errorf("unexpected: %+v", tok)
+	}
+}
+
+func TestResolveToken_TATSet(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"tenant_access_token": "t-file",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Value != "t-file" || tok.Source != "jsonfile:"+path {
+		t.Errorf("unexpected: %+v", tok)
+	}
+}
+
+func TestResolveToken_NotSet(t *testing.T) {
+	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
+	if err != nil || tok != nil {
+		t.Errorf("expected nil, nil; got %+v, %v", tok, err)
+	}
+}
+
+func TestResolveToken_TokenEmpty(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"user_access_token": "",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
+	if err != nil || tok != nil {
+		t.Errorf("expected nil, nil; got %+v, %v", tok, err)
+	}
+}
+
+func TestResolveAccount_FileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(envvars.CliCredentialFile, filepath.Join(dir, "nonexistent.json"))
+
+	_, err := (&Provider{}).ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+}
+
+func TestResolveAccount_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cred.json")
+	os.WriteFile(path, []byte("{not json}"), 0o600)
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	_, err := (&Provider{}).ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+}
+
+func TestResolveAccount_OnlyTokenSetWithoutAppID(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"user_access_token": "uat_test",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	_, err := (&Provider{}).ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+}
+
+func TestResolveAccount_RelativePathRejected(t *testing.T) {
+	t.Setenv(envvars.CliCredentialFile, "relative/path/cred.json")
+
+	_, err := (&Provider{}).ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+}
+
+func TestResolveAccount_RefreshTokenSetsUserSupport(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id":        "app",
+		"app_secret":    "secret",
+		"refresh_token": "rt-test",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	acct, err := (&Provider{}).ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acct.SupportedIdentities.UserOnly() {
+		t.Errorf("expected user-only from refresh_token, got %d", acct.SupportedIdentities)
+	}
+	if acct.DefaultAs != "user" {
+		t.Errorf("expected default-as user from refresh_token, got %q", acct.DefaultAs)
+	}
+}
+
+func TestResolveAccount_RefreshTokenWithoutAppSecret(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id":        "app",
+		"refresh_token": "rt-test",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	_, err := (&Provider{}).ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+}
+
+func TestResolveAccount_RefreshTokenWithoutAppID(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"refresh_token": "rt-test",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	_, err := (&Provider{}).ResolveAccount(context.Background())
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+}
+
+func TestResolveToken_UATPreferredOverRefreshToken(t *testing.T) {
+	path := writeTempJSON(t, map[string]string{
+		"app_id":            "app",
+		"app_secret":        "secret",
+		"user_access_token": "u-direct",
+		"refresh_token":     "rt-test",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Value != "u-direct" {
+		t.Errorf("expected direct UAT, got %q", tok.Value)
+	}
+}
+
+func TestResolveToken_RefreshTokenSuccess(t *testing.T) {
+	refreshMu.Lock()
+	refreshCache = nil
+	refreshMu.Unlock()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.FormValue("grant_type") != "refresh_token" {
+			http.Error(w, "bad grant_type", 400)
+			return
+		}
+		if r.FormValue("refresh_token") != "rt-valid" {
+			http.Error(w, "bad refresh_token", 400)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token":"u-refreshed","expires_in":7200}`)
+	}))
+	defer srv.Close()
+
+	orig := tokenEndpointFunc
+	tokenEndpointFunc = func(_ string) string { return srv.URL + "/open-apis/authen/v2/oauth/token" }
+	defer func() { tokenEndpointFunc = orig }()
+
+	path := writeTempJSON(t, map[string]string{
+		"app_id":        "app",
+		"app_secret":    "secret",
+		"refresh_token": "rt-valid",
+		"brand":         "feishu",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Value != "u-refreshed" {
+		t.Errorf("expected refreshed token, got %q", tok.Value)
+	}
+	if tok.Source != "jsonfile:"+path+":refreshed" {
+		t.Errorf("unexpected source: %s", tok.Source)
+	}
+}
+
+func TestResolveToken_RefreshTokenCached(t *testing.T) {
+	refreshMu.Lock()
+	refreshCache = &cachedToken{
+		value:     "u-cached",
+		expiresAt: time.Now().Add(time.Hour),
+	}
+	refreshMu.Unlock()
+	defer func() {
+		refreshMu.Lock()
+		refreshCache = nil
+		refreshMu.Unlock()
+	}()
+
+	path := writeTempJSON(t, map[string]string{
+		"app_id":        "app",
+		"app_secret":    "secret",
+		"refresh_token": "rt-test",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Value != "u-cached" {
+		t.Errorf("expected cached token, got %q", tok.Value)
+	}
+}
+
+func TestResolveToken_RefreshTokenError(t *testing.T) {
+	refreshMu.Lock()
+	refreshCache = nil
+	refreshMu.Unlock()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"error":"invalid_grant","error_description":"refresh token expired"}`)
+	}))
+	defer srv.Close()
+
+	orig := tokenEndpointFunc
+	tokenEndpointFunc = func(_ string) string { return srv.URL + "/open-apis/authen/v2/oauth/token" }
+	defer func() { tokenEndpointFunc = orig }()
+
+	path := writeTempJSON(t, map[string]string{
+		"app_id":        "app",
+		"app_secret":    "secret",
+		"refresh_token": "rt-expired",
+		"brand":         "feishu",
+	})
+	t.Setenv(envvars.CliCredentialFile, path)
+
+	_, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeUAT})
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+}

--- a/internal/envvars/envvars.go
+++ b/internal/envvars/envvars.go
@@ -11,4 +11,5 @@ const (
 	CliTenantAccessToken = "LARKSUITE_CLI_TENANT_ACCESS_TOKEN"
 	CliDefaultAs         = "LARKSUITE_CLI_DEFAULT_AS"
 	CliStrictMode        = "LARKSUITE_CLI_STRICT_MODE"
+	CliCredentialFile    = "LARKSUITE_CLI_CREDENTIAL_FILE"
 )

--- a/main.go
+++ b/main.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/larksuite/cli/cmd"
 
-	_ "github.com/larksuite/cli/extension/credential/env" // activate env credential provider
+	_ "github.com/larksuite/cli/extension/credential/env"      // activate env credential provider
+	_ "github.com/larksuite/cli/extension/credential/jsonfile" // activate jsonfile credential provider
 )
 
 func main() {


### PR DESCRIPTION
## Summary

Add a new credential extension provider (`jsonfile`) that enables non-interactive credential injection via a JSON file, specified through the `LARKSUITE_CLI_CREDENTIAL_FILE` environment variable.

This is useful for CI/CD pipelines, Docker containers, and scenarios where interactive `config init` is not feasible.

## Changes

- **New**: `extension/credential/jsonfile/jsonfile.go` — JSON file credential provider implementing the `credential.Provider` interface
- **New**: `extension/credential/jsonfile/jsonfile_test.go` — 27 comprehensive test cases with race detection
- **Modified**: `internal/envvars/envvars.go` — Added `LARKSUITE_CLI_CREDENTIAL_FILE` constant
- **Modified**: `main.go` — Blank import to activate the jsonfile provider
- **Modified**: `README.md`, `README.zh.md` — Documentation for credential file usage

### Key Features

- Reads `app_id`, `app_secret`, `brand`, `default_as`, `user_access_token`, `tenant_access_token`, and `refresh_token` from a JSON file
- Automatic UAT refresh via OAuth token endpoint when `refresh_token` is provided (with in-process caching)
- Path validation: requires absolute path, rejects control characters
- Proper `BlockError` handling for structured AI-agent-friendly error messages
- Provider priority: env vars → jsonfile → default config (`config init`)

## Test Plan

- [x] Unit tests pass (27 tests, all PASS with `-race`)
- [x] `go mod tidy` — no changes to `go.mod`/`go.sum`
- [x] `golangci-lint run --new-from-rev=origin/main` — 0 issues
- [x] `go build ./...` — compiles successfully
- [x] Manual local verification: `LARKSUITE_CLI_CREDENTIAL_FILE=/path/to/cred.json lark-cli --version` works

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for external JSON credential files via the `LARKSUITE_CLI_CREDENTIAL_FILE` environment variable, allowing users to bypass interactive credential setup.

* **Documentation**
  * Updated README and Chinese README with new Credential File section documenting the JSON credential schema, required fields, and environment variable priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->