### PR TITLE
ci: integrate Codecov for coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,3 +6,6 @@ coverage:
     patch:
       default:
         target: 60%
+
+github_checks:
+  annotations: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
           go test -race -coverprofile=coverage.txt -covermode=atomic $packages
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1571263c2de # v5
+        uses: codecov/codecov-action@3f20e214133d0983f9a10f3d63b0faf9241a3daa # v6
         with:
           files: coverage.txt
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,6 +43,12 @@ jobs:
           packages=$(go list ./... | grep -v '^github.com/larksuite/cli/tests/cli_e2e$' | grep -v '^github.com/larksuite/cli/tests/cli_e2e/')
           go test -race -coverprofile=coverage.txt -covermode=atomic $packages
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67af1571263c2de # v5
+        with:
+          files: coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Generate coverage report
         run: |
           total=$(go tool cover -func=coverage.txt | grep total | awk '{print $3}')

--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -12,6 +12,15 @@ func TruncateStr(s string, n int) string {
 	return string(r[:n])
 }
 
+// ReverseStr reverses a string, safe for multi-byte (e.g. CJK) characters.
+func ReverseStr(s string) string {
+	r := []rune(s)
+	for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+	return string(r)
+}
+
 // TruncateStrWithEllipsis truncates s to at most n runes (including "..." suffix).
 func TruncateStrWithEllipsis(s string, n int) string {
 	r := []rune(s)

--- a/internal/util/strings_test.go
+++ b/internal/util/strings_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package util
+
+import "testing"
+
+func TestTruncateStr(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		n    int
+		want string
+	}{
+		{"short string", "hello", 10, "hello"},
+		{"exact length", "hello", 5, "hello"},
+		{"truncate", "hello world", 5, "hello"},
+		{"empty", "", 5, ""},
+		{"zero limit", "hello", 0, ""},
+		{"CJK characters", "你好世界测试", 4, "你好世界"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TruncateStr(tt.s, tt.n); got != tt.want {
+				t.Errorf("TruncateStr(%q, %d) = %q, want %q", tt.s, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateStrWithEllipsis(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		n    int
+		want string
+	}{
+		{"short string", "hello", 10, "hello"},
+		{"exact length", "hello", 5, "hello"},
+		{"truncate with ellipsis", "hello world", 8, "hello..."},
+		{"limit less than 3", "hello", 2, "he"},
+		{"limit equals 3", "hello world", 3, "..."},
+		{"empty", "", 5, ""},
+		{"CJK with ellipsis", "你好世界测试", 5, "你好..."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TruncateStrWithEllipsis(tt.s, tt.n); got != tt.want {
+				t.Errorf("TruncateStrWithEllipsis(%q, %d) = %q, want %q", tt.s, tt.n, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add Codecov upload step to coverage workflow for PR-level coverage reporting
- Add unit tests for `internal/util/strings.go` (TruncateStr, TruncateStrWithEllipsis)

## Test plan
- [ ] CI coverage workflow passes
- [ ] Codecov bot comments on this PR with coverage report
- [ ] PR diff shows line-level coverage annotations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a string reversal utility with correct support for multi-byte characters.

* **Tests**
  * Added unit tests for string truncation utilities covering boundaries, empty and zero-length inputs, ellipsis behavior, and multi-byte character cases.

* **Chores**
  * CI now uploads coverage artifacts and enables coverage annotations in checks for richer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->