### PR TITLE
fix(mail): restrict --output-dir to current working directory

### DIFF
--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -209,24 +209,15 @@ var MailWatch = common.Shortcut{
 			if err := vfs.MkdirAll(outputDir, 0700); err != nil {
 				return fmt.Errorf("cannot create output directory %q: %w", outputDir, err)
 			}
-			// TOCTOU mitigation: after MkdirAll, resolve symlinks on the now-existing
-			// directory and re-verify it is still under CWD. This prevents an attacker
-			// from replacing the newly created directory with a symlink between mkdir
-			// and the first write.
-			resolved, err := filepath.EvalSymlinks(outputDir)
+			// TOCTOU mitigation: after MkdirAll the directory now exists, so
+			// re-validate with SafeOutputPath which will EvalSymlinks on the
+			// real path and re-verify CWD containment. This prevents an attacker
+			// from replacing the newly created directory with a symlink between
+			// mkdir and the first write.
+			outputDir, err = validate.SafeOutputPath(outputDir)
 			if err != nil {
-				return fmt.Errorf("cannot resolve output directory: %w", err)
+				return err
 			}
-			cwd, err := os.Getwd()
-			if err != nil {
-				return fmt.Errorf("cannot determine working directory: %w", err)
-			}
-			canonicalCwd, _ := filepath.EvalSymlinks(cwd)
-			rel, err := filepath.Rel(canonicalCwd, resolved)
-			if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
-				return output.ErrValidation("--output-dir %q resolves outside the current working directory after mkdir (possible symlink attack)", outputDir)
-			}
-			outputDir = resolved
 		}
 		labelIDsInput := runtime.Str("label-ids")
 		folderIDsInput := runtime.Str("folder-ids")

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -209,6 +209,24 @@ var MailWatch = common.Shortcut{
 			if err := vfs.MkdirAll(outputDir, 0700); err != nil {
 				return fmt.Errorf("cannot create output directory %q: %w", outputDir, err)
 			}
+			// TOCTOU mitigation: after MkdirAll, resolve symlinks on the now-existing
+			// directory and re-verify it is still under CWD. This prevents an attacker
+			// from replacing the newly created directory with a symlink between mkdir
+			// and the first write.
+			resolved, err := filepath.EvalSymlinks(outputDir)
+			if err != nil {
+				return fmt.Errorf("cannot resolve output directory: %w", err)
+			}
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("cannot determine working directory: %w", err)
+			}
+			canonicalCwd, _ := filepath.EvalSymlinks(cwd)
+			rel, err := filepath.Rel(canonicalCwd, resolved)
+			if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+				return output.ErrValidation("--output-dir %q resolves outside the current working directory after mkdir (possible symlink attack)", outputDir)
+			}
+			outputDir = resolved
 		}
 		labelIDsInput := runtime.Str("label-ids")
 		folderIDsInput := runtime.Str("folder-ids")

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -209,15 +209,6 @@ var MailWatch = common.Shortcut{
 			if err := vfs.MkdirAll(outputDir, 0700); err != nil {
 				return fmt.Errorf("cannot create output directory %q: %w", outputDir, err)
 			}
-			// TOCTOU mitigation: after MkdirAll the directory now exists, so
-			// re-validate with the original relative path. SafeOutputPath will
-			// EvalSymlinks on the now-existing directory and re-verify CWD
-			// containment. This catches symlink replacement between mkdir and
-			// the first write.
-			outputDir, err = validate.SafeOutputPath(runtime.Str("output-dir"))
-			if err != nil {
-				return err
-			}
 		}
 		labelIDsInput := runtime.Str("label-ids")
 		folderIDsInput := runtime.Str("folder-ids")

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -192,7 +192,13 @@ var MailWatch = common.Shortcut{
 		msgFormat := runtime.Str("msg-format")
 		outputDir := runtime.Str("output-dir")
 		if outputDir != "" {
-			// Enforce CWD containment: reject absolute paths, ~, path traversal,
+			// Reject tilde paths explicitly — SafeOutputPath treats "~/x" as a
+			// literal relative path (creating a directory named "~"), which is
+			// confusing. Fail fast with a clear hint instead.
+			if outputDir == "~" || strings.HasPrefix(outputDir, "~/") {
+				return fmt.Errorf("--output-dir does not support ~ expansion; use a relative path like ./output instead")
+			}
+			// Enforce CWD containment: reject absolute paths, path traversal,
 			// and symlink escapes. SafeOutputPath returns a resolved absolute path
 			// under CWD, preventing writes to arbitrary system directories.
 			safePath, err := validate.SafeOutputPath(outputDir)

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -192,36 +192,17 @@ var MailWatch = common.Shortcut{
 		msgFormat := runtime.Str("msg-format")
 		outputDir := runtime.Str("output-dir")
 		if outputDir != "" {
-			if outputDir == "~" || strings.HasPrefix(outputDir, "~/") {
-				home, err := vfs.UserHomeDir()
-				if err != nil {
-					return fmt.Errorf("cannot expand ~: %w", err)
-				}
-				if outputDir == "~" {
-					outputDir = home
-				} else {
-					outputDir = filepath.Join(home, outputDir[2:])
-				}
-			} else if filepath.IsAbs(outputDir) {
-				outputDir = filepath.Clean(outputDir)
-			} else {
-				safePath, err := validate.SafeOutputPath(outputDir)
-				if err != nil {
-					return err
-				}
-				outputDir = safePath
+			// Enforce CWD containment: reject absolute paths, ~, path traversal,
+			// and symlink escapes. SafeOutputPath returns a resolved absolute path
+			// under CWD, preventing writes to arbitrary system directories.
+			safePath, err := validate.SafeOutputPath(outputDir)
+			if err != nil {
+				return err
 			}
-			// Resolve symlinks on the output directory so all writes use the real
-			// filesystem path. This prevents a symlink from redirecting writes to
-			// an unintended location (TOCTOU mitigation).
+			outputDir = safePath
 			if err := vfs.MkdirAll(outputDir, 0700); err != nil {
 				return fmt.Errorf("cannot create output directory %q: %w", outputDir, err)
 			}
-			resolved, err := filepath.EvalSymlinks(outputDir)
-			if err != nil {
-				return fmt.Errorf("cannot resolve output directory: %w", err)
-			}
-			outputDir = resolved
 		}
 		labelIDsInput := runtime.Str("label-ids")
 		folderIDsInput := runtime.Str("folder-ids")

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -192,11 +192,11 @@ var MailWatch = common.Shortcut{
 		msgFormat := runtime.Str("msg-format")
 		outputDir := runtime.Str("output-dir")
 		if outputDir != "" {
-			// Reject tilde paths explicitly — SafeOutputPath treats "~/x" as a
+			// Reject all tilde-prefixed paths — SafeOutputPath treats "~/x" as a
 			// literal relative path (creating a directory named "~"), which is
-			// confusing. Fail fast with a clear hint instead.
-			if outputDir == "~" || strings.HasPrefix(outputDir, "~/") {
-				return fmt.Errorf("--output-dir does not support ~ expansion; use a relative path like ./output instead")
+			// confusing. This also covers ~user/path forms.
+			if strings.HasPrefix(outputDir, "~") {
+				return output.ErrValidation("--output-dir does not support ~ expansion; use a relative path like ./output instead")
 			}
 			// Enforce CWD containment: reject absolute paths, path traversal,
 			// and symlink escapes. SafeOutputPath returns a resolved absolute path

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -210,11 +210,11 @@ var MailWatch = common.Shortcut{
 				return fmt.Errorf("cannot create output directory %q: %w", outputDir, err)
 			}
 			// TOCTOU mitigation: after MkdirAll the directory now exists, so
-			// re-validate with SafeOutputPath which will EvalSymlinks on the
-			// real path and re-verify CWD containment. This prevents an attacker
-			// from replacing the newly created directory with a symlink between
-			// mkdir and the first write.
-			outputDir, err = validate.SafeOutputPath(outputDir)
+			// re-validate with the original relative path. SafeOutputPath will
+			// EvalSymlinks on the now-existing directory and re-verify CWD
+			// containment. This catches symlink replacement between mkdir and
+			// the first write.
+			outputDir, err = validate.SafeOutputPath(runtime.Str("output-dir"))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary
- Remove absolute path and `~` expansion support from `mail +watch --output-dir`
- All paths now go through `validate.SafeOutputPath`, enforcing CWD containment
- Prevents writing sender-controlled mail content to arbitrary system directories

## Security issue
`--output-dir` previously accepted absolute paths (e.g. `/etc`, `/tmp/evil`) and home directory expansion (`~/`). Since mail content is sender-controlled, this allowed potential writes of attacker-influenced data to sensitive locations.

## Test plan
- [x] Absolute path (`/tmp/evil`) → rejected
- [x] Home directory (`~/evil`) → rejected
- [x] Path traversal (`./../../etc`) → rejected
- [x] Nested traversal (`./mail-output/../../../`) → rejected
- [x] Valid relative path (`./mail-output`) → allowed
- [x] All existing mail package tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Mail Watch: tightened output-directory handling—paths beginning with ~ are now rejected with a hint to use a relative path (e.g., ./output). Non-empty paths are validated and created automatically. Symlinks are resolved and an explicit post-creation check ensures the output directory remains within the current working directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->