### PR TITLE
fix(doc): add task read scope to docs fetch

### DIFF
--- a/shortcuts/doc/docs_fetch.go
+++ b/shortcuts/doc/docs_fetch.go
@@ -17,7 +17,7 @@ var DocsFetch = common.Shortcut{
 	Command:     "+fetch",
 	Description: "Fetch Lark document content",
 	Risk:        "read",
-	Scopes:      []string{"docx:document:readonly"},
+	Scopes:      []string{"docx:document:readonly", "task:task:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{


### PR DESCRIPTION
## Summary

`docs +fetch` may need to read task-related data referenced in Lark documents. This PR adds the `task:task:read` scope to `docs +fetch` to avoid missing-scope failures when fetching docs that include tasks.

## Changes

- Add `task:task:read` to `DocsFetch.Scopes` in `shortcuts/doc/docs_fetch.go`

## Test Plan

- [x] `go test ./shortcuts/doc/...`

## Related Issues

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Expanded permission requirements to enable task reading capabilities for the DocsFetch shortcut, complementing existing document access permissions for enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->