### PR TITLE
docs(task): document custom_fields and custom_field_options API

### DIFF
--- a/skills/lark-task/SKILL.md
+++ b/skills/lark-task/SKILL.md
@@ -100,6 +100,20 @@ lark-cli task <resource> <method> [flags] # 调用 API
   - `patch` — 更新自定义分组
   - `tasks` — 获取自定义分组任务列表
 
+### custom_fields
+
+  - `create` — 创建自定义字段
+  - `get` — 获取自定义字段详情
+  - `patch` — 更新自定义字段
+  - `list` — 获取自定义字段列表
+  - `add` — 将自定义字段加入资源
+  - `remove` — 将自定义字段移出资源
+
+### custom_field_options
+
+  - `create` — 创建自定义字段选项
+  - `patch` — 更新自定义字段选项
+
 ## 权限表
 
 | 方法 | 所需 scope |
@@ -127,3 +141,11 @@ lark-cli task <resource> <method> [flags] # 调用 API
 | `sections.list` | `task:section:read` |
 | `sections.patch` | `task:section:write` |
 | `sections.tasks` | `task:section:read` |
+| `custom_fields.create` | `task:custom_field:write` |
+| `custom_fields.get` | `task:custom_field:read` |
+| `custom_fields.patch` | `task:custom_field:write` |
+| `custom_fields.list` | `task:custom_field:read` |
+| `custom_fields.add` | `task:custom_field:write` |
+| `custom_fields.remove` | `task:custom_field:write` |
+| `custom_field_options.create` | `task:custom_field:write` |
+| `custom_field_options.patch` | `task:custom_field:write` |


### PR DESCRIPTION
## Summary
This PR supplements the `SKILL.md` for Lark Tasks with the native API references and permission mappings for `custom_fields` and `custom_field_options`. This allows AI Agents to discover and correctly call the raw endpoints for task custom field operations, since these endpoints are not currently exposed in Level 2 OpenAPI commands or Level 1 Shortcuts.

## Changes
- Added `custom_fields` endpoints (create, get, patch, list, add, remove) to the API Resources list.
- Added `custom_field_options` endpoints (create, patch) to the API Resources list.
- Mapped all corresponding `task:custom_field:read` and `task:custom_field:write` scopes to the permission table.

## Test Plan
- [x] Unit tests pass (`go test ./shortcuts/task` and `make unit-test` verified)
- [x] Manual local verification confirms the documentation renders correctly and markdown formatting is intact.

## Related Issues
- None