### PR TITLE
Fix terminology in lark-whiteboard-update.md for clarity

### DIFF
--- a/skills/lark-whiteboard/references/lark-whiteboard-update.md
+++ b/skills/lark-whiteboard/references/lark-whiteboard-update.md
@@ -24,7 +24,7 @@
 
 **不要以直接生成 json 语法的方式创作 raw 格式的飞书 OpenAPI 原生画板节点参数**
 
-思维导图，时序图，类图，饼图，流程图等图标推荐使用 Mermaid/PlantUML 语法绘制。
+思维导图，时序图，类图，饼图，流程图等图表推荐使用 Mermaid/PlantUML 语法绘制。
 
 而当需要绘制架构图，组织架构图，泳道图，对比图，鱼骨图，柱状图，折线图，树状图，漏斗图，金字塔图，循环/飞轮图，里程碑或其他较为复杂的图表时，推荐参考 [lark-whiteboard-cli](../lark-whiteboard-cli/SKILL.md)
 使用 whiteboard-cli 工具创作。


### PR DESCRIPTION
Corrected the term '图标' to '图表' for clarity in the documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for creating diagrams in Lark Whiteboard by correcting terminology related to diagram types supported by Mermaid/PlantUML syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->