### PR TITLE
feat: add Claude Code marketplace support for skills installation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,17 +1,20 @@
 {
   "name": "larksuite-cli",
-  "publisher": {
-    "name": "larksuite",
-    "url": "https://github.com/larksuite"
+  "owner": {
+    "name": "larksuite"
   },
-  "description": "Official Lark/Feishu CLI skills for Claude Code — 22 AI Agent Skills covering Calendar, Messenger, Docs, Base, Sheets, Tasks, Mail, and more.",
+  "metadata": {
+    "description": "Official Lark/Feishu CLI skills for Claude Code — 22 AI Agent Skills covering Calendar, Messenger, Docs, Base, Sheets, Tasks, Mail, and more."
+  },
   "plugins": [
     {
       "name": "lark-cli",
       "source": ".",
       "description": "The official Lark/Feishu CLI tool with 22 structured AI Agent Skills covering 14 business domains.",
-      "skills": "./skills/",
-      "version": "1.0.10"
+      "version": "1.0.10",
+      "license": "MIT",
+      "repository": "https://github.com/larksuite/cli",
+      "keywords": ["lark", "feishu", "calendar", "messenger", "docs", "sheets", "base", "tasks", "mail"]
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "larksuite-cli",
+  "publisher": {
+    "name": "larksuite",
+    "url": "https://github.com/larksuite"
+  },
+  "description": "Official Lark/Feishu CLI skills for Claude Code — 22 AI Agent Skills covering Calendar, Messenger, Docs, Base, Sheets, Tasks, Mail, and more.",
+  "plugins": [
+    {
+      "name": "lark-cli",
+      "source": ".",
+      "description": "The official Lark/Feishu CLI tool with 22 structured AI Agent Skills covering 14 business domains.",
+      "skills": "./skills/",
+      "version": "1.0.10"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "lark-cli",
-      "source": ".",
+      "source": "./",
       "description": "The official Lark/Feishu CLI tool with 22 structured AI Agent Skills covering 14 business domains.",
       "version": "1.0.10",
       "license": "MIT",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "lark-cli",
+  "version": "1.0.10",
+  "description": "The official Lark/Feishu CLI tool with 22 structured AI Agent Skills covering 14 business domains.",
+  "author": {
+    "name": "larksuite"
+  },
+  "homepage": "https://github.com/larksuite/cli",
+  "repository": "https://github.com/larksuite/cli",
+  "license": "MIT",
+  "skills": "./skills/"
+}

--- a/README.md
+++ b/README.md
@@ -66,17 +66,7 @@ npm install -g @larksuite/cli
 npx skills add larksuite/cli -y -g
 ```
 
-**Option 2 — Install via Claude Code Marketplace:**
-
-If you are using [Claude Code](https://docs.anthropic.com/en/docs/claude-code), you can install directly from the marketplace:
-
-```bash
-# In Claude Code terminal
-claude plugin marketplace add larksuite/cli
-claude plugin install lark-cli@larksuite-cli
-```
-
-**Option 3 — From source:**
+**Option 2 — From source:**
 
 Requires Go `v1.23`+ and Python 3.
 
@@ -87,6 +77,16 @@ make install
 
 # Install CLI SKILL (required)
 npx skills add larksuite/cli -y -g
+```
+
+**Option 3 — Install via Claude Code Marketplace:**
+
+If you are using [Claude Code](https://docs.anthropic.com/en/docs/claude-code), you can install directly from the marketplace:
+
+```bash
+# In Claude Code terminal
+claude plugin marketplace add larksuite/cli
+claude plugin install lark-cli@larksuite-cli
 ```
 
 #### Configure & Use

--- a/README.md
+++ b/README.md
@@ -66,7 +66,17 @@ npm install -g @larksuite/cli
 npx skills add larksuite/cli -y -g
 ```
 
-**Option 2 — From source:**
+**Option 2 — Install via Claude Code Marketplace:**
+
+If you are using [Claude Code](https://docs.anthropic.com/en/docs/claude-code), you can install directly from the marketplace:
+
+```bash
+# In Claude Code terminal
+claude plugin marketplace add larksuite/cli
+claude plugin install lark-cli@larksuite-cli
+```
+
+**Option 3 — From source:**
 
 Requires Go `v1.23`+ and Python 3.
 
@@ -102,8 +112,11 @@ lark-cli calendar +agenda
 # Install CLI
 npm install -g @larksuite/cli
 
-# Install CLI SKILL (required)
+# Install CLI SKILL (required, choose one)
+# Option A: via npx skills
 npx skills add larksuite/cli -y -g
+# Option B: via Claude Code Marketplace
+claude plugin marketplace add larksuite/cli && claude plugin install lark-cli@larksuite-cli
 ```
 
 **Step 2 — Configure app credentials**

--- a/README.zh.md
+++ b/README.zh.md
@@ -66,17 +66,7 @@ npm install -g @larksuite/cli
 npx skills add larksuite/cli -y -g
 ```
 
-**方式二 — 通过 Claude Code Marketplace 安装：**
-
-如果你正在使用 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)，可以直接从 Marketplace 安装：
-
-```bash
-# 在 Claude Code 终端中执行
-claude plugin marketplace add larksuite/cli
-claude plugin install lark-cli@larksuite-cli
-```
-
-**方式三 — 从源码安装：**
+**方式二 — 从源码安装：**
 
 需要 Go `v1.23`+ 和 Python 3。
 
@@ -87,6 +77,16 @@ make install
 
 # 安装 CLI SKILL（必需）
 npx skills add larksuite/cli -y -g
+```
+
+**方式三 — 通过 Claude Code Marketplace 安装：**
+
+如果你正在使用 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)，可以直接从 Marketplace 安装：
+
+```bash
+# 在 Claude Code 终端中执行
+claude plugin marketplace add larksuite/cli
+claude plugin install lark-cli@larksuite-cli
 ```
 
 #### 配置与使用

--- a/README.zh.md
+++ b/README.zh.md
@@ -54,7 +54,7 @@
 
 #### 安装
 
-以下两种方式**任选其一**：
+以下方式**任选其一**：
 
 **方式一 — 从 npm 安装（推荐）：**
 
@@ -66,7 +66,17 @@ npm install -g @larksuite/cli
 npx skills add larksuite/cli -y -g
 ```
 
-**方式二 — 从源码安装：**
+**方式二 — 通过 Claude Code Marketplace 安装：**
+
+如果你正在使用 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)，可以直接从 Marketplace 安装：
+
+```bash
+# 在 Claude Code 终端中执行
+claude plugin marketplace add larksuite/cli
+claude plugin install lark-cli@larksuite-cli
+```
+
+**方式三 — 从源码安装：**
 
 需要 Go `v1.23`+ 和 Python 3。
 
@@ -102,8 +112,11 @@ lark-cli calendar +agenda
 # 安装 CLI
 npm install -g @larksuite/cli
 
-# 安装 CLI SKILL（必需）
+# 安装 CLI SKILL（必需，二选一）
+# 方式 A：通过 npx skills
 npx skills add larksuite/cli -y -g
+# 方式 B：通过 Claude Code Marketplace
+claude plugin marketplace add larksuite/cli && claude plugin install lark-cli@larksuite-cli
 ```
 
 **第 2 步 — 配置应用凭证**


### PR DESCRIPTION
## Summary

Add support for installing lark-cli skills via Claude Code's built-in marketplace feature by adding `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` manifests.

## Changes

- Add `.claude-plugin/marketplace.json` — marketplace catalog with correct `owner` / `metadata` schema
- Add `.claude-plugin/plugin.json` — plugin definition pointing skills to `./skills/`
- Update `README.md` — add Option 3 (Claude Code Marketplace) installation instructions
- Update `README.zh.md` — add 方式三（Claude Code Marketplace）安装说明

## Test Plan

- [x] `claude plugin validate <repo-path>` passes with no errors
- [x] `claude plugin marketplace add <repo-path>` successfully adds marketplace
- [x] `claude plugin install lark-cli@larksuite-cli` successfully installs plugin
- [x] All 23 skills confirmed present under `~/.claude/plugins/cache/` after install
- [x] Existing `npx skills add larksuite/cli -y -g` workflow unaffected

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing the Lark/Feishu CLI plugin through Claude Code Marketplace as an alternative installation method.

* **Documentation**
  * Updated installation instructions to present multiple installation options for users.
  * Updated documentation in both English and Chinese versions with marketplace installation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->