### PR TITLE
feat: add --file flag for multipart/form-data file uploads

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -41,6 +41,7 @@ type APIOptions struct {
 	Format    string
 	JqExpr    string
 	DryRun    bool
+	File      string
 }
 
 var urlPrefixRe = regexp.MustCompile(`https?://[^/]+(/open-apis/.+)`)
@@ -87,6 +88,7 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*APIOptions) error) *cobra.Command 
 	cmd.Flags().StringVar(&opts.Format, "format", "json", "output format: json|ndjson|table|csv")
 	cmd.Flags().StringVarP(&opts.JqExpr, "jq", "q", "", "jq expression to filter JSON output")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "print request without executing")
+	cmd.Flags().StringVar(&opts.File, "file", "", "file to upload as multipart/form-data ([field=]path, supports - for stdin)")
 
 	cmd.ValidArgsFunction = func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
@@ -106,17 +108,19 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*APIOptions) error) *cobra.Command 
 
 // buildAPIRequest validates flags and builds a RawApiRequest.
 func buildAPIRequest(opts *APIOptions) (client.RawApiRequest, error) {
-	// stdin is an io.Reader consumed at most once. Only one of --params/--data
-	// may use "-" (stdin); the conflict check below prevents silent data loss.
 	stdin := opts.Factory.IOStreams.In
-	if opts.Params == "-" && opts.Data == "-" {
-		return client.RawApiRequest{}, output.ErrValidation("--params and --data cannot both read from stdin (-)")
-	}
-	params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin)
-	if err != nil {
+
+	// Validate --file mutual exclusions first.
+	if err := cmdutil.ValidateFileFlag(opts.File, opts.Params, opts.Data, opts.Output, opts.PageAll, opts.Method); err != nil {
 		return client.RawApiRequest{}, err
 	}
-	data, err := cmdutil.ParseOptionalBody(opts.Method, opts.Data, stdin)
+
+	// Existing stdin conflict check (--params vs --data, without --file).
+	if opts.File == "" && opts.Params == "-" && opts.Data == "-" {
+		return client.RawApiRequest{}, output.ErrValidation("--params and --data cannot both read from stdin (-)")
+	}
+
+	params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin)
 	if err != nil {
 		return client.RawApiRequest{}, err
 	}
@@ -128,13 +132,44 @@ func buildAPIRequest(opts *APIOptions) (client.RawApiRequest, error) {
 		Method: opts.Method,
 		URL:    normalisePath(opts.Path),
 		Params: params,
-		Data:   data,
 		As:     opts.As,
 	}
-	// WithFileDownload tells the SDK to skip CodeError parsing on 200 OK.
-	if opts.Output != "" {
-		request.ExtraOpts = append(request.ExtraOpts, larkcore.WithFileDownload())
+
+	if opts.File != "" {
+		// File upload path: build formdata.
+		fieldName, filePath, isStdin := cmdutil.ParseFileFlag(opts.File, "file")
+
+		// Parse --data as JSON map for form fields (not as body).
+		var dataFields any
+		if opts.Data != "" {
+			dataFields, err = cmdutil.ParseOptionalBody(opts.Method, opts.Data, stdin)
+			if err != nil {
+				return client.RawApiRequest{}, err
+			}
+		}
+
+		fd, err := cmdutil.BuildFormdata(
+			opts.Ctx,
+			opts.Factory.ResolveFileIO(opts.Ctx),
+			fieldName, filePath, isStdin, stdin, dataFields,
+		)
+		if err != nil {
+			return client.RawApiRequest{}, err
+		}
+		request.Data = fd
+		request.ExtraOpts = append(request.ExtraOpts, larkcore.WithFileUpload())
+	} else {
+		// Normal path: JSON body.
+		data, err := cmdutil.ParseOptionalBody(opts.Method, opts.Data, stdin)
+		if err != nil {
+			return client.RawApiRequest{}, err
+		}
+		request.Data = data
+		if opts.Output != "" {
+			request.ExtraOpts = append(request.ExtraOpts, larkcore.WithFileDownload())
+		}
 	}
+
 	return request, nil
 }
 
@@ -151,6 +186,37 @@ func apiRun(opts *APIOptions) error {
 	}
 	if err := output.ValidateJqFlags(opts.JqExpr, opts.Output, opts.Format); err != nil {
 		return err
+	}
+
+	// Handle dry-run with file: skip building formdata, show file metadata instead.
+	if opts.DryRun && opts.File != "" {
+		if err := cmdutil.ValidateFileFlag(opts.File, opts.Params, opts.Data, opts.Output, opts.PageAll, opts.Method); err != nil {
+			return err
+		}
+		stdin := f.IOStreams.In
+		params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin)
+		if err != nil {
+			return err
+		}
+		var formFields any
+		if opts.Data != "" {
+			formFields, err = cmdutil.ParseOptionalBody(opts.Method, opts.Data, stdin)
+			if err != nil {
+				return err
+			}
+		}
+		config, err := f.Config()
+		if err != nil {
+			return err
+		}
+		fieldName, filePath, _ := cmdutil.ParseFileFlag(opts.File, "file")
+		request := client.RawApiRequest{
+			Method: opts.Method,
+			URL:    normalisePath(opts.Path),
+			Params: params,
+			As:     opts.As,
+		}
+		return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fieldName, filePath, formFields)
 	}
 
 	request, err := buildAPIRequest(opts)

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -117,8 +117,8 @@ func buildAPIRequest(opts *APIOptions) (client.RawApiRequest, *cmdutil.FileUploa
 		return client.RawApiRequest{}, nil, err
 	}
 
-	// Existing stdin conflict check (--params vs --data, without --file).
-	if opts.File == "" && opts.Params == "-" && opts.Data == "-" {
+	// stdin conflict: --params and --data cannot both read from stdin, regardless of --file.
+	if opts.Params == "-" && opts.Data == "-" {
 		return client.RawApiRequest{}, nil, output.ErrValidation("--params and --data cannot both read from stdin (-)")
 	}
 

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -148,6 +148,9 @@ func buildAPIRequest(opts *APIOptions) (client.RawApiRequest, *cmdutil.FileUploa
 			if err != nil {
 				return client.RawApiRequest{}, nil, err
 			}
+			if _, ok := dataFields.(map[string]any); !ok {
+				return client.RawApiRequest{}, nil, output.ErrValidation("--data must be a JSON object when used with --file")
+			}
 		}
 
 		if opts.DryRun {

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -107,22 +107,24 @@ func NewCmdApi(f *cmdutil.Factory, runF func(*APIOptions) error) *cobra.Command 
 }
 
 // buildAPIRequest validates flags and builds a RawApiRequest.
-func buildAPIRequest(opts *APIOptions) (client.RawApiRequest, error) {
+// When dryRun is true and a file is provided, file reading is skipped and
+// FileUploadMeta is returned instead so the caller can render dry-run output.
+func buildAPIRequest(opts *APIOptions) (client.RawApiRequest, *cmdutil.FileUploadMeta, error) {
 	stdin := opts.Factory.IOStreams.In
 
 	// Validate --file mutual exclusions first.
 	if err := cmdutil.ValidateFileFlag(opts.File, opts.Params, opts.Data, opts.Output, opts.PageAll, opts.Method); err != nil {
-		return client.RawApiRequest{}, err
+		return client.RawApiRequest{}, nil, err
 	}
 
 	// Existing stdin conflict check (--params vs --data, without --file).
 	if opts.File == "" && opts.Params == "-" && opts.Data == "-" {
-		return client.RawApiRequest{}, output.ErrValidation("--params and --data cannot both read from stdin (-)")
+		return client.RawApiRequest{}, nil, output.ErrValidation("--params and --data cannot both read from stdin (-)")
 	}
 
 	params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin)
 	if err != nil {
-		return client.RawApiRequest{}, err
+		return client.RawApiRequest{}, nil, err
 	}
 	if opts.PageSize > 0 {
 		params["page_size"] = opts.PageSize
@@ -144,17 +146,22 @@ func buildAPIRequest(opts *APIOptions) (client.RawApiRequest, error) {
 		if opts.Data != "" {
 			dataFields, err = cmdutil.ParseOptionalBody(opts.Method, opts.Data, stdin)
 			if err != nil {
-				return client.RawApiRequest{}, err
+				return client.RawApiRequest{}, nil, err
 			}
 		}
 
+		if opts.DryRun {
+			return request, &cmdutil.FileUploadMeta{
+				FieldName: fieldName, FilePath: filePath, FormFields: dataFields,
+			}, nil
+		}
+
 		fd, err := cmdutil.BuildFormdata(
-			opts.Ctx,
 			opts.Factory.ResolveFileIO(opts.Ctx),
 			fieldName, filePath, isStdin, stdin, dataFields,
 		)
 		if err != nil {
-			return client.RawApiRequest{}, err
+			return client.RawApiRequest{}, nil, err
 		}
 		request.Data = fd
 		request.ExtraOpts = append(request.ExtraOpts, larkcore.WithFileUpload())
@@ -162,7 +169,7 @@ func buildAPIRequest(opts *APIOptions) (client.RawApiRequest, error) {
 		// Normal path: JSON body.
 		data, err := cmdutil.ParseOptionalBody(opts.Method, opts.Data, stdin)
 		if err != nil {
-			return client.RawApiRequest{}, err
+			return client.RawApiRequest{}, nil, err
 		}
 		request.Data = data
 		if opts.Output != "" {
@@ -170,7 +177,7 @@ func buildAPIRequest(opts *APIOptions) (client.RawApiRequest, error) {
 		}
 	}
 
-	return request, nil
+	return request, nil, nil
 }
 
 func apiRun(opts *APIOptions) error {
@@ -188,38 +195,7 @@ func apiRun(opts *APIOptions) error {
 		return err
 	}
 
-	// Handle dry-run with file: skip building formdata, show file metadata instead.
-	if opts.DryRun && opts.File != "" {
-		if err := cmdutil.ValidateFileFlag(opts.File, opts.Params, opts.Data, opts.Output, opts.PageAll, opts.Method); err != nil {
-			return err
-		}
-		stdin := f.IOStreams.In
-		params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin)
-		if err != nil {
-			return err
-		}
-		var formFields any
-		if opts.Data != "" {
-			formFields, err = cmdutil.ParseOptionalBody(opts.Method, opts.Data, stdin)
-			if err != nil {
-				return err
-			}
-		}
-		config, err := f.Config()
-		if err != nil {
-			return err
-		}
-		fieldName, filePath, _ := cmdutil.ParseFileFlag(opts.File, "file")
-		request := client.RawApiRequest{
-			Method: opts.Method,
-			URL:    normalisePath(opts.Path),
-			Params: params,
-			As:     opts.As,
-		}
-		return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fieldName, filePath, formFields)
-	}
-
-	request, err := buildAPIRequest(opts)
+	request, fileMeta, err := buildAPIRequest(opts)
 	if err != nil {
 		return err
 	}
@@ -230,6 +206,9 @@ func apiRun(opts *APIOptions) error {
 	}
 
 	if opts.DryRun {
+		if fileMeta != nil {
+			return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fileMeta.FieldName, fileMeta.FilePath, fileMeta.FormFields)
+		}
 		return apiDryRun(f, request, config, opts.Format)
 	}
 	// Identity info is now included in the JSON envelope; skip stderr printing.

--- a/cmd/api/api_test.go
+++ b/cmd/api/api_test.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"errors"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -704,5 +705,100 @@ func TestApiCmd_MethodUppercase(t *testing.T) {
 	}
 	if gotOpts.Method != "POST" {
 		t.Errorf("expected method POST (uppercased), got %s", gotOpts.Method)
+	}
+}
+
+func TestApiCmd_FileFlagParsing(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	var gotOpts *APIOptions
+	cmd := NewCmdApi(f, func(opts *APIOptions) error {
+		gotOpts = opts
+		return nil
+	})
+	cmd.SetArgs([]string{"POST", "/open-apis/test", "--file", "image=photo.jpg", "--data", `{"image_type":"message"}`})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotOpts.File != "image=photo.jpg" {
+		t.Errorf("expected File = %q, got %q", "image=photo.jpg", gotOpts.File)
+	}
+}
+
+func TestApiCmd_FileAndOutputConflict(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	cmd := NewCmdApi(f, func(opts *APIOptions) error {
+		return apiRun(opts)
+	})
+	cmd.SetArgs([]string{"POST", "/open-apis/test", "--as", "bot", "--file", "photo.jpg", "--output", "out.json"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --file with --output")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected mutual exclusion error, got: %v", err)
+	}
+}
+
+func TestApiCmd_FileWithGET(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	cmd := NewCmdApi(f, func(opts *APIOptions) error {
+		return apiRun(opts)
+	})
+	cmd.SetArgs([]string{"GET", "/open-apis/test", "--as", "bot", "--file", "photo.jpg"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --file with GET")
+	}
+	if !strings.Contains(err.Error(), "requires POST") {
+		t.Errorf("expected method error, got: %v", err)
+	}
+}
+
+func TestApiCmd_FileStdinConflictWithData(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	cmd := NewCmdApi(f, func(opts *APIOptions) error {
+		return apiRun(opts)
+	})
+	cmd.SetArgs([]string{"POST", "/open-apis/test", "--as", "bot", "--file", "-", "--data", "-"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for --file stdin with --data stdin")
+	}
+	if !strings.Contains(err.Error(), "cannot both read from stdin") {
+		t.Errorf("expected stdin conflict error, got: %v", err)
+	}
+}
+
+func TestApiCmd_DryRunWithFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := tmpDir + "/test.jpg"
+	if err := os.WriteFile(tmpFile, []byte("fake-image"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	})
+	cmd := NewCmdApi(f, nil)
+	cmd.SetArgs([]string{"POST", "/open-apis/im/v1/images", "--file", "image=" + tmpFile, "--data", `{"image_type":"message"}`, "--dry-run", "--as", "bot"})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "image") {
+		t.Errorf("expected dry-run output to mention file field, got: %s", out)
+	}
+	if !strings.Contains(out, "Dry Run") {
+		t.Errorf("expected dry-run header, got: %s", out)
 	}
 }

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -73,6 +73,19 @@ func printResourceList(w io.Writer, spec map[string]interface{}) {
 	fmt.Fprintf(w, "%sUsage: lark-cli schema %s.<resource>.<method>%s\n", output.Dim, name, output.Reset)
 }
 
+// hasFileFields returns true if any requestBody field has type "file".
+func hasFileFields(method map[string]interface{}) (bool, []string) {
+	rb, _ := method["requestBody"].(map[string]interface{})
+	var names []string
+	for name, field := range rb {
+		f, _ := field.(map[string]interface{})
+		if registry.GetStrFromMap(f, "type") == "file" {
+			names = append(names, name)
+		}
+	}
+	return len(names) > 0, names
+}
+
 func printMethodDetail(w io.Writer, spec map[string]interface{}, resName, methodName string, method map[string]interface{}) {
 	servicePath := registry.GetStrFromMap(spec, "servicePath")
 	specName := registry.GetStrFromMap(spec, "name")
@@ -80,6 +93,7 @@ func printMethodDetail(w io.Writer, spec map[string]interface{}, resName, method
 	fullPath := servicePath + "/" + methodPath
 	httpMethod := registry.GetStrFromMap(method, "httpMethod")
 	desc := registry.GetStrFromMap(method, "description")
+	isFileUpload, fileFieldNames := hasFileFields(method)
 
 	fmt.Fprintf(w, "%s%s.%s.%s%s\n\n", output.Bold, specName, resName, methodName, output.Reset)
 
@@ -138,10 +152,23 @@ func printMethodDetail(w io.Writer, spec map[string]interface{}, resName, method
 		if len(params) == 0 {
 			fmt.Fprintf(w, "%sParameters:%s\n\n", output.Bold, output.Reset)
 		}
-		fmt.Fprintf(w, "  %s--data%s  <json>  %soptional%s\n", output.Cyan, output.Reset, output.Dim, output.Reset)
+		fileUploadTag := ""
+		if isFileUpload {
+			fileUploadTag = fmt.Sprintf("  %s[file upload]%s", output.Yellow, output.Reset)
+		}
+		fmt.Fprintf(w, "  %s--data%s  <json>  %soptional%s%s\n", output.Cyan, output.Reset, output.Dim, output.Reset, fileUploadTag)
 		requestBody, _ := method["requestBody"].(map[string]interface{})
 		if len(requestBody) > 0 {
 			printNestedFields(w, requestBody, "      ", "")
+		}
+
+		if isFileUpload {
+			defaultField := "file"
+			if len(fileFieldNames) == 1 {
+				defaultField = fileFieldNames[0]
+			}
+			fmt.Fprintf(w, "\n  %s--file%s  <[field=]path>  %sfile upload%s\n", output.Cyan, output.Reset, output.Dim, output.Reset)
+			fmt.Fprintf(w, "      Upload file as multipart/form-data. Default field: %q\n", defaultField)
 		}
 		fmt.Fprintln(w)
 	}
@@ -184,7 +211,11 @@ func printMethodDetail(w io.Writer, spec map[string]interface{}, resName, method
 	}
 
 	// CLI example
-	fmt.Fprintf(w, "%sCLI:%s      lark-cli %s %s %s\n", output.Bold, output.Reset, specName, resName, methodName)
+	if isFileUpload {
+		fmt.Fprintf(w, "%sCLI:%s      lark-cli %s %s %s --file <path>\n", output.Bold, output.Reset, specName, resName, methodName)
+	} else {
+		fmt.Fprintf(w, "%sCLI:%s      lark-cli %s %s %s\n", output.Bold, output.Reset, specName, resName, methodName)
+	}
 
 	// Docs
 	if docUrl := registry.GetStrFromMap(method, "docUrl"); docUrl != "" {

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -75,14 +75,7 @@ func printResourceList(w io.Writer, spec map[string]interface{}) {
 
 // hasFileFields returns true if any requestBody field has type "file".
 func hasFileFields(method map[string]interface{}) (bool, []string) {
-	rb, _ := method["requestBody"].(map[string]interface{})
-	var names []string
-	for name, field := range rb {
-		f, _ := field.(map[string]interface{})
-		if registry.GetStrFromMap(f, "type") == "file" {
-			names = append(names, name)
-		}
-	}
+	names := cmdutil.DetectFileFields(method)
 	return len(names) > 0, names
 }
 

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -156,12 +156,13 @@ func printMethodDetail(w io.Writer, spec map[string]interface{}, resName, method
 		}
 
 		if isFileUpload {
-			defaultField := "file"
 			if len(fileFieldNames) == 1 {
-				defaultField = fileFieldNames[0]
+				fmt.Fprintf(w, "\n  %s--file%s  <[field=]path>  %sfile upload%s\n", output.Cyan, output.Reset, output.Dim, output.Reset)
+				fmt.Fprintf(w, "      Upload file as multipart/form-data. Default field: %q\n", fileFieldNames[0])
+			} else {
+				fmt.Fprintf(w, "\n  %s--file%s  <field=path>  %sfile upload%s\n", output.Cyan, output.Reset, output.Dim, output.Reset)
+				fmt.Fprintf(w, "      Upload file as multipart/form-data. Fields: %s\n", strings.Join(fileFieldNames, ", "))
 			}
-			fmt.Fprintf(w, "\n  %s--file%s  <[field=]path>  %sfile upload%s\n", output.Cyan, output.Reset, output.Dim, output.Reset)
-			fmt.Fprintf(w, "      Upload file as multipart/form-data. Default field: %q\n", defaultField)
 		}
 		fmt.Fprintln(w)
 	}
@@ -204,8 +205,10 @@ func printMethodDetail(w io.Writer, spec map[string]interface{}, resName, method
 	}
 
 	// CLI example
-	if isFileUpload {
+	if isFileUpload && len(fileFieldNames) == 1 {
 		fmt.Fprintf(w, "%sCLI:%s      lark-cli %s %s %s --file <path>\n", output.Bold, output.Reset, specName, resName, methodName)
+	} else if isFileUpload {
+		fmt.Fprintf(w, "%sCLI:%s      lark-cli %s %s %s --file <field=path>\n", output.Bold, output.Reset, specName, resName, methodName)
 	} else {
 		fmt.Fprintf(w, "%sCLI:%s      lark-cli %s %s %s\n", output.Bold, output.Reset, specName, resName, methodName)
 	}

--- a/cmd/schema/schema_test.go
+++ b/cmd/schema/schema_test.go
@@ -4,6 +4,7 @@
 package schema
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -59,5 +60,125 @@ func TestSchemaCmd_UnknownService(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "Unknown service") {
 		t.Errorf("expected 'Unknown service' error, got: %v", err)
+	}
+}
+
+func TestPrintMethodDetail_FileUpload(t *testing.T) {
+	spec := map[string]interface{}{
+		"name":        "im",
+		"servicePath": "/open-apis/im/v1",
+	}
+	method := map[string]interface{}{
+		"path":        "images",
+		"httpMethod":  "POST",
+		"description": "Upload an image",
+		"requestBody": map[string]interface{}{
+			"image_type": map[string]interface{}{
+				"type":     "string",
+				"required": true,
+			},
+			"image": map[string]interface{}{
+				"type":     "file",
+				"required": true,
+			},
+		},
+		"accessTokens": []interface{}{"user", "tenant"},
+	}
+
+	var buf bytes.Buffer
+	printMethodDetail(&buf, spec, "images", "create", method)
+	out := buf.String()
+
+	if !strings.Contains(out, "file upload") {
+		t.Errorf("expected 'file upload' marker in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--file") {
+		t.Errorf("expected '--file' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, `"image"`) {
+		t.Errorf("expected default field name 'image' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--file <path>") {
+		t.Errorf("expected CLI example with --file <path>, got:\n%s", out)
+	}
+}
+
+func TestPrintMethodDetail_NoFileUpload(t *testing.T) {
+	spec := map[string]interface{}{
+		"name":        "calendar",
+		"servicePath": "/open-apis/calendar/v4",
+	}
+	method := map[string]interface{}{
+		"path":        "events",
+		"httpMethod":  "POST",
+		"description": "Create an event",
+		"requestBody": map[string]interface{}{
+			"summary": map[string]interface{}{
+				"type":     "string",
+				"required": true,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	printMethodDetail(&buf, spec, "events", "create", method)
+	out := buf.String()
+
+	if strings.Contains(out, "file upload") {
+		t.Errorf("did not expect 'file upload' marker for non-file method, got:\n%s", out)
+	}
+	if strings.Contains(out, "--file") {
+		t.Errorf("did not expect '--file' for non-file method, got:\n%s", out)
+	}
+}
+
+func TestHasFileFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     map[string]interface{}
+		wantBool   bool
+		wantFields []string
+	}{
+		{
+			name: "has file field",
+			method: map[string]interface{}{
+				"requestBody": map[string]interface{}{
+					"image": map[string]interface{}{"type": "file"},
+					"name":  map[string]interface{}{"type": "string"},
+				},
+			},
+			wantBool:   true,
+			wantFields: []string{"image"},
+		},
+		{
+			name: "no file field",
+			method: map[string]interface{}{
+				"requestBody": map[string]interface{}{
+					"name": map[string]interface{}{"type": "string"},
+				},
+			},
+			wantBool:   false,
+			wantFields: nil,
+		},
+		{
+			name:       "no requestBody",
+			method:     map[string]interface{}{},
+			wantBool:   false,
+			wantFields: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, names := hasFileFields(tt.method)
+			if got != tt.wantBool {
+				t.Errorf("hasFileFields() = %v, want %v", got, tt.wantBool)
+			}
+			if tt.wantFields == nil && names != nil {
+				t.Errorf("expected nil names, got %v", names)
+			}
+			if tt.wantFields != nil && len(names) != len(tt.wantFields) {
+				t.Errorf("expected %d field names, got %d", len(tt.wantFields), len(names))
+			}
+		})
 	}
 }

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -237,70 +237,15 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		}
 	}
 
-	// Handle dry-run with file: skip building formdata, show file metadata instead.
-	if opts.DryRun && opts.File != "" {
-		httpMethod := registry.GetStrFromMap(opts.Method, "httpMethod")
-		if err := cmdutil.ValidateFileFlag(opts.File, opts.Params, opts.Data, opts.Output, opts.PageAll, httpMethod); err != nil {
-			return err
-		}
-		stdin := f.IOStreams.In
-		params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin)
-		if err != nil {
-			return err
-		}
-		var formFields any
-		if opts.Data != "" {
-			formFields, err = cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin)
-			if err != nil {
-				return err
-			}
-		}
-		// Auto-detect default field name from metadata.
-		defaultField := "file"
-		if len(opts.FileFields) == 1 {
-			defaultField = opts.FileFields[0]
-		}
-		fieldName, filePath, _ := cmdutil.ParseFileFlag(opts.File, defaultField)
-
-		// Build URL with path params (same logic as buildServiceRequest).
-		spec := opts.Spec
-		method := opts.Method
-		url := registry.GetStrFromMap(spec, "servicePath") + "/" + registry.GetStrFromMap(method, "path")
-		parameters, _ := method["parameters"].(map[string]any)
-		for name, param := range parameters {
-			p, _ := param.(map[string]any)
-			if registry.GetStrFromMap(p, "location") != "path" {
-				continue
-			}
-			val, ok := params[name]
-			if !ok || util.IsEmptyValue(val) {
-				return output.ErrWithHint(output.ExitValidation, "validation",
-					fmt.Sprintf("missing required path parameter: %s", name),
-					fmt.Sprintf("lark-cli schema %s", opts.SchemaPath))
-			}
-			valStr := fmt.Sprintf("%v", val)
-			if err := validate.ResourceName(valStr, name); err != nil {
-				return output.ErrValidation("%s", err)
-			}
-			url = strings.Replace(url, "{"+name+"}", validate.EncodePathSegment(valStr), 1)
-			delete(params, name)
-		}
-
-		request := client.RawApiRequest{
-			Method: httpMethod,
-			URL:    url,
-			Params: params,
-			As:     opts.As,
-		}
-		return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fieldName, filePath, formFields)
-	}
-
-	request, err := buildServiceRequest(opts)
+	request, fileMeta, err := buildServiceRequest(opts)
 	if err != nil {
 		return err
 	}
 
 	if opts.DryRun {
+		if fileMeta != nil {
+			return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fileMeta.FieldName, fileMeta.FilePath, fileMeta.FormFields)
+		}
 		return serviceDryRun(f, request, config, opts.Format)
 	}
 
@@ -386,7 +331,9 @@ func checkServiceScopes(ctx context.Context, cred *credential.CredentialProvider
 }
 
 // buildServiceRequest parses flags, builds the URL with path/query params, and returns a RawApiRequest.
-func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, error) {
+// When dryRun is true and a file is provided, file reading is skipped and
+// FileUploadMeta is returned instead so the caller can render dry-run output.
+func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmdutil.FileUploadMeta, error) {
 	spec := opts.Spec
 	method := opts.Method
 	schemaPath := opts.SchemaPath
@@ -398,14 +345,14 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, erro
 
 	// Validate --file mutual exclusions.
 	if err := cmdutil.ValidateFileFlag(opts.File, opts.Params, opts.Data, opts.Output, opts.PageAll, httpMethod); err != nil {
-		return client.RawApiRequest{}, err
+		return client.RawApiRequest{}, nil, err
 	}
 	if opts.File == "" && opts.Params == "-" && opts.Data == "-" {
-		return client.RawApiRequest{}, output.ErrValidation("--params and --data cannot both read from stdin (-)")
+		return client.RawApiRequest{}, nil, output.ErrValidation("--params and --data cannot both read from stdin (-)")
 	}
 	params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin)
 	if err != nil {
-		return client.RawApiRequest{}, err
+		return client.RawApiRequest{}, nil, err
 	}
 
 	url := registry.GetStrFromMap(spec, "servicePath") + "/" + registry.GetStrFromMap(method, "path")
@@ -418,13 +365,13 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, erro
 		}
 		val, ok := params[name]
 		if !ok || util.IsEmptyValue(val) {
-			return client.RawApiRequest{}, output.ErrWithHint(output.ExitValidation, "validation",
+			return client.RawApiRequest{}, nil, output.ErrWithHint(output.ExitValidation, "validation",
 				fmt.Sprintf("missing required path parameter: %s", name),
 				fmt.Sprintf("lark-cli schema %s", schemaPath))
 		}
 		valStr := fmt.Sprintf("%v", val)
 		if err := validate.ResourceName(valStr, name); err != nil {
-			return client.RawApiRequest{}, output.ErrValidation("%s", err)
+			return client.RawApiRequest{}, nil, output.ErrValidation("%s", err)
 		}
 		url = strings.Replace(url, "{"+name+"}", validate.EncodePathSegment(valStr), 1)
 		delete(params, name)
@@ -440,7 +387,7 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, erro
 		required, _ := p["required"].(bool)
 		isPaginationParam := opts.PageAll && (name == "page_token" || name == "page_size")
 		if required && !isPaginationParam && (!exists || util.IsEmptyValue(value)) {
-			return client.RawApiRequest{}, output.ErrWithHint(output.ExitValidation, "validation",
+			return client.RawApiRequest{}, nil, output.ErrWithHint(output.ExitValidation, "validation",
 				fmt.Sprintf("missing required query parameter: %s", name),
 				fmt.Sprintf("lark-cli schema %s", schemaPath))
 		}
@@ -474,24 +421,29 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, erro
 		if opts.Data != "" {
 			dataFields, err = cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin)
 			if err != nil {
-				return client.RawApiRequest{}, err
+				return client.RawApiRequest{}, nil, err
 			}
 		}
 
+		if opts.DryRun {
+			return request, &cmdutil.FileUploadMeta{
+				FieldName: fieldName, FilePath: filePath, FormFields: dataFields,
+			}, nil
+		}
+
 		fd, err := cmdutil.BuildFormdata(
-			opts.Ctx,
 			opts.Factory.ResolveFileIO(opts.Ctx),
 			fieldName, filePath, isStdin, stdin, dataFields,
 		)
 		if err != nil {
-			return client.RawApiRequest{}, err
+			return client.RawApiRequest{}, nil, err
 		}
 		request.Data = fd
 		request.ExtraOpts = append(request.ExtraOpts, larkcore.WithFileUpload())
 	} else {
 		data, err := cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin)
 		if err != nil {
-			return client.RawApiRequest{}, err
+			return client.RawApiRequest{}, nil, err
 		}
 		request.Data = data
 		if opts.Output != "" {
@@ -499,7 +451,7 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, erro
 		}
 	}
 
-	return request, nil
+	return request, nil, nil
 }
 
 func serviceDryRun(f *cmdutil.Factory, request client.RawApiRequest, config *core.CliConfig, format string) error {

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -111,6 +111,21 @@ type ServiceMethodOptions struct {
 	Format    string
 	JqExpr    string
 	DryRun    bool
+	File       string   // --file flag value
+	FileFields []string // auto-detected file field names from metadata
+}
+
+// detectFileFields returns field names with type "file" in the method's requestBody.
+func detectFileFields(method map[string]interface{}) []string {
+	rb, _ := method["requestBody"].(map[string]interface{})
+	var fields []string
+	for name, field := range rb {
+		f, _ := field.(map[string]interface{})
+		if registry.GetStrFromMap(f, "type") == "file" {
+			fields = append(fields, name)
+		}
+	}
+	return fields
 }
 
 func registerMethod(parent *cobra.Command, spec map[string]interface{}, method map[string]interface{}, name string, resName string, f *cmdutil.Factory) {
@@ -161,6 +176,16 @@ func NewCmdServiceMethod(f *cmdutil.Factory, spec, method map[string]interface{}
 	cmd.Flags().StringVarP(&opts.JqExpr, "jq", "q", "", "jq expression to filter JSON output")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "print request without executing")
 
+	// Conditionally register --file for methods with file-type fields.
+	fileFields := detectFileFields(method)
+	opts.FileFields = fileFields
+	if len(fileFields) > 0 {
+		switch httpMethod {
+		case "POST", "PUT", "PATCH", "DELETE":
+			cmd.Flags().StringVar(&opts.File, "file", "", "file to upload ([field=]path, supports - for stdin)")
+		}
+	}
+
 	_ = cmd.RegisterFlagCompletionFunc("as", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{"user", "bot"}, cobra.ShellCompDirectiveNoFileComp
 	})
@@ -210,6 +235,64 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		if err := checkServiceScopes(opts.Ctx, f.Credential, opts.As, config, opts.Method, scopes); err != nil {
 			return err
 		}
+	}
+
+	// Handle dry-run with file: skip building formdata, show file metadata instead.
+	if opts.DryRun && opts.File != "" {
+		httpMethod := registry.GetStrFromMap(opts.Method, "httpMethod")
+		if err := cmdutil.ValidateFileFlag(opts.File, opts.Params, opts.Data, opts.Output, opts.PageAll, httpMethod); err != nil {
+			return err
+		}
+		stdin := f.IOStreams.In
+		params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin)
+		if err != nil {
+			return err
+		}
+		var formFields any
+		if opts.Data != "" {
+			formFields, err = cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin)
+			if err != nil {
+				return err
+			}
+		}
+		// Auto-detect default field name from metadata.
+		defaultField := "file"
+		if len(opts.FileFields) == 1 {
+			defaultField = opts.FileFields[0]
+		}
+		fieldName, filePath, _ := cmdutil.ParseFileFlag(opts.File, defaultField)
+
+		// Build URL with path params (same logic as buildServiceRequest).
+		spec := opts.Spec
+		method := opts.Method
+		url := registry.GetStrFromMap(spec, "servicePath") + "/" + registry.GetStrFromMap(method, "path")
+		parameters, _ := method["parameters"].(map[string]any)
+		for name, param := range parameters {
+			p, _ := param.(map[string]any)
+			if registry.GetStrFromMap(p, "location") != "path" {
+				continue
+			}
+			val, ok := params[name]
+			if !ok || util.IsEmptyValue(val) {
+				return output.ErrWithHint(output.ExitValidation, "validation",
+					fmt.Sprintf("missing required path parameter: %s", name),
+					fmt.Sprintf("lark-cli schema %s", opts.SchemaPath))
+			}
+			valStr := fmt.Sprintf("%v", val)
+			if err := validate.ResourceName(valStr, name); err != nil {
+				return output.ErrValidation("%s", err)
+			}
+			url = strings.Replace(url, "{"+name+"}", validate.EncodePathSegment(valStr), 1)
+			delete(params, name)
+		}
+
+		request := client.RawApiRequest{
+			Method: httpMethod,
+			URL:    url,
+			Params: params,
+			As:     opts.As,
+		}
+		return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fieldName, filePath, formFields)
 	}
 
 	request, err := buildServiceRequest(opts)
@@ -312,7 +395,12 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, erro
 	// stdin is an io.Reader consumed at most once. Only one of --params/--data
 	// may use "-" (stdin); the conflict check below prevents silent data loss.
 	stdin := opts.Factory.IOStreams.In
-	if opts.Params == "-" && opts.Data == "-" {
+
+	// Validate --file mutual exclusions.
+	if err := cmdutil.ValidateFileFlag(opts.File, opts.Params, opts.Data, opts.Output, opts.PageAll, httpMethod); err != nil {
+		return client.RawApiRequest{}, err
+	}
+	if opts.File == "" && opts.Params == "-" && opts.Data == "-" {
 		return client.RawApiRequest{}, output.ErrValidation("--params and --data cannot both read from stdin (-)")
 	}
 	params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin)
@@ -366,21 +454,51 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, erro
 		}
 	}
 
-	data, err := cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin)
-	if err != nil {
-		return client.RawApiRequest{}, err
-	}
-
 	request := client.RawApiRequest{
 		Method: httpMethod,
 		URL:    url,
 		Params: queryParams,
-		Data:   data,
 		As:     opts.As,
 	}
-	if opts.Output != "" {
-		request.ExtraOpts = append(request.ExtraOpts, larkcore.WithFileDownload())
+
+	if opts.File != "" {
+		// File upload: determine default field name from metadata.
+		defaultField := "file"
+		if len(opts.FileFields) == 1 {
+			defaultField = opts.FileFields[0]
+		}
+		fieldName, filePath, isStdin := cmdutil.ParseFileFlag(opts.File, defaultField)
+
+		// Parse --data as form fields.
+		var dataFields any
+		if opts.Data != "" {
+			dataFields, err = cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin)
+			if err != nil {
+				return client.RawApiRequest{}, err
+			}
+		}
+
+		fd, err := cmdutil.BuildFormdata(
+			opts.Ctx,
+			opts.Factory.ResolveFileIO(opts.Ctx),
+			fieldName, filePath, isStdin, stdin, dataFields,
+		)
+		if err != nil {
+			return client.RawApiRequest{}, err
+		}
+		request.Data = fd
+		request.ExtraOpts = append(request.ExtraOpts, larkcore.WithFileUpload())
+	} else {
+		data, err := cmdutil.ParseOptionalBody(httpMethod, opts.Data, stdin)
+		if err != nil {
+			return client.RawApiRequest{}, err
+		}
+		request.Data = data
+		if opts.Output != "" {
+			request.ExtraOpts = append(request.ExtraOpts, larkcore.WithFileDownload())
+		}
 	}
+
 	return request, nil
 }
 

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -415,6 +415,9 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 			if err != nil {
 				return client.RawApiRequest{}, nil, err
 			}
+			if _, ok := dataFields.(map[string]any); !ok {
+				return client.RawApiRequest{}, nil, output.ErrValidation("--data must be a JSON object when used with --file")
+			}
 		}
 
 		if opts.DryRun {

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -115,17 +115,9 @@ type ServiceMethodOptions struct {
 	FileFields []string // auto-detected file field names from metadata
 }
 
-// detectFileFields returns field names with type "file" in the method's requestBody.
+// detectFileFields delegates to the shared cmdutil.DetectFileFields helper.
 func detectFileFields(method map[string]interface{}) []string {
-	rb, _ := method["requestBody"].(map[string]interface{})
-	var fields []string
-	for name, field := range rb {
-		f, _ := field.(map[string]interface{})
-		if registry.GetStrFromMap(f, "type") == "file" {
-			fields = append(fields, name)
-		}
-	}
-	return fields
+	return cmdutil.DetectFileFields(method)
 }
 
 func registerMethod(parent *cobra.Command, spec map[string]interface{}, method map[string]interface{}, name string, resName string, f *cmdutil.Factory) {
@@ -347,7 +339,7 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 	if err := cmdutil.ValidateFileFlag(opts.File, opts.Params, opts.Data, opts.Output, opts.PageAll, httpMethod); err != nil {
 		return client.RawApiRequest{}, nil, err
 	}
-	if opts.File == "" && opts.Params == "-" && opts.Data == "-" {
+	if opts.Params == "-" && opts.Data == "-" {
 		return client.RawApiRequest{}, nil, output.ErrValidation("--params and --data cannot both read from stdin (-)")
 	}
 	params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin)

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -707,6 +708,144 @@ func TestScopeAwareChecker_ScopeError_BotMode(t *testing.T) {
 	// Bot mode should still include the scope hint
 	if !strings.Contains(err.Error(), "insufficient permissions") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ── file upload ──
+
+func imImageMethod() map[string]interface{} {
+	return map[string]interface{}{
+		"path":       "images",
+		"httpMethod": "POST",
+		"requestBody": map[string]interface{}{
+			"image_type": map[string]interface{}{
+				"type":     "string",
+				"required": true,
+			},
+			"image": map[string]interface{}{
+				"type":     "file",
+				"required": true,
+			},
+		},
+		"accessTokens": []interface{}{"user", "tenant"},
+	}
+}
+
+func imSpec() map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "im",
+		"servicePath": "/open-apis/im/v1",
+	}
+}
+
+func TestServiceMethod_FileFlagRegistered(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, imSpec(), imImageMethod(), "create", "images", nil)
+	flag := cmd.Flags().Lookup("file")
+	if flag == nil {
+		t.Fatal("expected --file flag to be registered for file upload method")
+	}
+}
+
+func TestServiceMethod_FileFlagNotRegistered(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, driveSpec(), driveMethod("POST", nil), "copy", "files", nil)
+	flag := cmd.Flags().Lookup("file")
+	if flag != nil {
+		t.Fatal("expected --file flag NOT to be registered for non-file method")
+	}
+}
+
+func TestServiceMethod_FileFlagNotRegisteredForGET(t *testing.T) {
+	getMethod := map[string]interface{}{
+		"path":       "images",
+		"httpMethod": "GET",
+		"requestBody": map[string]interface{}{
+			"image": map[string]interface{}{
+				"type": "file",
+			},
+		},
+	}
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, imSpec(), getMethod, "get", "images", nil)
+	flag := cmd.Flags().Lookup("file")
+	if flag != nil {
+		t.Fatal("expected --file flag NOT to be registered for GET method")
+	}
+}
+
+func TestServiceMethod_FileUpload_DryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile := tmpDir + "/test.jpg"
+	if err := os.WriteFile(tmpFile, []byte("fake-image"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, imSpec(), imImageMethod(), "create", "images", nil)
+	cmd.SetArgs([]string{
+		"--file", "image=" + tmpFile,
+		"--data", `{"image_type":"message"}`,
+		"--dry-run",
+		"--as", "bot",
+	})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "image") {
+		t.Errorf("expected dry-run output to mention file field, got: %s", out)
+	}
+	if !strings.Contains(out, "Dry Run") {
+		t.Errorf("expected dry-run header, got: %s", out)
+	}
+}
+
+func TestDetectFileFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		method map[string]interface{}
+		want   []string
+	}{
+		{
+			name: "single file field",
+			method: map[string]interface{}{
+				"requestBody": map[string]interface{}{
+					"image": map[string]interface{}{"type": "file"},
+					"name":  map[string]interface{}{"type": "string"},
+				},
+			},
+			want: []string{"image"},
+		},
+		{
+			name: "no file fields",
+			method: map[string]interface{}{
+				"requestBody": map[string]interface{}{
+					"name": map[string]interface{}{"type": "string"},
+				},
+			},
+			want: nil,
+		},
+		{
+			name:   "no requestBody",
+			method: map[string]interface{}{},
+			want:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectFileFields(tt.method)
+			if len(got) != len(tt.want) {
+				t.Errorf("detectFileFields() = %v, want %v", got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("detectFileFields()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
 	}
 }
 

--- a/internal/cmdutil/dryrun.go
+++ b/internal/cmdutil/dryrun.go
@@ -215,6 +215,47 @@ func encodeParams(params map[string]interface{}) string {
 	return vals.Encode()
 }
 
+// PrintDryRunWithFile outputs a dry-run summary for file upload requests.
+// Instead of serializing the Formdata body, it shows file metadata.
+func PrintDryRunWithFile(w io.Writer, request client.RawApiRequest, config *core.CliConfig, format, fileField, filePath string, formFields any) error {
+	dr := NewDryRunAPI()
+	switch request.Method {
+	case "POST":
+		dr.POST(request.URL)
+	case "PUT":
+		dr.PUT(request.URL)
+	case "PATCH":
+		dr.PATCH(request.URL)
+	case "DELETE":
+		dr.DELETE(request.URL)
+	default:
+		dr.GET(request.URL)
+	}
+	if len(request.Params) > 0 {
+		dr.Params(request.Params)
+	}
+	fileInfo := map[string]any{
+		"file": map[string]string{"field": fileField, "path": filePath},
+	}
+	if formFields != nil {
+		fileInfo["form_fields"] = formFields
+	}
+	fileInfo["options"] = []string{"WithFileUpload"}
+	dr.Body(fileInfo)
+	dr.Set("as", string(request.As))
+	dr.Set("appId", config.AppID)
+	if config.UserOpenId != "" {
+		dr.Set("userOpenId", config.UserOpenId)
+	}
+	fmt.Fprintln(w, "=== Dry Run ===")
+	if format == "pretty" {
+		fmt.Fprint(w, dr.Format())
+	} else {
+		output.PrintJson(w, dr)
+	}
+	return nil
+}
+
 // PrintDryRun outputs a standardised dry-run summary using DryRunAPI.
 // When format is "pretty", outputs human-readable text; otherwise JSON.
 func PrintDryRun(w io.Writer, request client.RawApiRequest, config *core.CliConfig, format string) error {

--- a/internal/cmdutil/dryrun.go
+++ b/internal/cmdutil/dryrun.go
@@ -234,8 +234,12 @@ func PrintDryRunWithFile(w io.Writer, request client.RawApiRequest, config *core
 	if len(request.Params) > 0 {
 		dr.Params(request.Params)
 	}
+	filePathDisplay := filePath
+	if filePathDisplay == "" {
+		filePathDisplay = "<stdin>"
+	}
 	fileInfo := map[string]any{
-		"file": map[string]string{"field": fileField, "path": filePath},
+		"file": map[string]string{"field": fileField, "path": filePathDisplay},
 	}
 	if formFields != nil {
 		fileInfo["form_fields"] = formFields

--- a/internal/cmdutil/fileupload.go
+++ b/internal/cmdutil/fileupload.go
@@ -5,7 +5,6 @@ package cmdutil
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -20,7 +19,7 @@ import (
 // prefix is present, defaultField is used as the field name.
 // A path of "-" indicates stdin; in that case filePath is empty and isStdin is true.
 func ParseFileFlag(raw, defaultField string) (fieldName, filePath string, isStdin bool) {
-	if idx := strings.IndexByte(raw, '='); idx >= 0 {
+	if idx := strings.IndexByte(raw, '='); idx > 0 {
 		fieldName = raw[:idx]
 		filePath = raw[idx+1:]
 	} else {
@@ -67,10 +66,18 @@ func ValidateFileFlag(file, params, data, outputPath string, pageAll bool, httpM
 	return nil
 }
 
+// FileUploadMeta holds file upload metadata for dry-run display.
+// Returned by request builders when dry-run mode skips actual file reading.
+type FileUploadMeta struct {
+	FieldName  string
+	FilePath   string
+	FormFields any
+}
+
 // BuildFormdata constructs a multipart form data payload for file upload.
 // If isStdin is true, the file content is read from stdin.
 // Top-level keys from dataJSON are added as text form fields.
-func BuildFormdata(ctx context.Context, fileIO fileio.FileIO, fieldName, filePath string, isStdin bool, stdin io.Reader, dataJSON any) (*larkcore.Formdata, error) {
+func BuildFormdata(fileIO fileio.FileIO, fieldName, filePath string, isStdin bool, stdin io.Reader, dataJSON any) (*larkcore.Formdata, error) {
 	fd := larkcore.NewFormdata()
 
 	if isStdin {
@@ -90,7 +97,12 @@ func BuildFormdata(ctx context.Context, fileIO fileio.FileIO, fieldName, filePat
 		if err != nil {
 			return nil, output.ErrValidation("cannot open file: %s", filePath)
 		}
-		fd.AddFile(fieldName, f)
+		defer f.Close()
+		data, err := io.ReadAll(f)
+		if err != nil {
+			return nil, output.ErrValidation("--file: failed to read %s: %v", filePath, err)
+		}
+		fd.AddFile(fieldName, bytes.NewReader(data))
 	}
 
 	// Add top-level JSON keys as text form fields.

--- a/internal/cmdutil/fileupload.go
+++ b/internal/cmdutil/fileupload.go
@@ -11,8 +11,22 @@ import (
 
 	"github.com/larksuite/cli/extension/fileio"
 	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/registry"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
+
+// DetectFileFields returns field names with type "file" in the method's requestBody.
+func DetectFileFields(method map[string]interface{}) []string {
+	rb, _ := method["requestBody"].(map[string]interface{})
+	var fields []string
+	for name, field := range rb {
+		f, _ := field.(map[string]interface{})
+		if registry.GetStrFromMap(f, "type") == "file" {
+			fields = append(fields, name)
+		}
+	}
+	return fields
+}
 
 // ParseFileFlag parses a --file flag value into its components.
 // The format is either "path" or "field=path". When no explicit "field="

--- a/internal/cmdutil/fileupload.go
+++ b/internal/cmdutil/fileupload.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmdutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/output"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+)
+
+// ParseFileFlag parses a --file flag value into its components.
+// The format is either "path" or "field=path". When no explicit "field="
+// prefix is present, defaultField is used as the field name.
+// A path of "-" indicates stdin; in that case filePath is empty and isStdin is true.
+func ParseFileFlag(raw, defaultField string) (fieldName, filePath string, isStdin bool) {
+	if idx := strings.IndexByte(raw, '='); idx >= 0 {
+		fieldName = raw[:idx]
+		filePath = raw[idx+1:]
+	} else {
+		fieldName = defaultField
+		filePath = raw
+	}
+	if filePath == "-" {
+		return fieldName, "", true
+	}
+	return fieldName, filePath, false
+}
+
+// ValidateFileFlag checks mutual exclusion rules for the --file flag.
+// Returns nil if file is empty (flag not provided).
+func ValidateFileFlag(file, params, data, outputPath string, pageAll bool, httpMethod string) error {
+	if file == "" {
+		return nil
+	}
+
+	_, filePath, isStdin := ParseFileFlag(file, "file")
+	if !isStdin && filePath == "" {
+		return output.ErrValidation("--file: empty file path")
+	}
+
+	if outputPath != "" {
+		return output.ErrValidation("--file and --output are mutually exclusive")
+	}
+	if pageAll {
+		return output.ErrValidation("--file and --page-all are mutually exclusive")
+	}
+	if isStdin && data == "-" {
+		return output.ErrValidation("--file and --data cannot both read from stdin")
+	}
+	if isStdin && params == "-" {
+		return output.ErrValidation("--file and --params cannot both read from stdin")
+	}
+
+	switch httpMethod {
+	case "POST", "PUT", "PATCH", "DELETE":
+	default:
+		return output.ErrValidation("--file requires POST, PUT, PATCH, or DELETE method")
+	}
+
+	return nil
+}
+
+// BuildFormdata constructs a multipart form data payload for file upload.
+// If isStdin is true, the file content is read from stdin.
+// Top-level keys from dataJSON are added as text form fields.
+func BuildFormdata(ctx context.Context, fileIO fileio.FileIO, fieldName, filePath string, isStdin bool, stdin io.Reader, dataJSON any) (*larkcore.Formdata, error) {
+	fd := larkcore.NewFormdata()
+
+	if isStdin {
+		if stdin == nil {
+			return nil, output.ErrValidation("--file: stdin is not available")
+		}
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, output.ErrValidation("--file: failed to read stdin: %v", err)
+		}
+		if len(data) == 0 {
+			return nil, output.ErrValidation("--file: stdin is empty")
+		}
+		fd.AddFile(fieldName, bytes.NewReader(data))
+	} else {
+		f, err := fileIO.Open(filePath)
+		if err != nil {
+			return nil, output.ErrValidation("cannot open file: %s", filePath)
+		}
+		fd.AddFile(fieldName, f)
+	}
+
+	// Add top-level JSON keys as text form fields.
+	if m, ok := dataJSON.(map[string]any); ok {
+		for k, v := range m {
+			fd.AddField(k, fmt.Sprintf("%v", v))
+		}
+	}
+
+	return fd, nil
+}

--- a/internal/cmdutil/fileupload_test.go
+++ b/internal/cmdutil/fileupload_test.go
@@ -5,7 +5,6 @@ package cmdutil
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,6 +84,14 @@ func TestParseFileFlag(t *testing.T) {
 			defaultField: "file",
 			wantField:    "image",
 			wantPath:     "/tmp/photo.jpg",
+			wantStdin:    false,
+		},
+		{
+			name:         "empty field prefix falls through to default",
+			raw:          "=photo.jpg",
+			defaultField: "file",
+			wantField:    "file",
+			wantPath:     "=photo.jpg",
 			wantStdin:    false,
 		},
 	}
@@ -220,12 +227,11 @@ func TestValidateFileFlag(t *testing.T) {
 }
 
 func TestBuildFormdata(t *testing.T) {
-	ctx := context.Background()
 	fio := &localfileio.LocalFileIO{}
 
 	t.Run("stdin success", func(t *testing.T) {
 		stdin := bytes.NewReader([]byte("file-content-here"))
-		fd, err := BuildFormdata(ctx, fio, "file", "", true, stdin, nil)
+		fd, err := BuildFormdata(fio, "file", "", true, stdin, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -235,7 +241,7 @@ func TestBuildFormdata(t *testing.T) {
 	})
 
 	t.Run("stdin nil reader", func(t *testing.T) {
-		_, err := BuildFormdata(ctx, fio, "file", "", true, nil, nil)
+		_, err := BuildFormdata(fio, "file", "", true, nil, nil)
 		if err == nil {
 			t.Fatal("expected error for nil stdin")
 		}
@@ -246,7 +252,7 @@ func TestBuildFormdata(t *testing.T) {
 
 	t.Run("stdin empty", func(t *testing.T) {
 		stdin := bytes.NewReader([]byte{})
-		_, err := BuildFormdata(ctx, fio, "file", "", true, stdin, nil)
+		_, err := BuildFormdata(fio, "file", "", true, stdin, nil)
 		if err == nil {
 			t.Fatal("expected error for empty stdin")
 		}
@@ -263,7 +269,7 @@ func TestBuildFormdata(t *testing.T) {
 			t.Fatalf("failed to create test file: %v", err)
 		}
 
-		fd, err := BuildFormdata(ctx, fio, "photo", "test.txt", false, nil, nil)
+		fd, err := BuildFormdata(fio, "photo", "test.txt", false, nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -276,7 +282,7 @@ func TestBuildFormdata(t *testing.T) {
 		dir := t.TempDir()
 		TestChdir(t, dir)
 
-		_, err := BuildFormdata(ctx, fio, "file", "nonexistent.txt", false, nil, nil)
+		_, err := BuildFormdata(fio, "file", "nonexistent.txt", false, nil, nil)
 		if err == nil {
 			t.Fatal("expected error for missing file")
 		}
@@ -299,7 +305,7 @@ func TestBuildFormdata(t *testing.T) {
 			"size":        1024,
 		}
 
-		fd, err := BuildFormdata(ctx, fio, "file", "upload.bin", false, nil, dataJSON)
+		fd, err := BuildFormdata(fio, "file", "upload.bin", false, nil, dataJSON)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -310,7 +316,7 @@ func TestBuildFormdata(t *testing.T) {
 
 	t.Run("dataJSON nil is fine", func(t *testing.T) {
 		stdin := bytes.NewReader([]byte("content"))
-		fd, err := BuildFormdata(ctx, fio, "file", "", true, stdin, nil)
+		fd, err := BuildFormdata(fio, "file", "", true, stdin, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -321,7 +327,7 @@ func TestBuildFormdata(t *testing.T) {
 
 	t.Run("dataJSON non-map is ignored", func(t *testing.T) {
 		stdin := bytes.NewReader([]byte("content"))
-		fd, err := BuildFormdata(ctx, fio, "file", "", true, stdin, "not-a-map")
+		fd, err := BuildFormdata(fio, "file", "", true, stdin, "not-a-map")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/internal/cmdutil/fileupload_test.go
+++ b/internal/cmdutil/fileupload_test.go
@@ -1,0 +1,332 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmdutil
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/vfs/localfileio"
+)
+
+func TestParseFileFlag(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          string
+		defaultField string
+		wantField    string
+		wantPath     string
+		wantStdin    bool
+	}{
+		{
+			name:         "simple filename uses default field",
+			raw:          "photo.jpg",
+			defaultField: "file",
+			wantField:    "file",
+			wantPath:     "photo.jpg",
+			wantStdin:    false,
+		},
+		{
+			name:         "simple filename with custom default",
+			raw:          "photo.jpg",
+			defaultField: "image",
+			wantField:    "image",
+			wantPath:     "photo.jpg",
+			wantStdin:    false,
+		},
+		{
+			name:         "explicit field prefix",
+			raw:          "image=photo.jpg",
+			defaultField: "file",
+			wantField:    "image",
+			wantPath:     "photo.jpg",
+			wantStdin:    false,
+		},
+		{
+			name:         "stdin bare",
+			raw:          "-",
+			defaultField: "file",
+			wantField:    "file",
+			wantPath:     "",
+			wantStdin:    true,
+		},
+		{
+			name:         "stdin with field prefix",
+			raw:          "image=-",
+			defaultField: "file",
+			wantField:    "image",
+			wantPath:     "",
+			wantStdin:    true,
+		},
+		{
+			name:         "path with equals sign (only first equals splits)",
+			raw:          "field=path/to/file=1.jpg",
+			defaultField: "file",
+			wantField:    "field",
+			wantPath:     "path/to/file=1.jpg",
+			wantStdin:    false,
+		},
+		{
+			name:         "absolute path no prefix",
+			raw:          "/tmp/photo.jpg",
+			defaultField: "file",
+			wantField:    "file",
+			wantPath:     "/tmp/photo.jpg",
+			wantStdin:    false,
+		},
+		{
+			name:         "absolute path with field prefix",
+			raw:          "image=/tmp/photo.jpg",
+			defaultField: "file",
+			wantField:    "image",
+			wantPath:     "/tmp/photo.jpg",
+			wantStdin:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field, path, isStdin := ParseFileFlag(tt.raw, tt.defaultField)
+			if field != tt.wantField {
+				t.Errorf("field = %q, want %q", field, tt.wantField)
+			}
+			if path != tt.wantPath {
+				t.Errorf("path = %q, want %q", path, tt.wantPath)
+			}
+			if isStdin != tt.wantStdin {
+				t.Errorf("isStdin = %v, want %v", isStdin, tt.wantStdin)
+			}
+		})
+	}
+}
+
+func TestValidateFileFlag(t *testing.T) {
+	tests := []struct {
+		name       string
+		file       string
+		params     string
+		data       string
+		outputPath string
+		pageAll    bool
+		httpMethod string
+		wantErr    string // empty means no error
+	}{
+		{
+			name:       "empty file is valid",
+			file:       "",
+			httpMethod: "GET",
+			wantErr:    "",
+		},
+		{
+			name:       "empty file path",
+			file:       "field=",
+			httpMethod: "POST",
+			wantErr:    "--file: empty file path",
+		},
+		{
+			name:       "file with output",
+			file:       "photo.jpg",
+			outputPath: "out.json",
+			httpMethod: "POST",
+			wantErr:    "--file and --output are mutually exclusive",
+		},
+		{
+			name:       "file with page-all",
+			file:       "photo.jpg",
+			pageAll:    true,
+			httpMethod: "POST",
+			wantErr:    "--file and --page-all are mutually exclusive",
+		},
+		{
+			name:       "stdin file with stdin data",
+			file:       "-",
+			data:       "-",
+			httpMethod: "POST",
+			wantErr:    "--file and --data cannot both read from stdin",
+		},
+		{
+			name:       "stdin file with stdin params",
+			file:       "-",
+			params:     "-",
+			httpMethod: "POST",
+			wantErr:    "--file and --params cannot both read from stdin",
+		},
+		{
+			name:       "file with GET method",
+			file:       "photo.jpg",
+			httpMethod: "GET",
+			wantErr:    "--file requires POST, PUT, PATCH, or DELETE method",
+		},
+		{
+			name:       "file with POST method",
+			file:       "photo.jpg",
+			httpMethod: "POST",
+			wantErr:    "",
+		},
+		{
+			name:       "file with PUT method",
+			file:       "photo.jpg",
+			httpMethod: "PUT",
+			wantErr:    "",
+		},
+		{
+			name:       "file with PATCH method",
+			file:       "photo.jpg",
+			httpMethod: "PATCH",
+			wantErr:    "",
+		},
+		{
+			name:       "file with DELETE method",
+			file:       "photo.jpg",
+			httpMethod: "DELETE",
+			wantErr:    "",
+		},
+		{
+			name:       "stdin with field prefix and data stdin",
+			file:       "image=-",
+			data:       "-",
+			httpMethod: "POST",
+			wantErr:    "--file and --data cannot both read from stdin",
+		},
+		{
+			name:       "stdin with field prefix and params stdin",
+			file:       "image=-",
+			params:     "-",
+			httpMethod: "POST",
+			wantErr:    "--file and --params cannot both read from stdin",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateFileFlag(tt.file, tt.params, tt.data, tt.outputPath, tt.pageAll, tt.httpMethod)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want containing %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildFormdata(t *testing.T) {
+	ctx := context.Background()
+	fio := &localfileio.LocalFileIO{}
+
+	t.Run("stdin success", func(t *testing.T) {
+		stdin := bytes.NewReader([]byte("file-content-here"))
+		fd, err := BuildFormdata(ctx, fio, "file", "", true, stdin, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fd == nil {
+			t.Fatal("expected non-nil Formdata")
+		}
+	})
+
+	t.Run("stdin nil reader", func(t *testing.T) {
+		_, err := BuildFormdata(ctx, fio, "file", "", true, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for nil stdin")
+		}
+		if !strings.Contains(err.Error(), "stdin is not available") {
+			t.Errorf("error = %q, want containing %q", err.Error(), "stdin is not available")
+		}
+	})
+
+	t.Run("stdin empty", func(t *testing.T) {
+		stdin := bytes.NewReader([]byte{})
+		_, err := BuildFormdata(ctx, fio, "file", "", true, stdin, nil)
+		if err == nil {
+			t.Fatal("expected error for empty stdin")
+		}
+		if !strings.Contains(err.Error(), "stdin is empty") {
+			t.Errorf("error = %q, want containing %q", err.Error(), "stdin is empty")
+		}
+	})
+
+	t.Run("file open success", func(t *testing.T) {
+		dir := t.TempDir()
+		TestChdir(t, dir)
+
+		if err := os.WriteFile(filepath.Join(dir, "test.txt"), []byte("hello"), 0600); err != nil {
+			t.Fatalf("failed to create test file: %v", err)
+		}
+
+		fd, err := BuildFormdata(ctx, fio, "photo", "test.txt", false, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fd == nil {
+			t.Fatal("expected non-nil Formdata")
+		}
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		dir := t.TempDir()
+		TestChdir(t, dir)
+
+		_, err := BuildFormdata(ctx, fio, "file", "nonexistent.txt", false, nil, nil)
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+		if !strings.Contains(err.Error(), "cannot open file:") {
+			t.Errorf("error = %q, want containing %q", err.Error(), "cannot open file:")
+		}
+	})
+
+	t.Run("dataJSON fields added", func(t *testing.T) {
+		dir := t.TempDir()
+		TestChdir(t, dir)
+
+		if err := os.WriteFile(filepath.Join(dir, "upload.bin"), []byte("data"), 0600); err != nil {
+			t.Fatalf("failed to create test file: %v", err)
+		}
+
+		dataJSON := map[string]any{
+			"file_name":   "report.pdf",
+			"parent_type": "doc_image",
+			"size":        1024,
+		}
+
+		fd, err := BuildFormdata(ctx, fio, "file", "upload.bin", false, nil, dataJSON)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fd == nil {
+			t.Fatal("expected non-nil Formdata")
+		}
+	})
+
+	t.Run("dataJSON nil is fine", func(t *testing.T) {
+		stdin := bytes.NewReader([]byte("content"))
+		fd, err := BuildFormdata(ctx, fio, "file", "", true, stdin, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fd == nil {
+			t.Fatal("expected non-nil Formdata")
+		}
+	})
+
+	t.Run("dataJSON non-map is ignored", func(t *testing.T) {
+		stdin := bytes.NewReader([]byte("content"))
+		fd, err := BuildFormdata(ctx, fio, "file", "", true, stdin, "not-a-map")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fd == nil {
+			t.Fatal("expected non-nil Formdata")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add `--file` flag to both raw `api` command and meta API service commands for multipart/form-data file uploads
- Auto-detect default field name from API metadata (e.g. `image` for `im.images.create`)
- Support stdin (`--file -`) and explicit field prefix (`--file image=photo.jpg`)
- Show `[file upload]` indicator and `--file` usage in `schema` display
- Shared helpers in `internal/cmdutil/fileupload.go` for parsing, validation, and form building

## Test plan

- [x] `lark-cli schema im.images.create` shows `[file upload]` tag and `--file` description
- [x] Non-file methods don't show `--file` in schema or `--help`
- [x] Dry-run shows file metadata without reading file
- [x] Error validation: `--file+GET`, `--file+--output`, `--file+--page-all`, dual stdin
- [x] Real API upload via raw API, meta API (auto-detect field), and stdin pipe
- [x] Unit tests pass for `cmd/api`, `cmd/service`, `internal/cmdutil`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--file` flag to upload files via multipart form-data in API and service commands, supporting both explicit field names and default field mapping.
  * Automatic detection and display of file upload options in command documentation.

* **Tests**
  * Added comprehensive test coverage for file upload flag parsing, validation, and dry-run rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->