### PR TITLE
fix: improve error hints for sandbox and initialization issues

### DIFF
--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -39,7 +39,7 @@ func wrapError(op string, err error) error {
 	hint := "Check if the OS keychain/credential manager is locked or accessible. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, you can try running this outside the sandbox."
 
 	if errors.Is(err, errNotInitialized) {
-		hint = "The keychain master key may have been cleaned up or deleted. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, you can try running this outside the sandbox. Otherwise, Please reconfigure the CLI by running lark-cli config init."
+		hint = "The keychain master key may have been cleaned up or deleted. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, you can try running this outside the sandbox. Otherwise, please reconfigure the CLI by running lark-cli config init."
 	}
 
 	func() {

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -36,10 +36,10 @@ func wrapError(op string, err error) error {
 	}
 
 	msg := fmt.Sprintf("keychain %s failed: %v", op, err)
-	hint := "Check if the OS keychain/credential manager is locked or accessible. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain."
+	hint := "Check if the OS keychain/credential manager is locked or accessible. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, You can try running this outside the sandbox."
 
 	if errors.Is(err, errNotInitialized) {
-		hint = "The keychain master key may have been cleaned up or deleted. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain. Otherwise, Please reconfigure the CLI by running lark-cli config init."
+		hint = "The keychain master key may have been cleaned up or deleted. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, You can try running this outside the sandbox. Otherwise, Please reconfigure the CLI by running lark-cli config init."
 	}
 
 	func() {

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -39,7 +39,7 @@ func wrapError(op string, err error) error {
 	hint := "Check if the OS keychain/credential manager is locked or accessible. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain."
 
 	if errors.Is(err, errNotInitialized) {
-		hint = "The keychain master key may have been cleaned up or deleted. Please reconfigure the CLI by running `lark-cli config init`."
+		hint = "The keychain master key may have been cleaned up or deleted. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain. Otherwise, Please reconfigure the CLI by running lark-cli config init."
 	}
 
 	func() {

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -36,10 +36,10 @@ func wrapError(op string, err error) error {
 	}
 
 	msg := fmt.Sprintf("keychain %s failed: %v", op, err)
-	hint := "Check if the OS keychain/credential manager is locked or accessible. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, You can try running this outside the sandbox."
+	hint := "Check if the OS keychain/credential manager is locked or accessible. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, you can try running this outside the sandbox."
 
 	if errors.Is(err, errNotInitialized) {
-		hint = "The keychain master key may have been cleaned up or deleted. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, You can try running this outside the sandbox. Otherwise, Please reconfigure the CLI by running lark-cli config init."
+		hint = "The keychain master key may have been cleaned up or deleted. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, you can try running this outside the sandbox. Otherwise, Please reconfigure the CLI by running lark-cli config init."
 	}
 
 	func() {


### PR DESCRIPTION
## Summary
Improve keychain-related error hints to make common failure scenarios easier to diagnose.
This update clarifies what users should do when keychain access fails in sandbox or CI environments, and when the keychain has not been initialized properly.

## Changes
- Improve the generic keychain access error hint with clearer guidance for sandbox and CI environments
- Add a suggestion to retry outside the sandbox when keychain access may be restricted
- Refine the uninitialized keychain hint to distinguish permission-related issues from cases that require re-running `lark-cli config init`

## Test Plan
- [ ] Unit tests pass
- [ ] Manually verify related `lark` commands work locally

## Related Issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for keychain access failures: troubleshooting hints now explicitly suggest trying the operation outside the sandbox. When initialization is detected as the cause, messages also include a clear “Otherwise” instruction to run the CLI configuration/init command to reconfigure the tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->