### PR TITLE
feat: Skip double confirmation for authorization

### DIFF
--- a/cmd/auth/login_interactive.go
+++ b/cmd/auth/login_interactive.go
@@ -184,27 +184,6 @@ func runInteractiveLogin(ios *cmdutil.IOStreams, lang string, msg *loginMsg) (*i
 	}
 	fmt.Fprintf(ios.ErrOut, msg.SummaryScopes, len(scopes), scopePreview)
 
-	// Phase 2: confirmation
-	var confirmed bool
-	form2 := huh.NewForm(
-		huh.NewGroup(
-			huh.NewConfirm().
-				Title(msg.ConfirmAuth).
-				Value(&confirmed),
-		),
-	).WithTheme(cmdutil.ThemeFeishu())
-
-	if err := form2.Run(); err != nil {
-		if err == huh.ErrUserAborted {
-			return nil, output.ErrBare(1)
-		}
-		return nil, err
-	}
-
-	if !confirmed {
-		return nil, output.ErrBare(1)
-	}
-
 	return &interactiveResult{
 		Domains:    selectedDomains,
 		ScopeLevel: permLevel,


### PR DESCRIPTION
## Summary                                                                           
                                                                                       
  - 移除了 `auth login` 交互式登录流程中的二次确认步骤（Phase 2:                       
  confirmation）。用户在选择完域名、权限级别和 scope                                   
  后，不再需要额外确认一次"是否授权"，直接进入授权流程。                               
                                                                                       
  ## Changes                                                                           

  - **`cmd/auth/login_interactive.go`**：删除 21 行代码，移除了基于 `huh.Confirm`      
  的确认弹窗逻辑。用户选完配置、打印摘要后直接返回结果，减少一步交互。
                                                                                       
  ## Motivation   

  简化 `lark-cli auth login` 的首次配置体验（easy-setup），减少不必要的交互摩擦。用户在
  前面的步骤中已经明确选择了域名和权限范围，摘要信息也已打印，额外的确认步骤显得冗余。
                                                                                       
  ## Test Plan    

  - [ ] 执行 `lark-cli auth
  login`，确认选择域名和权限后能直接完成授权，不再出现确认提示
  - [ ] 确认用户在前面步骤中按 Ctrl+C / ESC 仍能正常中止流程