### PR TITLE
fix: validate auth login scopes locally

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -187,6 +187,13 @@ func authLoginRun(opts *LoginOptions) error {
 	}
 
 	finalScope := opts.Scope
+	if finalScope != "" {
+		normalizedScope, err := validateExplicitScopes(finalScope, "user")
+		if err != nil {
+			return err
+		}
+		finalScope = normalizedScope
+	}
 
 	// Resolve scopes from domain/permission filters
 	if len(selectedDomains) > 0 || opts.Recommend {
@@ -519,6 +526,57 @@ func shortcutSupportsIdentity(sc common.Shortcut, identity string) bool {
 		}
 	}
 	return false
+}
+
+func validateExplicitScopes(scope, identity string) (string, error) {
+	normalized := strings.Fields(scope)
+	if len(normalized) == 0 {
+		return "", output.ErrValidation("please specify at least one scope")
+	}
+
+	knownScopes := knownScopesForIdentity(identity)
+	invalid := make([]string, 0)
+	result := make([]string, 0, len(normalized))
+	seen := make(map[string]bool, len(normalized))
+	for _, s := range normalized {
+		if !knownScopes[s] {
+			invalid = append(invalid, s)
+			continue
+		}
+		if seen[s] {
+			continue
+		}
+		seen[s] = true
+		result = append(result, s)
+	}
+
+	if len(invalid) > 0 {
+		return "", output.ErrValidation(
+			"invalid scope(s): %s\ncheck the exact scope names with `lark-cli auth scopes --format pretty`, or use `lark-cli auth login --domain <domain> --recommend` to avoid manual scope typos",
+			strings.Join(invalid, ", "),
+		)
+	}
+
+	return strings.Join(result, " "), nil
+}
+
+func knownScopesForIdentity(identity string) map[string]bool {
+	known := make(map[string]bool)
+	for scope := range registry.LoadScopePriorities() {
+		known[scope] = true
+	}
+	for _, scope := range registry.CollectAllScopesFromMeta(identity) {
+		known[scope] = true
+	}
+	for _, sc := range shortcuts.AllShortcuts() {
+		if shortcutSupportsIdentity(sc, identity) {
+			for _, scope := range sc.ScopesForIdentity(identity) {
+				known[scope] = true
+			}
+		}
+	}
+	known["offline_access"] = true
+	return known
 }
 
 // suggestDomain finds the best "did you mean" match for an unknown domain.

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -226,6 +226,46 @@ func TestCollectScopesForDomains_NonexistentDomain(t *testing.T) {
 	}
 }
 
+func TestValidateExplicitScopes_NormalizesWhitespaceAndDeduplicates(t *testing.T) {
+	got, err := validateExplicitScopes("base:app:create \n base:app:read\tbase:app:create", "user")
+	if err != nil {
+		t.Fatalf("validateExplicitScopes() error = %v", err)
+	}
+	if got != "base:app:create base:app:read" {
+		t.Fatalf("validateExplicitScopes() = %q, want %q", got, "base:app:create base:app:read")
+	}
+}
+
+func TestValidateExplicitScopes_RejectsUnknownScopes(t *testing.T) {
+	_, err := validateExplicitScopes("base:app:create malformed:scope", "user")
+	if err == nil {
+		t.Fatal("expected validation error for unknown scope")
+	}
+	if !strings.Contains(err.Error(), "invalid scope(s): malformed:scope") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "auth scopes --format pretty") {
+		t.Fatalf("expected auth scopes hint, got: %v", err)
+	}
+}
+
+func TestAuthLoginRun_ExplicitInvalidScopeFailsBeforeNetwork(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "cli_test", AppSecret: "secret", Brand: core.BrandFeishu,
+	})
+	err := authLoginRun(&LoginOptions{
+		Factory: f,
+		Ctx:     context.Background(),
+		Scope:   "base:app:create malformed:scope",
+	})
+	if err == nil {
+		t.Fatal("expected validation error for invalid scope")
+	}
+	if !strings.Contains(err.Error(), "invalid scope(s): malformed:scope") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestGetDomainMetadata_IncludesFromMeta(t *testing.T) {
 	domains := getDomainMetadata("zh")
 	nameSet := make(map[string]bool)


### PR DESCRIPTION
## Problem
`lark-cli auth login --scope` currently forwards the raw scope string to the device authorization endpoint. If the input contains malformed spacing, line breaks, or a typo in one scope name, the user only sees the remote OAuth error saying the scope list is invalid, without any indication of which scope caused it.

## Root Cause
The explicit `--scope` path does not normalize user input or validate the requested scope names against the CLI's known scope registry before making the device authorization request.

## Fix
Normalize explicit scope input with `strings.Fields`, deduplicate repeated entries, and validate each requested scope against the union of known registry scopes and shortcut scopes before calling the OAuth device authorization endpoint. Invalid scope names now fail fast with a local validation error that points users to `auth scopes` or the domain-based recommend flow.

## Validation
- Static code review of the new auth login validation path
- Added unit tests covering whitespace normalization, invalid scope rejection, and early failure before network calls

Closes #416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `auth login` command now validates scopes to ensure only recognized authentication scopes are accepted.
  * Scope parameters are automatically normalized, removing whitespace variations and duplicate scopes.
  * Invalid scopes are rejected with helpful error messages guiding users to valid options.

* **Tests**
  * Added test coverage for scope validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->