### PR TITLE
feat: add scheduled send support for all send shortcuts and cancel-scheduled-send

### DIFF
--- a/shortcuts/mail/draft/service.go
+++ b/shortcuts/mail/draft/service.go
@@ -63,6 +63,11 @@ func Send(runtime *common.RuntimeContext, mailboxID, draftID string) (map[string
 	return runtime.CallAPI("POST", mailboxPath(mailboxID, "drafts", draftID, "send"), nil, nil)
 }
 
+// SendWithBody sends a draft with an optional request body (e.g. for scheduled send with send_time).
+func SendWithBody(runtime *common.RuntimeContext, mailboxID, draftID string, body map[string]interface{}) (map[string]interface{}, error) {
+	return runtime.CallAPI("POST", mailboxPath(mailboxID, "drafts", draftID, "send"), nil, body)
+}
+
 func extractDraftID(data map[string]interface{}) string {
 	if id, ok := data["draft_id"].(string); ok && strings.TrimSpace(id) != "" {
 		return strings.TrimSpace(id)

--- a/shortcuts/mail/mail_cancel_scheduled_send.go
+++ b/shortcuts/mail/mail_cancel_scheduled_send.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// MailCancelScheduledSend cancels a scheduled email send, restoring the message as a draft.
+var MailCancelScheduledSend = common.Shortcut{
+	Service:     "mail",
+	Command:     "+cancel-scheduled-send",
+	Description: "Cancel a scheduled email send. The email will be restored as a draft.",
+	Risk:        "write",
+	Scopes:      []string{"mail:user_mailbox.message:send"},
+	AuthTypes:   []string{"user"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "message-id", Desc: "Message ID of the scheduled email to cancel (required)", Required: true},
+		{Name: "user-mailbox-id", Desc: "User mailbox ID (default: me)"},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if runtime.Str("message-id") == "" {
+			return output.ErrValidation("--message-id is required")
+		}
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		messageID := runtime.Str("message-id")
+		userMailboxID := runtime.Str("user-mailbox-id")
+		if userMailboxID == "" {
+			userMailboxID = "me"
+		}
+		return common.NewDryRunAPI().
+			Desc("Cancel scheduled send — message will be restored as draft").
+			POST(fmt.Sprintf(
+				"/open-apis/mail/v1/user_mailboxes/%s/messages/%s/cancel_scheduled_send",
+				validate.EncodePathSegment(userMailboxID),
+				validate.EncodePathSegment(messageID),
+			))
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		messageID := runtime.Str("message-id")
+		userMailboxID := runtime.Str("user-mailbox-id")
+		if userMailboxID == "" {
+			userMailboxID = "me"
+		}
+
+		path := fmt.Sprintf(
+			"/open-apis/mail/v1/user_mailboxes/%s/messages/%s/cancel_scheduled_send",
+			validate.EncodePathSegment(userMailboxID),
+			validate.EncodePathSegment(messageID),
+		)
+
+		_, err := runtime.CallAPI("POST", path, nil, nil)
+		if err != nil {
+			return err
+		}
+
+		result := map[string]interface{}{
+			"message_id":        messageID,
+			"status":            "cancelled",
+			"restored_as_draft": true,
+		}
+
+		runtime.Out(result, nil)
+		fmt.Fprintf(runtime.IO().ErrOut,
+			"tip: The scheduled send has been cancelled and the message restored as a draft.\n"+
+				"  Use lark-cli mail +draft-edit --id %s to edit\n"+
+				"  Use lark-cli mail user-mailbox-drafts send --draft-id %s --confirm-send to send immediately\n",
+			messageID, messageID)
+
+		return nil
+	},
+}

--- a/shortcuts/mail/mail_cancel_scheduled_send_test.go
+++ b/shortcuts/mail/mail_cancel_scheduled_send_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestCancelScheduledSend_Success(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/messages/msg_sched123/cancel_scheduled_send",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailCancelScheduledSend, []string{
+		"+cancel-scheduled-send",
+		"--message-id", "msg_sched123",
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["message_id"] != "msg_sched123" {
+		t.Fatalf("expected message_id=msg_sched123, got %v", data["message_id"])
+	}
+	if data["status"] != "cancelled" {
+		t.Fatalf("expected status=cancelled, got %v", data["status"])
+	}
+	if data["restored_as_draft"] != true {
+		t.Fatalf("expected restored_as_draft=true, got %v", data["restored_as_draft"])
+	}
+}
+
+func TestCancelScheduledSend_WithMailboxID(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/mbx_custom/messages/msg_sched456/cancel_scheduled_send",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailCancelScheduledSend, []string{
+		"+cancel-scheduled-send",
+		"--message-id", "msg_sched456",
+		"--user-mailbox-id", "mbx_custom",
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["message_id"] != "msg_sched456" {
+		t.Fatalf("expected message_id=msg_sched456, got %v", data["message_id"])
+	}
+}
+
+func TestCancelScheduledSend_MissingMessageID(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailCancelScheduledSend, []string{
+		"+cancel-scheduled-send",
+	}, f, stdout)
+
+	if err == nil {
+		t.Fatal("expected error for missing --message-id")
+	}
+}
+
+func TestCancelScheduledSend_APIError(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/messages/msg_bad/cancel_scheduled_send",
+		Body: map[string]interface{}{
+			"code": 99991,
+			"msg":  "message not found",
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailCancelScheduledSend, []string{
+		"+cancel-scheduled-send",
+		"--message-id", "msg_bad",
+	}, f, stdout)
+
+	if err == nil {
+		t.Fatal("expected error for API failure")
+	}
+}

--- a/shortcuts/mail/mail_forward.go
+++ b/shortcuts/mail/mail_forward.go
@@ -34,22 +34,30 @@ var MailForward = common.Shortcut{
 		{Name: "attach", Desc: "Attachment file path(s), comma-separated, appended after original attachments (relative path only)"},
 		{Name: "inline", Desc: "Inline images as a JSON array. Each entry: {\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}. All file_path values must be relative paths. Cannot be used with --plain-text. CID images are embedded via <img src=\"cid:...\"> in the HTML body. CID is a unique identifier, e.g. a random hex string like \"a1b2c3d4e5f6a7b8c9d0\"."},
 		{Name: "confirm-send", Type: "bool", Desc: "Send the forward immediately instead of saving as draft. Only use after the user has explicitly confirmed recipients and content."},
+		{Name: "send-time", Desc: "Schedule the forward to be sent at a future time (RFC 3339 format, e.g. 2026-04-14T09:00:00+08:00). Requires --confirm-send to actually schedule."},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		messageId := runtime.Str("message-id")
 		to := runtime.Str("to")
 		confirmSend := runtime.Bool("confirm-send")
+		sendTimeStr := runtime.Str("send-time")
 		mailboxID := resolveComposeMailboxID(runtime)
 		desc := "Forward: fetch original message → resolve sender address → save as draft"
-		if confirmSend {
+		if confirmSend && sendTimeStr != "" {
+			desc = "Forward (--confirm-send --send-time): fetch original message → resolve sender address → create draft → schedule send"
+		} else if confirmSend {
 			desc = "Forward (--confirm-send): fetch original message → resolve sender address → create draft → send draft"
+		}
+		body := map[string]interface{}{"raw": "<base64url-EML>", "_to": to}
+		if sendTimeStr != "" {
+			body["send_time"] = sendTimeStr
 		}
 		api := common.NewDryRunAPI().
 			Desc(desc).
 			GET(mailboxPath(mailboxID, "messages", messageId)).
 			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
-			Body(map[string]interface{}{"raw": "<base64url-EML>", "_to": to})
+			Body(body)
 		if confirmSend {
 			api = api.POST(mailboxPath(mailboxID, "drafts", "<draft_id>", "send"))
 		}
@@ -61,6 +69,11 @@ var MailForward = common.Shortcut{
 		}
 		if runtime.Bool("confirm-send") {
 			if err := validateComposeHasAtLeastOneRecipient(runtime.Str("to"), runtime.Str("cc"), runtime.Str("bcc")); err != nil {
+				return err
+			}
+		}
+		if sendTimeStr := runtime.Str("send-time"); sendTimeStr != "" {
+			if _, err := parseAndValidateSendTime(sendTimeStr); err != nil {
 				return err
 			}
 		}
@@ -76,6 +89,7 @@ var MailForward = common.Shortcut{
 		attachFlag := runtime.Str("attach")
 		inlineFlag := runtime.Str("inline")
 		confirmSend := runtime.Bool("confirm-send")
+		sendTimeStr := runtime.Str("send-time")
 
 		mailboxID := resolveComposeMailboxID(runtime)
 		sourceMsg, err := fetchComposeSourceMessage(runtime, mailboxID, messageId)
@@ -211,21 +225,44 @@ var MailForward = common.Shortcut{
 			return fmt.Errorf("failed to create draft: %w", err)
 		}
 		if !confirmSend {
-			runtime.Out(map[string]interface{}{
+			outData := map[string]interface{}{
 				"draft_id": draftID,
 				"tip":      fmt.Sprintf(`draft saved. To send: lark-cli mail user_mailbox.drafts send --params '{"user_mailbox_id":"%s","draft_id":"%s"}'`, mailboxID, draftID),
-			}, nil)
+			}
+			if sendTimeStr != "" {
+				outData["tip"] = fmt.Sprintf(
+					`draft saved. To schedule send, add --confirm-send: lark-cli mail +forward --send-time %q --confirm-send`, sendTimeStr)
+			}
+			runtime.Out(outData, nil)
 			hintSendDraft(runtime, mailboxID, draftID)
 			return nil
 		}
-		resData, err := draftpkg.Send(runtime, mailboxID, draftID)
+		var resData map[string]interface{}
+		if sendTimeStr != "" {
+			validatedTime, parseErr := parseAndValidateSendTime(sendTimeStr)
+			if parseErr != nil {
+				return parseErr
+			}
+			sendBody := map[string]interface{}{"send_time": validatedTime}
+			resData, err = draftpkg.SendWithBody(runtime, mailboxID, draftID, sendBody)
+		} else {
+			resData, err = draftpkg.Send(runtime, mailboxID, draftID)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to send forward (draft %s created but not sent): %w", draftID, err)
 		}
-		runtime.Out(map[string]interface{}{
+		outData := map[string]interface{}{
 			"message_id": resData["message_id"],
 			"thread_id":  resData["thread_id"],
-		}, nil)
+		}
+		if sendTimeStr != "" {
+			outData["status"] = "scheduled"
+			outData["send_time"] = sendTimeStr
+			if msgID, ok := resData["message_id"].(string); ok && msgID != "" {
+				outData["tip"] = fmt.Sprintf("To cancel: lark-cli mail +cancel-scheduled-send --message-id %s", msgID)
+			}
+		}
+		runtime.Out(outData, nil)
 		hintMarkAsRead(runtime, mailboxID, messageId)
 		return nil
 	},

--- a/shortcuts/mail/mail_reply.go
+++ b/shortcuts/mail/mail_reply.go
@@ -32,21 +32,29 @@ var MailReply = common.Shortcut{
 		{Name: "attach", Desc: "Attachment file path(s), comma-separated (relative path only)"},
 		{Name: "inline", Desc: "Inline images as a JSON array. Each entry: {\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}. All file_path values must be relative paths. Cannot be used with --plain-text. CID images are embedded via <img src=\"cid:...\"> in the HTML body. CID is a unique identifier, e.g. a random hex string like \"a1b2c3d4e5f6a7b8c9d0\"."},
 		{Name: "confirm-send", Type: "bool", Desc: "Send the reply immediately instead of saving as draft. Only use after the user has explicitly confirmed recipients and content."},
+		{Name: "send-time", Desc: "Schedule the reply to be sent at a future time (RFC 3339 format, e.g. 2026-04-14T09:00:00+08:00). Requires --confirm-send to actually schedule."},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		messageId := runtime.Str("message-id")
 		confirmSend := runtime.Bool("confirm-send")
+		sendTimeStr := runtime.Str("send-time")
 		mailboxID := resolveComposeMailboxID(runtime)
 		desc := "Reply: fetch original message → resolve sender address → save as draft"
-		if confirmSend {
+		if confirmSend && sendTimeStr != "" {
+			desc = "Reply (--confirm-send --send-time): fetch original message → resolve sender address → create draft → schedule send"
+		} else if confirmSend {
 			desc = "Reply (--confirm-send): fetch original message → resolve sender address → create draft → send draft"
+		}
+		body := map[string]interface{}{"raw": "<base64url-EML>"}
+		if sendTimeStr != "" {
+			body["send_time"] = sendTimeStr
 		}
 		api := common.NewDryRunAPI().
 			Desc(desc).
 			GET(mailboxPath(mailboxID, "messages", messageId)).
 			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
-			Body(map[string]interface{}{"raw": "<base64url-EML>"})
+			Body(body)
 		if confirmSend {
 			api = api.POST(mailboxPath(mailboxID, "drafts", "<draft_id>", "send"))
 		}
@@ -55,6 +63,11 @@ var MailReply = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := validateConfirmSendScope(runtime); err != nil {
 			return err
+		}
+		if sendTimeStr := runtime.Str("send-time"); sendTimeStr != "" {
+			if _, err := parseAndValidateSendTime(sendTimeStr); err != nil {
+				return err
+			}
 		}
 		return validateComposeInlineAndAttachments(runtime.FileIO(), runtime.Str("attach"), runtime.Str("inline"), runtime.Bool("plain-text"), "")
 	},
@@ -68,6 +81,7 @@ var MailReply = common.Shortcut{
 		attachFlag := runtime.Str("attach")
 		inlineFlag := runtime.Str("inline")
 		confirmSend := runtime.Bool("confirm-send")
+		sendTimeStr := runtime.Str("send-time")
 
 		inlineSpecs, err := parseInlineSpecs(inlineFlag)
 		if err != nil {
@@ -174,21 +188,44 @@ var MailReply = common.Shortcut{
 			return fmt.Errorf("failed to create draft: %w", err)
 		}
 		if !confirmSend {
-			runtime.Out(map[string]interface{}{
+			outData := map[string]interface{}{
 				"draft_id": draftID,
 				"tip":      fmt.Sprintf(`draft saved. To send: lark-cli mail user_mailbox.drafts send --params '{"user_mailbox_id":"%s","draft_id":"%s"}'`, mailboxID, draftID),
-			}, nil)
+			}
+			if sendTimeStr != "" {
+				outData["tip"] = fmt.Sprintf(
+					`draft saved. To schedule send, add --confirm-send: lark-cli mail +reply --send-time %q --confirm-send`, sendTimeStr)
+			}
+			runtime.Out(outData, nil)
 			hintSendDraft(runtime, mailboxID, draftID)
 			return nil
 		}
-		resData, err := draftpkg.Send(runtime, mailboxID, draftID)
+		var resData map[string]interface{}
+		if sendTimeStr != "" {
+			validatedTime, parseErr := parseAndValidateSendTime(sendTimeStr)
+			if parseErr != nil {
+				return parseErr
+			}
+			sendBody := map[string]interface{}{"send_time": validatedTime}
+			resData, err = draftpkg.SendWithBody(runtime, mailboxID, draftID, sendBody)
+		} else {
+			resData, err = draftpkg.Send(runtime, mailboxID, draftID)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to send reply (draft %s created but not sent): %w", draftID, err)
 		}
-		runtime.Out(map[string]interface{}{
+		outData := map[string]interface{}{
 			"message_id": resData["message_id"],
 			"thread_id":  resData["thread_id"],
-		}, nil)
+		}
+		if sendTimeStr != "" {
+			outData["status"] = "scheduled"
+			outData["send_time"] = sendTimeStr
+			if msgID, ok := resData["message_id"].(string); ok && msgID != "" {
+				outData["tip"] = fmt.Sprintf("To cancel: lark-cli mail +cancel-scheduled-send --message-id %s", msgID)
+			}
+		}
+		runtime.Out(outData, nil)
 		hintMarkAsRead(runtime, mailboxID, messageId)
 		return nil
 	},

--- a/shortcuts/mail/mail_reply_all.go
+++ b/shortcuts/mail/mail_reply_all.go
@@ -33,21 +33,29 @@ var MailReplyAll = common.Shortcut{
 		{Name: "attach", Desc: "Attachment file path(s), comma-separated (relative path only)"},
 		{Name: "inline", Desc: "Inline images as a JSON array. Each entry: {\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}. All file_path values must be relative paths. Cannot be used with --plain-text. CID images are embedded via <img src=\"cid:...\"> in the HTML body. CID is a unique identifier, e.g. a random hex string like \"a1b2c3d4e5f6a7b8c9d0\"."},
 		{Name: "confirm-send", Type: "bool", Desc: "Send the reply immediately instead of saving as draft. Only use after the user has explicitly confirmed recipients and content."},
+		{Name: "send-time", Desc: "Schedule the reply to be sent at a future time (RFC 3339 format, e.g. 2026-04-14T09:00:00+08:00). Requires --confirm-send to actually schedule."},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		messageId := runtime.Str("message-id")
 		confirmSend := runtime.Bool("confirm-send")
+		sendTimeStr := runtime.Str("send-time")
 		mailboxID := resolveComposeMailboxID(runtime)
 		desc := "Reply-all: fetch original message (with recipients) → resolve sender address → save as draft"
-		if confirmSend {
+		if confirmSend && sendTimeStr != "" {
+			desc = "Reply-all (--confirm-send --send-time): fetch original message → resolve sender address → create draft → schedule send"
+		} else if confirmSend {
 			desc = "Reply-all (--confirm-send): fetch original message (with recipients) → resolve sender address → create draft → send draft"
+		}
+		body := map[string]interface{}{"raw": "<base64url-EML>"}
+		if sendTimeStr != "" {
+			body["send_time"] = sendTimeStr
 		}
 		api := common.NewDryRunAPI().
 			Desc(desc).
 			GET(mailboxPath(mailboxID, "messages", messageId)).
 			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
-			Body(map[string]interface{}{"raw": "<base64url-EML>"})
+			Body(body)
 		if confirmSend {
 			api = api.POST(mailboxPath(mailboxID, "drafts", "<draft_id>", "send"))
 		}
@@ -56,6 +64,11 @@ var MailReplyAll = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := validateConfirmSendScope(runtime); err != nil {
 			return err
+		}
+		if sendTimeStr := runtime.Str("send-time"); sendTimeStr != "" {
+			if _, err := parseAndValidateSendTime(sendTimeStr); err != nil {
+				return err
+			}
 		}
 		return validateComposeInlineAndAttachments(runtime.FileIO(), runtime.Str("attach"), runtime.Str("inline"), runtime.Bool("plain-text"), "")
 	},
@@ -70,6 +83,7 @@ var MailReplyAll = common.Shortcut{
 		attachFlag := runtime.Str("attach")
 		inlineFlag := runtime.Str("inline")
 		confirmSend := runtime.Bool("confirm-send")
+		sendTimeStr := runtime.Str("send-time")
 
 		inlineSpecs, err := parseInlineSpecs(inlineFlag)
 		if err != nil {
@@ -188,21 +202,44 @@ var MailReplyAll = common.Shortcut{
 			return fmt.Errorf("failed to create draft: %w", err)
 		}
 		if !confirmSend {
-			runtime.Out(map[string]interface{}{
+			outData := map[string]interface{}{
 				"draft_id": draftID,
 				"tip":      fmt.Sprintf(`draft saved. To send: lark-cli mail user_mailbox.drafts send --params '{"user_mailbox_id":"%s","draft_id":"%s"}'`, mailboxID, draftID),
-			}, nil)
+			}
+			if sendTimeStr != "" {
+				outData["tip"] = fmt.Sprintf(
+					`draft saved. To schedule send, add --confirm-send: lark-cli mail +reply-all --send-time %q --confirm-send`, sendTimeStr)
+			}
+			runtime.Out(outData, nil)
 			hintSendDraft(runtime, mailboxID, draftID)
 			return nil
 		}
-		resData, err := draftpkg.Send(runtime, mailboxID, draftID)
+		var resData map[string]interface{}
+		if sendTimeStr != "" {
+			validatedTime, parseErr := parseAndValidateSendTime(sendTimeStr)
+			if parseErr != nil {
+				return parseErr
+			}
+			sendBody := map[string]interface{}{"send_time": validatedTime}
+			resData, err = draftpkg.SendWithBody(runtime, mailboxID, draftID, sendBody)
+		} else {
+			resData, err = draftpkg.Send(runtime, mailboxID, draftID)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to send reply-all (draft %s created but not sent): %w", draftID, err)
 		}
-		runtime.Out(map[string]interface{}{
+		outData := map[string]interface{}{
 			"message_id": resData["message_id"],
 			"thread_id":  resData["thread_id"],
-		}, nil)
+		}
+		if sendTimeStr != "" {
+			outData["status"] = "scheduled"
+			outData["send_time"] = sendTimeStr
+			if msgID, ok := resData["message_id"].(string); ok && msgID != "" {
+				outData["tip"] = fmt.Sprintf("To cancel: lark-cli mail +cancel-scheduled-send --message-id %s", msgID)
+			}
+		}
+		runtime.Out(outData, nil)
 		hintMarkAsRead(runtime, mailboxID, messageId)
 		return nil
 	},

--- a/shortcuts/mail/mail_scheduled_send_test.go
+++ b/shortcuts/mail/mail_scheduled_send_test.go
@@ -1,0 +1,450 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/zalando/go-keyring"
+
+	"github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+// mailShortcutTestFactoryWithSendScope creates a test factory with the send scope included.
+func mailShortcutTestFactoryWithSendScope(t *testing.T) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer, *httpmock.Registry) {
+	t.Helper()
+	keyring.MockInit()
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := mailTestConfig()
+	token := &auth.StoredUAToken{
+		UserOpenId:       cfg.UserOpenId,
+		AppId:            cfg.AppID,
+		AccessToken:      "test-user-access-token",
+		RefreshToken:     "test-refresh-token",
+		ExpiresAt:        time.Now().Add(1 * time.Hour).UnixMilli(),
+		RefreshExpiresAt: time.Now().Add(24 * time.Hour).UnixMilli(),
+		Scope:            "mail:user_mailbox.messages:write mail:user_mailbox.messages:read mail:user_mailbox.message:modify mail:user_mailbox.message:readonly mail:user_mailbox.message.address:read mail:user_mailbox.message.subject:read mail:user_mailbox.message.body:read mail:user_mailbox:readonly mail:user_mailbox.message:send",
+		GrantedAt:        time.Now().Add(-1 * time.Hour).UnixMilli(),
+	}
+	if err := auth.SetStoredToken(token); err != nil {
+		t.Fatalf("SetStoredToken() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = auth.RemoveStoredToken(cfg.AppID, cfg.UserOpenId)
+	})
+
+	return cmdutil.TestFactory(t, cfg)
+}
+
+// stubScheduledSendEndpoints registers HTTP stubs for profile, draft create, and draft send.
+func stubScheduledSendEndpoints(reg *httpmock.Registry) {
+	// Profile
+	reg.Register(&httpmock.Stub{
+		URL: "/user_mailboxes/me/profile",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"primary_email_address": "me@example.com",
+			},
+		},
+	})
+
+	// Draft create
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"draft_id": "draft_sched001",
+			},
+		},
+	})
+
+	// Draft send (for confirm-send)
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts/draft_sched001/send",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"message_id": "msg_sched001",
+				"thread_id":  "thread_sched001",
+			},
+		},
+	})
+}
+
+// stubScheduledSendEndpointsNoSend registers stubs for profile and draft create only (no send).
+func stubScheduledSendEndpointsNoSend(reg *httpmock.Registry) {
+	reg.Register(&httpmock.Stub{
+		URL: "/user_mailboxes/me/profile",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"primary_email_address": "me@example.com",
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"draft_id": "draft_sched001",
+			},
+		},
+	})
+}
+
+// stubReplyScheduledSendEndpoints registers stubs for reply/reply-all/forward with scheduled send.
+func stubReplyScheduledSendEndpoints(reg *httpmock.Registry) {
+	reg.Register(&httpmock.Stub{
+		URL: "/user_mailboxes/me/profile",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"primary_email_address": "me@example.com",
+			},
+		},
+	})
+
+	reg.Register(&httpmock.Stub{
+		URL: "/user_mailboxes/me/messages/msg_orig001",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"message": map[string]interface{}{
+					"message_id":      "msg_orig001",
+					"thread_id":       "thread_orig001",
+					"smtp_message_id": "<msg_orig001@example.com>",
+					"subject":         "Original Subject",
+					"head_from":       map[string]interface{}{"mail_address": "sender@example.com", "name": "Sender"},
+					"to":              []map[string]interface{}{{"mail_address": "me@example.com", "name": "Me"}},
+					"cc":              []interface{}{},
+					"bcc":             []interface{}{},
+					"body_html":       base64.URLEncoding.EncodeToString([]byte("<p>Original body</p>")),
+					"body_plain_text": base64.URLEncoding.EncodeToString([]byte("Original body")),
+					"internal_date":   "1704067200000",
+					"attachments":     []interface{}{},
+				},
+			},
+		},
+	})
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"draft_id": "draft_sched001",
+			},
+		},
+	})
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts/draft_sched001/send",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"message_id": "msg_sched001",
+				"thread_id":  "thread_sched001",
+			},
+		},
+	})
+}
+
+// stubReplyScheduledSendEndpointsNoSend registers stubs without draft send (for draft-only tests).
+func stubReplyScheduledSendEndpointsNoSend(reg *httpmock.Registry) {
+	reg.Register(&httpmock.Stub{
+		URL: "/user_mailboxes/me/profile",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"primary_email_address": "me@example.com",
+			},
+		},
+	})
+
+	reg.Register(&httpmock.Stub{
+		URL: "/user_mailboxes/me/messages/msg_orig001",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"message": map[string]interface{}{
+					"message_id":      "msg_orig001",
+					"thread_id":       "thread_orig001",
+					"smtp_message_id": "<msg_orig001@example.com>",
+					"subject":         "Original Subject",
+					"head_from":       map[string]interface{}{"mail_address": "sender@example.com", "name": "Sender"},
+					"to":              []map[string]interface{}{{"mail_address": "me@example.com", "name": "Me"}},
+					"cc":              []interface{}{},
+					"bcc":             []interface{}{},
+					"body_html":       base64.URLEncoding.EncodeToString([]byte("<p>Original body</p>")),
+					"body_plain_text": base64.URLEncoding.EncodeToString([]byte("Original body")),
+					"internal_date":   "1704067200000",
+					"attachments":     []interface{}{},
+				},
+			},
+		},
+	})
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"draft_id": "draft_sched001",
+			},
+		},
+	})
+}
+
+func futureTimeStr() string {
+	return time.Now().Add(2 * time.Hour).Format(time.RFC3339)
+}
+
+// ---------------------------------------------------------------------------
+// +send scheduled send tests
+// ---------------------------------------------------------------------------
+
+func TestSend_ScheduledSend_DraftOnly(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	stubScheduledSendEndpointsNoSend(reg)
+
+	sendTime := futureTimeStr()
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--to", "recipient@example.com",
+		"--subject", "Scheduled Test",
+		"--body", "<p>Hello</p>",
+		"--send-time", sendTime,
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["draft_id"] != "draft_sched001" {
+		t.Fatalf("expected draft_id=draft_sched001, got %v", data["draft_id"])
+	}
+}
+
+func TestSend_ScheduledSend_WithConfirmSend(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+	stubScheduledSendEndpoints(reg)
+
+	sendTime := futureTimeStr()
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--to", "recipient@example.com",
+		"--subject", "Scheduled Test",
+		"--body", "<p>Hello</p>",
+		"--send-time", sendTime,
+		"--confirm-send",
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["status"] != "scheduled" {
+		t.Fatalf("expected status=scheduled, got %v", data["status"])
+	}
+	if data["message_id"] != "msg_sched001" {
+		t.Fatalf("expected message_id=msg_sched001, got %v", data["message_id"])
+	}
+}
+
+func TestSend_ScheduledSend_InvalidTime(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--to", "recipient@example.com",
+		"--subject", "Scheduled Test",
+		"--body", "<p>Hello</p>",
+		"--send-time", "not-a-date",
+	}, f, stdout)
+
+	if err == nil {
+		t.Fatal("expected error for invalid send-time")
+	}
+}
+
+func TestSend_ScheduledSend_TooSoon(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	tooSoon := time.Now().Add(1 * time.Minute).Format(time.RFC3339)
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--to", "recipient@example.com",
+		"--subject", "Scheduled Test",
+		"--body", "<p>Hello</p>",
+		"--send-time", tooSoon,
+	}, f, stdout)
+
+	if err == nil {
+		t.Fatal("expected error for send-time too soon")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// +reply scheduled send tests
+// ---------------------------------------------------------------------------
+
+func TestReply_ScheduledSend_WithConfirmSend(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+	stubReplyScheduledSendEndpoints(reg)
+
+	sendTime := futureTimeStr()
+	err := runMountedMailShortcut(t, MailReply, []string{
+		"+reply",
+		"--message-id", "msg_orig001",
+		"--body", "<p>Reply body</p>",
+		"--send-time", sendTime,
+		"--confirm-send",
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["status"] != "scheduled" {
+		t.Fatalf("expected status=scheduled, got %v", data["status"])
+	}
+}
+
+func TestReply_ScheduledSend_DraftOnly(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	stubReplyScheduledSendEndpointsNoSend(reg)
+
+	sendTime := futureTimeStr()
+	err := runMountedMailShortcut(t, MailReply, []string{
+		"+reply",
+		"--message-id", "msg_orig001",
+		"--body", "<p>Reply body</p>",
+		"--send-time", sendTime,
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["draft_id"] != "draft_sched001" {
+		t.Fatalf("expected draft_id=draft_sched001, got %v", data["draft_id"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// +reply-all scheduled send tests
+// ---------------------------------------------------------------------------
+
+func TestReplyAll_ScheduledSend_WithConfirmSend(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+	stubReplyScheduledSendEndpoints(reg)
+
+	sendTime := futureTimeStr()
+	err := runMountedMailShortcut(t, MailReplyAll, []string{
+		"+reply-all",
+		"--message-id", "msg_orig001",
+		"--body", "<p>Reply all body</p>",
+		"--send-time", sendTime,
+		"--confirm-send",
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["status"] != "scheduled" {
+		t.Fatalf("expected status=scheduled, got %v", data["status"])
+	}
+}
+
+func TestReplyAll_ScheduledSend_DraftOnly(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	stubReplyScheduledSendEndpointsNoSend(reg)
+
+	sendTime := futureTimeStr()
+	err := runMountedMailShortcut(t, MailReplyAll, []string{
+		"+reply-all",
+		"--message-id", "msg_orig001",
+		"--body", "<p>Reply all body</p>",
+		"--send-time", sendTime,
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["draft_id"] != "draft_sched001" {
+		t.Fatalf("expected draft_id=draft_sched001, got %v", data["draft_id"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// +forward scheduled send tests
+// ---------------------------------------------------------------------------
+
+func TestForward_ScheduledSend_WithConfirmSend(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+	stubReplyScheduledSendEndpoints(reg)
+
+	sendTime := futureTimeStr()
+	err := runMountedMailShortcut(t, MailForward, []string{
+		"+forward",
+		"--message-id", "msg_orig001",
+		"--to", "forward-to@example.com",
+		"--send-time", sendTime,
+		"--confirm-send",
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["status"] != "scheduled" {
+		t.Fatalf("expected status=scheduled, got %v", data["status"])
+	}
+}
+
+func TestForward_ScheduledSend_DraftOnly(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	stubReplyScheduledSendEndpointsNoSend(reg)
+
+	sendTime := futureTimeStr()
+	err := runMountedMailShortcut(t, MailForward, []string{
+		"+forward",
+		"--message-id", "msg_orig001",
+		"--to", "forward-to@example.com",
+		"--send-time", sendTime,
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if data["draft_id"] != "draft_sched001" {
+		t.Fatalf("expected draft_id=draft_sched001, got %v", data["draft_id"])
+	}
+}

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -32,27 +32,35 @@ var MailSend = common.Shortcut{
 		{Name: "attach", Desc: "Attachment file path(s), comma-separated (relative path only)"},
 		{Name: "inline", Desc: "Inline images as a JSON array. Each entry: {\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}. All file_path values must be relative paths. Cannot be used with --plain-text. CID images are embedded via <img src=\"cid:...\"> in the HTML body. CID is a unique identifier, e.g. a random hex string like \"a1b2c3d4e5f6a7b8c9d0\"."},
 		{Name: "confirm-send", Type: "bool", Desc: "Send the email immediately instead of saving as draft. Only use after the user has explicitly confirmed recipients and content."},
+		{Name: "send-time", Desc: "Schedule the email to be sent at a future time (RFC 3339 format, e.g. 2026-04-14T09:00:00+08:00). Requires --confirm-send to actually schedule."},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		to := runtime.Str("to")
 		subject := runtime.Str("subject")
 		confirmSend := runtime.Bool("confirm-send")
+		sendTimeStr := runtime.Str("send-time")
 		mailboxID := resolveComposeMailboxID(runtime)
 		desc := "Compose email → save as draft"
-		if confirmSend {
+		if confirmSend && sendTimeStr != "" {
+			desc = "Compose email → save as draft → schedule send"
+		} else if confirmSend {
 			desc = "Compose email → save as draft → send draft"
+		}
+		bodyPreview := map[string]interface{}{
+			"raw": "<base64url-EML>",
+			"_preview": map[string]interface{}{
+				"to":      to,
+				"subject": subject,
+			},
+		}
+		if sendTimeStr != "" {
+			bodyPreview["send_time"] = sendTimeStr
 		}
 		api := common.NewDryRunAPI().
 			Desc(desc).
 			GET(mailboxPath(mailboxID, "profile")).
 			POST(mailboxPath(mailboxID, "drafts")).
-			Body(map[string]interface{}{
-				"raw": "<base64url-EML>",
-				"_preview": map[string]interface{}{
-					"to":      to,
-					"subject": subject,
-				},
-			})
+			Body(bodyPreview)
 		if confirmSend {
 			api = api.POST(mailboxPath(mailboxID, "drafts", "<draft_id>", "send"))
 		}
@@ -61,6 +69,11 @@ var MailSend = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := validateComposeHasAtLeastOneRecipient(runtime.Str("to"), runtime.Str("cc"), runtime.Str("bcc")); err != nil {
 			return err
+		}
+		if sendTimeStr := runtime.Str("send-time"); sendTimeStr != "" {
+			if _, err := parseAndValidateSendTime(sendTimeStr); err != nil {
+				return err
+			}
 		}
 		return validateComposeInlineAndAttachments(runtime.FileIO(), runtime.Str("attach"), runtime.Str("inline"), runtime.Bool("plain-text"), runtime.Str("body"))
 	},
@@ -74,6 +87,7 @@ var MailSend = common.Shortcut{
 		attachFlag := runtime.Str("attach")
 		inlineFlag := runtime.Str("inline")
 		confirmSend := runtime.Bool("confirm-send")
+		sendTimeStr := runtime.Str("send-time")
 
 		senderEmail := resolveComposeSenderEmail(runtime)
 
@@ -138,21 +152,44 @@ var MailSend = common.Shortcut{
 			return fmt.Errorf("failed to create draft: %w", err)
 		}
 		if !confirmSend {
-			runtime.Out(map[string]interface{}{
+			outData := map[string]interface{}{
 				"draft_id": draftID,
 				"tip":      fmt.Sprintf(`draft saved. To send: lark-cli mail user_mailbox.drafts send --params '{"user_mailbox_id":"%s","draft_id":"%s"}'`, mailboxID, draftID),
-			}, nil)
+			}
+			if sendTimeStr != "" {
+				outData["tip"] = fmt.Sprintf(
+					`draft saved. To schedule send, add --confirm-send: lark-cli mail +send --send-time %q --confirm-send`, sendTimeStr)
+			}
+			runtime.Out(outData, nil)
 			hintSendDraft(runtime, mailboxID, draftID)
 			return nil
 		}
-		resData, err := draftpkg.Send(runtime, mailboxID, draftID)
+		var resData map[string]interface{}
+		if sendTimeStr != "" {
+			validatedTime, parseErr := parseAndValidateSendTime(sendTimeStr)
+			if parseErr != nil {
+				return parseErr
+			}
+			sendBody := map[string]interface{}{"send_time": validatedTime}
+			resData, err = draftpkg.SendWithBody(runtime, mailboxID, draftID, sendBody)
+		} else {
+			resData, err = draftpkg.Send(runtime, mailboxID, draftID)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to send email (draft %s created but not sent): %w", draftID, err)
 		}
-		runtime.Out(map[string]interface{}{
+		outData := map[string]interface{}{
 			"message_id": resData["message_id"],
 			"thread_id":  resData["thread_id"],
-		}, nil)
+		}
+		if sendTimeStr != "" {
+			outData["status"] = "scheduled"
+			outData["send_time"] = sendTimeStr
+			if msgID, ok := resData["message_id"].(string); ok && msgID != "" {
+				outData["tip"] = fmt.Sprintf("To cancel: lark-cli mail +cancel-scheduled-send --message-id %s", msgID)
+			}
+		}
+		runtime.Out(outData, nil)
 		return nil
 	},
 }

--- a/shortcuts/mail/scheduled_send.go
+++ b/shortcuts/mail/scheduled_send.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/larksuite/cli/internal/output"
+)
+
+const (
+	// minScheduleLeadTime is the minimum time in the future for scheduled send.
+	minScheduleLeadTime = 5 * time.Minute
+)
+
+// parseAndValidateSendTime parses and validates the --send-time flag value.
+// Returns the RFC 3339 string to pass to the API, or an error if invalid.
+// If sendTimeStr is empty, returns ("", nil) indicating immediate send.
+func parseAndValidateSendTime(sendTimeStr string) (string, error) {
+	if sendTimeStr == "" {
+		return "", nil
+	}
+
+	t, err := time.Parse(time.RFC3339, sendTimeStr)
+	if err != nil {
+		// Try parsing without timezone offset - default to UTC
+		t, err = time.Parse("2006-01-02T15:04:05", sendTimeStr)
+		if err != nil {
+			return "", output.ErrValidation(
+				"Invalid time format for --send-time. Use RFC 3339 format, e.g. 2026-04-14T09:00:00+08:00",
+			)
+		}
+		t = t.UTC()
+	}
+
+	if time.Until(t) < minScheduleLeadTime {
+		return "", output.ErrValidation(
+			"Scheduled time must be at least 5 minutes in the future",
+		)
+	}
+
+	return t.Format(time.RFC3339), nil
+}
+
+// formatScheduledTimeHuman returns a human-readable scheduled time string
+// for pretty output, e.g. "2026-04-14T09:00:00+08:00 (Mon, in 14 hours)"
+func formatScheduledTimeHuman(sendTime string) string {
+	t, err := time.Parse(time.RFC3339, sendTime)
+	if err != nil {
+		return sendTime
+	}
+	dur := time.Until(t)
+	var relative string
+	switch {
+	case dur < time.Hour:
+		relative = fmt.Sprintf("in %d minutes", int(dur.Minutes()))
+	case dur < 24*time.Hour:
+		relative = fmt.Sprintf("in %d hours", int(dur.Hours()))
+	default:
+		relative = fmt.Sprintf("in %d days", int(dur.Hours()/24))
+	}
+	return fmt.Sprintf("%s (%s, %s)", sendTime, t.Format("Mon"), relative)
+}

--- a/shortcuts/mail/scheduled_send_test.go
+++ b/shortcuts/mail/scheduled_send_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseAndValidateSendTime_Empty(t *testing.T) {
+	got, err := parseAndValidateSendTime("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
+func TestParseAndValidateSendTime_ValidRFC3339(t *testing.T) {
+	future := time.Now().Add(1 * time.Hour).Format(time.RFC3339)
+	got, err := parseAndValidateSendTime(future)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == "" {
+		t.Fatal("expected non-empty result")
+	}
+}
+
+func TestParseAndValidateSendTime_ValidRFC3339WithTimezone(t *testing.T) {
+	future := time.Now().Add(2 * time.Hour).In(time.FixedZone("CST", 8*3600)).Format(time.RFC3339)
+	got, err := parseAndValidateSendTime(future)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == "" {
+		t.Fatal("expected non-empty result")
+	}
+}
+
+func TestParseAndValidateSendTime_WithoutTimezoneDefaultsToUTC(t *testing.T) {
+	future := time.Now().UTC().Add(1 * time.Hour).Format("2006-01-02T15:04:05")
+	got, err := parseAndValidateSendTime(future)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == "" {
+		t.Fatal("expected non-empty result")
+	}
+	// Parse the result to verify it's valid RFC 3339
+	parsed, err := time.Parse(time.RFC3339, got)
+	if err != nil {
+		t.Fatalf("result is not valid RFC 3339: %v", err)
+	}
+	// Should be in UTC since no timezone was provided
+	if parsed.Location().String() != "UTC" {
+		t.Fatalf("expected UTC timezone, got %s", parsed.Location())
+	}
+}
+
+func TestParseAndValidateSendTime_InvalidFormat(t *testing.T) {
+	testCases := []string{
+		"not-a-date",
+		"2026-04-14",
+		"2026/04/14T09:00:00",
+		"April 14, 2026",
+		"1234567890",
+	}
+	for _, tc := range testCases {
+		t.Run(tc, func(t *testing.T) {
+			_, err := parseAndValidateSendTime(tc)
+			if err == nil {
+				t.Fatalf("expected error for input %q, got nil", tc)
+			}
+		})
+	}
+}
+
+func TestParseAndValidateSendTime_TooSoon(t *testing.T) {
+	// 1 minute in the future - should fail (minimum 5 minutes)
+	tooSoon := time.Now().Add(1 * time.Minute).Format(time.RFC3339)
+	_, err := parseAndValidateSendTime(tooSoon)
+	if err == nil {
+		t.Fatal("expected error for time too soon in the future")
+	}
+}
+
+func TestParseAndValidateSendTime_PastTime(t *testing.T) {
+	past := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+	_, err := parseAndValidateSendTime(past)
+	if err == nil {
+		t.Fatal("expected error for past time")
+	}
+}
+
+func TestFormatScheduledTimeHuman_ValidTime(t *testing.T) {
+	future := time.Now().Add(2 * time.Hour).Format(time.RFC3339)
+	result := formatScheduledTimeHuman(future)
+	if result == "" {
+		t.Fatal("expected non-empty result")
+	}
+	if result == future {
+		t.Fatal("expected formatted result, got raw time")
+	}
+}
+
+func TestFormatScheduledTimeHuman_InvalidTime(t *testing.T) {
+	result := formatScheduledTimeHuman("not-a-date")
+	if result != "not-a-date" {
+		t.Fatalf("expected raw input returned, got %q", result)
+	}
+}
+
+func TestFormatScheduledTimeHuman_Minutes(t *testing.T) {
+	future := time.Now().Add(30 * time.Minute).Format(time.RFC3339)
+	result := formatScheduledTimeHuman(future)
+	if result == future {
+		t.Fatal("expected formatted result with relative time")
+	}
+}
+
+func TestFormatScheduledTimeHuman_Days(t *testing.T) {
+	future := time.Now().Add(48 * time.Hour).Format(time.RFC3339)
+	result := formatScheduledTimeHuman(future)
+	if result == future {
+		t.Fatal("expected formatted result with relative time")
+	}
+}

--- a/shortcuts/mail/shortcuts.go
+++ b/shortcuts/mail/shortcuts.go
@@ -19,5 +19,6 @@ func Shortcuts() []common.Shortcut {
 		MailDraftCreate,
 		MailDraftEdit,
 		MailForward,
+		MailCancelScheduledSend,
 	}
 }


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Task ID**: 01KP342QM8XZZT86SCJJGGK50Y-1
- **Branch**: harness/01KP547MGRRAWR0F7WVTKS7G2H-test
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Registry: register cancel-scheduled-send endpoint + send_time field + skill-meta update | passed | aff3a80 |
| S2 | CLI: scheduled send support for all send shortcuts + cancel-scheduled-send shortcut | passed | bedc4fa |

## Source specs

- /tmp/harness-agent-dev/repos/01KP547MGRRAWR0F7WVTKS7G2H-test/01KP342QM8XZZT86SCJJGGK50Y-1/input/tech-design.md

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--send-time` flag to schedule email delivery for future dates/times across send, reply, reply-all, and forward commands.
  * Added cancel-scheduled-send command to cancel previously scheduled emails.

* **Tests**
  * Added comprehensive test coverage for scheduled email functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->