### PR TITLE
fix(calendar): add default video meeting to +create

### DIFF
--- a/shortcuts/calendar/calendar_create.go
+++ b/shortcuts/calendar/calendar_create.go
@@ -23,6 +23,7 @@ func buildEventData(runtime *common.RuntimeContext, startTs, endTs string) map[s
 		"end_time":         map[string]string{"timestamp": endTs},
 		"attendee_ability": "can_modify_event",
 		"free_busy_status": "busy",
+		"vchat":            map[string]string{"vc_type": "vc"},
 		"reminders": []map[string]int{
 			{"minutes": 5},
 		},

--- a/shortcuts/calendar/calendar_test.go
+++ b/shortcuts/calendar/calendar_test.go
@@ -132,6 +132,26 @@ func TestCreate_CreateEventOnly(t *testing.T) {
 	}
 }
 
+func TestBuildEventData_DefaultVChat(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("summary", "", "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("rrule", "", "")
+	cmd.Flags().Set("summary", "Team Sync")
+	cmd.Flags().Set("description", "Weekly meeting")
+
+	runtime := common.TestNewRuntimeContext(cmd, defaultConfig())
+	eventData := buildEventData(runtime, "1742515200", "1742518800")
+
+	vchat, ok := eventData["vchat"].(map[string]string)
+	if !ok {
+		t.Fatalf("vchat = %T, want map[string]string", eventData["vchat"])
+	}
+	if got := vchat["vc_type"]; got != "vc" {
+		t.Fatalf("vchat.vc_type = %q, want %q", got, "vc")
+	}
+}
+
 func TestCreate_WithAttendees_Success(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 

--- a/skills/lark-calendar/references/lark-calendar-create.md
+++ b/skills/lark-calendar/references/lark-calendar-create.md
@@ -44,6 +44,7 @@ lark-cli calendar +create --summary "..." --start "..." --end "..." \
 > 自动设置 `attendee_ability: "can_modify_event"`，参会人可查看彼此并编辑日程。
 > 自动设置 `free_busy_status: "busy"`，默认日程忙闲状态为忙碌。
 > 自动设置 `reminders: [{"minutes": 5}]`，默认日程开始前 5 分钟提醒。
+> 自动设置 `vchat: {"vc_type": "vc"}`，默认日程包含飞书视频会议。如需其他视频会议类型或不含视频会议，请使用完整 API 命令。
 > 失败保护：若添加参会人失败（如 open_id 错误），CLI 会自动删除刚创建的空日程（回滚，不通知参会人）。
 
 ## 高级用法（完整 API 命令）


### PR DESCRIPTION
## Summary
Make `calendar +create` include a default Feishu video meeting in the created event payload.
This keeps the shortcut behavior aligned with expected default meeting creation behavior.

## Changes
- Add default `vchat: {"vc_type": "vc"}` to the event payload built by `calendar +create`
- Add a regression test covering the default `vchat` payload
- Update the calendar skill reference to document the new default behavior

## Test Plan
- [x] Unit tests pass
- [x] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Calendar events now automatically include a Feishu video meeting capability by default.

* **Documentation**
  * Updated documentation to clarify the default video meeting setting and options for other meeting types.

* **Tests**
  * Added test coverage for the default video meeting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->