### PR TITLE
feat: support send/reply card 2.0

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -50,6 +50,10 @@ When using bot identity (`--as bot`) to fetch messages (e.g. `+chat-messages-lis
 
 Card messages (`interactive` type) are not yet supported for compact conversion in event subscriptions. The raw event data will be returned instead, with a hint printed to stderr.
 
+**MANDATORY READ BEFORE SENDING/REPLYING TO INTERACTIVE CARD MESSAGES:**
+- [`+messages-send`](references/lark-im-messages-send.md) - Detailed guide for sending messages, including interactive cards. **Must read before any card operations**
+- [`+messages-reply`](references/lark-im-messages-reply.md) - Detailed guide for replying to messages, including interactive cards. **Must read before any card operations**
+
 ## Shortcuts（推荐优先使用）
 
 Shortcut 是对常用操作的高级封装（`lark-cli im +<verb> [flags]`）。有 Shortcut 的操作优先使用。

--- a/skills/lark-im/card-examples/ai-calendar-creation.json
+++ b/skills/lark-im/card-examples/ai-calendar-creation.json
@@ -1,0 +1,145 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "horizontal",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "12px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "20px 20px 20px 20px",
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": "开发者运营项目启动会",
+                    "text_align": "left",
+                    "text_size": "heading"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "2024年1月25日（周四） ",
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "icon": {
+                        "tag": "standard_icon",
+                        "token": "calendar_outlined",
+                        "color": "grey"
+                    }
+                },
+                {
+                    "tag": "markdown",
+                    "content": "14:30 - 15:00 (GMT+8)",
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "icon": {
+                        "tag": "standard_icon",
+                        "token": "time_outlined",
+                        "color": "grey"
+                    }
+                },
+                {
+                    "tag": "person_list",
+                    "persons": [
+                        {
+                            "id": "1"
+                        },
+                        {
+                            "id": "2"
+                        },
+                        {
+                            "id": "3"
+                        }
+                    ],
+                    "size": "small",
+                    "lines": 1,
+                    "show_avatar": true,
+                    "show_name": true,
+                    "icon": {
+                        "tag": "standard_icon",
+                        "token": "group_outlined",
+                        "color": "grey"
+                    },
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "12px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "确定日程"
+                                    },
+                                    "type": "primary_filled",
+                                    "width": "fill",
+                                    "size": "medium"
+                                }
+                            ],
+                            "direction": "horizontal",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "编辑日程"
+                                    },
+                                    "type": "default",
+                                    "width": "fill",
+                                    "size": "medium"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top"
+                        }
+                    ],
+                    "margin": "4px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "为您创建了一个会议日程，请确认："
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "yellow",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "calendar_colorful"
+            },
+            "padding": "12px 12px 12px 20px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/ai-chat-welcome.json
+++ b/skills/lark-im/card-examples/ai-chat-welcome.json
@@ -1,0 +1,321 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "locales": [
+                "zh_cn",
+                "en_us",
+                "ja_jp"
+            ],
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                },
+                "color": {
+                    "color_dtgiw98jw3s": {
+                        "light_mode": "rgba(129, 158, 38, 1)",
+                        "dark_mode": "rgba(196, 223, 112, 1)"
+                    },
+                    "color_aedgx4h5lst": {
+                        "light_mode": "rgba(75, 211, 187, 1)",
+                        "dark_mode": "rgba(46, 199, 172, 1)"
+                    },
+                    "color_cpi1ty18y07": {
+                        "light_mode": "rgba(205, 136, 97, 1)",
+                        "dark_mode": "rgba(176, 97, 53, 1)"
+                    },
+                    "color_yshuzkazoo": {
+                        "light_mode": "rgba(63, 65, 69, 1)",
+                        "dark_mode": "rgba(196, 198, 203, 1)"
+                    },
+                    "color_7u3svrs1gk": {
+                        "light_mode": "rgba(129, 158, 38, 1)",
+                        "dark_mode": "rgba(196, 223, 112, 1)"
+                    },
+                    "color_5fjelryhkr7": {
+                        "light_mode": "rgba(75, 211, 187, 1)",
+                        "dark_mode": "rgba(46, 199, 172, 1)"
+                    },
+                    "color_9uxmooevtbs": {
+                        "light_mode": "rgba(205, 136, 97, 1)",
+                        "dark_mode": "rgba(176, 97, 53, 1)"
+                    },
+                    "color_bqm6462lklw": {
+                        "light_mode": "rgba(63, 65, 69, 1)",
+                        "dark_mode": "rgba(196, 198, 203, 1)"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "12px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "24px 24px 24px 24px",
+            "elements": [
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": false,
+                                    "transparent": false,
+                                    "scale_type": "crop_center",
+                                    "size": "small",
+                                    "corner_radius": "40px",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "## 嗨，我是*丽萨*, ",
+                                    "i18n_content": {
+                                        "en_us": "## Hi，I'm Lisa~"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "##### 今天我可以为你做什么👋 ",
+                    "i18n_content": {
+                        "en_us": "##### How may I help you today👋 "
+                    },
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "interactive_container",
+                    "width": "fill",
+                    "height": "auto",
+                    "corner_radius": "6px",
+                    "elements": [
+                        {
+                            "tag": "column_set",
+                            "flex_mode": "stretch",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "background_style": "color_7u3svrs1gk",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "",
+                                            "text_align": "right",
+                                            "text_size": "heading",
+                                            "margin": "0px 0px 0px 0px",
+                                            "icon": {
+                                                "tag": "standard_icon",
+                                                "token": "sheet-iconsets-rightup-grey_filled",
+                                                "color": "white"
+                                            }
+                                        },
+                                        {
+                                            "tag": "markdown",
+                                            "content": "##### <font color=\"grey-00\">与机器人 </font>\n##### <font color=\"grey-00\">对话 </font>",
+                                            "i18n_content": {
+                                                "en_us": "##### <font color=\"grey-00\">Talk </font>\n##### <font color=\"grey-00\">with BOT</font>",
+                                                "ja_jp": "##### <font color=\"grey-00\">ボットと </font>\n##### <font color=\"grey-00\">話す </font>"
+                                            },
+                                            "text_align": "left",
+                                            "text_size": "normal_v2",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "padding": "12px 12px 12px 12px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "margin": "0px 0px 0px 0px",
+                                    "weight": 2
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "column_set",
+                                            "horizontal_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "columns": [
+                                                {
+                                                    "tag": "column",
+                                                    "width": "weighted",
+                                                    "background_style": "color_5fjelryhkr7",
+                                                    "elements": [
+                                                        {
+                                                            "tag": "markdown",
+                                                            "content": "",
+                                                            "text_align": "right",
+                                                            "text_size": "heading",
+                                                            "margin": "0px 0px 0px 0px",
+                                                            "icon": {
+                                                                "tag": "standard_icon",
+                                                                "token": "sheet-iconsets-rightup-grey_filled",
+                                                                "color": "white"
+                                                            }
+                                                        },
+                                                        {
+                                                            "tag": "markdown",
+                                                            "content": "##### <font color=\"grey-00\">与机器人</font>\n##### <font color=\"grey-00\">聊天</font>",
+                                                            "i18n_content": {
+                                                                "en_us": "##### <font color=\"grey-00\">Chat</font>\n##### <font color=\"grey-00\">with BOT</font>",
+                                                                "ja_jp": "##### <font color=\"grey-00\">ボットと</font>\n##### <font color=\"grey-00\">チャット</font>"
+                                                            },
+                                                            "text_align": "left",
+                                                            "text_size": "normal_v2",
+                                                            "margin": "0px 0px 0px 0px"
+                                                        }
+                                                    ],
+                                                    "padding": "12px 12px 32px 12px",
+                                                    "direction": "vertical",
+                                                    "horizontal_spacing": "8px",
+                                                    "vertical_spacing": "8px",
+                                                    "horizontal_align": "left",
+                                                    "vertical_align": "top",
+                                                    "margin": "0px 0px 0px 0px",
+                                                    "weight": 1
+                                                }
+                                            ],
+                                            "margin": "0px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "column_set",
+                                            "horizontal_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "columns": [
+                                                {
+                                                    "tag": "column",
+                                                    "width": "weighted",
+                                                    "background_style": "color_9uxmooevtbs",
+                                                    "elements": [
+                                                        {
+                                                            "tag": "markdown",
+                                                            "content": "",
+                                                            "text_align": "right",
+                                                            "text_size": "heading",
+                                                            "margin": "0px 0px 0px 0px",
+                                                            "icon": {
+                                                                "tag": "standard_icon",
+                                                                "token": "sheet-iconsets-rightup-grey_filled",
+                                                                "color": "white"
+                                                            }
+                                                        },
+                                                        {
+                                                            "tag": "markdown",
+                                                            "content": "##### <font color=\"grey-00\">根据图片</font>\n##### <font color=\"grey-00\">搜索</font>",
+                                                            "i18n_content": {
+                                                                "en_us": "##### <font color=\"grey-00\">Search</font>\n##### <font color=\"grey-00\">by Image</font>",
+                                                                "ja_jp": "##### <font color=\"grey-00\">画像で</font>\n##### <font color=\"grey-00\">検索</font>"
+                                                            },
+                                                            "text_align": "left",
+                                                            "text_size": "normal_v2",
+                                                            "margin": "0px 0px 0px 0px"
+                                                        }
+                                                    ],
+                                                    "padding": "12px 12px 32px 12px",
+                                                    "direction": "vertical",
+                                                    "horizontal_spacing": "8px",
+                                                    "vertical_spacing": "8px",
+                                                    "horizontal_align": "left",
+                                                    "vertical_align": "top",
+                                                    "margin": "0px 0px 0px 0px",
+                                                    "weight": 1
+                                                }
+                                            ],
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "padding": "0px 0px 0px 0px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "margin": "0px 0px 0px 0px",
+                                    "weight": 3
+                                }
+                            ],
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "has_border": false,
+                    "padding": "0px 0px 0px 0px",
+                    "direction": "vertical",
+                    "horizontal_spacing": "8px",
+                    "vertical_spacing": "8px",
+                    "horizontal_align": "left",
+                    "vertical_align": "top",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "interactive_container",
+                    "width": "fill",
+                    "height": "auto",
+                    "corner_radius": "6px",
+                    "elements": [
+                        {
+                            "tag": "markdown",
+                            "content": "🚀 <font color=\"grey-100\"> Get Started</font>",
+                            "text_align": "center",
+                            "text_size": "normal_v2",
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "has_border": false,
+                    "background_style": "color_bqm6462lklw",
+                    "padding": "4px 8px 4px 8px",
+                    "direction": "vertical",
+                    "horizontal_spacing": "8px",
+                    "vertical_spacing": "8px",
+                    "horizontal_align": "left",
+                    "vertical_align": "top",
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        }
+    }
+}

--- a/skills/lark-im/card-examples/ai-curated-recommendations.json
+++ b/skills/lark-im/card-examples/ai-curated-recommendations.json
@@ -1,0 +1,334 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                },
+                "color": {
+                    "color_cfmb5ym9qe5": {
+                        "light_mode": "rgba(45, 45, 45, 0.01)",
+                        "dark_mode": "rgba(221, 220, 220, 0.01)"
+                    },
+                    "color_m15uj3qb5s": {
+                        "light_mode": "rgba(247, 249, 255, 1)",
+                        "dark_mode": "rgba(10, 18, 41, 1)"
+                    },
+                    "color_fnqkyskz9bf": {
+                        "light_mode": "rgba(45, 45, 45, 0.01)",
+                        "dark_mode": "rgba(221, 220, 220, 0.01)"
+                    },
+                    "color_3o25f1yylor": {
+                        "light_mode": "rgba(247, 249, 255, 1)",
+                        "dark_mode": "rgba(10, 18, 41, 1)"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "0px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "0px 0px 0px 0px",
+            "elements": [
+                {
+                    "tag": "img",
+                    "img_key": "xxx",
+                    "preview": true,
+                    "transparent": true,
+                    "scale_type": "fit_horizontal",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey-600\">LarkDesign AI Platform</font>",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "16px 0px 0px 20px",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "premium-gleam_filled",
+                                        "color": "light_grey"
+                                    }
+                                },
+                                {
+                                    "tag": "column_set",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "repeat",
+                                                    "variable": "object_img",
+                                                    "elements": [
+                                                        {
+                                                            "tag": "interactive_container",
+                                                            "width": "fill",
+                                                            "height": "auto",
+                                                            "corner_radius": "8px",
+                                                            "elements": [
+                                                                {
+                                                                    "tag": "column_set",
+                                                                    "flex_mode": "stretch",
+                                                                    "horizontal_spacing": "8px",
+                                                                    "horizontal_align": "left",
+                                                                    "columns": [
+                                                                        {
+                                                                            "tag": "column",
+                                                                            "width": "weighted",
+                                                                            "elements": [
+                                                                                {
+                                                                                    "tag": "markdown",
+                                                                                    "content": "${object_img.title}",
+                                                                                    "text_align": "left",
+                                                                                    "text_size": "normal_v2",
+                                                                                    "margin": "0px 0px 0px 0px"
+                                                                                },
+                                                                                {
+                                                                                    "tag": "markdown",
+                                                                                    "content": "${object_img.list_content}",
+                                                                                    "text_align": "left",
+                                                                                    "text_size": "normal_v2",
+                                                                                    "margin": "0px 0px 0px 0px"
+                                                                                }
+                                                                            ],
+                                                                            "padding": "0px 0px 0px 0px",
+                                                                            "direction": "vertical",
+                                                                            "horizontal_spacing": "8px",
+                                                                            "vertical_spacing": "8px",
+                                                                            "horizontal_align": "left",
+                                                                            "vertical_align": "top",
+                                                                            "margin": "0px 0px 0px 0px",
+                                                                            "weight": 3
+                                                                        },
+                                                                        {
+                                                                            "tag": "column",
+                                                                            "width": "weighted",
+                                                                            "elements": [
+                                                                                {
+                                                                                    "tag": "img",
+                                                                                    "img_key": "${object_img.img}",
+                                                                                    "preview": true,
+                                                                                    "transparent": false,
+                                                                                    "scale_type": "fit_horizontal",
+                                                                                    "corner_radius": "12px",
+                                                                                    "margin": "0px 0px 0px 0px"
+                                                                                }
+                                                                            ],
+                                                                            "padding": "0px 0px 0px 0px",
+                                                                            "vertical_spacing": "8px",
+                                                                            "horizontal_align": "left",
+                                                                            "vertical_align": "top",
+                                                                            "margin": "0px 0px 0px 0px",
+                                                                            "weight": 1
+                                                                        }
+                                                                    ],
+                                                                    "margin": "0px 0px 0px 0px"
+                                                                }
+                                                            ],
+                                                            "has_border": false,
+                                                            "background_style": "color_fnqkyskz9bf",
+                                                            "behaviors": [
+                                                                {
+                                                                    "type": "callback",
+                                                                    "value": "view_detail"
+                                                                }
+                                                            ],
+                                                            "padding": "8px 8px 8px 8px",
+                                                            "direction": "vertical",
+                                                            "horizontal_spacing": "8px",
+                                                            "vertical_spacing": "8px",
+                                                            "horizontal_align": "left",
+                                                            "vertical_align": "top",
+                                                            "margin": "8px 12px 8px 12px"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "0px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px",
+                                            "weight": 1
+                                        }
+                                    ],
+                                    "margin": "0px 8px 8px 8px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "-40px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "background_style": "color_3o25f1yylor",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "52px",
+                            "elements": [
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": false,
+                                    "transparent": false,
+                                    "scale_type": "crop_center",
+                                    "size": "small",
+                                    "corner_radius": "100%",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "8px 8px 8px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "**五条 AI Daily**\n<font color=\"grey-600\">每天精选最真实的AI新知</font>",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "8px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 2
+                        },
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "column_set",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "auto",
+                                            "elements": [
+                                                {
+                                                    "tag": "button",
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": ""
+                                                    },
+                                                    "type": "text",
+                                                    "width": "fill",
+                                                    "size": "large",
+                                                    "icon": {
+                                                        "tag": "standard_icon",
+                                                        "token": "subscribe_outlined"
+                                                    },
+                                                    "hover_tips": {
+                                                        "tag": "plain_text",
+                                                        "content": "订阅，可每天收到推送"
+                                                    },
+                                                    "behaviors": [
+                                                        {
+                                                            "type": "callback",
+                                                            "value": "subscribe"
+                                                        }
+                                                    ],
+                                                    "margin": "0px 0px 0px 0px"
+                                                },
+                                                {
+                                                    "tag": "button",
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": ""
+                                                    },
+                                                    "type": "text",
+                                                    "width": "fill",
+                                                    "size": "large",
+                                                    "icon": {
+                                                        "tag": "standard_icon",
+                                                        "token": "bonus-payroll_outlined"
+                                                    },
+                                                    "hover_tips": {
+                                                        "tag": "plain_text",
+                                                        "content": "打赏，给 5 条买点狗粮"
+                                                    },
+                                                    "behaviors": [
+                                                        {
+                                                            "type": "callback",
+                                                            "value": "donation"
+                                                        }
+                                                    ],
+                                                    "margin": "0px 0px 0px 0px"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "direction": "horizontal",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "bottom",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "margin": "15px 15px 15px 15px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        }
+    }
+}

--- a/skills/lark-im/card-examples/ai-image-generation.json
+++ b/skills/lark-im/card-examples/ai-image-generation.json
@@ -1,0 +1,406 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                },
+                "color": {
+                    "color_xj6fr0l5p8e": {
+                        "light_mode": "rgba(65, 120, 40, 1)",
+                        "dark_mode": "rgba(172, 221, 149, 1)"
+                    },
+                    "color_j5ehqvnvpv": {
+                        "light_mode": "rgba(248, 253, 248, 1)",
+                        "dark_mode": "rgba(11, 40, 11, 1)"
+                    },
+                    "color_rrm0acxf3o": {
+                        "light_mode": "rgba(65, 120, 40, 1)",
+                        "dark_mode": "rgba(172, 221, 149, 1)"
+                    },
+                    "color_85reaik0d67": {
+                        "light_mode": "rgba(248, 253, 248, 1)",
+                        "dark_mode": "rgba(11, 40, 11, 1)"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "0px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "0px 0px 0px 0px",
+            "elements": [
+                {
+                    "tag": "interactive_container",
+                    "width": "fill",
+                    "height": "auto",
+                    "corner_radius": "",
+                    "elements": [
+                        {
+                            "tag": "markdown",
+                            "content": "🎄**<font color='grey-00'>即梦 - 圣诞特辑</font>**",
+                            "text_align": "left",
+                            "text_size": "normal_v2",
+                            "margin": "0px 0px 0px 8px"
+                        }
+                    ],
+                    "has_border": false,
+                    "background_style": "color_rrm0acxf3o",
+                    "padding": "12px 4px 12px 4px",
+                    "direction": "vertical",
+                    "horizontal_spacing": "8px",
+                    "vertical_spacing": "8px",
+                    "horizontal_align": "left",
+                    "vertical_align": "top",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "interactive_container",
+                    "width": "auto",
+                    "height": "auto",
+                    "corner_radius": "0px",
+                    "elements": [
+                        {
+                            "tag": "markdown",
+                            "content": "一个 Jellycat 风格的圣诞老人和驯鹿站在一起，圣诞老人圆滚滚，身穿红色毛绒服，手里举着一根糖果拐杖，旁边的🫎驯鹿则带着小鹿角，围着一条软绵的毛绒围巾。两人站在柔软的雪地上，背景是一棵闪烁着暖光的毛绒圣诞树🎄，四周点缀着礼物盒和飘舞的雪花❄️。:Movie: **<font color='green-600'>想象力挑战第21期</font>** ` 图片 2.1 `  ",
+                            "text_align": "left",
+                            "text_size": "normal",
+                            "margin": "0px 0px 4px 0px"
+                        },
+                        {
+                            "tag": "column_set",
+                            "flex_mode": "stretch",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "4px",
+                                    "elements": [
+                                        {
+                                            "tag": "column_set",
+                                            "flex_mode": "bisect",
+                                            "horizontal_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "columns": [
+                                                {
+                                                    "tag": "column",
+                                                    "width": "weighted",
+                                                    "elements": [
+                                                        {
+                                                            "tag": "column_set",
+                                                            "flex_mode": "stretch",
+                                                            "horizontal_spacing": "8px",
+                                                            "horizontal_align": "left",
+                                                            "columns": [
+                                                                {
+                                                                    "tag": "column",
+                                                                    "width": "weighted",
+                                                                    "elements": [
+                                                                        {
+                                                                            "tag": "img",
+                                                                            "img_key": "xxx",
+                                                                            "preview": true,
+                                                                            "transparent": false,
+                                                                            "scale_type": "fit_horizontal",
+                                                                            "alt": {
+                                                                                "tag": "plain_text",
+                                                                                "content": ""
+                                                                            },
+                                                                            "corner_radius": "6px",
+                                                                            "margin": "0px 0px 0px 0px"
+                                                                        },
+                                                                        {
+                                                                            "tag": "img",
+                                                                            "img_key": "xxx",
+                                                                            "preview": true,
+                                                                            "transparent": false,
+                                                                            "scale_type": "fit_horizontal",
+                                                                            "alt": {
+                                                                                "tag": "plain_text",
+                                                                                "content": ""
+                                                                            },
+                                                                            "corner_radius": "6px",
+                                                                            "margin": "0px 0px 0px 0px"
+                                                                        },
+                                                                        {
+                                                                            "tag": "img",
+                                                                            "img_key": "xxx",
+                                                                            "preview": true,
+                                                                            "transparent": false,
+                                                                            "scale_type": "fit_horizontal",
+                                                                            "alt": {
+                                                                                "tag": "plain_text",
+                                                                                "content": ""
+                                                                            },
+                                                                            "corner_radius": "6px",
+                                                                            "margin": "0px 0px 0px 0px"
+                                                                        },
+                                                                        {
+                                                                            "tag": "img",
+                                                                            "img_key": "xxx",
+                                                                            "preview": true,
+                                                                            "transparent": false,
+                                                                            "scale_type": "fit_horizontal",
+                                                                            "alt": {
+                                                                                "tag": "plain_text",
+                                                                                "content": ""
+                                                                            },
+                                                                            "corner_radius": "8px",
+                                                                            "margin": "0px 0px 0px 0px"
+                                                                        }
+                                                                    ],
+                                                                    "padding": "0px 0px 0px 0px",
+                                                                    "direction": "horizontal",
+                                                                    "horizontal_spacing": "8px",
+                                                                    "vertical_spacing": "8px",
+                                                                    "horizontal_align": "left",
+                                                                    "vertical_align": "top",
+                                                                    "margin": "0px 0px 0px 0px",
+                                                                    "weight": 1
+                                                                }
+                                                            ],
+                                                            "margin": "0px 0px 0px 0px"
+                                                        }
+                                                    ],
+                                                    "padding": "0px 0px 0px 0px",
+                                                    "direction": "vertical",
+                                                    "horizontal_spacing": "8px",
+                                                    "vertical_spacing": "8px",
+                                                    "horizontal_align": "left",
+                                                    "vertical_align": "top",
+                                                    "margin": "0px 0px 0px 0px",
+                                                    "weight": 1
+                                                },
+                                                {
+                                                    "tag": "column",
+                                                    "width": "weighted",
+                                                    "elements": [
+                                                        {
+                                                            "tag": "img",
+                                                            "img_key": "xxx",
+                                                            "preview": true,
+                                                            "transparent": false,
+                                                            "scale_type": "fit_horizontal",
+                                                            "alt": {
+                                                                "tag": "plain_text",
+                                                                "content": ""
+                                                            },
+                                                            "corner_radius": "6px",
+                                                            "margin": "0px 0px 0px 0px"
+                                                        },
+                                                        {
+                                                            "tag": "img",
+                                                            "img_key": "xxx",
+                                                            "preview": true,
+                                                            "transparent": false,
+                                                            "scale_type": "fit_horizontal",
+                                                            "alt": {
+                                                                "tag": "plain_text",
+                                                                "content": ""
+                                                            },
+                                                            "corner_radius": "6px",
+                                                            "margin": "0px 0px 0px 0px"
+                                                        },
+                                                        {
+                                                            "tag": "img",
+                                                            "img_key": "xxx",
+                                                            "preview": true,
+                                                            "transparent": false,
+                                                            "scale_type": "fit_horizontal",
+                                                            "alt": {
+                                                                "tag": "plain_text",
+                                                                "content": ""
+                                                            },
+                                                            "corner_radius": "6px",
+                                                            "margin": "0px 0px 0px 0px"
+                                                        },
+                                                        {
+                                                            "tag": "img",
+                                                            "img_key": "xxx",
+                                                            "preview": true,
+                                                            "transparent": false,
+                                                            "scale_type": "fit_horizontal",
+                                                            "alt": {
+                                                                "tag": "plain_text",
+                                                                "content": ""
+                                                            },
+                                                            "corner_radius": "6px",
+                                                            "margin": "0px 0px 0px 0px"
+                                                        }
+                                                    ],
+                                                    "padding": "0px 0px 0px 0px",
+                                                    "direction": "vertical",
+                                                    "horizontal_spacing": "8px",
+                                                    "vertical_spacing": "8px",
+                                                    "horizontal_align": "left",
+                                                    "vertical_align": "top",
+                                                    "margin": "0px 0px 0px 0px",
+                                                    "weight": 1
+                                                }
+                                            ],
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "padding": "0px 0px 0px 0px",
+                                    "direction": "horizontal",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column_set",
+                            "flex_mode": "flow",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "auto",
+                                    "elements": [
+                                        {
+                                            "tag": "button",
+                                            "text": {
+                                                "tag": "plain_text",
+                                                "content": ""
+                                            },
+                                            "type": "text",
+                                            "width": "fill",
+                                            "size": "large",
+                                            "icon": {
+                                                "tag": "standard_icon",
+                                                "token": "replace_outlined"
+                                            },
+                                            "hover_tips": {
+                                                "tag": "plain_text",
+                                                "content": "再次生成"
+                                            },
+                                            "behaviors": [
+                                                {
+                                                    "type": "callback",
+                                                    "value": "refresh"
+                                                }
+                                            ],
+                                            "margin": "0px 0px 0px 0px",
+                                            "element_id": "a1"
+                                        }
+                                    ],
+                                    "padding": "3px 4px 4px 4px",
+                                    "direction": "horizontal",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "auto",
+                                    "elements": [
+                                        {
+                                            "tag": "button",
+                                            "text": {
+                                                "tag": "plain_text",
+                                                "content": ""
+                                            },
+                                            "type": "text",
+                                            "width": "fill",
+                                            "size": "large",
+                                            "icon": {
+                                                "tag": "standard_icon",
+                                                "token": "ccm-edit_outlined"
+                                            },
+                                            "hover_tips": {
+                                                "tag": "plain_text",
+                                                "content": "重新编辑"
+                                            },
+                                            "behaviors": [
+                                                {
+                                                    "type": "callback",
+                                                    "value": "rewrite"
+                                                }
+                                            ],
+                                            "margin": "0px 0px 0px 0px",
+                                            "element_id": "a2"
+                                        }
+                                    ],
+                                    "padding": "3px 4px 4px 4px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "auto",
+                                    "elements": [
+                                        {
+                                            "tag": "button",
+                                            "text": {
+                                                "tag": "plain_text",
+                                                "content": ""
+                                            },
+                                            "type": "text",
+                                            "width": "fill",
+                                            "size": "large",
+                                            "icon": {
+                                                "tag": "standard_icon",
+                                                "token": "upload_outlined"
+                                            },
+                                            "hover_tips": {
+                                                "tag": "plain_text",
+                                                "content": "发布图片"
+                                            },
+                                            "behaviors": [
+                                                {
+                                                    "type": "callback",
+                                                    "value": "release"
+                                                }
+                                            ],
+                                            "margin": "0px 0px 0px 0px",
+                                            "element_id": "a3"
+                                        }
+                                    ],
+                                    "padding": "3px 4px 4px 4px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "margin": "4px 4px 4px 4px"
+                        }
+                    ],
+                    "has_border": false,
+                    "background_style": "color_85reaik0d67",
+                    "padding": "8px 8px 8px 8px",
+                    "direction": "vertical",
+                    "horizontal_spacing": "8px",
+                    "vertical_spacing": "8px",
+                    "horizontal_align": "left",
+                    "vertical_align": "top",
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        }
+    }
+}

--- a/skills/lark-im/card-examples/alert-initiation.json
+++ b/skills/lark-im/card-examples/alert-initiation.json
@@ -1,0 +1,211 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "locales": [
+                "en_us"
+            ],
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "padding": "12px 12px 12px 12px",
+            "elements": [
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">告警内容</font>\n移动端打开异常率达到5%",
+                                    "i18n_content": {
+                                        "en_us": "<font color=\"grey\">Alert details</font>\nMobile client crash rate at 5%"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">错误信息</font>\n服务请求数量过多，超出限频",
+                                    "i18n_content": {
+                                        "en_us": "<font color=\"grey\">Diagnostic info</font>\nService request volume exceeds rate limit"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">告警等级</font>\nP0",
+                                    "i18n_content": {
+                                        "en_us": "<font color=\"grey\">Priority level</font>\nP0"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">告警时间</font>\n${alarm_time}",
+                                    "i18n_content": {
+                                        "en_us": "<font color=\"grey\">Incident time</font>\n${alarm_time}"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "hr",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "form",
+                    "elements": [
+                        {
+                            "tag": "input",
+                            "placeholder": {
+                                "tag": "plain_text",
+                                "content": "处理情况说明，选填",
+                                "i18n_content": {
+                                    "en_us": "Action taken (if any)"
+                                }
+                            },
+                            "default_value": "",
+                            "width": "fill",
+                            "name": "notes_input",
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column_set",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "auto",
+                                    "elements": [
+                                        {
+                                            "tag": "button",
+                                            "text": {
+                                                "tag": "plain_text",
+                                                "content": "处理完成",
+                                                "i18n_content": {
+                                                    "en_us": "Mark as Resolved"
+                                                }
+                                            },
+                                            "type": "primary",
+                                            "width": "default",
+                                            "behaviors": [
+                                                {
+                                                    "type": "callback",
+                                                    "value": {
+                                                        "action": "complete_alarm",
+                                                        "time": "${alarm_time}"
+                                                    }
+                                                }
+                                            ],
+                                            "form_action_type": "submit",
+                                            "name": "Button_m6vy7xom"
+                                        }
+                                    ],
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top"
+                                }
+                            ],
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "direction": "vertical",
+                    "padding": "4px 0px 4px 0px",
+                    "margin": "0px 0px 0px 0px",
+                    "name": "Form_m6vy7xol"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "[待处理] 告警通知：操作执行出错请及时处理",
+                "i18n_content": {
+                    "en_us": "[Action Needed] Alert: Process Error - Please Address Promptly",
+                    "ja_jp": "注文確認待ち"
+                }
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "red",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "warning-hollow_filled"
+            },
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/alert-resolved.json
+++ b/skills/lark-im/card-examples/alert-resolved.json
@@ -1,0 +1,163 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "locales": [
+                "en_us"
+            ],
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "padding": "12px 12px 12px 12px",
+            "elements": [
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">告警内容</font>\n移动端打开异常率达到5%",
+                                    "i18n_content": {
+                                        "en_us": "<font color=\"grey\">Alert details</font>\nMobile client crash rate at 5%"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">错误信息</font>\n服务请求数量过多，超出限频",
+                                    "i18n_content": {
+                                        "en_us": "<font color=\"grey\">Diagnostic info</font>\nService request volume exceeds rate limit"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">告警等级</font>\nP0",
+                                    "i18n_content": {
+                                        "en_us": "<font color=\"grey\">Priority level</font>\nP0"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">告警时间</font>\n${alarm_time}",
+                                    "i18n_content": {
+                                        "en_us": "<font color=\"grey\">Incident time</font>\n${alarm_time}"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "hr",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "<font color=\"grey\">处理进展</font>",
+                    "i18n_content": {
+                        "en_us": "<font color=\"grey\">Action taken</font>"
+                    },
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "<person id=\"${open_id}\" show_avatar=\"true\" show_name=\"true\" style=\"medium\"> </person>  ${complete_time} &nbsp;已处理  ${notes}",
+                    "i18n_content": {
+                        "en_us": "<person id=\"${open_id}\" show_avatar=\"true\" show_name=\"true\" style=\"medium\"></person>  ${complete_time} Resolved ${notes}"
+                    },
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "1px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "[已处理] 告警通知：操作执行出错请及时处理",
+                "i18n_content": {
+                    "en_us": "[Resolved] Alert: Process Error - Please Address Promptly",
+                    "ja_jp": "注文確認待ち"
+                }
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "green",
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/approval-approved.json
+++ b/skills/lark-im/card-examples/approval-approved.json
@@ -1,0 +1,162 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "16px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "0px 20px 20px 20px",
+            "elements": [
+                {
+                    "tag": "hr",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "12px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color = \"grey\">时间</font>\n2024-3-11 至 2024-3-15 （共 5 天）",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color = \"grey\">备注</font>\n世界这么大，我想去转转世界这么大",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "12px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color = \"grey\">申请人</font>\n<person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"capsule\"></person>",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "2px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color = \"grey\">休假类型</font>\n年假",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "hr",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "你已同意该休假申请，并批注：好的，玩得开心",
+                    "text_align": "left",
+                    "text_size": "notation",
+                    "margin": "0px 0px 0px 0px",
+                    "icon": {
+                        "tag": "standard_icon",
+                        "token": "succeed_filled",
+                        "color": "green"
+                    }
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "该休假申请已审批"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "default",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "approval_colorful"
+            },
+            "padding": "12px 20px 12px 20px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/approval-reminder.json
+++ b/skills/lark-im/card-examples/approval-reminder.json
@@ -1,0 +1,268 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "16px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "0px 20px 20px 20px",
+            "elements": [
+                {
+                    "tag": "hr",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "column_set",
+                                    "flex_mode": "stretch",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "<font color = \"grey\">时间</font>\n2024-3-11 至 2024-3-15 （共 5 天）",
+                                                    "text_align": "left",
+                                                    "text_size": "normal_v2"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px",
+                                            "weight": 1
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "<font color = \"grey\">备注</font>\n世界这么大，我想去转转",
+                                                    "text_align": "left",
+                                                    "text_size": "normal_v2"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px",
+                                            "weight": 1
+                                        }
+                                    ],
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "column_set",
+                                    "flex_mode": "stretch",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "<font color = \"grey\">申请人</font>\n<person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"capsule\">",
+                                                    "text_align": "left",
+                                                    "text_size": "normal"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "2px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px",
+                                            "weight": 1
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "<font color = \"grey\">休假类型</font>\n年假",
+                                                    "text_align": "left",
+                                                    "text_size": "normal"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px",
+                                            "weight": 1
+                                        }
+                                    ],
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "16px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "form",
+                    "elements": [
+                        {
+                            "tag": "input",
+                            "placeholder": {
+                                "tag": "plain_text",
+                                "content": "请输入审批备注，选填"
+                            },
+                            "default_value": "",
+                            "max_length": 200,
+                            "width": "fill",
+                            "required": false,
+                            "name": "Input_m7d0zq9v",
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column_set",
+                            "flex_mode": "stretch",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "auto",
+                                    "elements": [
+                                        {
+                                            "tag": "button",
+                                            "text": {
+                                                "tag": "plain_text",
+                                                "content": "同意"
+                                            },
+                                            "type": "primary_filled",
+                                            "width": "fill",
+                                            "size": "medium",
+                                            "icon": {
+                                                "tag": "standard_icon",
+                                                "token": "list-check-bold_outlined"
+                                            },
+                                            "form_action_type": "submit",
+                                            "name": "Button_m7d0zqa2"
+                                        }
+                                    ],
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top"
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "auto",
+                                    "elements": [
+                                        {
+                                            "tag": "button",
+                                            "text": {
+                                                "tag": "plain_text",
+                                                "content": "拒绝"
+                                            },
+                                            "type": "default",
+                                            "width": "fill",
+                                            "icon": {
+                                                "tag": "standard_icon",
+                                                "token": "close_outlined"
+                                            },
+                                            "form_action_type": "submit",
+                                            "name": "Button_m7d0zqa3"
+                                        }
+                                    ],
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top"
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "auto",
+                                    "elements": [],
+                                    "padding": "0px 0px 0px 0px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "margin": "4px 0px 0px 0px"
+                        }
+                    ],
+                    "direction": "vertical",
+                    "horizontal_spacing": "8px",
+                    "vertical_spacing": "12px",
+                    "horizontal_align": "left",
+                    "vertical_align": "top",
+                    "padding": "0px 0px 0px 0px",
+                    "margin": "0px 0px 0px 0px",
+                    "name": "Form_m7d0zqa1"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "你有一个休假申请待审批"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "default",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "approval_colorful"
+            },
+            "padding": "12px 12px 12px 20px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/article-with-images.json
+++ b/skills/lark-im/card-examples/article-with-images.json
@@ -1,0 +1,204 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "8px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "12px 12px 20px 12px",
+            "elements": [
+                {
+                    "tag": "img",
+                    "img_key": "xxx",
+                    "preview": true,
+                    "transparent": false,
+                    "scale_type": "crop_center",
+                    "size": "16:5",
+                    "alt": {
+                        "tag": "plain_text",
+                        "content": ""
+                    },
+                    "corner_radius": "8px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "在当代艺术界，**某位艺术家**以其独特的未来主义风格和对传统与现代的巧妙融合而闻名。他的最新作品——**“未来茶具”** 系列，再次证明了他在艺术创作上的非凡才华和创新精神。",
+                    "text_align": "left",
+                    "text_size": "normal_v2"
+                },
+                {
+                    "tag": "img_combination",
+                    "combination_mode": "triple",
+                    "img_list": [
+                        {
+                            "img_key": "xxx"
+                        },
+                        {
+                            "img_key": "xxx"
+                        },
+                        {
+                            "img_key": "xxx"
+                        }
+                    ],
+                    "img_list_length": 3,
+                    "combination_transparent": false,
+                    "corner_radius": "8px",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "hr"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "**作品介绍**",
+                                    "text_align": "left",
+                                    "text_size": "normal",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "efficiency_outlined",
+                                        "color": "orange"
+                                    }
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "“未来茶具”系列包括一个水壶、一个茶壶、一个糖罐和一套茶杯，每件作品都体现了这位艺术家对未来生活的独特理解和想象。这些茶具不仅在功能上满足了日常使用的需求，更在视觉上给人以强烈的冲击和思考。",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                },
+                                {
+                                    "tag": "hr"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "**设计理念**",
+                                    "text_align": "left",
+                                    "text_size": "normal",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "hot_outlined",
+                                        "color": "orange"
+                                    }
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "这位艺术家在设计这一系列作品时，深受未来主义和赛博朋克风格的影响。他将传统的茶具与现代科技元素相结合，创造出一种既熟悉又陌生的视觉体验。每件作品都采用了流线型设计，表面光滑，反射出冷峻的金属光泽，仿佛来自未来的科技产品。",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "一键触达客户案例"
+                                    },
+                                    "type": "primary_filled",
+                                    "width": "fill",
+                                    "size": "medium",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "direction": "horizontal",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "查看更多社区精选"
+                                    },
+                                    "type": "default",
+                                    "width": "fill",
+                                    "size": "medium"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "未来主义茶具系列专题"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "text_tag_list": [
+                {
+                    "tag": "text_tag",
+                    "text": {
+                        "tag": "plain_text",
+                        "content": "0521 期"
+                    },
+                    "color": "lime"
+                }
+            ],
+            "template": "yellow",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "labs_outlined"
+            },
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/beta-feature-recruitment.json
+++ b/skills/lark-im/card-examples/beta-feature-recruitment.json
@@ -1,0 +1,197 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "color": {
+                    "color_5rohwuq2vxf": {
+                        "light_mode": "rgba(247, 250, 255, 1)",
+                        "dark_mode": "rgba(10, 22, 41, 1)"
+                    },
+                    "color_t7lsds46e9s": {
+                        "light_mode": "rgba(247, 250, 255, 1)",
+                        "dark_mode": "rgba(10, 22, 41, 1)"
+                    }
+                },
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "0px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "0px 0px 0px 0px",
+            "elements": [
+                {
+                    "tag": "img",
+                    "img_key": "xxx",
+                    "preview": true,
+                    "transparent": false,
+                    "scale_type": "crop_center",
+                    "size": "stretch",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "background_style": "color_t7lsds46e9s",
+                    "horizontal_spacing": "0px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "##### <number_tag background_color=\"blue-500\" font_color=\"white\">1</number_tag> **企业信息传递痛点**",
+                                    "text_align": "left",
+                                    "text_size": "heading",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "部门壁垒森严，信息难以流通，导致协同效率低下。\n信息传递不及时，反馈延迟，错过最佳决策时机。\n数据分散，缺乏整合，难以形成有效决策依据。",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "##### <number_tag background_color=\"blue-500\" font_color=\"white\">2</number_tag> **信息流开放来帮你**",
+                                    "text_align": "left",
+                                    "text_size": "heading"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "打破部门壁垒，实现信息无缝流通，提升协同效率。\n实时共享数据，快速反馈，助力高效决策。\n整合数据资源，智能分析，为决策提供有力支持。",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "8px 8px 8px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 5
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "interactive_container",
+                                    "width": "fill",
+                                    "height": "auto",
+                                    "corner_radius": "24px",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "<font color=\"white\">立即申请开通</font>",
+                                            "text_align": "center",
+                                            "text_size": "normal_v2",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "has_border": false,
+                                    "background_style": "blue-500",
+                                    "padding": "5px 24px 5px 24px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "center",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "interactive_container",
+                                    "width": "fill",
+                                    "height": "auto",
+                                    "corner_radius": "24px",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "<font color=\"blue\">查看接入指南</font>",
+                                            "text_align": "center",
+                                            "text_size": "normal_v2",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "has_border": true,
+                                    "border_color": "blue-500",
+                                    "padding": "5px 24px 5px 24px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "center",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "margin": "12px 12px 12px 12px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "重要信息找不到？让「飞书信息流开放」来帮你！"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "blue",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "lark-logo_colorful"
+            },
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/bot-tutorial-welcome.json
+++ b/skills/lark-im/card-examples/bot-tutorial-welcome.json
@@ -1,0 +1,127 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "locales": [
+                "en_us"
+            ],
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "padding": "12px 12px 12px 12px",
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": "👋 <at id=\"${open_id}\"></at> 你好，欢迎体验 **机器人卡片交互教程** ！\n\n📦 这个教程将以 “发起告警、告警处理” 作为示例，帮助你了解：\n- 如何搭建 1 个卡片\n- 如何实现卡片按钮点击交互\n- 如何配置机器人菜单",
+                    "i18n_content": {
+                        "en_us": "👋 <at id=\"${open_id}\"></at> Hello, ready to explore our **Bot Card Interaction Guide**? 🤖\n\nThis tutorial uses \"Alert System\" as an example to help you understand:\n- Creating your first interactive card\n- Setting up interactive buttons on your card\n- Customizing your bot's menu options"
+                    },
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "hr",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "**现在就点击按钮开始体验吧！**",
+                    "i18n_content": {
+                        "en_us": "**Jump right in – click the button below to get started!**"
+                    },
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "去体验：发起告警",
+                                        "i18n_content": {
+                                            "en_us": "Try It: Initiate Alert"
+                                        }
+                                    },
+                                    "type": "primary_filled",
+                                    "width": "default",
+                                    "size": "medium",
+                                    "behaviors": [
+                                        {
+                                            "type": "callback",
+                                            "value": {
+                                                "action": "send_alarm"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "查看教程",
+                                        "i18n_content": {
+                                            "en_us": "View Tutorial"
+                                        }
+                                    },
+                                    "type": "default",
+                                    "width": "default",
+                                    "size": "medium",
+                                    "behaviors": [
+                                        {
+                                            "type": "open_url",
+                                            "default_url": "about:blank#tutorial",
+                                            "pc_url": "",
+                                            "ios_url": "",
+                                            "android_url": ""
+                                        }
+                                    ]
+                                }
+                            ],
+                            "direction": "horizontal",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "欢迎体验「机器人卡片交互教程」",
+                "i18n_content": {
+                    "en_us": "👋 Dive into Bot Card Interactions: A Hands-on Tutorial"
+                }
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "blue",
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/daily-report-of-codebase.json
+++ b/skills/lark-im/card-examples/daily-report-of-codebase.json
@@ -1,0 +1,241 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "项目开发日报"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": "2025年12月2日 星期一"
+            },
+            "template": "blue",
+            "padding": "12px 12px 12px 12px",
+            "text_tag_list": [
+                {
+                    "tag": "text_tag",
+                    "text": {
+                        "tag": "plain_text",
+                        "content": "日报"
+                    },
+                    "color": "blue"
+                }
+            ]
+        },
+        "body": {
+            "direction": "vertical",
+            "padding": "12px 12px 12px 12px",
+            "elements": [
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "12px",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "weight": 1,
+                            "vertical_align": "top",
+                            "background_style": "blue-50",
+                            "padding": "8px 8px 8px 8px",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "**<font color='blue'>3</font>**\n<font color='grey'>总提交数</font>",
+                                    "text_align": "center"
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "weight": 1,
+                            "vertical_align": "top",
+                            "background_style": "wathet-50",
+                            "padding": "8px 8px 8px 8px",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "**<font color='wathet'>3</font>**\n<font color='grey'>活跃贡献者</font>",
+                                    "text_align": "center"
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "weight": 1,
+                            "vertical_align": "top",
+                            "background_style": "indigo-50",
+                            "padding": "8px 8px 8px 8px",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "**<font color='indigo'>2</font>**\n<font color='grey'>Open MR</font>",
+                                    "text_align": "center"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "tag": "hr"
+                },
+                {
+                    "tag": "div",
+                    "text": {
+                        "tag": "lark_md",
+                        "content": "🚀 **新功能**"
+                    }
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "margin": "4px 0px 0px 0px",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "weight": 1,
+                            "vertical_align": "top",
+                            "background_style": "green-50",
+                            "padding": "12px 12px 12px 12px",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "• **更新构建配置支持 Web Platform Baseline 标准**: 升级浏览器兼容性目标（Chrome 111+, Edge 111+, Firefox 113+, Safari 16.4+），确保构建输出利用现代 Web 平台特性 `维护者 A`"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "tag": "hr"
+                },
+                {
+                    "tag": "div",
+                    "text": {
+                        "tag": "lark_md",
+                        "content": "♻️ **代码重构**"
+                    }
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "margin": "4px 0px 0px 0px",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "weight": 1,
+                            "vertical_align": "top",
+                            "background_style": "purple-50",
+                            "padding": "12px 12px 12px 12px",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "• **重构核心追踪器以支持完整请求生命周期追踪**: 将请求追踪 Hook 从仅错误追踪扩展为完整请求生命周期追踪，添加 `isLoading` 参数支持请求开始和结束状态追踪 `维护者 B`\n\n⚠️ **BREAKING CHANGE**: 请求追踪 Hook API 变更，需要传入 isLoading 参数"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "tag": "hr"
+                },
+                {
+                    "tag": "div",
+                    "text": {
+                        "tag": "lark_md",
+                        "content": "💄 **样式优化**"
+                    }
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "margin": "4px 0px 0px 0px",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "weight": 1,
+                            "vertical_align": "top",
+                            "background_style": "turquoise-50",
+                            "padding": "12px 12px 12px 12px",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "• **优化任务列表组件 UI 样式**: 优化列表项字体样式为等宽字体，提升交互体验 `维护者 C`"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "tag": "hr"
+                },
+                {
+                    "tag": "div",
+                    "text": {
+                        "tag": "lark_md",
+                        "content": "📋 **当前处于 OPEN 状态的 MR**"
+                    }
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "margin": "4px 0px 0px 0px",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "weight": 1,
+                            "vertical_align": "top",
+                            "background_style": "grey-50",
+                            "padding": "12px 12px 12px 12px",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "**!306 - ✨ feat: 前端监控与日志系统优化** `维护者 D`"
+                                },
+                                {
+                                    "tag": "hr"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "**!289 - ✅ test: 为关键 UI 组件添加测试 ID 属性** `维护者 E`"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "tag": "hr"
+                },
+                {
+                    "tag": "div",
+                    "text": {
+                        "tag": "plain_text",
+                        "content": "Generated by Feishu Card Agent • 2025-12-02",
+                        "text_size": "caption",
+                        "text_color": "grey-400"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/skills/lark-im/card-examples/daily-work-summary.json
+++ b/skills/lark-im/card-examples/daily-work-summary.json
@@ -1,0 +1,347 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                },
+                "color": {
+                    "color_ab3oezw88gl": {
+                        "light_mode": "rgba(248, 250, 255, 1)",
+                        "dark_mode": "rgba(10, 19, 41, 1)"
+                    },
+                    "color_py8zcp0z9a": {
+                        "light_mode": "rgba(248, 250, 255, 1)",
+                        "dark_mode": "rgba(10, 19, 41, 1)"
+                    },
+                    "color_duazavbtkl": {
+                        "light_mode": "rgba(248, 250, 255, 1)",
+                        "dark_mode": "rgba(10, 19, 41, 1)"
+                    },
+                    "color_iua6qms32yh": {
+                        "light_mode": "rgba(248, 250, 255, 1)",
+                        "dark_mode": "rgba(10, 19, 41, 1)"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "8px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "0px 12px 12px 12px",
+            "elements": [
+                {
+                    "tag": "interactive_container",
+                    "width": "fill",
+                    "height": "auto",
+                    "corner_radius": "12px",
+                    "elements": [
+                        {
+                            "tag": "markdown",
+                            "content": "**重要结论**",
+                            "text_align": "left",
+                            "text_size": "normal_v2",
+                            "margin": "0px 20px 0px 20px",
+                            "icon": {
+                                "tag": "standard_icon",
+                                "token": "vote_colorful",
+                                "color": "grey"
+                            }
+                        },
+                        {
+                            "tag": "hr"
+                        },
+                        {
+                            "tag": "column_set",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "- **用原型模拟下真实效果再最后确定**\n- **暂时保持两种字号并存**",
+                                            "text_align": "left",
+                                            "text_size": "normal_v2",
+                                            "margin": "0px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "markdown",
+                                            "content": "\n<font color=\"grey\">AI x 飞书｜参会人员：</font><person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"capsule\"></person> <person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"capsule\"></person>",
+                                            "text_align": "left",
+                                            "text_size": "notation",
+                                            "margin": "0px 0px 0px 22px"
+                                        },
+                                        {
+                                            "tag": "markdown",
+                                            "content": "- **提供人员组件原子设计稿**",
+                                            "text_align": "left",
+                                            "text_size": "normal_v2",
+                                            "margin": "0px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "markdown",
+                                            "content": "<font color=\"grey\">人员组件方案讨论｜参会人员：</font><person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"capsule\"></person> <person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"capsule\"></person> ",
+                                            "text_align": "left",
+                                            "text_size": "notation",
+                                            "margin": "0px 0px 0px 22px"
+                                        },
+                                        {
+                                            "tag": "markdown",
+                                            "content": "- **方案方向正确，继续优化细节部分**",
+                                            "text_align": "left",
+                                            "text_size": "normal_v2",
+                                            "margin": "0px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "markdown",
+                                            "content": "<font color=\"grey\">统一卡片框架对齐</font><font color=\"grey\">｜参会人员：</font><person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"capsule\"></person>",
+                                            "text_align": "left",
+                                            "text_size": "notation",
+                                            "margin": "0px 0px 0px 22px"
+                                        }
+                                    ],
+                                    "padding": "0px 0px 12px 0px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "margin": "0px 0px 0px 20px",
+                                    "weight": 3
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "img",
+                                            "img_key": "xxx",
+                                            "preview": true,
+                                            "transparent": true,
+                                            "scale_type": "fit_horizontal",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "padding": "0px 0px 0px 0px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "bottom",
+                                    "margin": "0px 0px 0px 0px",
+                                    "weight": 1
+                                }
+                            ],
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "has_border": true,
+                    "border_color": "blue-100",
+                    "background_style": "color_duazavbtkl",
+                    "padding": "12px 0px 0px 0px",
+                    "direction": "vertical",
+                    "horizontal_spacing": "8px",
+                    "vertical_spacing": "12px",
+                    "horizontal_align": "left",
+                    "vertical_align": "top",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "interactive_container",
+                    "width": "fill",
+                    "height": "auto",
+                    "corner_radius": "12px",
+                    "elements": [
+                        {
+                            "tag": "markdown",
+                            "content": "**TODO**",
+                            "text_align": "left",
+                            "text_size": "normal",
+                            "margin": "0px 20px 0px 20px",
+                            "icon": {
+                                "tag": "standard_icon",
+                                "token": "todo_colorful",
+                                "color": "grey"
+                            }
+                        },
+                        {
+                            "tag": "hr"
+                        },
+                        {
+                            "tag": "column_set",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "- **主题：卡片标题主题色确定**",
+                                            "text_align": "left",
+                                            "text_size": "normal_v2",
+                                            "margin": "0px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "markdown",
+                                            "content": "<font color=\"grey\">验证一下长卡片的效果 </font>[创建待办](about:blank#todo)\n<font color=\"grey\">卡片讨论小群｜参会人员：</font><person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"capsule\"></person> <person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"capsule\"></person>",
+                                            "text_align": "left",
+                                            "text_size": "notation",
+                                            "margin": "0px 0px 0px 22px"
+                                        },
+                                        {
+                                            "tag": "markdown",
+                                            "content": "- **主题：模型自定义文档**",
+                                            "text_align": "left",
+                                            "text_size": "normal_v2",
+                                            "margin": "0px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "markdown",
+                                            "content": "<font color=\"grey\">查看模型自定义文档</font> [创建待办](about:blank#todo)\n<font color=\"grey\">模型｜参会人员：</font><person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"capsule\"></person>",
+                                            "text_align": "left",
+                                            "text_size": "notation",
+                                            "margin": "0px 0px 0px 22px"
+                                        },
+                                        {
+                                            "tag": "markdown",
+                                            "content": "- **主题：消息卡片自定义**",
+                                            "text_align": "left",
+                                            "text_size": "normal_v2",
+                                            "margin": "0px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "markdown",
+                                            "content": "<font color=\"grey\">人员组件方案讨论｜参会人员：</font><person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"capsule\"></person>",
+                                            "text_align": "left",
+                                            "text_size": "notation",
+                                            "margin": "0px 0px 0px 22px"
+                                        }
+                                    ],
+                                    "padding": "0px 0px 12px 0px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "margin": "0px 0px 0px 20px",
+                                    "weight": 3
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "img",
+                                            "img_key": "xxx",
+                                            "preview": true,
+                                            "transparent": true,
+                                            "scale_type": "fit_horizontal",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "padding": "0px 0px 0px 0px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "bottom",
+                                    "margin": "0px 0px 0px 0px",
+                                    "weight": 1
+                                }
+                            ],
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "has_border": true,
+                    "border_color": "blue-100",
+                    "background_style": "color_iua6qms32yh",
+                    "padding": "12px 0px 0px 0px",
+                    "direction": "vertical",
+                    "horizontal_spacing": "8px",
+                    "vertical_spacing": "12px",
+                    "horizontal_align": "left",
+                    "vertical_align": "top",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">每天早上为你带来前一天的工作消息回顾 😘 </font>",
+                                    "text_align": "left",
+                                    "text_size": "notation",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "退订"
+                                    },
+                                    "type": "primary_text",
+                                    "width": "default",
+                                    "size": "medium",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "no_outlined"
+                                    }
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top"
+                        }
+                    ]
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "早上好！请查收09月11号工作总结"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "default",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "myai_colorful"
+            },
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/data-report-dashboard.json
+++ b/skills/lark-im/card-examples/data-report-dashboard.json
@@ -1,0 +1,235 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                },
+                "color": {
+                    "color_bkz3vrj7o4b": {
+                        "light_mode": "rgba(250, 251, 255, 1)",
+                        "dark_mode": "rgba(10, 16, 41, 1)"
+                    },
+                    "color_w1ysuydl1b": {
+                        "light_mode": "rgba(250, 251, 255, 1)",
+                        "dark_mode": "rgba(10, 16, 41, 1)"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "8px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "12px 4px 12px 4px",
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": "**个人审批效率总览**",
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "0px 12px 0px 12px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "background_style": "color_w1ysuydl1b",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color = \"grey\">已审批单量（单）</font>\n### 10\n<font color='grey'>领先团队</font><font color='green'> 20% </font>",
+                                    "text_align": "left",
+                                    "text_size": "notation"
+                                }
+                            ],
+                            "padding": "8px 12px 8px 12px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "2px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color = \"grey\">平均审批耗时（小时）</font>\n### 32\n<font color='grey'>领先团队</font><font color='green'> 20% </font>",
+                                    "text_align": "left",
+                                    "text_size": "notation"
+                                }
+                            ],
+                            "padding": "8px 12px 8px 12px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "2px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color = \"grey\">待审批（单）</font>\n### 12\n<font color='grey'>落后团队</font><font color='red'> 20% </font>",
+                                    "text_align": "left",
+                                    "text_size": "notation"
+                                }
+                            ],
+                            "padding": "8px 12px 8px 12px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "2px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 12px 0px 12px"
+                },
+                {
+                    "tag": "chart",
+                    "chart_spec": {
+                        "type": "bar",
+                        "title": {
+                            "text": "柱状图"
+                        },
+                        "data": {
+                            "values": [
+                                {
+                                    "type": "已审批单量（单）",
+                                    "value": 10,
+                                    "year": ""
+                                },
+                                {
+                                    "type": "平均审批耗时（小时）",
+                                    "value": 32,
+                                    "year": ""
+                                },
+                                {
+                                    "type": "待审批（单）",
+                                    "value": 12,
+                                    "year": ""
+                                }
+                            ]
+                        },
+                        "xField": [
+                            "year",
+                            "type"
+                        ],
+                        "yField": "value",
+                        "seriesField": "type",
+                        "legends": {
+                            "visible": true,
+                            "orient": "bottom"
+                        }
+                    },
+                    "preview": true,
+                    "color_theme": "brand",
+                    "height": "300px",
+                    "margin": "8px 0px 24px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "**团队审批效率参考**",
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "8px 12px 0px 12px"
+                },
+                {
+                    "tag": "table",
+                    "columns": [
+                        {
+                            "data_type": "persons",
+                            "name": "name",
+                            "display_name": "审批人",
+                            "horizontal_align": "left",
+                            "width": "auto"
+                        },
+                        {
+                            "data_type": "text",
+                            "name": "duration",
+                            "display_name": "审批时长",
+                            "horizontal_align": "left",
+                            "width": "auto"
+                        },
+                        {
+                            "data_type": "markdown",
+                            "name": "diff",
+                            "display_name": "对比上周变化",
+                            "horizontal_align": "left",
+                            "width": "auto"
+                        }
+                    ],
+                    "rows": [
+                        {
+                            "name": [
+                                "xxx"
+                            ],
+                            "duration": "小于1小时",
+                            "diff": "↓12%"
+                        },
+                        {
+                            "name": [
+                                "xxx"
+                            ],
+                            "duration": "2 小时",
+                            "diff": "↑5%"
+                        },
+                        {
+                            "name": [
+                                "xxx"
+                            ],
+                            "duration": "3 小时",
+                            "diff": "↓10%"
+                        }
+                    ],
+                    "row_height": "low",
+                    "header_style": {
+                        "background_style": "grey",
+                        "bold": true,
+                        "lines": 1
+                    },
+                    "page_size": 5,
+                    "margin": "0px 12px 0px 12px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "**待优化的任务类型**\n- 加班申请审批耗时  ： <font color='grey'>低于部门</font> <font color='red'>95% </font><font color='grey'>的审批人</font> \n- 休假申请审批耗时：<font color='grey'>低于部门</font> <font color='red'>55% </font><font color='grey'>的审批人</font> ",
+                    "text_align": "left",
+                    "text_size": "normal",
+                    "margin": "8px 12px 0px 12px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "**效率高的任务类型**\n- 数据权限申请 ：<font color='grey'>高于部门</font> <font color='green'>68% </font><font color='grey'>的审批人</font> \n- BOT推送消息：<font color='grey'>高于部门</font> <font color='green'>56% </font><font color='grey'>的审批人</font> ",
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "16px 12px 8px 12px"
+                }
+            ]
+        }
+    }
+}

--- a/skills/lark-im/card-examples/deal-won-announcement.json
+++ b/skills/lark-im/card-examples/deal-won-announcement.json
@@ -1,0 +1,154 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "16px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "16px 16px 16px 16px",
+            "elements": [
+                {
+                    "tag": "img",
+                    "img_key": "xxx",
+                    "preview": true,
+                    "transparent": false,
+                    "scale_type": "crop_center",
+                    "size": "21:9",
+                    "corner_radius": "6px",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": ":FIREWORKS: 热烈祝贺 **华南区** 再下一城！其它区域的小伙伴们也要加油哦~~~",
+                    "text_align": "left",
+                    "text_size": "normal",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "background_style": "grey-100",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">订单金额</font>\n##### 1000万",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "padding": "8px 16px 8px 16px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "2px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "background_style": "grey-100",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "售前区域\n##### 华南区",
+                                    "text_align": "left",
+                                    "text_size": "notation"
+                                }
+                            ],
+                            "padding": "8px 16px 8px 16px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "2px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "background_style": "grey-100",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "赢单售前\n##### <at id=all></at>",
+                                    "text_align": "left",
+                                    "text_size": "notation"
+                                }
+                            ],
+                            "padding": "8px 16px 8px 16px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "2px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": ":Trophy:  每一个客户的成功都离不开各团队的紧密配合！",
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": ":LOVE:  衷心感谢在此项目中付出的各位同事和幕后英雄们！",
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "<font color=\"grey-600\">[机密] 请注意信息安全，严禁外传</font>",
+                    "text_align": "left",
+                    "text_size": "notation",
+                    "margin": "0px 0px 0px 8px",
+                    "icon": {
+                        "tag": "standard_icon",
+                        "token": "lowerhand_outlined",
+                        "color": "light_grey"
+                    }
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "👏 恭喜飞书科技有限公司正式签约 "
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "green",
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/equipment-pickup-notification.json
+++ b/skills/lark-im/card-examples/equipment-pickup-notification.json
@@ -1,0 +1,157 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "16px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "20px 20px 20px 20px",
+            "elements": [
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color = \"grey\">领取地点</font>\n办公区设备服务点",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color = \"grey\">申请单号：</font>\nAPL20240205xxxxxxxxx",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color = \"grey\">设备详情</font>\nMac 笔记本 标配(16G/256G)",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color = \"grey\">申请数量</font>\n1",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "button",
+                    "text": {
+                        "tag": "plain_text",
+                        "content": "打开领取码"
+                    },
+                    "type": "primary_filled",
+                    "width": "default",
+                    "size": "medium",
+                    "icon": {
+                        "tag": "standard_icon",
+                        "token": "team-code_outlined"
+                    },
+                    "margin": "4px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "【设备领取通知】你申请的设备已准备好"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": "请携带手机，前往 IT 服务台领取~"
+            },
+            "template": "green",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "bell_outlined"
+            },
+            "padding": "12px 12px 12px 20px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/equipment-service-feedback.json
+++ b/skills/lark-im/card-examples/equipment-service-feedback.json
@@ -1,0 +1,227 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "8px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "12px 12px 12px 12px",
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": "你的设备申请流程已结束，我们诚邀你对本次服务做出评价！",
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "form",
+                    "elements": [
+                        {
+                            "tag": "column_set",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "整体领用评分",
+                                            "text_align": "left",
+                                            "text_size": "normal"
+                                        },
+                                        {
+                                            "tag": "select_static",
+                                            "placeholder": {
+                                                "tag": "plain_text",
+                                                "content": "请选择"
+                                            },
+                                            "options": [
+                                                {
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": "非常满意"
+                                                    },
+                                                    "value": "1",
+                                                    "icon": {
+                                                        "tag": "standard_icon",
+                                                        "token": "sheet-iconsets-star-100_filled"
+                                                    }
+                                                },
+                                                {
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": "满意"
+                                                    },
+                                                    "value": "2",
+                                                    "icon": {
+                                                        "tag": "standard_icon",
+                                                        "token": "sheet-iconsets-star-100_filled"
+                                                    }
+                                                },
+                                                {
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": "一般"
+                                                    },
+                                                    "value": "5",
+                                                    "icon": {
+                                                        "tag": "standard_icon",
+                                                        "token": "sheet-iconsets-star-100_filled"
+                                                    }
+                                                },
+                                                {
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": "不满意"
+                                                    },
+                                                    "value": "3",
+                                                    "icon": {
+                                                        "tag": "standard_icon",
+                                                        "token": "sheet-iconsets-star-100_filled"
+                                                    }
+                                                },
+                                                {
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": "非常不满意"
+                                                    },
+                                                    "value": "4",
+                                                    "icon": {
+                                                        "tag": "standard_icon",
+                                                        "token": "sheet-iconsets-star-100_filled"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "default",
+                                            "width": "fill",
+                                            "name": "Select_m7d0zq95"
+                                        }
+                                    ],
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "center",
+                                    "weight": 1
+                                }
+                            ],
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column_set",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "更多优化建议",
+                                            "text_align": "left",
+                                            "text_size": "normal",
+                                            "margin": "4px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "input",
+                                            "placeholder": {
+                                                "tag": "plain_text",
+                                                "content": "请输入"
+                                            },
+                                            "default_value": "",
+                                            "width": "fill",
+                                            "name": "Input_m7d0zq9a"
+                                        }
+                                    ],
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "center",
+                                    "weight": 1
+                                }
+                            ],
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column_set",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "button",
+                                            "text": {
+                                                "tag": "plain_text",
+                                                "content": "提交"
+                                            },
+                                            "type": "primary_filled",
+                                            "width": "100px",
+                                            "form_action_type": "submit",
+                                            "name": "Button_m7t30yjl"
+                                        }
+                                    ],
+                                    "padding": "4px 0px 0px 0px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "margin": "0px 0px 0px 0px",
+                                    "weight": 1
+                                }
+                            ],
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "direction": "horizontal",
+                    "horizontal_spacing": "8px",
+                    "vertical_spacing": "8px",
+                    "horizontal_align": "left",
+                    "vertical_align": "top",
+                    "padding": "4px 0px 4px 0px",
+                    "margin": "0px 0px 0px 0px",
+                    "name": "Form_m7t30yjk"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "【设备领取评价】请对本次设备领用的服务做出评价"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "yellow",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "select-down_outlined"
+            },
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/event-announcement.json
+++ b/skills/lark-im/card-examples/event-announcement.json
@@ -1,0 +1,155 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "0px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "0px 0px 0px 0px",
+            "elements": [
+                {
+                    "tag": "img",
+                    "img_key": "xxx",
+                    "preview": true,
+                    "transparent": true,
+                    "scale_type": "crop_center",
+                    "size": "21:8",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "16px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "气温回暖，万象更新。我们即将组织 Q1 团建活动，有意向参与的同学快点击按钮报名接龙吧！",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "column_set",
+                                    "flex_mode": "stretch",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "background_style": "grey-100",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "<font color=\"grey\">📅  活动时间</font>\n2024 年 3 月 15 日",
+                                                    "text_align": "left",
+                                                    "text_size": "normal_v2"
+                                                }
+                                            ],
+                                            "padding": "8px 12px 8px 12px",
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px",
+                                            "weight": 1
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "background_style": "grey-100",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "<font color=\"grey\">📍 活动地点</font>\n云栖竹径",
+                                                    "text_align": "left",
+                                                    "text_size": "normal_v2"
+                                                }
+                                            ],
+                                            "padding": "8px 12px 8px 12px",
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "center",
+                                            "margin": "0px 0px 0px 0px",
+                                            "weight": 1
+                                        }
+                                    ],
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "<number_tag background_color='turquoise-100' font_color='black'>1</number_tag> <person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"normal\"></person> <font color=\"grey\">已报名</font>\n\n<number_tag background_color='turquoise-100' font_color='black'>2</number_tag> <person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"normal\"></person> <font color=\"grey\">已报名</font>\n\n<number_tag background_color='turquoise-100' font_color='black'>3</number_tag> <person id=\"xxx\" show_avatar=\"true\" show_name=\"true\" style=\"normal\"></person> <font color=\"grey\">已报名</font>",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "立即接龙"
+                                    },
+                                    "type": "primary_filled",
+                                    "width": "default",
+                                    "size": "medium",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "member-add_outlined"
+                                    },
+                                    "margin": "4px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "20px 20px 20px 20px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "16px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "春日团建活动报名接龙"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "turquoise",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "day_outlined"
+            },
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/order-confirmation-approval.json
+++ b/skills/lark-im/card-examples/order-confirmation-approval.json
@@ -1,0 +1,462 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "locales": [
+                "en_us",
+                "ja_jp"
+            ],
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "card_link": {
+            "url": ""
+        },
+        "body": {
+            "direction": "vertical",
+            "padding": "12px 12px 12px 12px",
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": "尊敬的客户：\n请于**${order_ddl_time}** 前确认订单。确认后，即可在服务开始时间使用产品并申请开票。",
+                    "i18n_content": {
+                        "en_us": "Dear Customer：\nPlease confirm the order before**${order_ddl_time}** After confirmation, you can use the product from the start of the service period and apply for invoicing.",
+                        "ja_jp": "**${order_ddl_time}**　までに注文を確認してください。確認後、サービス開始時に製品を使用し、請求を申請することができます。"
+                    },
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "background_style": "grey-100",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "飞书商业标准版, 100账号, 1年",
+                                    "i18n_content": {
+                                        "en_us": "Feishu Business Standard Edition, 100 accounts, 1 year",
+                                        "ja_jp": "飛書ビジネス標準版、100アカウント、1年"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "飞书项目商业版, 50账号, 1年",
+                                    "i18n_content": {
+                                        "en_us": "Feishu Project Business Edition, 50 accounts, 1 year",
+                                        "ja_jp": "飛書プロジェクトビジネス版、50アカウント、1年"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "[赠品]飞书项目商业版, 50账号, 1个月",
+                                    "i18n_content": {
+                                        "en_us": "[Free Gift] Feishu Project Business Edition, 50 accounts, 1 month",
+                                        "ja_jp": "[プレゼント] 飛書プロジェクトビジネス版、50アカウント、1ヶ月"
+                                    },
+                                    "text_align": "left",
+                                    "text_size": "normal_v2",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "hr",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "column_set",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "72px",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "**订单金额**",
+                                                    "i18n_content": {
+                                                        "en_us": "Order Amount",
+                                                        "ja_jp": "注文金額"
+                                                    },
+                                                    "text_align": "left",
+                                                    "text_size": "normal_v2",
+                                                    "margin": "0px 0px 0px 0px"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "auto",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "**${order_price}**",
+                                                    "text_align": "right",
+                                                    "text_size": "normal_v2",
+                                                    "margin": "0px 0px 0px 0px"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "column_set",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "72px",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "票款顺序",
+                                                    "i18n_content": {
+                                                        "en_us": "Invoicing Sequence",
+                                                        "ja_jp": "請求順序"
+                                                    },
+                                                    "text_align": "left",
+                                                    "text_size": "normal_v2",
+                                                    "margin": "0px 0px 0px 0px"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "auto",
+                                            "elements": [
+                                                {
+                                                    "tag": "div",
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": "先票后款",
+                                                        "i18n_content": {
+                                                            "en_us": "Invoice First, Payment After",
+                                                            "ja_jp": "請求書優先、支払いは後"
+                                                        },
+                                                        "text_size": "normal_v2",
+                                                        "text_align": "right",
+                                                        "text_color": "default"
+                                                    },
+                                                    "margin": "0px 0px 0px 0px"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "column_set",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "72px",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "支付账期",
+                                                    "i18n_content": {
+                                                        "en_us": "Payment Term",
+                                                        "ja_jp": "支払い条件"
+                                                    },
+                                                    "text_align": "left",
+                                                    "text_size": "normal_v2",
+                                                    "margin": "0px 0px 0px 0px"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "auto",
+                                            "elements": [
+                                                {
+                                                    "tag": "div",
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": "14 天 (自服务开始时间起)",
+                                                        "i18n_content": {
+                                                            "en_us": "Invoice First, Payment After",
+                                                            "ja_jp": "請求書優先、支払いは後"
+                                                        },
+                                                        "text_size": "normal_v2",
+                                                        "text_align": "right",
+                                                        "text_color": "default"
+                                                    },
+                                                    "margin": "0px 0px 0px 0px"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "column_set",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "72px",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "支付频率",
+                                                    "i18n_content": {
+                                                        "en_us": "Payment Frequency",
+                                                        "ja_jp": "支払い頻度"
+                                                    },
+                                                    "text_align": "left",
+                                                    "text_size": "normal_v2",
+                                                    "margin": "0px 0px 0px 0px"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px"
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "auto",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "按年支付",
+                                                    "i18n_content": {
+                                                        "en_us": "Annually",
+                                                        "ja_jp": "年払い"
+                                                    },
+                                                    "text_align": "right",
+                                                    "text_size": "normal_v2",
+                                                    "margin": "0px 0px 0px 0px"
+                                                }
+                                            ],
+                                            "padding": "0px 0px 0px 0px",
+                                            "vertical_spacing": "8px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "8px 8px 8px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "div",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "租户名称：\n",
+                                        "i18n_content": {
+                                            "en_us": "tenant：",
+                                            "ja_jp": "テナント："
+                                        },
+                                        "text_size": "normal_v2",
+                                        "text_align": "left",
+                                        "text_color": "default"
+                                    },
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "div",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "Feishu",
+                                        "text_size": "normal_v2",
+                                        "text_align": "left",
+                                        "text_color": "default"
+                                    },
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "立即确认",
+                                        "i18n_content": {
+                                            "ja_jp": "すぐに確認",
+                                            "en_us": "Confirm Now"
+                                        }
+                                    },
+                                    "type": "primary_filled",
+                                    "width": "default",
+                                    "size": "medium",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "div",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "点击前往 \"管理后台>费用中心“ 查看更多信息",
+                                        "i18n_content": {
+                                            "en_us": "Click to go to \"Management Console > Billing Center\" for more information.\n",
+                                            "ja_jp": "管理コンソール > 請求センター」に移動して詳細を確認してください。"
+                                        },
+                                        "text_size": "notation",
+                                        "text_align": "left",
+                                        "text_color": "grey"
+                                    },
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "您有订单待确认",
+                "i18n_content": {
+                    "en_us": "You Have an Order Pending Confirmation",
+                    "ja_jp": "注文確認待ち"
+                }
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "orange",
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/personal-birthday-greeting.json
+++ b/skills/lark-im/card-examples/personal-birthday-greeting.json
@@ -1,0 +1,192 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "8px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "0px 0px 0px 0px",
+            "elements": [
+                {
+                    "tag": "img",
+                    "img_key": "xxx",
+                    "preview": true,
+                    "transparent": false,
+                    "scale_type": "fit_horizontal",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "12px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "60px",
+                            "elements": [
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": true,
+                                    "scale_type": "crop_center",
+                                    "size": "60px 60px",
+                                    "alt": {
+                                        "tag": "plain_text",
+                                        "content": ""
+                                    }
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": " **生日快乐 ♍️**\n 希望你一直如少年，干净纯粹心安，看透不美好却相信美好，见过不善良却依旧善良",
+                                    "text_align": "left"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 4
+                        }
+                    ],
+                    "margin": "12px 20px 12px 20px"
+                },
+                {
+                    "tag": "hr"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "🎁 **领取专属生日礼物**\n地点：办公区服务台\n时间：9:00-18:00",
+                                    "text_align": "left"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "立刻领取"
+                                    },
+                                    "type": "default",
+                                    "width": "default",
+                                    "behaviors": [
+                                        {
+                                            "type": "open_url",
+                                            "default_url": "about:blank#birthday-action",
+                                            "pc_url": "about:blank#birthday-action",
+                                            "ios_url": "about:blank#birthday-action",
+                                            "android_url": "about:blank#birthday-action"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center"
+                        }
+                    ],
+                    "margin": "12px 20px 12px 20px"
+                },
+                {
+                    "tag": "hr"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "😘 **收到的生日祝福**\n多位同事给你送祝福啦～",
+                                    "text_align": "left"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "查看祝福"
+                                    },
+                                    "type": "default",
+                                    "width": "default",
+                                    "behaviors": [
+                                        {
+                                            "type": "open_url",
+                                            "default_url": "about:blank#birthday-action",
+                                            "pc_url": "about:blank#birthday-action",
+                                            "ios_url": "about:blank#birthday-action",
+                                            "android_url": "about:blank#birthday-action"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center"
+                        }
+                    ],
+                    "margin": "12px 20px 20px 20px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "生日祝福，永远 18 岁～"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "orange",
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/product-newsletter.json
+++ b/skills/lark-im/card-examples/product-newsletter.json
@@ -1,0 +1,295 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "20px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "12px 12px 20px 12px",
+            "elements": [
+                {
+                    "tag": "img",
+                    "img_key": "xxx",
+                    "preview": true,
+                    "transparent": false,
+                    "scale_type": "crop_center",
+                    "size": "16:4",
+                    "alt": {
+                        "tag": "plain_text",
+                        "content": ""
+                    },
+                    "corner_radius": "8px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "💿 **旋律黑胶**",
+                                    "text_align": "left",
+                                    "text_size": "normal"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "此款黑胶唱片机采用复古设计语言，融合现代声学技术，温暖木质色调搭配金属旋钮，重现经典音乐质感。每台唱片机均由资深工匠手工调校，呈现细腻音质与优雅外观，既传承黑胶文化精髓，又满足现代听觉需求，是音乐爱好者与家居装饰的理想之选。",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "140px",
+                            "elements": [
+                                {
+                                    "tag": "div",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "",
+                                        "text_size": "normal",
+                                        "text_align": "left",
+                                        "text_color": "default"
+                                    }
+                                },
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": true,
+                                    "scale_type": "crop_center",
+                                    "size": "4:3",
+                                    "alt": {
+                                        "tag": "plain_text",
+                                        "content": ""
+                                    },
+                                    "corner_radius": "8px"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top"
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "🎧 **降噪耳机**",
+                                    "text_align": "left",
+                                    "text_size": "normal"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "传承声学工程匠心，此款降噪耳机由经验丰富的音频工程师在专业工作室精心调校。每一个细节都凝聚着对音质的极致追求，主动降噪技术和人体工学设计使其成为音乐聆听与移动办公的理想伴侣。",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "140px",
+                            "elements": [
+                                {
+                                    "tag": "div",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "",
+                                        "text_size": "normal",
+                                        "text_align": "left",
+                                        "text_color": "default"
+                                    }
+                                },
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": true,
+                                    "scale_type": "crop_center",
+                                    "size": "4:3",
+                                    "alt": {
+                                        "tag": "plain_text",
+                                        "content": ""
+                                    },
+                                    "corner_radius": "8px"
+                                }
+                            ],
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top"
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "🎵 **蓝牙音箱**",
+                                    "text_align": "left",
+                                    "text_size": "normal"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "\n这款现代日式陶瓷以精美造型和艺术装饰风格脱颖而出。设计灵感源自传统与现代的交融，色彩明快、线条流畅，无论用作家居摆件还是实用器皿，都能为空间增添一份时尚雅致。",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "140px",
+                            "elements": [
+                                {
+                                    "tag": "div",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "",
+                                        "text_size": "normal",
+                                        "text_align": "left",
+                                        "text_color": "default"
+                                    }
+                                },
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": true,
+                                    "scale_type": "crop_center",
+                                    "size": "4:3",
+                                    "alt": {
+                                        "tag": "plain_text",
+                                        "content": ""
+                                    },
+                                    "corner_radius": "8px"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top"
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "hr"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "一键触达客户案例"
+                                    },
+                                    "type": "primary",
+                                    "width": "fill",
+                                    "size": "medium",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "direction": "horizontal",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "查看更多社区精选"
+                                    },
+                                    "type": "default",
+                                    "width": "fill",
+                                    "size": "medium"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "音乐期刊 No.25 “声动生活，品质音乐新体验”"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "violet",
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/project-assistant-form.json
+++ b/skills/lark-im/card-examples/project-assistant-form.json
@@ -1,0 +1,349 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "8px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "20px 20px 20px 20px",
+            "elements": [
+                {
+                    "tag": "form",
+                    "elements": [
+                        {
+                            "tag": "column_set",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "**项目名称**<font color='red'>*</font>",
+                                            "text_align": "left",
+                                            "text_size": "normal",
+                                            "icon": {
+                                                "tag": "standard_icon",
+                                                "token": "add-app_outlined",
+                                                "color": "light_grey"
+                                            }
+                                        }
+                                    ],
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "center",
+                                    "weight": 1
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "业务做大做强",
+                                            "text_align": "left",
+                                            "text_size": "normal_v2",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "weight": 4
+                                }
+                            ],
+                            "margin": "0px 0px 4px 0px"
+                        },
+                        {
+                            "tag": "column_set",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "**经办人**<font color='red'>*</font>",
+                                            "text_align": "left",
+                                            "text_size": "normal",
+                                            "icon": {
+                                                "tag": "standard_icon",
+                                                "token": "member_outlined",
+                                                "color": "light_grey"
+                                            }
+                                        }
+                                    ],
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "center",
+                                    "weight": 1
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "select_person",
+                                            "placeholder": {
+                                                "tag": "plain_text",
+                                                "content": "请选择"
+                                            },
+                                            "options": [],
+                                            "width": "fill",
+                                            "type": "default",
+                                            "name": "PersonSelect_d8a92vdf4m"
+                                        }
+                                    ],
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "weight": 4
+                                }
+                            ],
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column_set",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "**优先级**<font color='red'>*</font>",
+                                            "text_align": "left",
+                                            "text_size": "normal",
+                                            "icon": {
+                                                "tag": "standard_icon",
+                                                "token": "msgcard-rectangle_outlined",
+                                                "color": "light_grey"
+                                            }
+                                        }
+                                    ],
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "center",
+                                    "weight": 1
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "select_static",
+                                            "placeholder": {
+                                                "tag": "plain_text",
+                                                "content": "请选择"
+                                            },
+                                            "options": [
+                                                {
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": "P0"
+                                                    },
+                                                    "value": "1",
+                                                    "icon": {
+                                                        "tag": "standard_icon",
+                                                        "token": "sheet-iconsets-increase_filled"
+                                                    }
+                                                },
+                                                {
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": "P1"
+                                                    },
+                                                    "value": "P1",
+                                                    "icon": {
+                                                        "tag": "standard_icon",
+                                                        "token": "sheet-iconsets-stable_filled"
+                                                    }
+                                                },
+                                                {
+                                                    "text": {
+                                                        "tag": "plain_text",
+                                                        "content": "P2"
+                                                    },
+                                                    "value": "3",
+                                                    "icon": {
+                                                        "tag": "standard_icon",
+                                                        "token": "expand-down_filled"
+                                                    }
+                                                }
+                                            ],
+                                            "type": "default",
+                                            "width": "fill",
+                                            "name": "Select_fbg14loa99c"
+                                        }
+                                    ],
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "weight": 4
+                                }
+                            ],
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column_set",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "left",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "markdown",
+                                            "content": "**项目评论**",
+                                            "text_align": "left",
+                                            "text_size": "normal",
+                                            "icon": {
+                                                "tag": "standard_icon",
+                                                "token": "chat_outlined",
+                                                "color": "light_grey"
+                                            }
+                                        }
+                                    ],
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "center",
+                                    "weight": 1
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "input",
+                                            "placeholder": {
+                                                "tag": "plain_text",
+                                                "content": "请输入"
+                                            },
+                                            "default_value": "",
+                                            "width": "fill",
+                                            "name": "Input_cq6bixohu6n"
+                                        }
+                                    ],
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "weight": 4
+                                }
+                            ],
+                            "margin": "0px 0px 4px 0px"
+                        },
+                        {
+                            "tag": "column_set",
+                            "horizontal_spacing": "8px",
+                            "horizontal_align": "right",
+                            "columns": [
+                                {
+                                    "tag": "column",
+                                    "width": "110px",
+                                    "elements": [],
+                                    "padding": "0px 0px 0px 0px",
+                                    "direction": "vertical",
+                                    "horizontal_spacing": "8px",
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "button",
+                                            "text": {
+                                                "tag": "plain_text",
+                                                "content": "提交"
+                                            },
+                                            "type": "primary_filled",
+                                            "width": "fill",
+                                            "form_action_type": "submit",
+                                            "name": "Button_m7t30yjh"
+                                        }
+                                    ],
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "weight": 1
+                                },
+                                {
+                                    "tag": "column",
+                                    "width": "weighted",
+                                    "elements": [
+                                        {
+                                            "tag": "button",
+                                            "text": {
+                                                "tag": "plain_text",
+                                                "content": "取消"
+                                            },
+                                            "type": "default",
+                                            "width": "fill",
+                                            "size": "medium",
+                                            "name": "Button_vghtjecc609",
+                                            "margin": "0px 0px 0px 0px"
+                                        }
+                                    ],
+                                    "vertical_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "vertical_align": "top",
+                                    "weight": 1
+                                }
+                            ],
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "direction": "vertical",
+                    "horizontal_spacing": "8px",
+                    "vertical_spacing": "16px",
+                    "horizontal_align": "left",
+                    "vertical_align": "top",
+                    "padding": "4px 0px 4px 0px",
+                    "margin": "0px 0px 0px 0px",
+                    "name": "Form_m7t30yiz"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "项目小助理"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "wathet",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "app-default_outlined"
+            },
+            "padding": "12px 12px 12px 20px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/sales-leaderboard.json
+++ b/skills/lark-im/card-examples/sales-leaderboard.json
@@ -1,0 +1,375 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "16px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "20px 20px 20px 20px",
+            "elements": [
+                {
+                    "tag": "img",
+                    "img_key": "xxx",
+                    "preview": true,
+                    "scale_type": "crop_center",
+                    "size": "16:6",
+                    "alt": {
+                        "tag": "plain_text",
+                        "content": ""
+                    },
+                    "corner_radius": "6px"
+                },
+                {
+                    "tag": "column_set",
+                    "background_style": "grey-100",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": true,
+                                    "scale_type": "crop_center",
+                                    "alt": {
+                                        "tag": "plain_text",
+                                        "content": ""
+                                    },
+                                    "corner_radius": "6px"
+                                }
+                            ],
+                            "padding": "12px 0px 0px 10px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "销售顾问 A ｜  **金牛奖得主**\n<font color='grey'>销售部门精钢零件销售冠军🥇</font>",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                },
+                                {
+                                    "tag": "column_set",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "**<font color='red'> 1198 万</font>**\n<font color='grey'> 本月业绩</font>",
+                                                    "text_align": "left",
+                                                    "text_size": "normal"
+                                                }
+                                            ],
+                                            "direction": "vertical",
+                                            "horizontal_spacing": "8px",
+                                            "vertical_spacing": "0px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "weight": 1
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "**<font color='red'>+11.2% </font>**\n<font color='grey'> 较上月份</font>",
+                                                    "text_align": "left",
+                                                    "text_size": "normal"
+                                                }
+                                            ],
+                                            "vertical_spacing": "0px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "weight": 1
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "**<font color='red'>+34.7% </font>**\n<font color='grey'> 较上季度</font>",
+                                                    "text_align": "left",
+                                                    "text_size": "normal"
+                                                }
+                                            ],
+                                            "vertical_spacing": "0px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "weight": 1
+                                        }
+                                    ],
+                                    "margin": "0px 0px 0px -2px"
+                                }
+                            ],
+                            "padding": "8px 0px 8px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 5
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "background_style": "grey-100",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": true,
+                                    "scale_type": "crop_center",
+                                    "alt": {
+                                        "tag": "plain_text",
+                                        "content": ""
+                                    },
+                                    "corner_radius": "6px"
+                                }
+                            ],
+                            "padding": "12px 0px 0px 10px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "销售顾问 B ｜ **实力开拓者**\n<font color='grey'>销售部门精钢零件销售亚军🥈</font>",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                },
+                                {
+                                    "tag": "column_set",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "**<font color='red'> 975 万</font>**\n<font color='grey'> 本月业绩</font>",
+                                                    "text_align": "left",
+                                                    "text_size": "normal"
+                                                }
+                                            ],
+                                            "vertical_spacing": "0px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "weight": 1
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "**<font color='green'>-0.52%</font>**\n<font color='grey'> 较上月份</font>",
+                                                    "text_align": "left",
+                                                    "text_size": "normal"
+                                                }
+                                            ],
+                                            "vertical_spacing": "0px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "weight": 1
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "**<font color='red'>+13.9%</font>**\n<font color='grey'> 较上季度</font>",
+                                                    "text_align": "left",
+                                                    "text_size": "normal"
+                                                }
+                                            ],
+                                            "vertical_spacing": "0px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "weight": 1
+                                        }
+                                    ],
+                                    "margin": "0px 0px 0px -2px"
+                                }
+                            ],
+                            "padding": "8px 0px 8px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 5
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "background_style": "grey-100",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": true,
+                                    "scale_type": "crop_center",
+                                    "alt": {
+                                        "tag": "plain_text",
+                                        "content": ""
+                                    },
+                                    "corner_radius": "6px"
+                                }
+                            ],
+                            "padding": "12px 0px 0px 10px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "销售顾问 C ｜ **业务坚守标兵**\n<font color='grey'>销售部门精钢零件销售季军🥉</font>",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                },
+                                {
+                                    "tag": "column_set",
+                                    "horizontal_spacing": "8px",
+                                    "horizontal_align": "left",
+                                    "columns": [
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "**<font color='red'> 798 万</font>**\n<font color='grey'> 本月业绩</font>",
+                                                    "text_align": "left",
+                                                    "text_size": "normal"
+                                                }
+                                            ],
+                                            "vertical_spacing": "0px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "weight": 1
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "**<font color='red'>+8.2%</font>**\n<font color='grey'> 较上月份</font>",
+                                                    "text_align": "left",
+                                                    "text_size": "normal"
+                                                }
+                                            ],
+                                            "vertical_spacing": "0px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "weight": 1
+                                        },
+                                        {
+                                            "tag": "column",
+                                            "width": "weighted",
+                                            "elements": [
+                                                {
+                                                    "tag": "markdown",
+                                                    "content": "**<font color='red'>+5.8%</font>**\n<font color='grey'> 较上季度</font>",
+                                                    "text_align": "left",
+                                                    "text_size": "normal"
+                                                }
+                                            ],
+                                            "vertical_spacing": "0px",
+                                            "horizontal_align": "left",
+                                            "vertical_align": "top",
+                                            "weight": 1
+                                        }
+                                    ],
+                                    "margin": "0px 0px 0px -2px"
+                                }
+                            ],
+                            "padding": "8px 0px 8px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 5
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "2024 年 05 月销售部门业绩排行榜来啦 🎉🎉🎉"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "grey",
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/smart-locker-launch.json
+++ b/skills/lark-im/card-examples/smart-locker-launch.json
@@ -1,0 +1,115 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "16px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "20px 20px 20px 20px",
+            "elements": [
+                {
+                    "tag": "img",
+                    "img_key": "xxx",
+                    "preview": true,
+                    "transparent": false,
+                    "scale_type": "crop_center",
+                    "size": "21:8",
+                    "alt": {
+                        "tag": "plain_text",
+                        "content": ""
+                    },
+                    "corner_radius": "6px",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": ":GeneralSun: 为了提供更加多元便捷的快递取件服务，智能快递柜上线啦！让收包裹的喜悦快马加鞭来到你身边~",
+                    "text_align": "left",
+                    "text_size": "normal_v2"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "background_style": "grey-100",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">📍 具体位置</font>\n办公园区智能快递柜服务点",
+                                    "text_align": "left",
+                                    "text_size": "normal"
+                                }
+                            ],
+                            "padding": "8px 8px 8px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "background_style": "grey-100",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey\">🚚 取件方式</font>\n✔️工卡刷卡  ✔️飞书扫码  ✔️取件码取件",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                }
+                            ],
+                            "padding": "8px 8px 8px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "号外号外！智能快递柜正式入驻办公园区啦！"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": "24h 自助取件，方便快捷~"
+            },
+            "template": "blue",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "bell_filled"
+            },
+            "padding": "12px 12px 12px 20px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/streaming-service-desk.json
+++ b/skills/lark-im/card-examples/streaming-service-desk.json
@@ -1,0 +1,256 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "padding": "12px 12px 12px 12px",
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": "要配置消息卡片流式更新，可参考以下内容：",
+                    "text_align": "left",
+                    "text_size": "normal_v2",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": " **一、JSON结构中的相关字段配置**\n1. **streaming_mode字段**<number_tag>1</number_tag><number_tag>2</number_tag>\n<number_tag>4</number_tag><number_tag>5</number_tag>\n    - 类型为Boolean，用于开启或关闭流式更新模式 \n    - 若要开启卡片的流式更新模式，需将此值设为true \n2. **streaming_config字段**<number_tag>1</number_tag><number_tag>3</number_tag>\n<number_tag>4</number_tag>\n    - 类型为Object，用于指定流式更新的频率、步长和更新策略等参数\n    - **print_frequency_ms子字段**<number_tag>1</number_tag><number_tag>2</number_tag>\n        - 用于设置流式更新频率，即两次流式更新上屏之间的间隔时长，默认为70ms \n        - 支持分端配置，若要配置三端统一的流式参数，仅指定default的值即可；若要为三端指定不同的流式参数，则在填写default参数的基础上，可选增加android/ios/pc三端的参数 \n        - default（三端通用统一频率）为必填项，单位为毫秒，数据校验规则为20 - 1000；android、ios、pc端频率为可选项，同样需满足20 - 1000的毫秒数据校验规则 \n    - **print_step子字段**<number_tag>3</number_tag>\n<number_tag>4</number_tag>\n        - 用于设置流式更新步长，即每次流式更新上屏打印的增量字符数，默认为1\n        - 支持分端配置，若要配置三端统一的流式参数，仅指定default的值即可；若要为三端指定不同的流式参数，则在填写default参数的基础上，可选增加android/ios/pc三端的参数 \n        - default（三端通用统一频率）为必填项，单位为毫秒，数据校验规则为20 - 1000；android、ios、pc端频率为可选项，同样需满足20 - 1000的毫秒数据校验规则 \n    - **print_strategy子字段**<number_tag>1</number_tag><number_tag>5</number_tag>\n        - 类型为enum，用于设置单个文本或富文本组件内文本的流式更新策略，可选值有fast（快速上屏，为7.20 - 7.22版本的默认策略）和delay（延迟上屏），默认为fast\n\n        - fast策略下，调用 [流式更新文本](about:blank#streaming-content) 接口后，若历史文本尚未流式上屏完毕，未上屏的部分将立即全部上屏，然后立即开始本次内容上屏；delay策略下，调用 [流式更新文本](about:blank#streaming-content) 接口后，若历史文本尚未流式输出完毕，历史文本中未上屏部分将会继续按打字机效果输出直到全部输出完毕，再开始本次内容上屏。\n\n**二、前提条件**\n1. **创建应用并添加相关权限**<number_tag>1</number_tag>\n\n        - 已在 飞书开发者后台创建了一个应用，并为应用添加了机器人能力、开通了以下权限：以应用的身份发消息（im:message:send_as_bot）、获取与发送单聊、群组消息（im:message）、创建与更新卡片（cardkit:card:write） \n\n2. **构建卡片JSON**<number_tag>1</number_tag><number_tag>2</number_tag>\n<number_tag>4</number_tag><number_tag>5</number_tag>\n    - 已基于<link icon='file-link-bitable_outlined' url='about:blank#card-json-structure' pc_url='' ios_url='' android_url=''>卡片 JSON 2.0 结构</link>构建了卡片JSON \n    - 若要开启卡片的流式更新模式，需将此值设为true \n3. **设置流式更新参数并开启模式**<number_tag>1</number_tag>\n\n    - 按需设置了流式更新的频率、步长和策略，并将全局属性streaming_mode设置为true，以开启卡片流式更新模式 \n\n**三、操作步骤** \n\n1. **调用 创建卡片实体**<number_tag>1</number_tag><number_tag>2</number_tag>\n<number_tag>4</number_tag><number_tag>6</number_tag>\n    - 通过调用 <link icon='file-link-bitable_outlined' url='about:blank#card-create' pc_url='' ios_url='' android_url=''>创建卡片实体</link>体接口，开启卡片的流式更新模式。同时获取卡片实体的ID，用于发送卡片 。\n    - Mac系统和Windows系统都有对应的Curl示例。调用成功将返回卡片实体ID，同时为该卡片开启流式更新模式 。流式更新模式将在距上次开启10分钟后自动关闭，也可随时调用<link icon='file-link-bitable_outlined' url='about:blank#card-settings' pc_url='' ios_url='' android_url=''>更新卡片配置</link>API将streaming_mode字段值设置为false，以终止卡片的流式更新模式 \n2. **发送卡片实体**\n    - 参考 <link icon='file-link-bitable_outlined' url='about:blank#message-create' pc_url='' ios_url='' android_url=''>发送消息接口文档</link>，在请求体的content字段中传入卡片实体ID，以发送卡片实体 。\n    - 注意事项：\n        - 卡片实体仅支持发送一次 \n        - 发送卡片实体的应用必须是该卡片实体的创建应用 \n        - 发送卡片实体时，content字段中的结构有相应要求，文档中有请求体示例、Mac系统和Windows系统的Curl命令示例以及成功返回的响应示例 \n3. ** （可选）流式更新文本 **\n    - 飞书卡片中的普通文本组件和富文本组件支持对文本进行持续、增量的更新，从而实现“打字机”式的文字输出效果，提升终端用户体验 \n    - 卡片发送后，可调用 \n <link icon='file-link-bitable_outlined' url='about:blank#streaming-content' pc_url='' ios_url='' android_url=''>流式更新文本</link>\n 接口，对卡片中的普通文本组件或富文本组件传入全量文本内容 。若旧文本为传入的新文本的前缀子串，新增文本将在旧文本末尾继续以打字机效果输出；若新旧文本前缀不同，全量文本将直接上屏输出，无打字机效果。同样有Mac系统和Windows系统的Curl命令示例 。",
+                    "text_align": "left",
+                    "text_size": "normal",
+                    "margin": "0px 0px 0px 0px",
+                    "element_id": "streaming_txt"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "**为你找到 3 篇参考资料**",
+                    "text_align": "left",
+                    "text_size": "normal",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<number_tag>1</number_tag><link icon='file-link-bitable_outlined' url='about:blank#streaming-guide' pc_url='' ios_url='' android_url=''>飞书卡片流式更新 OpenAPI 调用指南</link>",
+                                    "text_align": "left",
+                                    "text_size": "normal",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "<number_tag>2</number_tag><link icon='file-link-bitable_outlined' url='about:blank#card-json-structure' pc_url='' ios_url='' android_url=''>卡片 JSON 2.0 结构</link>",
+                                    "text_align": "left",
+                                    "text_size": "normal",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "<number_tag>3</number_tag><link icon='file-link-bitable_outlined' url='about:blank#streaming-content' pc_url='' ios_url='' android_url=''>流式更新文本</link>",
+                                    "text_align": "left",
+                                    "text_size": "normal",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "2px",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "**相关问题**",
+                    "text_align": "left",
+                    "text_size": "normal",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "批量更新卡片实体"
+                                    },
+                                    "type": "default",
+                                    "width": "default",
+                                    "size": "medium",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "删除组件"
+                                    },
+                                    "type": "default",
+                                    "width": "default",
+                                    "size": "medium",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "新增组件"
+                                    },
+                                    "type": "default",
+                                    "width": "default",
+                                    "size": "medium",
+                                    "margin": "0px 0px 0px 0px"
+                                },
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "更新组件"
+                                    },
+                                    "type": "default",
+                                    "width": "default",
+                                    "size": "medium",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "horizontal",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "margin": "0px 0px 4px 0px"
+                },
+                {
+                    "tag": "hr",
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "12px",
+                    "horizontal_align": "right",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "<font color=\"grey-600\">以上内容由 AI 生成，仅供参考。更多详细、准确信息可点击引用链接查看</font>",
+                                    "text_align": "left",
+                                    "text_size": "notation",
+                                    "margin": "4px 0px 0px 0px",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "robot_outlined",
+                                        "color": "grey"
+                                    }
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "20px",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": ""
+                                    },
+                                    "type": "text",
+                                    "width": "fill",
+                                    "size": "medium",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "thumbsup_outlined"
+                                    },
+                                    "hover_tips": {
+                                        "tag": "plain_text",
+                                        "content": "有帮助"
+                                    },
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "30px",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": ""
+                                    },
+                                    "type": "text",
+                                    "width": "default",
+                                    "size": "medium",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "thumbdown_outlined"
+                                    },
+                                    "hover_tips": {
+                                        "tag": "plain_text",
+                                        "content": "无帮助"
+                                    },
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "vertical_spacing": "8px",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "margin": "0px 0px 4px 0px"
+                }
+            ]
+        }
+    }
+}

--- a/skills/lark-im/card-examples/team-birthday-greeting.json
+++ b/skills/lark-im/card-examples/team-birthday-greeting.json
@@ -1,0 +1,94 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "padding": "12px 12px 12px 12px",
+            "elements": [
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": true,
+                                    "scale_type": "crop_center",
+                                    "size": "small",
+                                    "alt": {
+                                        "tag": "plain_text",
+                                        "content": ""
+                                    }
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "**生日快乐～ 🎂🎂🎂**",
+                                    "text_align": "left"
+                                }
+                            ],
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "weight": 1
+                        }
+                    ]
+                },
+                {
+                    "tag": "img",
+                    "img_key": "xxx",
+                    "preview": true,
+                    "scale_type": "crop_top",
+                    "alt": {
+                        "tag": "plain_text",
+                        "content": ""
+                    },
+                    "corner_radius": "12px"
+                },
+                {
+                    "tag": "markdown",
+                    "content": "祝您入职周年快乐,事业腾飞展宏图。愿您继续精彩绽放,在职场中创辉煌!\n业腾飞展宏图。愿您继续精彩绽放,在职场中创辉煌!愿您继续精彩绽放,在职场中创辉煌!愿您继续精彩绽放,在职场中创辉煌!",
+                    "text_align": "left",
+                    "text_size": "normal_v2"
+                },
+                {
+                    "tag": "button",
+                    "text": {
+                        "tag": "plain_text",
+                        "content": "给未来的同学写祝福"
+                    },
+                    "type": "primary",
+                    "width": "fill",
+                    "size": "medium",
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        }
+    }
+}

--- a/skills/lark-im/card-examples/travel-hotel-recommendations.json
+++ b/skills/lark-im/card-examples/travel-hotel-recommendations.json
@@ -1,0 +1,368 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "horizontal_spacing": "8px",
+            "vertical_spacing": "0px",
+            "horizontal_align": "left",
+            "vertical_align": "top",
+            "padding": "12px 12px 12px 12px",
+            "elements": [
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "background_style": "grey-100",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "160px",
+                            "elements": [
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": true,
+                                    "transparent": false,
+                                    "scale_type": "fit_horizontal",
+                                    "corner_radius": "4px",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "8px 8px 8px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "北京香格里拉酒店 ⭐️⭐️⭐️⭐️⭐️",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "之前订过 <text_tag color='blue'>4.9</text_tag> ",
+                                    "text_align": "left",
+                                    "text_size": "notation",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "thumbsup_outlined",
+                                        "color": "grey"
+                                    }
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "西直门/北京展览馆地区",
+                                    "text_align": "left",
+                                    "text_size": "notation",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "local_outlined",
+                                        "color": "grey"
+                                    }
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "**<font color='red'>700</font>**/晚起 <text_tag color='yellow'></text_tag> <text_tag color='yellow'>协议价</text_tag>",
+                                    "text_align": "left",
+                                    "text_size": "notation",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "sheet-currency_outlined",
+                                        "color": "grey"
+                                    }
+                                }
+                            ],
+                            "padding": "6px 8px 6px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "去预定"
+                                    },
+                                    "type": "default",
+                                    "width": "default",
+                                    "size": "medium"
+                                }
+                            ],
+                            "padding": "10px 10px 10px 10px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "background_style": "grey-100",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "160px",
+                            "elements": [
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": true,
+                                    "transparent": false,
+                                    "scale_type": "fit_horizontal",
+                                    "corner_radius": "4px",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "8px 8px 8px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "北京泰富酒店 ⭐️⭐️⭐️⭐️⭐️",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "之前订过 <text_tag color='blue'>4.6</text_tag> ",
+                                    "text_align": "left",
+                                    "text_size": "notation",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "thumbsup_outlined",
+                                        "color": "grey"
+                                    }
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "中关村/五道口",
+                                    "text_align": "left",
+                                    "text_size": "notation",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "local_outlined",
+                                        "color": "grey"
+                                    }
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "**<font color='red'>700</font>**/晚起 <text_tag color='yellow'></text_tag> <text_tag color='yellow'>协议价</text_tag>",
+                                    "text_align": "left",
+                                    "text_size": "notation",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "sheet-currency_outlined",
+                                        "color": "grey"
+                                    }
+                                }
+                            ],
+                            "padding": "6px 8px 6px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "去预定"
+                                    },
+                                    "type": "default",
+                                    "width": "default",
+                                    "size": "medium"
+                                }
+                            ],
+                            "padding": "10px 10px 10px 10px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "margin": "8px 0px 0px 0px"
+                },
+                {
+                    "tag": "column_set",
+                    "flex_mode": "stretch",
+                    "background_style": "grey-100",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "160px",
+                            "elements": [
+                                {
+                                    "tag": "img",
+                                    "img_key": "xxx",
+                                    "preview": true,
+                                    "transparent": false,
+                                    "scale_type": "fit_horizontal",
+                                    "corner_radius": "4px",
+                                    "margin": "0px 0px 0px 0px"
+                                }
+                            ],
+                            "padding": "8px 8px 8px 8px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "margin": "0px 0px 0px 0px"
+                        },
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "markdown",
+                                    "content": "北京朝阳公园亚朵酒店 ⭐️⭐️⭐️⭐️",
+                                    "text_align": "left",
+                                    "text_size": "normal_v2"
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "步行可达办公点 <text_tag color='blue'>4.5</text_tag> ",
+                                    "text_align": "left",
+                                    "text_size": "notation",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "thumbsup_outlined",
+                                        "color": "grey"
+                                    }
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "国贸地区",
+                                    "text_align": "left",
+                                    "text_size": "notation",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "local_outlined",
+                                        "color": "grey"
+                                    }
+                                },
+                                {
+                                    "tag": "markdown",
+                                    "content": "**<font color='red'>500</font>**/晚起 <text_tag color='yellow'> 同事推荐</text_tag> <text_tag color='yellow'>协议价</text_tag>",
+                                    "text_align": "left",
+                                    "text_size": "notation",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "sheet-currency_outlined",
+                                        "color": "grey"
+                                    }
+                                }
+                            ],
+                            "padding": "6px 0px 6px 0px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        },
+                        {
+                            "tag": "column",
+                            "width": "auto",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "去预定"
+                                    },
+                                    "type": "default",
+                                    "width": "default",
+                                    "size": "medium"
+                                }
+                            ],
+                            "padding": "10px 10px 10px 10px",
+                            "direction": "vertical",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "center",
+                            "margin": "0px 0px 0px 0px"
+                        }
+                    ],
+                    "margin": "8px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "前往北京的差旅即将开始，别忘记预定酒店啦！"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": "为你推荐以下酒店："
+            },
+            "template": "blue",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "building_outlined"
+            },
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/card-examples/workplace-social-share.json
+++ b/skills/lark-im/card-examples/workplace-social-share.json
@@ -1,0 +1,131 @@
+{
+    "msg_type": "interactive",
+    "card": {
+        "schema": "2.0",
+        "config": {
+            "update_multi": true,
+            "style": {
+                "text_size": {
+                    "normal_v2": {
+                        "default": "normal",
+                        "pc": "normal",
+                        "mobile": "heading"
+                    }
+                }
+            }
+        },
+        "body": {
+            "direction": "vertical",
+            "padding": "12px 12px 12px 12px",
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": "【拉萨札记｜在仓央嘉措的诗行间流浪】住进布达拉宫  /  我是雪域最大的王  /  流浪在拉萨街头 /  我是世间最美的情郎」",
+                    "text_align": "left",
+                    "text_size": "normal_v2"
+                },
+                {
+                    "tag": "img_combination",
+                    "combination_mode": "trisect",
+                    "img_list": [
+                        {
+                            "img_key": "xxx"
+                        },
+                        {
+                            "img_key": "xxx"
+                        },
+                        {
+                            "img_key": "xxx"
+                        },
+                        {
+                            "img_key": "xxx"
+                        },
+                        {
+                            "img_key": "xxx"
+                        },
+                        {
+                            "img_key": "xxx"
+                        },
+                        {
+                            "img_key": "xxx"
+                        },
+                        {
+                            "img_key": "xxx"
+                        },
+                        {
+                            "img_key": "xxx"
+                        }
+                    ],
+                    "img_list_length": 9,
+                    "corner_radius": "5%"
+                },
+                {
+                    "tag": "column_set",
+                    "horizontal_spacing": "8px",
+                    "horizontal_align": "left",
+                    "columns": [
+                        {
+                            "tag": "column",
+                            "width": "weighted",
+                            "elements": [
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "11"
+                                    },
+                                    "type": "text",
+                                    "width": "fill",
+                                    "size": "large",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "thumbsup_outlined"
+                                    }
+                                },
+                                {
+                                    "tag": "button",
+                                    "text": {
+                                        "tag": "plain_text",
+                                        "content": "8"
+                                    },
+                                    "type": "text",
+                                    "width": "fill",
+                                    "size": "large",
+                                    "icon": {
+                                        "tag": "standard_icon",
+                                        "token": "reply-cn_outlined"
+                                    }
+                                }
+                            ],
+                            "padding": "0px 0px 0px 0px",
+                            "direction": "horizontal",
+                            "horizontal_spacing": "8px",
+                            "vertical_spacing": "8px",
+                            "horizontal_align": "left",
+                            "vertical_align": "top",
+                            "margin": "0px 0px 0px 0px",
+                            "weight": 1
+                        }
+                    ],
+                    "margin": "0px 0px 0px 0px"
+                }
+            ]
+        },
+        "header": {
+            "title": {
+                "tag": "plain_text",
+                "content": "某位同事发布了 1 条公司圈动态"
+            },
+            "subtitle": {
+                "tag": "plain_text",
+                "content": ""
+            },
+            "template": "blue",
+            "icon": {
+                "tag": "standard_icon",
+                "token": "larkcommunity_colorful"
+            },
+            "padding": "12px 12px 12px 12px"
+        }
+    }
+}

--- a/skills/lark-im/references/lark-im-messages-reply.md
+++ b/skills/lark-im/references/lark-im-messages-reply.md
@@ -170,6 +170,25 @@ lark-cli im +messages-reply --message-id om_xxx --markdown $'## Test\n\nhello' -
 - Explicitly setting `--msg-type` to something that conflicts with `--text`, `--markdown`, or media flags.
 - Mixing `--text`, `--markdown`, or `--content` with media flags in one command.
 
+## Interactive Cards
+
+- Use **version 2.0** when:
+  1. the user explicitly asks for **2.0**, or
+  2. the requested card involves **complex interactive behavior**.
+
+- Before building a **2.0** card:
+  1. Read the **structure** doc to understand the overall schema.
+  2. Read the **component overview** to see available components.
+  3. Then read **only the necessary component detail docs**.
+  4. Choose **1-2** relevant examples under [`../card-examples`](../card-examples) to read and learn from before composing the final card reply; **do not** read the whole folder.
+
+- Prefer the **markdown** version of documentation URLs by appending `.md`.
+
+Reference docs:
+- component overview: https://open.larkoffice.com/document/feishu-cards/card-json-v2-components/component-json-v2-overview.md
+- structure: https://open.larkoffice.com/document/feishu-cards/card-json-v2-structure.md
+
+
 ## Return Value
 
 ```json

--- a/skills/lark-im/references/lark-im-messages-send.md
+++ b/skills/lark-im/references/lark-im-messages-send.md
@@ -190,6 +190,24 @@ lark-cli im +messages-send --chat-id oc_xxx --markdown $'## Test\n\nhello' --dry
 | `share_user` | `{"user_id":"ou_xxx"}` |
 | `interactive` | Card JSON (see Feishu interactive card documentation) |
 
+## Interactive Cards
+
+- Use **version 2.0** when:
+  1. the user explicitly asks for **2.0**, or
+  2. the requested card involves **complex interactive behavior**.
+
+- Before building a **2.0** card:
+  1. Read the **structure** doc to understand the overall schema.
+  2. Read the **component overview** to see available components.
+  3. Then read **only the necessary component detail docs**.
+  4. Choose **1-2** relevant examples under [`../card-examples`](../card-examples) to read and learn from before composing the final card; **do not** read the whole folder.
+
+- Prefer the **markdown** version of documentation URLs by appending `.md`.
+
+Reference docs:
+- component overview: https://open.larkoffice.com/document/feishu-cards/card-json-v2-components/component-json-v2-overview.md
+- structure: https://open.larkoffice.com/document/feishu-cards/card-json-v2-structure.md
+
 ## Return Value
 
 ```json


### PR DESCRIPTION
Change-Id: I5e5cdfb37946af52ef7a2a812460e50fa8b09e9c

  ## Summary

  `im +messages-send` and `im +messages-reply` already support interactive card payloads, but the IM skill currently lacks a concrete Card 2.0 example library and explicit guidance on how agents should study examples before composing
  a card.

  This PR adds a curated `card-examples` library under `skills/lark-im` and updates the send/reply references so Card 2.0 tasks follow a consistent reading path: read the structure docs, read only the necessary component docs, then
  pick 1-2 relevant local examples instead of scanning the whole example set.

  ## Changes

  - **`skills/lark-im/card-examples/*.json`**:
    - Add 28 interactive Card 2.0 JSON examples covering common IM card scenarios:
      - AI assistant / onboarding / recommendation cards
      - alert and approval flows
      - article, newsletter, and announcement cards
      - daily report, dashboard, and leaderboard cards
      - form, feedback, and service workflow cards
      - greeting, travel, and social-sharing cards
    - Include representative patterns such as multi-locale content, callback/open_url actions, forms and selects, charts/tables, image-heavy layouts, and reusable interactive containers

  - **`skills/lark-im/references/lark-im-messages-send.md`**:
    - Add an `Interactive Cards` section for Card 2.0 usage
    - Document the required reading order for official structure/component docs
    - Require choosing 1-2 relevant examples under `../card-examples` before composing the final card, and explicitly forbid reading the whole folder

  - **`skills/lark-im/references/lark-im-messages-reply.md`**:
    - Add the same Card 2.0 guidance for reply flows
    - Keep send/reply example-selection rules aligned

  - **`skills/lark-im/SKILL.md`**:
    - Mark `+messages-send` and `+messages-reply` as mandatory reads before interactive card operations

  ## Test Plan

  - [x] `make unit-test`
    - Local run is currently blocked because the local toolchain is `go1.15`, which rejects `go 1.23.0` in `go.mod`
  - [x] `jq empty skills/lark-im/card-examples/*.json`
  - [x] Manual review confirms the new Card 2.0 guidance is present in both `im +messages-send` and `im +messages-reply`
  - [x] Manual review confirms the example library is available under `skills/lark-im/card-examples` and covers common daily IM card scenarios

  ## Related Issues

  - None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a mandatory warning requiring operators to read the send/reply reference guides before performing interactive card send/reply operations.
  * Added “Interactive Cards” guidance to message send/reply docs with a recommended pre-composition workflow and reference links.
* **New Examples**
  * Added 28 new interactive Lark/Feishu card templates covering AI, approvals, alerts, notifications, reports, forms, galleries, onboarding, and more.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->