### PR TITLE
feat: support user access token for im file and image upload

### DIFF
--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -263,8 +263,8 @@ func (ctx *RuntimeContext) DoAPI(req *larkcore.ApiReq, opts ...larkcore.RequestO
 }
 
 // DoAPIAsBot executes a raw Lark SDK request using bot identity (tenant access token),
-// regardless of the current --as flag. Use this for bot-only APIs (e.g. image/file upload)
-// that must be called with TAT even when the surrounding shortcut runs as user.
+// regardless of the current --as flag. Use this for APIs that must always be called
+// with TAT even when the surrounding shortcut runs as user.
 func (ctx *RuntimeContext) DoAPIAsBot(req *larkcore.ApiReq, opts ...larkcore.RequestOptionFunc) (*larkcore.ApiResp, error) {
 	ac, err := ctx.getAPIClient()
 	if err != nil {

--- a/shortcuts/im/helpers.go
+++ b/shortcuts/im/helpers.go
@@ -1131,7 +1131,7 @@ func uploadImageToIM(ctx context.Context, runtime *common.RuntimeContext, filePa
 	fd.AddField("image_type", imageType)
 	fd.AddFile("image", f)
 
-	apiResp, err := runtime.DoAPIAsBot(&larkcore.ApiReq{
+	apiResp, err := runtime.DoAPI(&larkcore.ApiReq{
 		HttpMethod: http.MethodPost,
 		ApiPath:    "/open-apis/im/v1/images",
 		Body:       fd,
@@ -1172,7 +1172,7 @@ func uploadFileToIM(ctx context.Context, runtime *common.RuntimeContext, filePat
 	}
 	fd.AddFile("file", f)
 
-	apiResp, err := runtime.DoAPIAsBot(&larkcore.ApiReq{
+	apiResp, err := runtime.DoAPI(&larkcore.ApiReq{
 		HttpMethod: http.MethodPost,
 		ApiPath:    "/open-apis/im/v1/files",
 		Body:       fd,
@@ -1200,7 +1200,7 @@ func uploadImageFromReader(ctx context.Context, runtime *common.RuntimeContext, 
 	fd.AddField("image_type", imageType)
 	fd.AddFile("image", r)
 
-	apiResp, err := runtime.DoAPIAsBot(&larkcore.ApiReq{
+	apiResp, err := runtime.DoAPI(&larkcore.ApiReq{
 		HttpMethod: http.MethodPost,
 		ApiPath:    "/open-apis/im/v1/images",
 		Body:       fd,
@@ -1232,7 +1232,7 @@ func uploadFileFromReader(ctx context.Context, runtime *common.RuntimeContext, r
 	}
 	fd.AddFile("file", r)
 
-	apiResp, err := runtime.DoAPIAsBot(&larkcore.ApiReq{
+	apiResp, err := runtime.DoAPI(&larkcore.ApiReq{
 		HttpMethod: http.MethodPost,
 		ApiPath:    "/open-apis/im/v1/files",
 		Body:       fd,

--- a/skills/lark-im/references/lark-im-messages-reply.md
+++ b/skills/lark-im/references/lark-im-messages-reply.md
@@ -211,7 +211,7 @@ The reply appears in the target message's thread and does not show up in the mai
 - When using `--content`, you are responsible for making the JSON structure match the effective `msg_type`
 - `--reply-in-thread` adds `reply_in_thread=true` to the API request
 - `--reply-in-thread` is mainly meaningful in chats that support thread replies
-- `--image`/`--file`/`--video`/`--audio`/`--video-cover` support local file paths; the shortcut uploads first and then sends the reply; file/image upload is bot-only, so when using `--as user`, the upload step is automatically performed with bot identity, and only the final send uses user identity
+- `--image`/`--file`/`--video`/`--audio`/`--video-cover` support local file paths; the shortcut uploads first and then sends the reply; both the upload and send steps use the same identity (UAT when `--as user`, TAT when `--as bot`)
 - If the provided media value starts with `img_` or `file_`, it is treated as an existing key and used directly
 - `--markdown` always sends `msg_type=post`
 - If you explicitly set `--msg-type` and it conflicts with the chosen content flag, validation fails

--- a/skills/lark-im/references/lark-im-messages-send.md
+++ b/skills/lark-im/references/lark-im-messages-send.md
@@ -211,7 +211,7 @@ lark-cli im +messages-send --chat-id oc_xxx --markdown $'## Test\n\nhello' --dry
 - `--chat-id` and `--user-id` are mutually exclusive; you must provide exactly one
 - `--content` must be valid JSON
 - When using `--content`, you are responsible for making the JSON structure match the effective `msg_type`
-- `--image`/`--file`/`--video`/`--audio` support local file paths; the shortcut uploads first and then sends the message; file/image upload is bot-only, so when using `--as user`, the upload step is automatically performed with bot identity, and only the final send uses user identity
+- `--image`/`--file`/`--video`/`--audio` support local file paths; the shortcut uploads first and then sends the message; both the upload and send steps use the same identity (UAT when `--as user`, TAT when `--as bot`)
 - If the provided media value starts with `img_` or `file_`, it is treated as an existing key and used directly
 - `--markdown` always sends `msg_type=post`, even if you do not explicitly set `--msg-type post`
 - If you explicitly set `--msg-type` and it conflicts with the chosen content flag, validation fails


### PR DESCRIPTION
## Summary

The `/open-apis/im/v1/images` and `/open-apis/im/v1/files` APIs now support User Access Token (UAT) in addition to Tenant Access Token (TAT). Previously the upload helpers forced bot identity unconditionally; this PR aligns them with the surrounding shortcut's `--as` flag so uploads and sends share the same identity.

## Changes

- `shortcuts/im/helpers.go`: replace `DoAPIAsBot` with `DoAPI` in all four upload helpers (`uploadImageToIM`, `uploadFileToIM`, `uploadImageFromReader`, `uploadFileFromReader`) so they respect the runtime identity instead of always using TAT
- `shortcuts/common/runner.go`: remove the stale "e.g. image/file upload" example from the `DoAPIAsBot` doc comment
- `skills/lark-im/references/lark-im-messages-send.md`: update note to reflect that upload and send now use the same identity
- `skills/lark-im/references/lark-im-messages-reply.md`: same doc fix as above

## Test Plan

- [x] `make unit-test` passed
- [x] Manual verification with `--as user`:
  - `lark-cli im +messages-send --user-id ou_xxx --image ./photo.png --as user`
  - `lark-cli im +messages-send --user-id ou_xxx --file ./doc.pdf --as user`
  - Confirmed upload and send both use UAT
- [x] Existing `--as bot` behavior unchanged (still uses TAT)

## Related Issues

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Lark IM media uploads (images, files, video, audio) now use consistent authentication identity for both upload and send operations.

* **Documentation**
  * Updated media upload behavior documentation in Lark IM references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->