### PR TITLE
fix: add atomic overwrite for whiteboard +update

### DIFF
--- a/shortcuts/whiteboard/shortcuts.go
+++ b/shortcuts/whiteboard/shortcuts.go
@@ -23,6 +23,8 @@ type WbCliOutput struct {
 }
 
 type WbCliOutputData struct {
-	To     string      `json:"to"`
-	Result interface{} `json:"result"`
+	To     string `json:"to"`
+	Result struct {
+		Nodes []interface{} `json:"nodes"`
+	} `json:"result"`
 }

--- a/shortcuts/whiteboard/whiteboard_update.go
+++ b/shortcuts/whiteboard/whiteboard_update.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
@@ -31,9 +30,8 @@ var formatCodeMap = map[string]int{
 	FormatMermaid:  2,
 }
 
-var wbUpdateScopes = []string{"board:whiteboard:node:read", "board:whiteboard:node:create", "board:whiteboard:node:delete"}
+var wbUpdateScopes = []string{"board:whiteboard:node:create"}
 var wbUpdateAuthTypes = []string{"user", "bot"}
-var skipDeleteNodesBatchSleep = false // for accelerate UT testing only
 var wbUpdateFlags = []common.Flag{
 	{Name: "idempotent-token", Desc: "idempotent token to ensure the update is idempotent. Default is empty. min length is 10.", Required: false},
 	{Name: "whiteboard-token", Desc: "whiteboard token of the whiteboard to update. You will need edit permission to update the whiteboard.", Required: true},
@@ -82,19 +80,6 @@ func wbUpdateDryRun(ctx context.Context, runtime *common.RuntimeContext) *common
 	token := runtime.Str("whiteboard-token")
 	overwrite := runtime.Bool("overwrite")
 	descStr := "will call whiteboard open api to update content."
-	var delNum int
-	var err error
-	if overwrite {
-		// 还是会读取一下 whiteboard nodes，确认是否有节点要删除
-		delNum, _, err = clearWhiteboardContent(ctx, runtime, token, []string{}, true)
-		if err != nil {
-			return common.NewDryRunAPI().Desc("read whiteboard nodes failed: " + err.Error())
-		}
-		if delNum > 0 {
-			descStr += fmt.Sprintf(" %d existing nodes deleted before update.", delNum)
-		}
-	}
-
 	desc := common.NewDryRunAPI().Desc(descStr)
 
 	switch format {
@@ -103,7 +88,11 @@ func wbUpdateDryRun(ctx context.Context, runtime *common.RuntimeContext) *common
 		if err != nil {
 			return common.NewDryRunAPI().Desc("parse input failed: " + err.Error())
 		}
-		desc.POST(fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes", common.MaskToken(url.PathEscape(token)))).Body(nodes).Desc("create all nodes of the whiteboard.")
+		reqBody := rawNodesCreateReq{
+			Nodes:     nodes,
+			Overwrite: overwrite,
+		}
+		desc.POST(fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes", common.MaskToken(url.PathEscape(token)))).Body(reqBody).Desc("create all nodes of the whiteboard.")
 	case FormatPlantUML, FormatMermaid:
 		syntaxType := formatCodeMap[format]
 		reqBody := plantumlCreateReq{
@@ -111,16 +100,11 @@ func wbUpdateDryRun(ctx context.Context, runtime *common.RuntimeContext) *common
 			SyntaxType:   syntaxType,
 			ParseMode:    1,
 			DiagramType:  0,
+			Overwrite:    overwrite,
 		}
 		desc.POST(fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes/plantuml", common.MaskToken(url.PathEscape(token)))).Body(reqBody).Desc(fmt.Sprintf("create %s node on the whiteboard.", format))
 	}
 
-	if overwrite && delNum > 0 {
-		// 在 DryRun 中只记录意图，不实际拉取和计算节点
-		desc.GET(fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes", common.MaskToken(url.PathEscape(token)))).Desc("get all nodes of the whiteboard to delete, then filter out newly created ones.")
-		desc.DELETE(fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes/batch_delete", common.MaskToken(url.PathEscape(token)))).Body("{\"ids\":[\"...\"]}").
-			Desc(fmt.Sprintf("delete all old nodes of the whiteboard 100 nodes at a time. This API may be called multiple times and is not reversible. %d whiteboard nodes will be deleted while update.", delNum))
-	}
 	return desc
 }
 
@@ -185,31 +169,17 @@ type createResponse struct {
 	} `json:"data"`
 }
 
-type deleteResponse struct {
-	Code int    `json:"code"`
-	Msg  string `json:"msg"`
-}
-
-type simpleNodeResp struct {
-	Code int    `json:"code"`
-	Msg  string `json:"msg"`
-	Data struct {
-		Nodes []struct {
-			Id       string   `json:"id"`
-			Children []string `json:"children"`
-		} `json:"nodes"`
-	} `json:"data"`
-}
-
-type deleteNodeReqBody struct {
-	Ids []string `json:"ids"`
-}
-
 type plantumlCreateReq struct {
 	PlantUmlCode string `json:"plant_uml_code"`
 	SyntaxType   int    `json:"syntax_type"`
 	DiagramType  int    `json:"diagram_type,omitempty"`
 	ParseMode    int    `json:"parse_mode,omitempty"`
+	Overwrite    bool   `json:"overwrite,omitempty"`
+}
+
+type rawNodesCreateReq struct {
+	Nodes     []interface{} `json:"nodes"`
+	Overwrite bool          `json:"overwrite,omitempty"`
 }
 
 type plantumlCreateResp struct {
@@ -220,7 +190,7 @@ type plantumlCreateResp struct {
 	} `json:"data"`
 }
 
-func parseWBcliNodes(rawjson []byte) (wbNodes interface{}, err error, isRaw bool) {
+func parseWBcliNodes(rawjson []byte) (wbNodes []interface{}, err error, isRaw bool) {
 	var wbOutput WbCliOutput
 	if err := json.Unmarshal(rawjson, &wbOutput); err != nil {
 		return nil, output.Errorf(output.ExitValidation, "parsing", fmt.Sprintf("unmarshal input json failed: %v", err)), false
@@ -229,119 +199,15 @@ func parseWBcliNodes(rawjson []byte) (wbNodes interface{}, err error, isRaw bool
 		return nil, output.Errorf(output.ExitValidation, "whiteboard-cli", "whiteboard-cli failed. please check previous log."), false
 	}
 	if wbOutput.RawNodes != nil {
-		wbNodes = struct {
-			Nodes []interface{} `json:"nodes"`
-		}{
-			Nodes: wbOutput.RawNodes,
-		}
+		wbNodes = wbOutput.RawNodes
 		isRaw = true
 	} else {
-		wbNodes = wbOutput.Data.Result
+		if wbOutput.Data.Result.Nodes == nil {
+			return nil, output.Errorf(output.ExitValidation, "whiteboard-cli", "whiteboard-cli failed. please check previous log."), false
+		}
+		wbNodes = wbOutput.Data.Result.Nodes
 	}
 	return wbNodes, nil, isRaw
-}
-
-func clearWhiteboardContent(ctx context.Context, runtime *common.RuntimeContext, wbToken string, newNodeIDs []string, dryRun bool) (int, []string, error) {
-	resp, err := runtime.DoAPI(&larkcore.ApiReq{
-		HttpMethod: http.MethodGet,
-		ApiPath:    fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes", url.PathEscape(wbToken)),
-	})
-	if err != nil {
-		return 0, nil, output.ErrNetwork(fmt.Sprintf("get whiteboard nodes failed: %v", err))
-	}
-	if resp.StatusCode != http.StatusOK {
-		return 0, nil, output.ErrAPI(resp.StatusCode, string(resp.RawBody), nil)
-	}
-	var nodes simpleNodeResp
-	err = json.Unmarshal(resp.RawBody, &nodes)
-	if err != nil {
-		return 0, nil, output.Errorf(output.ExitInternal, "parsing", fmt.Sprintf("parse whiteboard nodes failed: %v", err))
-	}
-	if nodes.Code != 0 {
-		return 0, nil, output.ErrAPI(nodes.Code, "get whiteboard nodes failed", fmt.Sprintf("get whiteboard nodes failed: %s", nodes.Msg))
-	}
-
-	// 收集所有新节点及其 children 的 ID，递归处理
-	protectedIDs := make(map[string]bool)
-	for _, id := range newNodeIDs {
-		protectedIDs[id] = true
-	}
-	// 构建 node map 以便快速查找
-	nodeMap := make(map[string][]string)
-	if nodes.Data.Nodes != nil {
-		for _, node := range nodes.Data.Nodes {
-			nodeMap[node.Id] = node.Children
-		}
-	}
-	// 递归收集所有 children
-	visited := make(map[string]bool)
-	var collectChildren func(id string)
-	collectChildren = func(id string) {
-		if visited[id] {
-			return
-		}
-		visited[id] = true
-		if children, ok := nodeMap[id]; ok {
-			for _, child := range children {
-				protectedIDs[child] = true
-				collectChildren(child)
-			}
-		}
-	}
-	for _, id := range newNodeIDs {
-		collectChildren(id)
-	}
-
-	// 确定要删除的节点
-	nodeIds := make([]string, 0, len(nodes.Data.Nodes))
-	if nodes.Data.Nodes != nil {
-		for _, node := range nodes.Data.Nodes {
-			nodeIds = append(nodeIds, node.Id)
-		}
-	}
-	delIds := make([]string, 0, len(nodeIds))
-	for _, nodeId := range nodeIds {
-		if !protectedIDs[nodeId] {
-			delIds = append(delIds, nodeId)
-		}
-	}
-	if dryRun {
-		return len(delIds), delIds, nil
-	}
-	// 实际删除节点，按每批最多100个进行切分
-	for i := 0; i < len(delIds); i += 100 {
-		if !skipDeleteNodesBatchSleep {
-			time.Sleep(time.Millisecond * 1000) // 画板内删除大量节点时，内部会有大量写操作，需要稍等一下，避免被限流
-		}
-		end := i + 100
-		if end > len(delIds) {
-			end = len(delIds)
-		}
-		batchIds := delIds[i:end]
-		delReq := deleteNodeReqBody{
-			Ids: batchIds,
-		}
-		resp, err = runtime.DoAPI(&larkcore.ApiReq{
-			HttpMethod: http.MethodDelete,
-			ApiPath:    fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes/batch_delete", url.PathEscape(wbToken)),
-			Body:       delReq,
-		})
-		if err != nil {
-			return 0, nil, output.ErrNetwork(fmt.Sprintf("delete whiteboard nodes failed: %v", err))
-		}
-		if resp.StatusCode != http.StatusOK {
-			return 0, nil, output.ErrAPI(resp.StatusCode, string(resp.RawBody), nil)
-		}
-		var delResp deleteResponse
-		err = json.Unmarshal(resp.RawBody, &delResp)
-		if err != nil {
-			return 0, nil, output.Errorf(output.ExitInternal, "parsing", fmt.Sprintf("parse whiteboard delete response failed: %v", err))
-		}
-		if delResp.Code != 0 {
-			return 0, nil, output.ErrAPI(delResp.Code, "delete whiteboard nodes failed", fmt.Sprintf("delete whiteboard nodes failed: %s", delResp.Msg))
-		}
-	}
-	return len(delIds), delIds, nil
 }
 
 // updateWhiteboardByCode 使用 plantuml/mermaid 代码更新画板
@@ -352,6 +218,7 @@ func updateWhiteboardByCode(ctx context.Context, runtime *common.RuntimeContext,
 		SyntaxType:   syntaxType,
 		ParseMode:    1,
 		DiagramType:  0, // 0 表示自动识别
+		Overwrite:    overwrite,
 	}
 
 	req := &larkcore.ApiReq{
@@ -383,20 +250,7 @@ func updateWhiteboardByCode(ctx context.Context, runtime *common.RuntimeContext,
 
 	outData := make(map[string]string)
 	outData["created_node_id"] = createResp.Data.NodeID
-	newNodeIDs := []string{createResp.Data.NodeID}
-
-	if overwrite {
-		numNodes, _, err := clearWhiteboardContent(ctx, runtime, wbToken, newNodeIDs, false)
-		if err != nil {
-			return err
-		}
-		outData["deleted_nodes_num"] = fmt.Sprintf("%d", numNodes)
-	}
-
 	runtime.OutFormat(outData, nil, func(w io.Writer) {
-		if outData["deleted_nodes_num"] != "" {
-			fmt.Fprintf(w, "%s existing nodes deleted.\n", outData["deleted_nodes_num"])
-		}
 		if outData["created_node_id"] != "" {
 			fmt.Fprintf(w, "New node created.\n")
 		}
@@ -413,11 +267,15 @@ func updateWhiteboardByRawNodes(ctx context.Context, runtime *common.RuntimeCont
 		return err
 	}
 	outData := make(map[string]string)
+	reqBody := rawNodesCreateReq{
+		Nodes:     nodes,
+		Overwrite: overwrite,
+	}
 
 	req := &larkcore.ApiReq{
 		HttpMethod:  http.MethodPost,
 		ApiPath:     fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes", url.PathEscape(wbToken)),
-		Body:        nodes,
+		Body:        reqBody,
 		QueryParams: map[string][]string{},
 	}
 	if idempotentToken != "" {
@@ -452,19 +310,7 @@ func updateWhiteboardByRawNodes(ctx context.Context, runtime *common.RuntimeCont
 	}
 
 	outData["created_node_ids"] = strings.Join(createResp.Data.NodeIDs, ",")
-
-	if overwrite {
-		numNodes, _, err := clearWhiteboardContent(ctx, runtime, wbToken, createResp.Data.NodeIDs, false)
-		if err != nil {
-			return err
-		}
-		outData["deleted_nodes_num"] = fmt.Sprintf("%d", numNodes)
-	}
-
 	runtime.OutFormat(outData, nil, func(w io.Writer) {
-		if outData["deleted_nodes_num"] != "" {
-			fmt.Fprintf(w, "%s existing nodes deleted.\n", outData["deleted_nodes_num"])
-		}
 		if outData["created_node_ids"] != "" {
 			fmt.Fprintf(w, "%d new nodes created.\n", len(createResp.Data.NodeIDs))
 		}

--- a/shortcuts/whiteboard/whiteboard_update_test.go
+++ b/shortcuts/whiteboard/whiteboard_update_test.go
@@ -478,36 +478,9 @@ invalid
 }
 
 func TestWhiteboardUpdateExecute_WithOverwrite(t *testing.T) {
-	// Skip sleep for testing
-	origSkip := skipDeleteNodesBatchSleep
-	skipDeleteNodesBatchSleep = true
-	defer func() { skipDeleteNodesBatchSleep = origSkip }()
-
 	factory, stdout, reg := newUpdateExecuteFactory(t)
 
-	// Mock 1: Get existing nodes (for clearWhiteboardContent)
-	reg.Register(&httpmock.Stub{
-		Method: "GET",
-		URL:    "/open-apis/board/v1/whiteboards/test-token-overwrite/nodes",
-		Body: map[string]interface{}{
-			"code": 0,
-			"msg":  "",
-			"data": map[string]interface{}{
-				"nodes": []map[string]interface{}{
-					{
-						"id":       "old-node-1",
-						"children": []string{},
-					},
-					{
-						"id":       "old-node-2",
-						"children": []string{},
-					},
-				},
-			},
-		},
-	})
-
-	// Mock 2: Create nodes API response
+	// Mock: Create nodes API response with overwrite in request body
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/board/v1/whiteboards/test-token-overwrite/nodes/plantuml",
@@ -520,16 +493,6 @@ func TestWhiteboardUpdateExecute_WithOverwrite(t *testing.T) {
 		},
 	})
 
-	// Mock 3: Delete nodes batch
-	reg.Register(&httpmock.Stub{
-		Method: "DELETE",
-		URL:    "/open-apis/board/v1/whiteboards/test-token-overwrite/nodes/batch_delete",
-		Body: map[string]interface{}{
-			"code": 0,
-			"msg":  "success",
-		},
-	})
-
 	source := `graph TD
 A-->B`
 	args := []string{"+update", "--whiteboard-token", "test-token-overwrite", "--input_format", "mermaid", "--overwrite", "--source", source}
@@ -539,36 +502,9 @@ A-->B`
 }
 
 func TestWhiteboardUpdateExecute_RawWithOverwrite(t *testing.T) {
-	// Skip sleep for testing
-	origSkip := skipDeleteNodesBatchSleep
-	skipDeleteNodesBatchSleep = true
-	defer func() { skipDeleteNodesBatchSleep = origSkip }()
-
 	factory, stdout, reg := newUpdateExecuteFactory(t)
 
-	// Mock 1: Get existing nodes (for clearWhiteboardContent)
-	reg.Register(&httpmock.Stub{
-		Method: "GET",
-		URL:    "/open-apis/board/v1/whiteboards/test-token-raw-overwrite/nodes",
-		Body: map[string]interface{}{
-			"code": 0,
-			"msg":  "",
-			"data": map[string]interface{}{
-				"nodes": []map[string]interface{}{
-					{
-						"id":       "old-node-1",
-						"children": []string{"old-child-1"},
-					},
-					{
-						"id":       "old-child-1",
-						"children": []string{},
-					},
-				},
-			},
-		},
-	})
-
-	// Mock 2: Create nodes API response
+	// Mock: Create nodes API response with overwrite in request body
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/board/v1/whiteboards/test-token-raw-overwrite/nodes",
@@ -578,16 +514,6 @@ func TestWhiteboardUpdateExecute_RawWithOverwrite(t *testing.T) {
 			"data": map[string]interface{}{
 				"ids": []string{"new-node-1", "new-node-2"},
 			},
-		},
-	})
-
-	// Mock 3: Delete nodes batch
-	reg.Register(&httpmock.Stub{
-		Method: "DELETE",
-		URL:    "/open-apis/board/v1/whiteboards/test-token-raw-overwrite/nodes/batch_delete",
-		Body: map[string]interface{}{
-			"code": 0,
-			"msg":  "success",
 		},
 	})
 


### PR DESCRIPTION
## Summary
This PR updates the whiteboard update functionality to use the new backend API's `overwrite` parameter for atomic overwrite operations, replacing the previous approach of first reading and then deleting nodes.

## Changes
- Added `overwrite` field to API request bodies for both raw nodes and PlantUML/Mermaid updates
- Removed the separate node reading and deletion logic in dry run and execution paths

## Test Plan
- [x] Unit tests pass
- [x] Manual local verification confirms the `lark whiteboard +update` command works as expected with `--overwrite` flag


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Overwrite now performed via create-with-overwrite requests instead of clearing then recreating board content.
  * API requests for whiteboard create/update include an explicit overwrite flag.
  * Reduced permission scope for node operations to creation-only.

* **Behavioral Change**
  * Responses no longer report deleted-node counts or deletion details.

* **Tests**
  * Overwrite tests simplified to exercise create-with-overwrite paths (no pre-delete stubbing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->