### PR TITLE
Support --fields flag for record-upsert

### DIFF
--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -247,6 +247,15 @@ func TestBaseRecordValidate(t *testing.T) {
 	if err := BaseRecordUpsert.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1", "json": "{"}, nil, nil)); err != nil {
 		t.Fatalf("invalid record json should bypass CLI validate, err=%v", err)
 	}
+	if err := BaseRecordUpsert.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1", "fields": `{"Name":"A"}`}, nil, nil)); err != nil {
+		t.Fatalf("fields validate err=%v", err)
+	}
+	if err := BaseRecordUpsert.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, nil)); err == nil {
+		t.Fatalf("expected error when neither --json nor --fields provided")
+	}
+	if err := BaseRecordUpsert.Validate(ctx, newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1", "json": `{"Name":"A"}`, "fields": `{"Name":"A"}`}, nil, nil)); err == nil {
+		t.Fatalf("expected error when both --json and --fields provided")
+	}
 }
 
 func TestBaseViewValidate(t *testing.T) {

--- a/shortcuts/base/record_ops.go
+++ b/shortcuts/base/record_ops.go
@@ -1,3 +1,4 @@
+```go
 // Copyright (c) 2026 Lark Technologies Pte. Ltd.
 // SPDX-License-Identifier: MIT
 
@@ -5,6 +6,7 @@ package base
 
 import (
 	"context"
+	"strings"
 
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -34,9 +36,23 @@ func dryRunRecordGet(_ context.Context, runtime *common.RuntimeContext) *common.
 		Set("record_id", runtime.Str("record-id"))
 }
 
+func recordBody(runtime *common.RuntimeContext) (map[string]interface{}, error) {
+	jsonVal := strings.TrimSpace(runtime.Str("json"))
+	fieldsVal := strings.TrimSpace(runtime.Str("fields"))
+	if jsonVal != "" && fieldsVal != "" {
+		return nil, common.FlagErrorf("--json and --fields are mutually exclusive")
+	}
+	if jsonVal != "" {
+		return parseJSONObject(jsonVal, "json")
+	}
+	if fieldsVal != "" {
+		return parseJSONObject(fieldsVal, "fields")
+	}
+	return nil, common.FlagErrorf("provide --json or --fields")
+}
+
 func dryRunRecordUpsert(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
-	pc := newParseCtx(runtime)
-	body, _ := parseJSONObject(pc, runtime.Str("json"), "json")
+	body, _ := recordBody(runtime)
 	if recordID := runtime.Str("record-id"); recordID != "" {
 		return common.NewDryRunAPI().
 			PATCH("/open-apis/base/v3/bases/:base_token/tables/:table_id/records/:record_id").
@@ -76,6 +92,14 @@ func dryRunRecordHistoryList(_ context.Context, runtime *common.RuntimeContext) 
 }
 
 func validateRecordJSON(runtime *common.RuntimeContext) error {
+	jsonVal := strings.TrimSpace(runtime.Str("json"))
+	fieldsVal := strings.TrimSpace(runtime.Str("fields"))
+	if jsonVal != "" && fieldsVal != "" {
+		return common.FlagErrorf("--json and --fields are mutually exclusive")
+	}
+	if jsonVal == "" && fieldsVal == "" {
+		return common.FlagErrorf("provide --json or --fields")
+	}
 	return nil
 }
 
@@ -107,8 +131,7 @@ func executeRecordGet(runtime *common.RuntimeContext) error {
 }
 
 func executeRecordUpsert(runtime *common.RuntimeContext) error {
-	pc := newParseCtx(runtime)
-	body, err := parseJSONObject(pc, runtime.Str("json"), "json")
+	body, err := recordBody(runtime)
 	if err != nil {
 		return err
 	}
@@ -138,3 +161,4 @@ func executeRecordDelete(runtime *common.RuntimeContext) error {
 	runtime.Out(map[string]interface{}{"deleted": true, "record_id": runtime.Str("record-id")}, nil)
 	return nil
 }
+```

--- a/shortcuts/base/record_upsert.go
+++ b/shortcuts/base/record_upsert.go
@@ -20,7 +20,8 @@ var BaseRecordUpsert = common.Shortcut{
 		baseTokenFlag(true),
 		tableRefFlag(true),
 		recordRefFlag(false),
-		{Name: "json", Desc: "record JSON object", Required: true},
+		{Name: "json", Desc: "record JSON object"},
+		{Name: "fields", Desc: "record field values as JSON object"},
 	},
 	Tips: []string{
 		`Example: --json '{"Name":"Alice"}'`,

--- a/skills/lark-base/references/lark-base-record-upsert.md
+++ b/skills/lark-base/references/lark-base-record-upsert.md
@@ -7,16 +7,24 @@
 ## 推荐命令
 
 ```bash
+# 使用 --fields 创建记录（推荐用于脚本）
 lark-cli base +record-upsert \
   --base-token app_xxx \
   --table-id tbl_xxx \
-  --json '{"项目名称":"Apollo","状态":"进行中"}' 
+  --fields '{"项目名称":"Apollo","状态":"进行中"}'
 
+# 使用 --json 创建记录
+lark-cli base +record-upsert \
+  --base-token app_xxx \
+  --table-id tbl_xxx \
+  --json '{"项目名称":"Apollo","状态":"进行中"}'
+
+# 更新记录
 lark-cli base +record-upsert \
   --base-token app_xxx \
   --table-id tbl_xxx \
   --record-id rec_xxx \
-  --json '{"项目名称":"Apollo","状态":"进行中","标签":["高优","外部依赖"],"截止日期":"2026-03-24 10:00:00"}'
+  --fields '{"项目名称":"Apollo","状态":"进行中","标签":["高优","外部依赖"],"截止日期":"2026-03-24 10:00:00"}'
 ```
 
 ## 参数
@@ -26,7 +34,8 @@ lark-cli base +record-upsert \
 | `--base-token <token>` | 是 | Base Token |
 | `--table-id <id_or_name>` | 是 | 表 ID 或表名 |
 | `--record-id <id>` | 否 | 传入时走更新，不传时走创建 |
-| `--json <body>` | 是 | 记录 JSON 对象 |
+| `--fields <json>` | 二选一 | 字段值 JSON 对象，与 `--json` 互斥 |
+| `--json <body>` | 二选一 | 记录 JSON 对象，与 `--fields` 互斥 |
 
 ## API 入参详情
 
@@ -79,7 +88,8 @@ POST /open-apis/base/v3/bases/:base_token/tables/:table_id/records
 
 ## 坑点
 
-- ⚠️ `--json` 必须是对象，不支持数组。
+- ⚠️ `--fields` 和 `--json` 互斥，必须且只能提供一个。
+- ⚠️ `--fields` / `--json` 必须是 JSON 对象，不支持数组。
 - ⚠️ 有 `--record-id` 就一定走更新；不传就一定走创建，不会自动查重。
 - ⚠️ 这是写入操作，执行前必须确认。
 


### PR DESCRIPTION
Fixes #365

Only had `--json` for specifying record data, which wasn't ideal. Added `--fields` as an alternative way to pass records. Made them mutually exclusive so you can't mix them.

Updated validation to require one of them and block both. Added test cases for the new behavior.

Also updated the docs with clearer examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--fields` option as an alternative to `--json` for supplying record data to the record upsert command; exactly one must be provided.

* **Bug Fixes**
  * Enforced mutual exclusivity and "provide one" validation for the two input flags.

* **Documentation**
  * Updated docs and examples to show `--fields` usage and clarify exclusivity.

* **Tests**
  * Expanded tests to cover the new validation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->