### PR TITLE
feat(doc): warn when callout uses type= without background-color

### DIFF
--- a/shortcuts/doc/docs_create.go
+++ b/shortcuts/doc/docs_create.go
@@ -110,6 +110,11 @@ func dryRunCreateV1(_ context.Context, runtime *common.RuntimeContext) *common.D
 
 func executeCreateV1(_ context.Context, runtime *common.RuntimeContext) error {
 	warnDeprecatedV1(runtime, "+create")
+	// Surface callout type= hint so users know to switch to background-color/
+	// border-color when they want a colored callout. Non-blocking, advisory.
+	if md := runtime.Str("markdown"); md != "" {
+		WarnCalloutType(md, runtime.IO().ErrOut)
+	}
 	args := buildCreateArgsV1(runtime)
 	result, err := common.CallMCPTool(runtime, "create-doc", args)
 	if err != nil {
@@ -122,8 +127,9 @@ func executeCreateV1(_ context.Context, runtime *common.RuntimeContext) error {
 }
 
 func buildCreateArgsV1(runtime *common.RuntimeContext) map[string]interface{} {
+	md := runtime.Str("markdown")
 	args := map[string]interface{}{
-		"markdown": prepareMarkdownForCreate(runtime.Str("markdown")),
+		"markdown": md,
 	}
 	if v := runtime.Str("title"); v != "" {
 		args["title"] = v

--- a/shortcuts/doc/docs_create.go
+++ b/shortcuts/doc/docs_create.go
@@ -123,7 +123,7 @@ func executeCreateV1(_ context.Context, runtime *common.RuntimeContext) error {
 
 func buildCreateArgsV1(runtime *common.RuntimeContext) map[string]interface{} {
 	args := map[string]interface{}{
-		"markdown": runtime.Str("markdown"),
+		"markdown": prepareMarkdownForCreate(runtime.Str("markdown")),
 	}
 	if v := runtime.Str("title"); v != "" {
 		args["title"] = v

--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -177,7 +177,7 @@ func buildUpdateArgsV1(runtime *common.RuntimeContext) map[string]interface{} {
 		"mode":   runtime.Str("mode"),
 	}
 	if v := runtime.Str("markdown"); v != "" {
-		args["markdown"] = v
+		args["markdown"] = prepareMarkdownForCreate(v)
 	}
 	if v := runtime.Str("selection-with-ellipsis"); v != "" {
 		args["selection_with_ellipsis"] = v

--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -159,6 +159,12 @@ func executeUpdateV1(_ context.Context, runtime *common.RuntimeContext) error {
 		fmt.Fprintf(runtime.IO().ErrOut, "warning: %s\n", w)
 	}
 
+	// Surface callout type= hint so users know to switch to background-color/
+	// border-color when they want a colored callout. Non-blocking, advisory.
+	if md := runtime.Str("markdown"); md != "" {
+		WarnCalloutType(md, runtime.IO().ErrOut)
+	}
+
 	args := buildUpdateArgsV1(runtime)
 
 	result, err := common.CallMCPTool(runtime, "update-doc", args)
@@ -177,7 +183,7 @@ func buildUpdateArgsV1(runtime *common.RuntimeContext) map[string]interface{} {
 		"mode":   runtime.Str("mode"),
 	}
 	if v := runtime.Str("markdown"); v != "" {
-		args["markdown"] = prepareMarkdownForCreate(v)
+		args["markdown"] = v
 	}
 	if v := runtime.Str("selection-with-ellipsis"); v != "" {
 		args["selection_with_ellipsis"] = v

--- a/shortcuts/doc/markdown_fix.go
+++ b/shortcuts/doc/markdown_fix.go
@@ -4,6 +4,8 @@
 package doc
 
 import (
+	"fmt"
+	"io"
 	"regexp"
 	"strings"
 	"unicode"
@@ -37,14 +39,6 @@ import (
 //  6. fixCalloutEmoji: replaces named emoji aliases (e.g. emoji="warning") with
 //     actual Unicode emoji characters that create-doc understands. Applied only
 //     outside fenced code blocks.
-//
-// prepareMarkdownForCreate applies fixes that should run on any Markdown before
-// it is sent to the create-doc / update-doc MCP tools, regardless of whether
-// the content originated from a Lark export or was written by hand.
-func prepareMarkdownForCreate(md string) string {
-	return applyOutsideCodeFences(md, fixCalloutType)
-}
-
 func fixExportedMarkdown(md string) string {
 	md = applyOutsideCodeFences(md, fixBoldSpacing)
 	md = applyOutsideCodeFences(md, normalizeNestedListIndentation)
@@ -52,7 +46,6 @@ func fixExportedMarkdown(md string) string {
 	md = applyOutsideCodeFences(md, fixBlockquoteHardBreaks)
 	md = fixTopLevelSoftbreaks(md)
 	md = applyOutsideCodeFences(md, fixCalloutEmoji)
-	md = applyOutsideCodeFences(md, fixCalloutType)
 	// Collapse runs of 3+ consecutive newlines into exactly 2 (one blank line),
 	// but only outside fenced code blocks to preserve intentional blank lines in code.
 	md = applyOutsideCodeFences(md, func(s string) string {
@@ -315,8 +308,9 @@ func fixSetextAmbiguity(md string) string {
 	return setextRe.ReplaceAllString(md, "$1\n\n$2")
 }
 
-// calloutTypeColors maps callout type="<name>" to a [background-color, border-color] pair.
-// When a callout tag has type= but no background-color=, these defaults are applied.
+// calloutTypeColors maps the semantic type= shorthand to a recommended
+// [background-color, border-color] pair for Feishu callout blocks.
+// Used only for hint messages — the Markdown itself is never rewritten.
 var calloutTypeColors = map[string][2]string{
 	"warning":   {"light-yellow", "yellow"},
 	"caution":   {"light-orange", "orange"},
@@ -330,42 +324,47 @@ var calloutTypeColors = map[string][2]string{
 	"important": {"light-purple", "purple"},
 }
 
-// calloutTypeRe matches a <callout …> opening tag so individual attributes can
-// be inspected and patched.
-var calloutTypeRe = regexp.MustCompile(`<callout(\s[^>]*)?>`)
+// calloutOpenTagRe matches a <callout …> opening tag.
+var calloutOpenTagRe = regexp.MustCompile(`<callout(\s[^>]*)?>`)
 
-// fixCalloutType expands the semantic type="<name>" shorthand on callout tags
-// into explicit background-color= (and border-color= when absent).  When a
-// background-color is already present the tag is left unchanged so that an
-// explicit color always wins.
-func fixCalloutType(md string) string {
-	return calloutTypeRe.ReplaceAllStringFunc(md, func(tag string) string {
+// calloutTypeAttrRe extracts the value of a type= attribute (single or double
+// quoted) from a callout opening tag's attribute string.
+var calloutTypeAttrRe = regexp.MustCompile(`\btype=(?:"([^"]*)"|'([^']*)')`)
+
+// WarnCalloutType scans md for callout tags that carry a type= attribute but
+// no background-color= attribute, then writes a hint line to w for each one
+// suggesting the explicit Feishu color attributes to use instead.
+//
+// The Markdown is not modified — the caller is responsible for acting on the
+// hints or ignoring them. This keeps the create/update path transparent: user
+// input reaches create-doc exactly as written.
+func WarnCalloutType(md string, w io.Writer) {
+	calloutOpenTagRe.ReplaceAllStringFunc(md, func(tag string) string {
 		attrs := ""
-		if m := calloutTypeRe.FindStringSubmatch(tag); len(m) == 2 {
+		if m := calloutOpenTagRe.FindStringSubmatch(tag); len(m) == 2 {
 			attrs = m[1]
 		}
-		// Extract type value.
-		typeRe := regexp.MustCompile(`\btype="([^"]*)"`)
-		typeParts := typeRe.FindStringSubmatch(attrs)
-		if len(typeParts) != 2 {
-			return tag // no type= attribute
-		}
-		typeName := typeParts[1]
-		colors, ok := calloutTypeColors[typeName]
-		if !ok {
-			return tag // unknown type — leave as-is
-		}
-		// Only inject background-color when it is absent.
+		// Skip tags that already carry an explicit background-color.
 		if strings.Contains(attrs, "background-color=") {
 			return tag
 		}
-		// Inject background-color (and border-color when absent) before the
-		// closing >.
-		extra := ` background-color="` + colors[0] + `"`
-		if !strings.Contains(attrs, "border-color=") {
-			extra += ` border-color="` + colors[1] + `"`
+		parts := calloutTypeAttrRe.FindStringSubmatch(attrs)
+		if len(parts) < 2 {
+			return tag // no type= attribute
 		}
-		return tag[:len(tag)-1] + extra + ">"
+		// parts[1] is the double-quoted capture, parts[2] is single-quoted.
+		typeName := parts[1]
+		if typeName == "" {
+			typeName = parts[2]
+		}
+		colors, ok := calloutTypeColors[typeName]
+		if !ok {
+			return tag // unknown type — no hint to give
+		}
+		fmt.Fprintf(w,
+			"hint: callout type=%q has no background-color; consider: background-color=%q border-color=%q\n",
+			typeName, colors[0], colors[1])
+		return tag
 	})
 }
 

--- a/shortcuts/doc/markdown_fix.go
+++ b/shortcuts/doc/markdown_fix.go
@@ -331,6 +331,11 @@ var calloutOpenTagRe = regexp.MustCompile(`<callout(\s[^>]*)?>`)
 // quoted) from a callout opening tag's attribute string.
 var calloutTypeAttrRe = regexp.MustCompile(`\btype=(?:"([^"]*)"|'([^']*)')`)
 
+// calloutBackgroundColorAttrRe matches a background-color= attribute name
+// with optional whitespace around the equals sign, so forms like
+// `background-color="..."` and `background-color = "..."` are both accepted.
+var calloutBackgroundColorAttrRe = regexp.MustCompile(`\bbackground-color\s*=`)
+
 // WarnCalloutType scans md for callout tags that carry a type= attribute but
 // no background-color= attribute, then writes a hint line to w for each one
 // suggesting the explicit Feishu color attributes to use instead.
@@ -345,7 +350,7 @@ func WarnCalloutType(md string, w io.Writer) {
 			attrs = m[1]
 		}
 		// Skip tags that already carry an explicit background-color.
-		if strings.Contains(attrs, "background-color=") {
+		if calloutBackgroundColorAttrRe.MatchString(attrs) {
 			return tag
 		}
 		parts := calloutTypeAttrRe.FindStringSubmatch(attrs)

--- a/shortcuts/doc/markdown_fix.go
+++ b/shortcuts/doc/markdown_fix.go
@@ -327,35 +327,78 @@ var calloutTypeColors = map[string][2]string{
 // calloutOpenTagRe matches a <callout …> opening tag.
 var calloutOpenTagRe = regexp.MustCompile(`<callout(\s[^>]*)?>`)
 
-// calloutTypeAttrRe extracts the value of a type= attribute (single or double
-// quoted) from a callout opening tag's attribute string.
-var calloutTypeAttrRe = regexp.MustCompile(`\btype=(?:"([^"]*)"|'([^']*)')`)
+// calloutTypeAttrRe extracts the value of a type= attribute (single or
+// double quoted) from a callout opening tag's attribute string. The
+// (?:^|\s) anchor instead of \b is intentional: \b sits at any
+// word/non-word boundary, and `-` is a non-word character, so
+// `\btype=` would also match the suffix of `data-type=` and yield a
+// bogus type lookup. Anchoring on start-of-string-or-whitespace
+// requires a real attribute separator before the name.
+var calloutTypeAttrRe = regexp.MustCompile(`(?:^|\s)type=(?:"([^"]*)"|'([^']*)')`)
 
-// calloutBackgroundColorAttrRe matches a background-color= attribute name
-// with optional whitespace around the equals sign, so forms like
-// `background-color="..."` and `background-color = "..."` are both accepted.
-var calloutBackgroundColorAttrRe = regexp.MustCompile(`\bbackground-color\s*=`)
+// calloutBackgroundColorAttrRe matches a background-color= attribute
+// name with optional whitespace around the equals sign, so forms like
+// `background-color="..."` and `background-color = "..."` are both
+// accepted. Same (?:^|\s) anchor as calloutTypeAttrRe, for the same
+// reason: `data-background-color="..."` must not look like a present
+// background-color and silently suppress the hint.
+var calloutBackgroundColorAttrRe = regexp.MustCompile(`(?:^|\s)background-color\s*=`)
 
 // WarnCalloutType scans md for callout tags that carry a type= attribute but
 // no background-color= attribute, then writes a hint line to w for each one
 // suggesting the explicit Feishu color attributes to use instead.
 //
-// The Markdown is not modified — the caller is responsible for acting on the
-// hints or ignoring them. This keeps the create/update path transparent: user
-// input reaches create-doc exactly as written.
+// Callout tags inside fenced code blocks (``` or ~~~) are skipped — they
+// are documentation samples, not real callouts the user wants Feishu to
+// render. Fence detection uses the shared codeFenceOpenMarker /
+// isCodeFenceClose helpers so both backtick and tilde fences are handled
+// (matching CommonMark §4.5).
+//
+// The Markdown is not modified — the caller is responsible for acting on
+// the hints or ignoring them. This keeps the create/update path
+// transparent: user input reaches create-doc exactly as written.
 func WarnCalloutType(md string, w io.Writer) {
-	calloutOpenTagRe.ReplaceAllStringFunc(md, func(tag string) string {
-		attrs := ""
-		if m := calloutOpenTagRe.FindStringSubmatch(tag); len(m) == 2 {
-			attrs = m[1]
+	fenceMarker := ""
+	for _, line := range strings.Split(md, "\n") {
+		if fenceMarker != "" {
+			// Inside a fenced block — skip everything until the matching
+			// closer. Code samples that show literal <callout type=...>
+			// must not produce a phantom hint.
+			if isCodeFenceClose(line, fenceMarker) {
+				fenceMarker = ""
+			}
+			continue
 		}
+		if marker := codeFenceOpenMarker(line); marker != "" {
+			fenceMarker = marker
+			continue
+		}
+		scanCalloutTagsForWarning(line, w)
+	}
+}
+
+// scanCalloutTagsForWarning emits a hint to w for every <callout type="...">
+// tag in s that lacks an explicit background-color= attribute. Pulled out
+// of WarnCalloutType so the line walker only handles fence state and the
+// per-tag scan is its own readable unit.
+//
+// The previous implementation routed the tag iteration through
+// calloutOpenTagRe.ReplaceAllStringFunc with a callback that always
+// returned the original tag and threw the rebuilt string away — using a
+// rewrite primitive purely for its iteration side-effect, plus a second
+// regex execution to recover the capture groups inside the callback.
+// FindAllStringSubmatch hands us both the iteration and the groups in one
+// pass, no allocation thrown away.
+func scanCalloutTagsForWarning(s string, w io.Writer) {
+	for _, m := range calloutOpenTagRe.FindAllStringSubmatch(s, -1) {
+		attrs := m[1]
 		// Skip tags that already carry an explicit background-color.
 		if calloutBackgroundColorAttrRe.MatchString(attrs) {
-			return tag
+			continue
 		}
 		parts := calloutTypeAttrRe.FindStringSubmatch(attrs)
-		if len(parts) < 2 {
-			return tag // no type= attribute
+		if len(parts) < 3 {
+			continue // no type= attribute
 		}
 		// parts[1] is the double-quoted capture, parts[2] is single-quoted.
 		typeName := parts[1]
@@ -364,13 +407,12 @@ func WarnCalloutType(md string, w io.Writer) {
 		}
 		colors, ok := calloutTypeColors[typeName]
 		if !ok {
-			return tag // unknown type — no hint to give
+			continue // unknown type — no hint to give
 		}
 		fmt.Fprintf(w,
 			"hint: callout type=%q has no background-color; consider: background-color=%q border-color=%q\n",
 			typeName, colors[0], colors[1])
-		return tag
-	})
+	}
 }
 
 // calloutEmojiAliases maps named emoji strings that fetch-doc emits to actual

--- a/shortcuts/doc/markdown_fix.go
+++ b/shortcuts/doc/markdown_fix.go
@@ -37,6 +37,14 @@ import (
 //  6. fixCalloutEmoji: replaces named emoji aliases (e.g. emoji="warning") with
 //     actual Unicode emoji characters that create-doc understands. Applied only
 //     outside fenced code blocks.
+//
+// prepareMarkdownForCreate applies fixes that should run on any Markdown before
+// it is sent to the create-doc / update-doc MCP tools, regardless of whether
+// the content originated from a Lark export or was written by hand.
+func prepareMarkdownForCreate(md string) string {
+	return applyOutsideCodeFences(md, fixCalloutType)
+}
+
 func fixExportedMarkdown(md string) string {
 	md = applyOutsideCodeFences(md, fixBoldSpacing)
 	md = applyOutsideCodeFences(md, normalizeNestedListIndentation)
@@ -44,6 +52,7 @@ func fixExportedMarkdown(md string) string {
 	md = applyOutsideCodeFences(md, fixBlockquoteHardBreaks)
 	md = fixTopLevelSoftbreaks(md)
 	md = applyOutsideCodeFences(md, fixCalloutEmoji)
+	md = applyOutsideCodeFences(md, fixCalloutType)
 	// Collapse runs of 3+ consecutive newlines into exactly 2 (one blank line),
 	// but only outside fenced code blocks to preserve intentional blank lines in code.
 	md = applyOutsideCodeFences(md, func(s string) string {
@@ -304,6 +313,60 @@ var setextRe = regexp.MustCompile(`(?m)^([^\n]+)\n(-{3,}\s*$)`)
 
 func fixSetextAmbiguity(md string) string {
 	return setextRe.ReplaceAllString(md, "$1\n\n$2")
+}
+
+// calloutTypeColors maps callout type="<name>" to a [background-color, border-color] pair.
+// When a callout tag has type= but no background-color=, these defaults are applied.
+var calloutTypeColors = map[string][2]string{
+	"warning":   {"light-yellow", "yellow"},
+	"caution":   {"light-orange", "orange"},
+	"note":      {"light-blue", "blue"},
+	"info":      {"light-blue", "blue"},
+	"tip":       {"light-green", "green"},
+	"success":   {"light-green", "green"},
+	"check":     {"light-green", "green"},
+	"error":     {"light-red", "red"},
+	"danger":    {"light-red", "red"},
+	"important": {"light-purple", "purple"},
+}
+
+// calloutTypeRe matches a <callout …> opening tag so individual attributes can
+// be inspected and patched.
+var calloutTypeRe = regexp.MustCompile(`<callout(\s[^>]*)?>`)
+
+// fixCalloutType expands the semantic type="<name>" shorthand on callout tags
+// into explicit background-color= (and border-color= when absent).  When a
+// background-color is already present the tag is left unchanged so that an
+// explicit color always wins.
+func fixCalloutType(md string) string {
+	return calloutTypeRe.ReplaceAllStringFunc(md, func(tag string) string {
+		attrs := ""
+		if m := calloutTypeRe.FindStringSubmatch(tag); len(m) == 2 {
+			attrs = m[1]
+		}
+		// Extract type value.
+		typeRe := regexp.MustCompile(`\btype="([^"]*)"`)
+		typeParts := typeRe.FindStringSubmatch(attrs)
+		if len(typeParts) != 2 {
+			return tag // no type= attribute
+		}
+		typeName := typeParts[1]
+		colors, ok := calloutTypeColors[typeName]
+		if !ok {
+			return tag // unknown type — leave as-is
+		}
+		// Only inject background-color when it is absent.
+		if strings.Contains(attrs, "background-color=") {
+			return tag
+		}
+		// Inject background-color (and border-color when absent) before the
+		// closing >.
+		extra := ` background-color="` + colors[0] + `"`
+		if !strings.Contains(attrs, "border-color=") {
+			extra += ` border-color="` + colors[1] + `"`
+		}
+		return tag[:len(tag)-1] + extra + ">"
+	})
 }
 
 // calloutEmojiAliases maps named emoji strings that fetch-doc emits to actual

--- a/shortcuts/doc/markdown_fix_test.go
+++ b/shortcuts/doc/markdown_fix_test.go
@@ -359,73 +359,75 @@ func TestFixExportedMarkdown(t *testing.T) {
 	}
 }
 
-func TestFixCalloutType(t *testing.T) {
+func TestWarnCalloutType(t *testing.T) {
 	tests := []struct {
-		name  string
-		input string
-		want  string
+		name         string
+		input        string
+		wantHint     bool   // whether a hint line is expected
+		hintContains string // substring the hint must contain
 	}{
 		{
-			name:  "warning type gets light-yellow background and border",
-			input: `<callout type="warning" emoji="📝">`,
-			want:  `<callout type="warning" emoji="📝" background-color="light-yellow" border-color="yellow">`,
+			name:         "warning type without background-color emits hint",
+			input:        `<callout type="warning" emoji="📝">`,
+			wantHint:     true,
+			hintContains: `background-color="light-yellow"`,
 		},
 		{
-			name:  "info type gets light-blue",
-			input: `<callout type="info" emoji="ℹ️">`,
-			want:  `<callout type="info" emoji="ℹ️" background-color="light-blue" border-color="blue">`,
+			name:         "info type without background-color emits hint",
+			input:        `<callout type="info" emoji="ℹ️">`,
+			wantHint:     true,
+			hintContains: `background-color="light-blue"`,
 		},
 		{
-			name:  "tip type gets light-green",
-			input: `<callout type="tip" emoji="💡">`,
-			want:  `<callout type="tip" emoji="💡" background-color="light-green" border-color="green">`,
+			name:         "single-quoted type attribute emits hint",
+			input:        `<callout type='warning' emoji="📝">`,
+			wantHint:     true,
+			hintContains: `background-color="light-yellow"`,
 		},
 		{
-			name:  "error type gets light-red",
-			input: `<callout type="error" emoji="❌">`,
-			want:  `<callout type="error" emoji="❌" background-color="light-red" border-color="red">`,
+			name:     "explicit background-color suppresses hint",
+			input:    `<callout type="warning" emoji="📝" background-color="light-red">`,
+			wantHint: false,
 		},
 		{
-			name:  "important type gets light-purple",
-			input: `<callout type="important" emoji="❗">`,
-			want:  `<callout type="important" emoji="❗" background-color="light-purple" border-color="purple">`,
+			name:     "unknown type emits no hint",
+			input:    `<callout type="custom" emoji="🔥">`,
+			wantHint: false,
 		},
 		{
-			name:  "caution type gets light-orange",
-			input: `<callout type="caution" emoji="⚠️">`,
-			want:  `<callout type="caution" emoji="⚠️" background-color="light-orange" border-color="orange">`,
+			name:     "no type attribute emits no hint",
+			input:    `<callout emoji="💡" background-color="light-green">`,
+			wantHint: false,
 		},
 		{
-			name:  "explicit background-color is preserved",
-			input: `<callout type="warning" emoji="📝" background-color="light-red">`,
-			want:  `<callout type="warning" emoji="📝" background-color="light-red">`,
+			name:     "non-callout tag emits no hint",
+			input:    `<div type="warning">`,
+			wantHint: false,
 		},
 		{
-			name:  "explicit border-color is preserved when background-color absent",
-			input: `<callout type="info" emoji="ℹ️" border-color="red">`,
-			want:  `<callout type="info" emoji="ℹ️" border-color="red" background-color="light-blue">`,
-		},
-		{
-			name:  "unknown type left unchanged",
-			input: `<callout type="custom" emoji="🔥">`,
-			want:  `<callout type="custom" emoji="🔥">`,
-		},
-		{
-			name:  "no type attribute left unchanged",
-			input: `<callout emoji="💡" background-color="light-green">`,
-			want:  `<callout emoji="💡" background-color="light-green">`,
-		},
-		{
-			name:  "non-callout tag unchanged",
-			input: `<div type="warning">`,
-			want:  `<div type="warning">`,
+			name:         "hint includes border-color suggestion",
+			input:        `<callout type="error" emoji="❌">`,
+			wantHint:     true,
+			hintContains: `border-color="red"`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := fixCalloutType(tt.input)
-			if got != tt.want {
-				t.Errorf("fixCalloutType(%q)\n  got  %q\n  want %q", tt.input, got, tt.want)
+			var buf strings.Builder
+			WarnCalloutType(tt.input, &buf)
+			got := buf.String()
+			if tt.wantHint {
+				if got == "" {
+					t.Errorf("WarnCalloutType(%q): expected hint, got no output", tt.input)
+					return
+				}
+				if tt.hintContains != "" && !strings.Contains(got, tt.hintContains) {
+					t.Errorf("WarnCalloutType(%q): hint %q missing %q", tt.input, got, tt.hintContains)
+				}
+			} else {
+				if got != "" {
+					t.Errorf("WarnCalloutType(%q): expected no output, got %q", tt.input, got)
+				}
 			}
 		})
 	}

--- a/shortcuts/doc/markdown_fix_test.go
+++ b/shortcuts/doc/markdown_fix_test.go
@@ -390,6 +390,11 @@ func TestWarnCalloutType(t *testing.T) {
 			wantHint: false,
 		},
 		{
+			name:     "whitespace around equals is tolerated in background-color",
+			input:    `<callout type="warning" emoji="📝" background-color = "light-red">`,
+			wantHint: false,
+		},
+		{
 			name:     "unknown type emits no hint",
 			input:    `<callout type="custom" emoji="🔥">`,
 			wantHint: false,

--- a/shortcuts/doc/markdown_fix_test.go
+++ b/shortcuts/doc/markdown_fix_test.go
@@ -359,6 +359,78 @@ func TestFixExportedMarkdown(t *testing.T) {
 	}
 }
 
+func TestFixCalloutType(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "warning type gets light-yellow background and border",
+			input: `<callout type="warning" emoji="📝">`,
+			want:  `<callout type="warning" emoji="📝" background-color="light-yellow" border-color="yellow">`,
+		},
+		{
+			name:  "info type gets light-blue",
+			input: `<callout type="info" emoji="ℹ️">`,
+			want:  `<callout type="info" emoji="ℹ️" background-color="light-blue" border-color="blue">`,
+		},
+		{
+			name:  "tip type gets light-green",
+			input: `<callout type="tip" emoji="💡">`,
+			want:  `<callout type="tip" emoji="💡" background-color="light-green" border-color="green">`,
+		},
+		{
+			name:  "error type gets light-red",
+			input: `<callout type="error" emoji="❌">`,
+			want:  `<callout type="error" emoji="❌" background-color="light-red" border-color="red">`,
+		},
+		{
+			name:  "important type gets light-purple",
+			input: `<callout type="important" emoji="❗">`,
+			want:  `<callout type="important" emoji="❗" background-color="light-purple" border-color="purple">`,
+		},
+		{
+			name:  "caution type gets light-orange",
+			input: `<callout type="caution" emoji="⚠️">`,
+			want:  `<callout type="caution" emoji="⚠️" background-color="light-orange" border-color="orange">`,
+		},
+		{
+			name:  "explicit background-color is preserved",
+			input: `<callout type="warning" emoji="📝" background-color="light-red">`,
+			want:  `<callout type="warning" emoji="📝" background-color="light-red">`,
+		},
+		{
+			name:  "explicit border-color is preserved when background-color absent",
+			input: `<callout type="info" emoji="ℹ️" border-color="red">`,
+			want:  `<callout type="info" emoji="ℹ️" border-color="red" background-color="light-blue">`,
+		},
+		{
+			name:  "unknown type left unchanged",
+			input: `<callout type="custom" emoji="🔥">`,
+			want:  `<callout type="custom" emoji="🔥">`,
+		},
+		{
+			name:  "no type attribute left unchanged",
+			input: `<callout emoji="💡" background-color="light-green">`,
+			want:  `<callout emoji="💡" background-color="light-green">`,
+		},
+		{
+			name:  "non-callout tag unchanged",
+			input: `<div type="warning">`,
+			want:  `<div type="warning">`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fixCalloutType(tt.input)
+			if got != tt.want {
+				t.Errorf("fixCalloutType(%q)\n  got  %q\n  want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFixCalloutEmoji(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/shortcuts/doc/markdown_fix_test.go
+++ b/shortcuts/doc/markdown_fix_test.go
@@ -415,6 +415,56 @@ func TestWarnCalloutType(t *testing.T) {
 			wantHint:     true,
 			hintContains: `border-color="red"`,
 		},
+		{
+			// Regression: the old `\btype=` regex matched the suffix of
+			// `data-type=` because `-` is a non-word character, so a tag
+			// carrying only data-attrs would silently get a bogus hint.
+			// The (?:^|\s) anchor requires a real attribute separator.
+			name:     "data-type attribute does not trigger hint",
+			input:    `<callout data-type="warning" emoji="📝">`,
+			wantHint: false,
+		},
+		{
+			// Symmetric guard for the background-color regex: a future
+			// `data-background-color=` attribute must not be mistaken
+			// for a present background-color and silently suppress the
+			// hint that the real type= would otherwise produce.
+			name:         "data-background-color does not suppress hint",
+			input:        `<callout type="warning" data-background-color="anything">`,
+			wantHint:     true,
+			hintContains: `background-color="light-yellow"`,
+		},
+		{
+			// Regression for the code-fence skip: a documentation sample
+			// inside a ``` fence is NOT a real callout the user wants
+			// rendered, so it must produce no stderr noise.
+			name: "callout inside backtick fence emits no hint",
+			input: "```markdown\n" +
+				`<callout type="warning" emoji="📝">` + "\n" +
+				"```\n",
+			wantHint: false,
+		},
+		{
+			// Same skip works for tilde fences (CommonMark §4.5 makes
+			// `~~~` an equivalent fence character).
+			name: "callout inside tilde fence emits no hint",
+			input: "~~~markdown\n" +
+				`<callout type="info" emoji="ℹ️">` + "\n" +
+				"~~~\n",
+			wantHint: false,
+		},
+		{
+			// Closing the fence must restore normal scanning: a real
+			// callout that follows a documentation block still gets a
+			// hint. Pins that fenceMarker is reset, not stuck.
+			name: "callout after fence close still emits hint",
+			input: "```markdown\n" +
+				`<callout type="warning">sample</callout>` + "\n" +
+				"```\n" +
+				`<callout type="error" emoji="❌">real</callout>` + "\n",
+			wantHint:     true,
+			hintContains: `border-color="red"`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

When a user writes `<callout type="warning" emoji="📝">` in markdown passed to `docs +create` / `docs +update`, the Feishu side renders the callout block with **no color** — `type=` is a semantic shorthand the `create-doc` API does not consume; it only understands `background-color=` / `border-color=`.

This PR is a **diagnostic, not a renderer fix**: it does not rewrite the markdown. Instead it scans the input and, when `type=` is used without an explicit `background-color=`, prints one hint line on stderr telling the user exactly which color attributes to write to get the color they probably wanted. The next manual edit fixes the document; the markdown reaching the API is byte-identical to what the user passed.

After review by [@SunPeiYang996](https://github.com/larksuite/cli/pull/467#issuecomment-4243136139) the original approach (silently expanding `type=` into the matching color pair inside the shortcut) was rejected as protocol-adaptation logic in the wrong layer. The hint-on-stderr design adopted here is option 3 of his suggested alternatives.

## Behavior

```
$ lark-cli docs +create --markdown '<callout type="warning">x</callout>'
hint: callout type="warning" has no background-color; consider: background-color="light-yellow" border-color="yellow"
{
  "ok": true,
  ...
}
```

- Markdown reaching `create-doc` is unmodified.
- Stdout JSON envelope, exit code, and dry-run renderer are all unchanged.
- Feishu rendering is unchanged from the pre-PR baseline (colorless callout); the user has to follow the hint and rewrite to get color. The PR's value is turning a silent failure into an actionable, copy-pasteable suggestion.

## Changes

- **`shortcuts/doc/markdown_fix.go`** — add `WarnCalloutType(md, w io.Writer)`. Fence-aware line walker that scans `<callout …>` opening tags; for each tag with a recognized `type=` but no `background-color=`, writes one hint line to `w`. Read-only; markdown is never modified.
- **`shortcuts/doc/docs_create.go` / `shortcuts/doc/docs_update.go`** — invoke `WarnCalloutType(runtime.Str("markdown"), runtime.IO().ErrOut)` from the v1 Execute path, immediately before the API call. v2 and `--dry-run` paths are intentionally not wired (out of scope; can be revisited if/when the same pattern proves useful there).
- **`shortcuts/doc/markdown_fix_test.go`** — 14 `TestWarnCalloutType` subtests covering emits-hint, suppression, fence skipping, attribute-prefix isolation, and regressions for false positives.

## Robustness (review fixes from @fangshuyu-768)

- **Regex anchors `(?:^|\s)type=` and `(?:^|\s)background-color\s*=`** — replace `\b`. `\b` sits at any word/non-word boundary, and `-` is a non-word character, so `\btype=` also matches the suffix of `data-type=`. Result before fix: `<callout data-type="warning">` would emit a phantom `light-yellow` hint, and a future `data-background-color=` attribute would silently suppress the real hint. The new anchor requires a real attribute separator.
- **Code fences skipped.** Walks lines and tracks fence state via the existing `codeFenceOpenMarker` / `isCodeFenceClose` helpers (CommonMark §4.5, both ` ``` ` and `~~~`). A documentation sample inside a fenced block no longer produces a phantom hint.
- **`scanCalloutTagsForWarning` extracted** as a `FindAllStringSubmatch`-based per-line scanner. Replaces the prior `ReplaceAllStringFunc`-as-iterator pattern (rebuilt string was discarded; a second regex execution inside the callback recovered the capture groups). Same observable behavior, half the work.
- **Whitespace around `=` tolerated** — `background-color = "..."` is recognized as a present attribute, same as `background-color="..."`.

## type → suggested color (advisory mapping used in hint text)

| type | background-color | border-color |
|------|-----------------|-------------|
| `warning` | `light-yellow` | `yellow` |
| `info` / `note` | `light-blue` | `blue` |
| `tip` / `success` / `check` | `light-green` | `green` |
| `error` / `danger` | `light-red` | `red` |
| `caution` | `light-orange` | `orange` |
| `important` | `light-purple` | `purple` |

This mapping is the CLI's own convention and is used **only** to compose the hint string. The markdown is never modified, so callers and downstream MCP clients are not asked to know or replicate the mapping.

## Test Plan

- [x] `go test ./shortcuts/doc/...` — 14 `TestWarnCalloutType` cases pass (incl. 5 review-driven regressions: `data-type` not triggering, `data-background-color` not suppressing, backtick fence skip, tilde fence skip, fence-state reset)
- [x] `go test -race ./shortcuts/doc/...` — clean
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `golangci-lint run --new-from-rev=origin/main` — 0 issues
- [x] Skill format check passes
- [x] Full unit suite (`go test $(go list ./... | grep -v cli_e2e) -count=1`) — all packages green
- [x] Docs e2e (`go test ./tests/cli_e2e/docs/...`) — passes

## Out of scope / follow-up

- Native `type=` support inside `create-doc` would obsolete this hint entirely; that is option 1 of @SunPeiYang996's review and the right long-term fix.
- Wiring `WarnCalloutType` into the v2 path or into `--dry-run` is a small follow-up if the diagnostic proves useful.
