### PR TITLE
fix(base): pass through table-list response and sort help

### DIFF
--- a/shortcuts/base/base_execute_test.go
+++ b/shortcuts/base/base_execute_test.go
@@ -376,7 +376,7 @@ func TestBaseTableExecuteReadAndDelete(t *testing.T) {
 		if err := runShortcut(t, BaseTableList, []string{"+table-list", "--base-token", "app_x", "--limit", "1"}, factory, stdout); err != nil {
 			t.Fatalf("err=%v", err)
 		}
-		if got := stdout.String(); !strings.Contains(got, `"total": 2`) || !strings.Contains(got, `"table_name": "Alpha"`) {
+		if got := stdout.String(); !strings.Contains(got, `"total": 2`) || !strings.Contains(got, `"tables"`) || !strings.Contains(got, `"name": "Alpha"`) || strings.Contains(got, `"items"`) || strings.Contains(got, `"offset"`) || strings.Contains(got, `"limit"`) || strings.Contains(got, `"count"`) || strings.Contains(got, `"table_name": "Alpha"`) {
 			t.Fatalf("stdout=%s", got)
 		}
 	})

--- a/shortcuts/base/table_ops.go
+++ b/shortcuts/base/table_ops.go
@@ -68,11 +68,7 @@ func executeTableList(runtime *common.RuntimeContext) error {
 	if total == 0 {
 		total = len(tables)
 	}
-	items := make([]interface{}, 0, len(tables))
-	for _, table := range tables {
-		items = append(items, map[string]interface{}{"table_id": tableID(table), "table_name": tableNameFromMap(table)})
-	}
-	runtime.Out(map[string]interface{}{"items": items, "offset": offset, "limit": limit, "count": len(items), "total": total}, nil)
+	runtime.Out(map[string]interface{}{"tables": tables, "total": total}, nil)
 	return nil
 }
 

--- a/shortcuts/base/view_set_sort.go
+++ b/shortcuts/base/view_set_sort.go
@@ -20,10 +20,10 @@ var BaseViewSetSort = common.Shortcut{
 		baseTokenFlag(true),
 		tableRefFlag(true),
 		viewRefFlag(true),
-		{Name: "json", Desc: "sort JSON object/array", Required: true},
+		{Name: "json", Desc: "sort_config JSON object", Required: true},
 	},
 	Tips: []string{
-		`Example: --json '[{"field":"fldPriority","desc":true}]'`,
+		`Example: --json '{"sort_config":[{"field":"fldPriority","desc":true}]}'`,
 		"Agent hint: use the lark-base skill's view-set-sort guide for usage and limits.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {


### PR DESCRIPTION
## Summary
`+table-list` was reshaping API output into synthetic fields instead of passing through the raw table payload. `+view-set-sort` help also still suggested the raw array form, so this change keeps the response raw and clarifies the CLI help toward `sort_config` usage.

## Changes
- Return raw `tables` data from `base +table-list` without adding `items`, `offset`, `limit`, or `count`
- Update `base +view-set-sort` Go help/example to show `sort_config` object usage
- Adjust base shortcut tests to cover the raw list output

## Test Plan
- [x] Unit tests pass
- [x] Manual local verification confirms the `lark xxx` command works as expected
- `make unit-test`
- `go mod tidy` (no changes to `go.mod` / `go.sum`)
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main` failed locally due Go VCS stamping in this worktree (`error obtaining VCS status`)
- `GOFLAGS=-buildvcs=false go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main`

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Simplified table list API response structure to return cleaner output with essential fields only.

* **Documentation**
  * Corrected the sort command JSON format documentation to accurately reflect the expected input structure.

* **Tests**
  * Updated test assertions to validate the correct table list response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->