### PR TITLE
chore: prepare v1.0.12 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.12] - 2026-04-15
+
+### Features
+
+- Add guided npm install flow that installs or upgrades the CLI, installs AI skills, and walks through app config and auth login (#464)
+- **mail**: Add email signature support with `+signature`, `--signature-id` compose flags, and draft signature edit operations (#485)
+- **mail**: Return recall hints for sent emails when recall is available (#481)
+- **slides**: Add `+media-upload` and support `@path` image placeholders in `+create --slides` (#450)
+
+### Documentation
+
+- **mail**: Add recipient search guidance to the mail skill workflow (#437)
+- **calendar/vc**: Route past meeting queries to `lark-vc` and clarify historical date matching in skills (#482, #480)
+
 ## [v1.0.11] - 2026-04-14
 
 ### Features
@@ -345,6 +359,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.12]: https://github.com/larksuite/cli/releases/tag/v1.0.12
 [v1.0.11]: https://github.com/larksuite/cli/releases/tag/v1.0.11
 [v1.0.10]: https://github.com/larksuite/cli/releases/tag/v1.0.10
 [v1.0.9]: https://github.com/larksuite/cli/releases/tag/v1.0.9

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary
Prepare the `v1.0.12` release metadata for the next publish. This PR keeps the release branch scoped to the version bump and the reviewed changelog entry.

## Changes
- Bump `@larksuite/cli` package version from `1.0.11` to `1.0.12`
- Add the `v1.0.12` changelog section and release link reference

## Test Plan
- [x] `make unit-test`
- [x] `go mod tidy`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main`
- [ ] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined CLI installation process
  * Enhanced mail with signature and recall hints
  * Improved slides media upload with image placeholders
  * Better mail recipient search guidance
  * Updated calendar and VC routing functionality
  * Clarified historical date handling

* **Documentation**
  * Comprehensive release documentation for v1.0.12

<!-- end of auto-generated comment: release notes by coderabbit.ai -->