### PR TITLE
fix: improve error message when auto-detected identity is unsupported

### DIFF
--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -127,8 +127,8 @@ func (f *Factory) CheckIdentity(as core.Identity, supported []string) error {
 	list := strings.Join(supported, ", ")
 	if f.IdentityAutoDetected {
 		return output.ErrValidation(
-			"resolved identity %q (via auto-detect or default-as) is not supported, this command only supports: %s\nhint: use --as %s",
-			as, list, supported[0])
+			"this command requires %s identity, but no user login was found (auto-detected as %s)\nhint: run `lark-cli auth login` first, then retry",
+			list, as)
 	}
 	return fmt.Errorf("--as %s is not supported, this command only supports: %s", as, list)
 }

--- a/internal/cmdutil/factory_test.go
+++ b/internal/cmdutil/factory_test.go
@@ -174,15 +174,15 @@ func TestCheckIdentity_Unsupported_AutoDetected(t *testing.T) {
 	f, _, _, _ := TestFactory(t, &core.CliConfig{AppID: "a", AppSecret: "s"})
 	f.IdentityAutoDetected = true
 
-	err := f.CheckIdentity(core.AsUser, []string{"bot"})
+	err := f.CheckIdentity(core.AsBot, []string{"user"})
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "resolved identity") {
-		t.Errorf("expected 'resolved identity' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "requires user identity") {
+		t.Errorf("expected 'requires user identity' in error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "hint: use --as bot") {
-		t.Errorf("expected hint in error, got: %v", err)
+	if !strings.Contains(err.Error(), "auth login") {
+		t.Errorf("expected 'auth login' hint in error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- When a user-only shortcut (e.g. `mail +draft-edit`) is invoked without `--as` and the user has no active login (or token expired), auto-detect resolves to `bot`, causing a misleading error: `"--as bot is not supported"`. The user never passed `--as bot` — they just need to login.
- This fix improves the error message to distinguish auto-detected vs explicit `--as` mismatches:
  - **Auto-detected**: `"this command requires user identity, but no user login was found (auto-detected as bot)\nhint: run lark-cli auth login first, then retry"`
  - **Explicit `--as bot`**: `"--as bot is not supported, this command only supports: user"` (unchanged)

## Test plan

- [x] `go test ./internal/cmdutil/ -run TestCheckIdentity` — updated test passes
- [x] Manual (no login): `lark-cli mail +draft-edit --draft-id <id> --inspect` → shows "requires user identity ... hint: run lark-cli auth login"
- [x] Manual (no login, explicit): `lark-cli mail +draft-edit --draft-id <id> --inspect --as bot` → shows "--as bot is not supported"
- [x] Manual (logged in): `lark-cli mail +draft-edit --draft-id <id> --inspect` → normal API call with identity=user

🤖 Generated with [Claude Code](https://claude.com/claude-code)