### PR TITLE
feat(mail): add contact search workflow and multi_entity search API

### DIFF
--- a/skill-template/domains/mail.md
+++ b/skill-template/domains/mail.md
@@ -60,6 +60,45 @@ lark-cli mail user_mailbox.messages -h
 
 `-h` 输出即可用 flag 的权威来源。reference 文档中的参数表可辅助理解语义，但实际 flag 名称以 `-h` 为准。
 
+### 收件人搜索：查找邮箱地址
+
+当需要查找收件人邮箱地址时，使用联系人搜索接口。支持多种搜索方式，如：
+- **按人名搜索**：如"给张三发邮件" → query="张三"
+- **按邮箱关键词搜索**：如"发到 larkmail 的邮箱" → query="@larkmail"
+- **按群名搜索**：如"发给项目群" → query="项目群"
+
+```bash
+lark-cli mail multi_entity search --as user --data '{"query":"<关键词>"}'
+```
+
+搜索结果包含多种实体类型：
+
+| `type` 值 | `tag` 示例 | 说明 |
+|-----------|-----------|------|
+| `user` / `chatter` | `chatter` | 个人用户 |
+| `enterprise_mail_group` | `mail_group` | 企业邮件组 |
+| `chat` / `group` | `chat_group_tenant` / `chat_group_normal` | 群聊（有群邮件地址） |
+| `external_contact` | `external_contact` | 外部联系人 |
+
+**处理规则：**
+1. 从结果中筛选有 `email` 字段的条目
+2. 若仅 1 个匹配且关键词吻合，直接使用其 `email`
+3. 若多个匹配，列出候选项供用户选择。展示尽可能多的字段帮助用户区分：
+   ```text
+   找到多个匹配"组"的结果，请选择：
+   1. 团队邮件组 <team@example.com>
+      类型：enterprise_mail_group | 标签：mail_group
+   2. 项目群 <project@example.com>
+      类型：chat | 成员数：50 | 标签：chat_group_normal
+   3. 张群 <zhangqun@example.com>
+      类型：user | 部门：研发团队 | 备注名：张群同学
+   ```
+   可用字段：`name`（名称）、`email`（邮箱）、`department`（部门）、`tag`（标签）、`display_name`（备注名）、`type`（实体类型）、`member_count`（成员数，群类型时展示）。字段为空时省略。
+4. 若无匹配，告知用户未找到，建议换关键词或直接提供邮箱地址
+5. 用户确认后，将 `email` 传入 compose shortcut 的 `--to` / `--cc` / `--bcc` 参数
+
+**注意：** 用户直接提供完整邮箱地址时不需要搜索，直接使用即可。
+
 ### 命令选择：先判断邮件类型，再决定草稿还是发送
 
 | 邮件类型 | 存草稿（不发送） | 直接发送 |

--- a/skill-template/domains/mail.md
+++ b/skill-template/domains/mail.md
@@ -82,9 +82,12 @@ lark-cli mail multi_entity search --as user --data '{"query":"<关键词>"}'
 
 **处理规则：**
 1. 从结果中筛选有 `email` 字段的条目
-2. 若仅 1 个匹配且关键词吻合，直接使用其 `email`
-3. 若多个匹配，列出候选项供用户选择。展示尽可能多的字段帮助用户区分：
+2. 无论匹配数量多少，都必须列出候选项供用户确认后再使用（搜索是模糊匹配，单条结果不代表精确命中）。展示尽可能多的字段帮助用户区分：
    ```text
+   找到以下匹配"张三"的结果：
+   1. 张三 <zhangsan@example.com>
+      类型：user | 部门：研发团队
+   ---
    找到多个匹配"组"的结果，请选择：
    1. 团队邮件组 <team@example.com>
       类型：enterprise_mail_group | 标签：mail_group
@@ -94,8 +97,8 @@ lark-cli mail multi_entity search --as user --data '{"query":"<关键词>"}'
       类型：user | 部门：研发团队 | 备注名：张群同学
    ```
    可用字段：`name`（名称）、`email`（邮箱）、`department`（部门）、`tag`（标签）、`display_name`（备注名）、`type`（实体类型）、`member_count`（成员数，群类型时展示）。字段为空时省略。
-4. 若无匹配，告知用户未找到，建议换关键词或直接提供邮箱地址
-5. 用户确认后，将 `email` 传入 compose shortcut 的 `--to` / `--cc` / `--bcc` 参数
+3. 若无匹配，告知用户未找到，建议换关键词或直接提供邮箱地址
+4. 用户确认后，将 `email` 传入 compose shortcut 的 `--to` / `--cc` / `--bcc` 参数
 
 **注意：** 用户直接提供完整邮箱地址时不需要搜索，直接使用即可。
 

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -74,6 +74,45 @@ lark-cli mail user_mailbox.messages -h
 
 `-h` 输出即可用 flag 的权威来源。reference 文档中的参数表可辅助理解语义，但实际 flag 名称以 `-h` 为准。
 
+### 收件人搜索：查找邮箱地址
+
+当需要查找收件人邮箱地址时，使用联系人搜索接口。支持多种搜索方式，如：
+- **按人名搜索**：如"给张三发邮件" → query="张三"
+- **按邮箱关键词搜索**：如"发到 larkmail 的邮箱" → query="@larkmail"
+- **按群名搜索**：如"发给项目群" → query="项目群"
+
+```bash
+lark-cli mail multi_entity search --as user --data '{"query":"<关键词>"}'
+```
+
+搜索结果包含多种实体类型：
+
+| `type` 值 | `tag` 示例 | 说明 |
+|-----------|-----------|------|
+| `user` / `chatter` | `chatter` | 个人用户 |
+| `enterprise_mail_group` | `mail_group` | 企业邮件组 |
+| `chat` / `group` | `chat_group_tenant` / `chat_group_normal` | 群聊（有群邮件地址） |
+| `external_contact` | `external_contact` | 外部联系人 |
+
+**处理规则：**
+1. 从结果中筛选有 `email` 字段的条目
+2. 若仅 1 个匹配且关键词吻合，直接使用其 `email`
+3. 若多个匹配，列出候选项供用户选择。展示尽可能多的字段帮助用户区分：
+   ```text
+   找到多个匹配"组"的结果，请选择：
+   1. 团队邮件组 <team@example.com>
+      类型：enterprise_mail_group | 标签：mail_group
+   2. 项目群 <project@example.com>
+      类型：chat | 成员数：50 | 标签：chat_group_normal
+   3. 张群 <zhangqun@example.com>
+      类型：user | 部门：研发团队 | 备注名：张群同学
+   ```
+   可用字段：`name`（名称）、`email`（邮箱）、`department`（部门）、`tag`（标签）、`display_name`（备注名）、`type`（实体类型）、`member_count`（成员数，群类型时展示）。字段为空时省略。
+4. 若无匹配，告知用户未找到，建议换关键词或直接提供邮箱地址
+5. 用户确认后，将 `email` 传入 compose shortcut 的 `--to` / `--cc` / `--bcc` 参数
+
+**注意：** 用户直接提供完整邮箱地址时不需要搜索，直接使用即可。
+
 ### 命令选择：先判断邮件类型，再决定草稿还是发送
 
 | 邮件类型 | 存草稿（不发送） | 直接发送 |
@@ -340,6 +379,10 @@ lark-cli mail <resource> <method> [flags] # 调用 API
   - `modify` — 本接口提供修改邮件会话的能力，支持移动邮件会话的文件夹、给邮件会话添加和移除标签、标记邮件会话读和未读、移动邮件会话至垃圾邮件等能力。不支持移动邮件会话到已删除文件夹，如需，请使用删除邮件会话接口。至少填写add_label_ids、remove_label_ids、add_folder中的一个参数。
   - `trash` — 移动指定的邮件会话到已删除文件夹
 
+### multi_entity
+
+  - `search` — 
+
 ## 权限表
 
 | 方法 | 所需 scope |
@@ -391,4 +434,5 @@ lark-cli mail <resource> <method> [flags] # 调用 API
 | `user_mailbox.threads.list` | `mail:user_mailbox.message:readonly` |
 | `user_mailbox.threads.modify` | `mail:user_mailbox.message:modify` |
 | `user_mailbox.threads.trash` | `mail:user_mailbox.message:modify` |
+| `multi_entity.search` | `mail:user_mailbox:readonly` |
 

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -96,9 +96,12 @@ lark-cli mail multi_entity search --as user --data '{"query":"<关键词>"}'
 
 **处理规则：**
 1. 从结果中筛选有 `email` 字段的条目
-2. 若仅 1 个匹配且关键词吻合，直接使用其 `email`
-3. 若多个匹配，列出候选项供用户选择。展示尽可能多的字段帮助用户区分：
+2. 无论匹配数量多少，都必须列出候选项供用户确认后再使用（搜索是模糊匹配，单条结果不代表精确命中）。展示尽可能多的字段帮助用户区分：
    ```text
+   找到以下匹配"张三"的结果：
+   1. 张三 <zhangsan@example.com>
+      类型：user | 部门：研发团队
+   ---
    找到多个匹配"组"的结果，请选择：
    1. 团队邮件组 <team@example.com>
       类型：enterprise_mail_group | 标签：mail_group
@@ -108,8 +111,8 @@ lark-cli mail multi_entity search --as user --data '{"query":"<关键词>"}'
       类型：user | 部门：研发团队 | 备注名：张群同学
    ```
    可用字段：`name`（名称）、`email`（邮箱）、`department`（部门）、`tag`（标签）、`display_name`（备注名）、`type`（实体类型）、`member_count`（成员数，群类型时展示）。字段为空时省略。
-4. 若无匹配，告知用户未找到，建议换关键词或直接提供邮箱地址
-5. 用户确认后，将 `email` 传入 compose shortcut 的 `--to` / `--cc` / `--bcc` 参数
+3. 若无匹配，告知用户未找到，建议换关键词或直接提供邮箱地址
+4. 用户确认后，将 `email` 传入 compose shortcut 的 `--to` / `--cc` / `--bcc` 参数
 
 **注意：** 用户直接提供完整邮箱地址时不需要搜索，直接使用即可。
 
@@ -379,10 +382,6 @@ lark-cli mail <resource> <method> [flags] # 调用 API
   - `modify` — 本接口提供修改邮件会话的能力，支持移动邮件会话的文件夹、给邮件会话添加和移除标签、标记邮件会话读和未读、移动邮件会话至垃圾邮件等能力。不支持移动邮件会话到已删除文件夹，如需，请使用删除邮件会话接口。至少填写add_label_ids、remove_label_ids、add_folder中的一个参数。
   - `trash` — 移动指定的邮件会话到已删除文件夹
 
-### multi_entity
-
-  - `search` — 
-
 ## 权限表
 
 | 方法 | 所需 scope |
@@ -434,5 +433,4 @@ lark-cli mail <resource> <method> [flags] # 调用 API
 | `user_mailbox.threads.list` | `mail:user_mailbox.message:readonly` |
 | `user_mailbox.threads.modify` | `mail:user_mailbox.message:modify` |
 | `user_mailbox.threads.trash` | `mail:user_mailbox.message:modify` |
-| `multi_entity.search` | `mail:user_mailbox:readonly` |
 


### PR DESCRIPTION
## Summary

- Add recipient search workflow to mail skill template (search by name, email keyword, or group name with rich result display)
- Regenerate SKILL.md with `multi_entity.search` command

## Changes

- `skill-template/domains/mail.md`: new "Recipient Search" section with search examples, entity type table, and multi-match display format
- `skills/lark-mail/SKILL.md`: regenerated to include `multi_entity.search` and search workflow

No Go code changes. No breaking changes.

## Test plan

- [x] BOE environment: `lark-cli mail multi_entity search --as user --data '{"query":"陈煌"}'` returns results with name/email/department/tag
- [x] Multi-result display verified with various queries (name, email keyword, group name)
- [x] AI agent end-to-end: natural language "send email to X" triggers search workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added recipient-search guidance for finding email addresses by name, keyword, or group.
  * Clarified supported result types and that only entries containing an email are considered.
  * Defined handling: single match (auto-fill), multiple matches (show candidates with name/email/department/tag/display_name/type/member_count where present), no match (prompt new query or accept direct email).
  * Documented using confirmed emails in compose shortcuts and that full emails skip search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->