### PR TITLE
feat: default skip_task_detail in docs +fetch

### DIFF
--- a/shortcuts/doc/docs_fetch.go
+++ b/shortcuts/doc/docs_fetch.go
@@ -28,6 +28,8 @@ var DocsFetch = common.Shortcut{
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		args := map[string]interface{}{
 			"doc_id": runtime.Str("doc"),
+			// Default to skipping embedded task detail expansion for faster +fetch output.
+			"skip_task_detail": true,
 		}
 		if v := runtime.Str("offset"); v != "" {
 			n, _ := strconv.Atoi(v)
@@ -46,6 +48,8 @@ var DocsFetch = common.Shortcut{
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		args := map[string]interface{}{
 			"doc_id": runtime.Str("doc"),
+			// Default to skipping embedded task detail expansion for faster +fetch output.
+			"skip_task_detail": true,
 		}
 		if v := runtime.Str("offset"); v != "" {
 			n, _ := strconv.Atoi(v)

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -82,6 +82,21 @@ lark-cli docs +fetch --doc Z1FjxxxxxxxxxxxxxxxxxxxtnAc --format pretty
 | `bitable` | `lark-base` | 多维表格 |
 | 其他 | 告知用户暂不支持 | — |
 
+## 重要：任务卡片（task 标签）
+
+`docs +fetch` 默认不会查询/展开文档中内嵌的任务详情（例如任务标题、状态、负责人等）。
+它会在返回的 Markdown 中保留任务引用，并返回任务 ID（GUID），例如：
+
+```html
+<task task-id="30597dc9-262e-4597-97f4-f8efcd1aeb95"></task>
+```
+
+如果用户需要查看该任务的详情，需要用返回的 `task-id` 再调用任务 CLI 查询：
+
+```bash
+lark-cli task tasks get --as user --params '{"task_guid":"30597dc9-262e-4597-97f4-f8efcd1aeb95"}'
+```
+
 ## 工具组合
 
 | 需求 | 工具 |


### PR DESCRIPTION
## Summary

Currently `docs +fetch` may expand embedded task details when calling MCP
`fetch-doc`, which adds extra detail to the default fetch result and is not
always needed. This PR makes `docs +fetch` send `skip_task_detail=true` by
default, and updates the skill reference to clarify that task blocks are
returned as `<task task-id="..."></task>` and should be queried separately via
the task CLI when task details are needed.

## Changes

- Add default `skip_task_detail=true` to `shortcuts/doc/docs_fetch.go`
- Apply the default parameter in both DryRun and Execute paths
- Update `skills/lark-doc/references/lark-doc-fetch.md` to document task block behavior
- Add an example showing how to fetch task details via `lark-cli task tasks get`

## Test Plan

- [x] `go test ./shortcuts/doc`
- [x] Manual verification:
  - `lark-cli docs +fetch --doc "<doc_or_wiki_url>" --dry-run`
  - Confirmed MCP args include `skip_task_detail: true`
  - Verified the skill reference documents `<task task-id="..."></task>` behavior

## Related Issues

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified task detail behavior in `docs +fetch`: embedded task details are no longer automatically expanded. Users can retrieve task details via a separate command as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->