### PR TITLE
feat: add attendance user_task.query

### DIFF
--- a/skills/lark-attendance/SKILL.md
+++ b/skills/lark-attendance/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: lark-attendance
+version: 1.0.0
+description: "飞书考勤打卡：查询自己的考勤打卡记录"
+metadata:
+  requires:
+    bins: ["lark-cli"]
+  cliHelp: "lark-cli attendance --help"
+---
+
+# attendance (v1)
+
+**CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，其中包含认证、权限处理**
+
+## 默认参数自动填充规则
+
+调用任何 API 时，以下参数 **必须自动填充，禁止向用户询问**：
+
+| 参数 | 固定值 | 说明                                 |
+|------|--------|------------------------------------|
+| `employee_type` | `"employee_no"` | `employee_type`始终等于`"employee_no"` |
+| `user_ids` | `[]`（空数组） | `user_ids`始终等于`[]`                 |
+
+### 填充示例
+
+当构建 `--params` 参数时，自动注入上述字段：
+- `employee_type` 保持 `"employee_no"` 不变
+
+当构建 `--data` 参数时，自动注入上述字段：
+```json
+{
+  "user_ids": [],
+  ...用户提供的参数
+}
+```
+
+> **注意**：`user_ids` 数组保持为空[]，`employee_type` 保持 `"employee_no"` 不变。
+
+## API Resources
+
+```bash
+lark-cli schema attendance.<resource>.<method>   # 调用 API 前必须先查看参数结构
+lark-cli attendance <resource> <method> [flags]  # 调用 API
+```
+
+> **重要**：使用原生 API 时，必须先运行 `schema` 查看 `--data` / `--params` 参数结构，不要猜测字段格式。
+
+### user_tasks
+
+- `query` — 查询用户考勤打卡记录
+
+## 权限表
+
+| 方法 | 所需 scope |
+|------|-----------|
+| `user_tasks.query` | `attendance:task:readonly` |
+


### PR DESCRIPTION
Change-Id: I0c99b2178dd874f2a9f0e30ed8145b888c3a9965

## Summary
Add a new Lark attendance skill (`lark-attendance`) that enables querying user clock-in/attendance records via `lark-cli`. This skill provides the `user_tasks.query` API with built-in default parameter auto-fill rules to simplify usage.

## Changes
- **Added** `lark-attendance/SKILL.md`
  - Skill metadata definition (name, version, description, dependencies)
  - Default parameter auto-fill rules:
    - `employee_type` is always set to `"employee_no"` (in `--params`)
    - `user_ids` is always set to `[]` (in `--data`)
  - API resource documentation for `user_tasks.query`
  - Permission table: requires `attendance:task:readonly` scope
  - Reference to shared authentication module (`../lark-shared/SKILL.md`)

## Test Plan
- [ ] Run `lark-cli schema attendance.user_tasks.query` and verify the parameter structure is returned correctly
- [ ] Run `lark-cli attendance user_tasks query` with `employee_type="employee_no"` and `user_ids=[]`, verify it returns the current user's attendance records
- [ ] Verify the `../lark-shared/SKILL.md` reference path resolves correctly
- [ ] Verify the API call succeeds after granting `attendance:task:readonly` permission

## Related Issues

## Summary by CodeRabbit

- **New Feature**: Introduced a new `lark-attendance` skill for querying user attendance and clock-in records through the `lark-cli` tool.
- **Documentation**: Added `SKILL.md` with complete API usage instructions, including default parameter auto-fill rules (`employee_type="employee_no"`, `user_ids=[]`), API resource reference (`user_tasks.query`), and required permission scope (`attendance:task:readonly`).