### PR TITLE
chore: prepare v1.0.11 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.11] - 2026-04-14
+
+### Features
+
+- **sheets**: Add dropdown shortcuts for data validation management (`+set-dropdown`, `+update-dropdown`, `+get-dropdown`, `+delete-dropdown`) (#461)
+- **task**: Add task search, tasklist search, related-task, set-ancestor, and subscribe-event shortcuts (#377)
+- Streamline interactive login by removing the extra auth confirmation step (#451)
+
+### Bug Fixes
+
+- **base**: Validate JSON object inputs for base shortcuts and reject `null` objects (#458)
+
+### Documentation
+
+- **sheets**: Document value formats for formulas and special field types (#456)
+- **readme**: Add Attendance to the features table (#460)
+
 ## [v1.0.10] - 2026-04-13
 
 ### Features
@@ -328,6 +345,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.11]: https://github.com/larksuite/cli/releases/tag/v1.0.11
 [v1.0.10]: https://github.com/larksuite/cli/releases/tag/v1.0.10
 [v1.0.9]: https://github.com/larksuite/cli/releases/tag/v1.0.9
 [v1.0.8]: https://github.com/larksuite/cli/releases/tag/v1.0.8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary
Prepare the v1.0.11 release metadata so the package version and changelog stay in sync.

## Changes
- Bump `package.json` version from `1.0.10` to `1.0.11`
- Add the `v1.0.11` changelog entry and release link in `CHANGELOG.md`

## Test Plan
- [x] `make unit-test`
- [x] `go mod tidy` (no `go.mod`/`go.sum` changes)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main`
- [ ] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sheets dropdown shortcuts for improved navigation
  * Added task-related keyboard shortcuts
  * Enhanced interactive login flow

* **Bug Fixes**
  * Fixed handling of null values in JSON data

* **Documentation**
  * Updated documentation and readme files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->