### PR TITLE
fix(base): hide redundant option ids in field-search-options

### DIFF
--- a/shortcuts/base/base_execute_test.go
+++ b/shortcuts/base/base_execute_test.go
@@ -907,6 +907,8 @@ func TestBaseFieldExecuteSearchOptions(t *testing.T) {
 	}
 	if got := stdout.String(); !strings.Contains(got, `"options"`) || !strings.Contains(got, `"已完成"`) {
 		t.Fatalf("stdout=%s", got)
+	} else if strings.Contains(got, `"opt_1"`) {
+		t.Fatalf("stdout should not expose option ids: %s", got)
 	}
 }
 

--- a/shortcuts/base/field_ops.go
+++ b/shortcuts/base/field_ops.go
@@ -215,8 +215,31 @@ func executeFieldSearchOptions(runtime *common.RuntimeContext) error {
 		"field_id":   fieldRef,
 		"field_name": fieldRef,
 		"keyword":    strings.TrimSpace(runtime.Str("keyword")),
-		"options":    options,
+		"options":    stripFieldOptionIDs(options),
 		"total":      total,
 	}, nil)
 	return nil
+}
+
+func stripFieldOptionIDs(options []interface{}) []interface{} {
+	if len(options) == 0 {
+		return options
+	}
+	normalized := make([]interface{}, 0, len(options))
+	for _, option := range options {
+		record, ok := option.(map[string]interface{})
+		if !ok {
+			normalized = append(normalized, option)
+			continue
+		}
+		copied := make(map[string]interface{}, len(record))
+		for key, value := range record {
+			if key == "id" {
+				continue
+			}
+			copied[key] = value
+		}
+		normalized = append(normalized, copied)
+	}
+	return normalized
 }


### PR DESCRIPTION
Closes #381

## Summary
- remove redundant `options[].id` from `base +field-search-options` output
- keep the option shape aligned with `+field-create` and `+field-get`
- add a regression test that ensures the option id is not surfaced

## Test Plan
- [x] `GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache /opt/homebrew/opt/go/bin/go test ./shortcuts/base -run 'TestBaseFieldExecuteSearchOptions'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where internal option identifiers were being displayed in command output. Options now display user-friendly information without showing internal ID values, providing cleaner and more relevant results to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->