### PR TITLE
docs: route past meeting queries to lark-vc

### DIFF
--- a/skills/lark-calendar/SKILL.md
+++ b/skills/lark-calendar/SKILL.md
@@ -14,6 +14,9 @@ metadata:
 **CRITICAL — 所有的 Shortcuts 在执行之前，务必先使用 Read 工具读取其对应的说明文档，禁止直接盲目调用命令。**
 **CRITICAL — 凡涉及【预约日程/会议】或【查询/搜索会议室】，第一步 MUST 强制使用 Read 工具读取 [`references/lark-calendar-schedule-meeting.md`](references/lark-calendar-schedule-meeting.md)。禁止跳过此步直接调用 API 或 Shortcut！**
 **CRITICAL — 术语约束：用户日常表达中常说的“帮我约个日历”、“查一下今天的日历”等，其实际意图通常是针对 日程（Event） 的创建或查询，而非操作 日历（Calendar） 容器本身。请自动将口语化的“日历”意图映射为“日程”操作（如 `+create`, `+agenda`）。**
+**CRITICAL — 会议与日程的意图路由：**
+- **查询过去时间的会议**：如果用户明确查询过去时间的会议（如“昨天的会议”、“上周的会议”），**优先使用 [`../lark-vc/SKILL.md`](../lark-vc/SKILL.md) 搜索会议记录**。因为会议数据不仅包含从日程发起的视频会议，还包含即时会议，仅查询日程数据会导致结果不全。
+- **查询日历/日程或未来时间的会议**：如果用户明确表达的是“日历”、“日程”，或者涉及**未来时间**的安排，则属于本技能（lark-calendar）的业务域，请继续使用本技能处理。
 
 
 **时间与日期推断规范：**


### PR DESCRIPTION
## Summary
Clarify the routing rule between `lark-calendar` and `lark-vc` for meeting-related requests.
This makes past meeting queries go to meeting records, while keeping calendar/event and future meeting queries in `lark-calendar`.

## Changes
- Add an intent-routing rule to `skills/lark-calendar/SKILL.md` for past meeting queries
- Document that past meeting lookups should prefer `lark-vc` because calendar-only data can be incomplete
- Keep future meeting and explicit calendar/event queries handled by `lark-calendar`

## Test Plan
- [x] Unit tests pass (`make unit-test`)
- [x] Manual local verification confirms the behavior works as expected

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved intelligent routing for meeting and calendar queries: past meeting searches are now directed to meeting records, while future scheduling requests continue through the calendar feature for better accuracy and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->