### PR TITLE
feat: add RuntimeContext.BotInfo() for lazy bot identity retrieval

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -163,6 +163,16 @@ type CliConfig struct {
 	SupportedIdentities uint8 `json:"-"` // bitflag: 1=user, 2=bot; set by credential provider
 }
 
+// identityBotBit is the bit flag for bot identity in SupportedIdentities.
+// Must match extension/credential.SupportsBot.
+const identityBotBit uint8 = 1 << 1
+
+// CanBot reports whether the current credential context supports bot identity.
+// Returns true when SupportedIdentities is unset (0, unknown) or includes the bot bit.
+func (c *CliConfig) CanBot() bool {
+	return c.SupportedIdentities == 0 || c.SupportedIdentities&identityBotBit != 0
+}
+
 // GetConfigDir returns the config directory path.
 // If the home directory cannot be determined, it falls back to a relative path
 // and prints a warning to stderr.

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -187,3 +187,24 @@ func TestResolveConfigFromMulti_DoesNotUseEnvProfileFallback(t *testing.T) {
 		t.Fatalf("ResolveConfigFromMulti() profile = %q, want %q", cfg.ProfileName, "active")
 	}
 }
+
+func TestCliConfig_CanBot(t *testing.T) {
+	tests := []struct {
+		name                string
+		supportedIdentities uint8
+		want                bool
+	}{
+		{"unset (0) defaults to true", 0, true},
+		{"user only", 1, false},
+		{"bot only", 2, true},
+		{"both", 3, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &CliConfig{SupportedIdentities: tt.supportedIdentities}
+			if got := cfg.CanBot(); got != tt.want {
+				t.Errorf("CanBot() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -42,6 +42,7 @@ type RuntimeContext struct {
 	resolvedAs    core.Identity                     // effective identity resolved by framework
 	Factory       *cmdutil.Factory                  // injected by framework
 	apiClientFunc func() (*client.APIClient, error) // sync.OnceValues; initialized in newRuntimeContext
+	botInfoFunc   func() (*BotInfo, error)          // sync.OnceValues; lazy bot identity from /bot/v3/info
 	larkSDK       *lark.Client                      // eagerly initialized in mountDeclarative
 }
 
@@ -70,6 +71,57 @@ func (ctx *RuntimeContext) IsBot() bool {
 
 // UserOpenId returns the current user's open_id from config.
 func (ctx *RuntimeContext) UserOpenId() string { return ctx.Config.UserOpenId }
+
+// BotInfo holds bot identity metadata fetched lazily from /bot/v3/info.
+type BotInfo struct {
+	OpenID  string
+	AppName string
+}
+
+// BotInfo returns the bot's open_id and display name, fetched lazily from /bot/v3/info.
+// Unlike UserOpenId() (which reads from config), this requires a network call and may fail.
+// Thread-safe via sync.OnceValues; the API is called at most once per RuntimeContext.
+func (ctx *RuntimeContext) BotInfo() (*BotInfo, error) {
+	if ctx.botInfoFunc == nil {
+		return nil, fmt.Errorf("BotInfo not available (runtime context not fully initialized)")
+	}
+	return ctx.botInfoFunc()
+}
+
+// fetchBotInfo calls /bot/v3/info using bot identity and parses the response.
+func (ctx *RuntimeContext) fetchBotInfo() (*BotInfo, error) {
+	if !ctx.Config.CanBot() {
+		return nil, fmt.Errorf("fetch bot info: bot identity is not available in current credential context")
+	}
+	resp, err := ctx.DoAPIAsBot(&larkcore.ApiReq{
+		HttpMethod: http.MethodGet,
+		ApiPath:    "/open-apis/bot/v3/info",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fetch bot info: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("fetch bot info: HTTP %d", resp.StatusCode)
+	}
+	var envelope struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+		Data struct {
+			OpenID  string `json:"open_id"`
+			AppName string `json:"app_name"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &envelope); err != nil {
+		return nil, fmt.Errorf("fetch bot info: unmarshal: %w", err)
+	}
+	if envelope.Code != 0 {
+		return nil, fmt.Errorf("fetch bot info: [%d] %s", envelope.Code, envelope.Msg)
+	}
+	if envelope.Data.OpenID == "" {
+		return nil, fmt.Errorf("fetch bot info: open_id is empty")
+	}
+	return &BotInfo{OpenID: envelope.Data.OpenID, AppName: envelope.Data.AppName}, nil
+}
 
 // Ctx returns the context.Context propagated from cmd.Context().
 func (ctx *RuntimeContext) Ctx() context.Context { return ctx.ctx }
@@ -639,6 +691,7 @@ func newRuntimeContext(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, conf
 	rctx.apiClientFunc = sync.OnceValues(func() (*client.APIClient, error) {
 		return f.NewAPIClientWithConfig(config)
 	})
+	rctx.botInfoFunc = sync.OnceValues(rctx.fetchBotInfo)
 
 	sdk, err := f.LarkClient()
 	if err != nil {

--- a/shortcuts/common/runner_botinfo_test.go
+++ b/shortcuts/common/runner_botinfo_test.go
@@ -1,0 +1,297 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+// botInfoTestConfig returns a CliConfig suitable for bot info tests.
+func botInfoTestConfig(t *testing.T) *core.CliConfig {
+	t.Helper()
+	return &core.CliConfig{
+		AppID:     "test-app",
+		AppSecret: "test-secret",
+		Brand:     core.BrandFeishu,
+	}
+}
+
+// runBotInfoShortcut mounts a shortcut that calls BotInfo() and executes it.
+// The shortcut stores the result (or error) in the provided pointers.
+func runBotInfoShortcut(t *testing.T, f *cmdutil.Factory, gotInfo **BotInfo, gotErr *error) {
+	t.Helper()
+	s := Shortcut{
+		Service:   "test",
+		Command:   "+bot-info",
+		AuthTypes: []string{"bot"},
+		Execute: func(_ context.Context, rctx *RuntimeContext) error {
+			info, err := rctx.BotInfo()
+			*gotInfo = info
+			*gotErr = err
+			return nil
+		},
+	}
+	parent := &cobra.Command{Use: "test"}
+	s.Mount(parent, f)
+	parent.SetArgs([]string{"+bot-info", "--as", "bot"})
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	if err := parent.Execute(); err != nil {
+		t.Fatalf("shortcut execution failed: %v", err)
+	}
+}
+
+func TestFetchBotInfo_Success(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, botInfoTestConfig(t))
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/bot/v3/info",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"open_id":  "ou_bot_abc123",
+				"app_name": "TestBot",
+			},
+		},
+	})
+
+	var info *BotInfo
+	var err error
+	runBotInfoShortcut(t, f, &info, &err)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if info.OpenID != "ou_bot_abc123" {
+		t.Errorf("OpenID = %q, want %q", info.OpenID, "ou_bot_abc123")
+	}
+	if info.AppName != "TestBot" {
+		t.Errorf("AppName = %q, want %q", info.AppName, "TestBot")
+	}
+}
+
+func TestFetchBotInfo_ShortcutHeaders(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, botInfoTestConfig(t))
+	stub := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/bot/v3/info",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"open_id":  "ou_bot_header",
+				"app_name": "HeaderBot",
+			},
+		},
+	}
+	reg.Register(stub)
+
+	var info *BotInfo
+	var err error
+	runBotInfoShortcut(t, f, &info, &err)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Verify shortcut context headers were injected
+	if stub.CapturedHeaders.Get("X-Cli-Shortcut") == "" {
+		t.Error("missing X-Cli-Shortcut header on /bot/v3/info request")
+	}
+	if stub.CapturedHeaders.Get("X-Cli-Execution-Id") == "" {
+		t.Error("missing X-Cli-Execution-Id header on /bot/v3/info request")
+	}
+}
+
+func TestFetchBotInfo_OnceSemantics(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, botInfoTestConfig(t))
+	// Only register one stub — if fetchBotInfo is called twice, the second call
+	// would fail with "no stub" since the first stub is already matched.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/bot/v3/info",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"open_id":  "ou_bot_once",
+				"app_name": "OnceBot",
+			},
+		},
+	})
+
+	s := Shortcut{
+		Service:   "test",
+		Command:   "+bot-info-once",
+		AuthTypes: []string{"bot"},
+		Execute: func(_ context.Context, rctx *RuntimeContext) error {
+			// Call BotInfo twice — second should use cached result
+			_, _ = rctx.BotInfo()
+			info, err := rctx.BotInfo()
+			if err != nil {
+				t.Errorf("second BotInfo() call failed: %v", err)
+			}
+			if info.OpenID != "ou_bot_once" {
+				t.Errorf("OpenID = %q, want %q", info.OpenID, "ou_bot_once")
+			}
+			return nil
+		},
+	}
+	parent := &cobra.Command{Use: "test"}
+	s.Mount(parent, f)
+	parent.SetArgs([]string{"+bot-info-once", "--as", "bot"})
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	if err := parent.Execute(); err != nil {
+		t.Fatalf("shortcut execution failed: %v", err)
+	}
+}
+
+func TestFetchBotInfo_APICodeNonZero(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, botInfoTestConfig(t))
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/bot/v3/info",
+		Body: map[string]interface{}{
+			"code": 99991,
+			"msg":  "no permission",
+		},
+	})
+
+	var info *BotInfo
+	var err error
+	runBotInfoShortcut(t, f, &info, &err)
+
+	if err == nil {
+		t.Fatal("expected error for non-zero code")
+	}
+	if !strings.Contains(err.Error(), "[99991]") {
+		t.Errorf("error = %q, want substring [99991]", err.Error())
+	}
+}
+
+func TestFetchBotInfo_EmptyOpenID(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, botInfoTestConfig(t))
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/bot/v3/info",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"open_id":  "",
+				"app_name": "EmptyBot",
+			},
+		},
+	})
+
+	var info *BotInfo
+	var err error
+	runBotInfoShortcut(t, f, &info, &err)
+
+	if err == nil {
+		t.Fatal("expected error for empty open_id")
+	}
+	if !strings.Contains(err.Error(), "open_id is empty") {
+		t.Errorf("error = %q, want substring 'open_id is empty'", err.Error())
+	}
+}
+
+func TestFetchBotInfo_HTTP4xx(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, botInfoTestConfig(t))
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/bot/v3/info",
+		Status: 403,
+		Body:   map[string]interface{}{"code": 403, "msg": "forbidden"},
+	})
+
+	var info *BotInfo
+	var err error
+	runBotInfoShortcut(t, f, &info, &err)
+
+	if err == nil {
+		t.Fatal("expected error for HTTP 403")
+	}
+	if !strings.Contains(err.Error(), "403") {
+		t.Errorf("error = %q, want substring '403'", err.Error())
+	}
+}
+
+func TestFetchBotInfo_InvalidJSON(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, botInfoTestConfig(t))
+	reg.Register(&httpmock.Stub{
+		Method:  "GET",
+		URL:     "/open-apis/bot/v3/info",
+		RawBody: []byte("not json"),
+	})
+
+	var info *BotInfo
+	var err error
+	runBotInfoShortcut(t, f, &info, &err)
+
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	// Error may come from SDK-level parse or our unmarshal wrapper
+	if !strings.Contains(err.Error(), "unmarshal") && !strings.Contains(err.Error(), "invalid character") {
+		t.Errorf("error = %q, want JSON parse failure", err.Error())
+	}
+}
+
+func TestFetchBotInfo_CanBotFalse(t *testing.T) {
+	cfg := botInfoTestConfig(t)
+	cfg.SupportedIdentities = 1 // user only
+	f, _, _, _ := cmdutil.TestFactory(t, cfg)
+
+	// Use a dual-auth shortcut running as user, calling BotInfo() internally.
+	// No /bot/v3/info stub — CanBot should short-circuit before API call.
+	var info *BotInfo
+	var err error
+	s := Shortcut{
+		Service:   "test",
+		Command:   "+bot-info-canbot",
+		AuthTypes: []string{"user", "bot"},
+		Execute: func(_ context.Context, rctx *RuntimeContext) error {
+			i, e := rctx.BotInfo()
+			info = i
+			err = e
+			return nil
+		},
+	}
+	parent := &cobra.Command{Use: "test"}
+	s.Mount(parent, f)
+	parent.SetArgs([]string{"+bot-info-canbot", "--as", "user"})
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	if execErr := parent.Execute(); execErr != nil {
+		t.Fatalf("shortcut execution failed: %v", execErr)
+	}
+
+	if err == nil {
+		t.Fatal("expected error when bot identity not available")
+	}
+	if info != nil {
+		t.Errorf("expected nil info, got %+v", info)
+	}
+	if !strings.Contains(err.Error(), "not available") {
+		t.Errorf("error = %q, want substring 'not available'", err.Error())
+	}
+}
+
+func TestBotInfo_NilFunc(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	rctx := TestNewRuntimeContext(cmd, &core.CliConfig{})
+	_, err := rctx.BotInfo()
+	if err == nil {
+		t.Fatal("expected error for nil botInfoFunc")
+	}
+	if !strings.Contains(err.Error(), "not fully initialized") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/shortcuts/common/testing.go
+++ b/shortcuts/common/testing.go
@@ -5,6 +5,7 @@ package common
 
 import (
 	"context"
+	"sync"
 
 	"github.com/spf13/cobra"
 
@@ -26,4 +27,13 @@ func TestNewRuntimeContextWithCtx(ctx context.Context, cmd *cobra.Command, cfg *
 // TestNewRuntimeContextWithIdentity creates a RuntimeContext with a specific identity for testing.
 func TestNewRuntimeContextWithIdentity(cmd *cobra.Command, cfg *core.CliConfig, as core.Identity) *RuntimeContext {
 	return &RuntimeContext{Cmd: cmd, Config: cfg, resolvedAs: as}
+}
+
+// TestNewRuntimeContextWithBotInfo creates a RuntimeContext with a pre-set BotInfo for testing.
+func TestNewRuntimeContextWithBotInfo(cmd *cobra.Command, cfg *core.CliConfig, info *BotInfo) *RuntimeContext {
+	rctx := &RuntimeContext{Cmd: cmd, Config: cfg}
+	rctx.botInfoFunc = sync.OnceValues(func() (*BotInfo, error) {
+		return info, nil
+	})
+	return rctx
 }


### PR DESCRIPTION
## Summary

- Add `BotInfo()` method on `RuntimeContext` that lazily fetches the current app's bot `open_id` and display name from `/bot/v3/info`, cached via `sync.OnceValues`
- Add `CanBot()` on `CliConfig` to gate the call when bot identity is unavailable (e.g. external credential provider only injecting UAT)
- Add `fetchBotInfo()` private method using `DoAPIAsBot` for consistent shortcut header injection (`X-Cli-Shortcut`, `X-Cli-Execution-Id`)
- Add `TestNewRuntimeContextWithBotInfo` test helper for shortcut tests that need a pre-set bot identity

## Test plan

- [x] `TestFetchBotInfo_Success` — full path via httpmock
- [x] `TestFetchBotInfo_ShortcutHeaders` — verifies X-Cli-Shortcut/X-Cli-Execution-Id injection
- [x] `TestFetchBotInfo_OnceSemantics` — single stub, two calls
- [x] `TestFetchBotInfo_APICodeNonZero` — code != 0 error branch
- [x] `TestFetchBotInfo_EmptyOpenID` — empty open_id error branch
- [x] `TestFetchBotInfo_HTTP4xx` — HTTP status code >= 400
- [x] `TestFetchBotInfo_InvalidJSON` — malformed response body
- [x] `TestFetchBotInfo_CanBotFalse` — SupportedIdentities=user-only pre-check
- [x] `TestBotInfo_NilFunc` — nil guard for uninitialized contexts
- [x] `TestCliConfig_CanBot` — 4 sub-cases for CanBot() bitflag logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bot identity authentication capability support with validation to ensure bots are properly configured and authorized
  * Implemented bot metadata retrieval functionality allowing bots to securely fetch their open ID and application name

<!-- end of auto-generated comment: release notes by coderabbit.ai -->