### PR TITLE
Add client_secret to device authorization request

### DIFF
--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -79,6 +79,7 @@ func RequestDeviceAuthorization(httpClient *http.Client, appId, appSecret string
 
 	form := url.Values{}
 	form.Set("client_id", appId)
+	form.Set("client_secret", appSecret)
 	form.Set("scope", scope)
 
 	req, err := http.NewRequest("POST", endpoints.DeviceAuthorization, strings.NewReader(form.Encode()))

--- a/internal/auth/device_flow_test.go
+++ b/internal/auth/device_flow_test.go
@@ -109,6 +109,36 @@ func TestFormatAuthCmdline_TruncatesExtraArgs(t *testing.T) {
 	}
 }
 
+// TestRequestDeviceAuthorization_ClientSecretInBody checks that client_secret is sent in the form body.
+func TestRequestDeviceAuthorization_ClientSecretInBody(t *testing.T) {
+	reg := &httpmock.Registry{}
+	t.Cleanup(func() { reg.Verify(t) })
+
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    PathDeviceAuthorization,
+		Body: map[string]interface{}{
+			"device_code":               "dc",
+			"user_code":                 "uc",
+			"verification_uri":          "https://example.com/verify",
+			"verification_uri_complete": "https://example.com/verify?code=123",
+			"expires_in":                240,
+			"interval":                  5,
+		},
+	}
+	reg.Register(stub)
+
+	_, err := RequestDeviceAuthorization(httpmock.NewClient(reg), "cli_a", "secret_b", core.BrandFeishu, "", nil)
+	if err != nil {
+		t.Fatalf("RequestDeviceAuthorization() error: %v", err)
+	}
+
+	body := string(stub.CapturedBody)
+	if !strings.Contains(body, "client_secret=secret_b") {
+		t.Errorf("expected client_secret in form body, got %q", body)
+	}
+}
+
 // TestLogAuthResponse_IgnoresTypedNilHTTPResponse tests that a typed nil HTTP response is ignored gracefully.
 func TestLogAuthResponse_IgnoresTypedNilHTTPResponse(t *testing.T) {
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary
Device auth was failing because the endpoint requires client_secret but we weren't sending it. Added the missing parameter and a test to verify it gets included.

## Changes
Added client_secret to the form payload in RequestDeviceAuthorization. Also added a test case that checks client_secret is in the request body.

## Test Plan
New test passes. Tested locally with lark auth login and it works now.

## Related Issues
Fixes #509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device authorization flow now transmits client credentials within the request payload in addition to authentication headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->