### PR TITLE
feat(base): support record share link

### DIFF
--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -132,7 +132,7 @@ func TestShortcutsCatalog(t *testing.T) {
 		"+table-list", "+table-get", "+table-create", "+table-update", "+table-delete",
 		"+field-list", "+field-get", "+field-create", "+field-update", "+field-delete", "+field-search-options",
 		"+view-list", "+view-get", "+view-create", "+view-delete", "+view-get-filter", "+view-set-filter", "+view-get-visible-fields", "+view-set-visible-fields", "+view-get-group", "+view-set-group", "+view-get-sort", "+view-set-sort", "+view-get-timebar", "+view-set-timebar", "+view-get-card", "+view-set-card", "+view-rename",
-		"+record-list", "+record-search", "+record-get", "+record-upsert", "+record-batch-create", "+record-batch-update", "+record-upload-attachment", "+record-delete",
+		"+record-list", "+record-search", "+record-get", "+record-upsert", "+record-batch-create", "+record-batch-update", "+record-share-link-create", "+record-upload-attachment", "+record-delete",
 		"+record-history-list",
 		"+base-get", "+base-copy", "+base-create",
 		"+role-create", "+role-delete", "+role-update", "+role-list", "+role-get", "+advperm-enable", "+advperm-disable",

--- a/shortcuts/base/record_ops.go
+++ b/shortcuts/base/record_ops.go
@@ -112,6 +112,56 @@ func dryRunRecordHistoryList(_ context.Context, runtime *common.RuntimeContext) 
 		Set("base_token", runtime.Str("base-token"))
 }
 
+func dryRunRecordShareBatch(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+	recordIDs := deduplicateRecordIDs(runtime)
+	return common.NewDryRunAPI().
+		POST("/open-apis/base/v3/bases/:base_token/tables/:table_id/records/share_links/batch").
+		Body(map[string]interface{}{"record_ids": recordIDs}).
+		Set("base_token", runtime.Str("base-token")).
+		Set("table_id", baseTableID(runtime))
+}
+
+const maxShareBatchSize = 100
+
+func validateRecordShareBatch(runtime *common.RuntimeContext) error {
+	recordIDs := deduplicateRecordIDs(runtime)
+	if len(recordIDs) == 0 {
+		return common.FlagErrorf("--record-ids is required and must not be empty")
+	}
+	if len(recordIDs) > maxShareBatchSize {
+		return common.FlagErrorf("--record-ids exceeds maximum limit of %d (got %d)", maxShareBatchSize, len(recordIDs))
+	}
+	return nil
+}
+
+func deduplicateRecordIDs(runtime *common.RuntimeContext) []string {
+	raw := runtime.StrSlice("record-ids")
+	seen := make(map[string]bool, len(raw))
+	result := make([]string, 0, len(raw))
+	for _, id := range raw {
+		if id != "" && !seen[id] {
+			seen[id] = true
+			result = append(result, id)
+		}
+	}
+	return result
+}
+
+func executeRecordShareBatch(runtime *common.RuntimeContext) error {
+	recordIDs := deduplicateRecordIDs(runtime)
+	body := map[string]interface{}{
+		"record_ids": recordIDs,
+	}
+	data, err := baseV3Call(runtime, "POST",
+		baseV3Path("bases", runtime.Str("base-token"), "tables", baseTableID(runtime), "records", "share_links", "batch"),
+		nil, body)
+	if err != nil {
+		return err
+	}
+	runtime.Out(data, nil)
+	return nil
+}
+
 func validateRecordJSON(runtime *common.RuntimeContext) error {
 	return nil
 }

--- a/shortcuts/base/record_share_link_create.go
+++ b/shortcuts/base/record_share_link_create.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"context"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var BaseRecordShareLinkCreate = common.Shortcut{
+	Service:     "base",
+	Command:     "+record-share-link-create",
+	Description: "Generate share links for one or more records (max 100 per request)",
+	Risk:        "read",
+	Scopes:      []string{"base:record:read"},
+	AuthTypes:   authTypes(),
+	Flags: []common.Flag{
+		baseTokenFlag(true),
+		tableRefFlag(true),
+		{Name: "record-ids", Type: "string_slice", Desc: "record IDs to generate share links for (comma-separated or repeatable, max 100)", Required: true},
+	},
+	Tips: []string{
+		`Single record:  --base-token xxx --table-id tblxxx --record-ids recxxx`,
+		`Multiple records: --base-token xxx --table-id tblxxx --record-ids rec001,rec002,rec003`,
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		return validateRecordShareBatch(runtime)
+	},
+	DryRun: dryRunRecordShareBatch,
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		return executeRecordShareBatch(runtime)
+	},
+}

--- a/shortcuts/base/shortcuts.go
+++ b/shortcuts/base/shortcuts.go
@@ -42,6 +42,7 @@ func Shortcuts() []common.Shortcut {
 		BaseRecordUpsert,
 		BaseRecordBatchCreate,
 		BaseRecordBatchUpdate,
+		BaseRecordShareLinkCreate,
 		BaseRecordUploadAttachment,
 		BaseRecordDelete,
 		BaseRecordHistoryList,

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -181,6 +181,12 @@ func (ctx *RuntimeContext) StrArray(name string) []string {
 	return v
 }
 
+// StrSlice returns a string-slice flag value (supports CSV splitting and repeated flags).
+func (ctx *RuntimeContext) StrSlice(name string) []string {
+	v, _ := ctx.Cmd.Flags().GetStringSlice(name)
+	return v
+}
+
 // ── API helpers ──
 
 //	CallAPI uses an internal HTTP wrapper with limited control over request/response.
@@ -849,6 +855,8 @@ func registerShortcutFlags(cmd *cobra.Command, s *Shortcut) {
 			cmd.Flags().Int(fl.Name, d, desc)
 		case "string_array":
 			cmd.Flags().StringArray(fl.Name, nil, desc)
+		case "string_slice":
+			cmd.Flags().StringSlice(fl.Name, nil, desc)
 		default:
 			cmd.Flags().String(fl.Name, fl.Default, desc)
 		}

--- a/skills/lark-base/references/lark-base-record-share-link-create.md
+++ b/skills/lark-base/references/lark-base-record-share-link-create.md
@@ -1,0 +1,72 @@
+# base +record-share-link-create
+
+> **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
+
+为一条或多条记录生成分享链接（单次调用最多传入 100 条，内部调用批量接口）。
+
+## 推荐命令
+
+```bash
+# 单条记录
+lark-cli base +record-share-link-create \
+  --base-token xxx \
+  --table-id tbl_xxx \
+  --record-ids rec_xxx
+
+# 多条记录（使用 "," 分隔）
+lark-cli base +record-share-link-create \
+  --base-token xxx \
+  --table-id tbl_xxx \
+  --record-ids rec001,rec002,rec003
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--base-token <token>` | 是 | Base Token |
+| `--table-id <id>` | 是 | 表 ID |
+| `--record-ids <ids...>` | 是 | 记录 ID 列表，逗号分隔或重复使用该标志，最多 100 条 |
+
+## API 入参详情
+
+**HTTP 方法和路径：**
+
+```http
+POST /open-apis/base/v3/bases/:base_token/tables/:table_id/records/share_links/batch
+```
+
+**请求体：**
+
+```json
+{
+  "record_ids": ["rec001", "rec002", "rec003"]
+}
+```
+
+> CLI 会自动对 `--record-ids` 去重后再调用接口。
+
+## 返回重点
+
+- 成功时直接返回接口 `data` 字段内容，包含 `record_share_links` 映射（key 为 record_id，value 为分享链接）。结构如下：
+
+```json
+{
+  "record_share_links": {
+    "rec001": "https://example.feishu.cn/record/TW2wrdbkoeoYXYcwvyIczJ2ZnFb"
+  }
+}
+```
+
+- 若部分记录 ID 无权限/不存在，则 `record_share_links` 中只会包含有效记录对应的分享链接
+- 若全部记录 ID 都无权限/不存在，则会返回错误信息 `records do not exist or no read permission`
+
+## 坑点
+
+- ⚠️ 单次最多 100 条记录，超出会被 CLI 校验拦截。
+- ⚠️ 重复的 record_id 会在调用前自动去重。
+- ⚠️ `--record-ids` 为空时会被校验拦截。
+
+## 参考
+
+- [lark-base-record.md](lark-base-record.md) — record 索引页

--- a/skills/lark-base/references/lark-base-record.md
+++ b/skills/lark-base/references/lark-base-record.md
@@ -17,6 +17,7 @@ record 相关命令索引。
 | [lark-base-record-upload-attachment.md](lark-base-record-upload-attachment.md) | `+record-upload-attachment` | 上传本地文件到附件字段并更新记录 |
 | [`../../lark-doc/references/lark-doc-media-download.md`](../../lark-doc/references/lark-doc-media-download.md) | `lark-cli docs +media-download` | 下载 Base 附件到本地（附件的 `file_token` 来自 `+record-get` 的附件字段） |
 | [lark-base-record-delete.md](lark-base-record-delete.md) | `+record-delete` | 删除记录 |
+| [lark-base-record-share-link-create.md](lark-base-record-share-link-create.md) | `+record-share-link-create` | 生成记录分享链接（支持单条或批量，最多 100 条）|
 
 ## 说明
 


### PR DESCRIPTION
Change-Id: Ie78da99096cc1fc8a4671d8178176f4c587466ba

 ## Summary                                                                                                                                                                
                                                                                                                                                                            
  Add +record-share-link-create and +record-share-link-batch-create base shortcuts for generating share links for single or batch records.                                  

## Changes                                                                                                                                                                
                                                                                                                                                                            
  1. Add +record-share-link-create — generate share link for a single record                                                                                                
                                                                                                                                                                            
  • Endpoint: POST /bases/:base_token/tables/:table_id/records/:record_id/share_links                                                                                       
  • Flags: --base-token, --table-id, --record-id                                                                                                                            
  • Returns the share link for the given record                                                                                                                             
                                                                                                                                                                            
  2. Add +record-share-link-batch-create — batch generate share links (max 100 per call)                                                                                    
                                                                                                                                                                            
  • Endpoint: POST /bases/:base_token/tables/:table_id/records/share_links/batch                                                                                            
  • Flags: --base-token, --table-id, --record-ids (string_slice type, comma-separated, max 100)                                                                             
  • Auto-deduplication + validation (empty input / over 100 records are rejected)                                                                                           
  • Returns record_share_links map (key: record_id, value: share link)                                                                                                      
                                                                                                                                                                            
  3. Add string_slice flag type and StrSlice() method in runner                                                                                                             
                                                                                                                                                                            
  • Leverages pflag's StringSlice, supporting both comma-separated and repeatable flag styles                                                                               
                                                                                                                                                                            
  4. Add skill documentation                                                                                                                                                
                                                                                                                                                                        
  • lark-base-record-share-link-create.md                                                                                                                                   
  • lark-base-record-share-link-batch-create.md (with request/response JSON examples)                                                                                       
  • Update lark-base-record.md index page                                                                                                                                   
                                                                                                                                                                            
## Test Plan                                                                                                                                                                                                                                                                                                                               
  • Unit tests pass (shortcuts/base, shortcuts/common)                                                                                                                      
  • Manual local verification confirms the lark base +record-share-link-* commands work as expected                                                                         
                                                                                                                                                                            
## Related Issues                                                                                                                                                         
   None
  
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added record share link generation for individual records
  * Added batch record share link generation supporting up to 100 records per batch
  * Added string slice flag type support for CLI parameters

* **Documentation**
  * Added documentation for record share link creation commands
  * Added reference guides for both single and batch share link operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add single-record share link command (+record-share-link-create).
  * Add batch share link command (+record-share-link-batch-create) with a 100-record cap, input deduplication, and validation (rejects empty input).

* **Documentation**
  * Added user guides and examples for single and batch record share link commands, including CLI usage, request behavior, and return/partial-failure semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->