### PR TITLE
feat(slides): add slide templates catalog and guidance

### DIFF
--- a/skills/lark-slides/SKILL.md
+++ b/skills/lark-slides/SKILL.md
@@ -14,6 +14,11 @@ metadata:
 
 **CRITICAL — 生成任何 XML 之前，MUST 先用 Read 工具读取 [xml-schema-quick-ref.md](references/xml-schema-quick-ref.md)，禁止凭记忆猜测 XML 结构。**
 
+**CRITICAL — 如果用户提到“模板”“套用模板”“参考某种主题/风格/版式”，或用户需求明显落在已有场景模板内（如工作汇报、产品介绍、商业计划书、培训、晋升汇报等），MUST 先读取 [template-index.json](references/template-index.json) 或运行 [`scripts/template-tool.py`](scripts/template-tool.py) 做模板检索；默认给出 2-3 个最匹配模板候选供用户选择。只有确定要复用某类版式时，才进一步读取 [template-catalog.md](references/template-catalog.md) 或按页型裁切 `references/templates/*.xml` 片段；不要默认阅读全文模板 XML。**
+
+> [!NOTE]
+> `scripts/template-tool.py` / `scripts/layout-lint.py` 需要 Python 3，但它们是可选辅助路径，不是强制依赖。没有 Python 时，退回 “`template-index.json` → `template-catalog.md` → 按范围读取 XML 片段” 的纯文档路径。
+
 **编辑已有幻灯片页面**：优先用 [`+replace-slide`](references/lark-slides-replace-slide.md)（块级替换/插入，不动页序）；选择 action 和完整读-改-写流程见 [`lark-slides-edit-workflows.md`](references/lark-slides-edit-workflows.md)。
 
 ## 身份选择
@@ -46,6 +51,12 @@ lark-cli slides +create --title "演示文稿标题" --slides '[
 
 也可以分两步（先创建空白 PPT，再逐页添加），详见 [+create 参考文档](references/lark-slides-create.md)。
 
+> [!WARNING]
+> `--slides '[...]'` 适合简单页面批量创建，但并不等同于“10 页以内都安全”。如果 slide XML 含中文、大段文本、复杂布局、嵌套引号或较多特殊字符，shell 传参时可能出现转义或截断问题，导致内容丢失、页面空白或布局异常。遇到复杂页面时，优先改用“两步创建法”。
+
+> [!IMPORTANT]
+> `slides +create --slides` 底层是“先创建空白 PPT，再逐页调用 `xml_presentation.slide.create`”。这不是原子操作；中途某一页失败时，前面已创建成功的页面会保留。skill 必须把这种“部分成功”风险提前告诉用户，并在失败后先记录 `xml_presentation_id`，回读确认当前状态，再决定是否在现有 PPT 上继续修复或追加。
+
 > 以上是最小可用示例。更丰富的页面效果（渐变背景、卡片、图表、表格等），参考下方 Workflow 和 XML 模板。
 
 ## 执行前必做
@@ -63,6 +74,10 @@ lark-cli slides +create --title "演示文稿标题" --slides '[
 | 场景 | 文档 |
 |------|------|
 | 需要了解详细 XML 结构 | [xml-format-guide.md](references/xml-format-guide.md) |
+| 需要快速筛模板、做低成本路由 | [template-index.json](references/template-index.json) |
+| 需要匹配 PPT 模板/主题风格 | [template-catalog.md](references/template-catalog.md) |
+| 需要按页型抽摘要或裁切 XML 片段 | [`scripts/template-tool.py`](scripts/template-tool.py) |
+| 需要做本地布局风险检查 | [`scripts/layout-lint.py`](scripts/layout-lint.py) |
 | 需要 CLI 调用示例 | [examples.md](references/examples.md) |
 | 需要参考真实 PPT 的 XML | [slides_demo.xml](references/slides_demo.xml) |
 | 需要用 table/chart 等复杂元素 | [slides_xml_schema_definition.xml](references/slides_xml_schema_definition.xml)（完整 Schema） |
@@ -73,39 +88,151 @@ lark-cli slides +create --title "演示文稿标题" --slides '[
 
 > **这是演示文稿，不是文档。** 每页 slide 是独立的视觉画面，信息密度要低，排版要留白。
 
+### 创建方式选择
+
+| 场景 | 推荐方式 |
+|------|----------|
+| 简单 XML（1-3 页、结构简单、几乎无复杂中文和特殊字符） | `slides +create --slides '[...]'` 一步创建 |
+| 复杂 XML（多页、含中文、大段文本、复杂布局、嵌套引号、特殊字符较多） | **两步创建**：先 `slides +create` 创建空白 PPT，再用 `xml_presentation.slide create` 逐页添加 |
+| 已有 PPT 继续追加或插入页面 | 使用 `xml_presentation.slide create`，必要时配合 `before_slide_id` |
+
+> [!WARNING]
+> `--slides '[...]'` 的风险点主要在 shell 参数传递，而不是单纯页数。即使只有 1 页，只要 XML 足够复杂，也建议使用两步创建法。
+
 ```text
 Step 1: 需求澄清 & 读取知识
   - 澄清用户需求：主题、受众、页数、风格偏好
+  - 如果需求明显落在已有模板场景内，主动提示用户“可以直接基于现成模板生成”，并给出 2-3 个最匹配模板候选（模板名 + 适用场景 + 风格/色调 + 简短推荐理由）
+  - 默认不要把完整模板目录直接贴给用户；除非用户明确要求看更多，否则只展示 2-3 个候选
+  - 候选优先选场景强相关模板；只有没有明显场景模板时，才用 `light_general.xml` / `dark_general.xml` 这类通用模板兜底
   - 如果用户没有明确风格，根据主题推荐（见下方风格判断表）
+  - 如果用户要求“模板/主题/风格参考”，或主题属于常见模板场景：
+    · 先读 template-index.json，或运行 `python3 skills/lark-slides/scripts/template-tool.py search --query "<主题>" --limit 3` 做低成本模板匹配
+    · 需要人类可读说明时，再读 template-catalog.md 组织候选文案
+    · 锁定模板后，优先运行 `template-tool.py summarize` 看 `<theme>` / 页型摘要；需要具体布局时，再用 `template-tool.py extract` 或按 range 读取 XML 片段
+    · 复用模板的 theme、配色、页面流、布局骨架，不要照搬占位文案
+    · 除非用户明确要求查看整份模板，否则不要默认读取 `references/templates/*.xml` 全文
   - 读取 XML Schema 参考：
     · xml-schema-quick-ref.md — 元素和属性速查
     · xml-format-guide.md — 详细结构与示例
     · slides_demo.xml — 真实 XML 示例
 
 Step 2: 生成大纲 → 用户确认 → 创建
+  - 生成大纲前，先确认用户是否采用推荐模板；如果用户没有明确反对且候选中有明显最佳匹配，可默认按最匹配模板继续
   - 生成结构化大纲（每页标题 + 要点 + 布局描述），交给用户确认
-  - 10 页以内：用 slides +create --slides '[...]' 一步创建 PPT 并添加所有页面
-  - 超过 10 页：先 `slides +create` 创建空白 PPT，再用 `xml_presentation.slide.create` 逐页添加
+  - 如果已选模板，大纲和页面布局要明确标注“基于哪个模板/哪些模板改写”
+  - 如果用户明确不要模板，直接按自定义风格继续，不要重复推动模板选择
+  - 先判断创建方式：
+    · 简单 XML：可用 `slides +create --slides '[...]'` 一步创建
+    · 多页复杂 XML：优先用 `slides +compose --slides-dir ./slides --asset-root ./assets`
+      或 `--manifest @compose.json`，由 CLI 统一完成建空白 PPT、上传图片、逐页创建
+    · 复杂 XML：优先先 `slides +create` 创建空白 PPT，再用 `xml_presentation.slide.create` 逐页添加
+    · 超过 10 页：默认使用两步创建，避免单次输入过长
   - 含本地图片：
     · 新建带图 PPT —— 在 slide XML 里写 <img src="@./pic.png" .../>，
       +create 会自动上传并替换为 file_token（详见 lark-slides-create.md）
+    · 批量把一组图片预上传到已有 PPT —— 用 `slides +bulk-media-upload --presentation $PID --dir ./assets`
+      或重复 `--files`，直接拿到 `file_name -> file_token` map
     · 给已有 PPT 加带图新页 —— 先 `slides +media-upload --file ./pic.png --presentation $PID`
       拿到 file_token，再用它写进 slide XML 调 xml_presentation.slide.create
     · 给已有页加图 —— 两步：① `slides +media-upload` 拿 file_token
       ② `slides +replace-slide --parts '[{"action":"block_insert","insertion":"<img src=\"<file_token>\" .../>"}]'`
       不动其他元素，不要再整页重建（完整示例见 lark-slides-edit-workflows.md 的 block_insert 章节）
     · 路径必须是 CWD 内的相对路径（如 ./pic.png 或 ./assets/x.png）；
-      绝对路径会被 CLI 拒绝，先 cd 到素材所在目录再执行
+      `+compose` / `+replace-slide-xml` / `+bulk-media-upload` 可额外用 `--asset-root ./assets`
+      降低素材目录切换成本，但本质上仍要求路径落在当前工作目录白名单内
   - 每页 slide 需要完整的 XML：背景、文本、图形、配色
   - 复杂元素（table、chart）需参考 XSD 原文
+  - 创建前必须做 XML 自检：
+    · 检查特殊字符是否按 XML 规则转义：`& -> &amp;`、`< -> &lt;`、`> -> &gt;`
+    · 属性值里的双引号必须转义或改为外层安全包装，避免 shell 和 JSON 双重截断
+    · 确认所有标签闭合，且 `<slide>` 直接子元素只包含 `<style>`、`<data>`、`<note>`
+    · 如果内容里同时出现中文、大段文本、复杂布局、较多特殊字符，默认不要走 `--slides '[...]'`，直接改用两步创建法或 `+compose`
+  - 如果使用模板生成页面，先复用模板骨架再填内容，不要直接复制模板中的长段占位文本
+  - 默认不要推荐 heredoc Python 作为主路径：
+    · 多页 XML 文件已落盘时，优先 `slides +compose --slides-dir ./slides`
+    · 已有 manifest 时，优先 `slides +compose --manifest @compose.json`
+    · 只有在 CLI 现有 shortcut 明显覆盖不了时，才退回临时脚本包装
 
 Step 3: 审查 & 交付
-  - 创建完成后，用 xml_presentations.get 读取全文 XML，确认：
-    · 页数是否正确？每页内容是否完整？
+  - 创建完成后，必须用 xml_presentations.get 读取全文 XML 做创建后验证，确认：
+    · 页数是否正确？
+    · 每页 `<data>` 是否包含预期的 `<shape>` / `<img>` / 其他元素？
+    · 文本内容是否完整，是否有被截断、丢失、空白区域？
+    · 关键布局坐标和尺寸是否合理，是否出现明显重叠？
     · 配色是否统一？字号层级是否合理？
+  - 如果本地有 Python 3，建议额外运行
+    `python3 skills/lark-slides/scripts/layout-lint.py --input presentation.xml`
+    做重叠、越界、文本高度风险检查
+  - 如果创建过程中失败：
+    · 先保留并记录 `xml_presentation_id`，不要假设失败代表什么都没创建
+    · 先判断是否已有部分页面写入，再决定是否在现有 PPT 上修复后继续追加
+    · 优先排查当前失败页：先看该页 XML，再检查是否存在未转义 `&`、错误引号、标签未闭合、shell 传参截断
   - 局部问题 → 用 `+replace-slide` 块级修正；整页结构要改 → `slide.delete` 旧页 + `slide.create` 新页
   - 没问题 → 交付：告知用户演示文稿 ID 和访问方式
 ```
+
+### 创建后验证
+
+创建成功不等于内容正确。创建完 PPT 后，**必须**读取全文 XML 校验结果：
+
+```bash
+lark-cli slides xml_presentations get --as user \
+  --params '{"xml_presentation_id":"YOUR_ID"}'
+```
+
+重点检查：
+
+- [ ] 页数是否与预期一致
+- [ ] 每页 `<data>` 中是否包含所有预期元素
+- [ ] 文本内容是否完整，没有被 shell 截断或转义损坏
+- [ ] 白底内容区、卡片区、图文区等关键布局是否实际生成
+- [ ] 坐标、宽高是否合理，是否出现堆叠或越界
+
+发现问题时：
+
+1. 不要假设“创建成功就代表渲染正确”
+2. 先读取问题页的 XML，确认是生成问题还是传参损坏
+3. 删除问题页后重新添加；复杂页面优先改用两步创建法
+
+### 最小验收清单
+
+创建完成后，默认按下面顺序验收，不要省略：
+
+1. 记录 `xml_presentation_id`
+2. 确认返回的 `slides_added` 或实际页数是否符合预期
+3. 立即执行 `xml_presentations get`
+4. 检查标题、关键页面、关键文本是否存在
+5. 检查是否有明显空白页、内容缺失、页序错误
+6. 再决定是否向用户交付 URL 和后续编辑建议
+
+推荐最小闭环：
+
+```bash
+# 创建
+lark-cli slides +create --as user --title "Demo" --slides '[...]'
+
+# 立即回读
+lark-cli slides xml_presentations get --as user \
+  --params '{"xml_presentation_id":"YOUR_ID"}'
+```
+
+## XML 自检与排障
+
+在真正创建前，至少做下面 4 项检查：
+
+- [ ] 特殊字符已转义：正文和标题里的 `&`、`<`、`>` 不能裸写
+- [ ] 属性引号安全：XML 属性、shell 引号、JSON 字符串包装之间没有互相打断
+- [ ] 结构合法：`<slide>` 下只放 `<style>`、`<data>`、`<note>`，文本都在 `<content>` 内
+- [ ] 路径正确：`<img src="@...">` 只在 `+create --slides` / `+compose` / `+replace-slide-xml` 的支持链路中使用
+
+高频失败信号和处理顺序：
+
+1. `invalid param` / 某一页创建失败
+2. 先检查失败页是否含未转义 `&`
+3. 再检查标签闭合、属性引号、`<content>` 结构
+4. 如果是 `--slides '[...]'`，怀疑 shell 截断时直接切两步创建法
+5. 创建后无论成功失败，都优先记录 `xml_presentation_id` 并回读确认是否已有部分页面写入
 
 ### jq 命令模板（编辑已有 PPT 时使用）
 
@@ -163,6 +290,8 @@ lark-cli slides xml_presentation.slide create \
 ```text
 [PPT 标题] — [定位描述]，面向 [目标受众]
 
+模板：[未使用模板 / <category>/<template>.xml（推荐原因）]
+
 页面结构（N 页）：
 1. 封面页：[标题文案]
 2. [页面主题]：[要点1]、[要点2]、[要点3]
@@ -173,9 +302,72 @@ N. 结尾页：[结尾文案]
 风格：[配色方案]，[排版风格]
 ```
 
+### 模板引导话术模板
+
+当主题明显可套用现成模板时，优先用下面的方式引导用户选择：
+
+```text
+这个主题可以直接基于现成模板来做，会比纯自定义更快。我先给你 3 个可选方向：
+
+1. office/work_report.xml
+   适合：工作汇报、项目进展
+   风格：浅色正式、卡片布局
+   推荐理由：信息密度中等时最稳
+
+2. product/product_intro.xml
+   适合：产品介绍、产品发布
+   风格：多彩分节、视觉更强
+   推荐理由：适合强调亮点和分章节表达
+
+3. office/light_general.xml
+   适合：内容较自由、但想沿用成熟浅色版式
+   风格：浅色通用、页型丰富
+   推荐理由：适合作为兜底模板按需挑版式
+
+你可以直接选一个模板，我再按你的内容出大纲；如果不想套模板，我也可以按自定义风格来做。
+```
+
+### 场景 -> 模板快速路由
+
+优先按下面的固定顺序推荐模板，减少 agent 临时猜测：
+
+| 用户场景 | 默认推荐 | 备选 1 | 备选 2 |
+|---------|---------|--------|--------|
+| 读书分享 / 读书会 / 方法论分享 | `misc--book_sharing` | `personal--teaching_sharing` | `personal--experience_sharing` |
+| 教学分享 / 培训课件 / 技术分享 | `personal--teaching_sharing` | `hr--employee_training` | `hr--employee_training_workshop` |
+| 工作汇报 / 周报 / 月报 / 项目进展 | `office--work_report` | `office--work_summary_report` | `office--light_general` |
+| 工作总结 / 年度总结 / 季度复盘 | `office--work_summary` | `office--quarterly_review` | `office--dept_annual_report` |
+| 项目启动 / 宣讲 / kickoff | `office--project_kickoff` | `product--product_intro` | `office--dark_general` |
+| 产品介绍 / 产品发布 / 产品方案 | `product--product_intro` | `product--product_promotion` | `product--product_promotion_2` |
+| 产品分析 / 竞品分析 / 商业分析 | `product--product_analysis` | `product--market_analysis` | `product--business_case_analysis` |
+| 商业计划书 / 路演 / 营销方案 | `marketing--business_plan` | `marketing--roadshow_business_plan` | `marketing--marketing_plan` |
+| 晋升答辩 / 晋升汇报 / 个人述职 | `personal--promotion_report` | `personal--promotion_defense` | `personal--self_intro` |
+| 公司介绍 / 文化宣导 / 全员会 | `administration--company_intro` | `administration--corporate_culture` | `administration--all_hands_meeting` |
+| 没有明显场景，但想要成熟版式 | `office--light_general` | `office--dark_general` | 无 |
+
+推荐顺序规则：
+
+1. 先选场景最强相关模板，不先拿 `light_general` / `dark_general` 兜底
+2. 用户没提风格时，优先给 1 个默认推荐 + 2 个备选
+3. 用户只说“模板化一点”，但主题不明确时，才拿通用模板兜底
+4. 用户明确拒绝模板后，直接走自定义风格，不要重复推动模板选择
+
 ### 常用 Slide XML 模板
 
 可直接复制使用的模板（封面页、内容页、数据卡片页、结尾页）：[slide-templates.md](references/slide-templates.md)
+
+### 场景模板目录（优先匹配）
+
+当用户明确要求模板，或需求本身已经能映射到典型 PPT 主题时，优先走下面的模板匹配流程：
+
+1. 先读 [template-index.json](references/template-index.json)，或运行 `python3 skills/lark-slides/scripts/template-tool.py search --query "<主题>" --tone <light|dark|colorful> --limit 3`，按场景、色调、正式度先整理出 2-3 个用户可选模板候选
+2. 如果用户未明确拒绝模板，优先按最匹配候选继续；如果用户已选择模板，则锁定该模板
+3. 需要页型摘要时，先运行 `python3 skills/lark-slides/scripts/template-tool.py summarize --template <template-id> --label <封面|目录|分节|内容|结尾>`
+4. 需要具体布局骨架时，再运行 `python3 skills/lark-slides/scripts/template-tool.py extract --template <template-id> --label <页型>`，或用 Read 工具按 range 读取 `references/templates/<category>--<file>.xml` 的局部片段
+5. 提取模板中的 `<theme>`、封面样式、目录页、分节页、内容页、结尾页结构
+6. 用用户的真实内容重写页面，不要直接复用模板里的占位文字
+
+如果用户只说“帮我做一个产品介绍/晋升汇报/商业计划书 PPT”，即使没明确说“模板”，只要主题与目录中的模板明显匹配，也应该主动给出模板候选，而不是只在内部默默参考模板。
 
 ---
 
@@ -253,7 +445,9 @@ Shortcut 是对常用操作的高级封装（`lark-cli slides +<verb> [flags]`�
 
 | Shortcut | 说明 |
 |----------|------|
+| [`+compose`](references/lark-slides-compose.md) | 从 slide XML 目录或 manifest 创建 PPT，自动上传 `@path` 图片并逐页创建 |
 | [`+create`](references/lark-slides-create.md) | 创建 PPT（可选 `--slides` 一步添加页面，支持 `<img src="@./local.png">` 占位符自动上传），bot 模式自动授权 |
+| [`+bulk-media-upload`](references/lark-slides-bulk-media-upload.md) | 批量上传本地图片到指定演示文稿，返回 `file_name -> file_token` map |
 | [`+media-upload`](references/lark-slides-media-upload.md) | 上传本地图片到指定演示文稿，返回 `file_token`（用作 `<img src="...">`），最大 20 MB |
 | [`+replace-slide`](references/lark-slides-replace-slide.md) | 对已有幻灯片页面进行块级替换/插入（`block_replace` / `block_insert`），自动注入 id 和 `<content/>`，不改变页序 |
 
@@ -279,8 +473,8 @@ lark-cli slides <resource> <method> [flags] # 调用 API
 
 ## 核心规则
 
-1. **先出大纲再动手**：创建 PPT 前先生成大纲交给用户确认，避免返工
-2. **创建流程**：10 页以内推荐 `slides +create --slides '[...]'` 一步创建；超过 10 页先 `slides +create` 创建空白 PPT，再用 `xml_presentation.slide.create` 逐页添加
+1. **先定模板/风格并出大纲再动手**：如果需求可匹配模板，先给用户 2-3 个模板候选；模板或自定义风格确定后，再生成大纲交给用户确认，避免返工
+2. **创建流程按复杂度优先判断，不只看页数**：简单 XML 可用 `slides +create --slides '[...]'`；复杂 XML（含中文、大段文本、复杂布局、特殊字符）即使页数很少，也优先先 `slides +create` 创建空白 PPT，再用 `xml_presentation.slide.create` 逐页添加。超过 10 页默认使用两步创建
 3. **`<slide>` 直接子元素只有 `<style>`、`<data>`、`<note>`**：文本和图形必须放在 `<data>` 内
 4. **文本通过 `<content>` 表达**：必须用 `<content><p>...</p></content>`，不能把文字直接写在 shape 内
 5. **保存关键 ID**：后续操作需要 `xml_presentation_id`、`slide_id`、`revision_id`
@@ -307,6 +501,7 @@ lark-cli slides <resource> <method> [flags] # 调用 API
 |--------|------|----------|
 | 400 | XML 格式错误 | 检查 XML 语法，确保标签闭合 |
 | 400 | 请求包装错误 | 检查 `--data` 是否按 schema 传入 `xml_presentation.content` 或 `slide.content` |
+| 创建成功但页面空白/内容缺失/布局错乱 | 常见于 `--slides '[...]'` 的 shell 转义或长参数传递问题 | 改用两步创建：先 `slides +create`，再用 `jq -n` 包装 `xml_presentation.slide.create` 逐页添加，并在创建后立即读取 XML 验证 |
 | 404 | 演示文稿不存在 | 检查 `xml_presentation_id` 是否正确 |
 | 404 | 幻灯片不存在 | 检查 `slide_id` 是否正确 |
 | 403 | 权限不足 | 检查是否拥有对应的 scope |
@@ -356,9 +551,15 @@ lark-cli slides <resource> <method> [flags] # 调用 API
 | 文档 | 说明 |
 |------|------|
 | [lark-slides-create.md](references/lark-slides-create.md) | **+create Shortcut：创建 PPT（支持 `--slides` 一步添加页面，含 `@` 占位符自动上传图片）** |
+| [lark-slides-compose.md](references/lark-slides-compose.md) | **+compose Shortcut：从 slide XML 目录或 manifest 创建 PPT，并自动处理本地图片** |
+| [lark-slides-bulk-media-upload.md](references/lark-slides-bulk-media-upload.md) | **+bulk-media-upload Shortcut：批量上传图片并返回 `file_name -> file_token`** |
 | [lark-slides-media-upload.md](references/lark-slides-media-upload.md) | **+media-upload Shortcut：上传本地图片，返回 `file_token`** |
 | [lark-slides-replace-slide.md](references/lark-slides-replace-slide.md) | **+replace-slide Shortcut：块级替换/插入，含合法根元素速查与 3350001 排错** |
 | [lark-slides-edit-workflows.md](references/lark-slides-edit-workflows.md) | 编辑已有页面的读-改-写流程与 action 决策树 |
+| [template-index.json](references/template-index.json) | **机器可读模板索引：优先用来做模板路由和候选筛选** |
+| [template-catalog.md](references/template-catalog.md) | **按场景/色调匹配现成 PPT 模板，并定位到页型范围** |
+| [`scripts/template-tool.py`](scripts/template-tool.py) | **可选 Python 辅助脚本：`search` / `summarize` / `extract`，支持 `--layout-tag` 与 `extract --with-summary`** |
+| [`scripts/layout-lint.py`](scripts/layout-lint.py) | **本地布局检查脚本：检测重叠、越界、页脚碰撞、文本高度风险** |
 | [xml-schema-quick-ref.md](references/xml-schema-quick-ref.md) | **XML Schema 精简速查（必读）** |
 | [slide-templates.md](references/slide-templates.md) | 可复制的 Slide XML 模板 |
 | [xml-format-guide.md](references/xml-format-guide.md) | XML 详细结构与示例 |

--- a/skills/lark-slides/references/lark-slides-bulk-media-upload.md
+++ b/skills/lark-slides/references/lark-slides-bulk-media-upload.md
@@ -1,0 +1,48 @@
+# lark-slides +bulk-media-upload
+
+## 用途
+
+批量上传本地图片到指定演示文稿，并返回稳定的 `file_name -> file_token` map。
+
+## 命令
+
+```bash
+lark-cli slides +bulk-media-upload --as user \
+  --presentation "slides_xxx" \
+  --dir ./assets
+```
+
+或重复传文件：
+
+```bash
+lark-cli slides +bulk-media-upload --as user \
+  --presentation "slides_xxx" \
+  --asset-root ./assets \
+  --files cover.png \
+  --files chip.jpg
+```
+
+## 关键参数
+
+| 参数 | 说明 |
+|------|------|
+| `--presentation` | `xml_presentation_id`、`/slides/` URL，或能解析成 slides 的 wiki URL |
+| `--files` | 本地图片路径，可重复 |
+| `--dir` | 本地图片目录，非递归扫描常见图片后缀 |
+| `--asset-root` | `--files` 的素材根目录 |
+
+## 返回值
+
+成功时返回：
+
+- `presentation_id`
+- `uploaded_count`
+- `file_names`
+- `file_tokens`
+- `files`
+
+## 注意事项
+
+1. 相同文件名会被拒绝，因为返回结果按文件名建 map
+2. 目录扫描只包含常见图片后缀：png/jpg/jpeg/webp/gif/bmp/svg
+3. 单图仍受 20 MB 限制

--- a/skills/lark-slides/references/lark-slides-compose.md
+++ b/skills/lark-slides/references/lark-slides-compose.md
@@ -1,0 +1,71 @@
+# lark-slides +compose
+
+## 用途
+
+从一组 slide XML 文件创建新的飞书幻灯片演示文稿。适合多页、复杂 XML、带本地图片占位符的场景。
+
+## 命令
+
+```bash
+lark-cli slides +compose --as user --title "发布会" --slides-dir ./slides --asset-root ./assets
+```
+
+或使用 manifest：
+
+```bash
+lark-cli slides +compose --as user --manifest @compose.json --asset-root ./assets
+```
+
+## 关键参数
+
+| 参数 | 说明 |
+|------|------|
+| `--title` | 演示文稿标题；未传时回退到 manifest.title 或 `Untitled` |
+| `--slides-dir` | 存放 `.xml` slide 文件的目录，按文件名字典序逐页创建 |
+| `--manifest` | compose manifest JSON，可通过 `@file` 或 stdin 传入 |
+| `--asset-root` | 本地图片素材根目录；slide XML 中的 `@path` 会相对该目录解析 |
+
+## manifest 结构
+
+```json
+{
+  "title": "iPhone 17 Pro Max 发布会",
+  "slides": [
+    { "file": "01-cover.xml" },
+    { "file": "02-hero.xml" },
+    { "content": "<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data>...</data></slide>" }
+  ]
+}
+```
+
+每个 slide 必须二选一：
+
+- `file`：相对 `--slides-dir` 或当前工作目录的 XML 文件
+- `content`：内联 slide XML
+
+## 行为
+
+1. 创建空白 PPT
+2. 扫描所有 slide XML 中的 `<img src="@...">`
+3. 自动上传本地图片到新 PPT
+4. 用 `file_token` 替换 XML 中的 `@path`
+5. 逐页调用 `xml_presentation.slide.create`
+
+## 返回值
+
+成功时返回：
+
+- `xml_presentation_id`
+- `title`
+- `revision_id`
+- `images_uploaded`
+- `slide_ids`
+- `slides_added`
+- `url`
+
+## 注意事项
+
+1. `--slides-dir` 只做单层目录扫描，不递归
+2. `--asset-root` 只是降低素材路径切换成本，路径仍必须位于当前工作目录内
+3. 复杂 XML 仍建议创建后用 `xml_presentations.get` 回读校验
+4. 如果本地有 Python 3，可再配合 `python3 skills/lark-slides/scripts/layout-lint.py --input presentation.xml` 做布局检查

--- a/skills/lark-slides/references/lark-slides-create.md
+++ b/skills/lark-slides/references/lark-slides-create.md
@@ -58,6 +58,20 @@ lark-cli slides +create --title "项目汇报" --slides '[...]' --dry-run
 | `--title` | 否 | 演示文稿标题（不传则默认 "Untitled"） |
 | `--slides` | 否 | slide 内容 JSON 数组，每个元素是一个 `<slide>` XML 字符串（最多 10 个；超过 10 页请先用 `+create` 创建空白 PPT，再用 `xml_presentation.slide create` 逐页添加） |
 
+## 创建方式选择
+
+| 场景 | 推荐方式 |
+|------|----------|
+| 简单 XML，且页数少、结构简单 | 直接用 `+create --slides` |
+| XML 含中文、大段文本、复杂布局、嵌套引号、特殊字符较多 | 优先用“两步创建法” |
+| 已有 PPT 继续加页 | 使用 `xml_presentation.slide create` |
+
+> [!WARNING]
+> `+create --slides` 的主要风险是 shell 传参，不是单纯的页数限制。即使只有 1 页，只要 XML 复杂，也可能出现内容丢失、空白区域或布局错乱。复杂页面不要强行一步创建。
+
+> [!IMPORTANT]
+> `+create --slides` 不是原子操作。CLI 会先创建空白演示文稿，再逐页创建 slide；如果第 N 页失败，前面已成功的页面和演示文稿会保留。失败后先记录 `xml_presentation_id`，回读确认当前状态，再决定是否在现有 PPT 上继续修复或追加。
+
 ## `--slides` 参数格式
 
 ```json
@@ -68,6 +82,16 @@ lark-cli slides +create --title "项目汇报" --slides '[...]' --dry-run
 ```
 
 JSON string 数组，每个元素是一页 slide 的完整 XML。CLI 内部负责包装成 API 所需的 `{"slide": {"content": "..."}}` 格式并逐页调用。
+
+> [!WARNING]
+> 当 `--slides` 中的 XML 同时包含中文、复杂结构、很多属性、嵌套引号或特殊字符（如 `<`、`>`、`&`）时，shell 传参可能造成转义损坏或内容截断。出现这类风险时，改用下方“复杂 PPT 创建流程”。
+
+创建前至少做这几项自检：
+
+- [ ] 标题、正文中的 `&`、`<`、`>` 已按 XML 规则转义
+- [ ] 所有标签已闭合，且文本都包在 `<content><p>...</p></content>` 中
+- [ ] 属性引号、shell 引号、JSON 包装不会互相冲突
+- [ ] 如果内容复杂，改用两步创建法，不要强行塞进单条 `--slides`
 
 ### 本地图片：`@<path>` 占位符
 
@@ -123,6 +147,61 @@ lark-cli slides xml_presentation.slide create --as user \
     }
   }'
 ```
+
+## 复杂 PPT 创建流程
+
+当页面 XML 较复杂时，推荐使用“两步创建法”避免 shell 转义问题：
+
+```bash
+# Step 1: 创建空白 PPT
+PRES_ID=$(lark-cli slides +create --as user --title "项目汇报" | jq -r '.data.xml_presentation_id')
+
+# Step 2: 逐页添加，使用 jq -n 安全包装 XML
+lark-cli slides xml_presentation.slide create --as user \
+  --params "{\"xml_presentation_id\":\"$PRES_ID\"}" \
+  --data "$(jq -n --arg content '<slide xmlns=\"http://www.larkoffice.com/sml/2.0\"><data><shape type=\"text\" topLeftX=\"80\" topLeftY=\"80\" width=\"800\" height=\"120\"><content textType=\"title\"><p>第一页</p></content></shape></data></slide>' '{slide:{content:$content}}')"
+```
+
+如果页面较多，建议把每页 XML 放到独立文件，再逐页添加：
+
+```bash
+# 假设每个文件都只包含一页完整的 <slide>...</slide>
+for slide_xml in ./slides/01.xml ./slides/02.xml ./slides/03.xml; do
+  lark-cli slides xml_presentation.slide create --as user \
+    --params "{\"xml_presentation_id\":\"$PRES_ID\"}" \
+    --data "$(jq -n --arg content "$(cat "$slide_xml")" '{slide:{content:$content}}')"
+done
+```
+
+这种方式的优点：
+
+- 每次只传一页 XML，避免长 JSON 数组在 shell 中被错误解析
+- `jq -n` 负责字符串包装，减少手写转义
+- 出问题时更容易定位到具体页面并重试
+
+## 创建后验证
+
+无论是一步创建还是两步创建，完成后都应立即验证：
+
+```bash
+lark-cli slides xml_presentations get --as user \
+  --params "{\"xml_presentation_id\":\"$PRES_ID\"}"
+```
+
+至少检查：
+
+- [ ] 页数是否正确
+- [ ] 每页 XML 是否完整返回
+- [ ] 关键文本、卡片、白底内容区是否真实存在
+- [ ] 是否出现内容堆叠、空白区域或明显缺失
+
+如果验证发现问题，优先删除问题页并用两步创建法重新添加，而不是继续沿用有风险的 `--slides` 输入。
+
+如果命令中途失败，也要做一次验收：
+
+- 记录返回或日志里的 `xml_presentation_id`
+- 回读演示文稿，确认是否已经有部分页面写入
+- 若存在部分已写入页面，按实际情况在当前 PPT 上继续追加或逐页修复
 
 ## 常见错误
 

--- a/skills/lark-slides/references/lark-slides-replace-slide-xml.md
+++ b/skills/lark-slides/references/lark-slides-replace-slide-xml.md
@@ -1,0 +1,47 @@
+# lark-slides +replace-slide-xml
+
+## 用途
+
+整页替换已有 slide。CLI 会固定执行：
+
+1. 如有 `@path` 图片占位符，先上传素材
+2. 在旧页前创建新页
+3. 删除旧页
+
+适合“改一页 XML 但不想手工做 create + delete 编排”的场景。
+
+## 命令
+
+```bash
+lark-cli slides +replace-slide-xml --as user \
+  --presentation "slides_xxx" \
+  --slide-id "slide_old" \
+  --content @./slides/replacement.xml \
+  --asset-root ./assets
+```
+
+## 关键参数
+
+| 参数 | 说明 |
+|------|------|
+| `--presentation` | `xml_presentation_id`、`/slides/` URL，或 wiki URL |
+| `--slide-id` | 要被替换的旧 `slide_id` |
+| `--content` | 新的 slide XML，支持 `@file` / stdin |
+| `--asset-root` | 新 XML 中 `@path` 图片占位符的素材根目录 |
+
+## 返回值
+
+成功时返回：
+
+- `presentation_id`
+- `replaced_slide_id`
+- `replacement_slide_id`
+- `create_revision_id`
+- `delete_revision_id`
+- `images_uploaded`
+
+## 注意事项
+
+1. 这是整页替换，不是元素级 patch
+2. 新页 `slide_id` 一定会变化
+3. 如果“创建新页成功但删除旧页失败”，错误信息会带上新的 `slide_id`，便于人工恢复

--- a/skills/lark-slides/references/lark-slides-xml-presentations-get.md
+++ b/skills/lark-slides/references/lark-slides-xml-presentations-get.md
@@ -90,6 +90,39 @@ lark-cli slides xml_presentations get --as user --params '{"xml_presentation_id"
 2. 返回的 XML 在 `data.xml_presentation.content` 字段中
 3. 如果只需要部分信息，可以使用 `jq` 等工具过滤返回结果
 4. 建议将获取的 XML 保存为文件，便于后续编辑或备份
+5. 创建 PPT 后，应把 `xml_presentations get` 作为默认验收步骤，而不是可选步骤
+
+## 创建后验收建议
+
+最小验收顺序：
+
+1. 记录 `xml_presentation_id`
+2. 回读最新 XML
+3. 确认页数是否符合预期
+4. 确认标题、关键文本、关键布局元素是否存在
+5. 如果创建过程中报错，也要回读确认是否已经发生部分写入
+
+### 推荐验收命令
+
+```bash
+# 保存完整 JSON
+lark-cli slides xml_presentations get --as user \
+  --params '{"xml_presentation_id":"slides_example_presentation_id"}' \
+  > presentation_data.json
+
+# 只导出 XML 内容
+lark-cli slides xml_presentations get --as user \
+  --params '{"xml_presentation_id":"slides_example_presentation_id"}' \
+  | jq -r '.xml_presentation.content' \
+  > presentation.xml
+```
+
+### 建议检查项
+
+- [ ] 页数是否正确
+- [ ] 标题页是否存在
+- [ ] 关键文本是否完整，没有被截断
+- [ ] 关键 shape / img / table / chart 是否都在 XML 中出现
 
 ## 相关命令
 

--- a/skills/lark-slides/references/template-catalog.md
+++ b/skills/lark-slides/references/template-catalog.md
@@ -1,0 +1,419 @@
+# Slides 模板目录
+
+> **创建 PPT 前必读。** 先根据用户需求匹配 1-2 个最佳模板，再根据每个模板下方的“页型索引”按需读取对应 slide 范围。**默认不要阅读全文模板 XML**，尤其不要默认读取 `light_general.xml` / `dark_general.xml` 这类 54/56 页通用变体库全文。
+
+> **机器优先路径。** 优先先读 [`template-index.json`](template-index.json) 做低成本路由；需要按页型抽摘要或裁切 XML 时，优先运行 [`../scripts/template-tool.py`](../scripts/template-tool.py) 的 `search` / `summarize` / `extract`。只有当你已经锁定了具体页型，才继续读取模板 XML 片段。
+
+> **降级路径。** 如果 `template-tool.py` 不可用，退回这条纯文档路径：`template-index.json` 初筛 → 本文按场景确定模板 → 按页型索引读取目标 XML 范围。不要因为脚本不可用就直接阅读全文模板 XML。
+
+> **对话输出规则。** 当处于需求澄清阶段时，应该把匹配结果整理成 **2-3 个用户可选模板候选**，不要默认把整份目录贴给用户。每个候选至少包含：模板名、适用场景、风格/色调、简短推荐理由。优先展示场景强相关模板；`light_general.xml` / `dark_general.xml` 这类通用模板只作为兜底或补充选项。
+
+## 使用方法
+
+1. 先读 [`template-index.json`](template-index.json)，或运行 `python3 skills/lark-slides/scripts/template-tool.py search --query "<主题>" --limit 3`，根据用户描述的 **场景、风格、色调** 做初筛
+2. 整理出 **2-3 个**最匹配的用户可选模板候选；优先选场景强相关模板，没有明显场景模板时再用标 ⭐ 的通用模板兜底
+3. 用户选定后，再锁定 **1-2 个**最匹配的模板作为实际参考
+4. 先看模板下方的 **页型索引**，锁定你真正需要的页型：封面 / 目录 / 分节 / 内容 / 结尾
+5. 优先运行 `template-tool.py summarize` 查看 `<theme>` / 页型摘要；只有需要具体布局骨架时，再运行 `template-tool.py extract` 或按需读取对应模板 XML 的相关 slide 范围
+6. 从模板中提取并复用：`<theme>` 配色、页面流、shape 排列布局、装饰元素风格
+7. 将用户的实际内容填充到模板的结构框架中，**不要照搬模板的占位文字**
+
+### 脚本快捷命令
+
+```bash
+# 先找候选模板
+python3 skills/lark-slides/scripts/template-tool.py search --query "工作汇报" --tone light --limit 3
+
+# 看指定页型的紧凑摘要
+python3 skills/lark-slides/scripts/template-tool.py summarize --template office--work_report --label 内容
+
+# 只裁切目标页型，避免把整份 XML 拉进上下文
+python3 skills/lark-slides/scripts/template-tool.py extract --template office--work_report --label 封面 --out /tmp/work-report-cover.xml
+```
+
+如果脚本路径不可用，按这个顺序手动降级：
+
+1. 先读 `template-index.json` 按 query / tone / formality 选 2-3 个候选
+2. 再回到本文对应分类，确认页数、色调、适用场景
+3. 只读取目标模板的目标页型范围，不要整份展开
+
+## 匹配维度
+
+| 维度 | 说明 |
+|------|------|
+| 场景 | 用户要做什么？（工作汇报、产品介绍、商业计划书、培训...） |
+| 色调 | light（浅色/白底）、dark（深色/黑底）、colorful（多彩活泼） |
+| 正式度 | formal（正式商务）、casual（轻松分享）、creative（创意设计） |
+
+---
+
+## office — 办公通用
+
+### ⭐ light_general.xml — 浅色通用变体库
+
+- **54 页 slide 变体**（非完整 PPT，是按需挑选的页面类型库）
+- 色调：light | 正式度：formal
+- 配色：白底 `#f4f5f6`，蓝色点缀 `#4e6efd`，深灰文字 `#1f2329`
+- 页面类型：封面×2, 目录×4, 分节页, 内容×30, 数据卡片×2, 结尾
+- 页型索引（建议先读）：封面 `1-2` | 目录 `3-6` | 分节/过渡 `7-8` | 内容/图文/时间线/数据 `9-53` | 结尾 `54`
+- **适用**：任何需要浅色风格的场景，从中挑选合适的页面布局
+
+### ⭐ dark_general.xml — 深色通用变体库
+
+- **56 页 slide 变体**（同上，深色版）
+- 色调：dark | 正式度：formal
+- 配色：深灰底 `#1f2329`，蓝色点缀 `#4e6efd`，白色文字
+- 页面类型：封面×2, 目录×4, 分节页, 内容×31, 数据卡片×2, 结尾
+- 页型索引（建议先读）：封面 `1-2` | 目录 `3-6` | 分节/过渡 `7-8` | 内容/图文/时间线/数据 `9-54` | 结尾 `55-56`
+- **适用**：任何需要深色风格的场景，渐变填充（蓝-青）、透明度叠加
+
+### work_report.xml — 工作汇报
+
+- 13 页 | 色调：light | 正式度：formal
+- 配色：图片底图 + 半透明白色卡片（alpha=0.51），紫色 `#7f3bf5`/蓝色 `#3370ff` 点缀
+- 结构：封面 → 目录(4 Part) → 数据页 → 内容×9 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `4-12` | 结尾 `13`
+- **适用**：工作汇报、月报、项目进展。中英双语标题，4 宫格布局，圆角卡片
+
+### work_summary_report.xml — 工作总结报告
+
+- 16 页 | 色调：dark | 正式度：formal
+- 配色：深灰底 `#2b2f36`，深蓝 `#3a6cea`/靛蓝 `#0e5efd` 点缀
+- 结构：封面 → 目录 → [分节页 → 内容]×4 → 结尾（4 个清晰分节）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `3, 6, 9, 12` | 内容 `4-5, 7-8, 10-11, 13-15` | 结尾 `16`
+- **适用**：年度/季度工作总结，分节清晰的正式汇报
+
+### work_summary.xml — 工作总结
+
+- 20 页 | 色调：light | 正式度：formal
+- 配色：暖黄 `#fff6dc` + 浅蓝 `#ddeff7` 交替，天蓝 `#1393cf` 点缀，金色 `#f7c15f` 强调
+- 结构：封面 → 目录 → 内容×7 → 数据×2 → 内容×8 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-9, 12-19` | 结尾 `20`
+- **适用**：轻松温暖风格的工作总结。shape 类型最丰富（饼图、三角、弧形等）
+
+### quarterly_review.xml — 季度复盘
+
+- 17 页 | 色调：dark | 正式度：formal
+- 配色：海军蓝图片底图，钢蓝 `#435671` 文字，半透明白色叠加（alpha=0.6）
+- 结构：封面 → 目录 → 内容×2 → 数据×2 → 内容×10 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-4, 7-16` | 结尾 `17`
+- **适用**：季度复盘、OKR 回顾，数据驱动型汇报
+
+### dept_annual_report.xml — 部门年度汇报
+
+- 17 页 | 色调：dark | 正式度：formal
+- 配色：黑色底图 + 极光渐变（紫/青/蓝），青色 `#64e8d6` → 蓝色 `#73bbff` 渐变点缀
+- 结构：封面 → 目录 → 内容×4 → 数据 → 内容×9 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-6, 8-16` | 结尾 `17`
+- **适用**：年度部门汇报，视觉冲击力强，多彩渐变风
+
+### project_kickoff.xml — 项目启动宣讲
+
+- 18 页 | 色调：dark | 正式度：formal
+- 配色：蓝色渐变底 `linear-gradient(#4b5cf5, #233afb)`，紫色 `#ad82f7` 强调
+- 结构：封面 → 目录 → 内容×15 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-17` | 结尾 `18`
+- **适用**：项目启动、产品发布、技术宣讲。大胆蓝紫渐变，卡片式布局
+
+---
+
+## product — 产品
+
+### product_analysis.xml — 产品分析报告
+
+- 17 页 | 色调：light | 正式度：formal
+- 配色：柔蓝渐变底图 `#deebff → #ffffff`，蓝色 `#2e4ef6 → #2182f4` 点缀，浅蓝卡片 `#e2eaf9`
+- 结构：封面 → 目录 → 内容 → 数据 → 内容×4 → 数据 → 内容×5 → SWOT → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3, 5-8, 10-16` | 结尾 `17`
+- **适用**：产品分析、竞品分析。包含 SWOT 分析页，数据图表页
+
+### product_intro.xml — 产品介绍
+
+- 18 页 | 色调：colorful | 正式度：formal
+- 配色：多彩渐变（每个分节不同色系：青蓝、橙红、紫、蓝靛）
+- 结构：封面 → 目录 → [分节页 → 内容]×4 → 结尾（含对比页、时间线页）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `3, 7, 11, 15` | 内容 `4-6, 8-10, 12-14, 16-17` | 结尾 `18`
+- **适用**：产品发布、产品介绍。视觉最丰富，每节独立配色
+
+### market_analysis.xml — 市场分析报告
+
+- 11 页 | 色调：dark | 正式度：formal
+- 配色：黑底，蓝紫渐变 `#0d47db → #7d00fa` 点缀
+- 结构：封面 → 目录 → 分节 → 数据 → 内容×2 → 分节 → 内容×3 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `3, 7` | 内容 `5-6, 8-10` | 结尾 `11`
+- **适用**：市场分析、行业报告。精简紧凑（11 页），蓝紫科技感
+
+### business_case_analysis.xml — 商业案例分析
+
+- 18 页 | 色调：dark | 正式度：formal
+- 配色：深灰图片底图，金属银渐变 `#9c9c9e → #c0c5d3` 点缀
+- 结构：封面 → 内容 → [分节页 → 内容]×4 → 结尾（4 个清晰分节）
+- 页型索引（建议先读）：封面 `1` | 目录 `无` | 分节 `3, 7, 11, 15` | 内容 `2, 4-6, 8-10, 12-14, 16-17` | 结尾 `18`
+- **适用**：商业案例、行业案例拆解。金属质感，分节明确
+
+### product_promotion.xml — 产品推广方案
+
+- 13 页 | 色调：dark | 正式度：formal
+- 配色：深灰 `#2b2f36` + 白色交替，极简黑白
+- 结构：封面 → 目录 → 内容×6 → 分节 → 内容×3 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `9` | 内容 `3-8, 10-12` | 结尾 `13`
+- **适用**：推广方案、营销策略。极简风，黑白对比
+
+---
+
+## marketing — 市场营销
+
+### business_plan.xml — 商业计划书
+
+- 18 页 | 色调：light | 正式度：formal
+- 配色：白底，蓝青渐变封面 `#0b3be5 → #25d8ff`，鲜蓝 `#194cff` 点缀，含甜甜圈图表
+- 结构：封面 → 目录 → 内容×12 → 时间线 → 内容×2 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-14, 16-17` | 结尾 `18`
+- **适用**：商业计划书、创业路演。含时间线页、图表页
+
+### roadshow_business_plan.xml — 企业路演商业计划书
+
+- 20 页 | 色调：light | 正式度：formal
+- 配色：白底，绿色 `#20b14e` 点缀（增长/商业感）
+- 结构：封面 → 目录 → [分节页 → 内容]×5 → 结尾（含时间线、流程图）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `3, 6, 9, 12, 15` | 内容 `4-5, 7-8, 10-11, 13-14, 16-19` | 结尾 `20`
+- **适用**：融资路演、企业路演。绿色增长主题，含 chevron 流程图形
+
+### brand_communication.xml — 品牌传播方案
+
+- 17 页 | 色调：dark | 正式度：formal
+- 配色：黑色图片底图，青绿渐变 `#59c2ff → #a1ffc8` 点缀，半透明白色卡片
+- 结构：封面 → 目录 → 内容×8 → 数据 → 内容×5 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-10, 12-16` | 结尾 `17`
+- **适用**：品牌传播、公关方案。青绿科技感 + 暗色背景
+
+### marketing_strategy.xml — 市场营销策略
+
+- 16 页 | 色调：dark | 正式度：creative
+- 配色：纯黑底 `#0b0b0b`，红橙霓虹渐变 `#ff0000 → #fa6627`，紫蓝 `#bc50ff → #2f2bfd`
+- 结构：封面 → 目录 → 内容×13 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-15` | 结尾 `16`
+- **适用**：营销策略、品牌推广。最具视觉冲击力，霓虹风格
+
+### marketing_plan.xml — 营销策划方案
+
+- 15 页 | 色调：dark | 正式度：formal
+- 配色：近黑底 `#18181a`，亮黄 `#ffdb1d` 强调，灰色 `#93969c` 文字
+- 结构：封面 → 目录 → 内容×10 → 数据 → 内容 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-12, 14` | 结尾 `15`
+- **适用**：营销策划、推广计划。黄+黑高对比，醒目
+
+### product_whitepaper.xml — 产品白皮书
+
+- 21 页 | 色调：colorful | 正式度：formal
+- 配色：图片底图，暖橙粉渐变 `#ffaeac → #ffe6c8`，珊瑚 `#ff7d34 → #ff3ebd`
+- 结构：封面 → 目录 → 内容×18 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-20` | 结尾 `21`
+- **适用**：产品白皮书、技术白皮书、深度报告。页数最多（21 页），暖色调
+
+### brand_operations_plan.xml — 品牌运营计划
+
+- 18 页 | 色调：light | 正式度：formal
+- 配色：浅灰底 `#eff2f6`，中蓝 `#3c6fe5` 点缀
+- 结构：封面 → 目录 → [分节页 → 内容]×5 → 结尾（5 个分节，结构最清晰）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `3, 6, 9, 12, 15` | 内容 `4-5, 7-8, 10-11, 13-14, 16-17` | 结尾 `18`
+- **适用**：品牌运营、年度运营计划。蓝灰企业风，分节最规范
+
+### brand_logo_design.xml — 品牌标志设计
+
+- 16 页 | 色调：light | 正式度：formal
+- 配色：近白底 `#fbfbfb`，亮蓝 `#1c66f6` 点缀，浅蓝卡片 `#c6e7ff`
+- 结构：封面 → 目录 → 内容×7 → 数据 → 内容×4 → 数据 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-9, 11-14` | 结尾 `16`
+- **适用**：品牌设计、VI 设计提案。清爽蓝白，专业设计感
+
+---
+
+## hr — 人力资源
+
+### employee_training.xml — 员工培训
+
+- 14 页 | 色调：dark | 正式度：formal
+- 配色：近黑底 `rgba(13,20,32)`，图片分节页交替，单色简洁
+- 结构：封面 → 目录 → [分节页(01-05) → 内容]×5 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `3, 5, 7, 9, 11` | 内容 `4, 6, 8, 10, 12-13` | 结尾 `14`
+- **适用**：员工培训、规章制度宣讲。暗色严肃风，5 个章节分节页
+
+### employee_training_workshop.xml — 员工培训训练
+
+- 19 页 | 色调：colorful | 正式度：casual
+- 配色：暖米底 `rgba(247,245,240)` + 深灰 `rgba(60,60,60)` 交替，5 种彩色点缀（钢蓝、青绿、橄榄金、鲑鱼粉）
+- 结构：封面 → 目录 → [深色标题卡 → 浅色内容]×7 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `3, 5, 7, 9, 11, 13, 15` | 内容 `4, 6, 8, 10, 12, 14, 16-18` | 结尾 `19`
+- **适用**：培训工作坊、技能培训。温暖多彩，轻松氛围
+
+### onboarding.xml — 新人入职培训
+
+- 15 页 | 色调：dark | 正式度：formal
+- 配色：深炭灰底 `rgba(43,47,54)`，亮紫 `rgba(75,63,221)` 点缀，浅灰卡片 `rgba(243,244,246)`
+- 结构：封面 → 目录 → [分节页(01-05) → 内容]×5 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `3, 5, 7, 9, 11` | 内容 `4, 6, 8, 10, 12-14` | 结尾 `15`
+- **适用**：新人入职、公司介绍。紫色 CTA 按钮，包含公司概况/愿景/价值观/流程/制度等章节
+
+---
+
+## administration — 行政
+
+### all_hands_meeting.xml — 全员大会
+
+- 18 页 | 色调：light | 正式度：formal
+- 配色：蓝紫渐变图片底图，毛玻璃白色卡片（alpha=0.7），薰衣草 `rgba(155,177,255)` 点缀
+- 结构：封面 → 目录 → [分节页 → 内容]×4 → 结尾（含图表页）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `3, 7, 11, 15` | 内容 `4-6, 8-10, 12-14, 16-17` | 结尾 `18`
+- **适用**：全员大会、季度会议、公司大会。毛玻璃风格，蓝紫渐变，含 chart 图表
+
+### company_intro.xml — 企业介绍
+
+- 16 页 | 色调：light | 正式度：formal
+- 配色：白底极简，金黄 `rgba(255,196,25)` 点缀，深灰 `rgba(31,35,41)` 文字
+- 结构：封面 → 目录 → 内容×12 → 数据(chart) → 结尾（含图表页）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-14` | 结尾 `16`
+- **适用**：企业介绍、公司宣传。极简白底，中英双语，含行业前景图表
+
+### corporate_culture.xml — 企业文化宣传
+
+- 17 页 | 色调：dark | 正式度：formal
+- 配色：深炭灰底 `rgba(31,35,41)`，橙红 `rgba(255,104,68)` 强调，浅灰 `rgba(246,246,246)` 内容区
+- 结构：封面 → 前言 → 目录 → [分节页 → 内容]×4 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `3` | 分节 `4, 7, 10, 13` | 内容 `2, 5-6, 8-9, 11-12, 14-16` | 结尾 `17`
+- **适用**：企业文化、公司愿景宣传。含前言页、组织架构页，橙红活力色
+
+### annual_gala.xml — 年度盛典
+
+- 16 页 | 色调：dark | 正式度：creative
+- 配色：近黑底 `rgba(16,15,21)`，紫蓝青多色渐变 `rgba(210,132,232) → rgba(69,96,245)` 霓虹风
+- 结构：封面 → 目录 → [分节页 → 内容]×6 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `3, 5, 7, 9, 11, 13` | 内容 `4, 6, 8, 10, 12, 14-15` | 结尾 `16`
+- **适用**：年会、庆典、颁奖典礼。多彩霓虹渐变，节日庆典感，含 LOGO 占位
+
+---
+
+## personal — 个人
+
+### experience_sharing.xml — 经验分享
+
+- 20 页 | 色调：light | 正式度：casual
+- 配色：图片底图，亮蓝 `rgba(52,113,252)` 点缀，毛玻璃白色卡片（alpha=0.7）
+- 结构：封面 → 目录 → 内容×17 → 结尾（含 table 表格页、前后对比布局）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-19` | 结尾 `20`
+- **适用**：经验分享、项目复盘分享。含步骤流程页、数据指标展示、表格
+
+### teaching_sharing.xml — 分享教学
+
+- 20 页 | 色调：colorful | 正式度：casual
+- 配色：插画风图片底图，蓝紫 `rgba(128,145,239)` + 暖橙 `rgba(242,170,104)` 双色调
+- 结构：封面 → 目录 → 内容×17 → 结尾（含 Demo 案例、痛点分析、推荐书单）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-19` | 结尾 `20`
+- **适用**：教学分享、技术分享、读书会。温暖蓝橙配色，含 chevron 流程图
+
+### personal_resume.xml — 个人简历
+
+- 16 页 | 色调：dark | 正式度：formal
+- 配色：深炭灰图片底图，暖橙 `rgba(253,151,51)` + 霓虹绿 `rgba(76,241,29)` 渐变点缀
+- 结构：封面(含联系方式) → 目录 → [分节页 → 内容]×4 → 结尾
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `3, 6, 9, 12` | 内容 `4-5, 7-8, 10-11, 13-15` | 结尾 `16`
+- **适用**：个人简历、求职展示。橙绿双色点缀，含个人信息字段
+
+### promotion_report.xml — 职位晋升汇报
+
+- 15 页 | 色调：dark | 正式度：formal
+- 配色：纯黑底 `rgba(3,3,1)`，薰衣草渐变 `rgba(216,216,255) → rgba(171,194,255)` 点缀，白色文字
+- 结构：封面 → 目录 → 内容×12 → 结尾（中英双语标题）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-14` | 结尾 `15`
+- **适用**：晋升汇报、述职报告。暗色稳重 + 薰衣草柔和点缀
+
+### promotion_defense.xml — 晋级答辩
+
+- 11 页 | 色调：light | 正式度：formal
+- 配色：白底，亮紫 `rgba(74,58,255)` 点缀
+- 结构：封面 → 目录 → 内容×8 → 结尾（紧凑无分节页）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-10` | 结尾 `11`
+- **适用**：晋级答辩、技术答辩。最精简（11 页），紫色点缀，中英双语
+
+### self_intro.xml — 个人介绍
+
+- 11 页 | 色调：colorful | 正式度：casual
+- 配色：暖白底 `rgba(248,247,246)`，5 种彩色（红 `#d83931`、青 `#17b69c`、橙 `#ec914e`、黄 `#fad355`、蓝 `#3347ff`）
+- 结构：封面 → 内容×9 → 结尾（含表格、甜甜圈图表、饼图）
+- 页型索引（建议先读）：封面 `1` | 目录 `无` | 分节 `无` | 内容 `2-10` | 结尾 `11`
+- **适用**：个人介绍、设计师作品集。shape 类型最丰富，图表元素多
+
+---
+
+## misc — 其他
+
+### book_sharing.xml — 读书分享
+
+- 16 页 | 色调：light | 正式度：casual
+- 配色：白底 + 深橄榄绿侧边栏 `rgba(43,54,44)`，棕褐 `rgba(128,66,8)` 点缀
+- 结构：封面 → 内容×14 → 结尾（中文传统编号：壹贰叁肆）
+- 页型索引（建议先读）：封面 `1` | 目录 `无` | 分节 `无` | 内容 `2-15` | 结尾 `16`
+- **适用**：读书分享、文学赏析。文艺复古风，装饰性诗句分隔，中国传统美学
+
+### club_event_plan.xml — 社团活动策划
+
+- 15 页 | 色调：dark | 正式度：casual
+- 配色：纯黑底，红色 `rgba(216,57,49)` + 金色 `rgba(219,168,0)` 双色强调
+- 结构：封面 → 目录 → 内容×12 → 结尾（含预算页、应急方案页）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-14` | 结尾 `15`
+- **适用**：活动策划、社团方案。黑红金配色，含预算/应急等实用页面
+
+### student_career_plan.xml — 学生职业规划
+
+- 15 页 | 色调：colorful | 正式度：casual
+- 配色：深靛蓝底 `rgba(21,20,87)`，霓虹多彩（品红、青、黄、粉、热粉）
+- 结构：封面 → 目录 → 内容×12 → 结尾（含 SWOT 分析、短/中/长期目标时间线）
+- 页型索引（建议先读）：封面 `1` | 目录 `2` | 分节 `无` | 内容 `3-14` | 结尾 `15`
+- **适用**：职业规划、学生汇报。最鲜艳多彩，霓虹风格，含 SWOT 和时间线
+
+---
+
+## 快速匹配索引
+
+### 按场景
+
+| 场景关键词 | 推荐模板（优先级从高到低） |
+|-----------|------------------------|
+| 工作汇报/月报/周报 | `office--work_report` > `office--work_summary` > `office--light_general` |
+| 工作总结/年度总结 | `office--work_summary_report` > `office--work_summary` |
+| 季度复盘/OKR | `office--quarterly_review` > `office--work_summary_report` |
+| 部门年度汇报 | `office--dept_annual_report` > `office--work_summary_report` |
+| 项目启动/技术宣讲 | `office--project_kickoff` |
+| 产品介绍/产品发布 | `product--product_intro` > `product--product_analysis` |
+| 产品分析/竞品分析 | `product--product_analysis` |
+| 市场分析/行业报告 | `product--market_analysis` |
+| 商业案例 | `product--business_case_analysis` |
+| 商业计划书/创业 | `marketing--business_plan` > `marketing--roadshow_business_plan` |
+| 融资路演/企业路演 | `marketing--roadshow_business_plan` |
+| 品牌传播/公关 | `marketing--brand_communication` |
+| 营销策略/推广 | `marketing--marketing_strategy` > `marketing--marketing_plan` |
+| 产品白皮书 | `marketing--product_whitepaper` |
+| 品牌运营/年度计划 | `marketing--brand_operations_plan` |
+| 品牌设计/VI | `marketing--brand_logo_design` |
+| 员工培训/制度宣讲 | `hr--employee_training` > `hr--employee_training_workshop` |
+| 新人入职 | `hr--onboarding` |
+| 全员大会/公司大会 | `administration--all_hands_meeting` |
+| 企业介绍/公司宣传 | `administration--company_intro` |
+| 企业文化 | `administration--corporate_culture` |
+| 年会/庆典/颁奖 | `administration--annual_gala` |
+| 经验分享/项目分享 | `personal--experience_sharing` |
+| 教学分享/技术分享 | `personal--teaching_sharing` |
+| 个人简历/求职 | `personal--personal_resume` |
+| 晋升汇报/述职 | `personal--promotion_report` > `personal--promotion_defense` |
+| 个人介绍 | `personal--self_intro` |
+| 读书分享 | `misc--book_sharing` |
+| 活动策划 | `misc--club_event_plan` |
+| 职业规划 | `misc--student_career_plan` |
+
+### 按色调
+
+| 色调 | 模板 |
+|------|------|
+| **light** | `office--light_general` ⭐, `office--work_report`, `office--work_summary`, `product--product_analysis`, `marketing--business_plan`, `marketing--roadshow_business_plan`, `marketing--brand_operations_plan`, `marketing--brand_logo_design`, `administration--all_hands_meeting`, `administration--company_intro`, `personal--experience_sharing`, `personal--promotion_defense`, `misc--book_sharing` |
+| **dark** | `office--dark_general` ⭐, `office--work_summary_report`, `office--quarterly_review`, `office--dept_annual_report`, `office--project_kickoff`, `product--market_analysis`, `product--business_case_analysis`, `product--product_promotion`, `marketing--brand_communication`, `marketing--marketing_strategy`, `marketing--marketing_plan`, `hr--employee_training`, `hr--onboarding`, `administration--corporate_culture`, `administration--annual_gala`, `personal--personal_resume`, `personal--promotion_report`, `misc--club_event_plan` |
+| **colorful** | `product--product_intro`, `marketing--product_whitepaper`, `hr--employee_training_workshop`, `personal--self_intro`, `personal--teaching_sharing`, `misc--student_career_plan` |

--- a/skills/lark-slides/references/template-index.json
+++ b/skills/lark-slides/references/template-index.json
@@ -1,0 +1,24587 @@
+{
+  "schema_version": "1.0.0",
+  "generated_at": "2026-04-18T08:53:16.402Z",
+  "template_count": 37,
+  "templates": [
+    {
+      "template_id": "office--light_general",
+      "category": "office",
+      "category_label": "办公通用",
+      "scene": "浅色通用变体库",
+      "tone": "light",
+      "formality": "formal",
+      "is_general_template": true,
+      "slide_count": 54,
+      "presentation_title": "白底通用模板",
+      "palette": "白底 #f4f5f6，蓝色点缀 #4e6efd，深灰文字 #1f2329",
+      "structure": null,
+      "page_types": "封面×2, 目录×4, 分节页, 内容×30, 数据卡片×2, 结尾",
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-text-left-image-right",
+        "image-backed",
+        "section-divider",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "任何需要浅色风格的场景，从中挑选合适的页面布局",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 100,
+          "y": 229,
+          "width": 668,
+          "height": 66
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 100,
+          "y": 293,
+          "width": 668,
+          "height": 36
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "caption",
+          "x": 70,
+          "y": 397,
+          "width": 818,
+          "height": 48
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "caption",
+          "x": 70,
+          "y": 448,
+          "width": 818,
+          "height": 24
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 70,
+          "y": 73,
+          "width": 818,
+          "height": 21
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 70,
+          "y": 98,
+          "width": 818,
+          "height": 21
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 41,
+          "y": 181,
+          "width": 200,
+          "height": 260
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 267,
+          "y": 181,
+          "width": 200,
+          "height": 260
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 493,
+          "y": 181,
+          "width": 200,
+          "height": 260
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 719,
+          "y": 181,
+          "width": 200,
+          "height": 260
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 70,
+          "y": 88,
+          "width": 818,
+          "height": 48
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "caption",
+          "x": 59,
+          "y": 311,
+          "width": 164,
+          "height": 105
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 54,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 2,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 100,
+                "y": 229,
+                "width": 668,
+                "height": 100
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 100,
+                  "y": 229,
+                  "width": 668,
+                  "height": 66
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 100,
+                  "y": 293,
+                  "width": 668,
+                  "height": 36
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 70,
+                "y": 73,
+                "width": 818,
+                "height": 399
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 73,
+                  "width": 818,
+                  "height": 21
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 98,
+                  "width": 818,
+                  "height": 21
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 397,
+                  "width": 818,
+                  "height": 48
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 448,
+                  "width": 818,
+                  "height": 24
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 17,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 41,
+                "y": 88,
+                "width": 878,
+                "height": 353
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 88,
+                  "width": 818,
+                  "height": 48
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 41,
+                  "y": 181,
+                  "width": 200,
+                  "height": 260
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 267,
+                  "y": 181,
+                  "width": 200,
+                  "height": 260
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 493,
+                  "y": 181,
+                  "width": 200,
+                  "height": 260
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 719,
+                  "y": 181,
+                  "width": 200,
+                  "height": 260
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 59,
+                  "y": 215,
+                  "width": 164,
+                  "height": 52
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 285,
+                  "y": 215,
+                  "width": 164,
+                  "height": 52
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 511,
+                  "y": 215,
+                  "width": 164,
+                  "height": 52
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 13,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 100,
+                "y": 108,
+                "width": 760,
+                "height": 307
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 100,
+                  "y": 108,
+                  "width": 760,
+                  "height": 48
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 100,
+                  "y": 198,
+                  "width": 40,
+                  "height": 40
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 505,
+                  "y": 198,
+                  "width": 40,
+                  "height": 40
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 155,
+                  "y": 205,
+                  "width": 300,
+                  "height": 27
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 560,
+                  "y": 205,
+                  "width": 300,
+                  "height": 27
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 100,
+                  "y": 287,
+                  "width": 40,
+                  "height": 40
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 505,
+                  "y": 287,
+                  "width": 40,
+                  "height": 40
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 155,
+                  "y": 293,
+                  "width": 300,
+                  "height": 27
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 70,
+                "y": 0,
+                "width": 890,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 510,
+                  "y": 0,
+                  "width": 450,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 70,
+                  "width": 376,
+                  "height": 48
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 70,
+                  "y": 149,
+                  "width": 24,
+                  "height": 27
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 116,
+                  "y": 149,
+                  "width": 330,
+                  "height": 27
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 70,
+                  "y": 201,
+                  "width": 24,
+                  "height": 27
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 116,
+                  "y": 201,
+                  "width": 330,
+                  "height": 27
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 70,
+                  "y": 253,
+                  "width": 24,
+                  "height": 27
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 116,
+                  "y": 253,
+                  "width": 330,
+                  "height": 27
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 25,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 70,
+                "y": 70,
+                "width": 819,
+                "height": 396
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 70,
+                  "width": 400,
+                  "height": 32
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 480,
+                  "y": 70,
+                  "width": 380,
+                  "height": 21
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 865,
+                  "y": 70,
+                  "width": 24,
+                  "height": 18
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 480,
+                  "y": 104,
+                  "width": 380,
+                  "height": 18
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 865,
+                  "y": 104,
+                  "width": 24,
+                  "height": 18
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 480,
+                  "y": 133,
+                  "width": 380,
+                  "height": 18
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 865,
+                  "y": 133,
+                  "width": 24,
+                  "height": 18
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 480,
+                  "y": 175,
+                  "width": 380,
+                  "height": 21
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1-2"
+        },
+        {
+          "label": "目录",
+          "range": "3-6"
+        },
+        {
+          "label": "分节/过渡",
+          "range": "7-8"
+        },
+        {
+          "label": "内容/图文/时间线/数据",
+          "range": "9-53"
+        },
+        {
+          "label": "结尾",
+          "range": "54"
+        }
+      ]
+    },
+    {
+      "template_id": "office--dark_general",
+      "category": "office",
+      "category_label": "办公通用",
+      "scene": "深色通用变体库",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": true,
+      "slide_count": 56,
+      "presentation_title": "黑底通用模板",
+      "palette": "深灰底 #1f2329，蓝色点缀 #4e6efd，白色文字",
+      "structure": null,
+      "page_types": "封面×2, 目录×4, 分节页, 内容×31, 数据卡片×2, 结尾",
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-text-left-image-right",
+        "section-divider",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "任何需要深色风格的场景，渐变填充（蓝-青）、透明度叠加",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 100,
+          "y": 229,
+          "width": 668,
+          "height": 66
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 100,
+          "y": 293,
+          "width": 668,
+          "height": 36
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "caption",
+          "x": 70,
+          "y": 397,
+          "width": 818,
+          "height": 48
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "caption",
+          "x": 70,
+          "y": 448,
+          "width": 818,
+          "height": 24
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 70,
+          "y": 73,
+          "width": 818,
+          "height": 21
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 70,
+          "y": 98,
+          "width": 818,
+          "height": 21
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 41,
+          "y": 181,
+          "width": 200,
+          "height": 260
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 267,
+          "y": 181,
+          "width": 200,
+          "height": 260
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 493,
+          "y": 181,
+          "width": 200,
+          "height": 260
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 719,
+          "y": 181,
+          "width": 200,
+          "height": 260
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 70,
+          "y": 88,
+          "width": 818,
+          "height": 48
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "caption",
+          "x": 59,
+          "y": 311,
+          "width": 164,
+          "height": 105
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 56,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 2,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 100,
+                "y": 229,
+                "width": 668,
+                "height": 100
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 100,
+                  "y": 229,
+                  "width": 668,
+                  "height": 66
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 100,
+                  "y": 293,
+                  "width": 668,
+                  "height": 36
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 70,
+                "y": 73,
+                "width": 818,
+                "height": 399
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 73,
+                  "width": 818,
+                  "height": 21
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 98,
+                  "width": 818,
+                  "height": 21
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 397,
+                  "width": 818,
+                  "height": 48
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 448,
+                  "width": 818,
+                  "height": 24
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 17,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 41,
+                "y": 88,
+                "width": 878,
+                "height": 353
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 88,
+                  "width": 818,
+                  "height": 48
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 41,
+                  "y": 181,
+                  "width": 200,
+                  "height": 260
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 267,
+                  "y": 181,
+                  "width": 200,
+                  "height": 260
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 493,
+                  "y": 181,
+                  "width": 200,
+                  "height": 260
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 719,
+                  "y": 181,
+                  "width": 200,
+                  "height": 260
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 59,
+                  "y": 215,
+                  "width": 164,
+                  "height": 48
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 285,
+                  "y": 215,
+                  "width": 164,
+                  "height": 48
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 511,
+                  "y": 215,
+                  "width": 164,
+                  "height": 48
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 13,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 100,
+                "y": 108,
+                "width": 760,
+                "height": 307
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 100,
+                  "y": 108,
+                  "width": 760,
+                  "height": 48
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 100,
+                  "y": 198,
+                  "width": 40,
+                  "height": 40
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 505,
+                  "y": 198,
+                  "width": 40,
+                  "height": 40
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 155,
+                  "y": 205,
+                  "width": 300,
+                  "height": 27
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 560,
+                  "y": 205,
+                  "width": 300,
+                  "height": 27
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 100,
+                  "y": 287,
+                  "width": 40,
+                  "height": 40
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 505,
+                  "y": 287,
+                  "width": 40,
+                  "height": 40
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 155,
+                  "y": 293,
+                  "width": 300,
+                  "height": 27
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 70,
+                "y": 0,
+                "width": 890,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 510,
+                  "y": 0,
+                  "width": 450,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 70,
+                  "width": 376,
+                  "height": 48
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 70,
+                  "y": 149,
+                  "width": 24,
+                  "height": 27
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 116,
+                  "y": 149,
+                  "width": 330,
+                  "height": 27
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 70,
+                  "y": 201,
+                  "width": 24,
+                  "height": 27
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 116,
+                  "y": 201,
+                  "width": 330,
+                  "height": 27
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 70,
+                  "y": 253,
+                  "width": 24,
+                  "height": 27
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 116,
+                  "y": 253,
+                  "width": 330,
+                  "height": 27
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 25,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 70,
+                "y": 70,
+                "width": 819,
+                "height": 396
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 70,
+                  "width": 400,
+                  "height": 32
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 480,
+                  "y": 70,
+                  "width": 380,
+                  "height": 21
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 865,
+                  "y": 70,
+                  "width": 24,
+                  "height": 18
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 480,
+                  "y": 104,
+                  "width": 380,
+                  "height": 18
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 865,
+                  "y": 104,
+                  "width": 24,
+                  "height": 18
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 480,
+                  "y": 133,
+                  "width": 380,
+                  "height": 18
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 865,
+                  "y": 133,
+                  "width": 24,
+                  "height": 18
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 480,
+                  "y": 175,
+                  "width": 380,
+                  "height": 21
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1-2"
+        },
+        {
+          "label": "目录",
+          "range": "3-6"
+        },
+        {
+          "label": "分节/过渡",
+          "range": "7-8"
+        },
+        {
+          "label": "内容/图文/时间线/数据",
+          "range": "9-54"
+        },
+        {
+          "label": "结尾",
+          "range": "55-56"
+        }
+      ]
+    },
+    {
+      "template_id": "office--work_report",
+      "category": "office",
+      "category_label": "办公通用",
+      "scene": "工作汇报",
+      "tone": "light",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 13,
+      "presentation_title": "工作汇报",
+      "palette": "图片底图 + 半透明白色卡片（alpha=0.51），紫色 #7f3bf5/蓝色 #3370ff 点缀",
+      "structure": "封面 → 目录(4 Part) → 数据页 → 内容×9 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-text-left-image-right",
+        "image-backed",
+        "section-divider",
+        "two-column-text"
+      ],
+      "use_cases": "工作汇报、月报、项目进展。中英双语标题，4 宫格布局，圆角卡片",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "32"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 349,
+          "y": 206,
+          "width": 350,
+          "height": 88
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "text",
+          "x": 349,
+          "y": 179,
+          "width": 350,
+          "height": 47
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "text",
+          "x": 349,
+          "y": 286,
+          "width": 350,
+          "height": 47
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 42,
+          "y": 54,
+          "width": 488,
+          "height": 64
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "caption",
+          "x": 45,
+          "y": 106,
+          "width": 327,
+          "height": 62
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 46,
+          "y": 374,
+          "width": 206,
+          "height": 83
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 276,
+          "y": 374,
+          "width": 206,
+          "height": 83
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 503,
+          "y": 374,
+          "width": 206,
+          "height": 83
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "caption",
+          "x": 730,
+          "y": 374,
+          "width": 206,
+          "height": 83
+        },
+        {
+          "id": "img-7",
+          "kind": "img",
+          "role": "image",
+          "x": 56,
+          "y": 218,
+          "width": 105,
+          "height": 105
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 56,
+          "y": 218,
+          "width": 105,
+          "height": 105
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 42,
+          "y": 54,
+          "width": 488,
+          "height": 64
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 13,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 349,
+                "y": 179,
+                "width": 350,
+                "height": 154
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 349,
+                  "y": 179,
+                  "width": 350,
+                  "height": 47
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 349,
+                  "y": 206,
+                  "width": 350,
+                  "height": 88
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 349,
+                  "y": 286,
+                  "width": 350,
+                  "height": 47
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 18,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 42,
+                "y": 54,
+                "width": 894,
+                "height": 403
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 42,
+                  "y": 54,
+                  "width": 488,
+                  "height": 64
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 45,
+                  "y": 106,
+                  "width": 327,
+                  "height": 62
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 56,
+                  "y": 218,
+                  "width": 105,
+                  "height": 105
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 56,
+                  "y": 218,
+                  "width": 105,
+                  "height": 105
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 286,
+                  "y": 218,
+                  "width": 105,
+                  "height": 105
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 286,
+                  "y": 218,
+                  "width": 105,
+                  "height": 105
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 513,
+                  "y": 218,
+                  "width": 105,
+                  "height": 105
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 513,
+                  "y": 218,
+                  "width": 105,
+                  "height": 105
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 42,
+                "y": 54,
+                "width": 858,
+                "height": 451
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 42,
+                  "y": 54,
+                  "width": 488,
+                  "height": 64
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 450,
+                  "y": 63,
+                  "width": 90,
+                  "height": 52
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 534,
+                  "y": 63,
+                  "width": 366,
+                  "height": 44
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 534,
+                  "y": 98,
+                  "width": 366,
+                  "height": 62
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 45,
+                  "y": 106,
+                  "width": 327,
+                  "height": 62
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 450,
+                  "y": 178,
+                  "width": 90,
+                  "height": 52
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 534,
+                  "y": 178,
+                  "width": 366,
+                  "height": 44
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 534,
+                  "y": 213,
+                  "width": 366,
+                  "height": 62
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 16,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 42,
+                "y": 54,
+                "width": 879,
+                "height": 432
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 42,
+                  "y": 54,
+                  "width": 488,
+                  "height": 64
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 509,
+                  "y": 80,
+                  "width": 56,
+                  "height": 56
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 726,
+                  "y": 80,
+                  "width": 56,
+                  "height": 56
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 45,
+                  "y": 106,
+                  "width": 327,
+                  "height": 62
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 502,
+                  "y": 148,
+                  "width": 202,
+                  "height": 44
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 719,
+                  "y": 148,
+                  "width": 202,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 502,
+                  "y": 182,
+                  "width": 202,
+                  "height": 83
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 719,
+                  "y": 182,
+                  "width": 202,
+                  "height": 83
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 8,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 42,
+                "y": 45,
+                "width": 888,
+                "height": 449
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 42,
+                  "y": 45,
+                  "width": 279,
+                  "height": 116
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 358,
+                  "y": 45,
+                  "width": 217,
+                  "height": 449
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 365,
+                  "y": 52,
+                  "width": 202,
+                  "height": 437
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 611,
+                  "y": 171,
+                  "width": 299,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 611,
+                  "y": 204,
+                  "width": 299,
+                  "height": 84
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 611,
+                  "y": 301,
+                  "width": 319,
+                  "height": 167
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 42,
+                  "y": 345,
+                  "width": 299,
+                  "height": 63
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 42,
+                  "y": 406,
+                  "width": 279,
+                  "height": 62
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 11,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 44,
+                "y": 53,
+                "width": 886,
+                "height": 451
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 44,
+                  "y": 53,
+                  "width": 299,
+                  "height": 63
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 361,
+                  "y": 53,
+                  "width": 358,
+                  "height": 62
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 44,
+                  "y": 244,
+                  "width": 202,
+                  "height": 44
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 361,
+                  "y": 244,
+                  "width": 202,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 44,
+                  "y": 279,
+                  "width": 267,
+                  "height": 62
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 361,
+                  "y": 279,
+                  "width": 267,
+                  "height": 62
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 44,
+                  "y": 374,
+                  "width": 202,
+                  "height": 44
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 361,
+                  "y": 374,
+                  "width": 202,
+                  "height": 44
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "4-12"
+        },
+        {
+          "label": "结尾",
+          "range": "13"
+        }
+      ]
+    },
+    {
+      "template_id": "office--work_summary_report",
+      "category": "office",
+      "category_label": "办公通用",
+      "scene": "工作总结报告",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 16,
+      "presentation_title": "工作总结报告",
+      "palette": "深灰底 #2b2f36，深蓝 #3a6cea/靛蓝 #0e5efd 点缀",
+      "structure": "封面 → 目录 → [分节页 → 内容]×4 → 结尾（4 个清晰分节）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "hero-image-left-text-right",
+        "hero-text-left-image-right",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "年度/季度工作总结，分节清晰的正式汇报",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "60"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "36"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 456,
+          "y": 108,
+          "width": 454,
+          "height": 381
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 456,
+          "y": 152,
+          "width": 292,
+          "height": 292
+        },
+        {
+          "id": "img-3",
+          "kind": "img",
+          "role": "image",
+          "x": 532,
+          "y": 83,
+          "width": 251,
+          "height": 251
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 67,
+          "y": 66,
+          "width": 408,
+          "height": 97
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 67,
+          "y": 147,
+          "width": 262,
+          "height": 56
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 67,
+          "y": 413,
+          "width": 225,
+          "height": 44
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 72,
+          "y": 364,
+          "width": 216,
+          "height": 45
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 57,
+          "y": 84,
+          "width": 8,
+          "height": 60
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 57,
+          "y": 111,
+          "width": 292,
+          "height": 292
+        },
+        {
+          "id": "img-2",
+          "kind": "img",
+          "role": "image",
+          "x": 130,
+          "y": 247,
+          "width": 288,
+          "height": 206
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 510,
+          "y": 119,
+          "width": 346,
+          "height": 66
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 510,
+          "y": 198,
+          "width": 346,
+          "height": 66
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 16,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 8,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 57,
+                "y": 66,
+                "width": 853,
+                "height": 423
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 67,
+                  "y": 66,
+                  "width": 408,
+                  "height": 97
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 532,
+                  "y": 83,
+                  "width": 251,
+                  "height": 251
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 57,
+                  "y": 84,
+                  "width": 8,
+                  "height": 60
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 456,
+                  "y": 108,
+                  "width": 454,
+                  "height": 381
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 67,
+                  "y": 147,
+                  "width": 262,
+                  "height": 56
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 456,
+                  "y": 152,
+                  "width": 292,
+                  "height": 292
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 72,
+                  "y": 364,
+                  "width": 216,
+                  "height": 45
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 67,
+                  "y": 413,
+                  "width": 225,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 20,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 57,
+                "y": 111,
+                "width": 799,
+                "height": 342
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 57,
+                  "y": 111,
+                  "width": 292,
+                  "height": 292
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 510,
+                  "y": 119,
+                  "width": 346,
+                  "height": 66
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 510,
+                  "y": 119,
+                  "width": 65,
+                  "height": 65
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 517,
+                  "y": 126,
+                  "width": 51,
+                  "height": 51
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 576,
+                  "y": 128,
+                  "width": 280,
+                  "height": 47
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 143,
+                  "y": 140,
+                  "width": 242,
+                  "height": 68
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 218,
+                  "y": 140,
+                  "width": 232,
+                  "height": 68
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 510,
+                  "y": 198,
+                  "width": 346,
+                  "height": 66
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 224,
+                "y": 187,
+                "width": 705,
+                "height": 159
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 385,
+                  "y": 187,
+                  "width": 544,
+                  "height": 110
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 224,
+                  "y": 191,
+                  "width": 116,
+                  "height": 132
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 392,
+                  "y": 282,
+                  "width": 416,
+                  "height": 64
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 15,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 58,
+                "y": 64,
+                "width": 868,
+                "height": 408
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 70,
+                  "y": 64,
+                  "width": 118,
+                  "height": 56
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 174,
+                  "y": 64,
+                  "width": 302,
+                  "height": 56
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 58,
+                  "y": 77,
+                  "width": 5,
+                  "height": 30
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 92,
+                  "y": 201,
+                  "width": 134,
+                  "height": 134
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 318,
+                  "y": 201,
+                  "width": 134,
+                  "height": 134
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 544,
+                  "y": 201,
+                  "width": 134,
+                  "height": 134
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 769,
+                  "y": 201,
+                  "width": 134,
+                  "height": 134
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 69,
+                  "y": 345,
+                  "width": 180,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 19,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 58,
+                "y": 64,
+                "width": 824,
+                "height": 439
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 70,
+                  "y": 64,
+                  "width": 118,
+                  "height": 56
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 174,
+                  "y": 64,
+                  "width": 302,
+                  "height": 56
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 58,
+                  "y": 77,
+                  "width": 5,
+                  "height": 30
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 119,
+                  "y": 156,
+                  "width": 373,
+                  "height": 167
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 509,
+                  "y": 156,
+                  "width": 373,
+                  "height": 167
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 205,
+                  "y": 171,
+                  "width": 188,
+                  "height": 38
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 594,
+                  "y": 171,
+                  "width": 188,
+                  "height": 38
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 139,
+                  "y": 176,
+                  "width": 60,
+                  "height": 60
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 8,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 37,
+                "y": 38,
+                "width": 886,
+                "height": 464
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 37,
+                  "y": 38,
+                  "width": 886,
+                  "height": 464
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 708,
+                  "y": 76,
+                  "width": 183,
+                  "height": 149
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 85,
+                  "y": 88,
+                  "width": 256,
+                  "height": 68
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 226,
+                  "y": 94,
+                  "width": 230,
+                  "height": 56
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 85,
+                  "y": 241,
+                  "width": 225,
+                  "height": 44
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 85,
+                  "y": 285,
+                  "width": 619,
+                  "height": 92
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 90,
+                  "y": 418,
+                  "width": 216,
+                  "height": 45
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 357,
+                  "y": 418,
+                  "width": 216,
+                  "height": 45
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节 3, 6, 9,",
+          "range": "12"
+        },
+        {
+          "label": "内容 4-5, 7-8, 10-11,",
+          "range": "13-15"
+        },
+        {
+          "label": "结尾",
+          "range": "16"
+        }
+      ]
+    },
+    {
+      "template_id": "office--work_summary",
+      "category": "office",
+      "category_label": "办公通用",
+      "scene": "工作总结",
+      "tone": "light",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 20,
+      "presentation_title": "工作总结",
+      "palette": "暖黄 #fff6dc + 浅蓝 #ddeff7 交替，天蓝 #1393cf 点缀，金色 #f7c15f 强调",
+      "structure": "封面 → 目录 → 内容×7 → 数据×2 → 内容×8 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "text-focused"
+      ],
+      "use_cases": "轻松温暖风格的工作总结。shape 类型最丰富（饼图、三角、弧形等）",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 520,
+          "y": 0,
+          "width": 470,
+          "height": 470
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "pie",
+          "x": 550,
+          "y": 30,
+          "width": 410,
+          "height": 410
+        },
+        {
+          "id": "img-3",
+          "kind": "img",
+          "role": "image",
+          "x": 582,
+          "y": 62,
+          "width": 346,
+          "height": 346
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "rect",
+          "x": 749,
+          "y": 270,
+          "width": 211,
+          "height": 270
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "title",
+          "x": 31,
+          "y": 134,
+          "width": 408,
+          "height": 90
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "title",
+          "x": 31,
+          "y": 305,
+          "width": 407,
+          "height": 63
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "title",
+          "x": 31,
+          "y": 224,
+          "width": 408,
+          "height": 48
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "title",
+          "x": 31,
+          "y": 448,
+          "width": 407,
+          "height": 42
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 95,
+          "y": 80,
+          "width": 404,
+          "height": 404
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "rect",
+          "x": 0,
+          "y": 0,
+          "width": 298,
+          "height": 540
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "pie",
+          "x": 121,
+          "y": 105,
+          "width": 353,
+          "height": 353
+        },
+        {
+          "id": "img-4",
+          "kind": "img",
+          "role": "image",
+          "x": 149,
+          "y": 133,
+          "width": 298,
+          "height": 298
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 20,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 17,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 31,
+                "y": 0,
+                "width": 959,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 520,
+                  "y": 0,
+                  "width": 470,
+                  "height": 470
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "pie",
+                  "x": 550,
+                  "y": 30,
+                  "width": 410,
+                  "height": 410
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 31,
+                  "y": 37,
+                  "width": 24,
+                  "height": 24
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 68,
+                  "y": 40,
+                  "width": 72,
+                  "height": 18
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 466,
+                  "y": 58,
+                  "width": 37,
+                  "height": 37
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 582,
+                  "y": 62,
+                  "width": 346,
+                  "height": 346
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 486,
+                  "y": 87,
+                  "width": 10,
+                  "height": 10
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 31,
+                  "y": 134,
+                  "width": 408,
+                  "height": 90
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 27,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": -29,
+                "width": 931,
+                "height": 569
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 851,
+                  "y": -29,
+                  "width": 80,
+                  "height": 139
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 298,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 52,
+                  "y": 45,
+                  "width": 233,
+                  "height": 60
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 95,
+                  "y": 80,
+                  "width": 404,
+                  "height": 404
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 579,
+                  "y": 94,
+                  "width": 332,
+                  "height": 30
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round2diag-rect",
+                  "x": 514,
+                  "y": 99,
+                  "width": 47,
+                  "height": 46
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round2diag-rect",
+                  "x": 516,
+                  "y": 101,
+                  "width": 47,
+                  "height": 46
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 52,
+                  "y": 102,
+                  "width": 233,
+                  "height": 30
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": -17,
+                "width": 960,
+                "height": 557
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 769,
+                  "y": -17,
+                  "width": 132,
+                  "height": 132
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 31,
+                  "y": 37,
+                  "width": 24,
+                  "height": 24
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 68,
+                  "y": 40,
+                  "width": 72,
+                  "height": 18
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 769,
+                  "y": 74,
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 334,
+                  "y": 199,
+                  "width": 407,
+                  "height": 72
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 531,
+                  "y": 205,
+                  "width": 15,
+                  "height": 15
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 22,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -3,
+                "y": -29,
+                "width": 965,
+                "height": 599
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 851,
+                  "y": -29,
+                  "width": 80,
+                  "height": 139
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": -3,
+                  "y": 0,
+                  "width": 963,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": -1,
+                  "y": 0,
+                  "width": 963,
+                  "height": 540
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 77,
+                  "y": 30,
+                  "width": 403,
+                  "height": 36
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 816,
+                  "y": 30,
+                  "width": 24,
+                  "height": 12
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 55,
+                  "y": 39,
+                  "width": 14,
+                  "height": 41
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 77,
+                  "y": 67,
+                  "width": 403,
+                  "height": 21
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 215,
+                  "y": 71,
+                  "width": 103,
+                  "height": 12
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 67,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 29,
+                "y": -29,
+                "width": 902,
+                "height": 599
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 851,
+                  "y": -29,
+                  "width": 80,
+                  "height": 139
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 77,
+                  "y": 30,
+                  "width": 403,
+                  "height": 36
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 816,
+                  "y": 30,
+                  "width": 24,
+                  "height": 12
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 55,
+                  "y": 39,
+                  "width": 14,
+                  "height": 41
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 77,
+                  "y": 67,
+                  "width": 403,
+                  "height": 21
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 186,
+                  "y": 71,
+                  "width": 103,
+                  "height": 12
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 331,
+                  "y": 127,
+                  "width": 38,
+                  "height": 40
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 674,
+                  "y": 127,
+                  "width": 38,
+                  "height": 40
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 54,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -3,
+                "y": -29,
+                "width": 965,
+                "height": 599
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 851,
+                  "y": -29,
+                  "width": 80,
+                  "height": 139
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": -3,
+                  "y": 0,
+                  "width": 963,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": -1,
+                  "y": 0,
+                  "width": 963,
+                  "height": 540
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 77,
+                  "y": 30,
+                  "width": 403,
+                  "height": 36
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 816,
+                  "y": 30,
+                  "width": 24,
+                  "height": 12
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 55,
+                  "y": 39,
+                  "width": 14,
+                  "height": 41
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 77,
+                  "y": 67,
+                  "width": 403,
+                  "height": 21
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 215,
+                  "y": 71,
+                  "width": 103,
+                  "height": 12
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容 3-9,",
+          "range": "12-19"
+        },
+        {
+          "label": "结尾",
+          "range": "20"
+        }
+      ]
+    },
+    {
+      "template_id": "office--quarterly_review",
+      "category": "office",
+      "category_label": "办公通用",
+      "scene": "季度复盘",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 17,
+      "presentation_title": "季度复盘",
+      "palette": "海军蓝图片底图，钢蓝 #435671 文字，半透明白色叠加（alpha=0.6）",
+      "structure": "封面 → 目录 → 内容×2 → 数据×2 → 内容×10 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-text-left-image-right",
+        "image-backed",
+        "section-divider",
+        "two-column-text"
+      ],
+      "use_cases": "季度复盘、OKR 回顾，数据驱动型汇报",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "rgba(67, 86, 113, 1)",
+            "font_size": "90"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "rgba(67, 86, 113, 1)",
+            "font_size": "64"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "rgba(67, 86, 113, 1)",
+            "font_size": "24"
+          },
+          {
+            "text_type": "body",
+            "font_color": "rgba(67, 86, 113, 1)",
+            "font_size": "14"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "rgba(67, 86, 113, 1)"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 438,
+          "y": 193,
+          "width": 551,
+          "height": 347
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 48,
+          "y": 149,
+          "width": 646,
+          "height": 116
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "text",
+          "x": 52,
+          "y": 244,
+          "width": 642,
+          "height": 41
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 40,
+          "y": 24,
+          "width": 268,
+          "height": 41
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 58,
+          "y": 295,
+          "width": 140,
+          "height": 36
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "caption",
+          "x": 491,
+          "y": 24,
+          "width": 90,
+          "height": 38
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "caption",
+          "x": 596,
+          "y": 24,
+          "width": 90,
+          "height": 38
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "caption",
+          "x": 701,
+          "y": 24,
+          "width": 90,
+          "height": 38
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 556,
+          "y": 0,
+          "width": 404,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "text",
+          "x": 37,
+          "y": 160,
+          "width": 443,
+          "height": 92
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 40,
+          "y": 266,
+          "width": 345,
+          "height": 44
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 40,
+          "y": 324,
+          "width": 345,
+          "height": 44
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 17,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 10,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 37,
+                "y": 24,
+                "width": 952,
+                "height": 516
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 40,
+                  "y": 24,
+                  "width": 268,
+                  "height": 41
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 491,
+                  "y": 24,
+                  "width": 90,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 596,
+                  "y": 24,
+                  "width": 90,
+                  "height": 38
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 701,
+                  "y": 24,
+                  "width": 90,
+                  "height": 38
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 807,
+                  "y": 24,
+                  "width": 90,
+                  "height": 38
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 37,
+                  "y": 34,
+                  "width": 2,
+                  "height": 20
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 48,
+                  "y": 149,
+                  "width": 646,
+                  "height": 116
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 438,
+                  "y": 193,
+                  "width": 551,
+                  "height": 347
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 12,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 37,
+                "y": 0,
+                "width": 923,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 556,
+                  "y": 0,
+                  "width": 404,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 40,
+                  "y": 24,
+                  "width": 223,
+                  "height": 41
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 37,
+                  "y": 34,
+                  "width": 2,
+                  "height": 20
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 37,
+                  "y": 160,
+                  "width": 443,
+                  "height": 92
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 40,
+                  "y": 266,
+                  "width": 345,
+                  "height": 44
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 58,
+                  "y": 268,
+                  "width": 282,
+                  "height": 41
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 40,
+                  "y": 324,
+                  "width": 345,
+                  "height": 44
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 58,
+                  "y": 326,
+                  "width": 295,
+                  "height": 41
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 2,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 109,
+                "y": 156,
+                "width": 727,
+                "height": 146
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 124,
+                  "y": 156,
+                  "width": 712,
+                  "height": 146
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 109,
+                  "y": 169,
+                  "width": 4,
+                  "height": 120
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 2,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 283,
+                "y": 38,
+                "width": 395,
+                "height": 77
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 283,
+                  "y": 38,
+                  "width": 395,
+                  "height": 56
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 283,
+                  "y": 74,
+                  "width": 395,
+                  "height": 41
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 26,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 59,
+                "y": 49,
+                "width": 866,
+                "height": 452
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 59,
+                  "y": 49,
+                  "width": 395,
+                  "height": 77
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 804,
+                  "y": 74,
+                  "width": 120,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 792,
+                  "y": 87,
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 59,
+                  "y": 116,
+                  "width": 363,
+                  "height": 62
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 805,
+                  "y": 121,
+                  "width": 120,
+                  "height": 38
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 792,
+                  "y": 134,
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 280,
+                  "y": 222,
+                  "width": 51,
+                  "height": 44
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 64,
+                  "y": 258,
+                  "width": 126,
+                  "height": 68
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 132,
+                "y": 38,
+                "width": 696,
+                "height": 382
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 282,
+                  "y": 38,
+                  "width": 396,
+                  "height": 56
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 282,
+                  "y": 74,
+                  "width": 396,
+                  "height": 41
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 132,
+                  "y": 160,
+                  "width": 220,
+                  "height": 260
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 370,
+                  "y": 160,
+                  "width": 220,
+                  "height": 260
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 608,
+                  "y": 160,
+                  "width": 220,
+                  "height": 260
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 142,
+                  "y": 196,
+                  "width": 200,
+                  "height": 70
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 380,
+                  "y": 196,
+                  "width": 200,
+                  "height": 70
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 618,
+                  "y": 196,
+                  "width": 200,
+                  "height": 70
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容 3-4,",
+          "range": "7-16"
+        },
+        {
+          "label": "结尾",
+          "range": "17"
+        }
+      ]
+    },
+    {
+      "template_id": "office--dept_annual_report",
+      "category": "office",
+      "category_label": "办公通用",
+      "scene": "部门年度汇报",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 17,
+      "presentation_title": "部门年度工作汇报",
+      "palette": "黑色底图 + 极光渐变（紫/青/蓝），青色 #64e8d6 → 蓝色 #73bbff 渐变点缀",
+      "structure": "封面 → 目录 → 内容×4 → 数据 → 内容×9 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-image-left-text-right",
+        "image-backed",
+        "two-column-text"
+      ],
+      "use_cases": "年度部门汇报，视觉冲击力强，多彩渐变风",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "text_type": "body",
+            "font_color": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "rgba(255, 255, 255, 1)",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 63,
+          "y": 179,
+          "width": 261,
+          "height": 182
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 347,
+          "y": 184,
+          "width": 172,
+          "height": 101
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "text",
+          "x": 350,
+          "y": 294,
+          "width": 234,
+          "height": 44
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "rect",
+          "x": 280,
+          "y": 0,
+          "width": 680,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "rect",
+          "x": 280,
+          "y": 0,
+          "width": 680,
+          "height": 540
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "rect",
+          "x": 0,
+          "y": 0,
+          "width": 280,
+          "height": 540
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "headline",
+          "x": 48,
+          "y": 148,
+          "width": 192,
+          "height": 80
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 48,
+          "y": 207,
+          "width": 232,
+          "height": 56
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 388,
+          "y": 166,
+          "width": 200,
+          "height": 47
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "text",
+          "x": 686,
+          "y": 166,
+          "width": 200,
+          "height": 47
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "text",
+          "x": 387,
+          "y": 250,
+          "width": 200,
+          "height": 47
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 86,
+          "y": 348,
+          "width": 790,
+          "height": 101
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 17,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 63,
+                "y": 179,
+                "width": 521,
+                "height": 182
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 63,
+                  "y": 179,
+                  "width": 261,
+                  "height": 182
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 347,
+                  "y": 184,
+                  "width": 172,
+                  "height": 101
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 350,
+                  "y": 294,
+                  "width": 234,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 15,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 280,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 280,
+                  "y": 0,
+                  "width": 680,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 280,
+                  "y": 0,
+                  "width": 680,
+                  "height": 540
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 48,
+                  "y": 148,
+                  "width": 192,
+                  "height": 80
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 328,
+                  "y": 155,
+                  "width": 68,
+                  "height": 69
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 628,
+                  "y": 156,
+                  "width": 68,
+                  "height": 69
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 388,
+                  "y": 166,
+                  "width": 200,
+                  "height": 47
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 686,
+                  "y": 166,
+                  "width": 200,
+                  "height": 47
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 55,
+                "y": 59,
+                "width": 821,
+                "height": 415
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 55,
+                  "y": 59,
+                  "width": 192,
+                  "height": 202
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 86,
+                  "y": 348,
+                  "width": 790,
+                  "height": 101
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 75,
+                  "y": 370,
+                  "width": 3,
+                  "height": 98
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 86,
+                  "y": 430,
+                  "width": 790,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 50,
+                "y": 59,
+                "width": 871,
+                "height": 421
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 52,
+                  "y": 59,
+                  "width": 315,
+                  "height": 74
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 509,
+                  "y": 80,
+                  "width": 56,
+                  "height": 56
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 726,
+                  "y": 80,
+                  "width": 56,
+                  "height": 56
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 502,
+                  "y": 148,
+                  "width": 202,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 719,
+                  "y": 148,
+                  "width": 202,
+                  "height": 44
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 502,
+                  "y": 182,
+                  "width": 202,
+                  "height": 62
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 719,
+                  "y": 182,
+                  "width": 202,
+                  "height": 62
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 50,
+                  "y": 293,
+                  "width": 378,
+                  "height": 187
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 13,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 52,
+                "y": 59,
+                "width": 842,
+                "height": 410
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 52,
+                  "y": 59,
+                  "width": 636,
+                  "height": 74
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 68,
+                  "y": 162,
+                  "width": 262,
+                  "height": 307
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 350,
+                  "y": 162,
+                  "width": 262,
+                  "height": 307
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 632,
+                  "y": 162,
+                  "width": 262,
+                  "height": 307
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 78,
+                  "y": 174,
+                  "width": 240,
+                  "height": 153
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 361,
+                  "y": 174,
+                  "width": 240,
+                  "height": 153
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 641,
+                  "y": 174,
+                  "width": 240,
+                  "height": 153
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 82,
+                  "y": 340,
+                  "width": 236,
+                  "height": 47
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 55,
+                "y": 59,
+                "width": 821,
+                "height": 421
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 55,
+                  "y": 59,
+                  "width": 192,
+                  "height": 202
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 86,
+                  "y": 348,
+                  "width": 790,
+                  "height": 101
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 75,
+                  "y": 370,
+                  "width": 3,
+                  "height": 98
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 86,
+                  "y": 436,
+                  "width": 790,
+                  "height": 44
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容 3-6,",
+          "range": "8-16"
+        },
+        {
+          "label": "结尾",
+          "range": "17"
+        }
+      ]
+    },
+    {
+      "template_id": "office--project_kickoff",
+      "category": "office",
+      "category_label": "办公通用",
+      "scene": "项目启动宣讲",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 18,
+      "presentation_title": "项目启动宣讲",
+      "palette": "蓝色渐变底 linear-gradient(#4b5cf5, #233afb)，紫色 #ad82f7 强调",
+      "structure": "封面 → 目录 → 内容×15 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "hero-image-left-text-right",
+        "hero-text-left-image-right",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "项目启动、产品发布、技术宣讲。大胆蓝紫渐变，卡片式布局",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "headline",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "body",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "rgba(155, 158, 162, 1)",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "round1rect",
+          "x": 32,
+          "y": 21,
+          "width": 909,
+          "height": 488
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "round1rect",
+          "x": 32,
+          "y": 21,
+          "width": 909,
+          "height": 488
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "round1rect",
+          "x": 20,
+          "y": 34,
+          "width": 909,
+          "height": 488
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "round1rect",
+          "x": 20,
+          "y": 34,
+          "width": 909,
+          "height": 488
+        },
+        {
+          "id": "img-5",
+          "kind": "img",
+          "role": "image",
+          "x": 524,
+          "y": 141,
+          "width": 355,
+          "height": 350
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "headline",
+          "x": 68,
+          "y": 220,
+          "width": 420,
+          "height": 81
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "headline",
+          "x": 68,
+          "y": 140,
+          "width": 420,
+          "height": 80
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "headline",
+          "x": 68,
+          "y": 308,
+          "width": 420,
+          "height": 54
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "round1rect",
+          "x": 32,
+          "y": 21,
+          "width": 909,
+          "height": 488
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "round1rect",
+          "x": 32,
+          "y": 21,
+          "width": 909,
+          "height": 488
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "round1rect",
+          "x": 20,
+          "y": 34,
+          "width": 909,
+          "height": 488
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "round1rect",
+          "x": 20,
+          "y": 34,
+          "width": 909,
+          "height": 488
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 18,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 20,
+                "y": 21,
+                "width": 921,
+                "height": 501
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 32,
+                  "y": 21,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 32,
+                  "y": 21,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 20,
+                  "y": 34,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 20,
+                  "y": 34,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 512,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 610,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 707,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 804,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 26,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 20,
+                "y": 21,
+                "width": 921,
+                "height": 501
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 32,
+                  "y": 21,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 32,
+                  "y": 21,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 20,
+                  "y": 34,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 20,
+                  "y": 34,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 96,
+                  "y": 64,
+                  "width": 72,
+                  "height": 18
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 672,
+                  "y": 86,
+                  "width": 37,
+                  "height": 48
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 49,
+                  "y": 106,
+                  "width": 268,
+                  "height": 345
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 335,
+                  "y": 110,
+                  "width": 546,
+                  "height": 75
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 12,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 20,
+                "y": 21,
+                "width": 921,
+                "height": 501
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 32,
+                  "y": 21,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 20,
+                  "y": 34,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 508,
+                  "y": 59,
+                  "width": 90,
+                  "height": 28
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 512,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 610,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 707,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 804,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 96,
+                  "y": 64,
+                  "width": 72,
+                  "height": 18
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 22,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 20,
+                "y": 21,
+                "width": 921,
+                "height": 501
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 32,
+                  "y": 21,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 20,
+                  "y": 34,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 508,
+                  "y": 59,
+                  "width": 90,
+                  "height": 28
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 512,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 610,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 707,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 804,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 96,
+                  "y": 64,
+                  "width": 72,
+                  "height": 18
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 27,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 6,
+                "y": 21,
+                "width": 935,
+                "height": 507
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 32,
+                  "y": 21,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 20,
+                  "y": 34,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 508,
+                  "y": 59,
+                  "width": 90,
+                  "height": 28
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 512,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 610,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 707,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 804,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 96,
+                  "y": 64,
+                  "width": 72,
+                  "height": 18
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 19,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 20,
+                "y": 21,
+                "width": 921,
+                "height": 501
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 32,
+                  "y": 21,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 20,
+                  "y": 34,
+                  "width": 909,
+                  "height": 488
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 508,
+                  "y": 59,
+                  "width": 90,
+                  "height": 28
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 512,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 610,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 707,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 804,
+                  "y": 63,
+                  "width": 86,
+                  "height": 21
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 96,
+                  "y": 64,
+                  "width": 72,
+                  "height": 18
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "3-17"
+        },
+        {
+          "label": "结尾",
+          "range": "18"
+        }
+      ]
+    },
+    {
+      "template_id": "product--product_analysis",
+      "category": "product",
+      "category_label": "产品",
+      "scene": "产品分析报告",
+      "tone": "light",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 17,
+      "presentation_title": "产品分析报告",
+      "palette": "柔蓝渐变底图 #deebff → #ffffff，蓝色 #2e4ef6 → #2182f4 点缀，浅蓝卡片 #e2eaf9",
+      "structure": "封面 → 目录 → 内容 → 数据 → 内容×4 → 数据 → 内容×5 → SWOT → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "image-backed",
+        "section-divider",
+        "two-column-text"
+      ],
+      "use_cases": "产品分析、竞品分析。包含 SWOT 分析页，数据图表页",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "60"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "36"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF",
+            "font_size": "20"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 470,
+          "y": 132,
+          "width": 557,
+          "height": 557
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 646,
+          "y": -103,
+          "width": 514,
+          "height": 514
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "title",
+          "x": 30,
+          "y": 320,
+          "width": 640,
+          "height": 110
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 30,
+          "y": 428,
+          "width": 397,
+          "height": 56
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 30,
+          "y": 28,
+          "width": 162,
+          "height": 39
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 641,
+          "y": 146,
+          "width": 11,
+          "height": 11
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 626,
+          "y": -123,
+          "width": 514,
+          "height": 514
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 532,
+          "y": 88,
+          "width": 449,
+          "height": 449
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 412,
+          "y": 169,
+          "width": 222,
+          "height": 74
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 669,
+          "y": 169,
+          "width": 222,
+          "height": 74
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 412,
+          "y": 321,
+          "width": 222,
+          "height": 74
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "caption",
+          "x": 669,
+          "y": 321,
+          "width": 222,
+          "height": 74
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 17,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 30,
+                "y": -103,
+                "width": 1130,
+                "height": 792
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 646,
+                  "y": -103,
+                  "width": 514,
+                  "height": 514
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 30,
+                  "y": 28,
+                  "width": 162,
+                  "height": 39
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 470,
+                  "y": 132,
+                  "width": 557,
+                  "height": 557
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 641,
+                  "y": 146,
+                  "width": 11,
+                  "height": 11
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 30,
+                  "y": 320,
+                  "width": 640,
+                  "height": 110
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 30,
+                  "y": 428,
+                  "width": 397,
+                  "height": 56
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 18,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 67,
+                "y": -123,
+                "width": 1073,
+                "height": 660
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 626,
+                  "y": -123,
+                  "width": 514,
+                  "height": 514
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 532,
+                  "y": 88,
+                  "width": 449,
+                  "height": 449
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 83,
+                  "y": 122,
+                  "width": 181,
+                  "height": 74
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 406,
+                  "y": 131,
+                  "width": 30,
+                  "height": 30
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 415,
+                  "y": 131,
+                  "width": 219,
+                  "height": 40
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 663,
+                  "y": 131,
+                  "width": 30,
+                  "height": 30
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 672,
+                  "y": 131,
+                  "width": 219,
+                  "height": 40
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 412,
+                  "y": 169,
+                  "width": 222,
+                  "height": 74
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 70,
+                "y": 62,
+                "width": 1032,
+                "height": 804
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 70,
+                  "y": 62,
+                  "width": 692,
+                  "height": 92
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 831,
+                  "y": 100,
+                  "width": 271,
+                  "height": 271
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 70,
+                  "y": 150,
+                  "width": 200,
+                  "height": 74
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 411,
+                  "y": 247,
+                  "width": 619,
+                  "height": 619
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 832,
+                  "y": 265,
+                  "width": 11,
+                  "height": 11
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 647,
+                  "y": 362,
+                  "width": 291,
+                  "height": 160
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -40,
+                "y": 57,
+                "width": 962,
+                "height": 848
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 60,
+                  "y": 57,
+                  "width": 315,
+                  "height": 420
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 490,
+                  "y": 113,
+                  "width": 432,
+                  "height": 64
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": -21,
+                  "y": 168,
+                  "width": 277,
+                  "height": 277
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 490,
+                  "y": 173,
+                  "width": 352,
+                  "height": 74
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 517,
+                  "y": 293,
+                  "width": 128,
+                  "height": 78
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 714,
+                  "y": 293,
+                  "width": 128,
+                  "height": 78
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 490,
+                  "y": 315,
+                  "width": 43,
+                  "height": 49
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 687,
+                  "y": 315,
+                  "width": 43,
+                  "height": 49
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 11,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 76,
+                "y": 110,
+                "width": 809,
+                "height": 334
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 110,
+                  "y": 110,
+                  "width": 212,
+                  "height": 40
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 644,
+                  "y": 110,
+                  "width": 212,
+                  "height": 40
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 76,
+                  "y": 142,
+                  "width": 241,
+                  "height": 56
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 644,
+                  "y": 142,
+                  "width": 241,
+                  "height": 56
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 374,
+                  "y": 168,
+                  "width": 212,
+                  "height": 212
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 389,
+                  "y": 184,
+                  "width": 182,
+                  "height": 182
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 434,
+                  "y": 221,
+                  "width": 91,
+                  "height": 97
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 110,
+                  "y": 357,
+                  "width": 212,
+                  "height": 40
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 85,
+                "y": 0,
+                "width": 875,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 593,
+                  "y": 0,
+                  "width": 367,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 85,
+                  "y": 100,
+                  "width": 432,
+                  "height": 64
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 85,
+                  "y": 170,
+                  "width": 269,
+                  "height": 56
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 85,
+                  "y": 299,
+                  "width": 298,
+                  "height": 39
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 85,
+                  "y": 343,
+                  "width": 298,
+                  "height": 94
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容 3, 5-8,",
+          "range": "10-16"
+        },
+        {
+          "label": "结尾",
+          "range": "17"
+        }
+      ]
+    },
+    {
+      "template_id": "product--product_intro",
+      "category": "product",
+      "category_label": "产品",
+      "scene": "产品介绍",
+      "tone": "colorful",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 18,
+      "presentation_title": "产品介绍",
+      "palette": "多彩渐变（每个分节不同色系：青蓝、橙红、紫、蓝靛）",
+      "structure": "封面 → 目录 → [分节页 → 内容]×4 → 结尾（含对比页、时间线页）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-image-left-text-right",
+        "image-backed",
+        "two-column-text"
+      ],
+      "use_cases": "产品发布、产品介绍。视觉最丰富，每节独立配色",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 62,
+          "y": 166,
+          "width": 648,
+          "height": 90
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 62,
+          "y": 261,
+          "width": 648,
+          "height": 60
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 62,
+          "y": 420,
+          "width": 400,
+          "height": 63
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 762,
+          "y": 61,
+          "width": 160,
+          "height": 42
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 722,
+          "y": 24,
+          "width": 200,
+          "height": 30
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 64,
+          "y": 26,
+          "width": 72,
+          "height": 18
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 42,
+          "y": 0,
+          "width": 687,
+          "height": 406
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 214,
+          "y": 136,
+          "width": 531,
+          "height": 54
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "text",
+          "x": 87,
+          "y": 338,
+          "width": 167,
+          "height": 84
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "headline",
+          "x": 42,
+          "y": 22,
+          "width": 272,
+          "height": 48
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 283,
+          "y": 338,
+          "width": 167,
+          "height": 63
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 472,
+          "y": 338,
+          "width": 167,
+          "height": 42
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 18,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 62,
+                "y": 24,
+                "width": 860,
+                "height": 459
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 722,
+                  "y": 24,
+                  "width": 200,
+                  "height": 30
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 64,
+                  "y": 26,
+                  "width": 72,
+                  "height": 18
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 762,
+                  "y": 61,
+                  "width": 160,
+                  "height": 42
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 62,
+                  "y": 166,
+                  "width": 648,
+                  "height": 90
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 62,
+                  "y": 261,
+                  "width": 648,
+                  "height": 60
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 62,
+                  "y": 420,
+                  "width": 400,
+                  "height": 63
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 16,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 42,
+                "y": 0,
+                "width": 899,
+                "height": 422
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 42,
+                  "y": 0,
+                  "width": 687,
+                  "height": 406
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 42,
+                  "y": 22,
+                  "width": 272,
+                  "height": 48
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 869,
+                  "y": 26,
+                  "width": 72,
+                  "height": 18
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 214,
+                  "y": 136,
+                  "width": 531,
+                  "height": 54
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 87,
+                  "y": 261,
+                  "width": 167,
+                  "height": 30
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 283,
+                  "y": 261,
+                  "width": 167,
+                  "height": 30
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 472,
+                  "y": 261,
+                  "width": 167,
+                  "height": 30
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 664,
+                  "y": 261,
+                  "width": 167,
+                  "height": 30
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 83,
+                "y": 26,
+                "width": 858,
+                "height": 429
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 869,
+                  "y": 26,
+                  "width": 72,
+                  "height": 18
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 83,
+                  "y": 87,
+                  "width": 328,
+                  "height": 368
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 480,
+                  "y": 145,
+                  "width": 431,
+                  "height": 54
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 480,
+                  "y": 202,
+                  "width": 431,
+                  "height": 40
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 480,
+                  "y": 270,
+                  "width": 431,
+                  "height": 42
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 480,
+                  "y": 351,
+                  "width": 100,
+                  "height": 34
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 31,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 42,
+                "y": 17,
+                "width": 899,
+                "height": 469
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 42,
+                  "y": 17,
+                  "width": 653,
+                  "height": 42
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 869,
+                  "y": 26,
+                  "width": 72,
+                  "height": 18
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 46,
+                  "y": 88,
+                  "width": 269,
+                  "height": 114
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 632,
+                  "y": 88,
+                  "width": 269,
+                  "height": 114
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 63,
+                  "y": 102,
+                  "width": 235,
+                  "height": 24
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 649,
+                  "y": 102,
+                  "width": 235,
+                  "height": 24
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 393,
+                  "y": 131,
+                  "width": 160,
+                  "height": 160
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 403,
+                  "y": 141,
+                  "width": 140,
+                  "height": 140
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 23,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 42,
+                "y": 17,
+                "width": 899,
+                "height": 465
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 42,
+                  "y": 17,
+                  "width": 653,
+                  "height": 42
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 869,
+                  "y": 26,
+                  "width": 72,
+                  "height": 18
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 46,
+                  "y": 99,
+                  "width": 269,
+                  "height": 383
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 389,
+                  "y": 99,
+                  "width": 269,
+                  "height": 383
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 684,
+                  "y": 99,
+                  "width": 245,
+                  "height": 176
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 131,
+                  "y": 124,
+                  "width": 100,
+                  "height": 30
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 473,
+                  "y": 124,
+                  "width": 100,
+                  "height": 30
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 753,
+                  "y": 143,
+                  "width": 154,
+                  "height": 30
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 29,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 42,
+                "y": 17,
+                "width": 899,
+                "height": 420
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 42,
+                  "y": 17,
+                  "width": 653,
+                  "height": 42
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 869,
+                  "y": 26,
+                  "width": 72,
+                  "height": 18
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 112,
+                  "y": 99,
+                  "width": 51,
+                  "height": 30
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 285,
+                  "y": 99,
+                  "width": 51,
+                  "height": 30
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 462,
+                  "y": 99,
+                  "width": 51,
+                  "height": 30
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 631,
+                  "y": 99,
+                  "width": 51,
+                  "height": 30
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 801,
+                  "y": 99,
+                  "width": 51,
+                  "height": 30
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 134,
+                  "y": 145,
+                  "width": 8,
+                  "height": 8
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节 3, 7, 11,",
+          "range": "15"
+        },
+        {
+          "label": "内容 4-6, 8-10, 12-14,",
+          "range": "16-17"
+        },
+        {
+          "label": "结尾",
+          "range": "18"
+        }
+      ]
+    },
+    {
+      "template_id": "product--market_analysis",
+      "category": "product",
+      "category_label": "产品",
+      "scene": "市场分析报告",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 11,
+      "presentation_title": "市场分析报告",
+      "palette": "黑底，蓝紫渐变 #0d47db → #7d00fa 点缀",
+      "structure": "封面 → 目录 → 分节 → 数据 → 内容×2 → 分节 → 内容×3 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "image-backed",
+        "section-divider",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "市场分析、行业报告。精简紧凑（11 页），蓝紫科技感",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "48"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF",
+            "font_size": "24"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF",
+            "font_size": "14"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 39,
+          "y": 364,
+          "width": 798,
+          "height": 96
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 49,
+          "y": 88,
+          "width": 369,
+          "height": 85
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "caption",
+          "x": 480,
+          "y": 339,
+          "width": 231,
+          "height": 116
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 49,
+          "y": 339,
+          "width": 231,
+          "height": 92
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 49,
+          "y": 167,
+          "width": 502,
+          "height": 38
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 49,
+          "y": 270,
+          "width": 356,
+          "height": 53
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 480,
+          "y": 270,
+          "width": 356,
+          "height": 53
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 575,
+          "y": 0,
+          "width": 387,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 40,
+          "y": 409,
+          "width": 469,
+          "height": 96
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 46,
+          "y": 385,
+          "width": 228,
+          "height": 38
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 83,
+          "y": 108,
+          "width": 343,
+          "height": 343
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 126,
+          "y": 194,
+          "width": 257,
+          "height": 257
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 11,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 1,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 39,
+                "y": 364,
+                "width": 798,
+                "height": 96
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 39,
+                  "y": 364,
+                  "width": 798,
+                  "height": 96
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 49,
+                "y": 88,
+                "width": 787,
+                "height": 367
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 49,
+                  "y": 88,
+                  "width": 369,
+                  "height": 85
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 49,
+                  "y": 167,
+                  "width": 502,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 49,
+                  "y": 270,
+                  "width": 356,
+                  "height": 53
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 480,
+                  "y": 270,
+                  "width": 356,
+                  "height": 53
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 49,
+                  "y": 339,
+                  "width": 231,
+                  "height": 92
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 480,
+                  "y": 339,
+                  "width": 231,
+                  "height": 116
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 40,
+                "y": 0,
+                "width": 922,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 575,
+                  "y": 0,
+                  "width": 387,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 46,
+                  "y": 385,
+                  "width": 228,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 40,
+                  "y": 409,
+                  "width": 469,
+                  "height": 96
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 15,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 83,
+                "y": 108,
+                "width": 772,
+                "height": 344
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 83,
+                  "y": 108,
+                  "width": 343,
+                  "height": 343
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 433,
+                  "y": 129,
+                  "width": 78,
+                  "height": 52
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 509,
+                  "y": 129,
+                  "width": 165,
+                  "height": 41
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 215,
+                  "y": 134,
+                  "width": 78,
+                  "height": 41
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 509,
+                  "y": 159,
+                  "width": 297,
+                  "height": 56
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 126,
+                  "y": 194,
+                  "width": 257,
+                  "height": 257
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 482,
+                  "y": 240,
+                  "width": 78,
+                  "height": 52
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 558,
+                  "y": 240,
+                  "width": 165,
+                  "height": 41
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 12,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 50,
+                "y": 68,
+                "width": 860,
+                "height": 426
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 275,
+                  "y": 68,
+                  "width": 635,
+                  "height": 426
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 282,
+                  "y": 177,
+                  "width": 140,
+                  "height": 35
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 744,
+                  "y": 204,
+                  "width": 140,
+                  "height": 35
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 344,
+                  "y": 211,
+                  "width": 16,
+                  "height": 12
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 348,
+                  "y": 228,
+                  "width": 8,
+                  "height": 8
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 806,
+                  "y": 238,
+                  "width": 16,
+                  "height": 12
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 810,
+                  "y": 255,
+                  "width": 8,
+                  "height": 8
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 518,
+                  "y": 277,
+                  "width": 140,
+                  "height": 35
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 20,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 49,
+                "y": 88,
+                "width": 879,
+                "height": 360
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 49,
+                  "y": 88,
+                  "width": 238,
+                  "height": 85
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 331,
+                  "y": 103,
+                  "width": 305,
+                  "height": 56
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 51,
+                  "y": 231,
+                  "width": 82,
+                  "height": 82
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 331,
+                  "y": 231,
+                  "width": 82,
+                  "height": 82
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 611,
+                  "y": 231,
+                  "width": 82,
+                  "height": 82
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 144,
+                  "y": 237,
+                  "width": 224,
+                  "height": 41
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 424,
+                  "y": 237,
+                  "width": 224,
+                  "height": 41
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 704,
+                  "y": 237,
+                  "width": 224,
+                  "height": 41
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节 3,",
+          "range": "7"
+        },
+        {
+          "label": "内容 5-6,",
+          "range": "8-10"
+        },
+        {
+          "label": "结尾",
+          "range": "11"
+        }
+      ]
+    },
+    {
+      "template_id": "product--business_case_analysis",
+      "category": "product",
+      "category_label": "产品",
+      "scene": "商业案例分析",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 18,
+      "presentation_title": "商业案例分析",
+      "palette": "深灰图片底图，金属银渐变 #9c9c9e → #c0c5d3 点缀",
+      "structure": "封面 → 内容 → [分节页 → 内容]×4 → 结尾（4 个清晰分节）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "image-backed",
+        "section-divider",
+        "two-column-text"
+      ],
+      "use_cases": "商业案例、行业案例拆解。金属质感，分节明确",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "rgba(255, 255, 255, 1)",
+            "font_size": "80"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "rgba(255, 255, 255, 1)",
+            "font_size": "28"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "text_type": "body",
+            "font_color": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "rgba(255, 255, 255, 1)"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 42,
+          "y": 373,
+          "width": 547,
+          "height": 116
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 53,
+          "y": 85,
+          "width": 488,
+          "height": 58
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "caption",
+          "x": 56,
+          "y": 126,
+          "width": 318,
+          "height": 38
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 69,
+          "y": 379,
+          "width": 175,
+          "height": 56
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 281,
+          "y": 379,
+          "width": 175,
+          "height": 56
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 492,
+          "y": 379,
+          "width": 175,
+          "height": 56
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "caption",
+          "x": 704,
+          "y": 379,
+          "width": 175,
+          "height": 56
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "text",
+          "x": 69,
+          "y": 348,
+          "width": 200,
+          "height": 44
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "text",
+          "x": 281,
+          "y": 348,
+          "width": 200,
+          "height": 44
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 82,
+          "y": 280,
+          "width": 391,
+          "height": 97
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 82,
+          "y": 140,
+          "width": 139,
+          "height": 140
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 474,
+          "y": 48,
+          "width": 343,
+          "height": 447
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 18,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 1,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 42,
+                "y": 373,
+                "width": 547,
+                "height": 116
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 42,
+                  "y": 373,
+                  "width": 547,
+                  "height": 116
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 53,
+                "y": 85,
+                "width": 851,
+                "height": 350
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 53,
+                  "y": 85,
+                  "width": 488,
+                  "height": 58
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 56,
+                  "y": 126,
+                  "width": 318,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 81,
+                  "y": 284,
+                  "width": 48,
+                  "height": 48
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 293,
+                  "y": 284,
+                  "width": 48,
+                  "height": 48
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 504,
+                  "y": 284,
+                  "width": 48,
+                  "height": 48
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 716,
+                  "y": 284,
+                  "width": 48,
+                  "height": 48
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 69,
+                  "y": 348,
+                  "width": 200,
+                  "height": 44
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 281,
+                  "y": 348,
+                  "width": 200,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 2,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 82,
+                "y": 140,
+                "width": 391,
+                "height": 237
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 82,
+                  "y": 140,
+                  "width": 139,
+                  "height": 140
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 82,
+                  "y": 280,
+                  "width": 391,
+                  "height": 97
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 16,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 59,
+                "y": 48,
+                "width": 758,
+                "height": 447
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 59,
+                  "y": 48,
+                  "width": 423,
+                  "height": 74
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 474,
+                  "y": 48,
+                  "width": 343,
+                  "height": 447
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 59,
+                  "y": 128,
+                  "width": 368,
+                  "height": 110
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 59,
+                  "y": 323,
+                  "width": 105,
+                  "height": 24
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 175,
+                  "y": 323,
+                  "width": 146,
+                  "height": 24
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 333,
+                  "y": 323,
+                  "width": 94,
+                  "height": 24
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 59,
+                  "y": 360,
+                  "width": 109,
+                  "height": 38
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 260,
+                  "y": 390,
+                  "width": 94,
+                  "height": 38
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 17,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 50,
+                "y": 46,
+                "width": 818,
+                "height": 448
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 50,
+                  "y": 46,
+                  "width": 343,
+                  "height": 447
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 445,
+                  "y": 46,
+                  "width": 423,
+                  "height": 74
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 51,
+                  "y": 48,
+                  "width": 340,
+                  "height": 442
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 445,
+                  "y": 143,
+                  "width": 368,
+                  "height": 128
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 445,
+                  "y": 337,
+                  "width": 105,
+                  "height": 24
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 561,
+                  "y": 337,
+                  "width": 146,
+                  "height": 24
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 719,
+                  "y": 337,
+                  "width": 94,
+                  "height": 24
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 445,
+                  "y": 374,
+                  "width": 109,
+                  "height": 38
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 25,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 51,
+                "y": 71,
+                "width": 826,
+                "height": 397
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 321,
+                  "y": 71,
+                  "width": 50,
+                  "height": 38
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 755,
+                  "y": 115,
+                  "width": 22,
+                  "height": 311
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 320,
+                  "y": 134,
+                  "width": 50,
+                  "height": 38
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 842,
+                  "y": 144,
+                  "width": 22,
+                  "height": 282
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 666,
+                  "y": 179,
+                  "width": 22,
+                  "height": 247
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 488,
+                  "y": 182,
+                  "width": 22,
+                  "height": 244
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 842,
+                  "y": 193,
+                  "width": 22,
+                  "height": 234
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 320,
+                  "y": 204,
+                  "width": 50,
+                  "height": 38
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": ""
+        },
+        {
+          "label": "分节 3, 7, 11,",
+          "range": "15"
+        },
+        {
+          "label": "内容 2, 4-6, 8-10, 12-14,",
+          "range": "16-17"
+        },
+        {
+          "label": "结尾",
+          "range": "18"
+        }
+      ]
+    },
+    {
+      "template_id": "product--product_promotion",
+      "category": "product",
+      "category_label": "产品",
+      "scene": "产品推广方案",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 13,
+      "presentation_title": "产品推广方案-裂图重新上传",
+      "palette": "深灰 #2b2f36 + 白色交替，极简黑白",
+      "structure": "封面 → 目录 → 内容×6 → 分节 → 内容×3 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "推广方案、营销策略。极简风，黑白对比",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "64"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF",
+            "font_size": "14"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 578,
+          "y": 65,
+          "width": 251,
+          "height": 425
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 84,
+          "y": 85,
+          "width": 536,
+          "height": 180
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 84,
+          "y": 257,
+          "width": 325,
+          "height": 68
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "rect",
+          "x": 578,
+          "y": 65,
+          "width": 39,
+          "height": 425
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 56,
+          "y": 85,
+          "width": 250,
+          "height": 77
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 56,
+          "y": 142,
+          "width": 250,
+          "height": 68
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "text",
+          "x": 581,
+          "y": 114,
+          "width": 330,
+          "height": 41
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 581,
+          "y": 201,
+          "width": 330,
+          "height": 41
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 581,
+          "y": 288,
+          "width": 330,
+          "height": 41
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 581,
+          "y": 385,
+          "width": 330,
+          "height": 41
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "headline",
+          "x": 463,
+          "y": 113,
+          "width": 118,
+          "height": 43
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "headline",
+          "x": 463,
+          "y": 200,
+          "width": 118,
+          "height": 43
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 13,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 84,
+                "y": 65,
+                "width": 745,
+                "height": 425
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 578,
+                  "y": 65,
+                  "width": 251,
+                  "height": 425
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 578,
+                  "y": 65,
+                  "width": 39,
+                  "height": 425
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 84,
+                  "y": 85,
+                  "width": 536,
+                  "height": 180
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 84,
+                  "y": 257,
+                  "width": 325,
+                  "height": 68
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 56,
+                "y": 85,
+                "width": 855,
+                "height": 353
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 56,
+                  "y": 85,
+                  "width": 250,
+                  "height": 77
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 390,
+                  "y": 102,
+                  "width": 66,
+                  "height": 66
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 463,
+                  "y": 113,
+                  "width": 118,
+                  "height": 43
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 581,
+                  "y": 114,
+                  "width": 330,
+                  "height": 41
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 56,
+                  "y": 142,
+                  "width": 250,
+                  "height": 68
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 390,
+                  "y": 189,
+                  "width": 66,
+                  "height": 66
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 463,
+                  "y": 200,
+                  "width": 118,
+                  "height": 43
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 581,
+                  "y": 201,
+                  "width": 330,
+                  "height": 41
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 182,
+                "y": 193,
+                "width": 598,
+                "height": 118
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 182,
+                  "y": 193,
+                  "width": 118,
+                  "height": 118
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 316,
+                  "y": 227,
+                  "width": 118,
+                  "height": 51
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 450,
+                  "y": 229,
+                  "width": 330,
+                  "height": 47
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 8,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 28,
+                "y": 75,
+                "width": 874,
+                "height": 388
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 38,
+                  "y": 75,
+                  "width": 202,
+                  "height": 128
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 257,
+                  "y": 75,
+                  "width": 202,
+                  "height": 128
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 507,
+                  "y": 99,
+                  "width": 395,
+                  "height": 74
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 34,
+                  "y": 215,
+                  "width": 318,
+                  "height": 56
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 507,
+                  "y": 229,
+                  "width": 395,
+                  "height": 230
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 507,
+                  "y": 229,
+                  "width": 395,
+                  "height": 230
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 32,
+                  "y": 293,
+                  "width": 250,
+                  "height": 68
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 28,
+                  "y": 323,
+                  "width": 250,
+                  "height": 140
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 28,
+                "y": 44,
+                "width": 874,
+                "height": 415
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 507,
+                  "y": 44,
+                  "width": 395,
+                  "height": 415
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 863,
+                  "y": 44,
+                  "width": 39,
+                  "height": 415
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 32,
+                  "y": 103,
+                  "width": 250,
+                  "height": 56
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 28,
+                  "y": 130,
+                  "width": 372,
+                  "height": 116
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 32,
+                  "y": 235,
+                  "width": 318,
+                  "height": 74
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 182,
+                "y": 193,
+                "width": 608,
+                "height": 118
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 182,
+                  "y": 193,
+                  "width": 118,
+                  "height": 118
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 316,
+                  "y": 227,
+                  "width": 141,
+                  "height": 51
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 460,
+                  "y": 229,
+                  "width": 330,
+                  "height": 47
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": "9"
+        },
+        {
+          "label": "内容 3-8,",
+          "range": "10-12"
+        },
+        {
+          "label": "结尾",
+          "range": "13"
+        }
+      ]
+    },
+    {
+      "template_id": "marketing--business_plan",
+      "category": "marketing",
+      "category_label": "市场营销",
+      "scene": "商业计划书",
+      "tone": "light",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 18,
+      "presentation_title": "商业计划书",
+      "palette": "白底，蓝青渐变封面 #0b3be5 → #25d8ff，鲜蓝 #194cff 点缀，含甜甜圈图表",
+      "structure": "封面 → 目录 → 内容×12 → 时间线 → 内容×2 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-text-left-image-right",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "商业计划书、创业路演。含时间线页、图表页",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "90"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "36"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "donut",
+          "x": 690,
+          "y": 0,
+          "width": 540,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 36,
+          "y": 171,
+          "width": 608,
+          "height": 146
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 36,
+          "y": 306,
+          "width": 360,
+          "height": 62
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 61,
+          "y": 36,
+          "width": 450,
+          "height": 34
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 900,
+          "y": 210,
+          "width": 120,
+          "height": 120
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "donut",
+          "x": -270,
+          "y": 0,
+          "width": 540,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 353,
+          "y": 91,
+          "width": 496,
+          "height": 69
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "headline",
+          "x": 434,
+          "y": 91,
+          "width": 294,
+          "height": 69
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 412,
+          "y": 196,
+          "width": 208,
+          "height": 44
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 691,
+          "y": 196,
+          "width": 208,
+          "height": 44
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 412,
+          "y": 282,
+          "width": 208,
+          "height": 44
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "text",
+          "x": 691,
+          "y": 282,
+          "width": 208,
+          "height": 44
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 18,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 36,
+                "y": 0,
+                "width": 1194,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "donut",
+                  "x": 690,
+                  "y": 0,
+                  "width": 540,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 61,
+                  "y": 36,
+                  "width": 450,
+                  "height": 34
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 36,
+                  "y": 171,
+                  "width": 608,
+                  "height": 146
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 900,
+                  "y": 210,
+                  "width": 120,
+                  "height": 120
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 36,
+                  "y": 306,
+                  "width": 360,
+                  "height": 62
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -270,
+                "y": 0,
+                "width": 1169,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "donut",
+                  "x": -270,
+                  "y": 0,
+                  "width": 540,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 353,
+                  "y": 91,
+                  "width": 496,
+                  "height": 69
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 353,
+                  "y": 91,
+                  "width": 98,
+                  "height": 70
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 434,
+                  "y": 91,
+                  "width": 294,
+                  "height": 69
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 412,
+                  "y": 196,
+                  "width": 208,
+                  "height": 44
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 691,
+                  "y": 196,
+                  "width": 208,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 412,
+                  "y": 227,
+                  "width": 208,
+                  "height": 41
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 691,
+                  "y": 227,
+                  "width": 208,
+                  "height": 41
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 272,
+                  "y": 232,
+                  "width": 416,
+                  "height": 69
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 115,
+                  "y": 291,
+                  "width": 729,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 8,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 31,
+                "y": 16,
+                "width": 902,
+                "height": 505
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 51,
+                  "y": 16,
+                  "width": 202,
+                  "height": 41
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 731,
+                  "y": 16,
+                  "width": 202,
+                  "height": 41
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "donut",
+                  "x": 31,
+                  "y": 24,
+                  "width": 24,
+                  "height": 24
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 773,
+                  "y": 88,
+                  "width": 114,
+                  "height": 110
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 475,
+                  "y": 97,
+                  "width": 400,
+                  "height": 400
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 31,
+                  "y": 118,
+                  "width": 416,
+                  "height": 69
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 31,
+                  "y": 190,
+                  "width": 418,
+                  "height": 209
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 425,
+                  "y": 346,
+                  "width": 182,
+                  "height": 175
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 17,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 31,
+                "y": 16,
+                "width": 1125,
+                "height": 457
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 51,
+                  "y": 16,
+                  "width": 202,
+                  "height": 41
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 731,
+                  "y": 16,
+                  "width": 202,
+                  "height": 41
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "donut",
+                  "x": 31,
+                  "y": 24,
+                  "width": 24,
+                  "height": 24
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 764,
+                  "y": 74,
+                  "width": 392,
+                  "height": 392
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 92,
+                  "y": 113,
+                  "width": 34,
+                  "height": 33
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 104,
+                  "y": 128,
+                  "width": 80,
+                  "height": 80
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 465,
+                  "y": 128,
+                  "width": 416,
+                  "height": 69
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 188,
+                  "y": 136,
+                  "width": 227,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 272,
+                  "y": 232,
+                  "width": 416,
+                  "height": 69
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 115,
+                  "y": 291,
+                  "width": 729,
+                  "height": 44
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容 3-14,",
+          "range": "16-17"
+        },
+        {
+          "label": "结尾",
+          "range": "18"
+        }
+      ]
+    },
+    {
+      "template_id": "marketing--roadshow_business_plan",
+      "category": "marketing",
+      "category_label": "市场营销",
+      "scene": "企业路演商业计划书",
+      "tone": "light",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 20,
+      "presentation_title": "企业路演商业计划书",
+      "palette": "白底，绿色 #20b14e 点缀（增长/商业感）",
+      "structure": "封面 → 目录 → [分节页 → 内容]×5 → 结尾（含时间线、流程图）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "image-backed",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "融资路演、企业路演。绿色增长主题，含 chevron 流程图形",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "64"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF",
+            "font_size": "24"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "rect",
+          "x": 0,
+          "y": 0.19,
+          "width": 960,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 67,
+          "y": 85,
+          "width": 406,
+          "height": 187
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 67,
+          "y": 261,
+          "width": 277,
+          "height": 56
+        },
+        {
+          "id": "img-4",
+          "kind": "img",
+          "role": "image",
+          "x": 681,
+          "y": 374,
+          "width": 75,
+          "height": 103
+        },
+        {
+          "id": "img-5",
+          "kind": "img",
+          "role": "image",
+          "x": 744,
+          "y": 374,
+          "width": 75,
+          "height": 103
+        },
+        {
+          "id": "img-6",
+          "kind": "img",
+          "role": "image",
+          "x": 813,
+          "y": 374,
+          "width": 75,
+          "height": 103
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "caption",
+          "x": 79,
+          "y": 44,
+          "width": 138,
+          "height": 38
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "rect",
+          "x": 0,
+          "y": 0,
+          "width": 960,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 70,
+          "y": 82,
+          "width": 357,
+          "height": 77
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 562,
+          "y": 91,
+          "width": 260,
+          "height": 53
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 562,
+          "y": 171,
+          "width": 260,
+          "height": 53
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 562,
+          "y": 251,
+          "width": 260,
+          "height": 53
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 20,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 7,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0.19,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0.19,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 79,
+                  "y": 44,
+                  "width": 138,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 67,
+                  "y": 85,
+                  "width": 406,
+                  "height": 187
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 67,
+                  "y": 261,
+                  "width": 277,
+                  "height": 56
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 681,
+                  "y": 374,
+                  "width": 75,
+                  "height": 103
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 744,
+                  "y": 374,
+                  "width": 75,
+                  "height": 103
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 813,
+                  "y": 374,
+                  "width": 75,
+                  "height": 103
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 20,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 70,
+                  "y": 82,
+                  "width": 357,
+                  "height": 77
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 502,
+                  "y": 86,
+                  "width": 8,
+                  "height": 62
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 510,
+                  "y": 91,
+                  "width": 52,
+                  "height": 53
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 562,
+                  "y": 91,
+                  "width": 260,
+                  "height": 53
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 502,
+                  "y": 166,
+                  "width": 8,
+                  "height": 62
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 510,
+                  "y": 171,
+                  "width": 52,
+                  "height": 53
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 562,
+                  "y": 171,
+                  "width": 260,
+                  "height": 53
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 51,
+                "y": 60,
+                "width": 849,
+                "height": 422
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 60,
+                  "y": 60,
+                  "width": 840,
+                  "height": 292
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 52,
+                  "y": 373,
+                  "width": 414,
+                  "height": 44
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 51,
+                  "y": 399,
+                  "width": 404,
+                  "height": 83
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 804,
+                  "y": 420,
+                  "width": 32,
+                  "height": 44
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 831,
+                  "y": 420,
+                  "width": 32,
+                  "height": 44
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 861,
+                  "y": 420,
+                  "width": 32,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 345,
+                  "height": 540
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 344,
+                  "y": 0,
+                  "width": 616,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 28,
+                  "y": 40,
+                  "width": 291,
+                  "height": 56
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 28,
+                  "y": 134,
+                  "width": 291,
+                  "height": 128
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 27,
+                  "y": 472,
+                  "width": 291,
+                  "height": 38
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 48,
+                "y": 64,
+                "width": 302,
+                "height": 407
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 48,
+                  "y": 64,
+                  "width": 302,
+                  "height": 77
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 48,
+                  "y": 125,
+                  "width": 166,
+                  "height": 44
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 67,
+                  "y": 416,
+                  "width": 40,
+                  "height": 55
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 102,
+                  "y": 416,
+                  "width": 40,
+                  "height": 55
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 137,
+                  "y": 416,
+                  "width": 40,
+                  "height": 55
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 11,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 48,
+                "y": 30,
+                "width": 864,
+                "height": 456
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 48,
+                  "y": 30,
+                  "width": 173,
+                  "height": 77
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 233,
+                  "y": 30,
+                  "width": 166,
+                  "height": 77
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 48,
+                  "y": 132,
+                  "width": 864,
+                  "height": 354
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 48,
+                  "y": 155,
+                  "width": 166,
+                  "height": 56
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 250,
+                  "y": 155,
+                  "width": 166,
+                  "height": 56
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 421,
+                  "y": 155,
+                  "width": 166,
+                  "height": 56
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 591,
+                  "y": 155,
+                  "width": 166,
+                  "height": 56
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "slides-home-plate",
+                  "x": 591,
+                  "y": 298,
+                  "width": 314,
+                  "height": 40
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节 3, 6, 9, 12,",
+          "range": "15"
+        },
+        {
+          "label": "内容 4-5, 7-8, 10-11, 13-14,",
+          "range": "16-19"
+        },
+        {
+          "label": "结尾",
+          "range": "20"
+        }
+      ]
+    },
+    {
+      "template_id": "marketing--brand_communication",
+      "category": "marketing",
+      "category_label": "市场营销",
+      "scene": "品牌传播方案",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 17,
+      "presentation_title": "品牌传播方案",
+      "palette": "黑色图片底图，青绿渐变 #59c2ff → #a1ffc8 点缀，半透明白色卡片",
+      "structure": "封面 → 目录 → 内容×8 → 数据 → 内容×5 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-image-left-text-right",
+        "image-backed",
+        "section-divider",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "品牌传播、公关方案。青绿科技感 + 暗色背景",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "48"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "36"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF",
+            "font_size": "28"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 260,
+          "y": -24,
+          "width": 654,
+          "height": 564
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 289,
+          "y": 68,
+          "width": 399,
+          "height": 404
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 289,
+          "y": 68,
+          "width": 399,
+          "height": 404
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 289,
+          "y": 68,
+          "width": 399,
+          "height": 404
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 32,
+          "y": 296,
+          "width": 506,
+          "height": 193
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 46,
+          "y": 24,
+          "width": 196,
+          "height": 32
+        },
+        {
+          "id": "img-7",
+          "kind": "img",
+          "role": "image",
+          "x": 760,
+          "y": 402,
+          "width": 75,
+          "height": 75
+        },
+        {
+          "id": "img-8",
+          "kind": "img",
+          "role": "image",
+          "x": 826,
+          "y": 402,
+          "width": 75,
+          "height": 75
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 95,
+          "y": 261,
+          "width": 358,
+          "height": 68
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 538,
+          "y": 261,
+          "width": 358,
+          "height": 68
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 95,
+          "y": 352,
+          "width": 358,
+          "height": 68
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 538,
+          "y": 352,
+          "width": 358,
+          "height": 68
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 17,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 9,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 32,
+                "y": -24,
+                "width": 882,
+                "height": 564
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 260,
+                  "y": -24,
+                  "width": 654,
+                  "height": 564
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 46,
+                  "y": 24,
+                  "width": 196,
+                  "height": 32
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 289,
+                  "y": 68,
+                  "width": 399,
+                  "height": 404
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 289,
+                  "y": 68,
+                  "width": 399,
+                  "height": 404
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 289,
+                  "y": 68,
+                  "width": 399,
+                  "height": 404
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 32,
+                  "y": 296,
+                  "width": 506,
+                  "height": 193
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 760,
+                  "y": 352,
+                  "width": 141,
+                  "height": 38
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 760,
+                  "y": 402,
+                  "width": 75,
+                  "height": 75
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 10,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 93,
+                "y": 59,
+                "width": 803,
+                "height": 361
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 93,
+                  "y": 59,
+                  "width": 238,
+                  "height": 87
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 93,
+                  "y": 129,
+                  "width": 404,
+                  "height": 58
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 95,
+                  "y": 261,
+                  "width": 358,
+                  "height": 68
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 538,
+                  "y": 261,
+                  "width": 358,
+                  "height": 68
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 104,
+                  "y": 269,
+                  "width": 51,
+                  "height": 51
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 547,
+                  "y": 269,
+                  "width": 51,
+                  "height": 51
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 95,
+                  "y": 352,
+                  "width": 358,
+                  "height": 68
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 538,
+                  "y": 352,
+                  "width": 358,
+                  "height": 68
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -26,
+                "y": 83,
+                "width": 991,
+                "height": 300
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": -26,
+                  "y": 83,
+                  "width": 353,
+                  "height": 300
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 111,
+                  "y": 139,
+                  "width": 215,
+                  "height": 215
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 111,
+                  "y": 139,
+                  "width": 215,
+                  "height": 215
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 111,
+                  "y": 139,
+                  "width": 215,
+                  "height": 215
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 211,
+                  "y": 215,
+                  "width": 112,
+                  "height": 110
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 401,
+                  "y": 215,
+                  "width": 564,
+                  "height": 110
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 2,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 83,
+                "y": 24,
+                "width": 849,
+                "height": 96
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 730,
+                  "y": 24,
+                  "width": 202,
+                  "height": 34
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 83,
+                  "y": 59,
+                  "width": 416,
+                  "height": 61
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 16,
+                "y": 24,
+                "width": 916,
+                "height": 637
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 730,
+                  "y": 24,
+                  "width": 202,
+                  "height": 34
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 83,
+                  "y": 59,
+                  "width": 416,
+                  "height": 61
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 16,
+                  "y": 149,
+                  "width": 512,
+                  "height": 512
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 569,
+                  "y": 159,
+                  "width": 330,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 202,
+                  "y": 185,
+                  "width": 141,
+                  "height": 41
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 569,
+                  "y": 190,
+                  "width": 330,
+                  "height": 62
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 84,
+                  "y": 259,
+                  "width": 377,
+                  "height": 377
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 569,
+                  "y": 284,
+                  "width": 330,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 10,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 63,
+                "y": 24,
+                "width": 869,
+                "height": 497
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 730,
+                  "y": 24,
+                  "width": 202,
+                  "height": 34
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 83,
+                  "y": 59,
+                  "width": 416,
+                  "height": 61
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 107,
+                  "y": 117,
+                  "width": 404,
+                  "height": 404
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 449,
+                  "y": 117,
+                  "width": 404,
+                  "height": 404
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 771,
+                  "y": 121,
+                  "width": 92,
+                  "height": 92
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 189,
+                  "y": 226,
+                  "width": 240,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 531,
+                  "y": 226,
+                  "width": 240,
+                  "height": 44
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 189,
+                  "y": 281,
+                  "width": 240,
+                  "height": 146
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容 3-10,",
+          "range": "12-16"
+        },
+        {
+          "label": "结尾",
+          "range": "17"
+        }
+      ]
+    },
+    {
+      "template_id": "marketing--marketing_strategy",
+      "category": "marketing",
+      "category_label": "市场营销",
+      "scene": "市场营销策略",
+      "tone": "dark",
+      "formality": "creative",
+      "is_general_template": false,
+      "slide_count": 16,
+      "presentation_title": "市场营销策略",
+      "palette": "纯黑底 #0b0b0b，红橙霓虹渐变 #ff0000 → #fa6627，紫蓝 #bc50ff → #2f2bfd",
+      "structure": "封面 → 目录 → 内容×13 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-image-left-text-right",
+        "image-backed",
+        "section-divider",
+        "two-column-text"
+      ],
+      "use_cases": "营销策略、品牌推广。最具视觉冲击力，霓虹风格",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "48"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "28"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 54,
+          "y": 58,
+          "width": 547,
+          "height": 132
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "caption",
+          "x": 845,
+          "y": 80,
+          "width": 176,
+          "height": 38
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 845,
+          "y": 425,
+          "width": 176,
+          "height": 38
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 53,
+          "y": 85,
+          "width": 488,
+          "height": 58
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "caption",
+          "x": 56,
+          "y": 126,
+          "width": 318,
+          "height": 56
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 69,
+          "y": 379,
+          "width": 200,
+          "height": 74
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 360,
+          "y": 379,
+          "width": 200,
+          "height": 74
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 651,
+          "y": 379,
+          "width": 200,
+          "height": 74
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 69,
+          "y": 348,
+          "width": 200,
+          "height": 44
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "text",
+          "x": 360,
+          "y": 348,
+          "width": 200,
+          "height": 44
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "text",
+          "x": 651,
+          "y": 348,
+          "width": 200,
+          "height": 44
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 47,
+          "y": 343,
+          "width": 688,
+          "height": 132
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 16,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 54,
+                "y": 58,
+                "width": 967,
+                "height": 405
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 54,
+                  "y": 58,
+                  "width": 547,
+                  "height": 132
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 845,
+                  "y": 80,
+                  "width": 176,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 845,
+                  "y": 425,
+                  "width": 176,
+                  "height": 38
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 11,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 53,
+                "y": 85,
+                "width": 798,
+                "height": 368
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 53,
+                  "y": 85,
+                  "width": 488,
+                  "height": 58
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 56,
+                  "y": 126,
+                  "width": 318,
+                  "height": 56
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 81,
+                  "y": 284,
+                  "width": 48,
+                  "height": 48
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 372,
+                  "y": 284,
+                  "width": 48,
+                  "height": 48
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 663,
+                  "y": 284,
+                  "width": 48,
+                  "height": 48
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 69,
+                  "y": 348,
+                  "width": 200,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 360,
+                  "y": 348,
+                  "width": 200,
+                  "height": 44
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 651,
+                  "y": 348,
+                  "width": 200,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 47,
+                "y": 80,
+                "width": 974,
+                "height": 395
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 845,
+                  "y": 80,
+                  "width": 176,
+                  "height": 38
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 57,
+                  "y": 313,
+                  "width": 468,
+                  "height": 56
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 47,
+                  "y": 343,
+                  "width": 688,
+                  "height": 132
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 845,
+                  "y": 425,
+                  "width": 176,
+                  "height": 38
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 51,
+                "y": 52,
+                "width": 783,
+                "height": 436
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 498,
+                  "y": 52,
+                  "width": 336,
+                  "height": 436
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 51,
+                  "y": 71,
+                  "width": 353,
+                  "height": 58
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 51,
+                  "y": 125,
+                  "width": 342,
+                  "height": 110
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 25,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 51,
+                "y": 71,
+                "width": 826,
+                "height": 397
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 321,
+                  "y": 71,
+                  "width": 50,
+                  "height": 38
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 755,
+                  "y": 115,
+                  "width": 22,
+                  "height": 311
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 320,
+                  "y": 134,
+                  "width": 50,
+                  "height": 38
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 842,
+                  "y": 144,
+                  "width": 22,
+                  "height": 282
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 666,
+                  "y": 179,
+                  "width": 22,
+                  "height": 247
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 488,
+                  "y": 182,
+                  "width": 22,
+                  "height": 244
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 842,
+                  "y": 193,
+                  "width": 22,
+                  "height": 234
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 320,
+                  "y": 204,
+                  "width": 50,
+                  "height": 38
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 27,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -73,
+                "y": -75,
+                "width": 1046,
+                "height": 606
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": -21,
+                  "y": -75,
+                  "width": 404,
+                  "height": 404
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 327,
+                  "y": 6,
+                  "width": 244,
+                  "height": 39
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 60,
+                  "y": 7,
+                  "width": 242,
+                  "height": 242
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 286,
+                  "y": 52,
+                  "width": 70,
+                  "height": 70
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 123,
+                  "y": 70,
+                  "width": 115,
+                  "height": 115
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 569,
+                  "y": 93,
+                  "width": 44,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 256,
+                  "y": 122,
+                  "width": 128,
+                  "height": 38
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 528,
+                  "y": 137,
+                  "width": 128,
+                  "height": 38
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "3-15"
+        },
+        {
+          "label": "结尾",
+          "range": "16"
+        }
+      ]
+    },
+    {
+      "template_id": "marketing--marketing_plan",
+      "category": "marketing",
+      "category_label": "市场营销",
+      "scene": "营销策划方案",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 15,
+      "presentation_title": "营销策划方案-裂图重新上传",
+      "palette": "近黑底 #18181a，亮黄 #ffdb1d 强调，灰色 #93969c 文字",
+      "structure": "封面 → 目录 → 内容×10 → 数据 → 内容 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "image-backed",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "营销策划、推广计划。黄+黑高对比，醒目",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 207,
+          "y": 204,
+          "width": 545,
+          "height": 101
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "rect",
+          "x": 587,
+          "y": 184,
+          "width": 191,
+          "height": 202
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 172,
+          "y": 290,
+          "width": 615,
+          "height": 44
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 640,
+          "y": 16,
+          "width": 276,
+          "height": 38
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 158,
+          "y": 16,
+          "width": 49,
+          "height": 38
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 26,
+          "y": 26,
+          "width": 254,
+          "height": 489
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 319,
+          "y": 71,
+          "width": 161,
+          "height": 77
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 369,
+          "y": 254,
+          "width": 203,
+          "height": 56
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 614,
+          "y": 254,
+          "width": 203,
+          "height": 56
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 369,
+          "y": 374,
+          "width": 203,
+          "height": 56
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "caption",
+          "x": 614,
+          "y": 374,
+          "width": 203,
+          "height": 56
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "rect",
+          "x": 295,
+          "y": 26,
+          "width": 92,
+          "height": 116
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 15,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 158,
+                "y": 16,
+                "width": 758,
+                "height": 370
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 158,
+                  "y": 16,
+                  "width": 49,
+                  "height": 38
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 640,
+                  "y": 16,
+                  "width": 276,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 587,
+                  "y": 184,
+                  "width": 191,
+                  "height": 202
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 207,
+                  "y": 204,
+                  "width": 545,
+                  "height": 101
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 172,
+                  "y": 290,
+                  "width": 615,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 17,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 26,
+                "y": 26,
+                "width": 1035,
+                "height": 489
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 26,
+                  "y": 26,
+                  "width": 254,
+                  "height": 489
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 295,
+                  "y": 26,
+                  "width": 92,
+                  "height": 116
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 319,
+                  "y": 71,
+                  "width": 161,
+                  "height": 77
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 904,
+                  "y": 144,
+                  "width": 49,
+                  "height": 38
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 369,
+                  "y": 207,
+                  "width": 136,
+                  "height": 43
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 614,
+                  "y": 207,
+                  "width": 136,
+                  "height": 43
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 369,
+                  "y": 229,
+                  "width": 136,
+                  "height": 38
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 614,
+                  "y": 229,
+                  "width": 161,
+                  "height": 38
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 27,
+                "y": 0,
+                "width": 933,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 480,
+                  "y": 0,
+                  "width": 480,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 158,
+                  "y": 16,
+                  "width": 49,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 481,
+                  "y": 16,
+                  "width": 276,
+                  "height": 38
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 31,
+                  "y": 407,
+                  "width": 231,
+                  "height": 47
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 27,
+                  "y": 434,
+                  "width": 261,
+                  "height": 74
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 13,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 41,
+                "y": 16,
+                "width": 875,
+                "height": 475
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 158,
+                  "y": 16,
+                  "width": 49,
+                  "height": 38
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 640,
+                  "y": 16,
+                  "width": 276,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 41,
+                  "y": 88,
+                  "width": 101,
+                  "height": 90
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 331,
+                  "y": 88,
+                  "width": 240,
+                  "height": 403
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 589,
+                  "y": 88,
+                  "width": 152,
+                  "height": 403
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 758,
+                  "y": 88,
+                  "width": 152,
+                  "height": 403
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 77,
+                  "y": 118,
+                  "width": 407,
+                  "height": 62
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 41,
+                  "y": 204,
+                  "width": 240,
+                  "height": 41
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 12,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 38,
+                "y": 16,
+                "width": 884,
+                "height": 410
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 158,
+                  "y": 16,
+                  "width": 49,
+                  "height": 38
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 640,
+                  "y": 16,
+                  "width": 276,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 38,
+                  "y": 74,
+                  "width": 49,
+                  "height": 56
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 47,
+                  "y": 82,
+                  "width": 407,
+                  "height": 56
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 38,
+                  "y": 194,
+                  "width": 195,
+                  "height": 74
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 267,
+                  "y": 194,
+                  "width": 195,
+                  "height": 74
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 498,
+                  "y": 194,
+                  "width": 195,
+                  "height": 74
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 727,
+                  "y": 194,
+                  "width": 195,
+                  "height": 74
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 27,
+                "y": 0,
+                "width": 933,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 480,
+                  "y": 0,
+                  "width": 480,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 158,
+                  "y": 16,
+                  "width": 49,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 481,
+                  "y": 16,
+                  "width": 276,
+                  "height": 38
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 31,
+                  "y": 407,
+                  "width": 231,
+                  "height": 47
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 27,
+                  "y": 434,
+                  "width": 261,
+                  "height": 74
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容 3-12,",
+          "range": "14"
+        },
+        {
+          "label": "结尾",
+          "range": "15"
+        }
+      ]
+    },
+    {
+      "template_id": "marketing--product_whitepaper",
+      "category": "marketing",
+      "category_label": "市场营销",
+      "scene": "产品白皮书",
+      "tone": "colorful",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 21,
+      "presentation_title": "产品白皮书",
+      "palette": "图片底图，暖橙粉渐变 #ffaeac → #ffe6c8，珊瑚 #ff7d34 → #ff3ebd",
+      "structure": "封面 → 目录 → 内容×18 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-image-left-text-right",
+        "hero-text-left-image-right",
+        "image-backed",
+        "section-divider",
+        "two-column-text"
+      ],
+      "use_cases": "产品白皮书、技术白皮书、深度报告。页数最多（21 页），暖色调",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "90"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "42"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF",
+            "font_size": "18"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 23,
+          "y": 175,
+          "width": 698,
+          "height": 146
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "text",
+          "x": 28,
+          "y": 311,
+          "width": 488,
+          "height": 44
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 28,
+          "y": 476,
+          "width": 176,
+          "height": 39
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 28,
+          "y": 19,
+          "width": 178,
+          "height": 38
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 289,
+          "y": 112,
+          "width": 328,
+          "height": 77
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "caption",
+          "x": 391,
+          "y": 219,
+          "width": 385,
+          "height": 38
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 391,
+          "y": 270,
+          "width": 385,
+          "height": 38
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 391,
+          "y": 320,
+          "width": 385,
+          "height": 38
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 391,
+          "y": 371,
+          "width": 385,
+          "height": 38
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "headline",
+          "x": 164,
+          "y": 112,
+          "width": 125,
+          "height": 77
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "text",
+          "x": 200,
+          "y": 368,
+          "width": 157,
+          "height": 44
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "text",
+          "x": 200,
+          "y": 317,
+          "width": 139,
+          "height": 44
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 21,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 23,
+                "y": 19,
+                "width": 698,
+                "height": 496
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 28,
+                  "y": 19,
+                  "width": 178,
+                  "height": 38
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 23,
+                  "y": 175,
+                  "width": 698,
+                  "height": 146
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 28,
+                  "y": 311,
+                  "width": 488,
+                  "height": 44
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 28,
+                  "y": 476,
+                  "width": 176,
+                  "height": 39
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 164,
+                "y": 112,
+                "width": 612,
+                "height": 300
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 164,
+                  "y": 112,
+                  "width": 125,
+                  "height": 77
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 289,
+                  "y": 112,
+                  "width": 328,
+                  "height": 77
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 200,
+                  "y": 216,
+                  "width": 125,
+                  "height": 44
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 391,
+                  "y": 219,
+                  "width": 385,
+                  "height": 38
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 183,
+                  "y": 232,
+                  "width": 11,
+                  "height": 11
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 200,
+                  "y": 267,
+                  "width": 125,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 391,
+                  "y": 270,
+                  "width": 385,
+                  "height": 38
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 183,
+                  "y": 283,
+                  "width": 11,
+                  "height": 11
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 2,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 23,
+                "y": 203,
+                "width": 690,
+                "height": 107
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 23,
+                  "y": 203,
+                  "width": 115,
+                  "height": 106
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 126,
+                  "y": 203,
+                  "width": 587,
+                  "height": 107
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 7,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 31,
+                "y": 26,
+                "width": 899,
+                "height": 514
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 99,
+                  "y": 26,
+                  "width": 196,
+                  "height": 44
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 99,
+                  "y": 48,
+                  "width": 548,
+                  "height": 77
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 105,
+                  "y": 114,
+                  "width": 608,
+                  "height": 61
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 31,
+                  "y": 186,
+                  "width": 899,
+                  "height": 354
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 121,
+                  "y": 200,
+                  "width": 717,
+                  "height": 340
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 723,
+                  "y": 270,
+                  "width": 184,
+                  "height": 270
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 730,
+                  "y": 275,
+                  "width": 169,
+                  "height": 265
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 64,
+                "y": 62,
+                "width": 792,
+                "height": 478
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 480,
+                  "y": 62,
+                  "width": 376,
+                  "height": 478
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 69,
+                  "y": 70,
+                  "width": 196,
+                  "height": 44
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 498,
+                  "y": 74,
+                  "width": 339,
+                  "height": 466
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 64,
+                  "y": 92,
+                  "width": 364,
+                  "height": 77
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 65,
+                  "y": 157,
+                  "width": 359,
+                  "height": 110
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 150,
+                "y": 51,
+                "width": 624,
+                "height": 438
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 150,
+                  "y": 51,
+                  "width": 217,
+                  "height": 438
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 160,
+                  "y": 59,
+                  "width": 196,
+                  "height": 424
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 415,
+                  "y": 143,
+                  "width": 196,
+                  "height": 45
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 410,
+                  "y": 165,
+                  "width": 364,
+                  "height": 77
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 415,
+                  "y": 230,
+                  "width": 359,
+                  "height": 140
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "3-20"
+        },
+        {
+          "label": "结尾",
+          "range": "21"
+        }
+      ]
+    },
+    {
+      "template_id": "marketing--brand_operations_plan",
+      "category": "marketing",
+      "category_label": "市场营销",
+      "scene": "品牌运营计划",
+      "tone": "light",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 18,
+      "presentation_title": "品牌运营计划-裂图重新上传",
+      "palette": "浅灰底 #eff2f6，中蓝 #3c6fe5 点缀",
+      "structure": "封面 → 目录 → [分节页 → 内容]×5 → 结尾（5 个分节，结构最清晰）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "品牌运营、年度运营计划。蓝灰企业风，分节最规范",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "rgba(43, 47, 54, 1)",
+            "font_size": "80"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "rgba(43, 47, 54, 1)",
+            "font_size": "48"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "rgba(43, 47, 54, 1)"
+          },
+          {
+            "text_type": "body",
+            "font_color": "rgba(43, 47, 54, 1)",
+            "font_size": "14"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "rgba(43, 47, 54, 1)"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 501,
+          "y": 0,
+          "width": 459,
+          "height": 464
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 26,
+          "y": 375,
+          "width": 542,
+          "height": 116
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "text",
+          "x": 33,
+          "y": 326,
+          "width": 464,
+          "height": 62
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 59,
+          "y": 24,
+          "width": 73,
+          "height": 38
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 54,
+          "y": 93,
+          "width": 175,
+          "height": 92
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 60,
+          "y": 165,
+          "width": 175,
+          "height": 68
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "text",
+          "x": 551,
+          "y": 113,
+          "width": 175,
+          "height": 50
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 551,
+          "y": 170,
+          "width": 175,
+          "height": 50
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 551,
+          "y": 226,
+          "width": 175,
+          "height": 50
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 551,
+          "y": 282,
+          "width": 175,
+          "height": 50
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "text",
+          "x": 551,
+          "y": 338,
+          "width": 175,
+          "height": 50
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "text",
+          "x": 484,
+          "y": 113,
+          "width": 59,
+          "height": 50
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 18,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 26,
+                "y": 0,
+                "width": 934,
+                "height": 491
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 501,
+                  "y": 0,
+                  "width": 459,
+                  "height": 464
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 59,
+                  "y": 24,
+                  "width": 73,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 33,
+                  "y": 326,
+                  "width": 464,
+                  "height": 62
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 26,
+                  "y": 375,
+                  "width": 542,
+                  "height": 116
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 17,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 54,
+                "y": 93,
+                "width": 672,
+                "height": 295
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 54,
+                  "y": 93,
+                  "width": 175,
+                  "height": 92
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 484,
+                  "y": 113,
+                  "width": 59,
+                  "height": 50
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 551,
+                  "y": 113,
+                  "width": 175,
+                  "height": 50
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 468,
+                  "y": 123,
+                  "width": 5,
+                  "height": 32
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 60,
+                  "y": 165,
+                  "width": 175,
+                  "height": 68
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 484,
+                  "y": 170,
+                  "width": 59,
+                  "height": 50
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 551,
+                  "y": 170,
+                  "width": 175,
+                  "height": 50
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 468,
+                  "y": 179,
+                  "width": 5,
+                  "height": 32
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 150,
+                "y": 0,
+                "width": 810,
+                "height": 504
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 150,
+                  "y": 0,
+                  "width": 810,
+                  "height": 504
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 151,
+                  "y": 134,
+                  "width": 150,
+                  "height": 163
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 289,
+                  "y": 203,
+                  "width": 175,
+                  "height": 67
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 8,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": -3,
+                "width": 941,
+                "height": 543
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": -3,
+                  "width": 296,
+                  "height": 543
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 350,
+                  "y": 89,
+                  "width": 248,
+                  "height": 361
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 610,
+                  "y": 89,
+                  "width": 225,
+                  "height": 361
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 848,
+                  "y": 89,
+                  "width": 93,
+                  "height": 361
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 27,
+                  "y": 93,
+                  "width": 225,
+                  "height": 92
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 32,
+                  "y": 167,
+                  "width": 225,
+                  "height": 41
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 32,
+                  "y": 239,
+                  "width": 207,
+                  "height": 74
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 32,
+                  "y": 317,
+                  "width": 207,
+                  "height": 74
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": -3,
+                "width": 296,
+                "height": 543
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": -3,
+                  "width": 296,
+                  "height": 543
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 27,
+                  "y": 93,
+                  "width": 246,
+                  "height": 92
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 32,
+                  "y": 167,
+                  "width": 225,
+                  "height": 41
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 32,
+                  "y": 239,
+                  "width": 207,
+                  "height": 74
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 32,
+                  "y": 317,
+                  "width": 207,
+                  "height": 74
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 150,
+                "y": 0,
+                "width": 810,
+                "height": 504
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 150,
+                  "y": 0,
+                  "width": 810,
+                  "height": 504
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 151,
+                  "y": 134,
+                  "width": 150,
+                  "height": 164
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 289,
+                  "y": 203,
+                  "width": 175,
+                  "height": 67
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节 3, 6, 9, 12,",
+          "range": "15"
+        },
+        {
+          "label": "内容 4-5, 7-8, 10-11, 13-14,",
+          "range": "16-17"
+        },
+        {
+          "label": "结尾",
+          "range": "18"
+        }
+      ]
+    },
+    {
+      "template_id": "marketing--brand_logo_design",
+      "category": "marketing",
+      "category_label": "市场营销",
+      "scene": "品牌标志设计",
+      "tone": "light",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 16,
+      "presentation_title": "品牌标志设计",
+      "palette": "近白底 #fbfbfb，亮蓝 #1c66f6 点缀，浅蓝卡片 #c6e7ff",
+      "structure": "封面 → 目录 → 内容×7 → 数据 → 内容×4 → 数据 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "full-bleed-image-caption",
+        "image-backed",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "品牌设计、VI 设计提案。清爽蓝白，专业设计感",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title"
+          },
+          {
+            "text_type": "headline"
+          },
+          {
+            "text_type": "sub-headline"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "rgba(155, 157, 160, 1)",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 46,
+          "y": 211,
+          "width": 454,
+          "height": 110
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 60,
+          "y": 413,
+          "width": 206,
+          "height": 62
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "rect",
+          "x": 60,
+          "y": 170,
+          "width": 157,
+          "height": 42
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 85,
+          "y": 54,
+          "width": 132,
+          "height": 41
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 82,
+          "y": 424,
+          "width": 124,
+          "height": 41
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "caption",
+          "x": 787,
+          "y": 57,
+          "width": 124,
+          "height": 38
+        },
+        {
+          "id": "img-7",
+          "kind": "img",
+          "role": "image",
+          "x": 60,
+          "y": 62,
+          "width": 12,
+          "height": 25
+        },
+        {
+          "id": "img-8",
+          "kind": "img",
+          "role": "image",
+          "x": 74,
+          "y": 62,
+          "width": 12,
+          "height": 25
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 0,
+          "y": 0,
+          "width": 312,
+          "height": 402
+        },
+        {
+          "id": "img-2",
+          "kind": "img",
+          "role": "image",
+          "x": 528,
+          "y": 0,
+          "width": 432,
+          "height": 203
+        },
+        {
+          "id": "img-3",
+          "kind": "img",
+          "role": "image",
+          "x": 744,
+          "y": 203,
+          "width": 216,
+          "height": 337
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "headline",
+          "x": 47,
+          "y": 163,
+          "width": 355,
+          "height": 83
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 16,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 8,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 46,
+                "y": 54,
+                "width": 865,
+                "height": 421
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 85,
+                  "y": 54,
+                  "width": 132,
+                  "height": 41
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 787,
+                  "y": 57,
+                  "width": 124,
+                  "height": 38
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 60,
+                  "y": 62,
+                  "width": 12,
+                  "height": 25
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 74,
+                  "y": 62,
+                  "width": 12,
+                  "height": 25
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 60,
+                  "y": 170,
+                  "width": 157,
+                  "height": 42
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 46,
+                  "y": 211,
+                  "width": 454,
+                  "height": 110
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 60,
+                  "y": 413,
+                  "width": 206,
+                  "height": 62
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 82,
+                  "y": 424,
+                  "width": 124,
+                  "height": 41
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 12,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 312,
+                  "height": 402
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 528,
+                  "y": 0,
+                  "width": 432,
+                  "height": 203
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 47,
+                  "y": 163,
+                  "width": 355,
+                  "height": 83
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 414,
+                  "y": 175,
+                  "width": 57,
+                  "height": 56
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 471,
+                  "y": 181,
+                  "width": 357,
+                  "height": 44
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 744,
+                  "y": 203,
+                  "width": 216,
+                  "height": 337
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 414,
+                  "y": 240,
+                  "width": 57,
+                  "height": 56
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 471,
+                  "y": 246,
+                  "width": 357,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 11,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -10,
+                "y": -43,
+                "width": 970,
+                "height": 583
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 250,
+                  "y": -43,
+                  "width": 210,
+                  "height": 295
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 362,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 302,
+                  "y": 105,
+                  "width": 106,
+                  "height": 106
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 451,
+                  "y": 118,
+                  "width": 235,
+                  "height": 77
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 453,
+                  "y": 203,
+                  "width": 332,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 453,
+                  "y": 233,
+                  "width": 332,
+                  "height": 62
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": -10,
+                  "y": 239,
+                  "width": 311,
+                  "height": 291
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 17,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 995,
+                "height": 1470
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 344,
+                  "height": 412
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 396,
+                  "y": 91,
+                  "width": 78,
+                  "height": 78
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 683,
+                  "y": 91,
+                  "width": 78,
+                  "height": 78
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 47,
+                  "y": 150,
+                  "width": 249,
+                  "height": 77
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 396,
+                  "y": 174,
+                  "width": 236,
+                  "height": 44
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 683,
+                  "y": 174,
+                  "width": 236,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 397,
+                  "y": 207,
+                  "width": 236,
+                  "height": 74
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 684,
+                  "y": 207,
+                  "width": 236,
+                  "height": 74
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 2,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 40,
+                "y": 210,
+                "width": 879,
+                "height": 139
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 40,
+                  "y": 210,
+                  "width": 879,
+                  "height": 83
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 40,
+                  "y": 308,
+                  "width": 879,
+                  "height": 41
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 31,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -2,
+                "y": 0,
+                "width": 1046,
+                "height": 761
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": -2,
+                  "y": 0,
+                  "width": 241,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": -2,
+                  "y": 0,
+                  "width": 241,
+                  "height": 248
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 239,
+                  "y": 0,
+                  "width": 241,
+                  "height": 540
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 239,
+                  "y": 0,
+                  "width": 241,
+                  "height": 248
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 480,
+                  "y": 0,
+                  "width": 241,
+                  "height": 540
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 480,
+                  "y": 0,
+                  "width": 241,
+                  "height": 248
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 719,
+                  "y": 0,
+                  "width": 241,
+                  "height": 540
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 719,
+                  "y": 0,
+                  "width": 241,
+                  "height": 248
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容 3-9,",
+          "range": "11-14"
+        },
+        {
+          "label": "结尾",
+          "range": "16"
+        }
+      ]
+    },
+    {
+      "template_id": "hr--employee_training",
+      "category": "hr",
+      "category_label": "人力资源",
+      "scene": "员工培训",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 14,
+      "presentation_title": "员工培训",
+      "palette": "近黑底 rgba(13,20,32)，图片分节页交替，单色简洁",
+      "structure": "封面 → 目录 → [分节页(01-05) → 内容]×5 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-text-left-image-right",
+        "image-backed",
+        "section-divider",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "员工培训、规章制度宣讲。暗色严肃风，5 个章节分节页",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "48"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "36"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 46,
+          "y": 134,
+          "width": 547,
+          "height": 176
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "text",
+          "x": 51,
+          "y": 351,
+          "width": 300,
+          "height": 74
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 712,
+          "y": 28,
+          "width": 202,
+          "height": 41
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 51,
+          "y": 462,
+          "width": 202,
+          "height": 41
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 58,
+          "y": 462,
+          "width": 202,
+          "height": 39
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "caption",
+          "x": 702,
+          "y": 462,
+          "width": 202,
+          "height": 38
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "round2diag-rect",
+          "x": 48,
+          "y": 50,
+          "width": 36,
+          "height": 16
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 78,
+          "y": 39,
+          "width": 16,
+          "height": 15
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "caption",
+          "x": 60,
+          "y": 203,
+          "width": 310,
+          "height": 260
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 47,
+          "y": 38,
+          "width": 531,
+          "height": 104
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 512,
+          "y": 190,
+          "width": 422,
+          "height": 224
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 34,
+          "y": 31,
+          "width": 895,
+          "height": 64
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 14,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 9,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 46,
+                "y": 28,
+                "width": 868,
+                "height": 475
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 712,
+                  "y": 28,
+                  "width": 202,
+                  "height": 41
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 78,
+                  "y": 39,
+                  "width": 16,
+                  "height": 15
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round2diag-rect",
+                  "x": 48,
+                  "y": 50,
+                  "width": 36,
+                  "height": 16
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round2diag-rect",
+                  "x": 78,
+                  "y": 60,
+                  "width": 16,
+                  "height": 15
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 46,
+                  "y": 134,
+                  "width": 547,
+                  "height": 176
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 51,
+                  "y": 351,
+                  "width": 300,
+                  "height": 74
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 51,
+                  "y": 462,
+                  "width": 202,
+                  "height": 41
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 58,
+                  "y": 462,
+                  "width": 202,
+                  "height": 39
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 2,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 47,
+                "y": 38,
+                "width": 531,
+                "height": 425
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 47,
+                  "y": 38,
+                  "width": 531,
+                  "height": 104
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 60,
+                  "y": 203,
+                  "width": 310,
+                  "height": 260
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 7,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 34,
+                "y": 31,
+                "width": 900,
+                "height": 469
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 34,
+                  "y": 31,
+                  "width": 895,
+                  "height": 64
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 34,
+                  "y": 94,
+                  "width": 347,
+                  "height": 83
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 512,
+                  "y": 190,
+                  "width": 422,
+                  "height": 224
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 702,
+                  "y": 462,
+                  "width": 202,
+                  "height": 38
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 65,
+                  "y": 470,
+                  "width": 10,
+                  "height": 10
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round2diag-rect",
+                  "x": 45,
+                  "y": 476,
+                  "width": 24,
+                  "height": 10
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round2diag-rect",
+                  "x": 65,
+                  "y": 484,
+                  "width": 10,
+                  "height": 10
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 9,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 53,
+                "y": 48,
+                "width": 852,
+                "height": 428
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 53,
+                  "y": 48,
+                  "width": 468,
+                  "height": 53
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 59,
+                  "y": 150,
+                  "width": 413,
+                  "height": 326
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 492,
+                  "y": 150,
+                  "width": 413,
+                  "height": 326
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 75,
+                  "y": 164,
+                  "width": 382,
+                  "height": 191
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 508,
+                  "y": 164,
+                  "width": 382,
+                  "height": 191
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 75,
+                  "y": 374,
+                  "width": 382,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 508,
+                  "y": 374,
+                  "width": 382,
+                  "height": 44
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 75,
+                  "y": 411,
+                  "width": 382,
+                  "height": 56
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 7,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 34,
+                "y": 31,
+                "width": 900,
+                "height": 469
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 34,
+                  "y": 31,
+                  "width": 895,
+                  "height": 64
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 34,
+                  "y": 94,
+                  "width": 347,
+                  "height": 83
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 512,
+                  "y": 190,
+                  "width": 422,
+                  "height": 224
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 702,
+                  "y": 462,
+                  "width": 202,
+                  "height": 38
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 65,
+                  "y": 470,
+                  "width": 10,
+                  "height": 10
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round2diag-rect",
+                  "x": 45,
+                  "y": 476,
+                  "width": 24,
+                  "height": 10
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round2diag-rect",
+                  "x": 65,
+                  "y": 484,
+                  "width": 10,
+                  "height": 10
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 8,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 53,
+                "y": 48,
+                "width": 852,
+                "height": 422
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 53,
+                  "y": 48,
+                  "width": 468,
+                  "height": 53
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 561,
+                  "y": 164,
+                  "width": 344,
+                  "height": 300
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 59,
+                  "y": 180,
+                  "width": 63,
+                  "height": 68
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 110,
+                  "y": 195,
+                  "width": 411,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 59,
+                  "y": 234,
+                  "width": 341,
+                  "height": 74
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 60,
+                  "y": 342,
+                  "width": 63,
+                  "height": 68
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 115,
+                  "y": 358,
+                  "width": 411,
+                  "height": 44
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 59,
+                  "y": 396,
+                  "width": 341,
+                  "height": 74
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节 3, 5, 7, 9,",
+          "range": "11"
+        },
+        {
+          "label": "内容 4, 6, 8, 10,",
+          "range": "12-13"
+        },
+        {
+          "label": "结尾",
+          "range": "14"
+        }
+      ]
+    },
+    {
+      "template_id": "hr--employee_training_workshop",
+      "category": "hr",
+      "category_label": "人力资源",
+      "scene": "员工培训训练",
+      "tone": "colorful",
+      "formality": "casual",
+      "is_general_template": false,
+      "slide_count": 19,
+      "presentation_title": "员工培训训练",
+      "palette": "暖米底 rgba(247,245,240) + 深灰 rgba(60,60,60) 交替，5 种彩色点缀（钢蓝、青绿、橄榄金、鲑鱼粉）",
+      "structure": "封面 → 目录 → [深色标题卡 → 浅色内容]×7 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-text-left-image-right",
+        "two-column-text"
+      ],
+      "use_cases": "培训工作坊、技能培训。温暖多彩，轻松氛围",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_family": "Sans Serif"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_family": "Sans Serif"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF",
+            "font_family": "Sans Serif"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF",
+            "font_family": "Sans Serif"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14",
+            "font_family": "Sans Serif"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 480,
+          "y": 54,
+          "width": 394,
+          "height": 116
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 593,
+          "y": 142,
+          "width": 338,
+          "height": 116
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 378,
+          "y": 253,
+          "width": 302,
+          "height": 100
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 378,
+          "y": 253,
+          "width": 302,
+          "height": 100
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 621,
+          "y": 468,
+          "width": 302,
+          "height": 100
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 621,
+          "y": 468,
+          "width": 302,
+          "height": 100
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 345,
+          "y": 7,
+          "width": 281,
+          "height": 100
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 345,
+          "y": 7,
+          "width": 281,
+          "height": 100
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 554,
+          "y": 206,
+          "width": 661,
+          "height": 286
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 76,
+          "y": 30,
+          "width": 337,
+          "height": 335
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 347,
+          "y": -141,
+          "width": 300,
+          "height": 300
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": -36,
+          "y": 151,
+          "width": 300,
+          "height": 300
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 19,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 28,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -61,
+                "y": 0,
+                "width": 1086,
+                "height": 594
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 46,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 345,
+                  "y": 7,
+                  "width": 281,
+                  "height": 100
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 345,
+                  "y": 7,
+                  "width": 281,
+                  "height": 100
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 66,
+                  "y": 30,
+                  "width": 259,
+                  "height": 38
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 925,
+                  "y": 42,
+                  "width": 100,
+                  "height": 100
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 925,
+                  "y": 42,
+                  "width": 100,
+                  "height": 100
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 480,
+                  "y": 54,
+                  "width": 394,
+                  "height": 116
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 435,
+                  "y": 98,
+                  "width": 100,
+                  "height": 100
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 10,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -150,
+                "y": -141,
+                "width": 1365,
+                "height": 681
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 347,
+                  "y": -141,
+                  "width": 300,
+                  "height": 300
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 46,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 76,
+                  "y": 30,
+                  "width": 337,
+                  "height": 335
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 536,
+                  "y": 54,
+                  "width": 337,
+                  "height": 90
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 539,
+                  "y": 131,
+                  "width": 337,
+                  "height": 48
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": -36,
+                  "y": 151,
+                  "width": 300,
+                  "height": 300
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 554,
+                  "y": 206,
+                  "width": 661,
+                  "height": 286
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": -150,
+                  "y": 240,
+                  "width": 300,
+                  "height": 300
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": -111,
+                "width": 905,
+                "height": 651
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 484,
+                  "y": -111,
+                  "width": 421,
+                  "height": 629
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 46,
+                  "y": 0,
+                  "width": 1,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 66,
+                  "y": 30,
+                  "width": 337,
+                  "height": 41
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 66,
+                  "y": 366,
+                  "width": 337,
+                  "height": 83
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 0,
+                  "y": 461,
+                  "width": 46,
+                  "height": 39
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 11,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": -194,
+                "width": 1189,
+                "height": 951
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 304,
+                  "y": -194,
+                  "width": 300,
+                  "height": 300
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 385,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 46,
+                  "height": 540
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 66,
+                  "y": 30,
+                  "width": 337,
+                  "height": 41
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 66,
+                  "y": 56,
+                  "width": 337,
+                  "height": 54
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 517,
+                  "y": 110,
+                  "width": 312,
+                  "height": 312
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 110,
+                  "y": 117,
+                  "width": 234,
+                  "height": 91
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 769,
+                  "y": 158,
+                  "width": 420,
+                  "height": 286
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": -111,
+                "width": 905,
+                "height": 651
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 484,
+                  "y": -111,
+                  "width": 421,
+                  "height": 629
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 46,
+                  "y": 0,
+                  "width": 1,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 46,
+                  "y": 0,
+                  "width": 1,
+                  "height": 540
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 66,
+                  "y": 30,
+                  "width": 337,
+                  "height": 41
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 66,
+                  "y": 366,
+                  "width": 337,
+                  "height": 83
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 0,
+                  "y": 461,
+                  "width": 46,
+                  "height": 39
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 18,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": -194,
+                "width": 1189,
+                "height": 951
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 304,
+                  "y": -194,
+                  "width": 300,
+                  "height": 300
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 385,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 46,
+                  "height": 540
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 658,
+                  "y": 21,
+                  "width": 176,
+                  "height": 218
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 66,
+                  "y": 30,
+                  "width": 337,
+                  "height": 41
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 66,
+                  "y": 79,
+                  "width": 293,
+                  "height": 92
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 525,
+                  "y": 112,
+                  "width": 176,
+                  "height": 218
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 769,
+                  "y": 158,
+                  "width": 420,
+                  "height": 286
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节 3, 5, 7, 9, 11, 13,",
+          "range": "15"
+        },
+        {
+          "label": "内容 4, 6, 8, 10, 12, 14,",
+          "range": "16-18"
+        },
+        {
+          "label": "结尾",
+          "range": "19"
+        }
+      ]
+    },
+    {
+      "template_id": "hr--onboarding",
+      "category": "hr",
+      "category_label": "人力资源",
+      "scene": "新人入职培训",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 15,
+      "presentation_title": "新人入职培训",
+      "palette": "深炭灰底 rgba(43,47,54)，亮紫 rgba(75,63,221) 点缀，浅灰卡片 rgba(243,244,246)",
+      "structure": "封面 → 目录 → [分节页(01-05) → 内容]×5 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "image-backed",
+        "section-divider",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "新人入职、公司介绍。紫色 CTA 按钮，包含公司概况/愿景/价值观/流程/制度等章节",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "60"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "54"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "rect",
+          "x": 0,
+          "y": 0,
+          "width": 960,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "rect",
+          "x": 30,
+          "y": 476,
+          "width": 900,
+          "height": 40
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "title",
+          "x": 335,
+          "y": 197,
+          "width": 290,
+          "height": 92
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 324,
+          "y": 289,
+          "width": 312,
+          "height": 56
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 795,
+          "y": 474,
+          "width": 127,
+          "height": 44
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 66,
+          "y": 474,
+          "width": 126,
+          "height": 44
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 36,
+          "y": 481,
+          "width": 30,
+          "height": 30
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "caption",
+          "x": 59,
+          "y": 115,
+          "width": 311,
+          "height": 56
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "caption",
+          "x": 153,
+          "y": 302,
+          "width": 311,
+          "height": 56
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 581,
+          "y": 305,
+          "width": 311,
+          "height": 56
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 153,
+          "y": 420,
+          "width": 311,
+          "height": 56
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 581,
+          "y": 420,
+          "width": 311,
+          "height": 56
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 15,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 7,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 335,
+                  "y": 197,
+                  "width": 290,
+                  "height": 92
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 324,
+                  "y": 289,
+                  "width": 312,
+                  "height": 56
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 66,
+                  "y": 474,
+                  "width": 126,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 795,
+                  "y": 474,
+                  "width": 127,
+                  "height": 44
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 30,
+                  "y": 476,
+                  "width": 900,
+                  "height": 40
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 36,
+                  "y": 481,
+                  "width": 30,
+                  "height": 30
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 59,
+                "y": 47,
+                "width": 833,
+                "height": 429
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 59,
+                  "y": 47,
+                  "width": 100,
+                  "height": 68
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 59,
+                  "y": 115,
+                  "width": 311,
+                  "height": 56
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 62,
+                  "y": 267,
+                  "width": 70,
+                  "height": 70
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 153,
+                  "y": 267,
+                  "width": 100,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 489,
+                  "y": 267,
+                  "width": 70,
+                  "height": 70
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 581,
+                  "y": 270,
+                  "width": 100,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 153,
+                  "y": 302,
+                  "width": 311,
+                  "height": 56
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 581,
+                  "y": 305,
+                  "width": 311,
+                  "height": 56
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 62,
+                "y": 54,
+                "width": 837,
+                "height": 432
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 571,
+                  "y": 54,
+                  "width": 328,
+                  "height": 432
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 67,
+                  "y": 260,
+                  "width": 381,
+                  "height": 44
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 62,
+                  "y": 294,
+                  "width": 485,
+                  "height": 85
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 65,
+                "y": -27,
+                "width": 835,
+                "height": 582
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 487,
+                  "y": -27,
+                  "width": 194,
+                  "height": 236
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 706,
+                  "y": 55,
+                  "width": 194,
+                  "height": 316
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 65,
+                  "y": 116,
+                  "width": 240,
+                  "height": 68
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 65,
+                  "y": 203,
+                  "width": 354,
+                  "height": 164
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 487,
+                  "y": 229,
+                  "width": 194,
+                  "height": 236
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 706,
+                  "y": 391,
+                  "width": 194,
+                  "height": 164
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 56,
+                  "y": 36,
+                  "width": 131,
+                  "height": 42
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 56,
+                  "y": 98,
+                  "width": 822,
+                  "height": 164
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 56,
+                  "y": 429,
+                  "width": 53,
+                  "height": 53
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 18,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 55,
+                "y": 46,
+                "width": 850,
+                "height": 396
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 236,
+                  "y": 46,
+                  "width": 487,
+                  "height": 68
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 252,
+                  "y": 108,
+                  "width": 456,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 55,
+                  "y": 178,
+                  "width": 210,
+                  "height": 264
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 268,
+                  "y": 178,
+                  "width": 210,
+                  "height": 264
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 482,
+                  "y": 178,
+                  "width": 210,
+                  "height": 264
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 695,
+                  "y": 178,
+                  "width": 210,
+                  "height": 264
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 70,
+                  "y": 191,
+                  "width": 82,
+                  "height": 82
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 283,
+                  "y": 191,
+                  "width": 82,
+                  "height": 82
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节 3, 5, 7, 9,",
+          "range": "11"
+        },
+        {
+          "label": "内容 4, 6, 8, 10,",
+          "range": "12-14"
+        },
+        {
+          "label": "结尾",
+          "range": "15"
+        }
+      ]
+    },
+    {
+      "template_id": "administration--all_hands_meeting",
+      "category": "administration",
+      "category_label": "行政",
+      "scene": "全员大会",
+      "tone": "light",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 18,
+      "presentation_title": "全员大会",
+      "palette": "蓝紫渐变图片底图，毛玻璃白色卡片（alpha=0.7），薰衣草 rgba(155,177,255) 点缀",
+      "structure": "封面 → 目录 → [分节页 → 内容]×4 → 结尾（含图表页）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-text-left-image-right",
+        "image-backed",
+        "two-column-text"
+      ],
+      "use_cases": "全员大会、季度会议、公司大会。毛玻璃风格，蓝紫渐变，含 chart 图表",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "90"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "40"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF",
+            "font_size": "24"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 57,
+          "y": 342,
+          "width": 817,
+          "height": 146
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 57,
+          "y": 294,
+          "width": 479,
+          "height": 74
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 86,
+          "y": 71,
+          "width": 788,
+          "height": 398
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 144,
+          "y": 86,
+          "width": 672,
+          "height": 74
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 281,
+          "y": 153,
+          "width": 398,
+          "height": 56
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "caption",
+          "x": 306,
+          "y": 153,
+          "width": 348,
+          "height": 38
+        },
+        {
+          "id": "img-5",
+          "kind": "img",
+          "role": "image",
+          "x": 39,
+          "y": 112,
+          "width": 112,
+          "height": 112
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 430,
+          "y": 227,
+          "width": 225,
+          "height": 44
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "text",
+          "x": 430,
+          "y": 377,
+          "width": 225,
+          "height": 44
+        },
+        {
+          "id": "img-8",
+          "kind": "img",
+          "role": "image",
+          "x": 763,
+          "y": 428,
+          "width": 72,
+          "height": 72
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 659,
+          "y": 0,
+          "width": 301,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 126,
+          "y": 187,
+          "width": 627,
+          "height": 93
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 18,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 2,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 57,
+                "y": 294,
+                "width": 817,
+                "height": 194
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 57,
+                  "y": 294,
+                  "width": 479,
+                  "height": 74
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 57,
+                  "y": 342,
+                  "width": 817,
+                  "height": 146
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 18,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 39,
+                "y": 71,
+                "width": 835,
+                "height": 429
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 86,
+                  "y": 71,
+                  "width": 788,
+                  "height": 398
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 144,
+                  "y": 86,
+                  "width": 672,
+                  "height": 74
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 39,
+                  "y": 112,
+                  "width": 112,
+                  "height": 112
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 281,
+                  "y": 153,
+                  "width": 398,
+                  "height": 56
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 306,
+                  "y": 153,
+                  "width": 348,
+                  "height": 38
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 322,
+                  "y": 227,
+                  "width": 75,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 430,
+                  "y": 227,
+                  "width": 225,
+                  "height": 44
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 409,
+                  "y": 245,
+                  "width": 8,
+                  "height": 8
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 33,
+                "y": 0,
+                "width": 927,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 659,
+                  "y": 0,
+                  "width": 301,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 33,
+                  "y": 187,
+                  "width": 112,
+                  "height": 93
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 126,
+                  "y": 187,
+                  "width": 627,
+                  "height": 93
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 126,
+                  "y": 275,
+                  "width": 493,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 19,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 86,
+                "y": 44,
+                "width": 865,
+                "height": 457
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 92,
+                  "y": 44,
+                  "width": 777,
+                  "height": 69
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 762,
+                  "y": 51,
+                  "width": 189,
+                  "height": 189
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 86,
+                  "y": 124,
+                  "width": 788,
+                  "height": 377
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 361,
+                  "y": 175,
+                  "width": 78,
+                  "height": 78
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 181,
+                  "y": 176,
+                  "width": 78,
+                  "height": 78
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 533,
+                  "y": 176,
+                  "width": 78,
+                  "height": 78
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 702,
+                  "y": 176,
+                  "width": 78,
+                  "height": 78
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 151,
+                  "y": 258,
+                  "width": 137,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 81,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 29,
+                "y": 44,
+                "width": 902,
+                "height": 435
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 92,
+                  "y": 44,
+                  "width": 777,
+                  "height": 69
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 78,
+                  "y": 135,
+                  "width": 111,
+                  "height": 51
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 309,
+                  "y": 135,
+                  "width": 111,
+                  "height": 51
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 550,
+                  "y": 135,
+                  "width": 90,
+                  "height": 51
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 781,
+                  "y": 135,
+                  "width": 90,
+                  "height": 51
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 29,
+                  "y": 197,
+                  "width": 208,
+                  "height": 282
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 260,
+                  "y": 197,
+                  "width": 208,
+                  "height": 282
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 492,
+                  "y": 197,
+                  "width": 208,
+                  "height": 282
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 53,
+                "y": 26,
+                "width": 907,
+                "height": 514
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 526,
+                  "y": 26,
+                  "width": 434,
+                  "height": 514
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 53,
+                  "y": 207,
+                  "width": 112,
+                  "height": 93
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 146,
+                  "y": 207,
+                  "width": 627,
+                  "height": 85
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 146,
+                  "y": 295,
+                  "width": 493,
+                  "height": 40
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节 3, 7, 11,",
+          "range": "15"
+        },
+        {
+          "label": "内容 4-6, 8-10, 12-14,",
+          "range": "16-17"
+        },
+        {
+          "label": "结尾",
+          "range": "18"
+        }
+      ]
+    },
+    {
+      "template_id": "administration--company_intro",
+      "category": "administration",
+      "category_label": "行政",
+      "scene": "企业介绍",
+      "tone": "light",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 16,
+      "presentation_title": "企业介绍",
+      "palette": "白底极简，金黄 rgba(255,196,25) 点缀，深灰 rgba(31,35,41) 文字",
+      "structure": "封面 → 目录 → 内容×12 → 数据(chart) → 结尾（含图表页）",
+      "page_types": null,
+      "layout_tags": [
+        "full-bleed-image-caption",
+        "image-backed",
+        "text-focused"
+      ],
+      "use_cases": "企业介绍、公司宣传。极简白底，中英双语，含行业前景图表",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "48"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "32"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 323,
+          "y": 214,
+          "width": 495,
+          "height": 111
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 323,
+          "y": 214,
+          "width": 416,
+          "height": 110
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "donut",
+          "x": 229,
+          "y": 168,
+          "width": 158,
+          "height": 158
+        },
+        {
+          "id": "img-4",
+          "kind": "img",
+          "role": "image",
+          "x": 0,
+          "y": 107,
+          "width": 191,
+          "height": 115
+        },
+        {
+          "id": "img-5",
+          "kind": "img",
+          "role": "image",
+          "x": 515,
+          "y": 453,
+          "width": 241,
+          "height": 87
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 327,
+          "y": 305,
+          "width": 196,
+          "height": 47
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "text",
+          "x": 64,
+          "y": 24,
+          "width": 72,
+          "height": 38
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 30,
+          "y": 33,
+          "width": 20,
+          "height": 20
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "headline",
+          "x": 185,
+          "y": 49,
+          "width": 440,
+          "height": 64
+        },
+        {
+          "id": "img-2",
+          "kind": "img",
+          "role": "image",
+          "x": 0,
+          "y": 381,
+          "width": 159,
+          "height": 159
+        },
+        {
+          "id": "img-3",
+          "kind": "img",
+          "role": "image",
+          "x": 545,
+          "y": 453,
+          "width": 242,
+          "height": 87
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 112,
+          "y": 186,
+          "width": 320,
+          "height": 58
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 16,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 9,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 24,
+                "width": 818,
+                "height": 516
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 64,
+                  "y": 24,
+                  "width": 72,
+                  "height": 38
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 30,
+                  "y": 33,
+                  "width": 20,
+                  "height": 20
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 44,
+                  "y": 33,
+                  "width": 20,
+                  "height": 20
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 107,
+                  "width": 191,
+                  "height": 115
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "donut",
+                  "x": 229,
+                  "y": 168,
+                  "width": 158,
+                  "height": 158
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 323,
+                  "y": 214,
+                  "width": 416,
+                  "height": 110
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 323,
+                  "y": 214,
+                  "width": 495,
+                  "height": 111
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 327,
+                  "y": 305,
+                  "width": 196,
+                  "height": 47
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 12,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 49,
+                "width": 815,
+                "height": 491
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 112,
+                  "y": 49,
+                  "width": 91,
+                  "height": 64
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 185,
+                  "y": 49,
+                  "width": 440,
+                  "height": 64
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 121,
+                  "y": 136,
+                  "width": 107,
+                  "height": 104
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 503,
+                  "y": 136,
+                  "width": 107,
+                  "height": 104
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 112,
+                  "y": 186,
+                  "width": 320,
+                  "height": 58
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 495,
+                  "y": 186,
+                  "width": 320,
+                  "height": 58
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 121,
+                  "y": 261,
+                  "width": 107,
+                  "height": 104
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 503,
+                  "y": 261,
+                  "width": 107,
+                  "height": 104
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 8,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 1063,
+                "height": 411
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 160,
+                  "height": 160
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 403,
+                  "y": 160,
+                  "width": 515,
+                  "height": 74
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 652,
+                  "y": 192,
+                  "width": 411,
+                  "height": 205
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 158,
+                  "y": 202,
+                  "width": 280,
+                  "height": 136
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 403,
+                  "y": 215,
+                  "width": 372,
+                  "height": 45
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 229,
+                  "y": 260,
+                  "width": 136,
+                  "height": 132
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 403,
+                  "y": 260,
+                  "width": 302,
+                  "height": 74
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 295,
+                  "width": 193,
+                  "height": 116
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 10,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 811,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 533,
+                  "y": 0,
+                  "width": 252,
+                  "height": 79
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 67,
+                  "y": 31,
+                  "width": 372,
+                  "height": 64
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 67,
+                  "y": 79,
+                  "width": 372,
+                  "height": 44
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 202,
+                  "y": 162,
+                  "width": 278,
+                  "height": 298
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 70,
+                  "y": 163,
+                  "width": 119,
+                  "height": 297
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 533,
+                  "y": 206,
+                  "width": 278,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 533,
+                  "y": 236,
+                  "width": 261,
+                  "height": 74
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 533,
+                  "y": 316,
+                  "width": 278,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 16,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 891,
+                "height": 444
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 159,
+                  "height": 159
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 533,
+                  "y": 0,
+                  "width": 252,
+                  "height": 79
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 67,
+                  "y": 31,
+                  "width": 372,
+                  "height": 64
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 67,
+                  "y": 79,
+                  "width": 372,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 108,
+                  "y": 177,
+                  "width": 120,
+                  "height": 120
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 317,
+                  "y": 177,
+                  "width": 120,
+                  "height": 120
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 526,
+                  "y": 177,
+                  "width": 120,
+                  "height": 120
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 736,
+                  "y": 177,
+                  "width": 120,
+                  "height": 120
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 154,
+                "width": 466,
+                "height": 386
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 94,
+                  "y": 154,
+                  "width": 372,
+                  "height": 64
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 94,
+                  "y": 202,
+                  "width": 372,
+                  "height": 44
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 94,
+                  "y": 246,
+                  "width": 297,
+                  "height": 110
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 381,
+                  "width": 159,
+                  "height": 159
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 94,
+                  "y": 460,
+                  "width": 255,
+                  "height": 80
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "3-14"
+        },
+        {
+          "label": "结尾",
+          "range": "16"
+        }
+      ]
+    },
+    {
+      "template_id": "administration--corporate_culture",
+      "category": "administration",
+      "category_label": "行政",
+      "scene": "企业文化宣传",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 17,
+      "presentation_title": "企业文化宣传",
+      "palette": "深炭灰底 rgba(31,35,41)，橙红 rgba(255,104,68) 强调，浅灰 rgba(246,246,246) 内容区",
+      "structure": "封面 → 前言 → 目录 → [分节页 → 内容]×4 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-image-left-text-right",
+        "image-backed",
+        "section-divider",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "企业文化、公司愿景宣传。含前言页、组织架构页，橙红活力色",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 635,
+          "y": 69,
+          "width": 270,
+          "height": 432
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 48,
+          "y": 352,
+          "width": 490,
+          "height": 101
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "rect",
+          "x": 905,
+          "y": 0,
+          "width": 55,
+          "height": 371
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 52,
+          "y": 451,
+          "width": 137,
+          "height": 44
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 199,
+          "y": 451,
+          "width": 137,
+          "height": 44
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "rect",
+          "x": 0,
+          "y": 371,
+          "width": 32,
+          "height": 169
+        },
+        {
+          "id": "img-7",
+          "kind": "img",
+          "role": "image",
+          "x": 878,
+          "y": 31,
+          "width": 53,
+          "height": 53
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "rect",
+          "x": 805,
+          "y": 371,
+          "width": 100,
+          "height": 24
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 57,
+          "y": 119,
+          "width": 306,
+          "height": 366
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "rect",
+          "x": 262,
+          "y": 94,
+          "width": 131,
+          "height": 414
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 434,
+          "y": 167,
+          "width": 457,
+          "height": 77
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 436,
+          "y": 247,
+          "width": 456,
+          "height": 74
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 17,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 11,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 31,
+                  "y": 0,
+                  "width": 1,
+                  "height": 374
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 905,
+                  "y": 0,
+                  "width": 55,
+                  "height": 371
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 878,
+                  "y": 31,
+                  "width": 53,
+                  "height": 53
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 78,
+                  "y": 48,
+                  "width": 54,
+                  "height": 41
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 56,
+                  "y": 55,
+                  "width": 26,
+                  "height": 26
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 635,
+                  "y": 69,
+                  "width": 270,
+                  "height": 432
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 48,
+                  "y": 352,
+                  "width": 490,
+                  "height": 101
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 371,
+                  "width": 32,
+                  "height": 169
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 9,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 51,
+                "y": 0,
+                "width": 921,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 905,
+                  "y": 0,
+                  "width": 55,
+                  "height": 94
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 932,
+                  "y": 0,
+                  "width": 1,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 73,
+                  "y": 48,
+                  "width": 248,
+                  "height": 41
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 51,
+                  "y": 55,
+                  "width": 26,
+                  "height": 26
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 262,
+                  "y": 94,
+                  "width": 131,
+                  "height": 414
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 57,
+                  "y": 119,
+                  "width": 306,
+                  "height": 366
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 434,
+                  "y": 167,
+                  "width": 457,
+                  "height": 77
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 436,
+                  "y": 247,
+                  "width": 456,
+                  "height": 74
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 19,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 464
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 270
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 270
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 71,
+                  "width": 206,
+                  "height": 129
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 48,
+                  "y": 83,
+                  "width": 330,
+                  "height": 80
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 50,
+                  "y": 146,
+                  "width": 330,
+                  "height": 41
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 49,
+                  "y": 308,
+                  "width": 206,
+                  "height": 100
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 268,
+                  "y": 308,
+                  "width": 206,
+                  "height": 100
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 486,
+                  "y": 308,
+                  "width": 113,
+                  "height": 36
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 8,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 51,
+                "y": 0,
+                "width": 909,
+                "height": 527
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 930,
+                  "y": 0,
+                  "width": 30,
+                  "height": 85
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 73,
+                  "y": 48,
+                  "width": 248,
+                  "height": 41
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 51,
+                  "y": 55,
+                  "width": 26,
+                  "height": 26
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 930,
+                  "y": 84,
+                  "width": 1,
+                  "height": 402
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 84,
+                  "y": 193,
+                  "width": 122,
+                  "height": 94
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 196,
+                  "y": 205,
+                  "width": 400,
+                  "height": 77
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 199,
+                  "y": 271,
+                  "width": 254,
+                  "height": 56
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 889,
+                  "y": 497,
+                  "width": 56,
+                  "height": 30
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 7,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 31,
+                "width": 931,
+                "height": 509
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 878,
+                  "y": 31,
+                  "width": 53,
+                  "height": 53
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 54,
+                  "width": 690,
+                  "height": 486
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 54,
+                  "width": 45,
+                  "height": 45
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 481,
+                  "y": 145,
+                  "width": 424,
+                  "height": 309
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 515,
+                  "y": 184,
+                  "width": 74,
+                  "height": 10
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 504,
+                  "y": 201,
+                  "width": 376,
+                  "height": 68
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 506,
+                  "y": 334,
+                  "width": 376,
+                  "height": 92
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 895,
+                "height": 175
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 30,
+                  "height": 67
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 45,
+                  "y": 44,
+                  "width": 572,
+                  "height": 69
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 45,
+                  "y": 119,
+                  "width": 850,
+                  "height": 56
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "3"
+        },
+        {
+          "label": "分节 4, 7, 10,",
+          "range": "13"
+        },
+        {
+          "label": "内容 2, 5-6, 8-9, 11-12,",
+          "range": "14-16"
+        },
+        {
+          "label": "结尾",
+          "range": "17"
+        }
+      ]
+    },
+    {
+      "template_id": "administration--annual_gala",
+      "category": "administration",
+      "category_label": "行政",
+      "scene": "年度盛典",
+      "tone": "dark",
+      "formality": "creative",
+      "is_general_template": false,
+      "slide_count": 16,
+      "presentation_title": "企业年会",
+      "palette": "近黑底 rgba(16,15,21)，紫蓝青多色渐变 rgba(210,132,232) → rgba(69,96,245) 霓虹风",
+      "structure": "封面 → 目录 → [分节页 → 内容]×6 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "image-backed",
+        "section-divider",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "年会、庆典、颁奖典礼。多彩霓虹渐变，节日庆典感，含 LOGO 占位",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "48"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "64"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 182,
+          "y": 226,
+          "width": 596,
+          "height": 84
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "caption",
+          "x": 66,
+          "y": 30,
+          "width": 154,
+          "height": 34
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 187,
+          "y": 126,
+          "width": 266,
+          "height": 74
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "text",
+          "x": 632,
+          "y": 126,
+          "width": 320,
+          "height": 56
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "text",
+          "x": 632,
+          "y": 188,
+          "width": 320,
+          "height": 56
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 632,
+          "y": 250,
+          "width": 320,
+          "height": 56
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 632,
+          "y": 312,
+          "width": 320,
+          "height": 56
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 632,
+          "y": 374,
+          "width": 320,
+          "height": 56
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "text",
+          "x": 187,
+          "y": 183,
+          "width": 266,
+          "height": 44
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 548,
+          "y": 126,
+          "width": 72,
+          "height": 52
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 647,
+          "y": 82,
+          "width": 181,
+          "height": 458
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "headline",
+          "x": 68,
+          "y": 329,
+          "width": 429,
+          "height": 107
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 16,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 2,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 66,
+                "y": 30,
+                "width": 712,
+                "height": 280
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 66,
+                  "y": 30,
+                  "width": 154,
+                  "height": 34
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 182,
+                  "y": 226,
+                  "width": 596,
+                  "height": 84
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 12,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 187,
+                "y": 126,
+                "width": 765,
+                "height": 304
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 187,
+                  "y": 126,
+                  "width": 266,
+                  "height": 74
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 548,
+                  "y": 126,
+                  "width": 72,
+                  "height": 52
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 632,
+                  "y": 126,
+                  "width": 320,
+                  "height": 56
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 187,
+                  "y": 183,
+                  "width": 266,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 548,
+                  "y": 188,
+                  "width": 72,
+                  "height": 52
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 632,
+                  "y": 188,
+                  "width": 320,
+                  "height": 56
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 548,
+                  "y": 250,
+                  "width": 72,
+                  "height": 52
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 632,
+                  "y": 250,
+                  "width": 320,
+                  "height": 56
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 56,
+                "y": 82,
+                "width": 772,
+                "height": 458
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 647,
+                  "y": 82,
+                  "width": 181,
+                  "height": 458
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 56,
+                  "y": 315,
+                  "width": 3,
+                  "height": 136
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 68,
+                  "y": 329,
+                  "width": 429,
+                  "height": 107
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 73,
+                  "y": 416,
+                  "width": 425,
+                  "height": 56
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 89,
+                "y": 42,
+                "width": 784,
+                "height": 419
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 278,
+                  "y": 42,
+                  "width": 404,
+                  "height": 45
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 278,
+                  "y": 74,
+                  "width": 404,
+                  "height": 45
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 89,
+                  "y": 144,
+                  "width": 194,
+                  "height": 194
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 381,
+                  "y": 144,
+                  "width": 194,
+                  "height": 194
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 673,
+                  "y": 144,
+                  "width": 194,
+                  "height": 194
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 92,
+                  "y": 148,
+                  "width": 187,
+                  "height": 187
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 384,
+                  "y": 148,
+                  "width": 187,
+                  "height": 187
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 676,
+                  "y": 148,
+                  "width": 187,
+                  "height": 187
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 56,
+                "y": 81,
+                "width": 861,
+                "height": 459
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 597,
+                  "y": 81,
+                  "width": 320,
+                  "height": 459
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 56,
+                  "y": 315,
+                  "width": 3,
+                  "height": 136
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 68,
+                  "y": 329,
+                  "width": 429,
+                  "height": 107
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 73,
+                  "y": 416,
+                  "width": 425,
+                  "height": 56
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 187,
+                "y": 68,
+                "width": 772,
+                "height": 405
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 480,
+                  "y": 68,
+                  "width": 479,
+                  "height": 105
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 488,
+                  "y": 75,
+                  "width": 90,
+                  "height": 90
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 595,
+                  "y": 75,
+                  "width": 306,
+                  "height": 52
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 595,
+                  "y": 112,
+                  "width": 306,
+                  "height": 56
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 187,
+                  "y": 126,
+                  "width": 266,
+                  "height": 74
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 187,
+                  "y": 183,
+                  "width": 266,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 480,
+                  "y": 218,
+                  "width": 479,
+                  "height": 105
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 488,
+                  "y": 225,
+                  "width": 90,
+                  "height": 90
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节 3, 5, 7, 9, 11,",
+          "range": "13"
+        },
+        {
+          "label": "内容 4, 6, 8, 10, 12,",
+          "range": "14-15"
+        },
+        {
+          "label": "结尾",
+          "range": "16"
+        }
+      ]
+    },
+    {
+      "template_id": "personal--experience_sharing",
+      "category": "personal",
+      "category_label": "个人",
+      "scene": "经验分享",
+      "tone": "light",
+      "formality": "casual",
+      "is_general_template": false,
+      "slide_count": 20,
+      "presentation_title": "经验分享",
+      "palette": "图片底图，亮蓝 rgba(52,113,252) 点缀，毛玻璃白色卡片（alpha=0.7）",
+      "structure": "封面 → 目录 → 内容×17 → 结尾（含 table 表格页、前后对比布局）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "image-backed",
+        "section-divider",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "经验分享、项目复盘分享。含步骤流程页、数据指标展示、表格",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 521,
+          "y": 58,
+          "width": 439,
+          "height": 434
+        },
+        {
+          "id": "img-2",
+          "kind": "img",
+          "role": "image",
+          "x": 585,
+          "y": 68,
+          "width": 376,
+          "height": 388
+        },
+        {
+          "id": "img-3",
+          "kind": "img",
+          "role": "image",
+          "x": -14,
+          "y": 263,
+          "width": 548,
+          "height": 262
+        },
+        {
+          "id": "img-4",
+          "kind": "img",
+          "role": "image",
+          "x": 467,
+          "y": 194,
+          "width": 156,
+          "height": 316
+        },
+        {
+          "id": "img-5",
+          "kind": "img",
+          "role": "image",
+          "x": 474,
+          "y": 199,
+          "width": 141,
+          "height": 306
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "title",
+          "x": 50,
+          "y": 189,
+          "width": 400,
+          "height": 81
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "caption",
+          "x": 50,
+          "y": 293,
+          "width": 400,
+          "height": 63
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "rect",
+          "x": 50,
+          "y": 375,
+          "width": 120,
+          "height": 25
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 245,
+          "y": 179,
+          "width": 612,
+          "height": 361
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "rect",
+          "x": 50,
+          "y": 153,
+          "width": 192,
+          "height": 274
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "rect",
+          "x": 274,
+          "y": 153,
+          "width": 192,
+          "height": 274
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "rect",
+          "x": 498,
+          "y": 153,
+          "width": 192,
+          "height": 274
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 20,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 9,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -14,
+                "y": 40,
+                "width": 975,
+                "height": 485
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 78,
+                  "y": 40,
+                  "width": 72,
+                  "height": 18
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 521,
+                  "y": 58,
+                  "width": 439,
+                  "height": 434
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 585,
+                  "y": 68,
+                  "width": 376,
+                  "height": 388
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 50,
+                  "y": 189,
+                  "width": 400,
+                  "height": 81
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 467,
+                  "y": 194,
+                  "width": 156,
+                  "height": 316
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 474,
+                  "y": 199,
+                  "width": 141,
+                  "height": 306
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": -14,
+                  "y": 263,
+                  "width": 548,
+                  "height": 262
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 50,
+                  "y": 293,
+                  "width": 400,
+                  "height": 63
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 18,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 50,
+                "y": 40,
+                "width": 863,
+                "height": 500
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 50,
+                  "y": 40,
+                  "width": 418,
+                  "height": 48
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 50,
+                  "y": 153,
+                  "width": 192,
+                  "height": 274
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 274,
+                  "y": 153,
+                  "width": 192,
+                  "height": 274
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 498,
+                  "y": 153,
+                  "width": 192,
+                  "height": 274
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 721,
+                  "y": 153,
+                  "width": 192,
+                  "height": 274
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 61,
+                  "y": 164,
+                  "width": 170,
+                  "height": 130
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 285,
+                  "y": 164,
+                  "width": 170,
+                  "height": 130
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 509,
+                  "y": 164,
+                  "width": 170,
+                  "height": 130
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -5,
+                "y": 0,
+                "width": 965,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": -5,
+                  "y": 63,
+                  "width": 507,
+                  "height": 414
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 174,
+                  "y": 120,
+                  "width": 241,
+                  "height": 300
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 419,
+                  "y": 178,
+                  "width": 370,
+                  "height": 81
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 416,
+                  "y": 270,
+                  "width": 370,
+                  "height": 84
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 10,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 50,
+                "y": 0,
+                "width": 910,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 584,
+                  "y": 0,
+                  "width": 376,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 50,
+                  "y": 69,
+                  "width": 378,
+                  "height": 120
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 50,
+                  "y": 198,
+                  "width": 63,
+                  "height": 30
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 137,
+                  "y": 198,
+                  "width": 108,
+                  "height": 30
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 50,
+                  "y": 256,
+                  "width": 491,
+                  "height": 42
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 50,
+                  "y": 293,
+                  "width": 182,
+                  "height": 21
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 89,
+                  "y": 330,
+                  "width": 452,
+                  "height": 21
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 89,
+                  "y": 366,
+                  "width": 452,
+                  "height": 21
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 27,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": -17,
+                "width": 960,
+                "height": 557
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 456,
+                  "y": -17,
+                  "width": 480,
+                  "height": 319
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 224
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 224
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 42,
+                  "y": 50,
+                  "width": 490,
+                  "height": 48
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 42,
+                  "y": 106,
+                  "width": 490,
+                  "height": 42
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 189,
+                  "width": 960,
+                  "height": 351
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 0,
+                  "y": 189,
+                  "width": 960,
+                  "height": 351
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 42,
+                  "y": 272,
+                  "width": 200,
+                  "height": 30
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -5,
+                "y": 0,
+                "width": 965,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": -5,
+                  "y": 63,
+                  "width": 507,
+                  "height": 414
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 174,
+                  "y": 120,
+                  "width": 241,
+                  "height": 300
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 416,
+                  "y": 178,
+                  "width": 370,
+                  "height": 81
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 416,
+                  "y": 270,
+                  "width": 370,
+                  "height": 84
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "3-19"
+        },
+        {
+          "label": "结尾",
+          "range": "20"
+        }
+      ]
+    },
+    {
+      "template_id": "personal--teaching_sharing",
+      "category": "personal",
+      "category_label": "个人",
+      "scene": "分享教学",
+      "tone": "colorful",
+      "formality": "casual",
+      "is_general_template": false,
+      "slide_count": 20,
+      "presentation_title": "分享教学",
+      "palette": "插画风图片底图，蓝紫 rgba(128,145,239) + 暖橙 rgba(242,170,104) 双色调",
+      "structure": "封面 → 目录 → 内容×17 → 结尾（含 Demo 案例、痛点分析、推荐书单）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-image-left-text-right",
+        "hero-text-left-image-right",
+        "image-backed",
+        "two-column-text"
+      ],
+      "use_cases": "教学分享、技术分享、读书会。温暖蓝橙配色，含 chevron 流程图",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "headline",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "body",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "rgba(155, 158, 162, 1)",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 50,
+          "y": 200,
+          "width": 436,
+          "height": 102
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "caption",
+          "x": 74,
+          "y": 362,
+          "width": 435,
+          "height": 22
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 74,
+          "y": 328,
+          "width": 435,
+          "height": 21
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 219,
+          "y": 158,
+          "width": 215,
+          "height": 39
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "title",
+          "x": 50,
+          "y": 159,
+          "width": 182,
+          "height": 36
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 79,
+          "y": 50,
+          "width": 104,
+          "height": 24
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 50,
+          "y": 52,
+          "width": 20,
+          "height": 20
+        },
+        {
+          "id": "img-8",
+          "kind": "img",
+          "role": "image",
+          "x": 50,
+          "y": 331,
+          "width": 16,
+          "height": 16
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 41,
+          "y": 193,
+          "width": 200,
+          "height": 260
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 267,
+          "y": 193,
+          "width": 200,
+          "height": 260
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 493,
+          "y": 193,
+          "width": 200,
+          "height": 260
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 719,
+          "y": 193,
+          "width": 200,
+          "height": 260
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 20,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 9,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 50,
+                "y": 50,
+                "width": 459,
+                "height": 334
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 79,
+                  "y": 50,
+                  "width": 104,
+                  "height": 24
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 50,
+                  "y": 52,
+                  "width": 20,
+                  "height": 20
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 219,
+                  "y": 158,
+                  "width": 215,
+                  "height": 39
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 50,
+                  "y": 159,
+                  "width": 182,
+                  "height": 36
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 50,
+                  "y": 200,
+                  "width": 436,
+                  "height": 102
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 74,
+                  "y": 328,
+                  "width": 435,
+                  "height": 21
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 50,
+                  "y": 331,
+                  "width": 16,
+                  "height": 16
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 74,
+                  "y": 362,
+                  "width": 435,
+                  "height": 22
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 20,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 41,
+                "y": 50,
+                "width": 878,
+                "height": 403
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 50,
+                  "y": 50,
+                  "width": 112,
+                  "height": 24
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 168,
+                  "y": 50,
+                  "width": 121,
+                  "height": 24
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 403,
+                  "y": 106,
+                  "width": 154,
+                  "height": 24
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 403,
+                  "y": 137,
+                  "width": 154,
+                  "height": 32
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 41,
+                  "y": 193,
+                  "width": 200,
+                  "height": 260
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 267,
+                  "y": 193,
+                  "width": 200,
+                  "height": 260
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 493,
+                  "y": 193,
+                  "width": 200,
+                  "height": 260
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 719,
+                  "y": 193,
+                  "width": 200,
+                  "height": 260
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 50,
+                "y": 50,
+                "width": 597,
+                "height": 342
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 50,
+                  "y": 50,
+                  "width": 112,
+                  "height": 24
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 168,
+                  "y": 50,
+                  "width": 121,
+                  "height": 24
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 380,
+                  "y": 128,
+                  "width": 200,
+                  "height": 120
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 316,
+                  "y": 240,
+                  "width": 328,
+                  "height": 24
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 317,
+                  "y": 258,
+                  "width": 328,
+                  "height": 54
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 319,
+                  "y": 329,
+                  "width": 328,
+                  "height": 63
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 12,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 44,
+                "y": 47,
+                "width": 876,
+                "height": 467
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 50,
+                  "y": 47,
+                  "width": 328,
+                  "height": 24
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 50,
+                  "y": 68,
+                  "width": 328,
+                  "height": 36
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 106,
+                  "y": 139,
+                  "width": 231,
+                  "height": 96
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 365,
+                  "y": 139,
+                  "width": 231,
+                  "height": 96
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 623,
+                  "y": 139,
+                  "width": 231,
+                  "height": 96
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 181,
+                  "y": 155,
+                  "width": 81,
+                  "height": 16
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 439,
+                  "y": 155,
+                  "width": 81,
+                  "height": 16
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 698,
+                  "y": 155,
+                  "width": 81,
+                  "height": 16
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 18,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 45,
+                "y": 47,
+                "width": 871,
+                "height": 406
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 50,
+                  "y": 47,
+                  "width": 328,
+                  "height": 24
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 50,
+                  "y": 68,
+                  "width": 328,
+                  "height": 36
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 71,
+                  "y": 149,
+                  "width": 150,
+                  "height": 150
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 293,
+                  "y": 149,
+                  "width": 150,
+                  "height": 150
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 517,
+                  "y": 149,
+                  "width": 150,
+                  "height": 150
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 740,
+                  "y": 149,
+                  "width": 150,
+                  "height": 150
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 78,
+                  "y": 155,
+                  "width": 136,
+                  "height": 137
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 300,
+                  "y": 155,
+                  "width": 137,
+                  "height": 137
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 12,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 40,
+                "y": -42,
+                "width": 952,
+                "height": 624
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 260,
+                  "y": -42,
+                  "width": 732,
+                  "height": 624
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 40,
+                  "y": 50,
+                  "width": 440,
+                  "height": 129
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 815,
+                  "y": 50,
+                  "width": 104,
+                  "height": 24
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 786,
+                  "y": 52,
+                  "width": 20,
+                  "height": 20
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 59,
+                  "y": 72,
+                  "width": 154,
+                  "height": 16
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 59,
+                  "y": 95,
+                  "width": 402,
+                  "height": 63
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 40,
+                  "y": 205,
+                  "width": 440,
+                  "height": 129
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 59,
+                  "y": 227,
+                  "width": 154,
+                  "height": 16
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "3-19"
+        },
+        {
+          "label": "结尾",
+          "range": "20"
+        }
+      ]
+    },
+    {
+      "template_id": "personal--personal_resume",
+      "category": "personal",
+      "category_label": "个人",
+      "scene": "个人简历",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 16,
+      "presentation_title": "个人简历",
+      "palette": "深炭灰图片底图，暖橙 rgba(253,151,51) + 霓虹绿 rgba(76,241,29) 渐变点缀",
+      "structure": "封面(含联系方式) → 目录 → [分节页 → 内容]×4 → 结尾",
+      "page_types": null,
+      "layout_tags": [
+        "full-bleed-image-caption",
+        "image-backed"
+      ],
+      "use_cases": "个人简历、求职展示。橙绿双色点缀，含个人信息字段",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "headline",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "body",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "rgba(155, 158, 162, 1)",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 0,
+          "y": 0,
+          "width": 960,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "text",
+          "x": 50,
+          "y": 18,
+          "width": 484,
+          "height": 120
+        },
+        {
+          "id": "img-3",
+          "kind": "img",
+          "role": "image",
+          "x": 790,
+          "y": 363,
+          "width": 224,
+          "height": 255
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 50,
+          "y": 106,
+          "width": 381,
+          "height": 120
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 55,
+          "y": 316,
+          "width": 279,
+          "height": 63
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 50,
+          "y": 475,
+          "width": 217,
+          "height": 24
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "text",
+          "x": 272,
+          "y": 475,
+          "width": 217,
+          "height": 24
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "text",
+          "x": 494,
+          "y": 475,
+          "width": 217,
+          "height": 24
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 349,
+          "y": 431,
+          "width": 263,
+          "height": 310
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 50,
+          "y": 232,
+          "width": 350,
+          "height": 75
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 437,
+          "y": 153,
+          "width": 180,
+          "height": 54
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 658,
+          "y": 211,
+          "width": 180,
+          "height": 54
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 16,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 18,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 1014,
+                "height": 618
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 50,
+                  "y": 18,
+                  "width": 484,
+                  "height": 120
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 858,
+                  "y": 50,
+                  "width": 52,
+                  "height": 72
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 50,
+                  "y": 106,
+                  "width": 381,
+                  "height": 120
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 890,
+                  "y": 165,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 890,
+                  "y": 173,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 890,
+                  "y": 181,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 890,
+                  "y": 188,
+                  "width": 20,
+                  "height": 6
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 31,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 25,
+                "y": -641,
+                "width": 885,
+                "height": 1382
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 769,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 777,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 785,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 793,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 437,
+                  "y": 26,
+                  "width": 85,
+                  "height": 90
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 50,
+                  "y": 50,
+                  "width": 350,
+                  "height": 24
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 858,
+                  "y": 50,
+                  "width": 52,
+                  "height": 72
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 437,
+                  "y": 81,
+                  "width": 94,
+                  "height": 16
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 17,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 25,
+                "y": -641,
+                "width": 885,
+                "height": 1315
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 769,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 777,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 785,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 793,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 50,
+                  "y": 50,
+                  "width": 350,
+                  "height": 24
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 858,
+                  "y": 50,
+                  "width": 52,
+                  "height": 72
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 50,
+                  "y": 107,
+                  "width": 145,
+                  "height": 90
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 349,
+                  "y": 115,
+                  "width": 263,
+                  "height": 310
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 21,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 42,
+                "y": -641,
+                "width": 868,
+                "height": 1131
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 769,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 777,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 785,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 793,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 292,
+                  "y": -281,
+                  "width": 598,
+                  "height": 682
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 42,
+                  "y": 0,
+                  "width": 152,
+                  "height": 152
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 594,
+                  "y": 48,
+                  "width": 221,
+                  "height": 294
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 50,
+                  "y": 50,
+                  "width": 200,
+                  "height": 45
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 18,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 39,
+                "y": 0,
+                "width": 975,
+                "height": 618
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 42,
+                  "y": 0,
+                  "width": 152,
+                  "height": 152
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 164,
+                  "y": 25,
+                  "width": 16,
+                  "height": 16
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 50,
+                  "y": 50,
+                  "width": 200,
+                  "height": 45
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 858,
+                  "y": 50,
+                  "width": 52,
+                  "height": 72
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 39,
+                  "y": 95,
+                  "width": 30,
+                  "height": 30
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 44,
+                  "y": 152,
+                  "width": 273,
+                  "height": 167
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 344,
+                  "y": 152,
+                  "width": 273,
+                  "height": 167
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 643,
+                  "y": 152,
+                  "width": 273,
+                  "height": 167
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 17,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 25,
+                "y": -641,
+                "width": 885,
+                "height": 1315
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 769,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 777,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 785,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 793,
+                  "y": -641,
+                  "width": 20,
+                  "height": 6
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 50,
+                  "y": 50,
+                  "width": 350,
+                  "height": 24
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 858,
+                  "y": 50,
+                  "width": 52,
+                  "height": 72
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 50,
+                  "y": 107,
+                  "width": 145,
+                  "height": 90
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 349,
+                  "y": 115,
+                  "width": 263,
+                  "height": 310
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节 3, 6, 9,",
+          "range": "12"
+        },
+        {
+          "label": "内容 4-5, 7-8, 10-11,",
+          "range": "13-15"
+        },
+        {
+          "label": "结尾",
+          "range": "16"
+        }
+      ]
+    },
+    {
+      "template_id": "personal--promotion_report",
+      "category": "personal",
+      "category_label": "个人",
+      "scene": "职位晋升汇报",
+      "tone": "dark",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 15,
+      "presentation_title": "职位晋升汇报",
+      "palette": "纯黑底 rgba(3,3,1)，薰衣草渐变 rgba(216,216,255) → rgba(171,194,255) 点缀，白色文字",
+      "structure": "封面 → 目录 → 内容×12 → 结尾（中英双语标题）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "hero-image-left-text-right",
+        "section-divider",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "晋升汇报、述职报告。暗色稳重 + 薰衣草柔和点缀",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "rgba(255, 255, 255, 1)",
+            "font_size": "72"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "rgba(255, 255, 255, 1)",
+            "font_size": "16"
+          },
+          {
+            "text_type": "body",
+            "font_color": "rgba(255, 255, 255, 1)",
+            "font_size": "14"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "rgba(255, 255, 255, 1)"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 638,
+          "y": 221,
+          "width": 281,
+          "height": 280
+        },
+        {
+          "id": "img-2",
+          "kind": "img",
+          "role": "image",
+          "x": 565,
+          "y": 27,
+          "width": 258,
+          "height": 260
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "title",
+          "x": 53,
+          "y": 328,
+          "width": 470,
+          "height": 128
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "slides-full-round-rect",
+          "x": 673,
+          "y": 85,
+          "width": 152,
+          "height": 386
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 53,
+          "y": 304,
+          "width": 470,
+          "height": 47
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 53,
+          "y": 432,
+          "width": 470,
+          "height": 47
+        },
+        {
+          "id": "img-7",
+          "kind": "img",
+          "role": "image",
+          "x": 567,
+          "y": 222,
+          "width": 131,
+          "height": 131
+        },
+        {
+          "id": "img-8",
+          "kind": "img",
+          "role": "image",
+          "x": 814,
+          "y": 376,
+          "width": 131,
+          "height": 131
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 678,
+          "y": 0,
+          "width": 282,
+          "height": 177
+        },
+        {
+          "id": "img-2",
+          "kind": "img",
+          "role": "image",
+          "x": 0,
+          "y": 372,
+          "width": 257,
+          "height": 168
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "headline",
+          "x": 257,
+          "y": 100,
+          "width": 328,
+          "height": 77
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 332,
+          "y": 206,
+          "width": 385,
+          "height": 41
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 15,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 53,
+                "y": 11,
+                "width": 892,
+                "height": 496
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 736,
+                  "y": 11,
+                  "width": 74,
+                  "height": 74
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 565,
+                  "y": 27,
+                  "width": 258,
+                  "height": 260
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 787,
+                  "y": 45,
+                  "width": 131,
+                  "height": 128
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 53,
+                  "y": 47,
+                  "width": 152,
+                  "height": 38
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 205,
+                  "y": 47,
+                  "width": 152,
+                  "height": 38
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 673,
+                  "y": 85,
+                  "width": 152,
+                  "height": 386
+                },
+                {
+                  "id": "img-7",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 826,
+                  "y": 196,
+                  "width": 59,
+                  "height": 59
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 638,
+                  "y": 221,
+                  "width": 281,
+                  "height": 280
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 16,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 678,
+                  "y": 0,
+                  "width": 282,
+                  "height": 177
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 165,
+                  "y": 100,
+                  "width": 125,
+                  "height": 77
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 257,
+                  "y": 100,
+                  "width": 328,
+                  "height": 77
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 201,
+                  "y": 203,
+                  "width": 125,
+                  "height": 41
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 332,
+                  "y": 206,
+                  "width": 385,
+                  "height": 41
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 184,
+                  "y": 220,
+                  "width": 11,
+                  "height": 11
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 201,
+                  "y": 254,
+                  "width": 125,
+                  "height": 41
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 332,
+                  "y": 257,
+                  "width": 385,
+                  "height": 41
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 97,
+                "y": 121,
+                "width": 744,
+                "height": 284
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 97,
+                  "y": 121,
+                  "width": 285,
+                  "height": 284
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 125,
+                  "y": 148,
+                  "width": 716,
+                  "height": 230
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 382,
+                  "y": 193,
+                  "width": 404,
+                  "height": 77
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 178,
+                  "y": 200,
+                  "width": 124,
+                  "height": 128
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 382,
+                  "y": 260,
+                  "width": 404,
+                  "height": 68
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 17,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 26,
+                "y": 0,
+                "width": 847,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 567,
+                  "y": 0,
+                  "width": 284,
+                  "height": 141
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 26,
+                  "y": 27,
+                  "width": 87,
+                  "height": 41
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 98,
+                  "y": 27,
+                  "width": 110,
+                  "height": 41
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 525,
+                  "y": 115,
+                  "width": 310,
+                  "height": 310
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 75,
+                  "y": 131,
+                  "width": 416,
+                  "height": 74
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 75,
+                  "y": 197,
+                  "width": 325,
+                  "height": 74
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 75,
+                  "y": 301,
+                  "width": 80,
+                  "height": 37
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 143,
+                  "y": 301,
+                  "width": 120,
+                  "height": 37
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 4,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 26,
+                "y": 0,
+                "width": 886,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 748,
+                  "y": 0,
+                  "width": 164,
+                  "height": 81
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 26,
+                  "y": 27,
+                  "width": 81,
+                  "height": 41
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 90,
+                  "y": 27,
+                  "width": 110,
+                  "height": 41
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 50,
+                  "y": 422,
+                  "width": 238,
+                  "height": 118
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 97,
+                "y": 121,
+                "width": 744,
+                "height": 284
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 97,
+                  "y": 121,
+                  "width": 285,
+                  "height": 284
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 125,
+                  "y": 148,
+                  "width": 716,
+                  "height": 230
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 382,
+                  "y": 193,
+                  "width": 404,
+                  "height": 77
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 178,
+                  "y": 200,
+                  "width": 124,
+                  "height": 128
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 382,
+                  "y": 260,
+                  "width": 404,
+                  "height": 68
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "3-14"
+        },
+        {
+          "label": "结尾",
+          "range": "15"
+        }
+      ]
+    },
+    {
+      "template_id": "personal--promotion_defense",
+      "category": "personal",
+      "category_label": "个人",
+      "scene": "晋级答辩",
+      "tone": "light",
+      "formality": "formal",
+      "is_general_template": false,
+      "slide_count": 11,
+      "presentation_title": "晋级答辩",
+      "palette": "白底，亮紫 rgba(74,58,255) 点缀",
+      "structure": "封面 → 目录 → 内容×8 → 结尾（紧凑无分节页）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "晋级答辩、技术答辩。最精简（11 页），紫色点缀，中英双语",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "48"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "36"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 636,
+          "y": 0,
+          "width": 324,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 36,
+          "y": 249,
+          "width": 324,
+          "height": 208
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "text",
+          "x": 41,
+          "y": 448,
+          "width": 253,
+          "height": 56
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 36,
+          "y": 35,
+          "width": 216,
+          "height": 38
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 264,
+          "y": 35,
+          "width": 216,
+          "height": 38
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 0,
+          "y": 0,
+          "width": 216,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "text",
+          "x": 428,
+          "y": 121,
+          "width": 426,
+          "height": 80
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "text",
+          "x": 335,
+          "y": 271,
+          "width": 248,
+          "height": 62
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 620,
+          "y": 271,
+          "width": 248,
+          "height": 62
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "text",
+          "x": 335,
+          "y": 393,
+          "width": 248,
+          "height": 62
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "text",
+          "x": 620,
+          "y": 393,
+          "width": 248,
+          "height": 62
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "text",
+          "x": 335,
+          "y": 235,
+          "width": 248,
+          "height": 47
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 11,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 36,
+                "y": 0,
+                "width": 924,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 636,
+                  "y": 0,
+                  "width": 324,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 36,
+                  "y": 35,
+                  "width": 216,
+                  "height": 38
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 264,
+                  "y": 35,
+                  "width": 216,
+                  "height": 38
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 36,
+                  "y": 249,
+                  "width": 324,
+                  "height": 208
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 41,
+                  "y": 448,
+                  "width": 253,
+                  "height": 56
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 12,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 868,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 216,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 318,
+                  "y": 121,
+                  "width": 133,
+                  "height": 80
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 318,
+                  "y": 121,
+                  "width": 135,
+                  "height": 81
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 428,
+                  "y": 121,
+                  "width": 426,
+                  "height": 80
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 335,
+                  "y": 235,
+                  "width": 248,
+                  "height": 47
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 620,
+                  "y": 235,
+                  "width": 248,
+                  "height": 47
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 335,
+                  "y": 271,
+                  "width": 248,
+                  "height": 62
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 620,
+                  "y": 271,
+                  "width": 248,
+                  "height": 62
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 18,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 26,
+                "y": 0,
+                "width": 934,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 664,
+                  "y": 0,
+                  "width": 296,
+                  "height": 430
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 664,
+                  "y": 0,
+                  "width": 296,
+                  "height": 430
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 26,
+                  "y": 25,
+                  "width": 114,
+                  "height": 44
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 101,
+                  "y": 25,
+                  "width": 129,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 87,
+                  "y": 116,
+                  "width": 416,
+                  "height": 69
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 87,
+                  "y": 182,
+                  "width": 393,
+                  "height": 56
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 87,
+                  "y": 275,
+                  "width": 80,
+                  "height": 37
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 156,
+                  "y": 275,
+                  "width": 120,
+                  "height": 37
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 26,
+                "y": 26,
+                "width": 879,
+                "height": 420
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 26,
+                  "y": 26,
+                  "width": 88,
+                  "height": 44
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 98,
+                  "y": 26,
+                  "width": 450,
+                  "height": 44
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 55,
+                  "y": 98,
+                  "width": 196,
+                  "height": 68
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 56,
+                  "y": 162,
+                  "width": 388,
+                  "height": 83
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 62,
+                  "y": 318,
+                  "width": 843,
+                  "height": 26
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 68,
+                  "y": 323,
+                  "width": 18,
+                  "height": 17
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 374,
+                  "y": 323,
+                  "width": 18,
+                  "height": 17
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 680,
+                  "y": 323,
+                  "width": 18,
+                  "height": 17
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 18,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -183,
+                "y": 26,
+                "width": 1089,
+                "height": 514
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 26,
+                  "y": 26,
+                  "width": 88,
+                  "height": 44
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 98,
+                  "y": 26,
+                  "width": 450,
+                  "height": 44
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 250,
+                  "y": 96,
+                  "width": 9,
+                  "height": 9
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 521,
+                  "y": 108,
+                  "width": 196,
+                  "height": 44
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 69,
+                  "y": 118,
+                  "width": 330,
+                  "height": 330
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 521,
+                  "y": 140,
+                  "width": 265,
+                  "height": 64
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 424,
+                  "y": 142,
+                  "width": 2,
+                  "height": 2
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 677,
+                  "y": 145,
+                  "width": 229,
+                  "height": 58
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 19,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0.17,
+                "width": 906,
+                "height": 447.83
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 231,
+                  "y": 0.17,
+                  "width": 12,
+                  "height": 22
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 403,
+                  "y": 15,
+                  "width": 4,
+                  "height": 4
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 26,
+                  "y": 26,
+                  "width": 88,
+                  "height": 44
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 98,
+                  "y": 26,
+                  "width": 450,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 371,
+                  "y": 32,
+                  "width": 68,
+                  "height": 3
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 346,
+                  "y": 57,
+                  "width": 6,
+                  "height": 16
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 232,
+                  "y": 62,
+                  "width": 9,
+                  "height": 9
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 521,
+                  "y": 108,
+                  "width": 196,
+                  "height": 44
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "3-10"
+        },
+        {
+          "label": "结尾",
+          "range": "11"
+        }
+      ]
+    },
+    {
+      "template_id": "personal--self_intro",
+      "category": "personal",
+      "category_label": "个人",
+      "scene": "个人介绍",
+      "tone": "colorful",
+      "formality": "casual",
+      "is_general_template": false,
+      "slide_count": 11,
+      "presentation_title": "个人介绍-裂图重新上传",
+      "palette": "暖白底 rgba(248,247,246)，5 种彩色（红 #d83931、青 #17b69c、橙 #ec914e、黄 #fad355、蓝 #3347ff）",
+      "structure": "封面 → 内容×9 → 结尾（含表格、甜甜圈图表、饼图）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "hero-text-left-image-right",
+        "section-divider",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "个人介绍、设计师作品集。shape 类型最丰富，图表元素多",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF",
+            "font_size": "80"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF",
+            "font_size": "28"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF",
+            "font_size": "22"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 631,
+          "y": 122,
+          "width": 250,
+          "height": 373
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 39,
+          "y": 111,
+          "width": 494,
+          "height": 180
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "donut",
+          "x": 541,
+          "y": 32,
+          "width": 180,
+          "height": 180
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "headline",
+          "x": 39,
+          "y": 289,
+          "width": 250,
+          "height": 62
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "caption",
+          "x": 39,
+          "y": 455,
+          "width": 290,
+          "height": 41
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "round1rect",
+          "x": 534,
+          "y": 300,
+          "width": 98,
+          "height": 98
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "rt-triangle",
+          "x": 534,
+          "y": 398,
+          "width": 98,
+          "height": 98
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "round2diag-rect",
+          "x": 805,
+          "y": 47,
+          "width": 54,
+          "height": 98
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "title",
+          "x": 39,
+          "y": 101,
+          "width": 494,
+          "height": 84
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 39,
+          "y": 179,
+          "width": 494,
+          "height": 84
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "donut",
+          "x": 41,
+          "y": 301,
+          "width": 196,
+          "height": 196
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "round2diag-rect",
+          "x": 335,
+          "y": 399,
+          "width": 184,
+          "height": 98
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 11,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 8,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 39,
+                "y": 32,
+                "width": 842,
+                "height": 464
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "donut",
+                  "x": 541,
+                  "y": 32,
+                  "width": 180,
+                  "height": 180
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round2diag-rect",
+                  "x": 805,
+                  "y": 47,
+                  "width": 54,
+                  "height": 98
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 39,
+                  "y": 111,
+                  "width": 494,
+                  "height": 180
+                },
+                {
+                  "id": "img-4",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 631,
+                  "y": 122,
+                  "width": 250,
+                  "height": 373
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 39,
+                  "y": 289,
+                  "width": 250,
+                  "height": 62
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "round1rect",
+                  "x": 534,
+                  "y": 300,
+                  "width": 98,
+                  "height": 98
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rt-triangle",
+                  "x": 534,
+                  "y": 398,
+                  "width": 98,
+                  "height": 98
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 39,
+                  "y": 455,
+                  "width": 290,
+                  "height": 41
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 6,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 39,
+                "y": 101,
+                "width": 494,
+                "height": 396
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 39,
+                  "y": 101,
+                  "width": 494,
+                  "height": 84
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 39,
+                  "y": 179,
+                  "width": 494,
+                  "height": 84
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "donut",
+                  "x": 41,
+                  "y": 301,
+                  "width": 196,
+                  "height": 196
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rt-triangle",
+                  "x": 237,
+                  "y": 399,
+                  "width": 98,
+                  "height": 98
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round2diag-rect",
+                  "x": 335,
+                  "y": 399,
+                  "width": 184,
+                  "height": 98
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "pie",
+                  "x": 433,
+                  "y": 412,
+                  "width": 72,
+                  "height": 72
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 174,
+                "y": 142,
+                "width": 612,
+                "height": 241
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 174,
+                  "y": 142,
+                  "width": 612,
+                  "height": 53
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 174,
+                  "y": 176,
+                  "width": 612,
+                  "height": 116
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 174,
+                  "y": 291,
+                  "width": 612,
+                  "height": 92
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 1,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 174,
+                "y": 70,
+                "width": 612,
+                "height": 53
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 174,
+                  "y": 70,
+                  "width": 612,
+                  "height": 53
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 5,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 39,
+                "y": 54,
+                "width": 882,
+                "height": 196
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "donut",
+                  "x": 724,
+                  "y": 54,
+                  "width": 98,
+                  "height": 98
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rt-triangle",
+                  "x": 822,
+                  "y": 54,
+                  "width": 98,
+                  "height": 98
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 39,
+                  "y": 97,
+                  "width": 494,
+                  "height": 84
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 720,
+                  "y": 151,
+                  "width": 201,
+                  "height": 98
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "rt-triangle",
+                  "x": 660,
+                  "y": 190,
+                  "width": 60,
+                  "height": 60
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 3,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 39,
+                "y": 87,
+                "width": 877,
+                "height": 393
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 578,
+                  "y": 87,
+                  "width": 338,
+                  "height": 393
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 39,
+                  "y": 95,
+                  "width": 465,
+                  "height": 85
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 39,
+                  "y": 180,
+                  "width": 361,
+                  "height": 104
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": ""
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "2-10"
+        },
+        {
+          "label": "结尾",
+          "range": "11"
+        }
+      ]
+    },
+    {
+      "template_id": "misc--book_sharing",
+      "category": "misc",
+      "category_label": "其他",
+      "scene": "读书分享",
+      "tone": "light",
+      "formality": "casual",
+      "is_general_template": false,
+      "slide_count": 16,
+      "presentation_title": "读书分享",
+      "palette": "白底 + 深橄榄绿侧边栏 rgba(43,54,44)，棕褐 rgba(128,66,8) 点缀",
+      "structure": "封面 → 内容×14 → 结尾（中文传统编号：壹贰叁肆）",
+      "page_types": null,
+      "layout_tags": [
+        "full-bleed-image-caption",
+        "hero-image-left-text-right",
+        "text-focused"
+      ],
+      "use_cases": "读书分享、文学赏析。文艺复古风，装饰性诗句分隔，中国传统美学",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "headline",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "body",
+            "font_color": "rgba(31, 35, 41, 1)"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "rgba(155, 158, 162, 1)",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 235,
+          "y": 0,
+          "width": 726,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "rect",
+          "x": 255,
+          "y": 10,
+          "width": 685,
+          "height": 520
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "rect",
+          "x": 255,
+          "y": 10,
+          "width": 685,
+          "height": 520
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "rect",
+          "x": 255,
+          "y": 10,
+          "width": 685,
+          "height": 520
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "rect",
+          "x": 245,
+          "y": 20,
+          "width": 705,
+          "height": 500
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "rect",
+          "x": 245,
+          "y": 20,
+          "width": 705,
+          "height": 500
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 0,
+          "y": 0,
+          "width": 235,
+          "height": 540
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "headline",
+          "x": 28,
+          "y": 320,
+          "width": 173,
+          "height": 189
+        },
+        {
+          "id": "img-1",
+          "kind": "img",
+          "role": "image",
+          "x": 0,
+          "y": 0,
+          "width": 960,
+          "height": 540
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "round-rect",
+          "x": 0,
+          "y": 404,
+          "width": 960,
+          "height": 136
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "rect",
+          "x": 45,
+          "y": 263,
+          "width": 210,
+          "height": 184
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "rect",
+          "x": 485,
+          "y": 263,
+          "width": 210,
+          "height": 184
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 16,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 11,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 961,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 235,
+                  "height": 540
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 235,
+                  "y": 0,
+                  "width": 726,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 255,
+                  "y": 10,
+                  "width": 685,
+                  "height": 520
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 255,
+                  "y": 10,
+                  "width": 685,
+                  "height": 520
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 255,
+                  "y": 10,
+                  "width": 685,
+                  "height": 520
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 245,
+                  "y": 20,
+                  "width": 705,
+                  "height": 500
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 245,
+                  "y": 20,
+                  "width": 705,
+                  "height": 500
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 146,
+                  "y": 30,
+                  "width": 56,
+                  "height": 260
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 24,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960,
+                "height": 721
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 382,
+                  "y": 66,
+                  "width": 89,
+                  "height": 96
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 486,
+                  "y": 66,
+                  "width": 89,
+                  "height": 96
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 45,
+                  "y": 263,
+                  "width": 210,
+                  "height": 184
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 188,
+                  "y": 263,
+                  "width": 53,
+                  "height": 75
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 485,
+                  "y": 263,
+                  "width": 210,
+                  "height": 184
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 629,
+                  "y": 263,
+                  "width": 53,
+                  "height": 75
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 706,
+                  "y": 263,
+                  "width": 210,
+                  "height": 184
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 10,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 961,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 235,
+                  "height": 540
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 235,
+                  "y": 0,
+                  "width": 726,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 255,
+                  "y": 10,
+                  "width": 685,
+                  "height": 520
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 255,
+                  "y": 10,
+                  "width": 685,
+                  "height": 520
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 255,
+                  "y": 10,
+                  "width": 685,
+                  "height": 520
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 245,
+                  "y": 20,
+                  "width": 705,
+                  "height": 500
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 245,
+                  "y": 20,
+                  "width": 705,
+                  "height": 500
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 146,
+                  "y": 30,
+                  "width": 56,
+                  "height": 259
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 20,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0.23,
+                "y": 0,
+                "width": 960,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "img-1",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0.23,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 696,
+                  "y": 0,
+                  "width": 264,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 69,
+                  "y": 42,
+                  "width": 275,
+                  "height": 452
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 674,
+                  "y": 42,
+                  "width": 275,
+                  "height": 452
+                },
+                {
+                  "id": "img-5",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 57,
+                  "y": 43,
+                  "width": 274,
+                  "height": 274
+                },
+                {
+                  "id": "img-6",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 360,
+                  "y": 43,
+                  "width": 274,
+                  "height": 274
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 75,
+                  "y": 47,
+                  "width": 275,
+                  "height": 452
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 680,
+                  "y": 47,
+                  "width": 275,
+                  "height": 452
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 15,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 960.23,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 814,
+                  "height": 540
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 0.23,
+                  "y": 0,
+                  "width": 960,
+                  "height": 540
+                },
+                {
+                  "id": "img-3",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 20,
+                  "y": 21,
+                  "width": 342,
+                  "height": 498
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 391,
+                  "y": 49,
+                  "width": 30,
+                  "height": 97
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 446,
+                  "y": 49,
+                  "width": 83,
+                  "height": 30
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 48,
+                  "y": 52,
+                  "width": 56,
+                  "height": 259
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 446,
+                  "y": 82,
+                  "width": 314,
+                  "height": 63
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 391,
+                  "y": 222,
+                  "width": 30,
+                  "height": 97
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 10,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 0,
+                "y": 0,
+                "width": 961,
+                "height": 540
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 235,
+                  "height": 540
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 235,
+                  "y": 0,
+                  "width": 726,
+                  "height": 540
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 255,
+                  "y": 10,
+                  "width": 685,
+                  "height": 520
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 255,
+                  "y": 10,
+                  "width": 685,
+                  "height": 520
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 255,
+                  "y": 10,
+                  "width": 685,
+                  "height": 520
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 245,
+                  "y": 20,
+                  "width": 705,
+                  "height": 500
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 245,
+                  "y": 20,
+                  "width": 705,
+                  "height": 500
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 146,
+                  "y": 30,
+                  "width": 56,
+                  "height": 259
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": ""
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "2-15"
+        },
+        {
+          "label": "结尾",
+          "range": "16"
+        }
+      ]
+    },
+    {
+      "template_id": "misc--club_event_plan",
+      "category": "misc",
+      "category_label": "其他",
+      "scene": "社团活动策划",
+      "tone": "dark",
+      "formality": "casual",
+      "is_general_template": false,
+      "slide_count": 15,
+      "presentation_title": "社团活动策划方案",
+      "palette": "纯黑底，红色 rgba(216,57,49) + 金色 rgba(219,168,0) 双色强调",
+      "structure": "封面 → 目录 → 内容×12 → 结尾（含预算页、应急方案页）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "hero-text-left-image-right",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "活动策划、社团方案。黑红金配色，含预算/应急等实用页面",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "rgba(255, 255, 255, 1)"
+          },
+          {
+            "text_type": "body",
+            "font_color": "rgba(168, 174, 181, 1)"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "rgba(168, 174, 181, 1)",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "rect",
+          "x": 348,
+          "y": -349,
+          "width": 263,
+          "height": 961
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "rect",
+          "x": 363,
+          "y": -58,
+          "width": 234,
+          "height": 961
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "rect",
+          "x": 0,
+          "y": 0,
+          "width": 312,
+          "height": 540
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "rect",
+          "x": 648,
+          "y": 0,
+          "width": 312,
+          "height": 540
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "title",
+          "x": 361,
+          "y": 184,
+          "width": 239,
+          "height": 163
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 614,
+          "y": 361,
+          "width": 136,
+          "height": 136
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 215,
+          "y": 37,
+          "width": 129,
+          "height": 129
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "rect",
+          "x": 605,
+          "y": 355,
+          "width": 76,
+          "height": 147
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "rect",
+          "x": 210,
+          "y": -210,
+          "width": 540,
+          "height": 960
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 64,
+          "y": 61,
+          "width": 788,
+          "height": 68
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "caption",
+          "x": 65,
+          "y": 108,
+          "width": 312,
+          "height": 41
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "text",
+          "x": 80,
+          "y": 205,
+          "width": 110,
+          "height": 93
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 15,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 149,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -242,
+                "y": -349,
+                "width": 1444,
+                "height": 1252
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 348,
+                  "y": -349,
+                  "width": 263,
+                  "height": 961
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 363,
+                  "y": -58,
+                  "width": 234,
+                  "height": 961
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0,
+                  "width": 312,
+                  "height": 540
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 648,
+                  "y": 0,
+                  "width": 312,
+                  "height": 540
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 85,
+                  "y": 18,
+                  "width": 7,
+                  "height": 105
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 73,
+                  "y": 19,
+                  "width": 7,
+                  "height": 120
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 99,
+                  "y": 21,
+                  "width": 7,
+                  "height": 79
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 27,
+                  "width": 960,
+                  "height": 1
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 84,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -242,
+                "y": -210,
+                "width": 1444,
+                "height": 960
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 210,
+                  "y": -210,
+                  "width": 540,
+                  "height": 960
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 27,
+                  "width": 960,
+                  "height": 1
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 54,
+                  "width": 960,
+                  "height": 1
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 64,
+                  "y": 61,
+                  "width": 788,
+                  "height": 68
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 761,
+                  "y": 67,
+                  "width": 132,
+                  "height": 41
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 81,
+                  "width": 960,
+                  "height": 1
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 108,
+                  "width": 960,
+                  "height": 1
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 65,
+                  "y": 108,
+                  "width": 312,
+                  "height": 41
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 59,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -242,
+                "y": -210,
+                "width": 1444,
+                "height": 1365
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 210,
+                  "y": -210,
+                  "width": 540,
+                  "height": 960
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 113,
+                  "y": 201,
+                  "width": 144,
+                  "height": 144
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 325,
+                  "y": 202,
+                  "width": 117,
+                  "height": 117
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 433,
+                  "y": 226,
+                  "width": 218,
+                  "height": 77
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 103,
+                  "y": 277,
+                  "width": 169,
+                  "height": 87
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 433,
+                  "y": 286,
+                  "width": 218,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 669,
+                  "width": 960,
+                  "height": 1
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 696,
+                  "width": 960,
+                  "height": 1
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 19,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 64,
+                "y": 61,
+                "width": 830,
+                "height": 403
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 64,
+                  "y": 61,
+                  "width": 788,
+                  "height": 68
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "caption",
+                  "x": 65,
+                  "y": 108,
+                  "width": 312,
+                  "height": 41
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 68,
+                  "y": 166,
+                  "width": 262,
+                  "height": 298
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 350,
+                  "y": 166,
+                  "width": 262,
+                  "height": 298
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 632,
+                  "y": 166,
+                  "width": 262,
+                  "height": 298
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "pie",
+                  "x": 393,
+                  "y": 188,
+                  "width": 36,
+                  "height": 36
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 655,
+                  "y": 191,
+                  "width": 49,
+                  "height": 49
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "donut",
+                  "x": 86,
+                  "y": 192,
+                  "width": 55,
+                  "height": 56
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 106,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -268,
+                "y": -343,
+                "width": 1496,
+                "height": 1154
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 342,
+                  "y": -343,
+                  "width": 276,
+                  "height": 961
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 270,
+                  "y": -150,
+                  "width": 419,
+                  "height": 961
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 0.16,
+                  "width": 960,
+                  "height": 0.99
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 27,
+                  "width": 960,
+                  "height": 0.99
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 54,
+                  "width": 960,
+                  "height": 0.99
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 70,
+                  "y": 61,
+                  "width": 821,
+                  "height": 68
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 81,
+                  "width": 960,
+                  "height": 0.99
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 108,
+                  "width": 960,
+                  "height": 0.99
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 58,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -242,
+                "y": -210,
+                "width": 1444,
+                "height": 1365
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 210,
+                  "y": -210,
+                  "width": 540,
+                  "height": 960
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 325,
+                  "y": 202,
+                  "width": 117,
+                  "height": 117
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 320,
+                  "y": 207,
+                  "width": 114,
+                  "height": 91
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 433,
+                  "y": 226,
+                  "width": 218,
+                  "height": 77
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 433,
+                  "y": 286,
+                  "width": 218,
+                  "height": 44
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 669,
+                  "width": 960,
+                  "height": 1
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 696,
+                  "width": 960,
+                  "height": 1
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 0,
+                  "y": 723,
+                  "width": 960,
+                  "height": 1
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "3-14"
+        },
+        {
+          "label": "结尾",
+          "range": "15"
+        }
+      ]
+    },
+    {
+      "template_id": "misc--student_career_plan",
+      "category": "misc",
+      "category_label": "其他",
+      "scene": "学生职业规划",
+      "tone": "colorful",
+      "formality": "casual",
+      "is_general_template": false,
+      "slide_count": 15,
+      "presentation_title": "学生职业生涯规划",
+      "palette": "深靛蓝底 rgba(21,20,87)，霓虹多彩（品红、青、黄、粉、热粉）",
+      "structure": "封面 → 目录 → 内容×12 → 结尾（含 SWOT 分析、短/中/长期目标时间线）",
+      "page_types": null,
+      "layout_tags": [
+        "2x2-metric-cards",
+        "full-bleed-image-caption",
+        "hero-text-left-image-right",
+        "text-focused",
+        "two-column-text"
+      ],
+      "use_cases": "职业规划、学生汇报。最鲜艳多彩，霓虹风格，含 SWOT 和时间线",
+      "theme_summary": {
+        "has_theme_node": true,
+        "text_styles": [
+          {
+            "text_type": "title",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "sub-headline",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "body",
+            "font_color": "#000000FF"
+          },
+          {
+            "text_type": "caption",
+            "font_color": "#808080FF",
+            "font_size": "14"
+          }
+        ]
+      },
+      "editable_regions": [
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": 125,
+          "y": 122,
+          "width": 296,
+          "height": 296
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 129,
+          "y": 195,
+          "width": 668,
+          "height": 101
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "ellipse",
+          "x": -340,
+          "y": 140,
+          "width": 259,
+          "height": 260
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "sub-headline",
+          "x": 129,
+          "y": 276,
+          "width": 404,
+          "height": 68
+        },
+        {
+          "id": "shape-5",
+          "kind": "shape",
+          "role": "rect",
+          "x": -340,
+          "y": 270,
+          "width": 130,
+          "height": 130
+        },
+        {
+          "id": "shape-6",
+          "kind": "shape",
+          "role": "title",
+          "x": 41,
+          "y": 46,
+          "width": 355,
+          "height": 44
+        },
+        {
+          "id": "shape-7",
+          "kind": "shape",
+          "role": "title",
+          "x": 41,
+          "y": 450,
+          "width": 130,
+          "height": 44
+        },
+        {
+          "id": "shape-8",
+          "kind": "shape",
+          "role": "title",
+          "x": 834,
+          "y": 46,
+          "width": 73,
+          "height": 44
+        },
+        {
+          "id": "shape-1",
+          "kind": "shape",
+          "role": "rect",
+          "x": 376,
+          "y": 40,
+          "width": 546,
+          "height": 460
+        },
+        {
+          "id": "shape-2",
+          "kind": "shape",
+          "role": "title",
+          "x": 95,
+          "y": 84,
+          "width": 326,
+          "height": 71
+        },
+        {
+          "id": "shape-3",
+          "kind": "shape",
+          "role": "title",
+          "x": 517,
+          "y": 98,
+          "width": 284,
+          "height": 53
+        },
+        {
+          "id": "shape-4",
+          "kind": "shape",
+          "role": "title",
+          "x": 517,
+          "y": 189,
+          "width": 284,
+          "height": 53
+        }
+      ],
+      "bbox_summary": {
+        "slide_count": 15,
+        "slides": [
+          {
+            "slide_number": 1,
+            "bbox_summary": {
+              "region_count": 10,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": -340,
+                "y": 46,
+                "width": 1247,
+                "height": 448
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 41,
+                  "y": 46,
+                  "width": 355,
+                  "height": 44
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 834,
+                  "y": 46,
+                  "width": 73,
+                  "height": 44
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 125,
+                  "y": 122,
+                  "width": 296,
+                  "height": 296
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": -340,
+                  "y": 140,
+                  "width": 259,
+                  "height": 260
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 129,
+                  "y": 195,
+                  "width": 668,
+                  "height": 101
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": -340,
+                  "y": 270,
+                  "width": 130,
+                  "height": 130
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "sub-headline",
+                  "x": 129,
+                  "y": 276,
+                  "width": 404,
+                  "height": 68
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 41,
+                  "y": 450,
+                  "width": 130,
+                  "height": 44
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 2,
+            "bbox_summary": {
+              "region_count": 16,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 77,
+                "y": 40,
+                "width": 845,
+                "height": 460
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 376,
+                  "y": 40,
+                  "width": 546,
+                  "height": 460
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "donut",
+                  "x": 77,
+                  "y": 73,
+                  "width": 74,
+                  "height": 74
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 95,
+                  "y": 84,
+                  "width": 326,
+                  "height": 71
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 456,
+                  "y": 90,
+                  "width": 72,
+                  "height": 68
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 517,
+                  "y": 98,
+                  "width": 284,
+                  "height": 53
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 517,
+                  "y": 134,
+                  "width": 284,
+                  "height": 41
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 180,
+                  "y": 147,
+                  "width": 32,
+                  "height": 28
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "title",
+                  "x": 456,
+                  "y": 182,
+                  "width": 72,
+                  "height": 68
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 3,
+            "bbox_summary": {
+              "region_count": 28,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 63,
+                "y": -132,
+                "width": 1191,
+                "height": 841
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 520,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 539,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 557,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 576,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 595,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 614,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 520,
+                  "y": -113,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 539,
+                  "y": -113,
+                  "width": 6,
+                  "height": 6
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 4,
+            "bbox_summary": {
+              "region_count": 13,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 38,
+                "y": 53,
+                "width": 885,
+                "height": 447
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 755,
+                  "y": 53,
+                  "width": 167,
+                  "height": 44
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "donut",
+                  "x": 46,
+                  "y": 58,
+                  "width": 55,
+                  "height": 55
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "text",
+                  "text_type": "headline",
+                  "x": 63,
+                  "y": 61,
+                  "width": 367,
+                  "height": 71
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "round-rect",
+                  "x": 38,
+                  "y": 173,
+                  "width": 885,
+                  "height": 327
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 148,
+                  "y": 208,
+                  "width": 154,
+                  "height": 44
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 441,
+                  "y": 208,
+                  "width": 154,
+                  "height": 44
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 733,
+                  "y": 208,
+                  "width": 154,
+                  "height": 44
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 71,
+                  "y": 210,
+                  "width": 74,
+                  "height": 74
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 5,
+            "bbox_summary": {
+              "region_count": 14,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 68,
+                "y": 64,
+                "width": 832,
+                "height": 418
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "triangle",
+                  "x": 846,
+                  "y": 64,
+                  "width": 32,
+                  "height": 28
+                },
+                {
+                  "id": "img-2",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 475,
+                  "y": 68,
+                  "width": 202,
+                  "height": 202
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "slides-full-round-rect",
+                  "x": 68,
+                  "y": 73,
+                  "width": 116,
+                  "height": 42
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 68,
+                  "y": 73,
+                  "width": 116,
+                  "height": 44
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "text",
+                  "x": 68,
+                  "y": 125,
+                  "width": 200,
+                  "height": 97
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 290,
+                  "y": 150,
+                  "width": 185,
+                  "height": 56
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "rect",
+                  "x": 290,
+                  "y": 150,
+                  "width": 185,
+                  "height": 56
+                },
+                {
+                  "id": "img-8",
+                  "kind": "img",
+                  "type": "img",
+                  "x": 273,
+                  "y": 270,
+                  "width": 202,
+                  "height": 202
+                }
+              ]
+            }
+          },
+          {
+            "slide_number": 6,
+            "bbox_summary": {
+              "region_count": 28,
+              "canvas": {
+                "width": 960,
+                "height": 540
+              },
+              "occupied_bounds": {
+                "x": 63,
+                "y": -132,
+                "width": 1191,
+                "height": 841
+              },
+              "regions": [
+                {
+                  "id": "shape-1",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 520,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-2",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 539,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-3",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 557,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-4",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 576,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-5",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 595,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-6",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 614,
+                  "y": -132,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-7",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 520,
+                  "y": -113,
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "id": "shape-8",
+                  "kind": "shape",
+                  "type": "ellipse",
+                  "x": 539,
+                  "y": -113,
+                  "width": 6,
+                  "height": 6
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "ranges": [
+        {
+          "label": "封面",
+          "range": "1"
+        },
+        {
+          "label": "目录",
+          "range": "2"
+        },
+        {
+          "label": "分节",
+          "range": ""
+        },
+        {
+          "label": "内容",
+          "range": "3-14"
+        },
+        {
+          "label": "结尾",
+          "range": "15"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/lark-slides/references/templates/administration--all_hands_meeting.xml
+++ b/skills/lark-slides/references/templates/administration--all_hands_meeting.xml
@@ -1,0 +1,1999 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>全员大会</title>
+  <theme>
+    <fill alpha="1">
+      <fillImg src="RODFb1dufol5tsxbTpNcU9cbnid" alpha="1" rotateWithShape="false"/>
+    </fill>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="90"/>
+      <headline fontColor="#000000FF" fontSize="40"/>
+      <sub-headline fontColor="#000000FF" fontSize="24"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="RODFb1dufol5tsxbTpNcU9cbnid" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="479" height="74" topLeftX="57" topLeftY="294" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="40">202</span>
+            </strong>
+            <strong>
+              <span fontSize="40">6</span>
+            </strong>
+            <strong>
+              <span fontSize="40"> </span>
+            </strong>
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="40">Q</span>
+            </strong>
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="40">1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="817" height="146" topLeftX="57" topLeftY="342" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="90" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <strong>
+              <span fontSize="90">全员大会</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="AkfFbXJtZoBnSpx4bZecGd3Pnxe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="F4uob6k5aoLElPx01GdcxiB2nwg" width="72" height="72" topLeftX="763" topLeftY="428">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="788" height="398" topLeftX="86" topLeftY="71" presetHandlers="24" alpha="0.76" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.71)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <img src="Il4nb9FTAoWv0VxZaxNcafghnWg" width="112" height="112" topLeftX="39" topLeftY="112">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="398" height="56" topLeftX="281" topLeftY="153" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="672" height="74" topLeftX="144" topLeftY="86" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            目录 
+            <span color="rgba(51, 112, 255, 1)">CONTENTS</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="413" startY="248" endX="413" endY="399">
+        <border color="rgba(143, 149, 158, 1)" dashArray="round-dot" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="8" height="8" topLeftX="409" topLeftY="245" type="ellipse">
+        <fill>
+          <fillColor color="rgba(54, 53, 88, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="44" topLeftX="430" topLeftY="227" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="16">欢迎新人 &amp; 获奖公示</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="75" height="44" topLeftX="322" topLeftY="227" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(51, 112, 255, 1)" bold="true" italic="true" letterSpacing="1" textAlign="right">
+          <p letterSpacing="1">
+            <strong>
+              <em>
+                <span color="rgba(51, 112, 255, 1)" fontSize="16">Part1</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="75" height="44" topLeftX="322" topLeftY="277" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(51, 112, 255, 1)" bold="true" italic="true" letterSpacing="1" textAlign="right">
+          <p letterSpacing="1">
+            <strong>
+              <em>
+                <span color="rgba(51, 112, 255, 1)" fontSize="16">Part2</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="75" height="44" topLeftX="322" topLeftY="327" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(51, 112, 255, 1)" bold="true" italic="true" letterSpacing="1" textAlign="right">
+          <p letterSpacing="1">
+            <strong>
+              <em>
+                <span color="rgba(51, 112, 255, 1)" fontSize="16">Part3</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="75" height="44" topLeftX="322" topLeftY="377" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(51, 112, 255, 1)" bold="true" italic="true" letterSpacing="1" textAlign="right">
+          <p letterSpacing="1">
+            <strong>
+              <em>
+                <span color="rgba(51, 112, 255, 1)" fontSize="16">Part4</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="409" topLeftY="295" type="ellipse">
+        <fill>
+          <fillColor color="rgba(54, 53, 88, 1)"/>
+        </fill>
+      </shape>
+      <shape width="8" height="8" topLeftX="409" topLeftY="345" type="ellipse">
+        <fill>
+          <fillColor color="rgba(54, 53, 88, 1)"/>
+        </fill>
+      </shape>
+      <shape width="8" height="8" topLeftX="409" topLeftY="395" type="ellipse">
+        <fill>
+          <fillColor color="rgba(54, 53, 88, 1)"/>
+        </fill>
+      </shape>
+      <shape width="113" height="44" topLeftX="430" topLeftY="277" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="16">2025 年回顾</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="44" topLeftX="430" topLeftY="327" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="16">2026 年规划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="225" height="44" topLeftX="430" topLeftY="377" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="16">Q&amp;A</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="348" height="38" topLeftX="306" topLeftY="153" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" textAlign="center"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="RODFb1dufol5tsxbTpNcU9cbnid" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="W5g8b10TooGawdx2cI8crFS7nOh" width="301" height="540" topLeftX="659" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="123" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="493" height="44" topLeftX="126" topLeftY="275" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(51, 112, 255, 1)">
+          <p>介绍新人和获奖员工，鼓励大家融入团队，积极参加公司发展</p>
+        </content>
+      </shape>
+      <shape width="627" height="93" topLeftX="126" topLeftY="187" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>欢迎新人 &amp; 获奖公示</p>
+        </content>
+      </shape>
+      <shape width="112" height="93" topLeftX="33" topLeftY="187" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(51, 112, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>01</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="RODFb1dufol5tsxbTpNcU9cbnid" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="788" height="377" topLeftX="86" topLeftY="124" presetHandlers="24" alpha="0.76" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.71)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <img src="PhT5b9Bc1o3TvuxKxUIcJo0vnQb" width="189" height="189" topLeftX="762" topLeftY="51">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="777" height="69" topLeftX="92" topLeftY="44" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="36">欢迎来到这个大家庭</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="137" height="44" topLeftX="151" topLeftY="258" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="16">员工名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="137" height="44" topLeftX="331" topLeftY="258" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="16">员工名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="137" height="44" topLeftX="504" topLeftY="258" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="16">员工名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="137" height="44" topLeftX="672" topLeftY="258" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="16">员工名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="137" height="44" topLeftX="151" topLeftY="409" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="16">员工名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="137" height="44" topLeftX="331" topLeftY="409" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="16">员工名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="137" height="44" topLeftX="504" topLeftY="409" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="16">员工名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="137" height="44" topLeftX="672" topLeftY="409" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="16">员工名字</span>
+          </p>
+        </content>
+      </shape>
+      <img src="NHrIbt1A3oMbitxWsPZcyLTKnKf" width="78" height="78" topLeftX="181" topLeftY="176">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="V75Vb338vorgxkxjKx5cyZ6engb" width="78" height="78" topLeftX="361" topLeftY="175">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="SrnDbKWsaoznfwxLQEGcG4mcnQb" width="78" height="78" topLeftX="533" topLeftY="176">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="QahFbzNmCo9FB3xJ5TPcjg5xn8d" width="78" height="78" topLeftX="702" topLeftY="176">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="WRrTbgtPFoP713xmSIQc8iBVnYf" width="78" height="78" topLeftX="702" topLeftY="329">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="BiL5bqtgwoaN3exlYQgc4NVJnJd" width="78" height="78" topLeftX="533" topLeftY="330">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="UYAZbz9Eoo0XFmxlhEFcikqIn6g" width="78" height="78" topLeftX="361" topLeftY="330">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="LHEObkseLoQfsexqLOccXY53nRe" width="78" height="78" topLeftX="181" topLeftY="330">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="RODFb1dufol5tsxbTpNcU9cbnid" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="208" height="282" topLeftX="29" topLeftY="197" presetHandlers="16" alpha="0.76" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.71)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <shape width="208" height="282" topLeftX="260" topLeftY="197" presetHandlers="16" alpha="0.76" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.71)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <shape width="208" height="282" topLeftX="492" topLeftY="197" presetHandlers="16" alpha="0.76" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.71)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <shape width="208" height="282" topLeftX="723" topLeftY="197" presetHandlers="16" alpha="0.76" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.71)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <img src="C3GBbzpGIoMCDVxOQ3cczoFcnSg" width="90" height="51" topLeftX="781" topLeftY="135">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="BJy9bjLHOoayw6x78FMcmNoinVf" width="111" height="51" topLeftX="309" topLeftY="135">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="ZWzQbFpQhoqAqrxYvTgcf9qonac" width="111" height="51" topLeftX="78" topLeftY="135">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="QLFmbv7FZoTGOvxOYtdc3TCDn3c" width="90" height="51" topLeftX="550" topLeftY="135">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="777" height="69" topLeftX="92" topLeftY="44" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="36">本季度</span>
+            </strong>
+            <strong>
+              <span fontSize="36">获奖公示</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="SVpMbK6adoMpTVxpGbIc3RE8nVb" width="36" height="36" topLeftX="56" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="Annab41rxoBz8Exqhe7cyJtwnLd" width="36" height="36" topLeftX="56" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="NHrIbt1A3oMbitxWsPZcyLTKnKf" width="36" height="36" topLeftX="56" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="V5OUbGuJLov0xbx2bhkcBsJYnVe" width="36" height="36" topLeftX="116" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="FdFEbs6yToEbrRx4IVcc2jqcnIh" width="36" height="36" topLeftX="177" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="H6jXbm7ApocfhfxDxWccEoZSnWg" width="36" height="36" topLeftX="116" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="VfjMbo5pzoQYrcxkUxOcRszdn4g" width="36" height="36" topLeftX="177" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="SNwIbIO77oo2YPxO0rfcaVmHnRc" width="36" height="36" topLeftX="116" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="H7vcbaPAeoEvx2xqHdZcSqVCngf" width="36" height="36" topLeftX="177" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="JFB6b5KyroWF4YxTzI4cdA6fnsg" width="36" height="36" topLeftX="287" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="HDzwbrKTVoh68mxIK6rcclzOnwe" width="36" height="36" topLeftX="287" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="VGyxbRY80oMA8ixF4wbce8Mhn5e" width="36" height="36" topLeftX="287" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="Xax9bCmEYoSeL9xDj0ucMqSXnlf" width="36" height="36" topLeftX="348" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="GE5BbiQCpoojuSxJDigcrcR3nPx" width="36" height="36" topLeftX="409" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="Bw5bbvhNSoaPOXxBLkxcB0tZnCd" width="36" height="36" topLeftX="348" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="T50zbVpndox1HsxEPEjc95QlnUf" width="36" height="36" topLeftX="409" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="ErbqbpIXKoF5GKxSObHckvfDn4I" width="36" height="36" topLeftX="348" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="J9mPbQdhbov1nsxDyLMc4l0znYg" width="36" height="36" topLeftX="409" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="MFk7bOj22oE1ijxTtRKc6qV8n3g" width="36" height="36" topLeftX="517" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="RpgabG1B6odzkRx2g2nckSY1nId" width="36" height="36" topLeftX="517" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="C3CgbusUUoVamCxz5l8cFyC8nNc" width="36" height="36" topLeftX="517" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="P5dqbcq71oTesxx2vvJcaMHin8f" width="36" height="36" topLeftX="578" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="DfnubQhKVo19BGxDp5JctoeVn1c" width="36" height="36" topLeftX="639" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="RQPRbebY2oyZqlxx5FMcl5h4nrc" width="36" height="36" topLeftX="578" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="CazIbP4YZoNAMlxbLrXcKPOjn3v" width="36" height="36" topLeftX="639" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="NHrIbt1A3oMbitxWsPZcyLTKnKf" width="36" height="36" topLeftX="578" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="AgCVbxWmPoutqExH1isc0dopnfc" width="36" height="36" topLeftX="639" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="NrLzbva2IokLEsxEigPcXg5Xnmh" width="36" height="36" topLeftX="749" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="NsIMbdRMbodm6mxFheCcCNaXnGd" width="36" height="36" topLeftX="749" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="YkrgbYHQsoaouRxHWQacTxj0n8e" width="36" height="36" topLeftX="749" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="NHrIbt1A3oMbitxWsPZcyLTKnKf" width="36" height="36" topLeftX="810" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="WcmhbnhHWoSb5Wx1Y6jcIL9znRb" width="36" height="36" topLeftX="871" topLeftY="220">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="RAlob6feTonxC4xVZKmcXf7Mnhc" width="36" height="36" topLeftX="810" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="BjhxbSh4qo55SqxHGfMcTjk7nef" width="36" height="36" topLeftX="871" topLeftY="304">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="MLyyb2bTZorkxAxyCO4cyApZnXg" width="36" height="36" topLeftX="810" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="RMTVbHE1OoS4P9x0h11cTJl7nnf" width="36" height="36" topLeftX="871" topLeftY="388">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="74"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="72" height="32" topLeftX="38" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="98" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="159" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="38" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="98" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="159" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="38" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="98" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="159" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="267" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="328" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="389" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="501" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="562" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="623" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="731" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="792" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="267" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="328" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="501" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="562" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="731" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="792" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="853" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="623" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="267" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="501" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="731" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="792" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="853" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="562" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="623" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="328" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="389" topLeftY="256" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="389" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="32" topLeftX="853" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">名字</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="RODFb1dufol5tsxbTpNcU9cbnid" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="MXKebcj5RoreF2xLzGdcMEqMnbf" width="434" height="514" topLeftX="526" topLeftY="26" alpha="0.73">
+        <crop type="rect" leftOffset="0" rightOffset="80" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="493" height="40" topLeftX="146" topLeftY="295" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(51, 112, 255, 1)">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(51, 112, 255, 1)" fontSize="16">回顾202</span>
+            <span color="rgba(51, 112, 255, 1)" fontSize="16">5</span>
+            <span color="rgba(51, 112, 255, 1)" fontSize="16">年关键的OKR、项目及达成情况</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="627" height="85" topLeftX="146" topLeftY="207" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="54">202</span>
+            </strong>
+            <strong>
+              <span fontSize="54">5</span>
+            </strong>
+            <strong>
+              <span fontSize="54"> 年复盘</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="112" height="93" topLeftX="53" topLeftY="207" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(51, 112, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>02</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(155, 177, 255, 1) 0%,rgba(206, 197, 255, 1) 94%,rgba(210, 199, 255, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="180" height="180" topLeftX="60" topLeftY="184" presetHandlers="24" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.702)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.71)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="18">目标回顾</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <shape width="180" height="74" topLeftX="60" topLeftY="378" alpha="0.8" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="78" topLeftX="60" topLeftY="168" alpha="0.27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="linear-gradient(90deg,rgba(54, 115, 255, 1) 0%,rgba(0, 86, 255, 0.412) 83%,rgba(219, 228, 246, 0) 100%)" italic="true" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <em>
+                <span color="linear-gradient(90deg,rgba(54, 115, 255, 1) 0%,rgba(0, 86, 255, 0.412) 83%,rgba(219, 228, 246, 0) 100%)" fontSize="48">ONE</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="180" topLeftX="280" topLeftY="184" presetHandlers="24" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.702)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.71)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="18">实现策略</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <shape width="180" height="74" topLeftX="280" topLeftY="378" alpha="0.8" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="78" topLeftX="280" topLeftY="168" alpha="0.27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="linear-gradient(90deg,rgba(54, 115, 255, 1) 0%,rgba(0, 86, 255, 0.412) 83%,rgba(219, 228, 246, 0) 100%)" italic="true" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <em>
+                <span color="linear-gradient(90deg,rgba(54, 115, 255, 1) 0%,rgba(0, 86, 255, 0.412) 83%,rgba(219, 228, 246, 0) 100%)" fontSize="48">TWO</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="180" topLeftX="500" topLeftY="184" presetHandlers="24" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.702)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.71)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="18">核心项目</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <shape width="180" height="74" topLeftX="500" topLeftY="378" alpha="0.8" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="78" topLeftX="500" topLeftY="168" alpha="0.27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="linear-gradient(90deg,rgba(54, 115, 255, 1) 0%,rgba(0, 86, 255, 0.412) 83%,rgba(219, 228, 246, 0) 100%)" italic="true" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <em>
+                <span color="linear-gradient(90deg,rgba(54, 115, 255, 1) 0%,rgba(0, 86, 255, 0.412) 83%,rgba(219, 228, 246, 0) 100%)" fontSize="48">THREE</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="180" topLeftX="720" topLeftY="184" presetHandlers="24" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.702)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.71)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="18">数据&amp;结果</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <shape width="180" height="74" topLeftX="720" topLeftY="378" alpha="0.8" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="78" topLeftX="720" topLeftY="168" alpha="0.27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="linear-gradient(90deg,rgba(54, 115, 255, 1) 0%,rgba(0, 86, 255, 0.412) 83%,rgba(219, 228, 246, 0) 100%)" italic="true" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <em>
+                <span color="linear-gradient(90deg,rgba(54, 115, 255, 1) 0%,rgba(0, 86, 255, 0.412) 83%,rgba(219, 228, 246, 0) 100%)" fontSize="48">FOUR</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="535" height="40" topLeftX="213" topLeftY="118" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p lineSpacing="multiple:1.7" letterSpacing="1">
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="777" height="69" topLeftX="92" topLeftY="64" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="36">年度 OKR 回顾</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="RODFb1dufol5tsxbTpNcU9cbnid" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="JPmgbRXaPo46xxx57uDcDjpnnyh" width="780" height="399" topLeftX="90" topLeftY="70">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="60" height="44" topLeftX="133" topLeftY="177" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 1) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">O1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="480" height="44" topLeftX="210" topLeftY="177" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>目标一：年度总销售额达到600万</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="44" topLeftX="133" topLeftY="243" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 1) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">O2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="480" height="44" topLeftX="210" topLeftY="243" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>目标二：年度新用户增长超过30%</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="44" topLeftX="133" topLeftY="308" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 1) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">O3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="480" height="44" topLeftX="210" topLeftY="308" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>目标三：年度市场份额增长超过20%</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="44" topLeftX="133" topLeftY="374" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 1) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">O4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="480" height="44" topLeftX="210" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>目标四：年度用户满意度超过85%</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="460" height="53" topLeftX="250" topLeftY="79" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 0.71)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>团队 2025 年 OKR</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="RODFb1dufol5tsxbTpNcU9cbnid" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="DwazbOHa4oUJ5pxFvA1cLcronmh" width="780" height="192" topLeftX="90" topLeftY="104">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EVJhbkOi4oUA4ixtPTCcAdttnVb" width="119" height="117" topLeftX="163" topLeftY="236">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="NjDxblpZUoLsM5xsbtccJqhOnYb" width="119" height="117" topLeftX="163" topLeftY="288">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="460" height="49" topLeftX="250" topLeftY="114" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 0.71)" fontSize="24">团队 202</span>
+            </strong>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.71)" fontSize="24">5</span>
+            </strong>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.71)" fontSize="24"> 年度 OKR </span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="44" topLeftX="133" topLeftY="207" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 1) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">O1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="480" height="44" topLeftX="210" topLeftY="207" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>目标一：年度总销售额达到XXX万</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="540" height="44" topLeftX="306" topLeftY="331" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">关键结果1：华南区域成功签约X家重点客户，贡献XXX万销售额</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="540" height="44" topLeftX="306" topLeftY="383" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">关键结果2：西北区域启动售卖，拿到X家首批共创客户</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="18" height="18" topLeftX="272" topLeftY="396" type="ellipse">
+        <fill>
+          <fillColor color="rgba(67, 51, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="18" topLeftX="272" topLeftY="344" type="ellipse">
+        <fill>
+          <fillColor color="rgba(67, 51, 255, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Xy4HbnnvOofqqSxJS4Zcs7gJnGc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="583" height="429" topLeftX="377" topLeftY="111" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(54, 115, 255, 0.09) 0%,rgba(212, 227, 255, 0.12) 67%,rgba(255, 255, 255, 0.11) 100%)"/>
+        </fill>
+        <border color="linear-gradient(240deg,rgba(103, 100, 255, 0.22) 0%,rgba(255, 255, 255, 0) 21%,rgba(228, 237, 255, 1) 37%,rgba(202, 219, 251, 1) 79%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(255, 255, 255, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="225" blur="10" color="rgba(20, 79, 219, 0.07)"/>
+      </shape>
+      <shape width="583" height="413" topLeftX="389" topLeftY="122" presetHandlers="10" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(238, 243, 255, 1) 0%,rgba(222, 231, 254, 1) 50%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(202, 219, 251, 1) 100%,rgba(255, 255, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="308" height="56" topLeftX="35" topLeftY="389" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="308" height="44" topLeftX="35" topLeftY="356" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="16">客户成功服务品质提升 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="308" height="56" topLeftX="35" topLeftY="288" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="308" height="44" topLeftX="35" topLeftY="255" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="16">商业化定价改造上线 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="308" height="56" topLeftX="35" topLeftY="192" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="308" height="44" topLeftX="35" topLeftY="159" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="16"> 制造业重点客户共创 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="342" height="74" topLeftX="35" topLeftY="63" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="40">核心项目</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="ETlZbNnuVo9edxxliJ8cqqOInuY" width="637" height="390" topLeftX="331" topLeftY="108">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XFfgb8GIRoIWZzxycb3cXWMLnS8" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="651" height="74" topLeftX="37" topLeftY="34" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">关键结果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="278" height="56" topLeftX="37" topLeftY="108" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="204" height="203" topLeftX="267" topLeftY="239" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 0.9) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(90deg,rgba(0, 86, 255, 1) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="197" height="42" topLeftX="271" topLeftY="313" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">客户成功服务培训</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="152" height="52" topLeftX="293" topLeftY="265" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span fontSize="24">9场</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="189" height="56" topLeftX="275" topLeftY="347" alpha="0.6" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">这里可以输入简单的文案来描述你的关键结果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="204" height="203" topLeftX="37" topLeftY="239" type="ellipse">
+        <fill>
+          <fillColor color="rgba(254, 254, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="19" color="rgba(255, 255, 255, 0.52)"/>
+      </shape>
+      <shape width="197" height="42" topLeftX="41" topLeftY="313" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="16">共创客户</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="152" height="52" topLeftX="63" topLeftY="265" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="24">15 家</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="189" height="56" topLeftX="45" topLeftY="347" alpha="0.6" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)">这里可以输入简单的文案来描述你的关键结果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="204" height="203" topLeftX="497" topLeftY="239" type="ellipse">
+        <fill>
+          <fillColor color="rgba(254, 254, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="19" color="rgba(255, 255, 255, 0.52)"/>
+      </shape>
+      <shape width="197" height="38" topLeftX="501" topLeftY="313" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="16">市场占有率超过60%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="152" height="52" topLeftX="523" topLeftY="265" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="24">23 个城市</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="189" height="56" topLeftX="505" topLeftY="347" alpha="0.6" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)">这里可以输入简单的文案来描述你的关键结果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="204" height="203" topLeftX="727" topLeftY="239" type="ellipse">
+        <fill>
+          <fillColor color="rgba(254, 254, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="19" color="rgba(255, 255, 255, 0.52)"/>
+      </shape>
+      <shape width="197" height="40" topLeftX="731" topLeftY="313" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="16">新客户来自老客户推荐</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="152" height="52" topLeftX="753" topLeftY="265" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="24">80%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="189" height="56" topLeftX="735" topLeftY="347" alpha="0.6" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)">这里可以输入简单的文案来描述你的关键结果</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XFfgb8GIRoIWZzxycb3cXWMLnS8" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="651" height="74" topLeftX="37" topLeftY="34" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">关键结果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="359" height="134" topLeftX="37" topLeftY="108" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">核心数据可以涵盖各个方面，包括销售额、利润率、市场份额、客户满意度等。它们为决策者提供了洞察力，帮助他们了解业务的健康状况、趋势和问题所在。</span>
+          </p>
+          <p/>
+          <p>
+            <span color="rgba(31, 35, 41, 1)">通过对核心数据的分析，组织能够制定战略、优化资源配置、改进业务流程，并迅速做出应对市场变化的决策。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="268" height="267" topLeftX="396" topLeftY="224" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 0.9) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(90deg,rgba(0, 86, 255, 1) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="229" height="85" topLeftX="416" topLeftY="305" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <span fontSize="54"> 660万</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="248" height="33" topLeftX="406" topLeftY="374" alpha="0.6" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)">销售额</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="204" height="203" topLeftX="683" topLeftY="211" type="ellipse">
+        <fill>
+          <fillColor color="rgba(254, 254, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="19" color="rgba(255, 255, 255, 0.52)"/>
+      </shape>
+      <shape width="152" height="70" topLeftX="709" topLeftY="263" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="42">↑40%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="189" height="34" topLeftX="691" topLeftY="321" alpha="0.6" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(54, 53, 88, 1)">市场份额</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="171" height="170" topLeftX="562" topLeftY="59" type="ellipse">
+        <fill>
+          <fillColor color="rgba(254, 254, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="19" color="rgba(255, 255, 255, 0.52)"/>
+      </shape>
+      <shape width="127" height="70" topLeftX="583" topLeftY="95" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(54, 53, 88, 1)" fontSize="42">90%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="159" height="34" topLeftX="569" topLeftY="151" alpha="0.6" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(54, 53, 88, 1)">用户满意度</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="RODFb1dufol5tsxbTpNcU9cbnid" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="HVuBbmbytoOcNixScvUcmj0Unhf" width="480" height="498" topLeftX="480" topLeftY="42" alpha="0.17">
+        <crop type="rect" leftOffset="0" rightOffset="35" topOffset="0" bottomOffset="15"/>
+      </img>
+      <shape width="493" height="44" topLeftX="126" topLeftY="275" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(51, 112, 255, 1)">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(51, 112, 255, 1)" fontSize="16">对齐新一年的目标和策略</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="627" height="85" topLeftX="126" topLeftY="187" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="54">202</span>
+            </strong>
+            <strong>
+              <span fontSize="54">6</span>
+            </strong>
+            <strong>
+              <span fontSize="54"> 年规划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="112" height="93" topLeftX="33" topLeftY="187" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(51, 112, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>03</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(124deg,rgba(155, 177, 255, 1) 0%,rgba(210, 199, 255, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="132" height="44" topLeftX="513" topLeftY="930" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" autoFit="shape-auto-fit" wrap="false"/>
+      </shape>
+      <shape width="320" height="320" topLeftX="518" topLeftY="107" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="347" height="136" topLeftX="37" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p lineSpacing="multiple:1.7" letterSpacing="1">
+            <span fontSize="12">策略分析是一种评估和解析组织或个人在达成目标时采取的行动计划的过程。它涉及对内外部环境的综合分析，以确定适合当前情况和目标的最佳行动方案。</span>
+          </p>
+          <p/>
+          <p>
+            <span fontSize="12">策略分析的目的是帮助决策者更好地了解组织或个人所面临的挑战和机遇，并制定可行的策略来应对这些情况</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="347" height="64" topLeftX="37" topLeftY="263" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="36">我们的策略</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="265" height="265" topLeftX="546" topLeftY="135" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="24" height="18" topLeftX="668" topLeftY="98" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.71)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="24" height="18" topLeftX="806" topLeftY="336" rotation="210" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.71)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="24" height="18" topLeftX="527" topLeftY="335" rotation="330" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.71)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="231" height="44" topLeftX="563" topLeftY="245" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">公司使命、愿景和价值观</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="130" topLeftX="480" topLeftY="112" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="linear-gradient(90deg,rgba(0, 86, 255, 0.902) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)" bold="true">
+          <p>
+            <strong>
+              <span color="linear-gradient(90deg,rgba(0, 86, 255, 0.902) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)">业务目标与战略</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="130" topLeftX="750" topLeftY="112" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="linear-gradient(90deg,rgba(0, 86, 255, 0.902) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)" bold="true">
+          <p>
+            <strong>
+              <span color="linear-gradient(90deg,rgba(0, 86, 255, 0.902) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)">行业趋势</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="130" topLeftX="613" topLeftY="359" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="linear-gradient(90deg,rgba(0, 86, 255, 0.902) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)" bold="true">
+          <p>
+            <span color="linear-gradient(90deg,rgba(0, 86, 255, 0.902) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)">用户需求</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XFfgb8GIRoIWZzxycb3cXWMLnS8" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="180" height="180" topLeftX="69" topLeftY="169" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 0.902) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">OKR</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="HH7rbztBUoBX4SxqQFJc015FnHh" width="217" height="452" topLeftX="253" topLeftY="33">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="21" presetHandlers="0"/>
+      </img>
+      <shape width="408" height="71" topLeftX="439" topLeftY="82" presetHandlers="67" type="round-rect">
+        <fill>
+          <fillColor color="rgba(254, 254, 255, 0.702)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.71)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <strong>
+              <em>
+                <span fontSize="16">目标一：年度总销售额突破 1000万</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.05)"/>
+      </shape>
+      <shape width="64" height="64" topLeftX="406" topLeftY="86" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 0.9) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="408" height="71" topLeftX="439" topLeftY="180" presetHandlers="67" type="round-rect">
+        <fill>
+          <fillColor color="rgba(254, 254, 255, 0.702)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.71)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <strong>
+              <em>
+                <span fontSize="16">目标二：新产品X上线，市场占有率达到 20%</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.05)"/>
+      </shape>
+      <shape width="64" height="64" topLeftX="406" topLeftY="183" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 0.9) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="408" height="71" topLeftX="439" topLeftY="277" presetHandlers="67" type="round-rect">
+        <fill>
+          <fillColor color="rgba(254, 254, 255, 0.702)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.71)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <strong>
+              <em>
+                <span fontSize="16">目标三：年度用户满意度达到 90%</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.05)"/>
+      </shape>
+      <shape width="64" height="64" topLeftX="406" topLeftY="281" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 0.9) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="408" height="71" topLeftX="439" topLeftY="375" presetHandlers="67" type="round-rect">
+        <fill>
+          <fillColor color="rgba(254, 254, 255, 0.702)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.71)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <strong>
+              <em>
+                <span fontSize="16">目标四：客户复购率达到 80%</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.05)"/>
+      </shape>
+      <shape width="64" height="64" topLeftX="406" topLeftY="379" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 0.9) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="RODFb1dufol5tsxbTpNcU9cbnid" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KOHQb0T3Kouv6NxX3lycHwvrnLd" width="442" height="494" topLeftX="518" topLeftY="46">
+        <crop type="rect" leftOffset="0" rightOffset="52" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="493" height="44" topLeftX="126" topLeftY="275" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(51, 112, 255, 1)">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(51, 112, 255, 1)" fontSize="16">当面解答公司内部高频问题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="627" height="93" topLeftX="126" topLeftY="187" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="54">Q&amp;A</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="112" height="93" topLeftX="33" topLeftY="187" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(51, 112, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>04</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="AkfFbXJtZoBnSpx4bZecGd3Pnxe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="F4uob6k5aoLElPx01GdcxiB2nwg" width="72" height="72" topLeftX="763" topLeftY="428">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="788" height="398" topLeftX="86" topLeftY="71" presetHandlers="24" alpha="0.76" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.71)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <img src="Il4nb9FTAoWv0VxZaxNcafghnWg" width="112" height="112" topLeftX="39" topLeftY="112">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="348" height="56" topLeftX="306" topLeftY="153" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(54, 53, 88, 1)" textAlign="center">
+          <p>
+            <span color="rgba(54, 53, 88, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="672" height="74" topLeftX="144" topLeftY="86" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>Q&amp;A</p>
+        </content>
+      </shape>
+      <shape width="60" height="44" topLeftX="201" topLeftY="219" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 1) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">Q1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="502" height="44" topLeftX="278" topLeftY="219" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>2026年公司重点投入的方向是什么？</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="44" topLeftX="201" topLeftY="287" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 1) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">Q2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="503" height="44" topLeftX="278" topLeftY="287" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>AI发展是否会影响到公司的招聘策略，对一线的员工有哪些影响？</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="44" topLeftX="201" topLeftY="355" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 86, 255, 1) 0%,rgba(110, 124, 249, 1) 100%,rgba(163, 172, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">Q3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="503" height="44" topLeftX="278" topLeftY="355" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>问题3...</strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="RODFb1dufol5tsxbTpNcU9cbnid" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="341" height="379" topLeftX="511" topLeftY="73" presetHandlers="18" alpha="0.76" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0.78) 0%,rgba(255, 255, 255, 0.23) 19%,rgba(255, 255, 255, 0.63) 71%,rgba(255, 255, 255, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(124deg,rgba(103, 149, 255, 1) 0%,rgba(208, 164, 255, 1) 100%)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(24, 25, 59, 0.06)"/>
+      </shape>
+      <shape width="324" height="52" topLeftX="519" topLeftY="391" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)">满意度问卷</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="UizCbqwb9oqwLBxwQLPcziHxnKg" width="293" height="293" topLeftX="537" topLeftY="95">
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.05)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="16"/>
+      </img>
+      <shape width="288" height="44" topLeftX="71" topLeftY="394" alpha="0.6" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(54, 53, 88, 1)" textAlign="left">
+          <p>感谢您的参与</p>
+        </content>
+      </shape>
+      <shape width="409" height="133" topLeftX="67" topLeftY="279" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <strong>
+              <span fontSize="80">全员大会</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="229" height="69" topLeftX="71" topLeftY="235" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(54, 53, 88, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="36">202</span>
+            </strong>
+            <strong>
+              <span fontSize="36">6</span>
+            </strong>
+            <strong>
+              <span fontSize="36"> </span>
+            </strong>
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="36">Q</span>
+            </strong>
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="36">1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/administration--annual_gala.xml
+++ b/skills/lark-slides/references/templates/administration--annual_gala.xml
@@ -1,0 +1,1160 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>企业年会</title>
+  <theme>
+    <background>
+      <fillColor color="rgba(16, 15, 21, 1)"/>
+    </background>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="48"/>
+      <headline fontColor="#000000FF" fontSize="64"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="L8ckbEaLKotNZKxD2pkcf22EnO2" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="154" height="34" topLeftX="66" topLeftY="30" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="28" height="28" topLeftX="42" topLeftY="33" iconType="iconpark/Edit/radio-two.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="596" height="84" topLeftX="182" topLeftY="226" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" bold="true" lineSpacing="multiple:1.4">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="64">202</span>
+            </strong>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="64">6</span>
+            </strong>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="64"> 年会盛典</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content>
+        <p/>
+      </content>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XwK1bInndo6rbMxomq3cF40nnwc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="52" topLeftX="548" topLeftY="374" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">0</span>
+            </strong>
+            <strong>
+              <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">5</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="52" topLeftX="548" topLeftY="312" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">0</span>
+            </strong>
+            <strong>
+              <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="52" topLeftX="548" topLeftY="250" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">0</span>
+            </strong>
+            <strong>
+              <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="52" topLeftX="548" topLeftY="188" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">0</span>
+            </strong>
+            <strong>
+              <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="52" topLeftX="548" topLeftY="126" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="320" height="56" topLeftX="632" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">抽奖活动</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="320" height="56" topLeftX="632" topLeftY="312" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">新年展望</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="320" height="56" topLeftX="632" topLeftY="250" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">文艺演出</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="320" height="56" topLeftX="632" topLeftY="188" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">颁奖表彰</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="320" height="56" topLeftX="632" topLeftY="126" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">年度回顾</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="266" height="74" topLeftX="187" topLeftY="126" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="40">流程安排</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="266" height="44" topLeftX="187" topLeftY="183" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">OVERVIEW</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="YkPmbd8GyopGcDxWwVXchKsunSb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="3" height="136" topLeftX="56" topLeftY="315" presetHandlers="6" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="429" height="107" topLeftX="68" topLeftY="329" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="64">年度回顾</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="C6QobydO6ouO22xwxgEcgHz1njg" width="181" height="458" topLeftX="647" topLeftY="82">
+        <crop type="rect" leftOffset="42" rightOffset="42" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="425" height="56" topLeftX="73" topLeftY="416" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">YEAR IN REVIEW</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(16, 15, 21, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <icon width="257" height="257" topLeftX="57" topLeftY="112" alpha="0.15" iconType="iconpark/Base/loading-four.svg">
+        <border color="linear-gradient(38deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 25%,rgba(255, 255, 255, 0) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="257" height="257" topLeftX="349" topLeftY="113" rotation="270" alpha="0.15" iconType="iconpark/Base/loading-four.svg">
+        <border color="linear-gradient(14deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 18%,rgba(255, 255, 255, 0) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="257" height="257" topLeftX="641" topLeftY="112" rotation="90" alpha="0.15" iconType="iconpark/Base/loading-four.svg">
+        <border color="linear-gradient(38deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 32%,rgba(255, 255, 255, 0) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="200" height="92" topLeftX="89" topLeftY="369" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="92" topLeftX="381" topLeftY="369" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="92" topLeftX="673" topLeftY="369" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="JYsIbXjMgocyTMxMaoDcgxfDn7Z" width="194" height="194" topLeftX="89" topLeftY="144">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="187" height="187" topLeftX="92" topLeftY="148" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <icon width="60" height="60" topLeftX="156" topLeftY="202" iconType="iconpark/Abstract/hexagon-strip.svg">
+        <border color="linear-gradient(90deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="MNkVbr9sioyZ7gxDkrUcH5wxnOh" width="194" height="194" topLeftX="381" topLeftY="144">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="187" height="187" topLeftX="384" topLeftY="148" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <icon width="70" height="70" topLeftX="442" topLeftY="196" iconType="iconpark/Travel/mountain.svg">
+        <border color="linear-gradient(90deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" width="5" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="Kgjrb2pivobxibx3DFYcWSqvnNd" width="194" height="194" topLeftX="673" topLeftY="144">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="187" height="187" topLeftX="676" topLeftY="148" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <icon width="60" height="60" topLeftX="740" topLeftY="202" iconType="iconpark/Abstract/nine-points-connected.svg">
+        <border color="linear-gradient(90deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="189" height="42" topLeftX="89" topLeftY="270" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">创新</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="198" height="42" topLeftX="381" topLeftY="270" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">超越</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="189" height="42" topLeftX="673" topLeftY="270" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">引领</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="45" topLeftX="278" topLeftY="74" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18" bold="false">KEY WORDS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="45" topLeftX="278" topLeftY="42" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">年度关键词</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="YkPmbd8GyopGcDxWwVXchKsunSb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="3" height="136" topLeftX="56" topLeftY="315" presetHandlers="6" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)"/>
+        </fill>
+      </shape>
+      <img src="IiA9beJwtoQAS4xEscJc5IiRnyc" width="320" height="459" topLeftX="597" topLeftY="81">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="429" height="107" topLeftX="68" topLeftY="329" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="64">表彰颁奖</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="425" height="56" topLeftX="73" topLeftY="416" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">AWARDS CEREMONY</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XwK1bInndo6rbMxomq3cF40nnwc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="266" height="74" topLeftX="187" topLeftY="126" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>最佳团队</p>
+        </content>
+      </shape>
+      <shape width="266" height="44" topLeftX="187" topLeftY="183" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">BEST TEAMS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="479" height="105" topLeftX="480" topLeftY="68" type="slides-full-round-rect">
+        <border color="linear-gradient(90deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 0.2) 67%,rgba(69, 96, 245, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="306" height="56" topLeftX="595" topLeftY="112" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="306" height="52" topLeftX="595" topLeftY="75" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" bold="false">团队 #1</span>
+          </p>
+        </content>
+      </shape>
+      <img src="T8A2bfoFTooWJ0xkR0VcmeJlnRd" width="90" height="90" topLeftX="488" topLeftY="75">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <icon width="48" height="48" topLeftX="509" topLeftY="96" iconType="iconpark/Travel/enquire.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="479" height="105" topLeftX="480" topLeftY="368" type="slides-full-round-rect">
+        <border color="linear-gradient(90deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 0.2) 67%,rgba(69, 96, 245, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="306" height="56" topLeftX="595" topLeftY="412" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="306" height="52" topLeftX="595" topLeftY="375" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" bold="false">团队 #3</span>
+          </p>
+        </content>
+      </shape>
+      <img src="T8A2bfoFTooWJ0xkR0VcmeJlnRd" width="90" height="90" topLeftX="488" topLeftY="375">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <icon width="48" height="48" topLeftX="509" topLeftY="396" iconType="iconpark/Edit/application-two.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="479" height="105" topLeftX="480" topLeftY="218" type="slides-full-round-rect">
+        <border color="linear-gradient(90deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 0.2) 67%,rgba(69, 96, 245, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="306" height="56" topLeftX="595" topLeftY="262" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="306" height="52" topLeftX="595" topLeftY="225" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" bold="false">团队 #2</span>
+          </p>
+        </content>
+      </shape>
+      <img src="T8A2bfoFTooWJ0xkR0VcmeJlnRd" width="90" height="90" topLeftX="488" topLeftY="225">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <icon width="48" height="48" topLeftX="509" topLeftY="246" iconType="iconpark/Music/ppt.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(16, 15, 21, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="517" height="232" topLeftX="-47" topLeftY="283" rotation="90" type="slides-full-round-rect">
+        <border color="linear-gradient(90deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 0.2) 67%,rgba(69, 96, 245, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="164" height="110" topLeftX="135" topLeftY="405" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+          <p/>
+        </content>
+      </shape>
+      <img src="JA1tbQ10Vo3R8kxModMc1y3Hn5x" width="195" height="195" topLeftX="114" topLeftY="163">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="188" height="188" topLeftX="117" topLeftY="166" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="42" topLeftX="114" topLeftY="377" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">员工 #1</span>
+          </p>
+        </content>
+      </shape>
+      <img src="RzNlbzUFJoiXoBxbEDnc0K4ZnKg" width="175" height="175" topLeftX="124" topLeftY="173">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="337"/>
+      </img>
+      <shape width="517" height="232" topLeftX="221" topLeftY="283" rotation="90" type="slides-full-round-rect">
+        <border color="linear-gradient(90deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 0.2) 67%,rgba(69, 96, 245, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="164" height="110" topLeftX="403" topLeftY="405" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+          <p/>
+        </content>
+      </shape>
+      <img src="JA1tbQ10Vo3R8kxModMc1y3Hn5x" width="195" height="195" topLeftX="383" topLeftY="163">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="188" height="188" topLeftX="386" topLeftY="166" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="42" topLeftX="383" topLeftY="377" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">员工 #1</span>
+          </p>
+        </content>
+      </shape>
+      <img src="SCqwbWqaSoqnq4xivnLc055Wn0y" width="175" height="175" topLeftX="393" topLeftY="173">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="337"/>
+      </img>
+      <shape width="517" height="232" topLeftX="490" topLeftY="283" rotation="90" type="slides-full-round-rect">
+        <border color="linear-gradient(90deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 0.2) 67%,rgba(69, 96, 245, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="164" height="110" topLeftX="672" topLeftY="405" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+          <p/>
+        </content>
+      </shape>
+      <img src="JA1tbQ10Vo3R8kxModMc1y3Hn5x" width="195" height="195" topLeftX="651" topLeftY="163">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="188" height="188" topLeftX="655" topLeftY="166" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="42" topLeftX="651" topLeftY="377" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">员工 #1</span>
+          </p>
+        </content>
+      </shape>
+      <img src="VS2SbZ084o07LHxe2m4c2ko4nSe" width="175" height="175" topLeftX="661" topLeftY="173">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="337"/>
+      </img>
+      <shape width="404" height="45" topLeftX="278" topLeftY="74" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18" bold="false">BEST EMPLOYEE</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="45" topLeftX="278" topLeftY="42" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">最佳个人</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="YkPmbd8GyopGcDxWwVXchKsunSb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="3" height="136" topLeftX="56" topLeftY="315" presetHandlers="6" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)"/>
+        </fill>
+      </shape>
+      <img src="MuJkbzXdRo2gHuxkL50cWaOLn70" width="320" height="459" topLeftX="578" topLeftY="81">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="429" height="107" topLeftX="68" topLeftY="329" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="64">文艺演出</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="425" height="56" topLeftX="73" topLeftY="416" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">SHOW</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(16, 15, 21, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="334" topLeftX="133" topLeftY="140" presetHandlers="24" type="round-rect">
+        <border color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="328" height="334" topLeftX="499" topLeftY="140" presetHandlers="24" type="round-rect">
+        <border color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="150" height="56" topLeftX="155" topLeftY="400" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="150" height="44" topLeftX="155" topLeftY="364" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">节目活动 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="150" height="56" topLeftX="520" topLeftY="400" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="150" height="44" topLeftX="520" topLeftY="364" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">节目活动 #2</span>
+          </p>
+        </content>
+      </shape>
+      <img src="DnbNb14XhoI86Fx1cczcZtY0n1b" width="300" height="192" topLeftX="512" topLeftY="155">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="9" bottomOffset="99" presetHandlers="16"/>
+      </img>
+      <img src="RgX8bS9gsohIo4xs1ZHcRomyn9d" width="300" height="192" topLeftX="147" topLeftY="155">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="44" bottomOffset="64" presetHandlers="16"/>
+      </img>
+      <shape width="404" height="45" topLeftX="278" topLeftY="74" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18" bold="false">INTERACTIVE PROGRAMS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="45" topLeftX="278" topLeftY="42" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">互动节目</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(16, 15, 21, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="784" height="294" topLeftX="87" topLeftY="123" type="slides-full-round-rect">
+        <border color="linear-gradient(90deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="GjCvbfhIDo6w6bxsWL9csjWHn9e" width="275" height="275" topLeftX="98" topLeftY="132">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="HatbbDWDgozqYoxgr0ncX3uynMd" width="239" height="239" topLeftX="116" topLeftY="151">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="231" height="231" topLeftX="120" topLeftY="155" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <img src="CN4VbSqLAoepGzxbPy6chmOYn5b" width="210" height="210" topLeftX="131" topLeftY="165">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="105"/>
+      </img>
+      <shape width="373" height="85" topLeftX="439" topLeftY="217" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="48">节目名称</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="275" height="44" topLeftX="440" topLeftY="287" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">表演者: 马克，李天</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="YkPmbd8GyopGcDxWwVXchKsunSb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="3" height="136" topLeftX="56" topLeftY="315" presetHandlers="6" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)"/>
+        </fill>
+      </shape>
+      <img src="I2j9bmjJmoJ7uQxywXYcn9tznqe" width="320" height="459" topLeftX="578" topLeftY="81">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="429" height="107" topLeftX="68" topLeftY="329" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="64">新年展望</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="425" height="56" topLeftX="73" topLeftY="416" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">NEW YEAR EXPECTATIONS</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(16, 15, 21, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <icon width="257" height="257" topLeftX="57" topLeftY="112" alpha="0.15" iconType="iconpark/Base/loading-four.svg">
+        <border color="linear-gradient(38deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 25%,rgba(255, 255, 255, 0) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="257" height="257" topLeftX="349" topLeftY="113" rotation="270" alpha="0.15" iconType="iconpark/Base/loading-four.svg">
+        <border color="linear-gradient(14deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 18%,rgba(255, 255, 255, 0) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="257" height="257" topLeftX="641" topLeftY="112" rotation="90" alpha="0.15" iconType="iconpark/Base/loading-four.svg">
+        <border color="linear-gradient(38deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 32%,rgba(255, 255, 255, 0) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="200" height="92" topLeftX="89" topLeftY="399" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="92" topLeftX="381" topLeftY="399" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="92" topLeftX="673" topLeftY="399" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="JYsIbXjMgocyTMxMaoDcgxfDn7Z" width="194" height="194" topLeftX="89" topLeftY="144">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="187" height="187" topLeftX="92" topLeftY="148" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <img src="MNkVbr9sioyZ7gxDkrUcH5wxnOh" width="194" height="194" topLeftX="381" topLeftY="144">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="187" height="187" topLeftX="384" topLeftY="148" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <img src="Kgjrb2pivobxibx3DFYcWSqvnNd" width="194" height="194" topLeftX="673" topLeftY="144">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="187" height="187" topLeftX="676" topLeftY="148" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <img src="VsVBbQ9LzoHpwixzsaCcdUQAnfh" width="172" height="172" topLeftX="99" topLeftY="155">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="337"/>
+      </img>
+      <img src="TAR9bFyA1ob8ytxpyQac2inln6g" width="172" height="172" topLeftX="392" topLeftY="155">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="337"/>
+      </img>
+      <img src="Jn8ibSLhqoK6GqxZzcUcIlfSnVg" width="172" height="172" topLeftX="684" topLeftY="155">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="337"/>
+      </img>
+      <shape width="150" height="44" topLeftX="110" topLeftY="362" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">目标 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="150" height="44" topLeftX="405" topLeftY="362" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">目标 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="150" height="44" topLeftX="698" topLeftY="362" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">目标 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="45" topLeftX="278" topLeftY="74" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18" bold="false">OBJECTIVE</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="45" topLeftX="278" topLeftY="42" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">发展目标</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XwK1bInndo6rbMxomq3cF40nnwc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="266" height="74" topLeftX="187" topLeftY="126" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="40">技术创新</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="266" height="78" topLeftX="187" topLeftY="183" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">TECHNOLOGY INNOVATION</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="292" height="56" topLeftX="468" topLeftY="107" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="292" height="52" topLeftX="469" topLeftY="69" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" bold="false">创新方向 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="52" topLeftX="417" topLeftY="69" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="292" height="56" topLeftX="557" topLeftY="252" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="292" height="52" topLeftX="558" topLeftY="214" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" bold="false">创新方向 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="52" topLeftX="505" topLeftY="214" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="292" height="56" topLeftX="640" topLeftY="397" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="292" height="52" topLeftX="642" topLeftY="359" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" bold="false">创新方向 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="52" topLeftX="589" topLeftY="359" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="linear-gradient(330deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)" fontSize="24">03</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="YkPmbd8GyopGcDxWwVXchKsunSb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="3" height="136" topLeftX="56" topLeftY="315" presetHandlers="6" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 1) 67%,rgba(69, 96, 245, 1) 100%)"/>
+        </fill>
+      </shape>
+      <img src="KzMYb7avko43Yfx9x0xcNiW2nrb" width="320" height="459" topLeftX="578" topLeftY="81">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="429" height="107" topLeftX="68" topLeftY="329" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="64">抽奖活动</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="425" height="56" topLeftX="73" topLeftY="416" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">LUCKY DRAW</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DNRebAhjeoGRz5xqm2pc3Z1cnbg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <icon width="342" height="342" topLeftX="225" topLeftY="99" alpha="0.15" iconType="iconpark/Base/loading-four.svg">
+        <border color="linear-gradient(38deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 25%,rgba(255, 255, 255, 0) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="UgaYbXXJporI7xxUgpmcKqgLnze" width="245" height="245" topLeftX="272" topLeftY="148">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="NvtGbX1pco51LOxQwe1csYyHnGc" width="188" height="188" topLeftX="302" topLeftY="176">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="181" height="181" topLeftX="305" topLeftY="179" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <icon width="96" height="96" topLeftX="348" topLeftY="222" iconType="iconpark/Hardware/iphone.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="Wk3lbdbUGoIbB0xRy2scahdunre" width="90" height="90" topLeftX="643" topLeftY="353">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="87" height="87" topLeftX="645" topLeftY="355" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <icon width="48" height="48" topLeftX="664" topLeftY="374" iconType="iconpark/Hardware/new-computer.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="S0DWbxXSaoC8BQxaHaCcGskbnYb" width="90" height="90" topLeftX="643" topLeftY="225">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="87" height="87" topLeftX="645" topLeftY="226" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <icon width="48" height="48" topLeftX="664" topLeftY="246" iconType="iconpark/Game/nintendo-switch.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="G7dgb5XNbowIDfxxG89c5Enrnub" width="90" height="90" topLeftX="643" topLeftY="97">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="87" height="87" topLeftX="645" topLeftY="98" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 15, 21, 1)"/>
+        </fill>
+      </shape>
+      <icon width="48" height="48" topLeftX="664" topLeftY="118" iconType="iconpark/Travel/coconut-tree.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="160" height="56" topLeftX="743" topLeftY="134" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="44" topLeftX="743" topLeftY="98" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">奖项 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="56" topLeftX="743" topLeftY="261" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="44" topLeftX="743" topLeftY="225" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">奖项 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="56" topLeftX="743" topLeftY="390" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="44" topLeftX="743" topLeftY="353" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">奖项 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="56" topLeftX="369" topLeftY="426" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="44" topLeftX="209" topLeftY="427" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">特等奖项 </span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="53" topLeftX="42" topLeftY="136" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" bold="false">AWARDS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="190" height="74" topLeftX="42" topLeftY="79" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="40">奖项设置</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="L8ckbEaLKotNZKxD2pkcf22EnO2" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="154" height="34" topLeftX="66" topLeftY="30" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="28" height="28" topLeftX="42" topLeftY="33" iconType="iconpark/Edit/radio-two.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="404" height="53" topLeftX="278" topLeftY="179" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" bold="false">THANK YOU</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="589" height="84" topLeftX="185" topLeftY="219" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4" textAlign="center">
+          <p lineSpacing="multiple:1">感谢参与</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content>
+        <p/>
+      </content>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/administration--company_intro.xml
+++ b/skills/lark-slides/references/templates/administration--company_intro.xml
@@ -1,0 +1,1376 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>企业介绍</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="48"/>
+      <headline fontColor="#000000FF" fontSize="32"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="PRKebXdploaWlnxYHvEc5dzVnnb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Fy3PbjuDQozqAbxxxpxcAQOJn1U" width="241" height="87" topLeftX="515" topLeftY="453" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="28"/>
+      </img>
+      <img src="ChirbbFEtoEhfVxxkh1cdYqknbf" width="191" height="115" topLeftX="0" topLeftY="107" alpha="0.1">
+        <crop type="rect" leftOffset="49" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="158" height="158" topLeftX="229" topLeftY="168" type="donut">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+      </shape>
+      <shape width="416" height="110" topLeftX="323" topLeftY="214" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <strong>
+              <span fontSize="64">企业介绍模板</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="47" topLeftX="327" topLeftY="305" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p>
+            <span fontSize="18">Enterprise promotion</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="495" height="111" topLeftX="323" topLeftY="214" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" fontFamily="undefined" color="rgba(31, 35, 41, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" lineSpacing="multiple:1.4" list="none" listStyle="circle-hollow-square" textAlign="left" autoFit="shape-auto-fit"/>
+      </shape>
+      <shape width="72" height="38" topLeftX="64" topLeftY="24" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="18">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="20" height="20" topLeftX="44" topLeftY="33" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="20" topLeftX="30" topLeftY="33" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content>
+        <p/>
+      </content>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="UkEdbK1VEouPnpx1Q6BcQ8RFnL9" width="242" height="87" topLeftX="545" topLeftY="453" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="28"/>
+      </img>
+      <img src="SZhjbOWc5owSd6xKTauctJBMnRb" width="159" height="159" topLeftX="0" topLeftY="381" rotation="180">
+        <crop type="rect" leftOffset="0.07" rightOffset="159" topOffset="159" bottomOffset="0"/>
+      </img>
+      <shape width="320" height="58" topLeftX="112" topLeftY="186" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="24">企业介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="107" height="104" topLeftX="121" topLeftY="136" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <span fontSize="60">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="320" height="58" topLeftX="495" topLeftY="186" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="24">文化与荣耀</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="107" height="104" topLeftX="503" topLeftY="136" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <span fontSize="60">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="320" height="58" topLeftX="112" topLeftY="310" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="24">产品服务</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="107" height="104" topLeftX="121" topLeftY="261" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <span fontSize="60">03</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="320" height="58" topLeftX="495" topLeftY="310" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="24">行业场景</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="107" height="104" topLeftX="503" topLeftY="261" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <span fontSize="60">04</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="440" height="64" topLeftX="185" topLeftY="49" alpha="0.5" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span fontSize="32" bold="false">CONTENTS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="91" height="64" topLeftX="112" topLeftY="49" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">目录</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="280" height="136" topLeftX="158" topLeftY="202" rotation="90" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+      </shape>
+      <img src="TrZJbtv5ZoHd73x4QIScqpBbntf" width="160" height="160" topLeftX="0" topLeftY="0" rotation="270">
+        <crop type="rect" leftOffset="0.08" rightOffset="160" topOffset="160" bottomOffset="0"/>
+      </img>
+      <img src="CQL6b6AkQoUjYyxcCNTcwESPnYe" width="193" height="116" topLeftX="0" topLeftY="295" alpha="0.1">
+        <crop type="rect" leftOffset="50" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="SOFfbWd8Mo1lwuxxEJOcD4f7ngb" width="411" height="205" topLeftX="652" topLeftY="192" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="205" bottomOffset="0"/>
+      </img>
+      <shape width="136" height="132" topLeftX="229" topLeftY="260" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4" textAlign="center">
+          <p>01</p>
+        </content>
+      </shape>
+      <shape width="302" height="74" topLeftX="403" topLeftY="260" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="45" topLeftX="403" topLeftY="215" alpha="0.5" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="false" lineSpacing="multiple:1.35">
+          <p>Enterprise introduction</p>
+        </content>
+      </shape>
+      <shape width="515" height="74" topLeftX="403" topLeftY="160" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="40">企业介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="HgmJb3yJuoPwhJxuUUnc3Vrxnxe" width="159" height="159" topLeftX="0" topLeftY="381" rotation="180">
+        <crop type="rect" leftOffset="0" rightOffset="159" topOffset="159" bottomOffset="0"/>
+      </img>
+      <img src="Xj50bmPHuoYxROxoDoLckOtFnmi" width="252" height="79" topLeftX="533" topLeftY="0" rotation="180" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="42"/>
+      </img>
+      <shape width="372" height="44" topLeftX="67" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">ENTERPRISE INTRODU</span>
+            <span fontSize="16">C</span>
+            <span fontSize="16">TION</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="64" topLeftX="67" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">企业介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="119" height="297" topLeftX="70" topLeftY="163" presetHandlers="120" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="89" height="89" topLeftX="86" topLeftY="356" iconType="iconpark/Game/handle-round.svg">
+        <border color="rgba(255, 255, 255, 1)" width="7" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="XdB6bKBbGoQaAdxa1OZc0tBLnBc" width="278" height="298" topLeftX="202" topLeftY="162" exposure="-5" contrast="12" saturation="-16">
+        <crop type="rect" leftOffset="10" rightOffset="10" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+      </img>
+      <shape width="278" height="44" topLeftX="533" topLeftY="206" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 196, 25, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 196, 25, 1)" fontSize="16">企业定位</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="74" topLeftX="533" topLeftY="236" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="278" height="44" topLeftX="533" topLeftY="316" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 196, 25, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 196, 25, 1)" fontSize="16">企业</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="74" topLeftX="533" topLeftY="346" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="HgmJb3yJuoPwhJxuUUnc3Vrxnxe" width="159" height="159" topLeftX="0" topLeftY="0" rotation="270">
+        <crop type="rect" leftOffset="0" rightOffset="159" topOffset="159" bottomOffset="0"/>
+      </img>
+      <img src="Xj50bmPHuoYxROxoDoLckOtFnmi" width="252" height="79" topLeftX="533" topLeftY="0" rotation="180" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="42"/>
+      </img>
+      <shape width="372" height="44" topLeftX="67" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">ENTERPRISE INTRODU</span>
+            <span fontSize="16">C</span>
+            <span fontSize="16">TION</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="64" topLeftX="67" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">企业介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="120" topLeftX="108" topLeftY="177" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+      </shape>
+      <icon width="60" height="60" topLeftX="138" topLeftY="207" iconType="iconpark/Travel/local.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="120" height="120" topLeftX="317" topLeftY="177" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+      </shape>
+      <icon width="64" height="64" topLeftX="345" topLeftY="205" iconType="iconpark/Travel/mountain.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="120" height="120" topLeftX="526" topLeftY="177" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+      </shape>
+      <icon width="60" height="60" topLeftX="556" topLeftY="207" iconType="iconpark/Office/announcement.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="120" height="120" topLeftX="736" topLeftY="177" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+      </shape>
+      <icon width="64" height="64" topLeftX="763" topLeftY="205" iconType="iconpark/Travel/planet.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="190" height="92" topLeftX="73" topLeftY="352" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="190" height="44" topLeftX="73" topLeftY="310" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 196, 25, 1)" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 196, 25, 1)" fontSize="16">企业定位</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="190" height="92" topLeftX="282" topLeftY="352" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="190" height="44" topLeftX="282" topLeftY="310" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 196, 25, 1)" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 196, 25, 1)" fontSize="16">企业使命</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="190" height="92" topLeftX="491" topLeftY="352" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="190" height="44" topLeftX="491" topLeftY="310" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 196, 25, 1)" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 196, 25, 1)" fontSize="16">企业宗旨</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="190" height="92" topLeftX="701" topLeftY="352" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="190" height="44" topLeftX="701" topLeftY="310" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 196, 25, 1)" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 196, 25, 1)" fontSize="16">企业愿景</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="LfBEbmLvGoKkfHxm5aHcDyhgnyd" width="255" height="80" topLeftX="94" topLeftY="460" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="42"/>
+      </img>
+      <img src="HgmJb3yJuoPwhJxuUUnc3Vrxnxe" width="159" height="159" topLeftX="0" topLeftY="381" rotation="180">
+        <crop type="rect" leftOffset="0" rightOffset="159" topOffset="159" bottomOffset="0"/>
+      </img>
+      <shape width="297" height="110" topLeftX="94" topLeftY="246" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="44" topLeftX="94" topLeftY="202" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">TEAM INTRODUCTION</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="64" topLeftX="94" topLeftY="154" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">团队介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="HgmJb3yJuoPwhJxuUUnc3Vrxnxe" width="159" height="159" topLeftX="0" topLeftY="0" rotation="270">
+        <crop type="rect" leftOffset="0" rightOffset="159" topOffset="159" bottomOffset="0"/>
+      </img>
+      <img src="Xj50bmPHuoYxROxoDoLckOtFnmi" width="252" height="79" topLeftX="533" topLeftY="0" rotation="180" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="42"/>
+      </img>
+      <shape width="372" height="44" topLeftX="67" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">ENTERPRISE INTRODUTION</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="64" topLeftX="67" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">企业介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="280" height="136" topLeftX="158" topLeftY="202" rotation="90" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+      </shape>
+      <img src="TrZJbtv5ZoHd73x4QIScqpBbntf" width="160" height="160" topLeftX="0" topLeftY="0" rotation="270">
+        <crop type="rect" leftOffset="0.08" rightOffset="160" topOffset="160" bottomOffset="0"/>
+      </img>
+      <img src="CQL6b6AkQoUjYyxcCNTcwESPnYe" width="193" height="116" topLeftX="0" topLeftY="295" alpha="0.1">
+        <crop type="rect" leftOffset="50" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="SOFfbWd8Mo1lwuxxEJOcD4f7ngb" width="411" height="205" topLeftX="652" topLeftY="192" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="205" bottomOffset="0"/>
+      </img>
+      <shape width="136" height="132" topLeftX="229" topLeftY="260" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4" textAlign="center">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="302" height="74" topLeftX="403" topLeftY="260" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="53" topLeftX="403" topLeftY="215" alpha="0.5" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span fontSize="24" bold="false">CULTURE AND HONOR</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="515" height="60" topLeftX="403" topLeftY="160" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="40">文化与荣耀</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="HgmJb3yJuoPwhJxuUUnc3Vrxnxe" width="159" height="159" topLeftX="0" topLeftY="381" rotation="180">
+        <crop type="rect" leftOffset="0" rightOffset="159" topOffset="159" bottomOffset="0"/>
+      </img>
+      <img src="Xj50bmPHuoYxROxoDoLckOtFnmi" width="252" height="79" topLeftX="533" topLeftY="0" rotation="180" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="42"/>
+      </img>
+      <shape width="372" height="44" topLeftX="67" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">TEAM INTRODUCTION</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="64" topLeftX="67" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">文化与荣耀</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="44" topLeftX="656" topLeftY="249" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(255, 196, 25, 1)" fontSize="18">国家荣誉</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="74" topLeftX="656" topLeftY="279" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="44" topLeftX="656" topLeftY="135" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(255, 196, 25, 1)" fontSize="18">国际荣誉</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="74" topLeftX="656" topLeftY="165" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="44" topLeftX="656" topLeftY="363" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(255, 196, 25, 1)" fontSize="18">地区荣誉</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="74" topLeftX="656" topLeftY="393" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="GIxhbt0NxoGYgjxSRUacyksEnYf" width="203" height="310" topLeftX="423" topLeftY="145" exposure="4" contrast="-5" temperature="-100">
+        <crop type="rect" leftOffset="2" rightOffset="2" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+      <img src="ULEIb8QLhoMCi1xn0JWcuQrInUb" width="155" height="310" topLeftX="77" topLeftY="145" saturation="16" temperature="-32">
+        <crop type="rect" leftOffset="27" rightOffset="27" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+      <img src="Pti2bi2QTo2qbzx73wkcCpxon2S" width="155" height="310" topLeftX="250" topLeftY="145" saturation="20">
+        <crop type="rect" leftOffset="27" rightOffset="27" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="HgmJb3yJuoPwhJxuUUnc3Vrxnxe" width="159" height="159" topLeftX="0" topLeftY="0" rotation="270">
+        <crop type="rect" leftOffset="0" rightOffset="159" topOffset="159" bottomOffset="0"/>
+      </img>
+      <img src="Xj50bmPHuoYxROxoDoLckOtFnmi" width="252" height="79" topLeftX="533" topLeftY="0" rotation="180" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="42"/>
+      </img>
+      <shape width="372" height="44" topLeftX="67" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">TEAM INTRODUCTION</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="64" topLeftX="67" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">文化与荣耀</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="ExqybzOPBoAFAkxfJZFczEejnth" width="48" height="97" topLeftX="252" topLeftY="178">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="PBD2bJubkon53MxFmJXcRQBXn3e" width="51" height="97" topLeftX="89" topLeftY="178">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="130" height="47" topLeftX="131" topLeftY="184" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 196, 25, 1)" fontSize="18">20XX.04.04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="56" topLeftX="131" topLeftY="221" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="ExqybzOPBoAFAkxfJZFczEejnth" width="48" height="97" topLeftX="537" topLeftY="178">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="PBD2bJubkon53MxFmJXcRQBXn3e" width="51" height="97" topLeftX="375" topLeftY="178">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="130" height="47" topLeftX="417" topLeftY="184" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 196, 25, 1)" fontSize="18">20XX.04.04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="56" topLeftX="417" topLeftY="221" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="ExqybzOPBoAFAkxfJZFczEejnth" width="48" height="97" topLeftX="823" topLeftY="178">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="PBD2bJubkon53MxFmJXcRQBXn3e" width="51" height="97" topLeftX="660" topLeftY="178">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="130" height="47" topLeftX="703" topLeftY="184" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>20XX.04.04</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="56" topLeftX="703" topLeftY="221" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="VZKobRX1FoTKOLx5W2dclHU8n4g" width="48" height="97" topLeftX="252" topLeftY="346">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="MD0bb2phrogzu4xF0S3c8nIcnnb" width="51" height="97" topLeftX="89" topLeftY="346">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="130" height="47" topLeftX="131" topLeftY="352" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>20XX.04.04</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="56" topLeftX="131" topLeftY="388" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="VZKobRX1FoTKOLx5W2dclHU8n4g" width="48" height="97" topLeftX="537" topLeftY="346">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="MD0bb2phrogzu4xF0S3c8nIcnnb" width="51" height="97" topLeftX="375" topLeftY="346">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="130" height="47" topLeftX="417" topLeftY="352" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>20XX.04.04</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="56" topLeftX="417" topLeftY="388" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="VZKobRX1FoTKOLx5W2dclHU8n4g" width="48" height="97" topLeftX="823" topLeftY="346">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="MD0bb2phrogzu4xF0S3c8nIcnnb" width="51" height="97" topLeftX="660" topLeftY="346">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="130" height="47" topLeftX="703" topLeftY="352" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>20XX.04.04</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="56" topLeftX="703" topLeftY="388" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="280" height="136" topLeftX="158" topLeftY="202" rotation="90" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+      </shape>
+      <img src="TrZJbtv5ZoHd73x4QIScqpBbntf" width="160" height="160" topLeftX="0" topLeftY="0" rotation="270">
+        <crop type="rect" leftOffset="0.08" rightOffset="160" topOffset="160" bottomOffset="0"/>
+      </img>
+      <img src="CQL6b6AkQoUjYyxcCNTcwESPnYe" width="193" height="116" topLeftX="0" topLeftY="295" alpha="0.1">
+        <crop type="rect" leftOffset="50" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="SOFfbWd8Mo1lwuxxEJOcD4f7ngb" width="411" height="205" topLeftX="652" topLeftY="192" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="205" bottomOffset="0"/>
+      </img>
+      <shape width="136" height="132" topLeftX="229" topLeftY="260" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4" textAlign="center">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="302" height="74" topLeftX="403" topLeftY="260" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="45" topLeftX="403" topLeftY="215" alpha="0.5" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="false" lineSpacing="multiple:1.35">
+          <p>Enterprise introduction</p>
+        </content>
+      </shape>
+      <shape width="515" height="74" topLeftX="403" topLeftY="160" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="40">企业介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="HgmJb3yJuoPwhJxuUUnc3Vrxnxe" width="159" height="159" topLeftX="0" topLeftY="381" rotation="180">
+        <crop type="rect" leftOffset="0" rightOffset="159" topOffset="159" bottomOffset="0"/>
+      </img>
+      <img src="Xj50bmPHuoYxROxoDoLckOtFnmi" width="252" height="79" topLeftX="533" topLeftY="0" rotation="180" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="42"/>
+      </img>
+      <shape width="372" height="44" topLeftX="67" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">PRODUCT SERVICE</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="64" topLeftX="67" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">产品服务</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Iw33boP1DocNMHxSV16cG6Afncf" width="278" height="298" topLeftX="342" topLeftY="131">
+        <crop type="rect" leftOffset="10" rightOffset="10" topOffset="0" bottomOffset="0" presetHandlers="40"/>
+      </img>
+      <shape width="105" height="105" topLeftX="565" topLeftY="371" type="ellipse">
+        <border color="rgba(31, 35, 41, 1)" width="45" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="256" height="44" topLeftX="66" topLeftY="166" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(255, 196, 25, 1)" fontSize="18">产品类型</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="74" topLeftX="66" topLeftY="196" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="44" topLeftX="67" topLeftY="275" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(255, 196, 25, 1)" fontSize="18">产品功能</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="74" topLeftX="67" topLeftY="305" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="44" topLeftX="664" topLeftY="220" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <span color="rgba(255, 196, 25, 1)" fontSize="18">产品价值</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="74" topLeftX="664" topLeftY="250" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="HgmJb3yJuoPwhJxuUUnc3Vrxnxe" width="159" height="159" topLeftX="0" topLeftY="0" rotation="270">
+        <crop type="rect" leftOffset="0" rightOffset="159" topOffset="159" bottomOffset="0"/>
+      </img>
+      <img src="Xj50bmPHuoYxROxoDoLckOtFnmi" width="252" height="79" topLeftX="533" topLeftY="0" rotation="180" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="42"/>
+      </img>
+      <shape width="372" height="44" topLeftX="67" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">PRODUCT SERVICE</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="64" topLeftX="67" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">产品服务</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="310" height="310" topLeftX="326" topLeftY="149" alpha="0.15" type="ellipse">
+        <border color="rgba(31, 35, 41, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="59" height="59" topLeftX="451" topLeftY="275" iconType="iconpark/Money/workbench.svg">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+        <border width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="161" height="161" topLeftX="401" topLeftY="224" type="ellipse">
+        <border color="rgba(255, 196, 25, 1)" width="30" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="60" height="60" topLeftX="342" topLeftY="166" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="295" topLeftY="274" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="342" topLeftY="383" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="560" topLeftY="383" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">06</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="606" topLeftY="274" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">05</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="560" topLeftY="166" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="56" topLeftX="175" topLeftY="176" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="right">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="30" topLeftX="175" topLeftY="148" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">材料</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="56" topLeftX="139" topLeftY="315" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="right">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="30" topLeftX="139" topLeftY="287" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">材料</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="56" topLeftX="175" topLeftY="441" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="right">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="30" topLeftX="175" topLeftY="413" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">材料</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="56" topLeftX="666" topLeftY="176" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="30" topLeftX="666" topLeftY="148" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">材料</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="56" topLeftX="702" topLeftY="315" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="30" topLeftX="702" topLeftY="287" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">材料</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="56" topLeftX="666" topLeftY="441" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="30" topLeftX="666" topLeftY="413" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">材料</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="280" height="136" topLeftX="158" topLeftY="202" rotation="90" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+      </shape>
+      <img src="TrZJbtv5ZoHd73x4QIScqpBbntf" width="160" height="160" topLeftX="0" topLeftY="0" rotation="270">
+        <crop type="rect" leftOffset="0.08" rightOffset="160" topOffset="160" bottomOffset="0"/>
+      </img>
+      <img src="CQL6b6AkQoUjYyxcCNTcwESPnYe" width="193" height="116" topLeftX="0" topLeftY="295" alpha="0.1">
+        <crop type="rect" leftOffset="50" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="SOFfbWd8Mo1lwuxxEJOcD4f7ngb" width="411" height="205" topLeftX="652" topLeftY="192" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="205" bottomOffset="0"/>
+      </img>
+      <shape width="136" height="132" topLeftX="229" topLeftY="260" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4" textAlign="center">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="302" height="74" topLeftX="403" topLeftY="260" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="45" topLeftX="403" topLeftY="215" alpha="0.5" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span fontSize="18" bold="false">INDUSTRY PROSPECT</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="515" height="60" topLeftX="403" topLeftY="160" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="40">行业前景</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="HgmJb3yJuoPwhJxuUUnc3Vrxnxe" width="159" height="159" topLeftX="0" topLeftY="381" rotation="180">
+        <crop type="rect" leftOffset="0" rightOffset="159" topOffset="159" bottomOffset="0"/>
+      </img>
+      <img src="Xj50bmPHuoYxROxoDoLckOtFnmi" width="252" height="79" topLeftX="533" topLeftY="0" rotation="180" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="42"/>
+      </img>
+      <shape width="372" height="44" topLeftX="67" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">INDUSTRY PROSPECT</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="372" height="64" topLeftX="67" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">行业前景</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <chart width="590" height="360" topLeftX="342" topLeftY="125">
+        <chartPlotArea>
+          <chartPlot type="bar">
+            <chartExtra>
+              <chartStack percentage="true"/>
+            </chartExtra>
+            <chartLabels position="center"/>
+            <chartSeriesList>
+              <chartSeries index="1">
+                <chartBars color="rgb(38, 31, 31)"/>
+              </chartSeries>
+              <chartSeries index="2">
+                <chartBars color="rgb(255, 196, 25)"/>
+              </chartSeries>
+              <chartSeries index="3">
+                <chartBars color="rgb(255, 212, 88)"/>
+              </chartSeries>
+              <chartSeries index="4">
+                <chartBars color="rgb(255, 224, 133)"/>
+              </chartSeries>
+              <chartSeries index="5">
+                <chartBars color="rgb(255, 242, 202)"/>
+              </chartSeries>
+            </chartSeriesList>
+          </chartPlot>
+          <chartAxes>
+            <chartAxis type="y" position="left"/>
+            <chartAxis type="x"/>
+          </chartAxes>
+        </chartPlotArea>
+        <chartData>
+          <dim1>
+            <chartField name="">I love trying new product,I am satisfied with the product I currently use,I tend to learn about products online,I am happy to pay extra for quick and efficient feature,I spend more on products now than I used to</chartField>
+          </dim1>
+          <dim2>
+            <chartField name="Strongly agree">0.12,0.36,0.24,0.08,0.23</chartField>
+            <chartField name="Agree">0.28,0.12,0.24,0.3,0.17</chartField>
+            <chartField name="Neutral">0.4,0.12,0.36,0.22,0.1</chartField>
+            <chartField name="Disagree">0.1,0.2,0.07,0.28,0.25</chartField>
+            <chartField name="Strongly disagree">0.1,0.2,0.07,0.12,0.25</chartField>
+          </dim2>
+        </chartData>
+        <chartTitle/>
+        <chartStyle>
+          <chartColorTheme>
+            <color value="singleColorSeries-B-@v2"/>
+          </chartColorTheme>
+        </chartStyle>
+      </chart>
+      <shape width="590" height="359" topLeftX="342" topLeftY="126" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="7" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="261" height="47" topLeftX="67" topLeftY="369" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 196, 25, 1)" fontSize="18">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="74" topLeftX="67" topLeftY="407" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="47" topLeftX="67" topLeftY="254" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 196, 25, 1)" fontSize="18">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="74" topLeftX="67" topLeftY="292" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="47" topLeftX="67" topLeftY="139" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 196, 25, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 196, 25, 1)" fontSize="18">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="74" topLeftX="67" topLeftY="177" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="PRKebXdploaWlnxYHvEc5dzVnnb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Fy3PbjuDQozqAbxxxpxcAQOJn1U" width="241" height="87" topLeftX="515" topLeftY="453" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="28"/>
+      </img>
+      <img src="ChirbbFEtoEhfVxxkh1cdYqknbf" width="191" height="115" topLeftX="0" topLeftY="107" alpha="0.1">
+        <crop type="rect" leftOffset="49" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="416" height="110" topLeftX="253" topLeftY="193" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <strong>
+              <span fontSize="64">感谢您的观赏</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="47" topLeftX="257" topLeftY="284" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p>
+            <span fontSize="18">THANK YOU</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="38" topLeftX="64" topLeftY="24" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="18">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="20" height="20" topLeftX="44" topLeftY="33" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="20" topLeftX="30" topLeftY="33" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 196, 25, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/administration--corporate_culture.xml
+++ b/skills/lark-slides/references/templates/administration--corporate_culture.xml
@@ -1,0 +1,1765 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>企业文化宣传</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(246, 246, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="1" height="374" topLeftX="31" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(172, 175, 181, 1)"/>
+        </fill>
+      </shape>
+      <img src="Nw3pbLRCVoSKVMxNJJ2cdJaUnAn" width="270" height="432" topLeftX="635" topLeftY="69" flipX="true" exposure="8" saturation="-100">
+        <crop type="rect" leftOffset="114" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="55" height="371" topLeftX="905" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="24" topLeftX="805" topLeftY="371" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <img src="CGuCbw8Tboqg2VxtQdWcbFhQnne" width="53" height="53" topLeftX="878" topLeftY="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="32" height="169" topLeftX="0" topLeftY="371" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="490" height="101" topLeftX="48" topLeftY="352" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" bold="true">
+          <p>企业文化宣传</p>
+        </content>
+      </shape>
+      <shape width="137" height="44" topLeftX="52" topLeftY="451" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(116, 119, 122, 1)" bold="false">
+          <p>
+            <span color="rgba(116, 119, 122, 1)" fontSize="16" bold="false">汇报人：小李</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="137" height="44" topLeftX="199" topLeftY="451" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(116, 119, 122, 1)" bold="false">
+          <p>
+            <span color="rgba(116, 119, 122, 1)" fontSize="16" bold="false">2026 / 10 / 23</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="185" startY="465" endX="185" endY="485">
+        <border color="rgba(172, 175, 181, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="54" height="41" topLeftX="78" topLeftY="48" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">Logo</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="AFsQbNvkVooQFYxLPFucGo81nge" width="26" height="26" topLeftX="56" topLeftY="55" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="1" height="540" topLeftX="932" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(172, 175, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="55" height="94" topLeftX="905" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="52" height="28" topLeftX="920" topLeftY="446" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="131" height="414" topLeftX="262" topLeftY="94" rotation="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <img src="JzS9bSzFYoEnwxx8hQ2ciCvened" width="306" height="366" topLeftX="57" topLeftY="119" exposure="19" saturation="-100">
+        <crop type="rect" leftOffset="24" rightOffset="31" topOffset="36" bottomOffset="34" presetHandlers="0"/>
+      </img>
+      <shape width="457" height="77" topLeftX="434" topLeftY="167" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true">
+          <p>
+            <span fontSize="38">前言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="456" height="74" topLeftX="436" topLeftY="247" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="248" height="41" topLeftX="73" topLeftY="48" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">Logo</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="NQh5bzWRwo3Rdfx73FzcGtLanzd" width="26" height="26" topLeftX="51" topLeftY="55" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="960" height="270" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <img src="G5u8bcdFcogtlExDIW0cU3ranZg" width="960" height="270" topLeftX="0" topLeftY="0" alpha="0.3" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="134" bottomOffset="134" presetHandlers="0"/>
+      </img>
+      <shape width="206" height="129" topLeftX="0" topLeftY="71" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="113" height="36" topLeftX="486" topLeftY="308" alpha="0.06" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>3</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="113" height="36" topLeftX="714" topLeftY="308" alpha="0.06" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>4</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="80" topLeftX="48" topLeftY="83" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="40">目录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="50" topLeftY="146" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" bold="false">输入副标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="206" height="100" topLeftX="49" topLeftY="308" alpha="0.05" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="80">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="206" height="59" topLeftX="49" topLeftY="360" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="26">公司介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="206" height="56" topLeftX="49" topLeftY="408" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="206" height="100" topLeftX="268" topLeftY="308" alpha="0.05" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="80">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="206" height="59" topLeftX="268" topLeftY="360" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>公司愿景</p>
+        </content>
+      </shape>
+      <shape width="206" height="56" topLeftX="268" topLeftY="408" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="206" height="100" topLeftX="486" topLeftY="308" alpha="0.05" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="80">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="206" height="59" topLeftX="486" topLeftY="360" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="26">产品介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="206" height="56" topLeftX="486" topLeftY="408" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="206" height="100" topLeftX="705" topLeftY="308" alpha="0.05" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="80">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="206" height="59" topLeftX="705" topLeftY="360" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>战略规划</p>
+        </content>
+      </shape>
+      <shape width="206" height="56" topLeftX="705" topLeftY="408" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="YDWabyhLGoz1IAx2kdlcR7YTnG5" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="1" height="402" topLeftX="930" topLeftY="84" flipX="true" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="rgba(51, 51, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="56" height="30" topLeftX="889" topLeftY="497" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="85" topLeftX="930" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(51, 51, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="254" height="56" topLeftX="199" topLeftY="271" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(116, 119, 122, 1)">
+          <p>
+            <span color="rgba(116, 119, 122, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="77" topLeftX="196" topLeftY="205" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span fontSize="38">公司介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="122" height="94" topLeftX="84" topLeftY="193" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="74" color="rgba(255, 104, 68, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 104, 68, 1)" fontSize="74">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="86" startY="217" endX="55" endY="273">
+        <border width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="248" height="41" topLeftX="73" topLeftY="48" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">Logo</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="NQh5bzWRwo3Rdfx73FzcGtLanzd" width="26" height="26" topLeftX="51" topLeftY="55" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="FGVdbv20Uo0H78xXFCDca2FinEd" width="690" height="486" topLeftX="0" topLeftY="54" exposure="3" contrast="-3" saturation="-100">
+        <crop type="rect" leftOffset="185" rightOffset="172" topOffset="101" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="424" height="309" topLeftX="481" topLeftY="145" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="45" height="45" topLeftX="0" topLeftY="54" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="376" height="68" topLeftX="504" topLeftY="201" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true">
+          <p>
+            <span fontSize="32">公司概述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="376" height="92" topLeftX="506" topLeftY="334" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="74" height="10" topLeftX="515" topLeftY="184" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <img src="CGuCbw8Tboqg2VxtQdWcbFhQnne" width="53" height="53" topLeftX="878" topLeftY="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="30" height="67" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="850" height="56" topLeftX="45" topLeftY="119" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Arial Black" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)" fontSize="12" fontFamily="Arial Black">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="572" height="69" topLeftX="45" topLeftY="44" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="Arial Black" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="32" fontFamily="Arial Black">发展历程</span>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(246, 246, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="79" startY="292" endX="79" endY="465">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="702" startY="294" endX="702" endY="466">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="741" startY="466" endX="703" endY="466">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="737" startY="338" endX="701" endY="338">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="737" startY="404" endX="701" endY="404">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="118" startY="465" endX="80" endY="465">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="114" startY="337" endX="78" endY="337">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="114" startY="402" endX="78" endY="402">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="462" startY="148" endX="462" endY="238">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="755" startY="227" endX="131" endY="227">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="131" startY="226" endX="131" endY="248">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="462" startY="226" endX="462" endY="248">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="755" startY="226" endX="755" endY="248">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="574" startY="185" endX="462" endY="185">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="165" height="58" topLeftX="559" topLeftY="157" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="613" topLeftY="154" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(246, 246, 246, 1)" bold="true">
+          <p>
+            <span color="rgba(246, 246, 246, 1)">总经理</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="613" topLeftY="178" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(239, 219, 211, 1)">
+          <p>
+            <span color="rgba(239, 219, 211, 1)" fontSize="12">副标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="UPkebcdE1oy6NtxIMlzclVaNnWd" width="49" height="49" topLeftX="564" topLeftY="161" exposure="-4" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="380" topLeftY="96" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(50, 50, 50, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="434" topLeftY="93" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">董事会</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="434" topLeftY="117" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(184, 184, 184, 1)">
+          <p>
+            <span color="rgba(184, 184, 184, 1)" fontSize="12">副标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="MztAbK7Ykos8qOxXujKcCd7Kn3d" width="49" height="49" topLeftX="384" topLeftY="101" exposure="1" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="50" topLeftY="241" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="104" topLeftY="239" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>行政部</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="104" topLeftY="263" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span fontSize="12">副标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="EVxRbnLE5osTcMxaxZAcJ4O6nld" width="49" height="49" topLeftX="55" topLeftY="246" exposure="1" contrast="12" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="361" topLeftY="241" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="416" topLeftY="239" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>产研部</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="416" topLeftY="263" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span fontSize="12">副标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="C4SSbCFbpoCE4exRWzjcD6MGnWf" width="49" height="49" topLeftX="367" topLeftY="246" exposure="-8" contrast="15" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="673" topLeftY="241" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="728" topLeftY="239" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>市场部</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="728" topLeftY="263" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span fontSize="12">副标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="P0BRbWkhsousWJxYywacDaYcnfh" width="49" height="49" topLeftX="679" topLeftY="246" exposure="-8" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="572" height="69" topLeftX="45" topLeftY="44" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="Arial Black" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="32" fontFamily="Arial Black">组织架构</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="165" height="58" topLeftX="113" topLeftY="313" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="168" topLeftY="310" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>财务部</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="168" topLeftY="334" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span fontSize="12">副标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="EVxRbnLE5osTcMxaxZAcJ4O6nld" width="49" height="49" topLeftX="119" topLeftY="317" exposure="1" contrast="12" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="113" topLeftY="376" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="168" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>人事处</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="168" topLeftY="398" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span fontSize="12">副标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="EVxRbnLE5osTcMxaxZAcJ4O6nld" width="49" height="49" topLeftX="119" topLeftY="381" exposure="1" contrast="12" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="113" topLeftY="440" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="168" topLeftY="437" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>后勤部</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="168" topLeftY="461" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span fontSize="12">副标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="EVxRbnLE5osTcMxaxZAcJ4O6nld" width="49" height="49" topLeftX="119" topLeftY="444" exposure="1" contrast="12" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="425" topLeftY="313" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="479" topLeftY="310" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>前端</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="479" topLeftY="334" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>副标题</p>
+        </content>
+      </shape>
+      <img src="VAyqbIxsLo0EznxQquEcu5ixn1g" width="49" height="49" topLeftX="430" topLeftY="317" exposure="-9" contrast="12" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="425" topLeftY="376" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="479" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>服务端</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="479" topLeftY="398" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>副标题</p>
+        </content>
+      </shape>
+      <img src="VAyqbIxsLo0EznxQquEcu5ixn1g" width="49" height="49" topLeftX="430" topLeftY="381" exposure="-9" contrast="12" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="736" topLeftY="313" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="791" topLeftY="310" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>销售部</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="791" topLeftY="334" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span fontSize="12">副标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="DAizb7LdCoiG36xNHDhcTgvWnVb" width="49" height="49" topLeftX="742" topLeftY="317" exposure="-8" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="736" topLeftY="440" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="791" topLeftY="437" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>品牌部</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="791" topLeftY="461" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span fontSize="12">副标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="DAizb7LdCoiG36xNHDhcTgvWnVb" width="49" height="49" topLeftX="742" topLeftY="444" exposure="-8" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="736" topLeftY="376" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="791" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>客服部</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="791" topLeftY="398" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span fontSize="12">副标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="DQxgb7Ok9oz6p3xUXkucZKZInRg" width="49" height="49" topLeftX="742" topLeftY="381" exposure="-8" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <shape width="165" height="58" topLeftX="425" topLeftY="440" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="44" topLeftX="479" topLeftY="437" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>测试</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="479" topLeftY="461" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>副标题</p>
+        </content>
+      </shape>
+      <img src="YWw1bGQxJozaiqxPUYAc7rjAnBg" width="49" height="49" topLeftX="430" topLeftY="444" exposure="-9" contrast="12" saturation="-100">
+        <crop type="rect" leftOffset="19" rightOffset="19" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+      </img>
+      <line startX="391" startY="294" endX="391" endY="466">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="429" startY="466" endX="392" endY="466">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="426" startY="338" endX="390" endY="338">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="426" startY="404" endX="390" endY="404">
+        <border color="rgba(219, 221, 225, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="TokNblhQbo6EvdxefALcm9HonKA" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="1" height="402" topLeftX="930" topLeftY="84" flipX="true" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="rgba(51, 51, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="56" height="30" topLeftX="889" topLeftY="497" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="85" topLeftX="930" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(51, 51, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="182" height="56" topLeftX="199" topLeftY="245" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(116, 119, 122, 1)">
+          <p>
+            <span color="rgba(116, 119, 122, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="77" topLeftX="196" topLeftY="180" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span fontSize="38">企业文化</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="122" height="94" topLeftX="84" topLeftY="168" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="74" color="rgba(255, 104, 68, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 104, 68, 1)" fontSize="74">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="86" startY="192" endX="55" endY="247">
+        <border width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="248" height="41" topLeftX="73" topLeftY="48" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">Logo</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Tgvqb7QwjojIMbxu7QIcy8mpnnf" width="26" height="26" topLeftX="51" topLeftY="55" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="30" height="67" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="257" height="540" topLeftX="703" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(238, 239, 239, 1)"/>
+        </fill>
+      </shape>
+      <shape width="376" height="69" topLeftX="45" topLeftY="44" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="32" fontFamily="Arial Black">企业愿景</span>
+          </p>
+        </content>
+      </shape>
+      <img src="JhAsbKc0RoroepxyRx9clt0Znle" width="404" height="206" topLeftX="501" topLeftY="280" exposure="9" contrast="7" saturation="-100" temperature="-12">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="20" presetHandlers="0"/>
+      </img>
+      <img src="GqpNbBmK0oDUJ1xawgmcONDBnKc" width="404" height="206" topLeftX="501" topLeftY="54" exposure="8" contrast="4" saturation="-100" temperature="-27">
+        <crop type="rect" leftOffset="4" rightOffset="4" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="435" height="56" topLeftX="45" topLeftY="190" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="435" height="50" topLeftX="45" topLeftY="148" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">愿景一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="435" height="56" topLeftX="45" topLeftY="337" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="435" height="50" topLeftX="45" topLeftY="295" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">愿景二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="272" height="154" topLeftX="55" topLeftY="158" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(246, 246, 246, 1)"/>
+        </fill>
+        <border color="rgba(219, 221, 225, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="35" height="35" topLeftX="82" topLeftY="182" iconType="iconpark/Peoples/peoples.svg">
+        <fill>
+          <fillColor color="rgba(50, 50, 50, 1)"/>
+        </fill>
+      </icon>
+      <shape width="176" height="56" topLeftX="122" topLeftY="215" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Arial Black" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span color="rgba(172, 175, 181, 1)" fontSize="12" fontFamily="Arial Black">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="53" topLeftX="121" topLeftY="172" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(50, 50, 50, 1)" bold="true">
+          <p>
+            <span color="rgba(50, 50, 50, 1)" fontSize="22">服务客户</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="272" height="154" topLeftX="632" topLeftY="158" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(246, 246, 246, 1)"/>
+        </fill>
+        <border color="rgba(219, 221, 225, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="176" height="56" topLeftX="698" topLeftY="215" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Arial Black" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span color="rgba(172, 175, 181, 1)" fontSize="12" fontFamily="Arial Black">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="53" topLeftX="698" topLeftY="172" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(50, 50, 50, 1)" bold="true">
+          <p>
+            <span fontSize="22">开放包容</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="35" height="35" topLeftX="657" topLeftY="182" iconType="iconpark/Abstract/triangle-round-rectangle.svg">
+        <fill>
+          <fillColor color="rgba(50, 50, 50, 1)"/>
+        </fill>
+      </icon>
+      <shape width="272" height="154" topLeftX="344" topLeftY="158" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <icon width="35" height="35" topLeftX="369" topLeftY="182" iconType="iconpark/Edit/star.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </icon>
+      <shape width="176" height="56" topLeftX="411" topLeftY="215" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Arial Black" color="rgba(239, 219, 211, 1)">
+          <p>
+            <span color="rgba(239, 219, 211, 1)" fontSize="12" fontFamily="Arial Black">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="53" topLeftX="410" topLeftY="172" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span fontSize="22">创新进取</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="272" height="154" topLeftX="345" topLeftY="332" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(246, 246, 246, 1)"/>
+        </fill>
+        <border color="rgba(219, 221, 225, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="176" height="56" topLeftX="412" topLeftY="389" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Arial Black" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span color="rgba(172, 175, 181, 1)" fontSize="12" fontFamily="Arial Black">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="53" topLeftX="411" topLeftY="347" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(50, 50, 50, 1)" bold="true">
+          <p>
+            <span fontSize="22">合作共赢</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="35" height="35" topLeftX="372" topLeftY="357" iconType="iconpark/Abstract/two-semicircles.svg">
+        <fill>
+          <fillColor color="rgba(50, 50, 50, 1)"/>
+        </fill>
+      </icon>
+      <shape width="272" height="154" topLeftX="55" topLeftY="332" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(50, 50, 50, 1)"/>
+        </fill>
+      </shape>
+      <icon width="35" height="35" topLeftX="80" topLeftY="357" iconType="iconpark/Industry/spanner.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(50, 50, 50, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="176" height="56" topLeftX="122" topLeftY="389" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Arial Black" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span color="rgba(172, 175, 181, 1)" fontSize="12" fontFamily="Arial Black">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="53" topLeftX="121" topLeftY="347" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(246, 246, 246, 1)" bold="true">
+          <p>
+            <span color="rgba(246, 246, 246, 1)" fontSize="22">精益求精</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="272" height="154" topLeftX="632" topLeftY="332" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(50, 50, 50, 1)"/>
+        </fill>
+      </shape>
+      <shape width="176" height="56" topLeftX="699" topLeftY="389" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Arial Black" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span color="rgba(172, 175, 181, 1)" fontSize="12" fontFamily="Arial Black">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="53" topLeftX="698" topLeftY="347" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(246, 246, 246, 1)" bold="true">
+          <p>
+            <span color="rgba(246, 246, 246, 1)" fontSize="22">社会关怀</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="35" height="35" topLeftX="657" topLeftY="357" iconType="iconpark/Base/like.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </icon>
+      <shape width="869" height="69" topLeftX="45" topLeftY="48" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="32" fontFamily="Arial Black">企业价值观</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="JD1kbXuJzocwekxSLvKcOvp2nxc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.66" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(172deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 24%,rgba(255, 255, 255, 0.34) 54%,rgba(0, 0, 0, 0.51) 85%,rgba(17, 17, 17, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="409" height="38" topLeftX="199" topLeftY="243" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(116, 119, 122, 1)">
+          <p>
+            <span color="rgba(116, 119, 122, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="77" topLeftX="196" topLeftY="177" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span fontSize="38">产品介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="122" height="94" topLeftX="84" topLeftY="165" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="74" color="rgba(255, 104, 68, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 104, 68, 1)" fontSize="74">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="86" startY="189" endX="55" endY="245">
+        <border width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="1" height="402" topLeftX="930" topLeftY="84" flipX="true" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="rgba(51, 51, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="56" height="30" topLeftX="889" topLeftY="497" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="85" topLeftX="930" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(51, 51, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="248" height="41" topLeftX="73" topLeftY="48" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">Logo</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Tgvqb7QwjojIMbxu7QIcy8mpnnf" width="26" height="26" topLeftX="51" topLeftY="55" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="116" height="116" topLeftX="844" topLeftY="0" rotation="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="255" height="92" topLeftX="45" topLeftY="206" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="255" height="68" topLeftX="45" topLeftY="139" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true">
+          <p>
+            <span fontSize="32">核心产品介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="187" height="47" topLeftX="326" topLeftY="394" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true">
+          <p>
+            <strong>
+              <span fontSize="18">产品 A</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="187" height="56" topLeftX="326" topLeftY="428" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Arial Black" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)" fontSize="12" fontFamily="Arial Black">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="MOTZbhyLPon20UxwKe0caOFzn7g" width="178" height="328" topLeftX="335" topLeftY="54" exposure="-1" contrast="7" saturation="-100">
+        <crop type="rect" leftOffset="138" rightOffset="138" topOffset="0" bottomOffset="0" presetHandlers="4"/>
+      </img>
+      <img src="AxeSbPOgBoL1MqxJYrtcf48znec" width="178" height="328" topLeftX="531" topLeftY="54" exposure="11" contrast="5" saturation="-100">
+        <crop type="rect" leftOffset="173" rightOffset="102" topOffset="0" bottomOffset="0" presetHandlers="4"/>
+      </img>
+      <shape width="187" height="47" topLeftX="522" topLeftY="394" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true">
+          <p>
+            <strong>
+              <span fontSize="18">产品 B</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="187" height="56" topLeftX="522" topLeftY="428" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Arial Black" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)" fontSize="12" fontFamily="Arial Black">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="ZDhbb914Xoq7Xzxor1Bc2y0DnOe" width="178" height="328" topLeftX="727" topLeftY="54" exposure="-1" contrast="15" saturation="-100">
+        <crop type="rect" leftOffset="106" rightOffset="45" topOffset="0" bottomOffset="174" presetHandlers="4"/>
+      </img>
+      <shape width="187" height="47" topLeftX="718" topLeftY="394" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true">
+          <p>
+            <strong>
+              <span fontSize="18">产品 C</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="187" height="56" topLeftX="718" topLeftY="428" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Arial Black" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)" fontSize="12" fontFamily="Arial Black">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="V9A6bjCLVoz4L5x2WKQcoeCJnKf" width="53" height="53" topLeftX="878" topLeftY="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="16" height="116" topLeftX="0" topLeftY="424" rotation="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="1" height="540" topLeftX="932" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(172, 175, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="55" height="94" topLeftX="905" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="52" height="28" topLeftX="920" topLeftY="446" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="472" height="354" topLeftX="55" topLeftY="132" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(246, 246, 246, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="97" startY="439" endX="509" endY="440" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="97" startY="167" endX="509" endY="168" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="97" startY="221" endX="509" endY="222" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="98" startY="273" endX="510" endY="274" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="97" startY="330" endX="509" endY="331" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="98" startY="385" endX="510" endY="386" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="66" height="38" topLeftX="89" topLeftY="438" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2021</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="48" height="38" topLeftX="49" topLeftY="150" alpha="0.3" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">100</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="48" height="38" topLeftX="49" topLeftY="200" alpha="0.3" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">80</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="48" height="38" topLeftX="49" topLeftY="256" alpha="0.3" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">60</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="48" height="38" topLeftX="50" topLeftY="313" alpha="0.3" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">40</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="48" height="38" topLeftX="49" topLeftY="368" alpha="0.3" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">20</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="64" height="38" topLeftX="161" topLeftY="438" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2022</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="65" height="38" topLeftX="233" topLeftY="438" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2023</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="64" height="38" topLeftX="305" topLeftY="438" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2024</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="66" height="38" topLeftX="376" topLeftY="438" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2025</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="66" height="38" topLeftX="448" topLeftY="438" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2026</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="16" height="228" topLeftX="472" topLeftY="211" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="141" topLeftX="472" topLeftY="298" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="248" topLeftX="401" topLeftY="191" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="153" topLeftX="401" topLeftY="284" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="194" topLeftX="329" topLeftY="244" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="84" topLeftX="329" topLeftY="355" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="135" topLeftX="257" topLeftY="304" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="109" topLeftX="257" topLeftY="330" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="195" topLeftX="185" topLeftY="244" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="129" topLeftX="185" topLeftY="310" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="85" topLeftX="113" topLeftY="354" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="70" topLeftX="113" topLeftY="369" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="323" height="56" topLeftX="572" topLeftY="163" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="323" height="50" topLeftX="572" topLeftY="121" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>前景一</p>
+        </content>
+      </shape>
+      <shape width="323" height="56" topLeftX="572" topLeftY="293" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="323" height="50" topLeftX="572" topLeftY="251" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>前景二</p>
+        </content>
+      </shape>
+      <shape width="323" height="56" topLeftX="572" topLeftY="422" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="323" height="50" topLeftX="572" topLeftY="380" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>前景三</p>
+        </content>
+      </shape>
+      <shape width="376" height="68" topLeftX="45" topLeftY="44" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true">
+          <p>
+            <span fontSize="32">市场前景</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="JgftbWuCcoHDfgxe15wcHxWQnih" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.3" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="177" height="56" topLeftX="199" topLeftY="243" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(116, 119, 122, 1)">
+          <p>
+            <span color="rgba(116, 119, 122, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="77" topLeftX="196" topLeftY="177" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>战略规划</p>
+        </content>
+      </shape>
+      <shape width="122" height="94" topLeftX="84" topLeftY="165" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="74" color="rgba(255, 104, 68, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 104, 68, 1)" fontSize="74">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="86" startY="189" endX="55" endY="245">
+        <border width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="1" height="402" topLeftX="930" topLeftY="84" flipX="true" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="rgba(51, 51, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="56" height="30" topLeftX="889" topLeftY="497" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="85" topLeftX="930" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(51, 51, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="248" height="41" topLeftX="73" topLeftY="48" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">Logo</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Tgvqb7QwjojIMbxu7QIcy8mpnnf" width="26" height="26" topLeftX="51" topLeftY="55" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="282" height="201" topLeftX="322" topLeftY="56" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(246, 246, 246, 1)"/>
+        </fill>
+        <border color="rgba(219, 221, 225, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="DQEVbHjTKodA9OxGSM7c1L4Vnvd" width="68" height="68" topLeftX="341" topLeftY="75" exposure="28" contrast="43" saturation="-100">
+        <crop type="rect" leftOffset="13" rightOffset="23" topOffset="34" bottomOffset="0.83" presetHandlers="4"/>
+      </img>
+      <shape width="255" height="56" topLeftX="333" topLeftY="189" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="53" topLeftX="333" topLeftY="146" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)">项目一</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="282" height="201" topLeftX="623" topLeftY="278" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(246, 246, 246, 1)"/>
+        </fill>
+        <border color="rgba(219, 221, 225, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="NX6cbPBttocUDrxQo5Gc5t25nIe" width="68" height="68" topLeftX="642" topLeftY="297" exposure="28" contrast="43" saturation="-100">
+        <crop type="rect" leftOffset="48" rightOffset="0.75" topOffset="49" bottomOffset="0" presetHandlers="4"/>
+      </img>
+      <shape width="255" height="56" topLeftX="634" topLeftY="411" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="53" topLeftX="634" topLeftY="368" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)">项目四</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="282" height="201" topLeftX="322" topLeftY="278" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(50, 50, 50, 1)"/>
+        </fill>
+      </shape>
+      <shape width="255" height="56" topLeftX="333" topLeftY="411" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(172, 175, 181, 1)">
+          <p>
+            <span color="rgba(172, 175, 181, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="53" topLeftX="333" topLeftY="368" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(246, 246, 246, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(246, 246, 246, 1)">项目三</span>
+          </p>
+        </content>
+      </shape>
+      <img src="GbuebbRm4o5oPDxDA9ScCT7innc" width="68" height="68" topLeftX="341" topLeftY="297" exposure="-1" contrast="15" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="11" bottomOffset="11" presetHandlers="4"/>
+        <border color="rgba(219, 221, 225, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="282" height="201" topLeftX="623" topLeftY="56" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="255" height="56" topLeftX="634" topLeftY="189" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(239, 219, 211, 1)">
+          <p>
+            <span color="rgba(239, 219, 211, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="53" topLeftX="634" topLeftY="146" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(246, 246, 246, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(246, 246, 246, 1)">项目二</span>
+          </p>
+        </content>
+      </shape>
+      <img src="VyEQbKSykol0lix7IgFc3mwNn4e" width="68" height="68" topLeftX="642" topLeftY="75" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="11" bottomOffset="11" presetHandlers="4"/>
+        <border color="rgba(219, 221, 225, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="255" height="92" topLeftX="45" topLeftY="245" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="255" height="68" topLeftX="45" topLeftY="178" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true">
+          <p>
+            <span fontSize="32">重点项目</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="28" topLeftX="0" topLeftY="512" rotation="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="43" height="482" topLeftX="862" topLeftY="58" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <img src="InrKbmSgIongY7xDWWoc6B04nZe" width="424" height="540" topLeftX="439" topLeftY="0" exposure="24" contrast="-15" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="1" bottomOffset="1" presetHandlers="0"/>
+      </img>
+      <img src="CzqsbJfHboX3TJxKUOJcMK5Inxh" width="53" height="53" topLeftX="878" topLeftY="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="16" height="80" topLeftX="0" topLeftY="460" rotation="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+      <shape width="376" height="68" topLeftX="45" topLeftY="44" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true">
+          <p>
+            <span fontSize="32">展望未来</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="352" height="74" topLeftX="45" topLeftY="190" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="352" height="50" topLeftX="45" topLeftY="148" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>发展方向一</p>
+        </content>
+      </shape>
+      <shape width="352" height="74" topLeftX="45" topLeftY="337" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 149, 152, 1)">
+          <p>
+            <span color="rgba(147, 149, 152, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="352" height="50" topLeftX="45" topLeftY="295" rotation="0" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">发展方向二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(246, 246, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="248" height="41" topLeftX="73" topLeftY="48" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">Logo</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="QX1Lb2owNoIphsxBImZccHudnid" width="26" height="26" topLeftX="51" topLeftY="55" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="490" height="104" topLeftX="235" topLeftY="196" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="56" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="56">谢谢观看</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="355" height="50" topLeftX="307" topLeftY="290" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(116, 119, 122, 1)" bold="false" textAlign="center">
+          <p>
+            <span color="rgba(116, 119, 122, 1)" fontSize="20" bold="false">期待您的加入！</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="22" height="17" topLeftX="370" topLeftY="306" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="17" topLeftX="567" topLeftY="306" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 104, 68, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/hr--employee_training.xml
+++ b/skills/lark-slides/references/templates/hr--employee_training.xml
@@ -1,0 +1,912 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>员工培训</title>
+  <theme>
+    <background>
+      <fillColor color="rgba(13, 20, 32, 1)"/>
+    </background>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="48"/>
+      <headline fontColor="#000000FF" fontSize="36"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="AiubbdDtOosfbEx6K6Oc9jJPnhb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="51" startY="457" endX="904" endY="456">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="300" height="74" topLeftX="51" topLeftY="351" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">主讲人：李天天 </span>
+          </p>
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">资深研究员，创业公司CEO</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="547" height="176" topLeftX="46" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="65" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="65">员工</span>
+            </strong>
+          </p>
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="65">培训指南</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="51" topLeftY="462" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" autoFit="shape-auto-fit">
+          <p>输入你的互联网公司</p>
+        </content>
+      </shape>
+      <shape width="16" height="15" topLeftX="78" topLeftY="60" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="36" height="16" topLeftX="48" topLeftY="50" rotation="90" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="15" topLeftX="78" topLeftY="39" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="202" height="41" topLeftX="712" topLeftY="28" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="right" autoFit="shape-auto-fit">
+          <p list="none" textAlign="right">公司名字</p>
+        </content>
+      </shape>
+      <shape width="202" height="39" topLeftX="58" topLeftY="462" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="left" autoFit="shape-auto-fit">
+          <p>输入互联网公司</p>
+        </content>
+      </shape>
+      <shape width="202" height="38" topLeftX="702" topLeftY="462" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="right">
+          <p>2026年第一季度</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(13, 20, 32, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="60" startY="152" endX="540" endY="152" alpha="0.5">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="531" height="104" topLeftX="47" topLeftY="38" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="60">目录</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="310" height="260" topLeftX="60" topLeftY="203" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:2.3">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p lineSpacing="multiple:3">
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="16">培训目的</span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:3">
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="16">合同签订的注意事项</span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:3">
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="16">劳动争议风险</span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:3">
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="16">知识产权及商业机密风险</span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:3">
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="16">商业道德方面</span>
+                </strong>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NXFgbhXpSoDgJGxhkF4c8vC4n6e" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="51" startY="457" endX="904" endY="456">
+        <border color="linear-gradient(90deg,rgba(4, 58, 138, 1) 0%,rgba(104, 158, 239, 1) 16%,rgba(152, 222, 251, 1) 36%,rgba(255, 157, 11, 1) 66%,rgba(255, 92, 0, 1) 84%,rgba(62, 15, 197, 1) 100%)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="347" height="83" topLeftX="34" topLeftY="94" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="895" height="64" topLeftX="34" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">培训目的</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="422" height="224" topLeftX="512" topLeftY="190" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="200" fontFamily="黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p>01</p>
+        </content>
+      </shape>
+      <shape width="10" height="10" topLeftX="65" topLeftY="484" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="10" topLeftX="45" topLeftY="476" rotation="90" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="10" topLeftX="65" topLeftY="470" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="202" height="38" topLeftX="702" topLeftY="462" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="right">
+          <p>2026年第一季度</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(13, 20, 32, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="413" height="326" topLeftX="492" topLeftY="150" presetHandlers="8" flipX="true" alpha="0.2" type="round-rect">
+        <border color="rgba(170, 170, 170, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="413" height="326" topLeftX="59" topLeftY="150" presetHandlers="8" alpha="0.2" type="round-rect">
+        <border color="rgba(170, 170, 170, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="59" startY="101" endX="905" endY="101" alpha="0.5">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <img src="JOdrbcqdUoQvVwxO3bpcScHynPJ" width="382" height="191" topLeftX="508" topLeftY="164">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="PIvhbkqeaoY3O8xp9CEco4ZZnvg" width="382" height="191" topLeftX="75" topLeftY="164">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="468" height="53" topLeftX="53" topLeftY="48" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>培训目的</p>
+        </content>
+      </shape>
+      <shape width="382" height="56" topLeftX="507" topLeftY="411" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="382" height="56" topLeftX="75" topLeftY="411" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="382" height="44" topLeftX="508" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>提高自我防护意识和能力</p>
+        </content>
+      </shape>
+      <shape width="382" height="44" topLeftX="75" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>增强公司员工法律意识以及法律观念</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NXFgbhXpSoDgJGxhkF4c8vC4n6e" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="51" startY="457" endX="904" endY="456">
+        <border color="linear-gradient(90deg,rgba(4, 58, 138, 1) 0%,rgba(104, 158, 239, 1) 16%,rgba(152, 222, 251, 1) 36%,rgba(255, 157, 11, 1) 66%,rgba(255, 92, 0, 1) 84%,rgba(62, 15, 197, 1) 100%)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="347" height="83" topLeftX="34" topLeftY="94" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="895" height="64" topLeftX="34" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">合同签订的注意事项</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="422" height="224" topLeftX="512" topLeftY="190" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="200" fontFamily="黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="10" height="10" topLeftX="65" topLeftY="484" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="10" topLeftX="45" topLeftY="476" rotation="90" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="10" topLeftX="65" topLeftY="470" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="202" height="38" topLeftX="702" topLeftY="462" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="right">
+          <p>2026年第一季度</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(13, 20, 32, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="59" startY="101" endX="905" endY="101" alpha="0.5">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="63" height="68" topLeftX="59" topLeftY="180" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32" fontFamily="Arial Black">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="63" height="68" topLeftX="60" topLeftY="342" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32" fontFamily="Arial Black">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="468" height="53" topLeftX="53" topLeftY="48" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>合同签订的注意事项</p>
+        </content>
+      </shape>
+      <img src="A0G0btjSBoQYwwxHio7cjyTnnhh" width="344" height="300" topLeftX="561" topLeftY="164">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="22" bottomOffset="22" presetHandlers="12"/>
+      </img>
+      <shape width="341" height="74" topLeftX="59" topLeftY="396" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="341" height="74" topLeftX="59" topLeftY="234" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="411" height="44" topLeftX="115" topLeftY="358" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>签订合同过程中应注意的问题</p>
+        </content>
+      </shape>
+      <shape width="411" height="44" topLeftX="110" topLeftY="195" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>合同签订前的调查工作</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NXFgbhXpSoDgJGxhkF4c8vC4n6e" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="51" startY="457" endX="904" endY="456">
+        <border color="linear-gradient(90deg,rgba(4, 58, 138, 1) 0%,rgba(104, 158, 239, 1) 16%,rgba(152, 222, 251, 1) 36%,rgba(255, 157, 11, 1) 66%,rgba(255, 92, 0, 1) 84%,rgba(62, 15, 197, 1) 100%)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="347" height="83" topLeftX="34" topLeftY="94" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="895" height="64" topLeftX="34" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">劳动争议风险</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="422" height="224" topLeftX="512" topLeftY="190" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="200" fontFamily="黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="10" height="10" topLeftX="65" topLeftY="484" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="10" topLeftX="45" topLeftY="476" rotation="90" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="10" topLeftX="65" topLeftY="470" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="202" height="38" topLeftX="702" topLeftY="462" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="right">
+          <p>2026年第一季度</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(13, 20, 32, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="395" height="395" topLeftX="99" topLeftY="116" type="ellipse">
+        <border color="linear-gradient(140deg,rgba(0, 20, 51, 1) 0%,rgba(48, 171, 240, 1) 26%,rgba(255, 107, 0, 1) 62%,rgba(0, 16, 102, 1) 100%)" width="6" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="369" height="369" topLeftX="113" topLeftY="129" type="ellipse">
+        <border color="linear-gradient(140deg,rgba(0, 20, 51, 1) 0%,rgba(48, 171, 240, 1) 26%,rgba(255, 107, 0, 1) 62%,rgba(0, 16, 102, 1) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="340" height="340" topLeftX="127" topLeftY="144" type="ellipse">
+        <border color="linear-gradient(140deg,rgba(0, 20, 51, 1) 0%,rgba(48, 171, 240, 1) 26%,rgba(255, 107, 0, 1) 62%,rgba(0, 16, 102, 1) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="395" height="395" topLeftX="465" topLeftY="116" type="ellipse">
+        <fill>
+          <fillColor color="rgba(13, 20, 32, 1)"/>
+        </fill>
+        <border color="linear-gradient(90deg,rgba(4, 58, 138, 1) 0%,rgba(104, 158, 239, 1) 16%,rgba(152, 222, 251, 1) 36%,rgba(255, 157, 11, 1) 66%,rgba(255, 92, 0, 1) 84%,rgba(62, 15, 197, 1) 100%)" width="6" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="468" height="53" topLeftX="53" topLeftY="48" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>劳动争议风险</p>
+        </content>
+      </shape>
+      <shape width="236" height="74" topLeftX="545" topLeftY="306" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(212, 212, 212, 1)" bold="false" textAlign="center">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="236" height="74" topLeftX="179" topLeftY="305" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="395" height="49" topLeftX="465" topLeftY="250" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="21" color="rgba(212, 212, 212, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>合同内容与工资</p>
+        </content>
+      </shape>
+      <shape width="395" height="49" topLeftX="99" topLeftY="250" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="21" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>劳动合约签约的时间</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(13, 20, 32, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="59" startY="101" endX="905" endY="101" alpha="0.5">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="258" height="287" topLeftX="645" topLeftY="165" presetHandlers="8" alpha="0.2" type="round-rect">
+        <border color="rgba(170, 170, 170, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="258" height="287" topLeftX="351" topLeftY="165" presetHandlers="8" alpha="0.2" type="round-rect">
+        <border color="rgba(170, 170, 170, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="258" height="287" topLeftX="57" topLeftY="165" presetHandlers="8" alpha="0.2" type="round-rect">
+        <border color="rgba(170, 170, 170, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="Qd97bGCM1oeyAQxRUmvcPUJjnyb" width="231" height="116" topLeftX="658" topLeftY="181">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.02" bottomOffset="0.02" presetHandlers="8"/>
+      </img>
+      <img src="Z5ldbgltxoBN0XxyNxVcV2tWnWb" width="231" height="116" topLeftX="364" topLeftY="181">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.02" bottomOffset="0.02" presetHandlers="8"/>
+      </img>
+      <img src="YXs0befYaoW0X5xtARpcuGT0nCb" width="231" height="116" topLeftX="71" topLeftY="181">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.02" bottomOffset="0.02" presetHandlers="8"/>
+      </img>
+      <shape width="231" height="92" topLeftX="658" topLeftY="355" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="231" height="92" topLeftX="364" topLeftY="355" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="231" height="92" topLeftX="71" topLeftY="355" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="258" height="44" topLeftX="645" topLeftY="313" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>解除劳动合同</p>
+        </content>
+      </shape>
+      <shape width="258" height="44" topLeftX="351" topLeftY="313" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>工伤</p>
+        </content>
+      </shape>
+      <shape width="258" height="44" topLeftX="57" topLeftY="313" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>合同约定内容</p>
+        </content>
+      </shape>
+      <shape width="468" height="53" topLeftX="53" topLeftY="48" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>劳动争议风险</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NXFgbhXpSoDgJGxhkF4c8vC4n6e" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="51" startY="457" endX="904" endY="456">
+        <border color="linear-gradient(90deg,rgba(4, 58, 138, 1) 0%,rgba(104, 158, 239, 1) 16%,rgba(152, 222, 251, 1) 36%,rgba(255, 157, 11, 1) 66%,rgba(255, 92, 0, 1) 84%,rgba(62, 15, 197, 1) 100%)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="347" height="83" topLeftX="34" topLeftY="94" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="895" height="64" topLeftX="34" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">知识产权及商业机密风险</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="422" height="224" topLeftX="512" topLeftY="190" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="200" fontFamily="黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="202" height="38" topLeftX="702" topLeftY="462" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="right" autoFit="shape-auto-fit">
+          <p>2026年第一季度</p>
+        </content>
+      </shape>
+      <shape width="10" height="10" topLeftX="65" topLeftY="484" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="10" topLeftX="45" topLeftY="476" rotation="90" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="10" topLeftX="65" topLeftY="470" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(13, 20, 32, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="59" startY="101" endX="905" endY="101" alpha="0.5">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="278" height="278" topLeftX="627" topLeftY="202" presetHandlers="8" alpha="0.5" type="round-rect">
+        <border color="rgba(170, 170, 170, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="649" startY="303" endX="883" endY="304" alpha="0.25">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="62" height="62" topLeftX="644" topLeftY="221" iconType="iconpark/Safe/protect.svg">
+        <border color="linear-gradient(140deg,rgba(0, 20, 51, 1) 0%,rgba(48, 171, 240, 1) 26%,rgba(255, 107, 0, 1) 62%,rgba(0, 16, 102, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="278" height="278" topLeftX="59" topLeftY="202" presetHandlers="8" alpha="0.5" type="round-rect">
+        <border color="rgba(170, 170, 170, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="81" startY="303" endX="315" endY="304" alpha="0.25">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="62" height="62" topLeftX="76" topLeftY="221" iconType="iconpark/Clothes/bachelor-cap-one.svg">
+        <border color="linear-gradient(140deg,rgba(0, 20, 51, 1) 0%,rgba(48, 171, 240, 1) 26%,rgba(255, 107, 0, 1) 62%,rgba(0, 16, 102, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="278" height="278" topLeftX="343" topLeftY="202" presetHandlers="8" alpha="0.5" type="round-rect">
+        <border color="rgba(170, 170, 170, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="365" startY="303" endX="599" endY="304" alpha="0.25">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="62" height="62" topLeftX="360" topLeftY="221" iconType="iconpark/Edit/bring-to-front-one.svg">
+        <border color="linear-gradient(140deg,rgba(0, 20, 51, 1) 0%,rgba(48, 171, 240, 1) 26%,rgba(255, 107, 0, 1) 62%,rgba(0, 16, 102, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="230" height="38" topLeftX="713" topLeftY="222" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>Topic 03</p>
+        </content>
+      </shape>
+      <shape width="230" height="38" topLeftX="145" topLeftY="222" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>Topic 01</p>
+        </content>
+      </shape>
+      <shape width="468" height="53" topLeftX="53" topLeftY="48" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>知识产权及商业机密风险</p>
+        </content>
+      </shape>
+      <shape width="230" height="38" topLeftX="429" topLeftY="221" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>Topic 02</p>
+        </content>
+      </shape>
+      <shape width="228" height="44" topLeftX="145" topLeftY="245" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>什么是知识产权？</p>
+        </content>
+      </shape>
+      <shape width="237" height="92" topLeftX="649" topLeftY="324" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="237" height="92" topLeftX="361" topLeftY="324" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="237" height="92" topLeftX="78" topLeftY="324" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="228" height="44" topLeftX="713" topLeftY="245" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>风险防范</p>
+        </content>
+      </shape>
+      <shape width="228" height="44" topLeftX="429" topLeftY="245" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>专利的定义</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NXFgbhXpSoDgJGxhkF4c8vC4n6e" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="51" startY="457" endX="904" endY="456">
+        <border color="linear-gradient(90deg,rgba(4, 58, 138, 1) 0%,rgba(104, 158, 239, 1) 16%,rgba(152, 222, 251, 1) 36%,rgba(255, 157, 11, 1) 66%,rgba(255, 92, 0, 1) 84%,rgba(62, 15, 197, 1) 100%)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="347" height="83" topLeftX="34" topLeftY="94" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="895" height="64" topLeftX="34" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">商业道德方面</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="422" height="224" topLeftX="512" topLeftY="190" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="200" fontFamily="黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p>05</p>
+        </content>
+      </shape>
+      <shape width="202" height="38" topLeftX="702" topLeftY="462" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="right" autoFit="shape-auto-fit">
+          <p>2026年第一季度</p>
+        </content>
+      </shape>
+      <shape width="10" height="10" topLeftX="65" topLeftY="484" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="10" topLeftX="45" topLeftY="476" rotation="90" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="10" topLeftX="65" topLeftY="470" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(13, 20, 32, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="59" startY="101" endX="905" endY="101" alpha="0.5">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="64" startY="188" endX="185" endY="188">
+        <border color="linear-gradient(90deg,rgba(16, 0, 81, 1) 0%,rgba(62, 0, 239, 1) 100%)" width="6" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="242" startY="188" endX="363" endY="188">
+        <border color="linear-gradient(90deg,rgba(62, 0, 239, 1) 0%,rgba(48, 206, 196, 1) 100%)" width="6" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="414" startY="188" endX="535" endY="188">
+        <border color="linear-gradient(90deg,rgba(48, 206, 196, 1) 0%,rgba(255, 122, 0, 1) 100%)" width="6" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="591" startY="188" endX="712" endY="188">
+        <border color="linear-gradient(90deg,rgba(255, 122, 0, 1) 0%,rgba(152, 16, 174, 1) 100%)" width="6" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="770" startY="188" endX="891" endY="188">
+        <border color="linear-gradient(90deg,rgba(152, 16, 174, 1) 0%,rgba(5, 0, 36, 1) 100%)" width="6" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="230" height="41" topLeftX="685" topLeftY="64" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>公司名字</p>
+        </content>
+      </shape>
+      <shape width="468" height="53" topLeftX="53" topLeftY="48" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>商业道德标准</p>
+        </content>
+      </shape>
+      <shape width="132" height="200" topLeftX="765" topLeftY="254" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="132" height="200" topLeftX="586" topLeftY="254" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="132" height="200" topLeftX="409" topLeftY="254" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="132" height="200" topLeftX="237" topLeftY="254" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="132" height="200" topLeftX="59" topLeftY="254" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字请在此处编辑文字</p>
+        </content>
+      </shape>
+      <shape width="131" height="53" topLeftX="765" topLeftY="192" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>05</p>
+        </content>
+      </shape>
+      <shape width="131" height="53" topLeftX="586" topLeftY="192" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="131" height="53" topLeftX="409" topLeftY="192" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="131" height="53" topLeftX="237" topLeftY="192" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="131" height="53" topLeftX="59" topLeftY="192" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>01</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="YBLRbyEjxo8hiIxsQaFcYLSmnQc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="51" startY="457" endX="904" endY="456">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="230" height="41" topLeftX="684" topLeftY="28" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>公司名字</p>
+        </content>
+      </shape>
+      <shape width="678" height="116" topLeftX="236" topLeftY="302" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="80">谢谢观看</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="16" height="15" topLeftX="78" topLeftY="60" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="36" height="16" topLeftX="48" topLeftY="50" rotation="90" flipX="true" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="15" topLeftX="78" topLeftY="39" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="185" height="38" topLeftX="51" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="left" autoFit="shape-auto-fit">
+          <p list="none" textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="12" fontFamily="undefined" bold="false" italic="false" strikethrough="false" underline="false">A座32楼会议室</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="38" topLeftX="722" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="right" autoFit="shape-auto-fit">
+          <p list="none" textAlign="right">
+            <span color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="12" fontFamily="undefined" bold="false" italic="false" strikethrough="false" underline="false">2026年第一季度</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="42" topLeftX="712" topLeftY="28" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="right" autoFit="shape-auto-fit">
+          <p list="none" textAlign="right">公司名字</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/hr--employee_training_workshop.xml
+++ b/skills/lark-slides/references/templates/hr--employee_training_workshop.xml
@@ -1,0 +1,1504 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>员工培训训练</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF" fontFamily="Sans Serif"/>
+      <headline fontColor="#000000FF" fontFamily="Sans Serif"/>
+      <sub-headline fontColor="#000000FF" fontFamily="Sans Serif"/>
+      <body fontColor="#000000FF" fontFamily="Sans Serif"/>
+      <caption fontColor="#808080FF" fontFamily="Sans Serif" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="100" height="100" topLeftX="20" topLeftY="256" rotation="54" type="ellipse">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+      </shape>
+      <shape width="219" height="100" topLeftX="-61" topLeftY="183" rotation="144" alpha="0.8" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(251, 214, 188, 1)"/>
+        </fill>
+      </shape>
+      <shape width="302" height="100" topLeftX="621" topLeftY="468" rotation="144" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(83, 181, 169, 1)"/>
+        </fill>
+      </shape>
+      <shape width="213" height="100" topLeftX="54" topLeftY="494" rotation="144" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="302" height="100" topLeftX="378" topLeftY="253" rotation="144" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(181, 218, 213, 1)"/>
+        </fill>
+      </shape>
+      <shape width="182" height="100" topLeftX="343" topLeftY="478" rotation="144" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="100" topLeftX="822" topLeftY="358" rotation="54" alpha="0.95" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="100" topLeftX="925" topLeftY="42" rotation="54" type="ellipse">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+      </shape>
+      <shape width="281" height="100" topLeftX="345" topLeftY="7" rotation="144" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(220, 221, 169, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="100" topLeftX="435" topLeftY="98" rotation="54" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="100" topLeftX="20" topLeftY="256" rotation="54" type="ellipse">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+      </shape>
+      <shape width="219" height="100" topLeftX="-61" topLeftY="183" rotation="144" alpha="0.8" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(251, 214, 188, 1)"/>
+        </fill>
+      </shape>
+      <shape width="302" height="100" topLeftX="621" topLeftY="468" rotation="144" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(83, 181, 169, 1)"/>
+        </fill>
+      </shape>
+      <shape width="213" height="100" topLeftX="54" topLeftY="494" rotation="144" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="302" height="100" topLeftX="378" topLeftY="253" rotation="144" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(181, 218, 213, 1)"/>
+        </fill>
+      </shape>
+      <shape width="182" height="100" topLeftX="343" topLeftY="478" rotation="144" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="100" topLeftX="822" topLeftY="358" rotation="54" alpha="0.95" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="100" topLeftX="925" topLeftY="42" rotation="54" type="ellipse">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+      </shape>
+      <shape width="281" height="100" topLeftX="345" topLeftY="7" rotation="144" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(220, 221, 169, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="100" topLeftX="435" topLeftY="98" rotation="54" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="394" height="116" topLeftX="480" topLeftY="54" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" fontFamily="Sans Serif" bold="true">
+          <p>
+            <strong>
+              <span fontSize="64" fontFamily="Sans Serif">员工培训</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="338" height="116" topLeftX="593" topLeftY="142" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" fontFamily="Sans Serif" bold="true">
+          <p>
+            <strong>
+              <span fontSize="64" fontFamily="Sans Serif">训练模版</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="338" height="80" topLeftX="66" topLeftY="409" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" fontFamily="Sans Serif" bold="true" letterSpacing="1">
+          <p letterSpacing="1">
+            <strong>
+              <span fontSize="40" fontFamily="Sans Serif">李天天</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="338" height="47" topLeftX="67" topLeftY="388" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Sans Serif" bold="true" letterSpacing="1">
+          <p letterSpacing="1">
+            <strong>
+              <span fontSize="18" fontFamily="Sans Serif">演讲人</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="38" topLeftX="0" topLeftY="461" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(247, 245, 240, 1)" fontSize="12" fontFamily="Sans Serif">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="38" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>01</p>
+        </content>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="259" height="38" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(31, 35, 41, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="left" autoFit="shape-auto-fit">
+          <p list="none" textAlign="left">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="12" fontFamily="Sans Serif" italic="false" strikethrough="false" underline="false">公司名称</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="300" height="300" topLeftX="-150" topLeftY="240" rotation="54" alpha="0.6" type="ellipse">
+        <fill>
+          <fillColor color="rgba(251, 214, 188, 1)"/>
+        </fill>
+      </shape>
+      <shape width="300" height="300" topLeftX="-36" topLeftY="151" rotation="54" alpha="0.45" type="ellipse">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+      </shape>
+      <shape width="300" height="300" topLeftX="347" topLeftY="-141" rotation="54" alpha="0.75" type="ellipse">
+        <fill>
+          <fillColor color="rgba(220, 221, 169, 1)"/>
+        </fill>
+      </shape>
+      <shape width="661" height="286" topLeftX="554" topLeftY="206" rotation="144" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(157, 197, 192, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="337" height="90" topLeftX="536" topLeftY="54" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="46" fontFamily="Sans Serif" bold="true">
+          <p>
+            <strong>
+              <span fontSize="46" fontFamily="Sans Serif">目录页</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="337" height="48" topLeftX="539" topLeftY="131" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Sans Serif" bold="false">
+          <p>
+            <span fontSize="18" fontFamily="Sans Serif" bold="false">我们将在本培训课程中讨论什么</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="337" height="335" topLeftX="76" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Sans Serif" bold="true" lineSpacing="multiple:2.5" list="number">
+          <ol>
+            <li index="1">
+              <p lineSpacing="multiple:2.5">
+                <strong>
+                  <span fontSize="18" fontFamily="Sans Serif">简介 </span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2.5">
+                <strong>
+                  <span fontSize="18" fontFamily="Sans Serif">我们的培训目标 </span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2.5">
+                <strong>
+                  <span fontSize="18" fontFamily="Sans Serif">培训收益 </span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2.5">
+                <strong>
+                  <span fontSize="18" fontFamily="Sans Serif">涵盖的主题 </span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2.5">
+                <strong>
+                  <span fontSize="18" fontFamily="Sans Serif">关键学习总结 </span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2.5">
+                <strong>
+                  <span fontSize="18" fontFamily="Sans Serif">检查理解程度 </span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2.5">
+                <strong>
+                  <span fontSize="18" fontFamily="Sans Serif">讨论板</span>
+                </strong>
+              </p>
+            </li>
+          </ol>
+        </content>
+      </shape>
+      <shape width="337" height="38" topLeftX="66" topLeftY="461" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>公司名称</p>
+        </content>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>02</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 60, 60, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="1" height="540" topLeftX="46" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(247, 245, 240, 1)" fontSize="14" fontFamily="Sans Serif">简介</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="421" height="629" topLeftX="484" topLeftY="-111" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="400" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="right">
+          <p>1</p>
+        </content>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="337" height="83" topLeftX="66" topLeftY="366" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="300" height="300" topLeftX="315" topLeftY="390" rotation="54" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="rgba(251, 214, 188, 1)"/>
+        </fill>
+      </shape>
+      <shape width="300" height="300" topLeftX="462" topLeftY="457" rotation="54" alpha="0.24" type="ellipse">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+      </shape>
+      <shape width="300" height="300" topLeftX="304" topLeftY="-194" rotation="54" alpha="0.6" type="ellipse">
+        <fill>
+          <fillColor color="rgba(220, 221, 169, 1)"/>
+        </fill>
+      </shape>
+      <shape width="420" height="286" topLeftX="769" topLeftY="158" rotation="144" alpha="0.32" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(102, 130, 194, 1)"/>
+        </fill>
+      </shape>
+      <shape width="385" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(60, 60, 60, 1)" fontSize="14" fontFamily="Sans Serif">简介</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="337" height="54" topLeftX="66" topLeftY="56" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(60, 60, 60, 1)" fontSize="22" fontFamily="Sans Serif">大家好!</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="234" height="91" topLeftX="110" topLeftY="117" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="false" lineSpacing="multiple:1.7" list="bullet">
+          <ul>
+            <li>
+              <p lineSpacing="multiple:1.7">介绍一下将主持培训的演讲者。</p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:1.7">写另一条关于演讲者的信息。</p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:1.7">再写一条关于演讲者的信息。</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <img src="VxM1b9rn2o4sfXxvHu5coHVWnPg" width="312" height="312" topLeftX="517" topLeftY="110">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="156"/>
+      </img>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>04</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 60, 60, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="1" height="540" topLeftX="46" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </shape>
+      <shape width="337" height="83" topLeftX="66" topLeftY="366" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="1" height="540" topLeftX="46" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>05</p>
+        </content>
+      </shape>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>我们的培训目标</p>
+        </content>
+      </shape>
+      <shape width="421" height="629" topLeftX="484" topLeftY="-111" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="400" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="right">
+          <p>2</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="300" height="300" topLeftX="315" topLeftY="390" rotation="54" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="rgba(251, 214, 188, 1)"/>
+        </fill>
+      </shape>
+      <shape width="300" height="300" topLeftX="462" topLeftY="457" rotation="54" alpha="0.24" type="ellipse">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+      </shape>
+      <shape width="300" height="300" topLeftX="304" topLeftY="-194" rotation="54" alpha="0.6" type="ellipse">
+        <fill>
+          <fillColor color="rgba(220, 221, 169, 1)"/>
+        </fill>
+      </shape>
+      <shape width="420" height="286" topLeftX="769" topLeftY="158" rotation="144" alpha="0.32" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(102, 130, 194, 1)"/>
+        </fill>
+      </shape>
+      <shape width="385" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(60, 60, 60, 1)" fontSize="14" fontFamily="Sans Serif">我们的培训目标</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="293" height="92" topLeftX="66" topLeftY="79" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="false" lineSpacing="multiple:1.7" list="none">
+          <p list="none" lineSpacing="multiple:1.7">在此介绍该培训课程旨在向观众传授的主要概念。分享它将如何帮助他们在公司内部履行职责。</p>
+        </content>
+      </shape>
+      <shape width="176" height="218" topLeftX="392" topLeftY="205" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="130" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(60, 60, 60, 1)" fontSize="130">1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="70" height="12" topLeftX="486" topLeftY="392" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="176" height="218" topLeftX="525" topLeftY="112" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="130" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(60, 60, 60, 1)" fontSize="130">2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="70" height="12" topLeftX="619" topLeftY="298" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="176" height="218" topLeftX="658" topLeftY="21" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="130" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(60, 60, 60, 1)" fontSize="130">3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="70" height="12" topLeftX="752" topLeftY="208" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="234" height="37" topLeftX="476" topLeftY="423" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="true" lineSpacing="multiple:1.2" list="none">
+          <p list="none" lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="14" fontFamily="Sans Serif">此处输入副标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="234" height="37" topLeftX="608" topLeftY="331" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="true" lineSpacing="multiple:1.2" list="none">
+          <p list="none" lineSpacing="multiple:1.2">此处输入副标题</p>
+        </content>
+      </shape>
+      <shape width="234" height="37" topLeftX="743" topLeftY="238" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="true" lineSpacing="multiple:1.2" list="none">
+          <p list="none" lineSpacing="multiple:1.2">此处输入副标题</p>
+        </content>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>06</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 60, 60, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="1" height="540" topLeftX="46" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="337" height="83" topLeftX="66" topLeftY="366" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="false">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>07</p>
+        </content>
+      </shape>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>培训收益</p>
+        </content>
+      </shape>
+      <shape width="421" height="629" topLeftX="484" topLeftY="-111" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="400" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="right">
+          <p>3</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(60, 60, 60, 1)" fontSize="14" fontFamily="Sans Serif">培训收益</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="293" height="68" topLeftX="66" topLeftY="79" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="false" lineSpacing="multiple:1.7" list="none">
+          <p list="none" lineSpacing="multiple:1.7">写出培训对观众或整个公司的好处或重要影响。</p>
+        </content>
+      </shape>
+      <img src="JoTFbGXn4onvpuxaCHtcXfsMnVd" width="505" height="331" topLeftX="385" topLeftY="35">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="505" height="75" topLeftX="385" topLeftY="392" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" fontFamily="Sans Serif" bold="false" italic="true" lineSpacing="multiple:1.7" list="none" textAlign="right">
+          <p list="none" lineSpacing="multiple:1.7">
+            “日复一日，看似一切未变，但当你回首往事，一切却早已不同。”
+            <em>
+              <span fontSize="16" fontFamily="Sans Serif" bold="false"> </span>
+            </em>
+          </p>
+          <p list="none" lineSpacing="multiple:1.7">
+            <strong>
+              <span fontSize="16" fontFamily="Sans Serif" italic="false">— 凯斯宾 · 普林斯</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>08</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 60, 60, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="1" height="540" topLeftX="46" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </shape>
+      <shape width="337" height="83" topLeftX="66" topLeftY="366" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>09</p>
+        </content>
+      </shape>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>涵盖的主题</p>
+        </content>
+      </shape>
+      <shape width="421" height="629" topLeftX="484" topLeftY="-111" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="400" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="right">
+          <p>4</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="300" height="300" topLeftX="315" topLeftY="390" rotation="54" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="rgba(251, 214, 188, 1)"/>
+        </fill>
+      </shape>
+      <shape width="300" height="300" topLeftX="462" topLeftY="457" rotation="54" alpha="0.24" type="ellipse">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+      </shape>
+      <shape width="300" height="300" topLeftX="304" topLeftY="-194" rotation="54" alpha="0.6" type="ellipse">
+        <fill>
+          <fillColor color="rgba(220, 221, 169, 1)"/>
+        </fill>
+      </shape>
+      <shape width="420" height="286" topLeftX="769" topLeftY="158" rotation="144" alpha="0.32" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(102, 130, 194, 1)"/>
+        </fill>
+      </shape>
+      <shape width="385" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>涵盖的主题</p>
+        </content>
+      </shape>
+      <shape width="293" height="68" topLeftX="66" topLeftY="79" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="false" lineSpacing="multiple:1.7" list="none">
+          <p list="none" lineSpacing="multiple:1.7">讨论并探索这些主题，并使用简洁的语句总结每个主题。</p>
+        </content>
+      </shape>
+      <shape width="64" height="64" topLeftX="474" topLeftY="108" type="ellipse">
+        <fill>
+          <fillColor color="rgba(102, 130, 194, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="29" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(247, 245, 240, 1)" fontSize="29">I</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="337" height="45" topLeftX="548" topLeftY="95" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>主题方向一</p>
+        </content>
+      </shape>
+      <shape width="337" height="57" topLeftX="548" topLeftY="126" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="64" height="64" topLeftX="474" topLeftY="209" type="ellipse">
+        <fill>
+          <fillColor color="rgba(209, 198, 99, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="29" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(247, 245, 240, 1)" fontSize="29">II</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="337" height="45" topLeftX="548" topLeftY="196" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>主题方向二</p>
+        </content>
+      </shape>
+      <shape width="337" height="57" topLeftX="548" topLeftY="227" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="64" height="64" topLeftX="474" topLeftY="311" type="ellipse">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="29" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(247, 245, 240, 1)" fontSize="29">III</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="337" height="45" topLeftX="548" topLeftY="298" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>主题方向三</p>
+        </content>
+      </shape>
+      <shape width="337" height="57" topLeftX="548" topLeftY="329" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>10</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="385" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <img src="IYpObKWVQoriOsxvA24ccciwn9b" width="575" height="540" topLeftX="385" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="18" bottomOffset="18"/>
+      </img>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="293" height="44" topLeftX="66" topLeftY="160" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="false" lineSpacing="multiple:1.7" list="none">
+          <p list="none" lineSpacing="multiple:1.7">
+            <span fontSize="14" fontFamily="Sans Serif" bold="false">用此区域来讨论主题方向一。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="64" height="64" topLeftX="75" topLeftY="82" type="ellipse">
+        <fill>
+          <fillColor color="rgba(102, 130, 194, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="29" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(247, 245, 240, 1)" fontSize="29">I</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="45" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>涵盖的主题</p>
+        </content>
+      </shape>
+      <shape width="245" height="75" topLeftX="139" topLeftY="77" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="false">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>11</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="385" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <img src="DECYbWFvloCiCQxu8f2cxa96nKg" width="575" height="540" topLeftX="385" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="18" bottomOffset="18"/>
+      </img>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="293" height="44" topLeftX="66" topLeftY="160" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="false" lineSpacing="multiple:1.7" list="none">
+          <p list="none" lineSpacing="multiple:1.7">用此区域来讨论主题方向二。</p>
+        </content>
+      </shape>
+      <shape width="64" height="64" topLeftX="75" topLeftY="82" type="ellipse">
+        <fill>
+          <fillColor color="rgba(209, 198, 99, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="29" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(247, 245, 240, 1)" fontSize="29">II</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="45" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>涵盖的主题</p>
+        </content>
+      </shape>
+      <shape width="245" height="75" topLeftX="139" topLeftY="77" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="false">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>12</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="385" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <img src="X8Svb1SHPoNmoBxxspBch0dDnIf" width="575" height="540" topLeftX="385" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="18" bottomOffset="18"/>
+      </img>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="293" height="44" topLeftX="66" topLeftY="160" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="false" lineSpacing="multiple:1.7" list="none">
+          <p list="none" lineSpacing="multiple:1.7">用此区域来讨论主题方向三。</p>
+        </content>
+      </shape>
+      <shape width="64" height="64" topLeftX="75" topLeftY="82" type="ellipse">
+        <fill>
+          <fillColor color="rgba(234, 165, 143, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="29" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(247, 245, 240, 1)" fontSize="29">III</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="45" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>涵盖的主题</p>
+        </content>
+      </shape>
+      <shape width="245" height="75" topLeftX="139" topLeftY="77" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="false">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>13</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 60, 60, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="1" height="540" topLeftX="46" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </shape>
+      <shape width="337" height="83" topLeftX="66" topLeftY="366" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>14</p>
+        </content>
+      </shape>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>关键学习总结</p>
+        </content>
+      </shape>
+      <shape width="421" height="629" topLeftX="484" topLeftY="-111" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="400" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="right">
+          <p>5</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="385" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="575" height="270" topLeftX="385" topLeftY="270" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>
+            <span fontSize="14">关键学习总结</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="293" height="44" topLeftX="66" topLeftY="79" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="false" lineSpacing="multiple:1.7" list="none">
+          <p list="none" lineSpacing="multiple:1.7">在此处写出您的学习课程的摘要。</p>
+        </content>
+      </shape>
+      <shape width="248" height="47" topLeftX="92" topLeftY="147" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" fontFamily="Sans Serif" bold="true" lineSpacing="multiple:1.7" list="bullet">
+          <ul>
+            <li>
+              <p lineSpacing="multiple:1.7">
+                关键要点
+                <strong>
+                  <span fontSize="16"> 1</span>
+                </strong>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="575" height="165" topLeftX="385" topLeftY="46" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="84" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true" lineSpacing="multiple:1.7" letterSpacing="8" list="none" textAlign="center">
+          <p list="none" lineSpacing="multiple:1.7" letterSpacing="8">
+            要点
+            <strong>
+              <span color="rgba(60, 60, 60, 1)" fontSize="84"> 1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="12" topLeftX="747" topLeftY="179" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="575" height="165" topLeftX="385" topLeftY="311" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="84" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" lineSpacing="multiple:1.7" letterSpacing="8" list="none" textAlign="center">
+          <p list="none" lineSpacing="multiple:1.7" letterSpacing="8">
+            <strong>
+              <span color="rgba(247, 245, 240, 1)" fontSize="84">要点 2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="12" topLeftX="747" topLeftY="444" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </shape>
+      <shape width="248" height="83" topLeftX="110" topLeftY="179" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="false">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="248" height="47" topLeftX="92" topLeftY="268" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" fontFamily="Sans Serif" bold="true" lineSpacing="multiple:1.7" list="bullet">
+          <ul>
+            <li>
+              <p lineSpacing="multiple:1.7">
+                关键要点
+                <strong>
+                  <span fontSize="16"> 2</span>
+                </strong>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="248" height="83" topLeftX="110" topLeftY="299" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="false">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>15</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 60, 60, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="1" height="540" topLeftX="46" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </shape>
+      <shape width="337" height="83" topLeftX="66" topLeftY="366" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>16</p>
+        </content>
+      </shape>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true">
+          <p>检查理解程度</p>
+        </content>
+      </shape>
+      <shape width="421" height="629" topLeftX="484" topLeftY="-111" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="400" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="right">
+          <p>6</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="385" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="288" height="270" topLeftX="672" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(181, 218, 213, 1)"/>
+        </fill>
+      </shape>
+      <shape width="288" height="270" topLeftX="672" topLeftY="270" alpha="0.95" type="rect">
+        <fill>
+          <fillColor color="rgba(157, 197, 192, 1)"/>
+        </fill>
+      </shape>
+      <shape width="288" height="270" topLeftX="385" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(220, 221, 169, 1)"/>
+        </fill>
+      </shape>
+      <shape width="288" height="270" topLeftX="385" topLeftY="270" type="rect">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>检查理解程度</p>
+        </content>
+      </shape>
+      <shape width="300" height="68" topLeftX="66" topLeftY="79" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" bold="false" lineSpacing="multiple:1.7" list="none">
+          <p list="none" lineSpacing="multiple:1.7">在培训课程结束时，检查一下对我们讨论过的主题的理解。</p>
+        </content>
+      </shape>
+      <shape width="132" height="118" topLeftX="404" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true" letterSpacing="8">
+          <p letterSpacing="8">Q1</p>
+        </content>
+      </shape>
+      <shape width="245" height="60" topLeftX="408" topLeftY="142" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="false" lineSpacing="multiple:1.4">
+          <p lineSpacing="multiple:1.4">在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="50" height="8" topLeftX="461" topLeftY="128" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="118" topLeftX="692" topLeftY="31" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true" letterSpacing="8">
+          <p letterSpacing="8">Q2</p>
+        </content>
+      </shape>
+      <shape width="245" height="60" topLeftX="695" topLeftY="142" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="false" lineSpacing="multiple:1.4">
+          <p lineSpacing="multiple:1.4">在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="50" height="8" topLeftX="748" topLeftY="128" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="118" topLeftX="404" topLeftY="310" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true" letterSpacing="8">
+          <p letterSpacing="8">Q3</p>
+        </content>
+      </shape>
+      <shape width="245" height="60" topLeftX="408" topLeftY="420" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="false" lineSpacing="multiple:1.4">
+          <p lineSpacing="multiple:1.4">在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="50" height="8" topLeftX="461" topLeftY="407" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="118" topLeftX="691" topLeftY="310" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true" letterSpacing="8">
+          <p letterSpacing="8">Q4</p>
+        </content>
+      </shape>
+      <shape width="245" height="60" topLeftX="695" topLeftY="420" alpha="0.8" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="false" lineSpacing="multiple:1.4">
+          <p lineSpacing="multiple:1.4">在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="50" height="8" topLeftX="748" topLeftY="407" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>17</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <shape width="1" height="540" topLeftX="46" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </shape>
+      <shape width="337" height="83" topLeftX="66" topLeftY="366" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)">
+          <p>在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。在此输入信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>18</p>
+        </content>
+      </shape>
+      <shape width="337" height="41" topLeftX="66" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true">
+          <p>讨论板</p>
+        </content>
+      </shape>
+      <shape width="421" height="629" topLeftX="484" topLeftY="-111" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="400" fontFamily="Sans Serif" color="rgba(60, 60, 60, 1)" bold="true" textAlign="right">
+          <p>7</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(247, 245, 240, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="542" height="286" topLeftX="-185" topLeftY="99" rotation="144" alpha="0.32" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(220, 221, 169, 1)"/>
+        </fill>
+      </shape>
+      <shape width="300" height="300" topLeftX="723" topLeftY="141" rotation="54" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="rgba(157, 197, 192, 1)"/>
+        </fill>
+      </shape>
+      <shape width="300" height="300" topLeftX="330" topLeftY="-212" rotation="54" alpha="0.6" type="ellipse">
+        <fill>
+          <fillColor color="rgba(126, 185, 178, 1)"/>
+        </fill>
+      </shape>
+      <shape width="600" height="286" topLeftX="405" topLeftY="418" rotation="144" alpha="0.32" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(251, 214, 188, 1)"/>
+        </fill>
+      </shape>
+      <shape width="300" height="300" topLeftX="43" topLeftY="484" rotation="54" alpha="0.6" type="ellipse">
+        <fill>
+          <fillColor color="rgba(102, 130, 194, 1)"/>
+        </fill>
+      </shape>
+      <shape width="46" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 60, 60, 1)"/>
+        </fill>
+      </shape>
+      <icon width="22" height="22" topLeftX="12" topLeftY="35" iconType="iconpark/Brand/bydesign.svg">
+        <fill>
+          <fillColor color="rgba(247, 245, 240, 1)"/>
+        </fill>
+      </icon>
+      <shape width="612" height="141" topLeftX="313" topLeftY="89" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" fontFamily="Sans Serif" bold="true" letterSpacing="1">
+          <p letterSpacing="1">感谢您的观看，</p>
+          <p letterSpacing="1">如有任何问题请随时联系！</p>
+        </content>
+      </shape>
+      <shape width="46" height="39" topLeftX="0" topLeftY="461" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="Sans Serif" color="rgba(247, 245, 240, 1)" bold="true" textAlign="center">
+          <p>19</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/hr--onboarding.xml
+++ b/skills/lark-slides/references/templates/hr--onboarding.xml
@@ -1,0 +1,933 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>新人入职培训</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="60"/>
+      <headline fontColor="#000000FF" fontSize="54"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="SC2Wbh3kaopv4Jxk1cXc4laHnyd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" alpha="0.63" type="rect">
+        <fill>
+          <fillColor color="rgba(75, 63, 221, 1)"/>
+        </fill>
+      </shape>
+      <shape width="312" height="56" topLeftX="324" topLeftY="289" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="290" height="92" topLeftX="335" topLeftY="197" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>新人培训</p>
+        </content>
+      </shape>
+      <shape width="900" height="40" topLeftX="30" topLeftY="476" presetHandlers="48" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="30" topLeftX="36" topLeftY="481" type="ellipse">
+        <fill>
+          <fillColor color="rgba(75, 63, 221, 1)"/>
+        </fill>
+      </shape>
+      <icon width="18" height="18" topLeftX="43" topLeftY="487" iconType="iconpark/Arrows/arrow-right.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="126" height="44" topLeftX="66" topLeftY="474" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" textAlign="left">
+          <p>
+            <span color="rgba(44, 40, 64, 1)" fontSize="16">进入今日议程</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="127" height="44" topLeftX="795" topLeftY="474" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" textAlign="right">
+          <p>
+            <span color="rgba(44, 40, 64, 1)" fontSize="16">2026.05.04</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="100" height="68" topLeftX="59" topLeftY="47" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true">
+          <p>目录</p>
+        </content>
+      </shape>
+      <shape width="311" height="56" topLeftX="59" topLeftY="115" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="70" height="70" topLeftX="62" topLeftY="267" type="ellipse">
+        <fill>
+          <fillColor color="rgba(44, 40, 64, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="153" startY="370" endX="471" endY="371" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="70" height="70" topLeftX="62" topLeftY="385" type="ellipse">
+        <fill>
+          <fillColor color="rgba(44, 40, 64, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="581" startY="370" endX="898" endY="371" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="70" height="70" topLeftX="489" topLeftY="267" type="ellipse">
+        <fill>
+          <fillColor color="rgba(44, 40, 64, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="70" height="70" topLeftX="489" topLeftY="385" type="ellipse">
+        <fill>
+          <fillColor color="rgba(44, 40, 64, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="100" height="44" topLeftX="153" topLeftY="267" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>公司概况</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="100" height="44" topLeftX="153" topLeftY="385" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>规章制度</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="311" height="56" topLeftX="153" topLeftY="302" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="311" height="56" topLeftX="153" topLeftY="420" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="100" height="44" topLeftX="581" topLeftY="270" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>开始旅程</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="311" height="56" topLeftX="581" topLeftY="305" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="100" height="44" topLeftX="581" topLeftY="385" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>公司福利</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="311" height="56" topLeftX="581" topLeftY="420" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(75, 63, 221, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="XWWzbxvZmoztg2xETpEcw22mnEd" width="328" height="432" topLeftX="571" topLeftY="54">
+        <crop type="rect" leftOffset="0.05" rightOffset="0.05" topOffset="0" bottomOffset="0" presetHandlers="24"/>
+      </img>
+      <shape width="381" height="44" topLeftX="67" topLeftY="260" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">请输入相关描述信息以解释你的标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="485" height="85" topLeftX="62" topLeftY="294" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>公司概况</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="LHhDbYrgZo4vVVxiVmZc85dDn6d" width="194" height="236" topLeftX="487" topLeftY="229">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="39" bottomOffset="39" presetHandlers="18"/>
+      </img>
+      <img src="AooSbNkPko0FWUxrsAJchJgen5j" width="194" height="316" topLeftX="706" topLeftY="55" saturation="11">
+        <crop type="rect" leftOffset="0.8" rightOffset="0.8" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+      <img src="B0aKbJkekobG8exkYDIcZlcrnRd" width="194" height="236" topLeftX="487" topLeftY="-27">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="3" bottomOffset="3" presetHandlers="18"/>
+      </img>
+      <img src="WGEZb10uxoKMfoxPIHNcha7anxe" width="194" height="164" topLeftX="706" topLeftY="391" saturation="34">
+        <crop type="rect" leftOffset="56" rightOffset="18" topOffset="32" bottomOffset="161" presetHandlers="18"/>
+      </img>
+      <shape width="240" height="68" topLeftX="65" topLeftY="116" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true">
+          <p>创始人的故事</p>
+        </content>
+      </shape>
+      <shape width="354" height="164" topLeftX="65" topLeftY="203" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">这里可以展示创始人的职业经历。描述他如何在各种困难的条件下建立了公司</span>
+          </p>
+          <p/>
+          <p>
+            <span fontSize="16">描述他的理念和梦想，及为此付出的努力</span>
+          </p>
+          <p/>
+          <p>
+            <span fontSize="16">描述公司取得的成绩及下一个 10 年的目标规划</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Q9D9b6hOnoRxsgxSwU0cx3tAn1c" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" alpha="0.7" type="rect">
+        <fill>
+          <fillColor color="rgba(75, 63, 221, 1)"/>
+        </fill>
+      </shape>
+      <shape width="131" height="42" topLeftX="56" topLeftY="36" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2" letterSpacing="2" textAlign="left">
+          <p lineSpacing="multiple:1.2" letterSpacing="2">
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">公司愿景</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="53" topLeftX="56" topLeftY="429" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="32" height="32" topLeftX="67" topLeftY="439" iconType="iconpark/Arrows/arrow-right.svg">
+        <border color="rgba(75, 63, 221, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="822" height="164" topLeftX="56" topLeftY="98" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p letterSpacing="1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">如果你做了一件事，结果还不错，那么你应该去做其他精彩的事，不要在上面纠缠太久。只要想清楚下一步是什么</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="210" height="264" topLeftX="55" topLeftY="178" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(75, 63, 221, 1)"/>
+        </fill>
+      </shape>
+      <shape width="82" height="82" topLeftX="70" topLeftY="191" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="43" height="43" topLeftX="90" topLeftY="211" iconType="iconpark/Abstract/six-points.svg">
+        <border color="rgba(75, 63, 221, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="180" height="74" topLeftX="70" topLeftY="351" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="44" topLeftX="70" topLeftY="317" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">始终创业</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="264" topLeftX="268" topLeftY="178" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(44, 40, 64, 1)"/>
+        </fill>
+      </shape>
+      <shape width="82" height="82" topLeftX="283" topLeftY="191" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="43" height="43" topLeftX="303" topLeftY="211" iconType="iconpark/Abstract/cylinder.svg">
+        <border color="rgba(44, 40, 64, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="180" height="44" topLeftX="283" topLeftY="317" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">坦诚清晰</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="74" topLeftX="283" topLeftY="351" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="264" topLeftX="482" topLeftY="178" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(75, 63, 221, 1)"/>
+        </fill>
+      </shape>
+      <shape width="82" height="82" topLeftX="497" topLeftY="191" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="43" height="43" topLeftX="516" topLeftY="211" iconType="iconpark/Abstract/game-emoji.svg">
+        <border color="rgba(75, 63, 221, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="180" height="44" topLeftX="497" topLeftY="317" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">多元兼容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="74" topLeftX="497" topLeftY="351" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="264" topLeftX="695" topLeftY="178" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(44, 40, 64, 1)"/>
+        </fill>
+      </shape>
+      <shape width="82" height="82" topLeftX="710" topLeftY="191" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="43" height="43" topLeftX="729" topLeftY="211" iconType="iconpark/Abstract/oval-love-two.svg">
+        <border color="rgba(44, 40, 64, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="180" height="44" topLeftX="710" topLeftY="317" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">求真务实</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="74" topLeftX="710" topLeftY="351" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="456" height="38" topLeftX="252" topLeftY="108" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="487" height="68" topLeftX="236" topLeftY="46" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" textAlign="center">
+          <p>价值观</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(75, 63, 221, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="U9DGbgUQmo8Vg2xdYyfcLVKunqb" width="328" height="432" topLeftX="571" topLeftY="54">
+        <crop type="rect" leftOffset="52" rightOffset="52" topOffset="0" bottomOffset="0" presetHandlers="24"/>
+      </img>
+      <shape width="381" height="44" topLeftX="67" topLeftY="260" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">请输入相关描述信息以解释你的标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="485" height="85" topLeftX="62" topLeftY="294" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="54">开始你的旅程</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <line startX="558" startY="404" endX="839" endY="403" alpha="0.5">
+        <border color="rgba(143, 149, 158, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="367" height="92" topLeftX="62" topLeftY="367" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(44, 40, 64, 1)" textAlign="left">
+          <p>
+            <span color="rgba(44, 40, 64, 1)" fontSize="12">当开始时，我们会进行头脑风暴，分享彼此的想法，并从中激发灵感。在经过一系列的讨论后，开始制定策略，拟定计划。并开始进行分工合作，明确各个成员的职责。最后定期复盘进展，确保计划顺利执行。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="KImsboGLOoVLYexRUlScDoygnud" width="849" height="201" topLeftX="60" topLeftY="48" exposure="-16" contrast="19" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="256" bottomOffset="660" presetHandlers="18"/>
+      </img>
+      <shape width="180" height="58" topLeftX="144" topLeftY="289" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="32">入职流程</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="60" height="60" topLeftX="73" topLeftY="283" iconType="iconpark/Travel/cable-car.svg">
+        <border width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="12" height="12" topLeftX="550" topLeftY="398" type="ellipse">
+        <fill>
+          <fillColor color="rgba(75, 63, 221, 1)"/>
+        </fill>
+      </shape>
+      <shape width="12" height="12" topLeftX="645" topLeftY="398" type="ellipse">
+        <fill>
+          <fillColor color="rgba(44, 40, 64, 1)"/>
+        </fill>
+      </shape>
+      <shape width="12" height="12" topLeftX="739" topLeftY="398" type="ellipse">
+        <fill>
+          <fillColor color="rgba(44, 40, 64, 1)"/>
+        </fill>
+      </shape>
+      <shape width="12" height="12" topLeftX="833" topLeftY="398" type="ellipse">
+        <fill>
+          <fillColor color="rgba(44, 40, 64, 1)"/>
+        </fill>
+      </shape>
+      <shape width="76" height="38" topLeftX="541" topLeftY="412" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(44, 40, 64, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="12">签订合同</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="76" height="38" topLeftX="635" topLeftY="412" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(44, 40, 64, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="12">入职手续</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="76" height="38" topLeftX="729" topLeftY="412" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(44, 40, 64, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="12">申请设备</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="76" height="38" topLeftX="823" topLeftY="412" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(44, 40, 64, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="12">培训安排</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 40, 64, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="236" height="44" topLeftX="421" topLeftY="151" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">身份证 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="208" height="56" topLeftX="421" topLeftY="184" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="254" height="56" topLeftX="69" topLeftY="155" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="44" topLeftX="704" topLeftY="358" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">体检证明 #4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="208" height="56" topLeftX="704" topLeftY="391" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="44" topLeftX="421" topLeftY="358" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">学历/学位证明 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="208" height="56" topLeftX="421" topLeftY="391" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="44" topLeftX="704" topLeftY="151" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">银行卡 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="208" height="56" topLeftX="704" topLeftY="184" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="270" height="68" topLeftX="71" topLeftY="91" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">入职手续</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="60" height="60" topLeftX="433" topLeftY="91" iconType="iconpark/Peoples/id-card-h.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="60" height="60" topLeftX="711" topLeftY="91" iconType="iconpark/Money/bank-card.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="60" height="60" topLeftX="433" topLeftY="297" iconType="iconpark/Clothes/bachelor-cap-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="60" height="60" topLeftX="711" topLeftY="297" iconType="iconpark/Health/eeg.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(75, 63, 221, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="42" height="42" topLeftX="822" topLeftY="244" alpha="0.2" type="ellipse">
+        <border color="rgba(44, 40, 64, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="25" height="25" topLeftX="831" topLeftY="252" alpha="0.2" iconType="iconpark/Arrows/arrow-right.svg">
+        <border color="rgba(44, 40, 64, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="865" height="454" topLeftX="47" topLeftY="43" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="TbzSb8bX7oZhvoxGHYoch6qfnAg" width="296" height="408" topLeftX="72" topLeftY="66">
+        <crop type="rect" leftOffset="56" rightOffset="56" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="404" height="68" topLeftX="415" topLeftY="160" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="32">办公设备申请</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="263" height="128" topLeftX="415" topLeftY="218" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p list="none">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <icon width="25" height="25" topLeftX="831" topLeftY="252" alpha="0.2" iconType="iconpark/Arrows/arrow-right.svg">
+        <border color="rgba(44, 40, 64, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="42" height="42" topLeftX="822" topLeftY="244" alpha="0.2" type="ellipse">
+        <border color="rgba(44, 40, 64, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(75, 63, 221, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="YDX8brid2ofS9vxsbDCcW5MfnHd" width="328" height="432" topLeftX="571" topLeftY="54">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="2" bottomOffset="2" presetHandlers="24"/>
+      </img>
+      <shape width="381" height="44" topLeftX="67" topLeftY="260" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">请输入相关描述信息以解释你的标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="485" height="85" topLeftX="62" topLeftY="294" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2" letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="54">规章制度</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(243, 244, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="421" height="449" topLeftX="53" topLeftY="46" presetHandlers="24" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="421" height="449" topLeftX="487" topLeftY="46" presetHandlers="24" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="GduebSB0doQ9vAxRVTBcwJOIncf" width="358" height="202" topLeftX="518" topLeftY="74">
+        <crop type="rect" leftOffset="22" rightOffset="22" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Dwv9bc5ngozIaAxH02CcjmptnBs" width="358" height="202" topLeftX="84" topLeftY="74">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+      <shape width="221" height="74" topLeftX="222" topLeftY="373" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="221" height="44" topLeftX="222" topLeftY="339" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>年度旅游福利</p>
+        </content>
+      </shape>
+      <shape width="221" height="74" topLeftX="656" topLeftY="373" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="221" height="44" topLeftX="656" topLeftY="339" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">如何处理病假</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="100" height="100" topLeftX="84" topLeftY="343" presetHandlers="100" type="round-rect">
+        <fill>
+          <fillColor color="rgba(44, 40, 64, 1)"/>
+        </fill>
+      </shape>
+      <icon width="49" height="49" topLeftX="111" topLeftY="369" rotation="90" iconType="iconpark/Travel/airplane.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </icon>
+      <shape width="100" height="100" topLeftX="517" topLeftY="343" presetHandlers="100" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(44, 40, 64, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="49" height="49" topLeftX="543" topLeftY="369" iconType="iconpark/Health/cross-society.svg">
+        <fill>
+          <fillColor color="rgba(44, 40, 64, 1)"/>
+        </fill>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(75, 63, 221, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="FLAWbzsymo9ZUHxmDAkcNe40nbb" width="328" height="432" topLeftX="571" topLeftY="54">
+        <crop type="rect" leftOffset="52" rightOffset="52" topOffset="0" bottomOffset="0" presetHandlers="24"/>
+      </img>
+      <shape width="381" height="44" topLeftX="67" topLeftY="260" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">请输入相关描述信息以解释你的标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="485" height="85" topLeftX="62" topLeftY="294" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2" letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="54">公司福利</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <undefined type="fallback"/>
+      <shape width="255" height="92" topLeftX="341" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">关键点 #1</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">关键点 #2</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">关键点 #3</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="260" height="74" topLeftX="52" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>
+                <span color="rgba(255, 255, 255, 1)">关键点 #1</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">关键点 #</span>
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">2</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">关键点 #3</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="260" height="92" topLeftX="634" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">关键点 #1</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">关键点 #2</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">关键点 #3</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="487" height="68" topLeftX="236" topLeftY="46" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">公司福利</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 40, 64, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="404" height="116" topLeftX="278" topLeftY="202" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">愿你在这里度过愉快的时光</span>
+            </strong>
+          </p>
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">并在我们的团队中取得成功</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/marketing--brand_communication.xml
+++ b/skills/lark-slides/references/templates/marketing--brand_communication.xml
@@ -1,0 +1,1367 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>品牌传播方案</title>
+  <theme>
+    <fill alpha="1">
+      <fillImg src="Iyjybbnc2oSPDbxsyOUcD72Fnob" alpha="1" rotateWithShape="false"/>
+    </fill>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="48"/>
+      <headline fontColor="#000000FF" fontSize="36"/>
+      <sub-headline fontColor="#000000FF" fontSize="28"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style/>
+    <data>
+      <img src="YbHYbrBDQoc7xrxu3sJcWWS8n4b" width="654" height="564" topLeftX="260" topLeftY="-24" alpha="0.55">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="399" height="404" topLeftX="289" topLeftY="68" rotation="347" alpha="0.77" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="161" blur="150" color="rgba(79, 196, 147, 0.82)"/>
+      </shape>
+      <shape width="399" height="404" topLeftX="289" topLeftY="68" rotation="347" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)"/>
+        </fill>
+        <border color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="49" blur="77" color="rgba(23, 91, 194, 0.44)"/>
+      </shape>
+      <shape width="399" height="404" topLeftX="289" topLeftY="68" rotation="347" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="200" angle="0" blur="150" color="rgba(79, 196, 147, 0.56)"/>
+      </shape>
+      <shape width="506" height="193" topLeftX="32" topLeftY="296" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="72" color="rgba(0, 0, 0, 1)" bold="true" underline="false">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="72" underline="false">品牌</span>
+            </strong>
+          </p>
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="72" underline="false">传播方案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="38" topLeftX="760" topLeftY="352" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="12">演示者：小张和小王</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="MNT2bZ2pKoXX8lxKl42ctElLnDc" width="75" height="75" topLeftX="760" topLeftY="402" alpha="0.96">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="540"/>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="WOGWbt8S2oBh7hxnePJckDTcnZf" width="75" height="75" topLeftX="826" topLeftY="402" alpha="0.96">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="540"/>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <icon width="24" height="24" topLeftX="28" topLeftY="29" iconType="iconpark/Charts/chart-ring.svg">
+        <border color="rgba(44, 44, 45, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="196" height="32" topLeftX="46" topLeftY="24" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(44, 44, 45, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(44, 44, 45, 1)" fontSize="12">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Hme0bn76DoCxQKxHig9cS9w9nWg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="358" height="68" topLeftX="95" topLeftY="352" presetHandlers="80" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(121, 199, 255, 0.39) 0%,rgba(161, 255, 210, 0.68) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(44, 44, 45, 1)">
+          <p>
+            <span color="rgba(44, 44, 45, 1)" fontSize="20">品牌传播策略</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="51" topLeftX="104" topLeftY="360" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="358" height="68" topLeftX="95" topLeftY="261" presetHandlers="80" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(121, 199, 255, 0.39) 0%,rgba(161, 255, 210, 0.68) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(44, 44, 45, 1)">
+          <p>
+            <span color="rgba(44, 44, 45, 1)" fontSize="20">品牌概述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="51" topLeftX="104" topLeftY="269" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="358" height="68" topLeftX="538" topLeftY="261" presetHandlers="80" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(121, 199, 255, 0.39) 0%,rgba(161, 255, 210, 0.68) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(44, 44, 45, 1)">
+          <p>
+            <span color="rgba(44, 44, 45, 1)" fontSize="20">品牌传播分析</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="51" topLeftX="547" topLeftY="269" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="358" height="68" topLeftX="538" topLeftY="352" presetHandlers="80" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(121, 199, 255, 0.39) 0%,rgba(161, 255, 210, 0.68) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(44, 44, 45, 1)">
+          <p>
+            <span color="rgba(44, 44, 45, 1)" fontSize="20">品牌传播创意</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="51" topLeftX="547" topLeftY="360" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="238" height="87" topLeftX="93" topLeftY="59" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" bold="true" lineSpacing="multiple:1.4">
+          <p>目录</p>
+        </content>
+      </shape>
+      <shape width="404" height="58" topLeftX="93" topLeftY="129" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" bold="true" lineSpacing="multiple:1.35">
+          <p>Contents</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="AjidbbCsOoao9LxjA85cEdK8nhe" width="353" height="300" topLeftX="-26" topLeftY="83" flipX="true" alpha="0.55">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" alpha="0.77" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="78" angle="202" blur="150" color="rgba(79, 196, 147, 0.61)"/>
+      </shape>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)"/>
+        </fill>
+        <border color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="49" blur="77" color="rgba(23, 91, 194, 0.44)"/>
+      </shape>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="200" angle="180" blur="150" color="rgba(79, 196, 147, 0.56)"/>
+      </shape>
+      <shape width="564" height="110" topLeftX="401" topLeftY="215" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.4">
+          <p>品牌概述</p>
+        </content>
+      </shape>
+      <shape width="112" height="110" topLeftX="211" topLeftY="215" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.4">
+          <p>01</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HQLGbGBstowtlExrFa3cAPA5nfh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="202" height="34" topLeftX="730" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p>01 | 品牌概述</p>
+        </content>
+      </shape>
+      <shape width="416" height="61" topLeftX="83" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" bold="true" lineSpacing="multiple:1.35">
+          <p>发展回顾</p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+      <line startX="280" startY="256" endX="374" endY="256">
+        <border color="rgba(44, 44, 45, 1)" dashArray="dot" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="591" startY="256" endX="684" endY="256">
+        <border color="rgba(44, 44, 45, 1)" dashArray="dot" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HQLGbGBstowtlExrFa3cAPA5nfh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="202" height="34" topLeftX="730" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p>01 | 品牌概述</p>
+        </content>
+      </shape>
+      <shape width="416" height="61" topLeftX="83" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" bold="true" lineSpacing="multiple:1.35">
+          <p>品牌项目</p>
+        </content>
+      </shape>
+      <shape width="512" height="512" topLeftX="16" topLeftY="149" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(81, 191, 255, 0.23) 0%,rgba(161, 255, 216, 0) 35%,rgba(161, 255, 204, 0) 100%)"/>
+        </fill>
+        <border color="linear-gradient(180deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 0) 52%,rgba(161, 255, 179, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="377" height="377" topLeftX="84" topLeftY="259" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(81, 191, 255, 0.23) 0%,rgba(161, 255, 216, 0) 35%,rgba(161, 255, 204, 0) 100%)"/>
+        </fill>
+        <border color="linear-gradient(180deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 0) 52%,rgba(161, 255, 179, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="232" height="232" topLeftX="157" topLeftY="369" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(89, 194, 255, 0.23) 0%,rgba(161, 255, 204, 0) 23%,rgba(161, 255, 210, 0) 100%)"/>
+        </fill>
+        <border color="linear-gradient(180deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 0) 52%,rgba(161, 255, 179, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="141" height="41" topLeftX="202" topLeftY="185" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="center">
+          <p>
+            <strong>低端市场</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="41" topLeftX="202" topLeftY="310" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="center">
+          <p>
+            <strong>中端市场</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="41" topLeftX="202" topLeftY="428" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="center">
+          <p>
+            <strong>高端市场</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="62" topLeftX="569" topLeftY="445" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="330" height="44" topLeftX="569" topLeftY="413" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35">
+          <p>关键结论 #3</p>
+        </content>
+      </shape>
+      <shape width="330" height="62" topLeftX="569" topLeftY="316" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="330" height="44" topLeftX="569" topLeftY="284" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35">
+          <p>关键结论 #2</p>
+        </content>
+      </shape>
+      <shape width="330" height="44" topLeftX="569" topLeftY="159" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35">
+          <p>关键结论 #1</p>
+        </content>
+      </shape>
+      <shape width="330" height="62" topLeftX="569" topLeftY="190" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HQLGbGBstowtlExrFa3cAPA5nfh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="202" height="34" topLeftX="730" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p>01 | 品牌概述</p>
+        </content>
+      </shape>
+      <shape width="416" height="61" topLeftX="83" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" bold="true" lineSpacing="multiple:1.35">
+          <p>品牌目标</p>
+        </content>
+      </shape>
+      <shape width="404" height="404" topLeftX="107" topLeftY="117" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+        <shadow blur="97" color="rgba(64, 204, 112, 0.15)"/>
+      </shape>
+      <shape width="404" height="404" topLeftX="449" topLeftY="117" alpha="0.92" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+        <shadow blur="97" color="rgba(37, 202, 182, 0.15)"/>
+      </shape>
+      <icon width="54" height="54" topLeftX="624" topLeftY="167" iconType="iconpark/Travel/earth.svg">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(76, 169, 223, 1) 0%,rgba(161, 255, 179, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(90deg,rgba(76, 169, 223, 1) 0%,rgba(161, 255, 179, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="54" height="54" topLeftX="282" topLeftY="167" iconType="iconpark/Travel/local-two.svg">
+        <border color="linear-gradient(90deg,rgba(76, 169, 223, 1) 0%,rgba(161, 255, 179, 1) 100%)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="240" height="44" topLeftX="189" topLeftY="226" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">品牌宗旨</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="146" topLeftX="189" topLeftY="281" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">演示文稿是实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中内容，可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="44" topLeftX="531" topLeftY="226" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)">品牌理念</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="146" topLeftX="531" topLeftY="281" alpha="0.75" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">演示文稿是实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中内容，可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="100" height="101" topLeftX="63" topLeftY="402" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(76, 169, 223, 0.61) 0%,rgba(161, 255, 179, 0.65) 100%)" width="32" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="92" height="92" topLeftX="771" topLeftY="121" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(76, 169, 223, 0.61) 0%,rgba(161, 255, 179, 0.65) 100%)"/>
+        </fill>
+        <shadow offset="14" angle="90" blur="108" color="rgba(100, 232, 214, 0.5)"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="AjidbbCsOoao9LxjA85cEdK8nhe" width="353" height="300" topLeftX="-26" topLeftY="83" flipX="true" alpha="0.55">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" alpha="0.77" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="78" angle="202" blur="150" color="rgba(79, 196, 147, 0.61)"/>
+      </shape>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)"/>
+        </fill>
+        <border color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="49" blur="77" color="rgba(23, 91, 194, 0.44)"/>
+      </shape>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="200" angle="180" blur="150" color="rgba(79, 196, 147, 0.56)"/>
+      </shape>
+      <shape width="564" height="110" topLeftX="401" topLeftY="215" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.4">
+          <p>品牌分析传播</p>
+        </content>
+      </shape>
+      <shape width="112" height="110" topLeftX="211" topLeftY="215" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.4">
+          <p>02</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HQLGbGBstowtlExrFa3cAPA5nfh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="263" height="263" topLeftX="348" topLeftY="173" alpha="0.2" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(76, 169, 223, 0.61) 0%,rgba(161, 255, 179, 0.65) 100%)" width="36" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="163" height="163" topLeftX="398" topLeftY="222" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(76, 169, 223, 0.26) 0%,rgba(161, 255, 179, 0.4) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="69" height="69" topLeftX="329" topLeftY="190" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="9" blur="44" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <icon width="30" height="30" topLeftX="349" topLeftY="210" iconType="iconpark/Music/waves-right.svg">
+        <border color="rgba(0, 0, 0, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="69" height="69" topLeftX="328" topLeftY="342" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="9" blur="44" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="69" height="69" topLeftX="562" topLeftY="190" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="9" blur="44" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="69" height="69" topLeftX="562" topLeftY="342" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="9" blur="44" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <icon width="30" height="30" topLeftX="582" topLeftY="210" iconType="iconpark/Components/switch-button.svg">
+        <border width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="30" height="30" topLeftX="348" topLeftY="362" iconType="iconpark/Office/application-effect.svg">
+        <border width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="30" height="30" topLeftX="582" topLeftY="362" iconType="iconpark/Music/monitor-two.svg">
+        <border width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="202" height="34" topLeftX="730" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p>
+            02 | 
+            <strong>
+              <span fontSize="14">品牌分析传播</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="61" topLeftX="83" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" bold="true" lineSpacing="multiple:1.35">
+          <p>品牌建设分析</p>
+        </content>
+      </shape>
+      <shape width="283" height="38" topLeftX="338" topLeftY="297" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12">PRODUCT PLAN</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="284" height="47" topLeftX="338" topLeftY="270" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18">产品计划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="44" topLeftX="35" topLeftY="183" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">流量竞争</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="44" topLeftX="35" topLeftY="332" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">布局策略</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="35" topLeftY="370" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="35" topLeftY="221" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="44" topLeftX="685" topLeftY="183" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">产品转型</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="44" topLeftX="685" topLeftY="332" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">管理模式</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="685" topLeftY="370" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="685" topLeftY="221" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HQLGbGBstowtlExrFa3cAPA5nfh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="202" height="34" topLeftX="730" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="14">02 | 品牌分析传播</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="61" topLeftX="93" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" bold="true" lineSpacing="multiple:1.35">
+          <p>问题梳理</p>
+        </content>
+      </shape>
+      <shape width="240" height="260" topLeftX="89" topLeftY="163" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" blur="150" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="202" height="68" topLeftX="103" topLeftY="252" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>品牌如何打破行业壁垒，获取注意力？</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="83" topLeftX="103" topLeftY="324" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(161, 161, 161, 1)" textAlign="left">
+          <p>
+            <span color="rgba(161, 161, 161, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="68" topLeftX="103" topLeftY="175" alpha="0.27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="linear-gradient(0deg,rgba(54, 115, 255, 1) 0%,rgba(0, 86, 255, 0.412) 83%,rgba(219, 228, 246, 0) 100%)" italic="true" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <em>
+                <span color="linear-gradient(180deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.471) 100%)" fontSize="40">ONE</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="260" topLeftX="360" topLeftY="163" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" blur="150" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="202" height="68" topLeftX="374" topLeftY="252" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>品牌如何巩固且提升行业影响力？</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="83" topLeftX="374" topLeftY="324" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(161, 161, 161, 1)" textAlign="left">
+          <p>
+            <span color="rgba(161, 161, 161, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="68" topLeftX="374" topLeftY="175" alpha="0.27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="linear-gradient(0deg,rgba(54, 115, 255, 1) 0%,rgba(0, 86, 255, 0.412) 83%,rgba(219, 228, 246, 0) 100%)" italic="true" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <em>
+                <span color="linear-gradient(180deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.471) 100%)" fontSize="40">TWO</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="260" topLeftX="631" topLeftY="163" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" blur="150" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="202" height="68" topLeftX="645" topLeftY="252" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>如何提高品牌口碑，强化竞争力？</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="83" topLeftX="644" topLeftY="324" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(161, 161, 161, 1)" textAlign="left">
+          <p>
+            <span color="rgba(161, 161, 161, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="68" topLeftX="644" topLeftY="175" alpha="0.27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="linear-gradient(0deg,rgba(54, 115, 255, 1) 0%,rgba(0, 86, 255, 0.412) 83%,rgba(219, 228, 246, 0) 100%)" italic="true" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <em>
+                <span color="linear-gradient(180deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.471) 100%)" fontSize="40">THREE</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="AjidbbCsOoao9LxjA85cEdK8nhe" width="353" height="300" topLeftX="-26" topLeftY="83" flipX="true" alpha="0.55">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" alpha="0.77" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="78" angle="202" blur="150" color="rgba(79, 196, 147, 0.61)"/>
+      </shape>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)"/>
+        </fill>
+        <border color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="49" blur="77" color="rgba(23, 91, 194, 0.44)"/>
+      </shape>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="200" angle="180" blur="150" color="rgba(79, 196, 147, 0.56)"/>
+      </shape>
+      <shape width="564" height="110" topLeftX="401" topLeftY="215" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.4">
+          <p>品牌传播策略</p>
+        </content>
+      </shape>
+      <shape width="112" height="110" topLeftX="211" topLeftY="215" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.4">
+          <p>03</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HQLGbGBstowtlExrFa3cAPA5nfh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="202" height="34" topLeftX="730" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <span fontSize="14">03 | 品牌传播策略</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="61" topLeftX="93" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" bold="true" lineSpacing="multiple:1.35">
+          <p>品牌 IP 区域化</p>
+        </content>
+      </shape>
+      <shape width="229" height="229" topLeftX="460" topLeftY="239" presetHandlers="228" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(76, 169, 223, 0.31) 0%,rgba(161, 255, 179, 1) 100%)"/>
+        </fill>
+        <shadow offset="14" angle="187" blur="70" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="128" height="62" topLeftX="511" topLeftY="322" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(31, 35, 41, 1)" bold="true" italic="true" textAlign="center">
+          <p>
+            <strong>
+              <em>
+                <span color="rgba(31, 35, 41, 1)" fontSize="28">55%</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="180" topLeftX="271" topLeftY="252" presetHandlers="228" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 255, 255, 0.5) 0%,rgba(255, 255, 255, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(90deg,rgba(76, 169, 223, 0.31) 0%,rgba(161, 255, 179, 1) 100%)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="66" blur="53" color="rgba(0, 0, 0, 0.05)"/>
+      </shape>
+      <shape width="128" height="62" topLeftX="297" topLeftY="311" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(31, 35, 41, 1)" bold="true" italic="true" textAlign="center">
+          <p>
+            <strong>
+              <em>
+                <span color="rgba(31, 35, 41, 1)" fontSize="28">30%</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="138" height="138" topLeftX="382" topLeftY="127" presetHandlers="228" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 255, 255, 0.5) 0%,rgba(255, 255, 255, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(90deg,rgba(76, 169, 223, 0.31) 0%,rgba(161, 255, 179, 1) 100%)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="187" blur="100" color="rgba(0, 0, 0, 0.08)"/>
+      </shape>
+      <shape width="116" height="62" topLeftX="393" topLeftY="165" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(31, 35, 41, 1)" bold="true" italic="true" textAlign="center">
+          <p>
+            <strong>
+              <em>
+                <span color="rgba(31, 35, 41, 1)" fontSize="28">15%</span>
+              </em>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="533" topLeftY="137" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">产品转型</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="56" topLeftX="533" topLeftY="165" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题</span>
+          </p>
+          <p>
+            <span fontSize="12">现在就开始打字吧</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="701" topLeftY="306" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">产品转型</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="56" topLeftX="701" topLeftY="334" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题</span>
+          </p>
+          <p>
+            <span fontSize="12">现在就开始打字吧</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="57" topLeftY="302" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">产品转型</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="56" topLeftX="57" topLeftY="331" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题</span>
+          </p>
+          <p>
+            <span fontSize="12">现在就开始打字吧</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HQLGbGBstowtlExrFa3cAPA5nfh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="202" height="34" topLeftX="730" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="14">03 | 品牌传播策略</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="61" topLeftX="83" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span fontSize="30">社群品牌盛典化</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="722" height="56" topLeftX="83" topLeftY="392" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span color="rgba(161, 161, 161, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="156" height="64" topLeftX="309" topLeftY="229" presetHandlers="60" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">情人节活动</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="338" startY="192" endX="338" endY="221">
+        <border color="rgba(31, 35, 41, 1)" dashArray="dot" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="99" height="38" topLeftX="313" topLeftY="158" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2026.02.14</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="156" height="64" topLeftX="91" topLeftY="229" presetHandlers="60" type="round-rect">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">跨年活动</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="120" startY="192" endX="120" endY="221">
+        <border color="rgba(31, 35, 41, 1)" dashArray="dot" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="99" height="38" topLeftX="95" topLeftY="158" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2026.01.01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="156" height="64" topLeftX="746" topLeftY="229" presetHandlers="60" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">双十一购物节</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="774" startY="192" endX="774" endY="221">
+        <border color="rgba(31, 35, 41, 1)" dashArray="dot" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="99" height="38" topLeftX="750" topLeftY="158" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2026.11.11</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="156" height="64" topLeftX="527" topLeftY="229" presetHandlers="60" type="round-rect">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">618 购物节</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="556" startY="192" endX="556" endY="221">
+        <border color="rgba(31, 35, 41, 1)" dashArray="dot" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="99" height="38" topLeftX="531" topLeftY="158" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2026.06.18</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="101" topLeftY="305" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>活动描述</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="319" topLeftY="305" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>活动描述</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="537" topLeftY="305" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>活动描述</p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="756" topLeftY="305" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>活动描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HQLGbGBstowtlExrFa3cAPA5nfh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="202" height="34" topLeftX="730" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="14">03 | 品牌传播策略</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="61" topLeftX="83" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span fontSize="30">品牌代言人体系化</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="AjidbbCsOoao9LxjA85cEdK8nhe" width="353" height="300" topLeftX="-26" topLeftY="83" flipX="true" alpha="0.55">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" alpha="0.77" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="78" angle="202" blur="150" color="rgba(79, 196, 147, 0.61)"/>
+      </shape>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)"/>
+        </fill>
+        <border color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="49" blur="77" color="rgba(23, 91, 194, 0.44)"/>
+      </shape>
+      <shape width="215" height="215" topLeftX="111" topLeftY="139" flipX="true" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="200" angle="180" blur="150" color="rgba(79, 196, 147, 0.56)"/>
+      </shape>
+      <shape width="564" height="110" topLeftX="401" topLeftY="215" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.4">
+          <p>品牌传播创意</p>
+        </content>
+      </shape>
+      <shape width="112" height="110" topLeftX="211" topLeftY="215" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1.4">
+          <p>04</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="MV41bXGlYoTiIAxyTkgcAoCCnzg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="RQ4bb50gposPVmxmeBIcJiuMnpd" width="204" height="380" topLeftX="713" topLeftY="80">
+        <crop type="rect" leftOffset="0.12" rightOffset="0.12" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="VITubmUtxojYycxhKYVcML9un5L" width="162" height="132" topLeftX="537" topLeftY="328">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.19" bottomOffset="0.19" presetHandlers="12"/>
+      </img>
+      <img src="JO6IblecQoppuTxxuwXcfOq0nud" width="162" height="132" topLeftX="361" topLeftY="328">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.19" bottomOffset="0.19" presetHandlers="12"/>
+      </img>
+      <img src="GTYhbABKHoXRG5xHeVMcgw2EnUg" width="338" height="236" topLeftX="361" topLeftY="80">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.16" bottomOffset="0.16" presetHandlers="12"/>
+      </img>
+      <shape width="202" height="34" topLeftX="730" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="14">04 | 品牌传播创意</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="146" topLeftX="47" topLeftY="112" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">演示文稿是实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中内容，可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="266" height="61" topLeftX="43" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="30">平面风格</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Iyjybbnc2oSPDbxsyOUcD72Fnob" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="188" height="384" topLeftX="328" topLeftY="70" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="188" height="384" topLeftX="526" topLeftY="70" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="188" height="384" topLeftX="721" topLeftY="70" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <img src="LqVhbXxnLoDJIfxjldFccB3snnf" width="172" height="266" topLeftX="338" topLeftY="79" exposure="12" temperature="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.1" bottomOffset="0.1" presetHandlers="12"/>
+      </img>
+      <img src="RjVsbnbqNoKY5nxdZBfcFRYqnI3" width="172" height="266" topLeftX="534" topLeftY="79" exposure="19" contrast="-9" saturation="15" temperature="-20">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.1" bottomOffset="0.1" presetHandlers="12"/>
+      </img>
+      <img src="AVH7bdQimoVugyxJKgkcENr5nye" width="172" height="266" topLeftX="729" topLeftY="79">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.1" bottomOffset="0.1" presetHandlers="12"/>
+      </img>
+      <shape width="240" height="146" topLeftX="47" topLeftY="112" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">演示文稿是实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中内容，可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="272" height="61" topLeftX="43" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="30">短视频</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="34" topLeftX="730" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="14">04 | 品牌传播创意</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="74" topLeftX="729" topLeftY="373" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" bold="false">
+          <p>
+            <span fontSize="12" bold="false">输入相关的描述以解释你的标题。输入相关的描述以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="41" topLeftX="729" topLeftY="344" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">参考</span>
+            </strong>
+            <strong>
+              <span fontSize="14">三</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="74" topLeftX="534" topLeftY="373" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" bold="false">
+          <p>
+            <span fontSize="12" bold="false">输入相关的描述以解释你的标题。输入相关的描述以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="41" topLeftX="534" topLeftY="344" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">参考</span>
+            </strong>
+            <strong>
+              <span fontSize="14">二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="74" topLeftX="338" topLeftY="373" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" bold="false">
+          <p>
+            <span fontSize="12" bold="false">输入相关的描述以解释你的标题。输入相关的描述以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="41" topLeftX="338" topLeftY="344" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">参考一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="YbHYbrBDQoc7xrxu3sJcWWS8n4b" width="654" height="564" topLeftX="260" topLeftY="-24" alpha="0.55">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="399" height="404" topLeftX="289" topLeftY="68" rotation="347" alpha="0.77" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="161" blur="150" color="rgba(79, 196, 147, 0.82)"/>
+      </shape>
+      <shape width="399" height="404" topLeftX="289" topLeftY="68" rotation="347" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)"/>
+        </fill>
+        <border color="linear-gradient(54deg,rgba(222, 255, 241, 0) 0%,rgba(227, 255, 243, 0) 23%,rgba(242, 255, 250, 0.48) 100%)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="49" blur="77" color="rgba(23, 91, 194, 0.44)"/>
+      </shape>
+      <shape width="399" height="404" topLeftX="289" topLeftY="68" rotation="347" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(336deg,rgba(255, 255, 255, 0) 0%,rgba(255, 255, 255, 0.53) 100%)"/>
+        </fill>
+        <shadow offset="200" angle="0" blur="150" color="rgba(79, 196, 147, 0.56)"/>
+      </shape>
+      <shape width="202" height="37" topLeftX="730" topLeftY="23" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1.2">品牌传播方案</p>
+        </content>
+      </shape>
+      <shape width="418" height="106" topLeftX="271" topLeftY="217" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="72" color="rgba(0, 0, 0, 1)" bold="true" underline="false" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="72" underline="false">感谢观看</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="28" topLeftY="29" iconType="iconpark/Charts/chart-ring.svg">
+        <border color="rgba(44, 44, 45, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="196" height="32" topLeftX="46" topLeftY="24" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(44, 44, 45, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(44, 44, 45, 1)" fontSize="12">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/marketing--brand_logo_design.xml
+++ b/skills/lark-slides/references/templates/marketing--brand_logo_design.xml
@@ -1,0 +1,1347 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>品牌标志设计</title>
+  <theme>
+    <textStyles>
+      <title/>
+      <headline/>
+      <sub-headline/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="rgba(155, 157, 160, 1)" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Nz5gb0JwQoKtbWxj6vScCVdlnDg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="206" height="62" topLeftX="60" topLeftY="413" type="slides-full-round-rect">
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="124" height="41" topLeftX="82" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="14">April XX, 2026</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="215" startY="445" endX="245" endY="445">
+        <border lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <endArrow type="arrow"/>
+      </line>
+      <shape width="157" height="42" topLeftX="60" topLeftY="170" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(203, 205, 208, 1)">
+          <p letterSpacing="1">
+            <span color="rgba(203, 205, 208, 1)">XX 品牌</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="454" height="110" topLeftX="46" topLeftY="211" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="60">品牌标志设计</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="41" topLeftX="85" topLeftY="54" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="false">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="14" bold="false">YOUR LOGO</span>
+          </p>
+        </content>
+      </shape>
+      <img src="DD33b3w3XovpT9xFZpqco0TynEe" width="12" height="25" topLeftX="60" topLeftY="62" alpha="0.9">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="DD33b3w3XovpT9xFZpqco0TynEe" width="12" height="25" topLeftX="74" topLeftY="62" alpha="0.9">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="124" height="38" topLeftX="787" topLeftY="57" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(0, 0, 0, 1)" bold="false" textAlign="right">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12" bold="false">YOUR TEAM</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(28, 102, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="DYM4b6dzCoMD5gx4sn4cdPYlnxg" width="312" height="402" topLeftX="0" topLeftY="0" rotation="180">
+        <crop type="rect" leftOffset="0" rightOffset="86" topOffset="0" bottomOffset="186" presetHandlers="0"/>
+      </img>
+      <img src="ILOUbaURToeRBCx5VxicLMsKnsb" width="432" height="203" topLeftX="528" topLeftY="0">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="K8w1bqqEzoTR1bxSqC2cZaQKnmM" width="216" height="337" topLeftX="744" topLeftY="203">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="95" presetHandlers="0"/>
+      </img>
+      <shape width="357" height="44" topLeftX="471" topLeftY="371" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="16">品牌标志方案二</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="357" height="44" topLeftX="471" topLeftY="308" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="16">品牌标志方案一</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="357" height="44" topLeftX="471" topLeftY="246" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="16">设计目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="357" height="44" topLeftX="471" topLeftY="181" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="16">品牌背景</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="57" height="56" topLeftX="414" topLeftY="365" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="57" height="56" topLeftX="414" topLeftY="302" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="57" height="56" topLeftX="414" topLeftY="240" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="57" height="56" topLeftX="414" topLeftY="175" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>01</p>
+        </content>
+      </shape>
+      <shape width="355" height="83" topLeftX="47" topLeftY="163" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.949)" fontSize="42">目录</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(251, 251, 251, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(306deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 26%,rgba(230, 241, 255, 0.1) 63%,rgba(8, 120, 255, 0.11) 100%)"/>
+        </fill>
+      </shape>
+      <img src="CfGzbrtZQogLbGxoQ6NcBVgTnud" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="311" height="291" topLeftX="-10" topLeftY="239" rotation="270" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(19, 123, 255, 0) 0%,rgba(173, 230, 253, 0.4) 100%)"/>
+        </fill>
+      </shape>
+      <img src="FW7dbP5C1ol5nXxuNxEcNewknTd" width="210" height="295" topLeftX="250" topLeftY="-43" rotation="90" alpha="0.12">
+        <crop type="rect" leftOffset="50" rightOffset="0" topOffset="0" bottomOffset="87" presetHandlers="0"/>
+      </img>
+      <img src="I8dFbBRi4o5BJCx4XgycfspKnxI" width="362" height="540" topLeftX="0" topLeftY="0" exposure="12" contrast="-11" saturation="22" temperature="-82">
+        <crop type="rect" leftOffset="13" rightOffset="31" topOffset="7" bottomOffset="62" presetHandlers="0"/>
+      </img>
+      <shape width="106" height="106" topLeftX="302" topLeftY="105" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="64" height="64" topLeftX="322" topLeftY="126" iconType="iconpark/Abstract/graphic-stitching.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="235" height="77" topLeftX="451" topLeftY="118" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="38">品牌背景</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="332" height="44" topLeftX="453" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">背景一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="332" height="62" topLeftX="453" topLeftY="233" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(155, 157, 160, 1)" textAlign="left">
+          <p>
+            <span color="rgba(155, 157, 160, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="332" height="44" topLeftX="453" topLeftY="313" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">背景二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="332" height="62" topLeftX="453" topLeftY="343" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(155, 157, 160, 1)" textAlign="left">
+          <p>
+            <span color="rgba(155, 157, 160, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(251, 251, 251, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="V3PFbTK7oo0k82x2N1Rcu5x0nBc" width="344" height="412" topLeftX="0" topLeftY="0" alpha="0.15">
+        <crop type="rect" leftOffset="81" rightOffset="0" topOffset="172" bottomOffset="43" presetHandlers="0"/>
+      </img>
+      <img src="X9O3bMXTQoPTsSxLF9XciJtwnAf" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <img src="PT8Vb5020oH4AjxP0hacPvwDnhq" width="540" height="960" topLeftX="455" topLeftY="510" rotation="270" alpha="0.5">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="249" height="77" topLeftX="47" topLeftY="150" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="38">设计目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="244" height="83" topLeftX="52" topLeftY="227" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)" textAlign="left">
+          <p>
+            <span color="rgba(121, 124, 129, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="44" topLeftX="683" topLeftY="174" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">目标二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="74" topLeftX="684" topLeftY="207" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)">
+          <p>
+            <span color="rgba(121, 124, 129, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="78" topLeftX="683" topLeftY="91" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="40" height="40" topLeftX="702" topLeftY="110" iconType="iconpark/Charts/chart-proportion.svg">
+        <border color="linear-gradient(141deg,rgba(243, 249, 255, 1) 0%,rgba(244, 248, 253, 1) 27%,rgba(245, 246, 246, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="236" height="44" topLeftX="683" topLeftY="401" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">目标四</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="74" topLeftX="684" topLeftY="434" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)">
+          <p>
+            <span color="rgba(121, 124, 129, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="78" topLeftX="683" topLeftY="318" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 117, 239, 1)"/>
+        </fill>
+      </shape>
+      <icon width="40" height="40" topLeftX="702" topLeftY="337" iconType="iconpark/Abstract/triangular-pyramid.svg">
+        <border color="linear-gradient(141deg,rgba(243, 249, 255, 1) 0%,rgba(244, 248, 253, 1) 27%,rgba(245, 246, 246, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="236" height="44" topLeftX="396" topLeftY="401" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">目标三</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="74" topLeftX="397" topLeftY="434" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)">
+          <p>
+            <span color="rgba(121, 124, 129, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="78" topLeftX="396" topLeftY="318" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="40" height="40" topLeftX="415" topLeftY="337" iconType="iconpark/Operate/color-filter.svg">
+        <border color="linear-gradient(141deg,rgba(243, 249, 255, 1) 0%,rgba(244, 248, 253, 1) 27%,rgba(245, 246, 246, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <line startX="653" startY="91" endX="653" endY="502">
+        <border color="rgba(203, 205, 208, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="370" startY="292" endX="905" endY="292">
+        <border color="rgba(203, 205, 208, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="236" height="44" topLeftX="396" topLeftY="174" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">目标一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="74" topLeftX="397" topLeftY="207" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)">
+          <p>
+            <span color="rgba(121, 124, 129, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="78" topLeftX="396" topLeftY="91" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 117, 239, 1)"/>
+        </fill>
+      </shape>
+      <icon width="40" height="40" topLeftX="415" topLeftY="110" iconType="iconpark/Base/system.svg">
+        <border color="linear-gradient(141deg,rgba(243, 249, 255, 1) 0%,rgba(244, 248, 253, 1) 27%,rgba(245, 246, 246, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="BsaXbZFhXosMIaxe1q3cwVGinxh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="318" startY="298" endX="642" endY="298">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="879" height="41" topLeftX="40" topLeftY="308" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(78, 86, 102, 1)" textAlign="center">
+          <p letterSpacing="1">
+            <span color="rgba(78, 86, 102, 1)" fontSize="14">副标题信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="879" height="83" topLeftX="40" topLeftY="210" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="42">品牌标志方案一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="U9PNbCv3Loi5WNxYxvjclLXmn3e" width="241" height="540" topLeftX="-2" topLeftY="0" flipY="true" exposure="18" contrast="-7" saturation="14" temperature="-69">
+        <crop type="rect" leftOffset="15" rightOffset="14" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="-2" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="21" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="-2" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0.8) 0%,rgba(255, 255, 255, 0.4) 59%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="21" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="31" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="21" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(0, 0, 0, 1)">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="GRNXbSx7OoO9Lhx1YEBctcvunKc" width="241" height="540" topLeftX="480" topLeftY="0" rotation="180" exposure="9" temperature="-42">
+        <crop type="rect" leftOffset="150" rightOffset="150" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="480" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="503" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="480" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0.8) 0%,rgba(255, 255, 255, 0.4) 59%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="503" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="513" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="503" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(0, 0, 0, 1)">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Jys9bL5AYoTbL7xxuGFcddJvnzz" width="241" height="540" topLeftX="719" topLeftY="0" exposure="14" contrast="-5" saturation="11" temperature="-26">
+        <crop type="rect" leftOffset="15" rightOffset="14" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="719" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="742" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="719" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(0, 0, 0, 0.8) 0%,rgba(0, 0, 0, 0.4) 59%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="742" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="751" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(243, 244, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="742" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="HNMDbk5Afo4U9cx6RFec78s4npm" width="241" height="540" topLeftX="239" topLeftY="0" exposure="20" contrast="5" saturation="11" temperature="-20">
+        <crop type="rect" leftOffset="15" rightOffset="14" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="194" height="56" topLeftX="263" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="56" topLeftX="262" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="105" topLeftX="239" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="194" height="56" topLeftX="263" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="239" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(0, 0, 0, 0.8) 0%,rgba(0, 0, 0, 0.4) 59%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="262" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="271" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(243, 244, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="262" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="192" height="44" topLeftX="852" topLeftY="717" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="480" height="540" topLeftX="480" topLeftY="0" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="218" height="218" topLeftX="611" topLeftY="161" type="ellipse">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="218" height="218" topLeftX="611" topLeftY="161" presetHandlers="16" type="round-rect">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="161" height="161" topLeftX="639" topLeftY="189" presetHandlers="16" type="round-rect">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="551" startY="270" endX="889" endY="270">
+        <border color="rgba(203, 205, 208, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="720" startY="127" endX="720" endY="413">
+        <border color="rgba(203, 205, 208, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="183" height="183" topLeftX="629" topLeftY="179" iconType="iconpark/Abstract/two-ellipses.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(251, 251, 251, 1)" width="9" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="480" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="217" height="217" topLeftX="130" topLeftY="163" type="ellipse">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="217" height="217" topLeftX="130" topLeftY="163" presetHandlers="16" type="round-rect">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="161" height="161" topLeftX="158" topLeftY="191" presetHandlers="16" type="round-rect">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="70" startY="271" endX="408" endY="271">
+        <border color="rgba(129, 132, 135, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="239" startY="128" endX="239" endY="414">
+        <border color="rgba(129, 132, 135, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="182" height="182" topLeftX="148" topLeftY="180" iconType="iconpark/Abstract/two-ellipses.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="9" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="389" height="56" topLeftX="522" topLeftY="445" rotation="360" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)" textAlign="left">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="389" height="53" topLeftX="45" topLeftY="445" rotation="360" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(243, 244, 246, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="22">设计方案一</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="V4dIb4GvwoHVZ3xEqMmcvcMfnPc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="303" height="83" topLeftX="52" topLeftY="229" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(251, 251, 251, 1)" textAlign="left">
+          <p>
+            <span color="rgba(251, 251, 251, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="V3PFbTK7oo0k82x2N1Rcu5x0nBc" width="344" height="412" topLeftX="0" topLeftY="0" alpha="0.15">
+        <crop type="rect" leftOffset="81" rightOffset="0" topOffset="172" bottomOffset="43" presetHandlers="0"/>
+      </img>
+      <img src="X9O3bMXTQoPTsSxLF9XciJtwnAf" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="864" height="62" topLeftX="47" topLeftY="411" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)" textAlign="left">
+          <p>
+            <span color="rgba(121, 124, 129, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中展现内容，可以选择多种可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="296" height="263" topLeftX="47" topLeftY="125" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="160" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="160" fontFamily="Arial Black" bold="false">Aa</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="492" height="51" topLeftX="415" topLeftY="192" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Arial Black" bold="false">Aa Bb Cc Dd Ee Ff Gg Hh Ii Jj Kk Ll Mm Nn</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="492" height="51" topLeftX="415" topLeftY="239" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="false" letterSpacing="8">
+          <p letterSpacing="8">
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Arial Black" bold="false">1234567890</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="492" height="51" topLeftX="415" topLeftY="286" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="false" letterSpacing="8">
+          <p letterSpacing="8">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Arial Black">(&lt;!</span>
+            </strong>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Arial Black" bold="false">#$&amp;?]}</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="355" startY="191" endX="355" endY="338">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="V3PFbTK7oo0k82x2N1Rcu5x0nBc" width="344" height="412" topLeftX="0" topLeftY="0" alpha="0.15">
+        <crop type="rect" leftOffset="81" rightOffset="0" topOffset="172" bottomOffset="43" presetHandlers="0"/>
+      </img>
+      <img src="X9O3bMXTQoPTsSxLF9XciJtwnAf" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="146" height="146" topLeftX="717" topLeftY="103" type="ellipse">
+        <fill>
+          <fillColor color="rgba(134, 219, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.949)" fontSize="28">25%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="717" topLeftY="249" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#86DBFF</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="717" topLeftY="314" type="ellipse">
+        <fill>
+          <fillColor color="rgba(198, 231, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="28">5%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="717" topLeftY="460" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#C6E7FF</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="509" topLeftY="103" type="ellipse">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" color="rgba(251, 251, 251, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(251, 251, 251, 1)" fontSize="30">60%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="509" topLeftY="249" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#1C66F6</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="509" topLeftY="314" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.949)" fontSize="28">10%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="509" topLeftY="460" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#000000</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="249" height="77" topLeftX="47" topLeftY="150" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="38">色彩方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="360" height="104" topLeftX="52" topLeftY="227" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)" textAlign="left">
+          <p>
+            <span color="rgba(121, 124, 129, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中展现内容，可以选择多种可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="W9b6bRk6xoEMZJxK9SicuaaLnKp" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="318" startY="298" endX="642" endY="298">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="879" height="41" topLeftX="40" topLeftY="308" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(78, 86, 102, 1)" textAlign="center">
+          <p letterSpacing="1">
+            <span color="rgba(78, 86, 102, 1)" fontSize="14">副标题信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="879" height="83" topLeftX="40" topLeftY="210" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="42">品牌标志方案二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="KXVybTHCGoY3Gjxsnb5clEdbnud" width="241" height="540" topLeftX="0" topLeftY="0" exposure="18" temperature="-100">
+        <crop type="rect" leftOffset="15" rightOffset="26" topOffset="23" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="0" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="23" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="0" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0.8) 0%,rgba(255, 255, 255, 0.4) 59%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="23" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="33" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="23" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(0, 0, 0, 1)">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="AyzzbZ5KUoncRaxxMwecWRHAnOd" width="241" height="540" topLeftX="480" topLeftY="0" exposure="-7" contrast="-12" saturation="15" temperature="-16">
+        <crop type="rect" leftOffset="15" rightOffset="14" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="480" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="503" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="480" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0.8) 0%,rgba(255, 255, 255, 0.4) 59%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="503" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="513" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="503" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(0, 0, 0, 1)">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="EiPVblC7pomjKlxdqo1cXl89nBg" width="241" height="540" topLeftX="239" topLeftY="0" rotation="180" flipX="true" flipY="true" saturation="-22">
+        <crop type="rect" leftOffset="31" rightOffset="31" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="194" height="56" topLeftX="262" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="56" topLeftX="262" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="105" topLeftX="239" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="194" height="56" topLeftX="263" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="239" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(0, 0, 0, 0.8) 0%,rgba(0, 0, 0, 0.4) 59%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="262" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="271" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(243, 244, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="262" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="G3sIb7p4Qounv7xEwkMcuqfRnid" width="241" height="540" topLeftX="719" topLeftY="0" rotation="180" exposure="38" contrast="-8" saturation="9" temperature="-80">
+        <crop type="rect" leftOffset="31" rightOffset="31" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="719" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="742" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="719" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(0, 0, 0, 0.8) 0%,rgba(0, 0, 0, 0.4) 59%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="742" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="751" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(243, 244, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="742" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="480" height="540" topLeftX="480" topLeftY="0" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="218" height="218" topLeftX="611" topLeftY="161" type="ellipse">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="218" height="218" topLeftX="611" topLeftY="161" presetHandlers="16" type="round-rect">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="161" height="161" topLeftX="639" topLeftY="189" presetHandlers="16" type="round-rect">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="551" startY="270" endX="889" endY="270">
+        <border color="rgba(203, 205, 208, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="720" startY="127" endX="720" endY="413">
+        <border color="rgba(203, 205, 208, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="183" height="183" topLeftX="629" topLeftY="179" iconType="iconpark/Abstract/api-app.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(251, 251, 251, 1)" width="9" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="480" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="217" height="217" topLeftX="130" topLeftY="163" type="ellipse">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="217" height="217" topLeftX="130" topLeftY="163" presetHandlers="16" type="round-rect">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="161" height="161" topLeftX="158" topLeftY="191" presetHandlers="16" type="round-rect">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="70" startY="271" endX="408" endY="271">
+        <border color="rgba(129, 132, 135, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="239" startY="128" endX="239" endY="414">
+        <border color="rgba(129, 132, 135, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="182" height="182" topLeftX="148" topLeftY="180" iconType="iconpark/Abstract/api-app.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="9" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="389" height="56" topLeftX="522" topLeftY="445" rotation="360" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)" textAlign="left">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="389" height="53" topLeftX="45" topLeftY="445" rotation="360" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(243, 244, 246, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="22">设计方案二</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="41" topLeftX="85" topLeftY="54" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" bold="false">YOUR LOGO</span>
+          </p>
+        </content>
+      </shape>
+      <img src="KQ6ubZ4VJoHxRSxjPGecHsdHnNb" width="12" height="25" topLeftX="60" topLeftY="62">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Zte9b4vHRo6CjpxVGRvceHwtnWf" width="12" height="25" topLeftX="74" topLeftY="62">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="124" height="38" topLeftX="787" topLeftY="57" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(251, 251, 251, 1)" bold="false" textAlign="right">
+          <p>
+            <span color="rgba(251, 251, 251, 1)" fontSize="12" bold="false">YOUR TEAM</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="V3PFbTK7oo0k82x2N1Rcu5x0nBc" width="344" height="412" topLeftX="0" topLeftY="0" alpha="0.15">
+        <crop type="rect" leftOffset="81" rightOffset="0" topOffset="172" bottomOffset="43" presetHandlers="0"/>
+      </img>
+      <img src="X9O3bMXTQoPTsSxLF9XciJtwnAf" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="864" height="62" topLeftX="47" topLeftY="411" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)" textAlign="left">
+          <p>
+            <span color="rgba(121, 124, 129, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中展现内容，可以选择多种可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="296" height="263" topLeftX="47" topLeftY="125" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="160" fontFamily="Trebuchet MS" color="rgba(43, 47, 54, 1)" bold="false" letterSpacing="8">
+          <p letterSpacing="8">
+            <span color="rgba(43, 47, 54, 1)" fontSize="160" fontFamily="Trebuchet MS" bold="false">Aa</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="407" height="51" topLeftX="506" topLeftY="192" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Trebuchet MS" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Trebuchet MS" bold="false">Aa Bb Cc Dd Ee Ff Gg Hh Ii Jj Kk Ll Mm Nn</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="407" height="51" topLeftX="506" topLeftY="239" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Trebuchet MS" color="rgba(43, 47, 54, 1)" bold="false" letterSpacing="8">
+          <p letterSpacing="8">
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Trebuchet MS" bold="false">1234567890</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="407" height="51" topLeftX="506" topLeftY="286" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Trebuchet MS" color="rgba(43, 47, 54, 1)" bold="false" letterSpacing="8">
+          <p letterSpacing="8">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Trebuchet MS">(&lt;!</span>
+            </strong>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Trebuchet MS" bold="false">#$&amp;?]}</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="374" startY="197" endX="374" endY="343">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="V3PFbTK7oo0k82x2N1Rcu5x0nBc" width="344" height="412" topLeftX="0" topLeftY="0" alpha="0.15">
+        <crop type="rect" leftOffset="81" rightOffset="0" topOffset="172" bottomOffset="43" presetHandlers="0"/>
+      </img>
+      <img src="X9O3bMXTQoPTsSxLF9XciJtwnAf" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="146" height="146" topLeftX="717" topLeftY="103" type="ellipse">
+        <fill>
+          <fillColor color="rgba(41, 185, 246, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.949)" fontSize="28">25%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="717" topLeftY="249" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#86DBFF</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="717" topLeftY="314" type="ellipse">
+        <fill>
+          <fillColor color="rgba(225, 234, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="28">5%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="717" topLeftY="460" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#C6E7FF</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="509" topLeftY="103" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 145, 227, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" color="rgba(251, 251, 251, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(251, 251, 251, 1)" fontSize="30">60%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="509" topLeftY="249" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#1C66F6</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="509" topLeftY="314" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.949)" fontSize="28">10%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="509" topLeftY="460" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#000000</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="360" height="77" topLeftX="47" topLeftY="150" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="38">色彩方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="360" height="104" topLeftX="52" topLeftY="227" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)" textAlign="left">
+          <p>
+            <span color="rgba(121, 124, 129, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中展现内容，可以选择多种可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WsnNbo3j8oXqnWxynaZcVz6knrd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="132" height="41" topLeftX="85" topLeftY="54" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" bold="false">YOUR LOGO</span>
+          </p>
+        </content>
+      </shape>
+      <img src="CCJxbunFoosXKRxZiSwcrHKNnXe" width="12" height="25" topLeftX="60" topLeftY="62">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Um3Qb2dr1of3Swxw73Ec5hGlnyb" width="12" height="25" topLeftX="74" topLeftY="62">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="124" height="38" topLeftX="787" topLeftY="57" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(251, 251, 251, 1)" bold="false" textAlign="right">
+          <p>
+            <span color="rgba(251, 251, 251, 1)" fontSize="12" bold="false">YOUR TEAM</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/marketing--brand_operations_plan.xml
+++ b/skills/lark-slides/references/templates/marketing--brand_operations_plan.xml
@@ -1,0 +1,1309 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>品牌运营计划-裂图重新上传</title>
+  <theme>
+    <textStyles>
+      <title fontColor="rgba(43, 47, 54, 1)" fontSize="80"/>
+      <headline fontColor="rgba(43, 47, 54, 1)" fontSize="48"/>
+      <sub-headline fontColor="rgba(43, 47, 54, 1)"/>
+      <body fontColor="rgba(43, 47, 54, 1)" fontSize="14"/>
+      <caption fontColor="rgba(43, 47, 54, 1)"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="542" height="116" topLeftX="26" topLeftY="375" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)">品牌提案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="464" height="62" topLeftX="33" topLeftY="326" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">Brand proposal</span>
+          </p>
+        </content>
+      </shape>
+      <img src="XLyZb9phHo2eqMxA4TFcsriAnYg" width="459" height="464" topLeftX="501" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="22" topOffset="160" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="73" height="38" topLeftX="59" topLeftY="24" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="40" topLeftY="31" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(239, 242, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="175" height="92" topLeftX="54" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">目录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="68" topLeftX="60" topLeftY="165" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">Contents</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="59" height="50" topLeftX="484" topLeftY="113" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(60, 111, 229, 1)" fontSize="20">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="50" topLeftX="551" topLeftY="113" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(60, 111, 229, 1)" fontSize="20">品牌介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="59" height="50" topLeftX="484" topLeftY="170" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="50" topLeftX="551" topLeftY="170" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20">产品介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="59" height="50" topLeftX="484" topLeftY="226" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="50" topLeftX="551" topLeftY="226" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20">市场分析</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="59" height="50" topLeftX="484" topLeftY="282" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="50" topLeftX="551" topLeftY="282" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20">活动思路</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="59" height="50" topLeftX="484" topLeftY="338" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20">05</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="50" topLeftX="551" topLeftY="338" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20">营销推广</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="5" height="32" topLeftX="468" topLeftY="123" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <shape width="5" height="32" topLeftX="468" topLeftY="179" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="5" height="32" topLeftX="468" topLeftY="235" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="5" height="32" topLeftX="468" topLeftY="291" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="5" height="32" topLeftX="468" topLeftY="347" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PBaBbVkouoPSSDxKzfDcg0pFn3d" width="810" height="504" topLeftX="150" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="160" topOffset="309" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="150" height="163" topLeftX="151" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="96" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="96">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="67" topLeftX="289" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="31" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="31">品牌介绍</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Brand Story</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="225" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>
+            <span color="rgba(60, 111, 229, 1)">品牌故事</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Ob67bcca3obkWzxh5LtcdaEYnQh" width="248" height="361" topLeftX="350" topLeftY="89">
+        <crop type="rect" leftOffset="0" rightOffset="347" topOffset="127" bottomOffset="107" presetHandlers="0"/>
+      </img>
+      <img src="GsGwbhbE0oRA2pxH46BcHtBZnOp" width="225" height="361" topLeftX="610" topLeftY="89">
+        <crop type="rect" leftOffset="270" rightOffset="100" topOffset="128" bottomOffset="106" presetHandlers="0"/>
+      </img>
+      <img src="GYwAbOu11ofIfYxkiSlcX00bnvl" width="93" height="361" topLeftX="848" topLeftY="89">
+        <crop type="rect" leftOffset="502" rightOffset="0" topOffset="128" bottomOffset="105" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Milestone</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="246" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>发展回顾</p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PBaBbVkouoPSSDxKzfDcg0pFn3d" width="810" height="504" topLeftX="150" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="160" topOffset="309" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="150" height="164" topLeftX="151" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="96" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="96">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="67" topLeftX="289" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="31" color="rgba(255, 255, 255, 1)">
+          <p>产品介绍</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Product Line</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="246" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>产品线</p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="248" height="371" topLeftX="619" topLeftY="78" type="rect">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="248" height="371" topLeftX="351" topLeftY="79" type="rect">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Highlights</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="246" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>产品亮点</p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="644" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">亮点 </span>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">#2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="92" topLeftX="644" topLeftY="240" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="649" topLeftY="115" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="33" height="33" topLeftX="669" topLeftY="135" iconType="iconpark/Abstract/cylinder.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="180" height="41" topLeftX="370" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">亮点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="92" topLeftX="370" topLeftY="240" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="375" topLeftY="115" type="ellipse">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <icon width="32" height="32" topLeftX="395" topLeftY="135" iconType="iconpark/Abstract/six-points.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="205" height="74" topLeftX="370" topLeftY="332" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <ul>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="205" height="74" topLeftX="644" topLeftY="332" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <ul>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PBaBbVkouoPSSDxKzfDcg0pFn3d" width="810" height="504" topLeftX="150" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="160" topOffset="309" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="150" height="163" topLeftX="151" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="96" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="96">03</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="67" topLeftX="289" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="31" color="rgba(255, 255, 255, 1)">
+          <p>市场分析</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Market Environment</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="308" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>市场环境</p>
+        </content>
+      </shape>
+      <shape width="310" height="310" topLeftX="334" topLeftY="110" type="ellipse">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="310" height="310" topLeftX="605" topLeftY="111" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="180" height="44" topLeftX="387" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">国内市场</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="92" topLeftX="387" topLeftY="240" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="44" topLeftX="657" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">国际市场</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="92" topLeftX="657" topLeftY="240" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Consumer Group</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="308" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>消费人群</p>
+        </content>
+      </shape>
+      <shape width="79" height="32" topLeftX="415" topLeftY="257" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="12">18</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="32" topLeftX="415" topLeftY="289" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="12">18-25</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="32" topLeftX="414" topLeftY="321" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="12">25-35</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="79" height="32" topLeftX="414" topLeftY="351" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="12">35 以上</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="307" height="12" topLeftX="513" topLeftY="267" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="188" height="12" topLeftX="513" topLeftY="267" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <shape width="307" height="12" topLeftX="513" topLeftY="299" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="92" height="12" topLeftX="513" topLeftY="299" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <shape width="307" height="12" topLeftX="513" topLeftY="331" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="256" height="12" topLeftX="513" topLeftY="331" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <shape width="307" height="12" topLeftX="513" topLeftY="361" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="188" height="12" topLeftX="513" topLeftY="361" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <shape width="38" height="32" topLeftX="513" topLeftY="381" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" bold="false">0</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="38" height="32" topLeftX="603" topLeftY="381" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" bold="false">10</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="38" height="32" topLeftX="693" topLeftY="381" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" bold="false">20</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="38" height="32" topLeftX="782" topLeftY="381" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" bold="false">30</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="386" height="74" topLeftX="448" topLeftY="141" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="448" topLeftY="107" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">洞察分析</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Competition Analysis</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="269" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>竞对分析</p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="559" topLeftY="79" type="ellipse">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="20">竞品 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="559" topLeftY="194" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20">
+          <p>
+            <span fontSize="20">竞品 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="559" topLeftY="315" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="20">竞品 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="41" topLeftX="374" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>优势</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="374" topLeftY="120" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="374" topLeftY="233" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="374" topLeftY="354" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="41" topLeftX="745" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>劣势</p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="745" topLeftY="120" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="745" topLeftY="233" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="745" topLeftY="354" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="352" startY="208" endX="542" endY="208">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="352" startY="332" endX="542" endY="332">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="722" startY="208" endX="913" endY="208">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="722" startY="331" endX="913" endY="331">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PBaBbVkouoPSSDxKzfDcg0pFn3d" width="810" height="504" topLeftX="150" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="160" topOffset="309" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="150" height="164" topLeftX="151" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="96" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="96">04</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="67" topLeftX="289" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="31" color="rgba(255, 255, 255, 1)">
+          <p>活动思路</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p> Activity Ideas</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="308" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>活动思路</p>
+        </content>
+      </shape>
+      <img src="CZOnbA1troRlwZxlAtPcPnZynJh" width="244" height="150" topLeftX="366" topLeftY="120">
+        <crop type="rect" leftOffset="46" rightOffset="0" topOffset="64" bottomOffset="77" presetHandlers="0"/>
+      </img>
+      <img src="Dwj0bfLj6oNOvfxDDTPcXP38nQg" width="244" height="158" topLeftX="649" topLeftY="270">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="29" bottomOffset="57" presetHandlers="0"/>
+      </img>
+      <shape width="261" height="74" topLeftX="641" topLeftY="175" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="641" topLeftY="141" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>促销活动</p>
+        </content>
+      </shape>
+      <shape width="261" height="74" topLeftX="358" topLeftY="329" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="358" topLeftY="294" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true">
+          <p> 试用活动</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PBaBbVkouoPSSDxKzfDcg0pFn3d" width="810" height="504" topLeftX="150" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="160" topOffset="309" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="150" height="164" topLeftX="151" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="96" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="96">05</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="67" topLeftX="289" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="31" color="rgba(255, 255, 255, 1)">
+          <p>营销推广</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p> Activity Ideas</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="270" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>活动思路</p>
+        </content>
+      </shape>
+      <shape width="563" height="132" topLeftX="335" topLeftY="205" type="slides-full-round-rect">
+        <border color="rgba(60, 111, 229, 1)" width="24" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="191" height="200" topLeftX="321" topLeftY="259" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="119" height="282" topLeftX="304" topLeftY="98" flipX="true" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="78" height="78" topLeftX="365" topLeftY="168" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="78" height="78" topLeftX="568" topLeftY="168" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="180" height="41" topLeftX="570" topLeftY="67" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>主视觉设计</p>
+        </content>
+      </shape>
+      <shape width="167" height="56" topLeftX="570" topLeftY="101" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="365" topLeftY="67" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>产品定位</p>
+        </content>
+      </shape>
+      <shape width="167" height="56" topLeftX="365" topLeftY="101" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="478" topLeftY="383" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>营销活动</p>
+        </content>
+      </shape>
+      <shape width="167" height="56" topLeftX="478" topLeftY="417" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="78" topLeftX="478" topLeftY="297" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="78" height="78" topLeftX="678" topLeftY="297" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="180" height="41" topLeftX="678" topLeftY="383" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>广告投放</p>
+        </content>
+      </shape>
+      <shape width="167" height="56" topLeftX="678" topLeftY="417" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="42" height="42" topLeftX="383" topLeftY="187" iconType="iconpark/Base/home.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="42" height="42" topLeftX="586" topLeftY="187" iconType="iconpark/Base/pic.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="42" height="42" topLeftX="696" topLeftY="317" iconType="iconpark/Office/envelope-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="42" height="42" topLeftX="496" topLeftY="317" iconType="iconpark/Office/newspaper-folding.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p> Activity Ideas</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="267" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>活动思路</p>
+        </content>
+      </shape>
+      <line startX="362" startY="440" endX="362" endY="173" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="536" startY="440" endX="535" endY="173" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="722" startY="440" endX="722" endY="173" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="895" startY="440" endX="895" endY="173" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="399" height="48" topLeftX="495" topLeftY="191" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">事项 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="337" height="48" topLeftX="450" topLeftY="252" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">事项 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="48" topLeftX="362" topLeftY="313" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">事项 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="267" height="48" topLeftX="583" topLeftY="373" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>事项 #4</p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="362" topLeftY="84" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>前期筹备</p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="538" topLeftY="84" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>执行期</p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="715" topLeftY="84" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>总结复盘</p>
+        </content>
+      </shape>
+      <line startX="362" startY="136" endX="895" endY="136">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <endArrow type="solid-triangle"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="542" height="116" topLeftX="26" topLeftY="375" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)">感谢观看</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="464" height="62" topLeftX="33" topLeftY="326" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">Thank You</span>
+          </p>
+        </content>
+      </shape>
+      <img src="CaPpbVUruoFDoBxsOS2cpAOFnBe" width="459" height="464" topLeftX="501" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="22" topOffset="160" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="73" height="38" topLeftX="59" topLeftY="24" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="40" topLeftY="31" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/marketing--business_plan.xml
+++ b/skills/lark-slides/references/templates/marketing--business_plan.xml
@@ -1,0 +1,1646 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>商业计划书</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="90"/>
+      <headline fontColor="#000000FF" fontSize="36"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="540" height="540" topLeftX="690" topLeftY="0" type="donut">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="120" height="120" topLeftX="900" topLeftY="210" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="608" height="146" topLeftX="36" topLeftY="171" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="90" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="90">商业计划书</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="360" height="62" topLeftX="36" topLeftY="306" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="36" topLeftY="41" rotation="90" iconType="iconpark/Abstract/game-emoji.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </icon>
+      <shape width="450" height="34" topLeftX="61" topLeftY="36" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(255, 255, 255, 1)">公司名字</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content>
+        <p/>
+      </content>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="540" height="540" topLeftX="-270" topLeftY="0" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="496" height="69" topLeftX="353" topLeftY="91" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(31, 35, 41, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="linear-gradient(180deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)">目录 </span>
+            <span color="rgba(31, 35, 41, 1)">CONTENT</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="208" height="44" topLeftX="412" topLeftY="196" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">项目介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="208" height="41" topLeftX="412" topLeftY="227" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">一句简单的标题说明</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="40" height="40" topLeftX="362" topLeftY="211" iconType="iconpark/Charts/slide-two.svg">
+        <border color="rgba(43, 47, 54, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="208" height="44" topLeftX="691" topLeftY="196" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">产品服务</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="208" height="41" topLeftX="691" topLeftY="227" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">一句简单的标题说明</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="40" height="40" topLeftX="641" topLeftY="211" iconType="iconpark/Abstract/ad-product.svg">
+        <border color="rgba(43, 47, 54, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="208" height="44" topLeftX="412" topLeftY="282" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">财务计划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="208" height="41" topLeftX="412" topLeftY="314" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">一句简单的标题说明</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="40" height="40" topLeftX="362" topLeftY="298" iconType="iconpark/Charts/chart-histogram.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="208" height="44" topLeftX="691" topLeftY="282" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">商业模式</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="208" height="41" topLeftX="691" topLeftY="314" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">一句简单的标题说明</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="40" height="40" topLeftX="641" topLeftY="298" iconType="iconpark/Money/mall-bag.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="208" height="44" topLeftX="412" topLeftY="380" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">市场分析</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="208" height="41" topLeftX="412" topLeftY="412" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">一句简单的标题说明</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="40" height="40" topLeftX="362" topLeftY="396" iconType="iconpark/Money/optional.svg">
+        <border color="rgba(43, 47, 54, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="98" height="70" topLeftX="353" topLeftY="91" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="undefined" color="linear-gradient(180deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" lineSpacing="multiple:1.35" list="none" listStyle="circle-hollow-square" textAlign="left" autoFit="shape-auto-fit"/>
+      </shape>
+      <shape width="294" height="69" topLeftX="434" topLeftY="91" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.35" autoFit="shape-auto-fit"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="NKYqbbqjqoGoqwxkX8ocmnORnWe" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.35">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="30" bottomOffset="30"/>
+      </img>
+      <shape width="729" height="44" topLeftX="115" topLeftY="291" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="69" topLeftX="272" topLeftY="232" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="36">01 项目介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="72" height="72" topLeftX="444" topLeftY="158" iconType="iconpark/Charts/slide-two.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="24" height="24" topLeftX="31" topLeftY="24" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="182" height="175" topLeftX="425" topLeftY="346" alpha="0.4" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="BkDXbuLNNoclghxZ5IocqY7knhb" width="400" height="400" topLeftX="475" topLeftY="97" exposure="20" contrast="3" saturation="22" temperature="-84">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.06" bottomOffset="0.06" presetHandlers="396"/>
+      </img>
+      <shape width="202" height="41" topLeftX="51" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="14">项目概述</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="731" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span fontSize="14">01 项目介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="418" height="209" topLeftX="31" topLeftY="190" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">请在此处输入项目概述内容，用一句话来清晰地描述你的商业模式，即你的产品或服务；用一句话来明确表述为什么你的创新及时解决了用户的问题, 填补了市场的空缺；用一句话(包括具体数字)来描述巨大的市场规模和潜在的远景；用一句话来概括你的竞争优势；</span>
+          </p>
+          <p/>
+          <p>
+            <span fontSize="14">用一句话(包括具体数字)来描述巨大的市场规模和潜在的远景；用一句话来概括你的竞争优势；用一句话(包括具体数字)来描述巨大的市场规模和潜在的远景；用一句话来概括你的竞争优势；</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="69" topLeftX="31" topLeftY="118" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="36">输入你的标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="110" topLeftX="773" topLeftY="88" type="ellipse">
+        <border color="rgba(25, 76, 255, 1)" width="30" lineJoin="miter" miterLimit="10"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="392" height="392" topLeftX="764" topLeftY="74" alpha="0.2" type="ellipse">
+        <border color="rgba(208, 211, 214, 1)" width="150" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="24" height="24" topLeftX="31" topLeftY="24" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="227" height="41" topLeftX="188" topLeftY="164" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">团队成员相关信息介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="227" height="44" topLeftX="188" topLeftY="136" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">团队成员 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="WQkNbLxhFo8JjBxKyOLcq1QCn5d" width="80" height="80" topLeftX="104" topLeftY="128">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="40"/>
+      </img>
+      <shape width="418" height="209" topLeftX="465" topLeftY="200" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">请在此处输入项目概述内容，用一句话来清晰地描述你的商业模式，即你的产品或服务；用一句话来明确表述为什么你的创新及时解决了用户的问题, 填补了市场的空缺；用一句话(包括具体数字)来描述巨大的市场规模和潜在的远景；用一句话来概括你的竞争优势；</span>
+          </p>
+          <p/>
+          <p>
+            <span fontSize="14">用一句话(包括具体数字)来描述巨大的市场规模和潜在的远景；用一句话来概括你的竞争优势；用一句话(包括具体数字)来描述巨大的市场规模和潜在的远景；用一句话来概括你的竞争优势；</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="69" topLeftX="465" topLeftY="128" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="36">市场团队成员</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="FG6ebbrxQoQ3A0xoIMvcFwCynab" width="80" height="80" topLeftX="104" topLeftY="246">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="40"/>
+      </img>
+      <shape width="227" height="41" topLeftX="188" topLeftY="282" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">团队成员相关信息介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="227" height="44" topLeftX="188" topLeftY="254" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">团队成员 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="ZWpTb71pOoURwPxXsqvcWwDcnCc" width="80" height="80" topLeftX="104" topLeftY="367">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="40"/>
+      </img>
+      <shape width="227" height="41" topLeftX="188" topLeftY="403" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">团队成员相关信息介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="227" height="44" topLeftX="188" topLeftY="375" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">团队成员 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="51" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="left">
+          <p>团队介绍</p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="731" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="right">
+          <p>01 项目介绍</p>
+        </content>
+      </shape>
+      <shape width="54" height="54" topLeftX="62" topLeftY="419" type="ellipse">
+        <border color="rgba(25, 76, 255, 1)" width="16" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="34" height="33" topLeftX="92" topLeftY="113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="L9V8bWX5doWx99x9Rmbc9br6nyc" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.35">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="30" bottomOffset="30"/>
+      </img>
+      <shape width="729" height="44" topLeftX="115" topLeftY="291" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="69" topLeftX="272" topLeftY="232" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p lineSpacing="multiple:1.35">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="36">02   市场分析</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="72" height="72" topLeftX="444" topLeftY="158" iconType="iconpark/Money/optional.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="441" height="441" topLeftX="93" topLeftY="69" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="441" height="441" topLeftX="444" topLeftY="69" alpha="0.92" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="93" height="89" topLeftX="75" topLeftY="412" type="ellipse">
+        <border color="rgba(25, 76, 255, 1)" width="34" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="72" height="69" topLeftX="814" topLeftY="115" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="24" topLeftX="31" topLeftY="24" type="donut">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="267" height="41" topLeftX="665" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">02 市场分析</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="267" height="41" topLeftX="51" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">市场概述</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="125" topLeftX="545" topLeftY="270" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">请在此处输入项目概述内容，用一句话来清晰地描述你的商业模式，即你的产品或服务；用一句话来明确表述为什么你的创新及时解决了用户的问题, 填补了市场的空缺；</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="53" topLeftX="457" topLeftY="218" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="24">国际市场</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="125" topLeftX="194" topLeftY="270" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="center">
+          <p>
+            <span fontSize="14">请在此处输入项目概述内容，用一句话来清晰地描述你的商业模式，即你的产品或服务；用一句话来明确表述为什么你的创新及时解决了用户的问题, 填补了市场的空缺；</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="53" topLeftX="106" topLeftY="218" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span fontSize="24">国内市场</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="60" height="60" topLeftX="635" topLeftY="160" iconType="iconpark/Travel/earth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="60" height="60" topLeftX="284" topLeftY="160" iconType="iconpark/Travel/local-two.svg">
+        <border color="rgba(43, 47, 54, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="24" height="24" topLeftX="31" topLeftY="24" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="306" height="306" topLeftX="326" topLeftY="157" alpha="0.1" type="ellipse">
+        <border color="rgba(143, 149, 158, 1)" width="39" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="202" height="41" topLeftX="51" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <strong>行业分析</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="731" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="right">
+          <p>
+            <strong>
+              <span fontSize="14">02 市场分析</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="108" height="108" topLeftX="426" topLeftY="98" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12"> 新进入者的威胁</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="108" height="108" topLeftX="270" topLeftY="215" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">购买者的议价能力 </span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="108" height="108" topLeftX="329" topLeftY="389" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">供应商的议价能力 </span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="108" height="108" topLeftX="582" topLeftY="215" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12"> 同业竞争者的竞争程度</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="108" height="108" topLeftX="522" topLeftY="389" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12"> 替代品的威胁</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="193" height="193" topLeftX="383" topLeftY="214" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="250" height="67" topLeftX="363" topLeftY="32" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <span fontSize="12">新进入者在给行业带来新生产能力、新资源的同时，将希望在已被现有企业瓜分完毕的市场中赢得一席之地</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="63" topLeftX="700" topLeftY="235" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <span fontSize="12">现有企业之间的竞争常常表现在价格、广告、产品介绍、售后服务等方面，其竞争强度与许多因素有关。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="63" topLeftX="646" topLeftY="409" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <span fontSize="12">两个处于不同行业中的企业，可能会由于所生产的产品是互为替代品，从而在它们之间产生相互竞争行为</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="63" topLeftX="9" topLeftY="235" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" lineSpacing="multiple:1.2" textAlign="right">
+          <p lineSpacing="multiple:1.2">
+            <span fontSize="12">购买者主要通过其压价与要求提供较高的产品或服务质量的能力，来影响行业中现有企业的盈利能力。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="63" topLeftX="63" topLeftY="409" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" lineSpacing="multiple:1.2" textAlign="right">
+          <p lineSpacing="multiple:1.2">
+            <span fontSize="12">供方主要通过其提高投入要素价格与降低单位价值质量的能力，来影响行业中现有企业的盈利能力与产品竞争力。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="159" height="38" topLeftX="401" topLeftY="306" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">Porter's Five Forces</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="193" height="50" topLeftX="383" topLeftY="276" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">波特五力分析</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="NEpLb1Jjko0kZZxZY4hcfAYRn9g" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.35">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="30" bottomOffset="30"/>
+      </img>
+      <shape width="729" height="44" topLeftX="115" topLeftY="291" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="69" topLeftX="272" topLeftY="232" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="36">03   产品服务</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="72" height="72" topLeftX="444" topLeftY="158" iconType="iconpark/Abstract/ad-product.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="24" height="24" topLeftX="31" topLeftY="24" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="356" height="356" topLeftX="483" topLeftY="92" alpha="0.2" type="ellipse">
+        <border color="rgba(208, 211, 214, 1)" width="42" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="94" height="94" topLeftX="545" topLeftY="223" rotation="315" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="187" height="187" topLeftX="432" topLeftY="176" rotation="315" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="94" height="94" topLeftX="614" topLeftY="155" rotation="45" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="187" height="187" topLeftX="567" topLeftY="41" rotation="45" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="94" height="94" topLeftX="683" topLeftY="223" rotation="135" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="187" height="187" topLeftX="702" topLeftY="176" rotation="135" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="94" height="94" topLeftX="614" topLeftY="292" rotation="225" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="187" height="187" topLeftX="567" topLeftY="311" rotation="225" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="202" height="41" topLeftX="51" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span fontSize="14">产品分析</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="731" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="right">
+          <p>
+            <strong>
+              <span fontSize="14">03 产品服务</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="333" height="167" topLeftX="31" topLeftY="190" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">4Ps 理论产生于20世纪60年代的美国，随着营销组合理论的提出而出现的。1953年，尼尔·博登（Neil Borden）在美国市场营销学会的就职演说中创造了“市场营销组合”（Marketing mix）</span>
+          </p>
+          <p/>
+          <p>
+            <span fontSize="14">这一术语，其意是指市场需求或多或少的在某种程度上受到所谓“营销变量”或“营销要素”的影响。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="67" topLeftX="31" topLeftY="118" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span fontSize="36">4Ps 分析</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="179" height="47" topLeftX="439" topLeftY="204" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">价格</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="179" height="92" topLeftX="439" topLeftY="239" alpha="0.75" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">新进入者在给行业带来新生产能力、新资源的同时，将希望在已被现有企业瓜分完毕的市场中赢得一席之地</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="179" height="47" topLeftX="571" topLeftY="336" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">渠道</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="179" height="92" topLeftX="571" topLeftY="371" alpha="0.75" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">两个处于不同行业中的企业，可能会由于所生产的产品是互为替代品，从而在它们之间产生相互竞争行为</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="179" height="47" topLeftX="704" topLeftY="203" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">宣传</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="179" height="92" topLeftX="704" topLeftY="239" alpha="0.75" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">供方主要通过其提高投入要素价格与降低单位价值质量的能力，来影响行业中现有企业的盈利能力与产品竞争力。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="179" height="47" topLeftX="571" topLeftY="62" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">产品</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="179" height="92" topLeftX="571" topLeftY="98" alpha="0.75" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">购买者主要通过其压价与要求提供较高的产品或服务质量的能力，来影响行业中现有企业的盈利能力。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="24" height="24" topLeftX="31" topLeftY="24" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="202" height="41" topLeftX="51" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="14">营销方式</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="731" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span fontSize="14">03 产品服务</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="290" height="180" topLeftX="31" topLeftY="110" presetHandlers="16" alpha="0.25" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="260" height="44" topLeftX="37" topLeftY="184" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">营销手段 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="54" height="54" topLeftX="49" topLeftY="128" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="30" height="30" topLeftX="61" topLeftY="140" iconType="iconpark/Music/play.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="260" height="62" topLeftX="37" topLeftY="214" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="290" height="180" topLeftX="337" topLeftY="110" presetHandlers="16" alpha="0.25" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="260" height="44" topLeftX="343" topLeftY="184" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">营销手段 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="54" height="54" topLeftX="355" topLeftY="128" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="260" height="62" topLeftX="343" topLeftY="214" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <icon width="30" height="30" topLeftX="367" topLeftY="140" iconType="iconpark/Travel/international.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="290" height="180" topLeftX="643" topLeftY="110" presetHandlers="16" alpha="0.25" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="260" height="44" topLeftX="649" topLeftY="184" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">营销手段 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="54" height="54" topLeftX="661" topLeftY="128" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="260" height="62" topLeftX="649" topLeftY="214" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <icon width="30" height="30" topLeftX="673" topLeftY="140" iconType="iconpark/Office/envelope-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="290" height="180" topLeftX="643" topLeftY="305" presetHandlers="16" alpha="0.25" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="260" height="44" topLeftX="649" topLeftY="378" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">营销手段 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="54" height="54" topLeftX="661" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="260" height="62" topLeftX="649" topLeftY="409" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <icon width="30" height="30" topLeftX="673" topLeftY="335" iconType="iconpark/Hardware/broadcast-radio.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="290" height="180" topLeftX="337" topLeftY="305" presetHandlers="16" alpha="0.25" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="260" height="44" topLeftX="343" topLeftY="378" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">营销手段 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="54" height="54" topLeftX="355" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="260" height="62" topLeftX="343" topLeftY="409" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <icon width="30" height="30" topLeftX="367" topLeftY="335" iconType="iconpark/Office/announcement.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="290" height="180" topLeftX="31" topLeftY="305" presetHandlers="16" alpha="0.25" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="260" height="44" topLeftX="37" topLeftY="378" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">营销手段 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="54" height="54" topLeftX="49" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="260" height="62" topLeftX="37" topLeftY="409" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <icon width="30" height="30" topLeftX="61" topLeftY="335" iconType="iconpark/Hardware/iphone.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="24" height="24" topLeftX="31" topLeftY="24" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="202" height="41" topLeftX="51" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="left">
+          <p>竞对分析</p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="731" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="right">
+          <p>03 产品服务</p>
+        </content>
+      </shape>
+      <shape width="352" height="62" topLeftX="581" topLeftY="131" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="352" height="44" topLeftX="581" topLeftY="103" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">竞争对手 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="352" height="62" topLeftX="581" topLeftY="255" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="352" height="44" topLeftX="581" topLeftY="228" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">竞争对手 #</span>
+            </strong>
+            <strong>
+              <span fontSize="16">2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="352" height="62" topLeftX="581" topLeftY="379" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="352" height="44" topLeftX="581" topLeftY="352" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">竞争对手 #</span>
+            </strong>
+            <strong>
+              <span fontSize="16">3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="352" height="104" topLeftX="31" topLeftY="145" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="64" topLeftX="31" topLeftY="92" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span fontSize="32">竞争对手策略</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="165" height="159" topLeftX="324" topLeftY="263" alpha="0.25" type="ellipse">
+        <border color="rgba(222, 224, 227, 1)" width="30" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="IVyNbubw7o8DXzxtwcNcC9ktnLg" width="241" height="241" topLeftX="145" topLeftY="277" flipX="true" exposure="14" saturation="39" temperature="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.03" bottomOffset="0.03" presetHandlers="236"/>
+      </img>
+      <shape width="97" height="93" topLeftX="79" topLeftY="417" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Z2MmbbC1uoDQd3xIYhxcoiVnnwc" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.35">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="30" bottomOffset="30"/>
+      </img>
+      <shape width="729" height="44" topLeftX="115" topLeftY="291" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="69" topLeftX="272" topLeftY="232" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="36">04  商业模式</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="72" height="72" topLeftX="444" topLeftY="158" iconType="iconpark/Money/mall-bag.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="24" height="24" topLeftX="31" topLeftY="24" type="donut">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="267" height="41" topLeftX="665" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">04  商业模式</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="267" height="41" topLeftX="51" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">营销策略</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="838" height="28" topLeftX="49" topLeftY="289" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(270deg,rgba(37, 216, 255, 1) 0%,rgba(37, 216, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="12" height="12" topLeftX="83" topLeftY="297" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="247" startY="313" endX="247" endY="396">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="89" startY="167" endX="89" endY="293">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="12" height="12" topLeftX="398" topLeftY="297" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="12" topLeftX="550" topLeftY="297" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="12" topLeftX="703" topLeftY="297" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="556" startY="311" endX="556" endY="397">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="16" height="16" topLeftX="239" topLeftY="295" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="7" height="7" topLeftX="243" topLeftY="300" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <line startX="404" startY="169" endX="404" endY="295">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="709" startY="169" endX="709" endY="295">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="215" height="41" topLeftX="97" topLeftY="156" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">关键点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="215" height="74" topLeftX="97" topLeftY="184" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="215" height="41" topLeftX="412" topLeftY="156" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">关键点 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="215" height="74" topLeftX="412" topLeftY="184" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="215" height="41" topLeftX="718" topLeftY="156" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">关键点 #5</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="215" height="74" topLeftX="718" topLeftY="184" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="215" height="41" topLeftX="253" topLeftY="354" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">关键点 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="215" height="74" topLeftX="253" topLeftY="383" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="215" height="41" topLeftX="564" topLeftY="354" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">关键点 #4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="215" height="74" topLeftX="564" topLeftY="383" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="24" height="24" topLeftX="31" topLeftY="24" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="1600" height="1600" topLeftX="244" topLeftY="-12" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="202" height="41" topLeftX="51" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="left">
+          <p>发展计划</p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="731" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="right">
+          <p>04 商业模式</p>
+        </content>
+      </shape>
+      <shape width="320" height="104" topLeftX="31" topLeftY="190" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="69" topLeftX="31" topLeftY="118" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="36">推进里程碑</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="44" topLeftX="683" topLeftY="52" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">里程碑 # 4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="62" topLeftX="683" topLeftY="82" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="79" height="79" topLeftX="601" topLeftY="56" rotation="360" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="48" height="48" topLeftX="617" topLeftY="69" iconType="iconpark/Travel/mountain.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="261" height="44" topLeftX="547" topLeftY="158" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">里程碑 # 3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="62" topLeftX="547" topLeftY="189" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="79" height="79" topLeftX="465" topLeftY="163" rotation="360" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="261" height="44" topLeftX="436" topLeftY="277" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">里程碑 # 2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="62" topLeftX="436" topLeftY="308" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="79" height="79" topLeftX="355" topLeftY="281" rotation="360" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="261" height="44" topLeftX="361" topLeftY="411" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">里程碑 # 2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="62" topLeftX="361" topLeftY="442" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="79" height="79" topLeftX="280" topLeftY="416" rotation="360" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="48" height="48" topLeftX="480" topLeftY="178" iconType="iconpark/Travel/flag.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="48" height="48" topLeftX="371" topLeftY="296" iconType="iconpark/Travel/tent.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="48" height="48" topLeftX="295" topLeftY="431" iconType="iconpark/Travel/map-draw.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="UdunbEtuPoREO8xF0Bnc91gYn2e" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.35">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="30" bottomOffset="30"/>
+      </img>
+      <shape width="729" height="44" topLeftX="115" topLeftY="291" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="69" topLeftX="272" topLeftY="232" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="36">05   财务计划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="72" height="72" topLeftX="444" topLeftY="158" iconType="iconpark/Charts/chart-histogram.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="24" height="24" topLeftX="31" topLeftY="24" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="202" height="41" topLeftX="51" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="left">
+          <p>融资计划</p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="731" topLeftY="16" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true" textAlign="right">
+          <p>04 财务计划</p>
+        </content>
+      </shape>
+      <shape width="279" height="154" topLeftX="344" topLeftY="282" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="220" height="121" topLeftX="374" topLeftY="229" alpha="0.84" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="157" height="87" topLeftX="405" topLeftY="171" alpha="0.7" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="109" height="60" topLeftX="429" topLeftY="135" alpha="0.88" type="ellipse">
+        <fill>
+          <fillColor color="rgba(25, 76, 255, 1)"/>
+        </fill>
+      </shape>
+      <line startX="346" startY="164" endX="429" endY="164">
+        <border color="rgba(25, 76, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="302" startY="289" endX="372" endY="289">
+        <border color="rgba(25, 76, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="562" startY="211" endX="629" endY="211">
+        <border color="rgba(37, 216, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="623" startY="358" endX="658" endY="358">
+        <border color="rgba(37, 216, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="268" height="44" topLeftX="78" topLeftY="142" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">关键点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="269" height="62" topLeftX="78" topLeftY="170" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="268" height="44" topLeftX="30" topLeftY="268" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">关键点 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="269" height="62" topLeftX="31" topLeftY="295" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="268" height="44" topLeftX="628" topLeftY="188" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">关键点 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="269" height="62" topLeftX="628" topLeftY="215" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="268" height="44" topLeftX="663" topLeftY="335" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">关键点 #4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="269" height="62" topLeftX="664" topLeftY="363" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(305deg,rgba(11, 59, 229, 1) 0%,rgba(37, 216, 255, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="540" height="540" topLeftX="690" topLeftY="0" type="donut">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="120" height="120" topLeftX="900" topLeftY="210" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 216, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="456" height="236" topLeftX="36" topLeftY="157" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="90" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="90">感谢你的时间</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content>
+        <p/>
+      </content>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/marketing--marketing_plan.xml
+++ b/skills/lark-slides/references/templates/marketing--marketing_plan.xml
@@ -1,0 +1,1469 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>营销策划方案-裂图重新上传</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XfIfbc1tYoFJ1sx5FWxcsCoBn0f" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="191" height="202" topLeftX="587" topLeftY="184" presetHandlers="8" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="545" height="101" topLeftX="207" topLeftY="204" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" bold="true" textAlign="center">
+          <p>营销策划模板</p>
+        </content>
+      </shape>
+      <line startX="142" startY="47" endX="910" endY="47" alpha="0.29">
+        <border color="rgba(147, 150, 156, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="615" height="44" topLeftX="172" topLeftY="290" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="16">MARKETING PLANNING </span>
+            </strong>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="16">TEMPLATE</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="92" height="116" topLeftX="295" topLeftY="26" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="161" height="77" topLeftX="319" topLeftY="71" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true" textAlign="center">
+          <p>目录</p>
+        </content>
+      </shape>
+      <line startX="907" startY="119" endX="907" endY="515">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="908" startY="0" endX="908" endY="142">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="904" topLeftY="144" rotation="0" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="785" topLeftY="367" rotation="270" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="43" topLeftX="369" topLeftY="207" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="15" bold="true">
+          <p>
+            <strong>
+              <span fontSize="15">活动总体思路</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="38" topLeftX="369" topLeftY="229" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 219, 29, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="12">General Idea</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="203" height="56" topLeftX="369" topLeftY="254" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(66, 66, 66, 1)">
+          <p>
+            <span color="rgba(66, 66, 66, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="43" topLeftX="614" topLeftY="207" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="15" bold="true">
+          <p>
+            <strong>
+              <span fontSize="15">活动执行方案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="38" topLeftX="614" topLeftY="229" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 219, 29, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="12">Program of Activities</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="203" height="56" topLeftX="614" topLeftY="254" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(66, 66, 66, 1)">
+          <p>
+            <span color="rgba(66, 66, 66, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <img src="NUtabqkWpohkfCxb523ckUYfnIf" width="254" height="489" topLeftX="26" topLeftY="26" exposure="16" contrast="-46" saturation="-93" temperature="-14">
+        <crop type="rect" leftOffset="80" rightOffset="34" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="136" height="43" topLeftX="369" topLeftY="327" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="15" bold="true">
+          <p>
+            <strong>
+              <span fontSize="15">活动经费预算</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="38" topLeftX="369" topLeftY="349" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 219, 29, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="12">Budget</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="203" height="56" topLeftX="369" topLeftY="374" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(66, 66, 66, 1)">
+          <p>
+            <span color="rgba(66, 66, 66, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="43" topLeftX="614" topLeftY="327" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="15" bold="true">
+          <p>
+            <strong>
+              <span fontSize="15">活动预期效果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="38" topLeftX="614" topLeftY="349" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 219, 29, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="12">Expected Results</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="203" height="56" topLeftX="614" topLeftY="374" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(66, 66, 66, 1)">
+          <p>
+            <span color="rgba(66, 66, 66, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 219, 29, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Ha3Cbaf8PobZMvxI6VZcV7uznZc" width="480" height="540" topLeftX="480" topLeftY="0" exposure="14" contrast="-55" saturation="-92" temperature="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="261" height="74" topLeftX="27" topLeftY="434" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(24, 24, 26, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(24, 24, 26, 1)" fontSize="36">活动总体思路</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="47" topLeftX="31" topLeftY="407" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">General Idea</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="142" startY="47" endX="676" endY="47">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="481" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <line startX="142" startY="47" endX="910" endY="47">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="101" height="90" topLeftX="41" topLeftY="88" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="407" height="62" topLeftX="77" topLeftY="118" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" bold="true" textAlign="left">
+          <p>
+            <span fontSize="28">活动总体思路</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="41" topLeftY="232" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="41" topLeftX="41" topLeftY="204" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="41" topLeftY="326" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="41" topLeftX="41" topLeftY="298" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="41" topLeftY="420" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="41" topLeftX="41" topLeftY="392" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Yb3sbX2Vooj3HyxQfB3cH9ErnOb" width="240" height="403" topLeftX="331" topLeftY="88" exposure="4" contrast="-51" saturation="-91" temperature="20">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="MhGabCLEBoKmRox0Q7dc6txbnhg" width="152" height="403" topLeftX="589" topLeftY="88" exposure="22" contrast="-35" saturation="-92" temperature="26">
+        <crop type="rect" leftOffset="411" rightOffset="155" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="H8q1bdnT8o7bXAxIKIHc9IGLnUh" width="152" height="403" topLeftX="758" topLeftY="88" exposure="26" contrast="-35" saturation="-91" temperature="31">
+        <crop type="rect" leftOffset="4" rightOffset="4" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="49" height="56" topLeftX="38" topLeftY="74" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <line startX="142" startY="47" endX="910" endY="47">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">5</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="74" topLeftX="38" topLeftY="194" alpha="0.88" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="38" topLeftX="38" topLeftY="388" presetHandlers="45" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">第一阶段</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="407" height="56" topLeftX="47" topLeftY="82" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true" textAlign="left">
+          <p>
+            <span fontSize="24">活动时间轴</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="250" startY="194" endX="250" endY="426" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="195" height="74" topLeftX="267" topLeftY="194" alpha="0.88" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="38" topLeftX="267" topLeftY="388" presetHandlers="45" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">第二阶段</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="479" startY="194" endX="479" endY="426" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="195" height="74" topLeftX="498" topLeftY="194" alpha="0.88" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="38" topLeftX="498" topLeftY="388" presetHandlers="45" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">第三阶段</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="710" startY="194" endX="710" endY="426" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="195" height="74" topLeftX="727" topLeftY="194" alpha="0.88" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="38" topLeftX="727" topLeftY="388" presetHandlers="45" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">第四阶段</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 219, 29, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="JezPbVNsHopdNuxR7ZecFO7Xnhf" width="480" height="540" topLeftX="480" topLeftY="0" exposure="14" contrast="-55" saturation="-92" temperature="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="261" height="74" topLeftX="27" topLeftY="434" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(24, 24, 26, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(24, 24, 26, 1)" fontSize="36">活动执行方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="47" topLeftX="31" topLeftY="407" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">Program of Activities</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="142" startY="47" endX="676" endY="47">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">6</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="481" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <line startX="282" startY="250" endX="90" endY="250" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="907" startY="119" endX="907" endY="515">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="908" startY="0" endX="908" endY="142">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="904" topLeftY="144" rotation="0" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">7</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="785" topLeftY="367" rotation="270" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q3 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="68" topLeftX="30" topLeftY="64" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(24, 24, 26, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(24, 24, 26, 1)" fontSize="32">活动执行方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="44" topLeftX="34" topLeftY="41" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 219, 29, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="16">Program of Activities</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="34" height="34" topLeftX="46" topLeftY="233" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="53" topLeftY="240" iconType="iconpark/Base/all-application.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="34" height="34" topLeftX="294" topLeftY="233" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="301" topLeftY="240" iconType="iconpark/Office/transform.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="34" height="34" topLeftX="542" topLeftY="233" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="549" topLeftY="240" iconType="iconpark/Travel/airplane.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <line startX="530" startY="250" endX="337" endY="250" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="240" height="41" topLeftX="42" topLeftY="277" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="192" height="56" topLeftX="62" topLeftY="314" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="53" topLeftY="332" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="192" height="38" topLeftX="62" topLeftY="360" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="53" topLeftY="378" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="240" height="41" topLeftX="294" topLeftY="277" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="192" height="56" topLeftX="313" topLeftY="314" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="305" topLeftY="332" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="192" height="38" topLeftX="313" topLeftY="360" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="305" topLeftY="378" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="192" height="74" topLeftX="313" topLeftY="391" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="305" topLeftY="408" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="240" height="41" topLeftX="542" topLeftY="277" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="192" height="56" topLeftX="561" topLeftY="314" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="553" topLeftY="332" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <line startX="907" startY="119" endX="907" endY="515">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="908" startY="0" endX="908" endY="142">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="904" topLeftY="144" rotation="0" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">8</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="785" topLeftY="367" rotation="270" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="W2oebPLuVoS3XzxoJc7cz2xtnxf" width="243" height="466" topLeftX="35" topLeftY="37" exposure="16" contrast="-46" saturation="-93" temperature="-14">
+        <crop type="rect" leftOffset="8" rightOffset="8" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="60" height="64" topLeftX="341" topLeftY="163" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="177" height="59" topLeftX="361" topLeftY="179" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" bold="true" textAlign="left">
+          <p>
+            <span fontSize="26">活动执行方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="38" topLeftX="363" topLeftY="221" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 219, 29, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="12">Program of Activities</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="254" topLeftX="363" topLeftY="252" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文，此处添加正文。</span>
+          </p>
+          <p/>
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文，此处添加正文。此处添加正文此处添加正文，此处添加正文。此处添加正文此处添加正文，此处添加正文。</span>
+          </p>
+          <p/>
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="41" topLeftX="616" topLeftY="163" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题或更多内容</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="77" topLeftX="616" topLeftY="183" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 219, 29, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="38">1,891+</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="817" startY="252" endX="624" endY="252" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="240" height="41" topLeftX="616" topLeftY="286" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题或更多内容</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="77" topLeftX="616" topLeftY="307" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 219, 29, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="38">60+</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="817" startY="375" endX="624" endY="375" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="240" height="41" topLeftX="616" topLeftY="411" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题或更多内容</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="77" topLeftX="616" topLeftY="432" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 219, 29, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="38">13,762+</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="816" startY="500" endX="624" endY="500" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 219, 29, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KSLDbAtVTowNhQxnPfUcK4s2nzc" width="480" height="540" topLeftX="0" topLeftY="0" exposure="14" contrast="-55" saturation="-92" temperature="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="261" height="74" topLeftX="672" topLeftY="434" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(24, 24, 26, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(24, 24, 26, 1)" fontSize="36">活动经费预算</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="47" topLeftX="699" topLeftY="407" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">Budget</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="142" startY="47" endX="676" endY="47">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">9</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="481" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="49" height="56" topLeftX="58" topLeftY="84" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <line startX="142" startY="47" endX="910" endY="47">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">10</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+      <shape width="407" height="56" topLeftX="67" topLeftY="92" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true" textAlign="left">
+          <p>
+            <span fontSize="24">活动经费预算</span>
+          </p>
+        </content>
+      </shape>
+      <img src="IrLPbZFuSok7kHxnOvFciHi9nPA" width="145" height="145" topLeftX="58" topLeftY="198" exposure="12" saturation="-91" temperature="23">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="GO5pblEDSo03uExEIlEc9xXdnyd" width="145" height="145" topLeftX="267" topLeftY="198" exposure="12" saturation="-91" temperature="23">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="EzCabT0y8o65r8xgM2Jcf25zncb" width="145" height="145" topLeftX="476" topLeftY="198" exposure="12" saturation="-91" temperature="23">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="CULmb2XWmouit4xzxbKc3U7ynxg" width="145" height="145" topLeftX="685" topLeftY="198" exposure="12" saturation="-91" temperature="23">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="24" height="2" topLeftX="66" topLeftY="360" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="2" topLeftX="275" topLeftY="360" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="2" topLeftX="484" topLeftY="360" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="2" topLeftX="693" topLeftY="360" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="144" height="41" topLeftX="58" topLeftY="357" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="41" topLeftX="267" topLeftY="357" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="41" topLeftX="476" topLeftY="357" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="41" topLeftX="685" topLeftY="357" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="145" height="74" topLeftX="58" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="145" height="74" topLeftX="266" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="145" height="74" topLeftX="476" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="145" height="74" topLeftX="685" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="W9OibVJ7cooFpyxooUpcU5Jfnfd" width="527" height="361" topLeftX="433" topLeftY="96" exposure="62" contrast="12" saturation="-92" temperature="1">
+        <crop type="rect" leftOffset="59" rightOffset="59" topOffset="0" bottomOffset="0" presetHandlers="4"/>
+      </img>
+      <line startX="142" startY="47" endX="910" endY="47">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">11</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+      <img src="IcRMb9tt6ony53x6QO6cUxAknne" width="587" height="407" topLeftX="373" topLeftY="91" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="88" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="63" height="64" topLeftX="32" topLeftY="91" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="177" height="59" topLeftX="52" topLeftY="107" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" bold="true" textAlign="left">
+          <p>
+            <span fontSize="26">活动经费预算</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="34" height="34" topLeftX="63" topLeftY="201" alpha="0.6" type="ellipse">
+        <fill>
+          <fillColor color="rgba(66, 66, 66, 1)"/>
+        </fill>
+        <border color="rgba(147, 150, 156, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="20" height="20" topLeftX="70" topLeftY="208" alpha="0.6" iconType="iconpark/Money/paper-money-two.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="34" height="34" topLeftX="63" topLeftY="302" alpha="0.6" type="ellipse">
+        <fill>
+          <fillColor color="rgba(66, 66, 66, 1)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="70" topLeftY="309" alpha="0.6" iconType="iconpark/Money/financing-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="144" height="44" topLeftX="101" topLeftY="195" alpha="0.7" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="44" topLeftX="101" topLeftY="297" alpha="0.7" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="232" height="56" topLeftX="101" topLeftY="228" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文，此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="232" height="56" topLeftX="101" topLeftY="329" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文，此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 219, 29, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="UnojbYZiZoljtNxOh8AcvjpGnck" width="480" height="540" topLeftX="0" topLeftY="0" exposure="14" contrast="-55" saturation="-92" temperature="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="261" height="74" topLeftX="672" topLeftY="434" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(24, 24, 26, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(24, 24, 26, 1)" fontSize="36">活动预期效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="47" topLeftX="699" topLeftY="407" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">Expected Results</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="142" startY="47" endX="676" endY="47">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">12</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="481" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="FtzebenNwoDtQoxtmggceadnn1d" width="961" height="539" topLeftX="0" topLeftY="0" exposure="16" saturation="-91" temperature="12">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="674" height="476" topLeftX="217" topLeftY="22" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="300" fontFamily="Trebuchet MS" color="rgba(255, 219, 29, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(255, 219, 29, 1)" fontSize="300" fontFamily="Trebuchet MS">40%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="165" height="122" topLeftX="100" topLeftY="97" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="35" height="157" topLeftX="165" topLeftY="213" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <img src="HJQ4bD96zoxB41xEmHncaqUVnrc" width="771" height="202" topLeftX="73" topLeftY="318" exposure="16" saturation="-91" temperature="12">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="20" presetHandlers="0"/>
+      </img>
+      <line startX="142" startY="47" endX="910" endY="47" alpha="0.29">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">13</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="49" height="56" topLeftX="58" topLeftY="84" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <line startX="142" startY="47" endX="910" endY="47">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">14</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+      <shape width="407" height="56" topLeftX="67" topLeftY="92" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true" textAlign="left">
+          <p>
+            <span fontSize="24">活动预期效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="213" height="74" topLeftX="707" topLeftY="382" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="707" topLeftY="338" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #6</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="656" topLeftY="338" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="26" height="26" topLeftX="666" topLeftY="348" iconType="iconpark/Base/tag-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="213" height="74" topLeftX="707" topLeftY="244" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="707" topLeftY="200" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="656" topLeftY="199" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="30" height="30" topLeftX="664" topLeftY="206" iconType="iconpark/Base/hourglass-null.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="213" height="74" topLeftX="408" topLeftY="382" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="408" topLeftY="338" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #5</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="357" topLeftY="338" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="26" height="26" topLeftX="367" topLeftY="348" iconType="iconpark/Base/lightning.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="213" height="74" topLeftX="408" topLeftY="244" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="408" topLeftY="200" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="357" topLeftY="199" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="30" height="30" topLeftX="365" topLeftY="206" iconType="iconpark/Base/aiming.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="213" height="74" topLeftX="108" topLeftY="382" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="108" topLeftY="338" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="58" topLeftY="338" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="26" height="26" topLeftX="68" topLeftY="348" iconType="iconpark/Abstract/game-emoji.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="213" height="74" topLeftX="108" topLeftY="244" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="108" topLeftY="200" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="58" topLeftY="199" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="30" height="30" topLeftX="66" topLeftY="206" iconType="iconpark/Travel/mountain.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 219, 29, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="337" height="78" topLeftX="600" topLeftY="417" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" bold="true" lineSpacing="multiple:1.2" textAlign="right">
+          <p lineSpacing="multiple:1.2">
+            <span fontSize="48">谢谢观看</span>
+          </p>
+        </content>
+      </shape>
+      <img src="C7EfbhI7PoHav4xydHsc789rnsf" width="534" height="540" topLeftX="0" topLeftY="0" exposure="14" contrast="-55" saturation="-92" temperature="31">
+        <crop type="rect" leftOffset="0" rightOffset="6" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <line startX="142" startY="47" endX="726" endY="47">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">15</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="534" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+      <shape width="231" height="50" topLeftX="699" topLeftY="385" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">Thank you</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/marketing--marketing_strategy.xml
+++ b/skills/lark-slides/references/templates/marketing--marketing_strategy.xml
@@ -1,0 +1,1484 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>市场营销策略</title>
+  <theme>
+    <background>
+      <fillColor color="rgba(11, 11, 11, 1)"/>
+    </background>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="48"/>
+      <headline fontColor="#000000FF" fontSize="28"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Rqf0bfVG2oy8HDx7UIWcRixGngc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="906" startY="521" endX="906" endY="19" alpha="0.27">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="547" height="132" topLeftX="54" topLeftY="58" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="80">市场营销策略</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="80" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" autoFit="shape-auto-fit">
+          <p>你的团队</p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="425" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="right" autoFit="shape-auto-fit">
+          <p>2025.09.12</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HdIobFtI6oDJddxsI06cTH6BnJF" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="488" height="58" topLeftX="53" topLeftY="85" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>目录</p>
+        </content>
+      </shape>
+      <shape width="200" height="74" topLeftX="69" topLeftY="379" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="200" height="44" topLeftX="69" topLeftY="348" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>当下状况</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="74" topLeftX="360" topLeftY="379" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="200" height="44" topLeftX="360" topLeftY="348" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>走向市场</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="74" topLeftX="651" topLeftY="379" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="200" height="44" topLeftX="651" topLeftY="348" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>总结思考</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="48" height="48" topLeftX="81" topLeftY="284" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)">
+          <p>
+            <strong>
+              <span color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)" fontSize="18">1</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="9" blur="18" color="rgba(98, 99, 100, 0.5)"/>
+      </shape>
+      <shape width="48" height="48" topLeftX="372" topLeftY="284" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)">
+          <p>
+            <strong>
+              <span color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)" fontSize="18">2</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="9" blur="18" color="rgba(98, 99, 100, 0.5)"/>
+      </shape>
+      <shape width="48" height="48" topLeftX="663" topLeftY="284" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)">
+          <p>
+            <strong>
+              <span color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)" fontSize="18">3</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="9" blur="18" color="rgba(98, 99, 100, 0.5)"/>
+      </shape>
+      <shape width="318" height="56" topLeftX="56" topLeftY="126" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IbymbiVxAo8e40xyhx1cCN4onmd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="906" startY="521" endX="906" endY="19" alpha="0.27">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="468" height="56" topLeftX="57" topLeftY="313" alpha="0.65" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">CURRENT STATUS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="688" height="132" topLeftX="47" topLeftY="343" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="80">当下状况</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="80" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>你的团队</p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="425" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="right">
+          <p>2025.09.12</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="UAazbKaXDoWpMyxAkKUc4SMSndf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="342" height="110" topLeftX="51" topLeftY="125" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">在这份 Slides 中，我们会通过简洁明确地说明和介绍，告诉您如何让您的产品在市场中取得成功，已经您的竞争对手，市场环境的具体状况。  </span>
+          </p>
+          <p/>
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">您可以从中获得最新的信息，以帮助您更好地制定市场策略</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="353" height="58" topLeftX="51" topLeftY="71" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">行业背景</span>
+          </p>
+        </content>
+      </shape>
+      <img src="AtXobKQZnoZZhqxAbsqcVXm0nrd" width="336" height="436" topLeftX="498" topLeftY="52" temperature="-100">
+        <crop type="rect" leftOffset="50" rightOffset="50" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DFSxbbPAQoNi6WxFrj6csrHRnSf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="261" height="56" topLeftX="51" topLeftY="385" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="285" height="58" topLeftX="51" topLeftY="341" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">市场趋势</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="375" startY="425" endX="889" endY="426">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="375" startY="357" endX="889" endY="358" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="375" startY="290" endX="889" endY="291" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="375" startY="222" endX="890" endY="223" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="375" startY="155" endX="889" endY="156" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="375" startY="88" endX="889" endY="89" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="22" height="282" topLeftX="842" topLeftY="144" presetHandlers="0" alpha="0.3" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="103" topLeftX="397" topLeftY="323" presetHandlers="0" alpha="0.3" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="244" topLeftX="488" topLeftY="182" presetHandlers="0" alpha="0.3" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="169" topLeftX="574" topLeftY="257" presetHandlers="0" alpha="0.3" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="247" topLeftX="666" topLeftY="179" presetHandlers="0" alpha="0.3" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="311" topLeftX="755" topLeftY="115" presetHandlers="0" alpha="0.3" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="50" height="38" topLeftX="381" topLeftY="430" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2019</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="474" topLeftY="430" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2020</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="560" topLeftY="430" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2021</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="652" topLeftY="429" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2022</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="741" topLeftY="430" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2023</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="827" topLeftY="430" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2024</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="22" height="234" topLeftX="842" topLeftY="193" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="190" topLeftX="755" topLeftY="236" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="114" topLeftX="666" topLeftY="313" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="151" topLeftX="574" topLeftY="275" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="127" topLeftX="488" topLeftY="299" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="94" topLeftX="396" topLeftY="332" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="50" height="38" topLeftX="321" topLeftY="71" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(193, 193, 193, 1)" fontSize="12">100</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="320" topLeftY="134" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(193, 193, 193, 1)" fontSize="12">80</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="320" topLeftY="204" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(193, 193, 193, 1)" fontSize="12">60</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="321" topLeftY="274" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(193, 193, 193, 1)" fontSize="12">40</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="320" topLeftY="342" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(193, 193, 193, 1)" fontSize="12">20</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="K6PSbSEG3oGyjbxuVTpc9jeQnib" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="404" height="404" topLeftX="-21" topLeftY="-75" alpha="0.15" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="242" height="242" topLeftX="60" topLeftY="7" alpha="0.15" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="115" height="115" topLeftX="123" topLeftY="70" alpha="0.15" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="-21" startY="127" endX="383" endY="128" alpha="0.15">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="181" startY="248" endX="181" endY="7" alpha="0.15">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="244" height="39" topLeftX="-73" topLeftY="250" rotation="270" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">低效率</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="244" height="39" topLeftX="729" topLeftY="251" rotation="90" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">高效率</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="244" height="39" topLeftX="327" topLeftY="492" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">低价格</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="244" height="39" topLeftX="327" topLeftY="6" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">高价格</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="200" topLeftY="382" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(354deg,rgba(188, 80, 255, 1) 0%,rgba(47, 43, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">J</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="159" topLeftY="427" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="70" height="70" topLeftX="163" topLeftY="155" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(242, 243, 245, 1)">
+          <p>
+            <span color="rgba(242, 243, 245, 1)" fontSize="18">H</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="134" topLeftY="225" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="48" height="48" topLeftX="322" topLeftY="321" type="ellipse">
+        <fill>
+          <fillColor color="rgba(242, 243, 245, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>I</p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="282" topLeftY="367" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="58" height="58" topLeftX="346" topLeftY="182" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(354deg,rgba(188, 80, 255, 1) 0%,rgba(47, 43, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">F</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="309" topLeftY="234" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="70" height="70" topLeftX="286" topLeftY="52" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(242, 243, 245, 1)">
+          <p>
+            <span color="rgba(242, 243, 245, 1)" fontSize="18">G</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="256" topLeftY="122" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="503" topLeftY="175" type="ellipse">
+        <fill>
+          <fillColor color="rgba(242, 243, 245, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>C</p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="462" topLeftY="219" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="70" height="70" topLeftX="482" topLeftY="301" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(242, 243, 245, 1)">
+          <p>
+            <span color="rgba(242, 243, 245, 1)" fontSize="18">E</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="453" topLeftY="371" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="97" height="97" topLeftX="634" topLeftY="351" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(354deg,rgba(188, 80, 255, 1) 0%,rgba(47, 43, 253, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">D</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="618" topLeftY="448" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="70" height="70" topLeftX="646" topLeftY="160" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(242, 243, 245, 1)">
+          <p>
+            <span color="rgba(242, 243, 245, 1)" fontSize="18">B</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="617" topLeftY="230" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="44" height="44" topLeftX="569" topLeftY="93" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">A</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="528" topLeftY="137" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(11, 11, 11, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="488" height="69" topLeftX="48" topLeftY="43" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="36">你的目标用户</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(11, 11, 11, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="340" height="442" topLeftX="51" topLeftY="48" presetHandlers="36" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="RW4PbdtmJoW7ucxRXj3cMFxTnCb" width="343" height="447" topLeftX="50" topLeftY="46">
+        <crop type="rect" leftOffset="0.42" rightOffset="0.42" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+      <shape width="444" height="146" topLeftX="425" topLeftY="141" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">关于</span>
+          </p>
+          <p>
+            <span color="rgba(255, 255, 255, 1)">年近三十的单身独立男性。有雄心勃勃的创意，十几岁时就开始创办自己的服装品牌。</span>
+          </p>
+          <p/>
+          <p>
+            <span color="rgba(255, 255, 255, 1)">期望和需求</span>
+          </p>
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述您的产品或服务如何满足目标市场的期望和需求。您的业务将提供什么，目前的竞争对手没有提供的东西</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="423" height="74" topLeftX="426" topLeftY="76" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="linear-gradient(90deg,rgba(255, 46, 0, 1) 0%,rgba(250, 115, 39, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="linear-gradient(90deg,rgba(255, 46, 0, 1) 0%,rgba(250, 115, 39, 1) 100%)" fontSize="40">Aaron Smith</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="257" height="47" topLeftX="426" topLeftY="53" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">用户画像</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="24" topLeftX="435" topLeftY="316" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 0, 0, 1)">
+          <p>
+            <span color="rgba(255, 0, 0, 1)" fontSize="12">好奇心 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="24" topLeftX="535" topLeftY="316" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 0, 0, 1)">
+          <p>
+            <span color="rgba(255, 0, 0, 1)" fontSize="12">消费力 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="24" topLeftX="636" topLeftY="315" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 0, 0, 1)">
+          <p>
+            <span color="rgba(255, 0, 0, 1)" fontSize="12">带货能力 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="109" height="38" topLeftX="431" topLeftY="373" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="linear-gradient(0deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="linear-gradient(0deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)">个性特征</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="98" height="38" topLeftX="632" topLeftY="428" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="linear-gradient(0deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="linear-gradient(0deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)" fontSize="12">消费力 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="185" height="7" topLeftX="436" topLeftY="444" alpha="0.2" type="slides-full-round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="78" height="7" topLeftX="436" topLeftY="444" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(270deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="94" height="38" topLeftX="632" topLeftY="403" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="linear-gradient(0deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="linear-gradient(0deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)" fontSize="12">好奇心 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="185" height="7" topLeftX="436" topLeftY="418" alpha="0.2" type="slides-full-round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="109" height="7" topLeftX="436" topLeftY="418" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(270deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="38" topLeftX="631" topLeftY="455" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="linear-gradient(0deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="linear-gradient(0deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)" fontSize="12">带货能力 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="184" height="8" topLeftX="435" topLeftY="469" alpha="0.2" type="slides-full-round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="150" height="7" topLeftX="435" topLeftY="471" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(270deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IbymbiVxAo8e40xyhx1cCN4onmd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="906" startY="521" endX="906" endY="19" alpha="0.27">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="468" height="56" topLeftX="57" topLeftY="313" alpha="0.65" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">GO-TO-MARKET</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="688" height="132" topLeftX="47" topLeftY="343" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="80">走向市场</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="425" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>2025.09.12</p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="80" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>你的团队</p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="80" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>你的团队</p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="425" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="right">
+          <p>2025.09.12</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DkerbBnJBom9YbxaZaqcv7Ysnug" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="596" height="69" topLeftX="46" topLeftY="53" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">我们的目标</span>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(11, 11, 11, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="63" height="63" topLeftX="202" topLeftY="92" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(270deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="187" height="74" topLeftX="79" topLeftY="189" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="157" height="38" topLeftX="108" topLeftY="163" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">抖音 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="44" height="44" topLeftX="212" topLeftY="101" iconType="iconpark/Travel/planet.svg">
+        <border color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="63" height="63" topLeftX="202" topLeftY="277" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(270deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="175" height="74" topLeftX="90" topLeftY="374" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="157" height="38" topLeftX="108" topLeftY="347" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12"> 小红书 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="44" height="44" topLeftX="212" topLeftY="286" iconType="iconpark/Travel/world.svg">
+        <border color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="63" height="63" topLeftX="704" topLeftY="277" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(270deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="177" height="74" topLeftX="704" topLeftY="374" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="157" height="38" topLeftX="704" topLeftY="347" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">微信公众号 #4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="44" height="44" topLeftX="714" topLeftY="286" iconType="iconpark/Abstract/circular-connection.svg">
+        <border color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="63" height="63" topLeftX="704" topLeftY="92" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(270deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="177" height="74" topLeftX="704" topLeftY="189" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="157" height="38" topLeftX="704" topLeftY="162" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">微信视频号  #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="44" height="44" topLeftX="714" topLeftY="101" iconType="iconpark/Abstract/sphere.svg">
+        <border color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="K78bbZ4suoHJpHxY4vucGfrUnMF" width="303" height="303" topLeftX="331" topLeftY="115">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="178" height="85" topLeftX="359" topLeftY="216" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="right">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="54">1668</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="97" topLeftX="538" topLeftY="233" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)" fontSize="32">万</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="157" height="47" topLeftX="405" topLeftY="286" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">全平台曝光量</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="ILoYbyU76oWZoBxsAbNc80yOntg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="471" startY="175" endX="471" endY="360" alpha="0.3">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="262" startY="175" endX="262" endY="360" alpha="0.3">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="680" startY="175" endX="680" endY="360" alpha="0.3">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="54" startY="175" endX="54" endY="360" alpha="0.3">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="176" height="74" topLeftX="697" topLeftY="179" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="74" topLeftX="488" topLeftY="179" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="74" topLeftX="279" topLeftY="179" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="74" topLeftX="70" topLeftY="179" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="574" height="58" topLeftX="54" topLeftY="56" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">行动计划</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="30" topLeftX="80" topLeftY="331" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">多平台曝光 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="30" topLeftX="289" topLeftY="331" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">头部KOL签约 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="30" topLeftX="498" topLeftY="331" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">SEO优化 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="30" topLeftX="707" topLeftY="331" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">用户自发传播#4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(11, 11, 11, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="342" height="56" topLeftX="51" topLeftY="115" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="353" height="58" topLeftX="51" topLeftY="71" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">预算分配计划</span>
+          </p>
+        </content>
+      </shape>
+      <table topLeftX="59" topLeftY="226">
+        <colgroup>
+          <col span="3" width="269"/>
+        </colgroup>
+        <tr height="44">
+          <td>
+            <borderTop color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="linear-gradient(90deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(31, 35, 41, 1)" fontSize="16">行动项目</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="linear-gradient(270deg,rgba(255, 0, 0, 1) 0%,rgba(250, 102, 39, 1) 100%)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="16">分配预算</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(31, 35, 41, 1)" fontSize="16">负责人</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="14">多平台曝光</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(255, 0, 0, 0.43)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)">
+              <p>
+                <span color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)" fontSize="14">$ 20,000</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">@ 马克</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="14">头部 KOL 签约</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(255, 0, 0, 0.431)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)">
+              <p>
+                <span color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)" fontSize="14">$ 50,000</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">@ 马克</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="14">SOE 优化</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(255, 0, 0, 0.431)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="linear-gradient(0deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)">
+              <p>
+                <span color="linear-gradient(0deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)" fontSize="14">$30,000</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">@ 马克</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="14">总计</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(255, 0, 0, 0.431)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)">
+              <p>
+                <span color="linear-gradient(90deg,rgba(255, 77, 0, 1) 0%,rgba(250, 128, 39, 1) 100%)" fontSize="14">$ 100,000</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">@ 马克</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+      </table>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IbymbiVxAo8e40xyhx1cCN4onmd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="906" startY="521" endX="906" endY="19" alpha="0.27">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="468" height="56" topLeftX="57" topLeftY="313" alpha="0.65" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">SUMMARY</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="688" height="132" topLeftX="47" topLeftY="343" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="80">总结思考</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="80" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>你的团队</p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="425" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="right">
+          <p>2025.09.12</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="P7x5bUg3CoMr4kxUJTvcMo5Wncc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="460" startY="184" endX="460" endY="390" alpha="0.3">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="326" height="92" topLeftX="508" topLeftY="212" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">仅有规划还不够，必须积极地执行计划，采取行动并坚持不懈地追求目标。只有将规划与执行相结合，才能取得真正的成功。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="326" height="140" topLeftX="54" topLeftY="212" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">目标客户群体的定位是指确定公司或产品的目标市场，并确定目标客户群体的特征和需求。这有助于公司明确其产品或服务的目标客户，以便更好地满足他们的需求，提高市场份额，并实现公司的长期发展目标。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="360" height="44" topLeftX="508" topLeftY="174" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">2、 根据市场的变动实时调整策略，快速执行</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="360" height="44" topLeftX="58" topLeftY="174" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">1、目标客户群体的定位</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="574" height="58" topLeftX="54" topLeftY="56" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">关键影响因素</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CPTXblIQoo0A73xGUitcXPt9nzf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="906" startY="521" endX="906" endY="19" alpha="0.27">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="468" height="56" topLeftX="57" topLeftY="313" alpha="0.65" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">THANK YOU</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="688" height="132" topLeftX="47" topLeftY="343" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="80">感谢观看</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="80" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>你的团队</p>
+        </content>
+      </shape>
+      <shape width="176" height="38" topLeftX="845" topLeftY="425" rotation="90" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="right">
+          <p>2025.09.12</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/marketing--product_whitepaper.xml
+++ b/skills/lark-slides/references/templates/marketing--product_whitepaper.xml
@@ -1,0 +1,1455 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>产品白皮书</title>
+  <theme>
+    <fill alpha="1">
+      <fillImg src="KRmObhqQgoUyBAxPT9UcF2v9n3b" alpha="1" rotateWithShape="false"/>
+    </fill>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="90"/>
+      <headline fontColor="#000000FF" fontSize="42"/>
+      <sub-headline fontColor="#000000FF" fontSize="18"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Iag8bM9Nvo5gGFxoktKcGdaqnEd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="488" height="44" topLeftX="28" topLeftY="311" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 64, 58, 1)">
+          <p lineSpacing="multiple:1.4">
+            <span color="rgba(255, 64, 58, 1)" fontSize="16">你要做的第一件事是定义你正在开发的新产品。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="698" height="146" topLeftX="23" topLeftY="175" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="90" color="linear-gradient(60deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" bold="true" lineSpacing="multiple:1.4">
+          <p>
+            <strong>
+              <span color="linear-gradient(60deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" fontSize="90">互联网产品展示</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="39" topLeftX="28" topLeftY="476" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="left">
+          <p>团队名称</p>
+        </content>
+      </shape>
+      <shape width="178" height="38" topLeftX="28" topLeftY="19" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">品牌 LOGO</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="KRmObhqQgoUyBAxPT9UcF2v9n3b" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="189" startY="234" endX="189" endY="389" alpha="0.5">
+        <border color="rgba(255, 64, 58, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="125" height="77" topLeftX="164" topLeftY="112" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)">目录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="328" height="77" topLeftX="289" topLeftY="112" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">CONTENTS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="125" height="44" topLeftX="200" topLeftY="216" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>产品功能</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="125" height="44" topLeftX="200" topLeftY="267" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>功能展示</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="139" height="44" topLeftX="200" topLeftY="317" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>来自用户的声音</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="157" height="44" topLeftX="200" topLeftY="368" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>适合你的付费计划</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="385" height="38" topLeftX="391" topLeftY="371" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>单击此处输入关于主题的简单介绍，为了更好的演示效果</p>
+        </content>
+      </shape>
+      <shape width="11" height="11" topLeftX="183" topLeftY="385" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="385" height="38" topLeftX="391" topLeftY="320" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>单击此处输入关于主题的简单介绍，为了更好的演示效果</p>
+        </content>
+      </shape>
+      <shape width="11" height="11" topLeftX="183" topLeftY="334" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="385" height="38" topLeftX="391" topLeftY="270" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>单击此处输入关于主题的简单介绍，为了更好的演示效果</p>
+        </content>
+      </shape>
+      <shape width="11" height="11" topLeftX="183" topLeftY="283" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="385" height="38" topLeftX="391" topLeftY="219" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>单击此处输入关于主题的简单介绍，为了更好的演示效果</p>
+        </content>
+      </shape>
+      <shape width="11" height="11" topLeftX="183" topLeftY="232" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="ZUPsb9AoMoZJrTxfBrycsE04nzb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="587" height="107" topLeftX="126" topLeftY="203" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>产品介绍</p>
+        </content>
+      </shape>
+      <shape width="115" height="106" topLeftX="23" topLeftY="203" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>01</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="KRmObhqQgoUyBAxPT9UcF2v9n3b" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="548" height="77" topLeftX="99" topLeftY="48" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1" letterSpacing="2">
+            <strong>
+              <span fontSize="42">产品名称</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="99" topLeftY="26" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p lineSpacing="multiple:1">
+            <span fontSize="16">PRODUCT NAME</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="608" height="61" topLeftX="105" topLeftY="114" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p lineSpacing="multiple:1.7" letterSpacing="1">
+            <span fontSize="12">单击此处输入你的正文，文字是您思想的提炼，为了最终演示发布的良好效果，请尽量言简意赅的阐述观点；根据需要可酌情增减文字，以便观者可以准确理解您所传达的信息。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="HjPWbeFxAocdZqxrXwUcCmUBnUf" width="717" height="340" topLeftX="121" topLeftY="200">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="79" presetHandlers="0"/>
+      </img>
+      <img src="BqdMbEXRRoU0PdxalK8cNrojnOe" width="899" height="354" topLeftX="31" topLeftY="186" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="189"/>
+      </img>
+      <img src="Enr0be8iBoP2Q0xE7n3cHA2CnFb" width="169" height="265" topLeftX="730" topLeftY="275">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="102" presetHandlers="0"/>
+      </img>
+      <img src="Y8U2b9kf1ozJAgx5752ciAvCnSg" width="184" height="270" topLeftX="723" topLeftY="270">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="101" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="VZcZbYmGWovJc9xYjxYcMwDrnRh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="359" height="110" topLeftX="65" topLeftY="157" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</p>
+        </content>
+      </shape>
+      <shape width="364" height="77" topLeftX="64" topLeftY="92" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1" letterSpacing="2">
+            <strong>
+              <span fontSize="42">产品名称</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="69" topLeftY="70" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="false" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1">
+            <span fontSize="16">PRODUCT NAME</span>
+          </p>
+        </content>
+      </shape>
+      <img src="HWIFbnYcfoIOYTx0iuYcmgK3nqh" width="339" height="466" topLeftX="498" topLeftY="74">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="268" presetHandlers="0"/>
+      </img>
+      <img src="DNFgbeqhGocMcfxBkB8clhzbn3f" width="376" height="478" topLeftX="480" topLeftY="62">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="284" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="KRmObhqQgoUyBAxPT9UcF2v9n3b" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="359" height="140" topLeftX="415" topLeftY="230" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p lineSpacing="multiple:1.7" letterSpacing="1">
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</span>
+          </p>
+          <p lineSpacing="multiple:1.7" letterSpacing="1"/>
+          <p lineSpacing="multiple:1.7" letterSpacing="1">
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="364" height="77" topLeftX="410" topLeftY="165" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1" letterSpacing="2">
+            <strong>
+              <span fontSize="42">产品名称</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="45" topLeftX="415" topLeftY="143" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="false" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1">
+            <span fontSize="18" bold="false">PRODUCT NAME</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Htanbhm8Ioj6WIxnTkCcllaMnLf" width="196" height="424" topLeftX="160" topLeftY="59">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="KgrfbVWYnoqsorx2v5zcApudnRe" width="217" height="438" topLeftX="150" topLeftY="51">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="ZUPsb9AoMoZJrTxfBrycsE04nzb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="587" height="107" topLeftX="126" topLeftY="203" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>功能展示</p>
+        </content>
+      </shape>
+      <shape width="115" height="106" topLeftX="23" topLeftY="203" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>02</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="KRmObhqQgoUyBAxPT9UcF2v9n3b" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="N2MJbJN1OoLokkxeqF2cidMinth" width="623" height="359" topLeftX="169" topLeftY="181">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="2" bottomOffset="2" presetHandlers="0"/>
+      </img>
+      <img src="XLL8bZvomo41W5xzPX9cZ9NknVE" width="780" height="372" topLeftX="90" topLeftY="168" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="99" presetHandlers="0"/>
+      </img>
+      <shape width="472" height="56" topLeftX="244" topLeftY="103" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="548" height="77" topLeftX="206" topLeftY="37" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>功能演示</p>
+        </content>
+      </shape>
+      <line startX="556" startY="368" endX="829" endY="367">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <shape width="124" height="30" topLeftX="819" topLeftY="352" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1" letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">功能 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="254" startY="287" endX="124" endY="287">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <shape width="124" height="30" topLeftX="18" topLeftY="272" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1" letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">功能 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="254" startY="466" endX="124" endY="465">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <shape width="124" height="30" topLeftX="18" topLeftY="450" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1" letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">功能 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="FYWBbVp0toMv72xFHL3cgVrenag" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="240" height="44" topLeftX="80" topLeftY="368" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>功能名字 #1</p>
+        </content>
+      </shape>
+      <shape width="240" height="44" topLeftX="360" topLeftY="368" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>功能名字 #2</p>
+        </content>
+      </shape>
+      <shape width="240" height="44" topLeftX="640" topLeftY="368" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>功能名字 #3</p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="80" topLeftY="398" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。</span>
+          </p>
+          <p>
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="360" topLeftY="398" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。</span>
+          </p>
+          <p>
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="640" topLeftY="398" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。</span>
+          </p>
+          <p>
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="275" topLeftX="80" topLeftY="86" presetHandlers="8" alpha="0.12" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(66, 24, 21, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <shape width="240" height="275" topLeftX="360" topLeftY="86" presetHandlers="8" alpha="0.12" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(66, 24, 21, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <shape width="240" height="275" topLeftX="640" topLeftY="86" presetHandlers="8" alpha="0.12" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(66, 24, 21, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <img src="RUWVbhfBYogphYxc7esc1NRznBc" width="150" height="203" topLeftX="125" topLeftY="159">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="122" presetHandlers="0"/>
+      </img>
+      <img src="EwnnbNJh4ocDBDxGtdJceAEnnh4" width="168" height="210" topLeftX="116" topLeftY="151">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="129" presetHandlers="0"/>
+      </img>
+      <img src="WwAlbmoGnofr2MxpY1qc5vkHn9b" width="151" height="204" topLeftX="405" topLeftY="157">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="122" presetHandlers="0"/>
+      </img>
+      <img src="CbcvbbpX4oHR5gxjAAyc4tD9nvc" width="168" height="210" topLeftX="396" topLeftY="151">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="130" presetHandlers="0"/>
+      </img>
+      <img src="BqIHbeIjnokuhUxjUlZcUkmHnhb" width="151" height="203" topLeftX="685" topLeftY="159">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="124" presetHandlers="0"/>
+      </img>
+      <img src="M18cbwdukopqVaxtnPvcey9anrc" width="169" height="210" topLeftX="676" topLeftY="151">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="132" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="FYWBbVp0toMv72xFHL3cgVrenag" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="191" height="244" topLeftX="697" topLeftY="176" presetHandlers="8" alpha="0.12" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(66, 24, 21, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <img src="Ae64bWfE0ohJ2IxqIrgc6C35ntf" width="165" height="120" topLeftX="710" topLeftY="191">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="23" bottomOffset="23" presetHandlers="8"/>
+      </img>
+      <shape width="191" height="244" topLeftX="489" topLeftY="176" presetHandlers="8" alpha="0.12" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(66, 24, 21, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <img src="IL58bdiheo3EUyxiQ5kcrlalnvh" width="165" height="120" topLeftX="502" topLeftY="191">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="79" bottomOffset="18" presetHandlers="8"/>
+      </img>
+      <shape width="191" height="244" topLeftX="280" topLeftY="176" presetHandlers="8" alpha="0.12" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(66, 24, 21, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <img src="F63obrRbBormf2xAM6Uc5Tqjn5f" width="165" height="120" topLeftX="293" topLeftY="191">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="23" bottomOffset="23" presetHandlers="8"/>
+      </img>
+      <shape width="191" height="244" topLeftX="72" topLeftY="176" presetHandlers="8" alpha="0.12" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(66, 24, 21, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <img src="W21Lb9z2VoGRYVxlnZhc92XAn2d" width="165" height="120" topLeftX="85" topLeftY="191">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="97" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="608" height="56" topLeftX="176" topLeftY="103" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="548" height="77" topLeftX="206" topLeftY="37" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>功能演示</p>
+        </content>
+      </shape>
+      <shape width="191" height="44" topLeftX="72" topLeftY="314" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">功能 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="191" height="56" topLeftX="72" topLeftY="351" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">单击此处输入你的正文，</span>
+          </p>
+          <p>
+            <span color="rgba(43, 47, 54, 1)">为了更好地演示发布效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="191" height="44" topLeftX="280" topLeftY="314" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">功能 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="191" height="56" topLeftX="280" topLeftY="351" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">单击此处输入你的正文，</span>
+          </p>
+          <p>
+            <span color="rgba(43, 47, 54, 1)">为了更好地演示发布效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="191" height="44" topLeftX="489" topLeftY="314" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">功能 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="191" height="56" topLeftX="489" topLeftY="351" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">单击此处输入你的正文，</span>
+          </p>
+          <p>
+            <span color="rgba(43, 47, 54, 1)">为了更好地演示发布效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="191" height="44" topLeftX="697" topLeftY="314" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">功能 #4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="191" height="56" topLeftX="697" topLeftY="351" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">单击此处输入你的正文，</span>
+          </p>
+          <p>
+            <span color="rgba(43, 47, 54, 1)">为了更好地演示发布效果</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="KRmObhqQgoUyBAxPT9UcF2v9n3b" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="O3u4bxvhYooIFOxtEIZcg5t6n8f" width="196" height="424" topLeftX="160" topLeftY="59">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="RJ0kbLgPUok4P7xV57pc3EORnGf" width="217" height="438" topLeftX="150" topLeftY="51">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="260" height="44" topLeftX="447" topLeftY="385" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35">
+          <p>功能</p>
+        </content>
+      </shape>
+      <shape width="260" height="56" topLeftX="447" topLeftY="415" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">单击此处输入你的正文，文字是您思想的提炼</span>
+          </p>
+          <p>
+            <span fontSize="12">为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="432" startY="62" endX="432" endY="335">
+        <border color="linear-gradient(90deg,rgba(31, 35, 41, 0) 0%,rgba(31, 35, 41, 1) 30%,rgba(31, 35, 41, 1) 56%,rgba(31, 35, 41, 0) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="314" startY="169" endX="432" endY="169">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <img src="RchVbkX58oLbYQxsLWocrYdPnSg" width="206" height="313" topLeftX="447" topLeftY="62">
+        <shadow offset="10" angle="90" blur="28" color="rgba(0, 0, 0, 0.05)"/>
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="UogWbolgfoRv7dxhodzcRraWnsf" width="206" height="249" topLeftX="659" topLeftY="62">
+        <shadow offset="10" angle="90" blur="28" color="rgba(0, 0, 0, 0.05)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="KRmObhqQgoUyBAxPT9UcF2v9n3b" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="400" height="298" topLeftX="485" topLeftY="180" presetHandlers="8" alpha="0.12" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(66, 24, 21, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <shape width="400" height="298" topLeftX="74" topLeftY="180" presetHandlers="8" alpha="0.12" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(66, 24, 21, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <shape width="374" height="44" topLeftX="87" topLeftY="372" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">功能 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="374" height="56" topLeftX="87" topLeftY="409" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">单击此处输入你的正文，文字是您思想的提炼</span>
+          </p>
+          <p>
+            <span color="rgba(43, 47, 54, 1)">为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+      <img src="NIIabnaeoo3QffxQeyzcddQBnih" width="374" height="174" topLeftX="87" topLeftY="191" alpha="0.85">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="266" bottomOffset="53" presetHandlers="8"/>
+      </img>
+      <img src="ICuBbn3tQofEW9xdikZcoghnnyz" width="374" height="174" topLeftX="498" topLeftY="191" alpha="0.85">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="100" bottomOffset="100" presetHandlers="8"/>
+      </img>
+      <shape width="472" height="56" topLeftX="244" topLeftY="103" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="548" height="77" topLeftX="206" topLeftY="37" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>产品功能</p>
+        </content>
+      </shape>
+      <shape width="374" height="44" topLeftX="498" topLeftY="372" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">功能 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="374" height="56" topLeftX="498" topLeftY="409" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">单击此处输入你的正文，文字是您思想的提炼</span>
+          </p>
+          <p>
+            <span color="rgba(43, 47, 54, 1)">为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="KRmObhqQgoUyBAxPT9UcF2v9n3b" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Nyz2b1635odqLaxRkoEc4ZwXnfc" width="196" height="424" topLeftX="382" topLeftY="59">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EPAEbtakjolYMRxZWboc2BtvnUg" width="217" height="438" topLeftX="372" topLeftY="51">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="260" height="44" topLeftX="608" topLeftY="172" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35">
+          <p>功能 #1</p>
+        </content>
+      </shape>
+      <shape width="260" height="56" topLeftX="608" topLeftY="201" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">单击此处输入你的正文，文字是您思想的提炼</span>
+          </p>
+          <p>
+            <span fontSize="12">为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="564" startY="162" endX="774" endY="162">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <line startX="176" startY="388" endX="393" endY="388">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <endArrow type="solid-circle"/>
+      </line>
+      <shape width="260" height="44" topLeftX="91" topLeftY="288" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35" textAlign="right">
+          <p>功能 #2</p>
+        </content>
+      </shape>
+      <shape width="260" height="56" topLeftX="91" topLeftY="317" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="right">
+          <p>
+            <span fontSize="12">单击此处输入你的正文，文字是您思想的提炼</span>
+          </p>
+          <p>
+            <span fontSize="12">为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="ZUPsb9AoMoZJrTxfBrycsE04nzb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="587" height="107" topLeftX="126" topLeftY="203" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>来自客户的声音</p>
+        </content>
+      </shape>
+      <shape width="115" height="106" topLeftX="23" topLeftY="203" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>03</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DRk9boPBao4Fawxbtpwc6gz0nqf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Xf3lbN1csoErflxFfXtc2swPnce" width="635" height="426" topLeftX="275" topLeftY="68" alpha="0.15">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="278" height="56" topLeftX="50" topLeftY="356" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="359" height="77" topLeftX="50" topLeftY="287" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="42">主要使用国家</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="348" topLeftY="228" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="12" topLeftX="344" topLeftY="211" rotation="180" type="triangle">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="140" height="35" topLeftX="282" topLeftY="177" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>国家 A</p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="584" topLeftY="328" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="12" topLeftX="580" topLeftY="311" rotation="180" type="triangle">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="140" height="35" topLeftX="518" topLeftY="277" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">国家 B</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="810" topLeftY="255" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="12" topLeftX="806" topLeftY="238" rotation="180" type="triangle">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="140" height="35" topLeftX="744" topLeftY="204" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">国家 C</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DYTDbcVzaocBYbxvvcXcS75Gnze" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="818" height="392" topLeftX="71" topLeftY="74" presetHandlers="12" alpha="0.08" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(66, 24, 21, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <img src="JqvmbzTyPoEp9XxySs1cXck4nyc" width="278" height="368" topLeftX="83" topLeftY="86">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.6" bottomOffset="0.6" presetHandlers="8"/>
+      </img>
+      <shape width="482" height="77" topLeftX="382" topLeftY="97" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1" letterSpacing="2">
+            <strong>
+              <span color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" fontSize="42">用户反馈</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="193" height="44" topLeftX="382" topLeftY="159" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>FEEDBACK</p>
+        </content>
+      </shape>
+      <shape width="364" height="140" topLeftX="382" topLeftY="220" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p lineSpacing="multiple:1.7" letterSpacing="1">
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</span>
+          </p>
+          <p lineSpacing="multiple:1.7" letterSpacing="1"/>
+          <p lineSpacing="multiple:1.7" letterSpacing="1">
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="BT3Zb3NHLodP3PxZ7uXcK1NZnHd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="281" height="181" topLeftX="45" topLeftY="278" presetHandlers="8" alpha="0.28" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(232, 134, 125, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <shape width="231" height="77" topLeftX="50" topLeftY="83" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1" letterSpacing="2">
+            <strong>
+              <span color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" fontSize="42">用户反馈</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="44" topLeftX="50" topLeftY="142" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>FEEDBACK</p>
+        </content>
+      </shape>
+      <shape width="281" height="181" topLeftX="338" topLeftY="83" presetHandlers="8" alpha="0.28" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(232, 134, 125, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <shape width="281" height="181" topLeftX="631" topLeftY="83" presetHandlers="8" alpha="0.28" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(232, 134, 125, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <shape width="281" height="181" topLeftX="338" topLeftY="278" presetHandlers="8" alpha="0.28" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(232, 134, 125, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <img src="YSprbZcsRoq7Jjx13qVcghZanoe" width="40" height="40" topLeftX="355" topLeftY="99">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="208" height="44" topLeftX="402" topLeftY="99" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p>用户 #1</p>
+        </content>
+      </shape>
+      <shape width="264" height="74" topLeftX="347" topLeftY="147" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>如果你做了一件事，结果还不错，那么你应该去做其他精彩的事，不要在上面纠缠太久。只要想清楚下一步是什么</p>
+        </content>
+      </shape>
+      <img src="QJl8b4OgkoLXNqxLyoUcXalpngg" width="40" height="40" topLeftX="648" topLeftY="103">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+      </img>
+      <shape width="208" height="44" topLeftX="694" topLeftY="103" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p lineSpacing="multiple:1.35">
+            <span color="rgba(31, 35, 41, 1)">用户 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="264" height="74" topLeftX="639" topLeftY="151" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>如果你做了一件事，结果还不错，那么你应该去做其他精彩的事，不要在上面纠缠太久。只要想清楚下一步是什么</p>
+        </content>
+      </shape>
+      <img src="XluDbd7wcoPQttxUCkicuv8YnLh" width="40" height="40" topLeftX="355" topLeftY="296">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+      </img>
+      <shape width="208" height="44" topLeftX="402" topLeftY="296" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p lineSpacing="multiple:1.35">
+            <strong>
+              <span fontSize="18">用户 #4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="264" height="74" topLeftX="347" topLeftY="344" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>如果你做了一件事，结果还不错，那么你应该去做其他精彩的事，不要在上面纠缠太久。只要想清楚下一步是什么</p>
+        </content>
+      </shape>
+      <img src="DX3Lb5lFnowGa8xuAjWchM6dn7e" width="40" height="40" topLeftX="63" topLeftY="296">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+      </img>
+      <shape width="208" height="44" topLeftX="109" topLeftY="296" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p lineSpacing="multiple:1.35">
+            <span color="rgba(31, 35, 41, 1)">用户 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="264" height="74" topLeftX="54" topLeftY="344" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>如果你做了一件事，结果还不错，那么你应该去做其他精彩的事，不要在上面纠缠太久。只要想清楚下一步是什么</p>
+        </content>
+      </shape>
+      <shape width="281" height="181" topLeftX="631" topLeftY="278" presetHandlers="8" alpha="0.28" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <border color="rgba(232, 134, 125, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="10" angle="54" blur="24" color="rgba(147, 78, 95, 0.76)"/>
+      </shape>
+      <img src="HAPPbtkfJoqOvLxVZm6cSo6HnFf" width="40" height="40" topLeftX="648" topLeftY="296">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+      </img>
+      <shape width="208" height="44" topLeftX="694" topLeftY="296" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p lineSpacing="multiple:1.35">
+            <strong>
+              <span fontSize="18">用户 #5</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="264" height="74" topLeftX="639" topLeftY="344" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>如果你做了一件事，结果还不错，那么你应该去做其他精彩的事，不要在上面纠缠太久。只要想清楚下一步是什么</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="KRmObhqQgoUyBAxPT9UcF2v9n3b" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <icon width="55" height="55" topLeftX="50" topLeftY="124" iconType="iconpark/Music/voice.svg">
+        <border color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" width="6" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="176" height="38" topLeftX="630" topLeftY="384" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="right">
+          <p>
+            <span fontSize="12"> XXX. 创始人</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="739" height="149" topLeftX="110" topLeftY="190" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30">
+          <p lineSpacing="multiple:1.4">
+            <span fontSize="30">如果你做了一件事，结果还不错，那么你应该去做其他精彩的事，不要在上面纠缠太久。只要想清楚下一步是什么</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="221" height="77" topLeftX="110" topLeftY="113" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" fontSize="42">用户反馈</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="482" height="77" topLeftX="297" topLeftY="113" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="42">FEEDBACK</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Svapb9omnoLhHdxYWmpcxiwdnGt" width="65" height="65" topLeftX="806" topLeftY="357">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="33"/>
+      </img>
+      <shape width="196" height="44" topLeftX="610" topLeftY="357" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span fontSize="16">Jessica Davis</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="ZUPsb9AoMoZJrTxfBrycsE04nzb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="587" height="107" topLeftX="126" topLeftY="203" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>付费计划</p>
+        </content>
+      </shape>
+      <shape width="115" height="106" topLeftX="23" topLeftY="203" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>04</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(150deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="160" height="377" topLeftX="529" topLeftY="121" presetHandlers="8" alpha="0.6" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(330deg,rgba(255, 174, 172, 1) 0%,rgba(255, 230, 200, 1) 100%)"/>
+        </fill>
+        <shadow offset="0" blur="21" color="rgba(202, 43, 38, 0.2)"/>
+      </shape>
+      <table topLeftX="174" topLeftY="142">
+        <colgroup>
+          <col span="4" width="180"/>
+        </colgroup>
+        <tr height="75">
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12"/>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24">
+              <p>
+                <strong>
+                  <span color="rgba(242, 243, 245, 1)" fontSize="24">免费</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 64, 58, 1)">
+              <p>
+                <strong>
+                  <span color="rgba(255, 64, 58, 1)" fontSize="24">￥150/ 人月</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24">
+              <p>
+                <strong>
+                  <span color="rgba(242, 243, 245, 1)" fontSize="24">￥500/人月</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="51">
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12">标题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12"> 1 个团队账号</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 64, 58, 1)">
+              <p>
+                <span color="rgba(255, 64, 58, 1)" fontSize="12">5 个团队账号</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" underline="false">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12" underline="false"> 100 个团队账号</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="51">
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12">标题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12">3 个可保存模板</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 64, 58, 1)">
+              <p>
+                <span color="rgba(255, 64, 58, 1)" fontSize="12">10 个可保存的模板</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" underline="false">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12" underline="false">50 个可保存模板</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="51">
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12">标题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12">一些资源</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 64, 58, 1)">
+              <p>
+                <span color="rgba(255, 64, 58, 1)" fontSize="12">大量资源</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" underline="false">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12" underline="false">全部资源</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="51">
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12">标题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12">10 - 50</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 64, 58, 1)">
+              <p>
+                <span color="rgba(255, 64, 58, 1)" fontSize="12">50 -100</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" underline="false">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12" underline="false">100 -500</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="51">
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12">标题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12">导入 1 款自定义字体</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 64, 58, 1)">
+              <p>
+                <span color="rgba(255, 64, 58, 1)" fontSize="12">导入 3 款自定义字体</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderBottom color="rgba(255, 150, 150, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" underline="false">
+              <p>
+                <span color="rgba(242, 243, 245, 1)" fontSize="12" underline="false">导入无限款自定义字体</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+      </table>
+      <shape width="461" height="77" topLeftX="33" topLeftY="33" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">付费计划</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="FYWBbVp0toMv72xFHL3cgVrenag" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="691" height="77" topLeftX="134" topLeftY="228" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="linear-gradient(60deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="linear-gradient(60deg,rgba(255, 125, 52, 1) 0%,rgba(255, 110, 29, 1) 2%,rgba(255, 62, 189, 1) 100%)">感谢观看</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/marketing--roadshow_business_plan.xml
+++ b/skills/lark-slides/references/templates/marketing--roadshow_business_plan.xml
@@ -1,0 +1,1506 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>企业路演商业计划书</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="64"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF" fontSize="24"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="JcqDbBvoPoSe4SxrfSkcqgSenIf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0.19" alpha="0.75" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="406" height="187" topLeftX="67" topLeftY="85" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p>企业路演商业计划书</p>
+        </content>
+      </shape>
+      <shape width="138" height="38" topLeftX="79" topLeftY="44" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">宣讲人：李小天</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="277" height="56" topLeftX="67" topLeftY="261" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">Business Plan</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="A8GFbqJiEoHyU8xoOrwcS7z3nRd" width="75" height="103" topLeftX="681" topLeftY="374">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="UaSkbNcnEo6ZkNxiaXEcOLZlnNb" width="75" height="103" topLeftX="744" topLeftY="374">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="KmjObsGkfoZ8cTxqrZicrCV3nbd" width="75" height="103" topLeftX="813" topLeftY="374">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="ACcEbHOJRoUJiJxGjHTcUj0Ynsd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.7" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="357" height="77" topLeftX="70" topLeftY="82" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true">
+          <p>目录 CONTENTS</p>
+        </content>
+      </shape>
+      <img src="IrfWbIyPHo9clbx8inZcrzHfn1c" width="47" height="64" topLeftX="94" topLeftY="383">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="FCqwbdrr3oJmcjxdlKcclQlcnmh" width="47" height="64" topLeftX="133" topLeftY="383">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="FmEzbee5KoX42Kxc50acmsd3n6j" width="47" height="64" topLeftX="176" topLeftY="383">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="260" height="53" topLeftX="562" topLeftY="91" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">企业介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="53" topLeftX="562" topLeftY="171" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">市场分析</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="53" topLeftX="562" topLeftY="251" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">运营规划</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="53" topLeftX="562" topLeftY="331" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">产品服务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="53" topLeftX="562" topLeftY="411" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">市场推广</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="52" height="53" topLeftX="510" topLeftY="411" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">05</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="62" topLeftX="502" topLeftY="406" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="52" height="53" topLeftX="510" topLeftY="331" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">04</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="62" topLeftX="502" topLeftY="326" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="52" height="53" topLeftX="510" topLeftY="251" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">03</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="62" topLeftX="502" topLeftY="246" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="52" height="53" topLeftX="510" topLeftY="171" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="62" topLeftX="502" topLeftY="166" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="52" height="53" topLeftX="510" topLeftY="91" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="62" topLeftX="502" topLeftY="86" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="404" height="83" topLeftX="51" topLeftY="399" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true">
+          <p>
+            <span fontSize="42">企业介绍</span>
+          </p>
+        </content>
+      </shape>
+      <img src="SbxlbPCSporB4fx1Od5cvfxxnBg" width="840" height="292" topLeftX="60" topLeftY="60" contrast="23" temperature="-4">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="188" presetHandlers="10"/>
+      </img>
+      <shape width="414" height="44" topLeftX="52" topLeftY="373" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="16">PART 01</span>
+          </p>
+        </content>
+      </shape>
+      <img src="V0yxb53znojOvOxshfpcZm92nne" width="32" height="44" topLeftX="804" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="THoPbDGDbovqTKxpii8cNOR3nZS" width="32" height="44" topLeftX="831" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Gpsnbw662opuALx6jn2coywYnPd" width="32" height="44" topLeftX="861" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="345" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <img src="IpDgbjYszogAYCx8m4ScKwi0nOc" width="616" height="540" topLeftX="344" topLeftY="0" exposure="22" contrast="-26" saturation="-45" temperature="11">
+        <crop type="rect" leftOffset="323" rightOffset="318" topOffset="48" bottomOffset="131" presetHandlers="0"/>
+      </img>
+      <shape width="291" height="128" topLeftX="28" topLeftY="134" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="291" height="38" topLeftX="27" topLeftY="472" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>企业简介</p>
+        </content>
+      </shape>
+      <shape width="291" height="56" topLeftX="28" topLeftY="40" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>关于我们</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="302" height="77" topLeftX="48" topLeftY="64" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true">
+          <p>管理团队</p>
+        </content>
+      </shape>
+      <shape width="166" height="44" topLeftX="48" topLeftY="125" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)">Management team</span>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+      <img src="L5KdbfF6noBWYsxF3F5c8ij1npf" width="40" height="55" topLeftX="67" topLeftY="416" alpha="0.15">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="UOirbC1kyoZ3BbxwNjZcu7N4nyc" width="40" height="55" topLeftX="102" topLeftY="416" alpha="0.15">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="XvCEbvwvuoY9IJxTMfccgMZEn5b" width="40" height="55" topLeftX="137" topLeftY="416" alpha="0.15">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="864" height="354" topLeftX="48" topLeftY="132" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="left" autoFit="normal-auto-fit"/>
+      </shape>
+      <shape width="173" height="77" topLeftX="48" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true">
+          <p>发展历程</p>
+        </content>
+      </shape>
+      <shape width="166" height="77" topLeftX="233" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <span color="rgba(147, 150, 156, 1)">History</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="166" height="56" topLeftX="591" topLeftY="155" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="166" height="56" topLeftX="421" topLeftY="155" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="166" height="56" topLeftX="250" topLeftY="155" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="166" height="56" topLeftX="48" topLeftY="155" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="314" height="40" topLeftX="591" topLeftY="298" type="slides-home-plate">
+        <fill>
+          <fillColor/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="18">2026</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="591" startY="162" endX="591" endY="338">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="314" height="40" topLeftX="421" topLeftY="347" type="slides-home-plate">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">2025</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="421" startY="162" endX="421" endY="386">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="314" height="40" topLeftX="250" topLeftY="397" type="slides-home-plate">
+        <fill>
+          <fillColor/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="18">2024</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="250" startY="162" endX="250" endY="436">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="314" height="40" topLeftX="48" topLeftY="446" type="slides-home-plate">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">2023</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="48" startY="162" endX="48" endY="485">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="227" startY="51" endX="227" endY="85">
+        <border color="rgba(222, 224, 227, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="173" height="77" topLeftX="48" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true">
+          <p>企业优势</p>
+        </content>
+      </shape>
+      <shape width="236" height="77" topLeftX="233" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>Advantages</p>
+        </content>
+      </shape>
+      <line startX="227" startY="51" endX="227" endY="85">
+        <border color="rgba(222, 224, 227, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="315" height="315" topLeftX="68" topLeftY="157" type="ellipse">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="315" height="315" topLeftX="322" topLeftY="157" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="315" height="315" topLeftX="577" topLeftY="157" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="189" height="56" topLeftX="131" topLeftY="212" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">人才优势</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="166" height="128" topLeftX="142" topLeftY="270" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="189" height="56" topLeftX="385" topLeftY="212" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true" textAlign="center">
+          <p>资源优势</p>
+        </content>
+      </shape>
+      <shape width="166" height="128" topLeftX="397" topLeftY="270" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="189" height="56" topLeftX="640" topLeftY="212" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true" textAlign="center">
+          <p>技术优势</p>
+        </content>
+      </shape>
+      <shape width="166" height="128" topLeftX="651" topLeftY="270" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="864" height="354" topLeftX="48" topLeftY="132" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="left" autoFit="normal-auto-fit"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="404" height="83" topLeftX="51" topLeftY="399" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true">
+          <p>
+            <span fontSize="42">市场分析</span>
+          </p>
+        </content>
+      </shape>
+      <img src="VUWIbYM9ioBh3lxRC25c7BcfnJg" width="840" height="292" topLeftX="60" topLeftY="60">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="11" bottomOffset="177" presetHandlers="10"/>
+      </img>
+      <shape width="414" height="44" topLeftX="52" topLeftY="373" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="16">PART 02</span>
+          </p>
+        </content>
+      </shape>
+      <img src="ZPrtbCEOroAflgxvB8lcrvHLnXf" width="32" height="44" topLeftX="804" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="V8GDbiluWomyBHxgz3icDV6bnPb" width="32" height="44" topLeftX="831" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="GQiab1MGto3fDTxPjxRclIXcnze" width="32" height="44" topLeftX="861" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="345" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="291" height="128" topLeftX="28" topLeftY="134" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="291" height="38" topLeftX="27" topLeftY="472" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>市场分析</p>
+        </content>
+      </shape>
+      <shape width="291" height="56" topLeftX="28" topLeftY="40" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>市场现状</p>
+        </content>
+      </shape>
+      <shape width="74" height="74" topLeftX="401" topLeftY="44" type="ellipse">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="22">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="74" height="74" topLeftX="687" topLeftY="44" type="ellipse">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="22">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="74" height="74" topLeftX="401" topLeftY="292" type="ellipse">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="22">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="74" height="74" topLeftX="687" topLeftY="292" type="ellipse">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="22">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="388" startY="270" endX="928" endY="270">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="658" startY="31" endX="658" endY="509">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="198" height="92" topLeftX="401" topLeftY="134" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="198" height="92" topLeftX="687" topLeftY="134" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="198" height="92" topLeftX="401" topLeftY="382" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="198" height="92" topLeftX="687" topLeftY="382" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="345" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="291" height="128" topLeftX="28" topLeftY="134" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="291" height="38" topLeftX="27" topLeftY="472" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>市场分析</p>
+        </content>
+      </shape>
+      <shape width="291" height="56" topLeftX="28" topLeftY="40" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>用户需求</p>
+        </content>
+      </shape>
+      <shape width="343" height="56" topLeftX="397" topLeftY="100" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="53" topLeftX="457" topLeftY="47" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">需求 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="52" height="53" topLeftX="416" topLeftY="46" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="38" topLeftX="408" topLeftY="54" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="343" height="56" topLeftX="397" topLeftY="252" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="53" topLeftX="457" topLeftY="199" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">需求 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="52" height="53" topLeftX="416" topLeftY="198" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="38" topLeftX="408" topLeftY="206" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="343" height="56" topLeftX="397" topLeftY="404" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="53" topLeftX="457" topLeftY="351" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">需求 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="52" height="53" topLeftX="416" topLeftY="350" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">03</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="38" topLeftX="408" topLeftY="358" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="404" height="83" topLeftX="51" topLeftY="399" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true">
+          <p>
+            <span fontSize="42">运营规划</span>
+          </p>
+        </content>
+      </shape>
+      <img src="IgP0bewicodxAAxE7w3cvrUgnJg" width="840" height="292" topLeftX="60" topLeftY="60">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="188" bottomOffset="0" presetHandlers="10"/>
+      </img>
+      <shape width="414" height="44" topLeftX="52" topLeftY="373" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="16">PART 03</span>
+          </p>
+        </content>
+      </shape>
+      <img src="FuUtbHvZworNpOxFLwZcLTI2nqd" width="32" height="44" topLeftX="804" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="CiTtbmeIWom1iOx5lf1c4Tf9nNH" width="32" height="44" topLeftX="831" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="UYkBbFRuVo7Gc4x1qc3cv9EhnoM" width="32" height="44" topLeftX="861" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="345" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <img src="EMuAbY1b3oNTttx9mdfcqa3RnRS" width="196" height="289" topLeftX="683" topLeftY="53">
+        <crop type="rect" leftOffset="173" rightOffset="344" topOffset="106" bottomOffset="12" presetHandlers="0"/>
+      </img>
+      <shape width="291" height="128" topLeftX="28" topLeftY="134" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="291" height="38" topLeftX="27" topLeftY="472" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>市场分析</p>
+        </content>
+      </shape>
+      <shape width="291" height="56" topLeftX="28" topLeftY="40" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>用户需求</p>
+        </content>
+      </shape>
+      <shape width="196" height="92" topLeftX="424" topLeftY="418" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="53" topLeftX="484" topLeftY="365" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">C端模式</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="52" height="53" topLeftX="443" topLeftY="364" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="38" topLeftX="435" topLeftY="372" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="196" height="92" topLeftX="683" topLeftY="418" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="53" topLeftX="743" topLeftY="365" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">B端模式</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="52" height="53" topLeftX="703" topLeftY="364" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="38" topLeftX="695" topLeftY="372" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <img src="U7vbbhWkCofH9oxsvjxccnyYnDd" width="196" height="289" topLeftX="424" topLeftY="53">
+        <crop type="rect" leftOffset="225" rightOffset="374" topOffset="165" bottomOffset="0" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="173" height="77" topLeftX="48" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true">
+          <p>运营计划</p>
+        </content>
+      </shape>
+      <shape width="237" height="77" topLeftX="233" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>Plan</p>
+        </content>
+      </shape>
+      <line startX="227" startY="51" endX="227" endY="85">
+        <border color="rgba(222, 224, 227, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="722" height="56" topLeftX="48" topLeftY="395" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" textAlign="left">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="64" topLeftX="686" topLeftY="221" type="slides-chevron">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+        <border color="rgba(32, 177, 78, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">阶段四</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="714" startY="184" endX="714" endY="213">
+        <border color="rgba(147, 150, 156, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="99" height="38" topLeftX="690" topLeftY="150" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2026.11.11</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="696" topLeftY="297" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>活动描述</p>
+        </content>
+      </shape>
+      <shape width="205" height="64" topLeftX="487" topLeftY="221" type="slides-chevron">
+        <border color="rgba(147, 150, 156, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">阶段三</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="516" startY="184" endX="516" endY="213">
+        <border color="rgba(147, 150, 156, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="99" height="38" topLeftX="491" topLeftY="150" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2026.06.18</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="497" topLeftY="297" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" textAlign="left">
+          <p>
+            <span color="rgba(147, 150, 156, 1)">活动描述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="64" topLeftX="289" topLeftY="221" type="slides-chevron">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+        <border color="rgba(32, 177, 78, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">阶段二</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="318" startY="184" endX="318" endY="213">
+        <border color="rgba(147, 150, 156, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="99" height="38" topLeftX="293" topLeftY="150" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2026.02.14</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="299" topLeftY="297" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>活动描述</p>
+        </content>
+      </shape>
+      <shape width="205" height="64" topLeftX="91" topLeftY="221" type="slides-chevron">
+        <border color="rgba(147, 150, 156, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">阶段一</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="120" startY="184" endX="120" endY="213">
+        <border color="rgba(147, 150, 156, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="99" height="38" topLeftX="95" topLeftY="150" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2026.01.01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="38" topLeftX="101" topLeftY="297" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" textAlign="left">
+          <p>
+            <span color="rgba(147, 150, 156, 1)">活动描述</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="404" height="83" topLeftX="51" topLeftY="399" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true">
+          <p>
+            <span fontSize="42">产品服务</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Wqo3bpxNzoO4XvxjQg7cKTiJnGf" width="840" height="292" topLeftX="60" topLeftY="60">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="94" bottomOffset="94" presetHandlers="10"/>
+      </img>
+      <shape width="414" height="44" topLeftX="52" topLeftY="373" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="16">PART 04</span>
+          </p>
+        </content>
+      </shape>
+      <img src="IOxGbeOSAoJEaMxpBM4cNz3Jnxe" width="32" height="44" topLeftX="804" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="RSpUbiA5Bo4eXbx0TbEcYbY8nCq" width="32" height="44" topLeftX="831" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="MvU1bBL22oVsirxVJBbcRsdEnzh" width="32" height="44" topLeftX="861" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="345" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <img src="NvJcbWFtfou7pexBmdXcwIKan4g" width="220" height="452" topLeftX="401" topLeftY="49">
+        <crop type="rect" leftOffset="294" rightOffset="294" topOffset="0" bottomOffset="0" presetHandlers="42"/>
+      </img>
+      <img src="OGpRbofdyoDjDWxGuVtcTN2ynJc" width="258" height="492" topLeftX="381" topLeftY="29">
+        <crop type="rect" leftOffset="89" rightOffset="88" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="291" height="128" topLeftX="28" topLeftY="134" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="291" height="38" topLeftX="27" topLeftY="472" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>产品服务</p>
+        </content>
+      </shape>
+      <shape width="291" height="56" topLeftX="28" topLeftY="40" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>用户需求</p>
+        </content>
+      </shape>
+      <shape width="291" height="74" topLeftX="646" topLeftY="113" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="53" topLeftX="706" topLeftY="60" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">产品 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="52" height="53" topLeftX="665" topLeftY="60" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="38" topLeftX="657" topLeftY="67" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="198" height="56" topLeftX="720" topLeftY="254" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="62" height="62" topLeftX="652" topLeftY="251" type="ellipse">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <icon width="33" height="33" topLeftX="667" topLeftY="265" iconType="iconpark/Base/save-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="198" height="56" topLeftX="720" topLeftY="345" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="62" height="62" topLeftX="652" topLeftY="342" type="ellipse">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <icon width="33" height="33" topLeftX="667" topLeftY="356" iconType="iconpark/Office/envelope-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="345" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="291" height="128" topLeftX="28" topLeftY="134" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="291" height="38" topLeftX="27" topLeftY="472" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>产品服务</p>
+        </content>
+      </shape>
+      <shape width="291" height="56" topLeftX="28" topLeftY="40" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>产品展示</p>
+        </content>
+      </shape>
+      <shape width="342" height="56" topLeftX="567" topLeftY="424" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="53" topLeftX="445" topLeftY="425" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">产品 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="52" height="53" topLeftX="404" topLeftY="425" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="38" topLeftX="396" topLeftY="432" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <img src="V8ITbQgCNoorPDxcygjcS5UxnEc" width="542" height="320" topLeftX="375" topLeftY="71">
+        <shadow blur="24" color="rgba(0, 0, 0, 0.21)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="APRIb5hn4ovJqXxcbvtcRfYYnkg" width="441" height="247" topLeftX="427" topLeftY="88">
+        <crop type="rect" leftOffset="0.12" rightOffset="0.12" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="404" height="83" topLeftX="51" topLeftY="399" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true">
+          <p>
+            <span fontSize="42">市场推广</span>
+          </p>
+        </content>
+      </shape>
+      <img src="BNA9bqKYxorfvax1NNUcaKCLnhd" width="840" height="292" topLeftX="60" topLeftY="60" saturation="-35" temperature="5">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="94" bottomOffset="94" presetHandlers="10"/>
+      </img>
+      <shape width="414" height="44" topLeftX="52" topLeftY="373" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="16">PART 05</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Hb2DbF35BoOy6mxA1o2cz2rUnpd" width="32" height="44" topLeftX="804" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="VbNPbwJewoR6pdxla8Scf9YdnDf" width="32" height="44" topLeftX="831" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="ApBXbutsSoxDnuxofz2crkkenNd" width="32" height="44" topLeftX="861" topLeftY="420" alpha="0.7">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="173" height="77" topLeftX="48" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true">
+          <p>运营计划</p>
+        </content>
+      </shape>
+      <shape width="236" height="77" topLeftX="233" topLeftY="30" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>Plan</p>
+        </content>
+      </shape>
+      <line startX="227" startY="51" endX="227" endY="85">
+        <border color="rgba(222, 224, 227, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="160" height="92" topLeftX="132" topLeftY="389" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="44" topLeftX="132" topLeftY="352" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">关键词 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="195" topLeftX="114" topLeftY="137" type="ellipse">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+        <border color="rgba(32, 177, 78, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="56" height="56" topLeftX="184" topLeftY="207" iconType="iconpark/Abstract/six-points.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="160" height="92" topLeftX="311" topLeftY="389" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="92" topLeftX="490" topLeftY="389" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="92" topLeftX="669" topLeftY="389" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="44" topLeftX="669" topLeftY="352" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">关键词 #4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="44" topLeftX="490" topLeftY="352" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">关键词 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="44" topLeftX="311" topLeftY="352" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)">关键词 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="195" topLeftX="293" topLeftY="137" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="195" height="195" topLeftX="472" topLeftY="137" type="ellipse">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+        <border color="rgba(32, 177, 78, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="56" height="56" topLeftX="363" topLeftY="207" iconType="iconpark/Travel/earth.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="56" height="56" topLeftX="542" topLeftY="207" iconType="iconpark/Charts/chart-proportion.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="195" height="195" topLeftX="651" topLeftY="137" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="56" height="56" topLeftX="721" topLeftY="207" iconType="iconpark/Travel/parachute.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="345" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="291" height="128" topLeftX="28" topLeftY="134" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="291" height="38" topLeftX="27" topLeftY="472" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>市场推广</p>
+        </content>
+      </shape>
+      <shape width="291" height="56" topLeftX="28" topLeftY="40" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>市场目标</p>
+        </content>
+      </shape>
+      <shape width="260" height="74" topLeftX="419" topLeftY="361" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="53" topLeftX="479" topLeftY="308" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">线下销售</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="52" height="53" topLeftX="439" topLeftY="308" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="38" topLeftX="430" topLeftY="315" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="260" height="74" topLeftX="419" topLeftY="171" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="53" topLeftX="479" topLeftY="118" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true">
+          <p>
+            <span fontSize="22">线上引流</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="52" height="53" topLeftX="439" topLeftY="117" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="22">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="38" topLeftX="430" topLeftY="125" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="129" height="140" topLeftX="747" topLeftY="105" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" bold="true">
+          <p>
+            <span fontSize="80">64</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="53" topLeftX="860" topLeftY="167" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="false">
+          <p>
+            <span fontSize="22" bold="false">%</span>
+          </p>
+        </content>
+      </shape>
+      <img src="JOx2btdhloFP5sx1F8scoMIln7b" width="17" height="23" topLeftX="727" topLeftY="186" rotation="270" alpha="0.7">
+        <crop type="rect" leftOffset="2" rightOffset="2" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="BOXcbG8n8orE7IxUJASchZJ4nNb" width="17" height="23" topLeftX="727" topLeftY="170" rotation="270" alpha="0.7">
+        <crop type="rect" leftOffset="2" rightOffset="2" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="129" height="140" topLeftX="747" topLeftY="295" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" bold="true">
+          <p>
+            <span fontSize="80">24</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="53" topLeftX="860" topLeftY="358" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="false">
+          <p>
+            <span fontSize="22" bold="false">%</span>
+          </p>
+        </content>
+      </shape>
+      <img src="NISibfU3ao1hIPx6wGUc5zuqnwb" width="17" height="23" topLeftX="727" topLeftY="376" rotation="270" alpha="0.7">
+        <crop type="rect" leftOffset="2" rightOffset="2" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="GBJtbHctBot1abxgyZJc9Qfbnaf" width="17" height="23" topLeftX="727" topLeftY="361" rotation="270" alpha="0.7">
+        <crop type="rect" leftOffset="2" rightOffset="2" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="JcqDbBvoPoSe4SxrfSkcqgSenIf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0.19" alpha="0.75" type="rect">
+        <fill>
+          <fillColor color="rgba(32, 177, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="413" height="104" topLeftX="67" topLeftY="85" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p>感谢您的观看</p>
+        </content>
+      </shape>
+      <shape width="138" height="38" topLeftX="79" topLeftY="44" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">宣讲人：李小天</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="277" height="56" topLeftX="67" topLeftY="179" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">Thank you</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="SVIJbQrC7o2H2AxOuEUcFYDGnGb" width="75" height="103" topLeftX="681" topLeftY="374">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="CBg9bBy3qo9USrxdMfgc8dyRnkf" width="75" height="103" topLeftX="744" topLeftY="374">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="QtB5bvgsFo7hnAxM07tcSSGCn4e" width="75" height="103" topLeftX="813" topLeftY="374">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/misc--book_sharing.xml
+++ b/skills/lark-slides/references/templates/misc--book_sharing.xml
@@ -1,0 +1,1338 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>读书分享</title>
+  <theme>
+    <textStyles>
+      <headline fontColor="rgba(31, 35, 41, 1)"/>
+      <sub-headline fontColor="rgba(31, 35, 41, 1)"/>
+      <body fontColor="rgba(31, 35, 41, 1)"/>
+      <caption fontColor="rgba(155, 158, 162, 1)" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style/>
+    <data>
+      <shape width="235" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 54, 44, 1)"/>
+        </fill>
+      </shape>
+      <line startX="31" startY="305" endX="202" endY="305" alpha="0.2">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <shape width="705" height="500" topLeftX="245" topLeftY="20" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="685" height="520" topLeftX="255" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <img src="Vs1kbXlH7odmtpxtMvUcMpnln3b" width="726" height="540" topLeftX="235" topLeftY="0">
+        <crop type="rect" leftOffset="117" rightOffset="117" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="173" height="189" topLeftX="28" topLeftY="320" alpha="0.6" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。在书的世界里，我们汲取智慧，分享感悟，让书香飘满生活，让心灵在阅读中绽放光芒。</p>
+        </content>
+      </shape>
+      <shape width="21" height="101" topLeftX="84" topLeftY="109" alpha="0.6" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.2" textAlign="center">
+          <p>分享人</p>
+          <p/>
+          <p>无名</p>
+        </content>
+      </shape>
+      <shape width="21" height="144" topLeftX="115" topLeftY="88" alpha="0.6" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>十二月十二日</p>
+        </content>
+      </shape>
+      <shape width="56" height="260" topLeftX="146" topLeftY="30" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>读书分享</p>
+        </content>
+      </shape>
+      <shape width="685" height="520" topLeftX="255" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="705" height="500" topLeftX="245" topLeftY="20" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="685" height="520" topLeftX="255" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="BAxubS8njoiHOtxh55RcK8DWnWy" width="960" height="540" topLeftX="0" topLeftY="0" saturation="-8" temperature="-32">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="960" height="136" topLeftX="0" topLeftY="404" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 54, 44, 1)"/>
+        </fill>
+      </shape>
+      <shape width="89" height="96" topLeftX="382" topLeftY="66" alpha="0.9" type="text">
+        <content textType="title" fontSize="80" fontFamily="马善政毛笔楷体" color="rgba(32, 31, 29, 1)" bold="false" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(32, 31, 29, 1)" fontSize="80" fontFamily="马善政毛笔楷体" bold="false">目</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="89" height="96" topLeftX="486" topLeftY="66" alpha="0.9" type="text">
+        <content textType="title" fontSize="80" fontFamily="马善政毛笔楷体" color="rgba(32, 31, 29, 1)" bold="false" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(32, 31, 29, 1)" fontSize="80" fontFamily="马善政毛笔楷体" bold="false">录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="184" topLeftX="50" topLeftY="278" presetHandlers="4" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="210" height="184" topLeftX="45" topLeftY="263" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="53" height="75" topLeftX="188" topLeftY="263" type="text">
+        <content fontSize="50" fontFamily="有字库龙藏体" color="rgba(128, 66, 8, 1)" bold="true">
+          <p>
+            <span color="rgba(128, 66, 8, 1)" fontSize="50" fontFamily="有字库龙藏体">壹</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="69" startY="331" endX="141" endY="331" alpha="0.2">
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </line>
+      <shape width="210" height="184" topLeftX="270" topLeftY="278" presetHandlers="4" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="210" height="184" topLeftX="530" topLeftY="537" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="53" height="75" topLeftX="673" topLeftY="537" type="text">
+        <content fontSize="50" fontFamily="有字库龙藏体" color="rgba(128, 66, 8, 1)" bold="true">
+          <p>
+            <span color="rgba(128, 66, 8, 1)" fontSize="50" fontFamily="有字库龙藏体">贰</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="288" startY="331" endX="358" endY="331" alpha="0.2">
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </line>
+      <shape width="210" height="184" topLeftX="490" topLeftY="278" presetHandlers="4" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="210" height="184" topLeftX="485" topLeftY="263" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="53" height="75" topLeftX="629" topLeftY="263" type="text">
+        <content fontSize="50" fontFamily="有字库龙藏体" color="rgba(128, 66, 8, 1)" bold="true">
+          <p>
+            <span color="rgba(128, 66, 8, 1)">叁</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="508" startY="331" endX="597" endY="331" alpha="0.2">
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </line>
+      <shape width="210" height="184" topLeftX="711" topLeftY="278" presetHandlers="4" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="210" height="184" topLeftX="706" topLeftY="263" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="53" height="75" topLeftX="849" topLeftY="263" type="text">
+        <content fontSize="50" fontFamily="有字库龙藏体" color="rgba(128, 66, 8, 1)" bold="true">
+          <p>
+            <span color="rgba(128, 66, 8, 1)" fontSize="50" fontFamily="有字库龙藏体">肆</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="732" startY="331" endX="802" endY="331" alpha="0.2">
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </line>
+      <shape width="114" height="27" topLeftX="724" topLeftY="303" alpha="0.9" type="text">
+        <content textType="headline" fontSize="18" fontFamily="思源宋体" color="rgba(128, 66, 8, 1)" bold="true" textAlign="left">
+          <p>读书感悟</p>
+        </content>
+      </shape>
+      <shape width="173" height="72" topLeftX="724" topLeftY="358" alpha="0.9" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="114" height="27" topLeftX="504" topLeftY="303" alpha="0.9" type="text">
+        <content textType="headline" fontSize="18" fontFamily="思源宋体" color="rgba(128, 66, 8, 1)" bold="true" textAlign="left">
+          <p>运用与实践</p>
+        </content>
+      </shape>
+      <shape width="173" height="72" topLeftX="504" topLeftY="358" alpha="0.9" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="114" height="27" topLeftX="283" topLeftY="303" alpha="0.9" type="text">
+        <content textType="headline" fontSize="18" fontFamily="思源宋体" color="rgba(128, 66, 8, 1)" bold="true" textAlign="left">
+          <p>主要内容</p>
+        </content>
+      </shape>
+      <shape width="173" height="72" topLeftX="283" topLeftY="358" alpha="0.9" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="114" height="27" topLeftX="63" topLeftY="303" alpha="0.9" type="text">
+        <content textType="headline" fontSize="18" fontFamily="思源宋体" color="rgba(128, 66, 8, 1)" bold="true" textAlign="left">
+          <p>书籍简介</p>
+        </content>
+      </shape>
+      <shape width="173" height="72" topLeftX="63" topLeftY="358" alpha="0.9" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="235" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+      </shape>
+      <line startX="31" startY="305" endX="202" endY="305" alpha="0.2">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <shape width="705" height="500" topLeftX="245" topLeftY="20" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="685" height="520" topLeftX="255" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <line startX="31" startY="203" endX="54" endY="180" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <line startX="109" startY="122" endX="132" endY="98" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <img src="Rhznb8AGNochNBxKVXYcoW2Nn7e" width="726" height="540" topLeftX="235" topLeftY="0">
+        <crop type="rect" leftOffset="117" rightOffset="117" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="173" height="189" topLeftX="28" topLeftY="320" alpha="0.6" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。在书的世界里，我们汲取智慧，分享感悟，让书香飘满生活，让心灵在阅读中绽放光芒。</p>
+        </content>
+      </shape>
+      <shape width="87" height="96" topLeftX="43" topLeftY="95" alpha="0.2" type="text">
+        <content textType="headline" fontSize="80" fontFamily="有字库龙藏体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>壹</p>
+        </content>
+      </shape>
+      <shape width="56" height="259" topLeftX="146" topLeftY="30" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>书籍简介</p>
+        </content>
+      </shape>
+      <shape width="685" height="520" topLeftX="255" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="705" height="500" topLeftX="245" topLeftY="20" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="685" height="520" topLeftX="255" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="OaxvbuffroAXa9xbVQycZo52nUh" width="960" height="540" topLeftX="0.23" topLeftY="0" saturation="-8" temperature="-32">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="264" height="540" topLeftX="696" topLeftY="0" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 54, 44, 1)"/>
+        </fill>
+      </shape>
+      <shape width="275" height="452" topLeftX="75" topLeftY="47" presetHandlers="4" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="275" height="452" topLeftX="69" topLeftY="42" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <line startX="90" startY="397" endX="90" endY="469">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="275" height="452" topLeftX="680" topLeftY="47" presetHandlers="4" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="275" height="452" topLeftX="674" topLeftY="42" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <line startX="695" startY="397" endX="695" endY="469">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="75" height="75" topLeftX="765" topLeftY="423" alpha="0.9" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow angle="90" blur="21"/>
+      </shape>
+      <line startX="739" startY="214" endX="914" endY="214" alpha="0.2">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <img src="Sf0ib5ym0omh9bxgJK7c5s95nf3" width="274" height="274" topLeftX="360" topLeftY="43">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="10" bottomOffset="10" presetHandlers="4"/>
+      </img>
+      <img src="NAsKbXSjsoMWpYxsVJPcna3TnIe" width="274" height="274" topLeftX="57" topLeftY="43">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="10" bottomOffset="10" presetHandlers="4"/>
+      </img>
+      <shape width="173" height="126" topLeftX="739" topLeftY="61" alpha="0.6" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="56" height="259" topLeftX="858" topLeftY="239" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>书籍简介</p>
+        </content>
+      </shape>
+      <shape width="226" height="18" topLeftX="394" topLeftY="369" alpha="0.9" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p textAlign="center">作者 无名氏</p>
+        </content>
+      </shape>
+      <shape width="226" height="27" topLeftX="394" topLeftY="336" alpha="0.9" type="text">
+        <content textType="headline" fontSize="18" fontFamily="思源宋体" color="rgba(128, 66, 8, 1)" bold="true" textAlign="center">
+          <p>《书籍名称》</p>
+        </content>
+      </shape>
+      <shape width="226" height="72" topLeftX="394" topLeftY="398" alpha="0.9" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="226" height="18" topLeftX="89" topLeftY="369" alpha="0.9" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p textAlign="center">作者 无名氏</p>
+        </content>
+      </shape>
+      <shape width="226" height="27" topLeftX="89" topLeftY="336" alpha="0.9" type="text">
+        <content textType="headline" fontSize="18" fontFamily="思源宋体" color="rgba(128, 66, 8, 1)" bold="true" textAlign="center">
+          <p>《书籍名称》</p>
+        </content>
+      </shape>
+      <shape width="226" height="72" topLeftX="89" topLeftY="398" alpha="0.9" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="30" height="97" topLeftX="590" topLeftY="58" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="思源宋体">标签文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="97" topLeftX="288" topLeftY="58" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="思源宋体">标签文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="87" height="60" topLeftX="759" topLeftY="431" type="text">
+        <content textType="headline" fontSize="50" fontFamily="有字库龙藏体" color="rgba(43, 54, 44, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>壹</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="LX0Eb0lfOoOFBhxPjf5cTiL1nCb" width="960" height="540" topLeftX="0.23" topLeftY="0" saturation="-8" temperature="-32">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="814" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 54, 44, 1)"/>
+        </fill>
+      </shape>
+      <img src="FoG6bCzywoWLaOxhYXDcSTdZnxe" width="342" height="498" topLeftX="20" topLeftY="21">
+        <crop type="rect" leftOffset="80" rightOffset="76" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="75" height="75" topLeftX="39" topLeftY="426" alpha="0.9" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow angle="90" blur="21"/>
+      </shape>
+      <shape width="93" height="75" topLeftX="30" topLeftY="421" type="text">
+        <content fontSize="50" fontFamily="有字库龙藏体" color="rgba(43, 54, 44, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 54, 44, 1)" fontSize="50" fontFamily="有字库龙藏体">壹</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="56" height="259" topLeftX="48" topLeftY="52" alpha="0.9" type="text">
+        <content textType="title" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">作者简介</p>
+        </content>
+        <shadow offset="0" angle="90" blur="72" color="rgba(0, 0, 0, 0.68)"/>
+      </shape>
+      <shape width="83" height="30" topLeftX="446" topLeftY="49" alpha="0.9" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>关键标题</p>
+        </content>
+      </shape>
+      <shape width="314" height="63" topLeftX="446" topLeftY="82" alpha="0.5" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="30" height="97" topLeftX="391" topLeftY="49" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>基本信息</p>
+        </content>
+      </shape>
+      <shape width="93" height="30" topLeftX="446" topLeftY="222" alpha="0.9" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>关键标题</p>
+        </content>
+      </shape>
+      <shape width="314" height="63" topLeftX="446" topLeftY="255" alpha="0.5" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="30" height="97" topLeftX="391" topLeftY="222" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>生平经历</p>
+        </content>
+      </shape>
+      <shape width="80" height="30" topLeftX="446" topLeftY="394" alpha="0.9" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>关键标题</p>
+        </content>
+      </shape>
+      <shape width="314" height="63" topLeftX="446" topLeftY="428" alpha="0.5" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="30" height="97" topLeftX="391" topLeftY="394" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>文学成就</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="235" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+      </shape>
+      <line startX="31" startY="305" endX="202" endY="305" alpha="0.2">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <shape width="705" height="500" topLeftX="245" topLeftY="20" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="685" height="520" topLeftX="255" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <line startX="31" startY="203" endX="54" endY="180" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <line startX="109" startY="122" endX="132" endY="98" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <img src="ZINkbj3gpoXaTqxLDVIcJUbIn4b" width="726" height="540" topLeftX="235" topLeftY="0">
+        <crop type="rect" leftOffset="117" rightOffset="117" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="173" height="189" topLeftX="28" topLeftY="320" alpha="0.6" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。在书的世界里，我们汲取智慧，分享感悟，让书香飘满生活，让心灵在阅读中绽放光芒。</p>
+        </content>
+      </shape>
+      <shape width="87" height="96" topLeftX="43" topLeftY="95" alpha="0.2" type="text">
+        <content textType="headline" fontSize="80" fontFamily="有字库龙藏体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>贰</p>
+        </content>
+      </shape>
+      <shape width="56" height="259" topLeftX="146" topLeftY="30" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>主要内容</p>
+        </content>
+      </shape>
+      <shape width="685" height="520" topLeftX="255" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="705" height="500" topLeftX="245" topLeftY="20" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="685" height="520" topLeftX="255" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="ZTjJbjef3oBcQmx6s3HcHZ1MnKc" width="960" height="540" topLeftX="0.12" topLeftY="0" saturation="-8" temperature="-32">
+        <crop type="rect" leftOffset="0.34" rightOffset="0.34" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="275" height="280" topLeftX="50" topLeftY="218" presetHandlers="4" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="275" height="279" topLeftX="45" topLeftY="212" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <line startX="65" startY="273" endX="65" endY="338">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="275" height="280" topLeftX="347" topLeftY="218" presetHandlers="4" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="275" height="279" topLeftX="341" topLeftY="212" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <line startX="362" startY="273" endX="362" endY="338">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="275" height="280" topLeftX="643" topLeftY="218" presetHandlers="4" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="275" height="279" topLeftX="638" topLeftY="212" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <line startX="658" startY="273" endX="658" endY="338">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="75" height="75" topLeftX="835" topLeftY="43" alpha="0.9" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow angle="90" blur="21"/>
+      </shape>
+      <shape width="237" height="84" topLeftX="657" topLeftY="376" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="226" height="27" topLeftX="668" topLeftY="228" type="text">
+        <content textType="headline" fontSize="18" fontFamily="思源宋体" color="rgba(128, 66, 8, 1)" bold="true" textAlign="left">
+          <p>核心内容三</p>
+        </content>
+      </shape>
+      <shape width="226" height="72" topLeftX="668" topLeftY="269" alpha="0.6" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="237" height="84" topLeftX="361" topLeftY="376" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="226" height="27" topLeftX="372" topLeftY="228" type="text">
+        <content textType="headline" fontSize="18" fontFamily="思源宋体" color="rgba(128, 66, 8, 1)" bold="true" textAlign="left">
+          <p>核心内容二</p>
+        </content>
+      </shape>
+      <shape width="226" height="72" topLeftX="372" topLeftY="269" alpha="0.6" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="237" height="84" topLeftX="65" topLeftY="376" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="226" height="27" topLeftX="76" topLeftY="228" type="text">
+        <content textType="headline" fontSize="18" fontFamily="思源宋体" color="rgba(128, 66, 8, 1)" bold="true" textAlign="left">
+          <p>核心内容一</p>
+        </content>
+      </shape>
+      <shape width="226" height="72" topLeftX="76" topLeftY="269" alpha="0.6" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="425" height="65" topLeftX="46" topLeftY="38" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>书籍核心内容</p>
+        </content>
+      </shape>
+      <shape width="425" height="63" topLeftX="46" topLeftY="118" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="76" height="28" topLeftX="229" topLeftY="229" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="思源宋体">标签文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="76" height="28" topLeftX="524" topLeftY="229" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="思源宋体">标签文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="76" height="28" topLeftX="821" topLeftY="229" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="思源宋体">标签文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="87" height="60" topLeftX="830" topLeftY="49" type="text">
+        <content textType="headline" fontSize="50" fontFamily="有字库龙藏体" color="rgba(43, 54, 44, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>贰</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 54, 44, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="30" height="124" topLeftX="424" topLeftY="148" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>重点观点一</p>
+        </content>
+      </shape>
+      <shape width="75" height="75" topLeftX="842" topLeftY="43" alpha="0.9" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow angle="90" blur="21"/>
+      </shape>
+      <shape width="30" height="124" topLeftX="600" topLeftY="148" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>重点观点二</p>
+        </content>
+      </shape>
+      <shape width="30" height="124" topLeftX="774" topLeftY="148" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>重点观点二</p>
+        </content>
+      </shape>
+      <img src="IslubYfSdo3unxxJBsvcsCf8nlg" width="383" height="346" topLeftX="0" topLeftY="148">
+        <crop type="rect" leftOffset="116" rightOffset="116" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="93" height="231" topLeftX="822" topLeftY="148" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="93" height="231" topLeftX="648" topLeftY="148" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="93" height="231" topLeftX="472" topLeftY="148" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明请输入详细说明</p>
+        </content>
+      </shape>
+      <shape width="425" height="65" topLeftX="46" topLeftY="38" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>重点观点</p>
+        </content>
+      </shape>
+      <shape width="15" height="358" topLeftX="111" topLeftY="146" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 54, 44, 1)"/>
+        </fill>
+      </shape>
+      <shape width="15" height="358" topLeftX="251" topLeftY="146" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 54, 44, 1)"/>
+        </fill>
+      </shape>
+      <shape width="87" height="60" topLeftX="838" topLeftY="49" type="text">
+        <content textType="headline" fontSize="50" fontFamily="有字库龙藏体" color="rgba(43, 54, 44, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>贰</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="PCntbNU9WoYVGZxtkaYcaMPKnlg" width="725" height="540" topLeftX="235" topLeftY="0" contrast="5" saturation="-11">
+        <crop type="rect" leftOffset="118" rightOffset="118" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="235" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+      </shape>
+      <shape width="93" height="120" topLeftX="39" topLeftY="83" alpha="0.2" type="text">
+        <content fontSize="80" fontFamily="有字库龙藏体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="80" fontFamily="有字库龙藏体">叁</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="56" height="324" topLeftX="146" topLeftY="30" alpha="0.9" type="text">
+        <content textType="title" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">运用与实践</p>
+        </content>
+      </shape>
+      <shape width="173" height="126" topLeftX="28" topLeftY="384" alpha="0.5" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontFamily="思源宋体">书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="31" startY="368" endX="202" endY="368" alpha="0.2">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <shape width="112" height="24" topLeftX="318" topLeftY="-80" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)"/>
+      </shape>
+      <line startX="31" startY="203" endX="46" endY="188" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <line startX="109" startY="122" endX="132" endY="98" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <shape width="705" height="500" topLeftX="245" topLeftY="20" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="685" height="520" topLeftX="255" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 54, 44, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="75" height="75" topLeftX="765" topLeftY="43" alpha="0.9" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow angle="90" blur="21"/>
+      </shape>
+      <shape width="275" height="144" topLeftX="38" topLeftY="30" presetHandlers="4" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="275" height="143" topLeftX="32" topLeftY="24" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <line startX="52" startY="84" endX="52" endY="149">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="275" height="144" topLeftX="351" topLeftY="369" presetHandlers="4" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <shape width="275" height="143" topLeftX="345" topLeftY="363" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(64, 85, 62, 1)" width="1"/>
+      </shape>
+      <line startX="366" startY="423" endX="366" endY="488">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <img src="RNjQbZbFfomP8vx2FYhcMyLOnbg" width="277" height="338" topLeftX="36" topLeftY="202">
+        <crop type="rect" leftOffset="32" rightOffset="32" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="R6Vgbg6i1onkBIxt80tcE5O6ndd" width="277" height="338" topLeftX="345" topLeftY="0">
+        <crop type="rect" leftOffset="162" rightOffset="162" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="173" height="189" topLeftX="740" topLeftY="311" alpha="0.6" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。在书的世界里，我们汲取智慧，分享感悟，让书香飘满生活，让心灵在阅读中绽放光芒。</p>
+        </content>
+      </shape>
+      <shape width="236" height="27" topLeftX="366" topLeftY="377" type="text">
+        <content textType="headline" fontSize="18" fontFamily="思源宋体" color="rgba(128, 66, 8, 1)" bold="true" textAlign="left">
+          <p>启发二</p>
+        </content>
+      </shape>
+      <shape width="226" height="72" topLeftX="376" topLeftY="419" alpha="0.6" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="236" height="27" topLeftX="52" topLeftY="40" type="text">
+        <content textType="headline" fontSize="18" fontFamily="思源宋体" color="rgba(128, 66, 8, 1)" bold="true" textAlign="left">
+          <p>启发一</p>
+        </content>
+      </shape>
+      <shape width="226" height="72" topLeftX="62" topLeftY="82" alpha="0.6" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源宋体" color="rgba(43, 54, 44, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="56" height="130" topLeftX="858" topLeftY="38" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>启发</p>
+        </content>
+      </shape>
+      <shape width="87" height="60" topLeftX="761" topLeftY="49" type="text">
+        <content textType="headline" fontSize="50" fontFamily="有字库龙藏体" color="rgba(43, 54, 44, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>叁</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 54, 44, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="AA6EbfqopoFdxaxAtcFcm1evnKm" width="302" height="540" topLeftX="329" topLeftY="0">
+        <crop type="rect" leftOffset="202" rightOffset="43" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="30" height="102" topLeftX="659" topLeftY="79" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>重点一</p>
+        </content>
+      </shape>
+      <shape width="30" height="102" topLeftX="268" topLeftY="219" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>重点二</p>
+        </content>
+      </shape>
+      <shape width="30" height="102" topLeftX="659" topLeftY="359" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>重点三</p>
+        </content>
+      </shape>
+      <shape width="75" height="75" topLeftX="53" topLeftY="415" alpha="0.9" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow angle="90" blur="21"/>
+      </shape>
+      <shape width="207" height="105" topLeftX="707" topLeftY="359" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="207" height="105" topLeftX="707" topLeftY="79" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="207" height="105" topLeftX="46" topLeftY="219" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="right">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="182" height="130" topLeftX="46" topLeftY="38" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>运用与</p>
+          <p>实践</p>
+        </content>
+      </shape>
+      <shape width="87" height="60" topLeftX="47" topLeftY="422" type="text">
+        <content textType="headline" fontSize="50" fontFamily="有字库龙藏体" color="rgba(43, 54, 44, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>叁</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="235" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+      </shape>
+      <line startX="31" startY="305" endX="202" endY="305" alpha="0.2">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <shape width="705" height="500" topLeftX="245" topLeftY="20" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="685" height="520" topLeftX="255" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <line startX="31" startY="203" endX="54" endY="180" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <line startX="109" startY="122" endX="132" endY="98" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </line>
+      <img src="B9ZAbt2N2oftTjxO417c6Ax9nzf" width="726" height="540" topLeftX="235" topLeftY="0">
+        <crop type="rect" leftOffset="117" rightOffset="117" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="173" height="189" topLeftX="28" topLeftY="320" alpha="0.6" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left"/>
+      </shape>
+      <shape width="87" height="96" topLeftX="43" topLeftY="95" alpha="0.2" type="text">
+        <content textType="headline" fontSize="80" fontFamily="有字库龙藏体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>肆</p>
+        </content>
+      </shape>
+      <shape width="56" height="259" topLeftX="146" topLeftY="30" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>读书感悟</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 54, 44, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="450" height="450" topLeftX="61" topLeftY="45" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <img src="WVe4bI5ufo5WDkxpbIacwBfwnXe" width="450" height="450" topLeftX="48" topLeftY="45" contrast="5" saturation="-11">
+        <crop type="ellipse" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="75" height="75" topLeftX="47" topLeftY="423" alpha="0.9" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow angle="90" blur="21"/>
+      </shape>
+      <shape width="30" height="102" topLeftX="557" topLeftY="79" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>感悟一</p>
+        </content>
+      </shape>
+      <shape width="30" height="102" topLeftX="557" topLeftY="219" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>感悟二</p>
+        </content>
+      </shape>
+      <shape width="30" height="102" topLeftX="557" topLeftY="359" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>感悟二</p>
+        </content>
+      </shape>
+      <img src="H6qeb1mziotaEQx2asjcyF71nnf" width="450" height="450" topLeftX="48" topLeftY="45">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0" presetHandlers="225"/>
+      </img>
+      <shape width="207" height="105" topLeftX="605" topLeftY="357" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="207" height="105" topLeftX="605" topLeftY="217" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="207" height="105" topLeftX="605" topLeftY="77" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="56" height="259" topLeftX="858" topLeftY="212" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>读书感悟</p>
+        </content>
+      </shape>
+      <shape width="87" height="60" topLeftX="41" topLeftY="431" type="text">
+        <content textType="headline" fontSize="50" fontFamily="有字库龙藏体" color="rgba(43, 54, 44, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>肆</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 54, 44, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="30" height="102" topLeftX="173" topLeftY="213" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>总结一</p>
+        </content>
+      </shape>
+      <shape width="30" height="102" topLeftX="173" topLeftY="343" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(128, 66, 8, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)">
+          <p>总结二</p>
+        </content>
+      </shape>
+      <shape width="151" height="212" topLeftX="0" topLeftY="0" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(64, 85, 62, 1)"/>
+        </fill>
+      </shape>
+      <shape width="520" height="93" topLeftX="440" topLeftY="447" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(64, 85, 62, 1)"/>
+        </fill>
+      </shape>
+      <shape width="75" height="75" topLeftX="765" topLeftY="43" alpha="0.9" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow angle="90" blur="21"/>
+      </shape>
+      <img src="GQfkbUM1soULBWxx0KqcjZiMnJd" width="520" height="235" topLeftX="440" topLeftY="212">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="62" bottomOffset="62" presetHandlers="0"/>
+      </img>
+      <img src="W7jnbtvFXo2aNUxo960ctEXlncc" width="151" height="235" topLeftX="0" topLeftY="212">
+        <crop type="rect" leftOffset="95" rightOffset="95" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="473" height="42" topLeftX="464" topLeftY="472" alpha="0.5" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="207" height="105" topLeftX="219" topLeftY="341" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="207" height="105" topLeftX="219" topLeftY="211" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</p>
+        </content>
+      </shape>
+      <shape width="87" height="60" topLeftX="761" topLeftY="49" type="text">
+        <content textType="headline" fontSize="50" fontFamily="有字库龙藏体" color="rgba(43, 54, 44, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>肆</p>
+        </content>
+      </shape>
+      <shape width="56" height="130" topLeftX="858" topLeftY="38" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>总结</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="JMXPb7rVToic0yxUCMacn4YJnyd" width="960" height="540" topLeftX="0.12" topLeftY="0" alpha="0.2" saturation="-8" temperature="-32">
+        <crop type="rect" leftOffset="0.34" rightOffset="0.34" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="960" height="270" topLeftX="0" topLeftY="270" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 54, 44, 1)"/>
+        </fill>
+      </shape>
+      <img src="ToembDV69oCS2Axcw7XcHdwynz9" width="150" height="150" topLeftX="38" topLeftY="318">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="6" bottomOffset="6" presetHandlers="4"/>
+      </img>
+      <img src="Mz8Hb9vY0oJqC8x9C53cRiAUnuh" width="150" height="150" topLeftX="218" topLeftY="318">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="6" bottomOffset="6" presetHandlers="4"/>
+      </img>
+      <img src="WHVsbntGdoZiq6xVHNEcjKcDnih" width="150" height="150" topLeftX="397" topLeftY="318">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="6" bottomOffset="6" presetHandlers="4"/>
+      </img>
+      <shape width="327" height="293" topLeftX="595" topLeftY="134" type="rect">
+        <border color="rgba(43, 54, 44, 1)" width="1"/>
+      </shape>
+      <img src="EQN1bi9m9ohLo2xZAXzcVU0bnJe" width="327" height="327" topLeftX="588" topLeftY="140">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="12" bottomOffset="12" presetHandlers="4"/>
+      </img>
+      <shape width="75" height="75" topLeftX="843" topLeftY="37" alpha="0.9" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="93" height="75" topLeftX="834" topLeftY="34" type="text">
+        <content fontSize="50" fontFamily="有字库龙藏体" color="rgba(43, 54, 44, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>肆</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="167" height="21" topLeftX="669" topLeftY="476" alpha="0.7" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p textAlign="center">作者·书籍</p>
+        </content>
+      </shape>
+      <shape width="327" height="327" topLeftX="588" topLeftY="140" type="rect">
+        <border color="rgba(43, 54, 44, 1)" width="1"/>
+      </shape>
+      <shape width="238" height="65" topLeftX="40" topLeftY="34" alpha="0.9" type="text">
+        <content textType="title" fontSize="54" fontFamily="思源宋体" color="rgba(32, 31, 29, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1.2">
+            <span color="rgba(32, 31, 29, 1)">延伸阅读</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="489" height="42" topLeftX="39" topLeftY="191" alpha="0.7" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源宋体" color="rgba(0, 0, 0, 1)" bold="false">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontFamily="思源宋体" bold="false">书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="21" topLeftX="228" topLeftY="476" alpha="0.7" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)">作者·书籍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="21" topLeftX="51" topLeftY="476" alpha="0.7" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p textAlign="center">作者·书籍</p>
+        </content>
+      </shape>
+      <shape width="130" height="21" topLeftX="408" topLeftY="476" alpha="0.7" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p textAlign="center">作者·书籍</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="CTE8bLVM3o28DdxTy9NchsGCnbh" width="961" height="541" topLeftX="0" topLeftY="0">
+        <crop type="rect" leftOffset="0.65" rightOffset="0.65" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="940" height="364" topLeftX="10" topLeftY="20" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="920" height="384" topLeftX="20" topLeftY="10" type="rect">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="960" height="136" topLeftX="0" topLeftY="404" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 54, 44, 1)"/>
+        </fill>
+      </shape>
+      <shape width="89" height="96" topLeftX="380" topLeftY="22" alpha="0.9" type="text">
+        <content textType="title" fontSize="80" fontFamily="马善政毛笔楷体" color="rgba(32, 31, 29, 1)" bold="false" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(32, 31, 29, 1)" fontSize="80" fontFamily="马善政毛笔楷体" bold="false">感</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="89" height="96" topLeftX="444" topLeftY="65" alpha="0.9" type="text">
+        <content textType="title" fontSize="80" fontFamily="马善政毛笔楷体" color="rgba(32, 31, 29, 1)" bold="false" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(32, 31, 29, 1)" fontSize="80" fontFamily="马善政毛笔楷体" bold="false">谢</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="89" height="96" topLeftX="380" topLeftY="97" alpha="0.9" type="text">
+        <content textType="title" fontSize="80" fontFamily="马善政毛笔楷体" color="rgba(32, 31, 29, 1)" bold="false" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(32, 31, 29, 1)" fontSize="80" fontFamily="马善政毛笔楷体" bold="false">观</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="89" height="96" topLeftX="444" topLeftY="140" alpha="0.9" type="text">
+        <content textType="title" fontSize="80" fontFamily="马善政毛笔楷体" color="rgba(32, 31, 29, 1)" bold="false" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(32, 31, 29, 1)" fontSize="80" fontFamily="马善政毛笔楷体" bold="false">看</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="440" height="84" topLeftX="30" topLeftY="430" alpha="0.5" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源宋体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>书海畅游意无穷，墨香四溢映心中。分享佳作如明灯，照亮前路启智明。佳句共赏添雅趣，思想碰撞智慧生。读书之乐同分享，知识海洋任君行。在书的世界里，我们汲取智慧，分享感悟，让书香飘满生活，让心灵在阅读中绽放光芒。</p>
+        </content>
+      </shape>
+      <img src="YvRMb7i4NoiI30xZy4gc5E5Cn1c" width="89" height="89" topLeftX="843" topLeftY="427">
+        <shadow angle="90" color="rgba(17, 39, 112, 0.15)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/misc--club_event_plan.xml
+++ b/skills/lark-slides/references/templates/misc--club_event_plan.xml
@@ -1,0 +1,4885 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>社团活动策划方案</title>
+  <theme>
+    <background>
+      <fillColor color="rgba(0, 0, 0, 1)"/>
+    </background>
+    <textStyles>
+      <title fontColor="rgba(255, 255, 255, 1)"/>
+      <headline fontColor="rgba(255, 255, 255, 1)"/>
+      <sub-headline fontColor="rgba(255, 255, 255, 1)"/>
+      <body fontColor="rgba(168, 174, 181, 1)"/>
+      <caption fontColor="rgba(168, 174, 181, 1)" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="1" topLeftX="0" topLeftY="27" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="54" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="81" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="108" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="135" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="162" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="189" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="216" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="243" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="270" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="297" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="324" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="351" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="378" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="405" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="432" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="459" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="486" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="512" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-242" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-215" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-187" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-160" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-132" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-105" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-78" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-50" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-23" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="5" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="32" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="59" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="87" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="114" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="142" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="169" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="196" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="224" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="251" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="278" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="306" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="333" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="361" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="388" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="415" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="443" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="470" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="498" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="525" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="552" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="580" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="607" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="635" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="662" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="312" height="540" topLeftX="0" topLeftY="0" alpha="0.8" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.7) 73%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="312" height="540" topLeftX="648" topLeftY="0" rotation="180" alpha="0.8" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.7) 73%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="234" height="961" topLeftX="363" topLeftY="-58" rotation="270" alpha="0.8" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.7) 73%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="263" height="961" topLeftX="348" topLeftY="-349" rotation="90" alpha="0.7" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.6) 73%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="33" height="33" topLeftX="359" topLeftY="191" type="ellipse">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="89" height="89" topLeftX="217" topLeftY="309" rotation="90" type="ellipse">
+        <border color="rgba(216, 57, 49, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="105" height="54" topLeftX="180" topLeftY="329" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <line startX="260" startY="309" endX="260" endY="400">
+        <border color="rgba(216, 57, 49, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="239" height="163" topLeftX="361" topLeftY="184" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" fontFamily="undefined" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="54" fontFamily="undefined">社团活动</span>
+            </strong>
+          </p>
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="54" fontFamily="undefined">策划方案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="84" height="41" topLeftX="438" topLeftY="147" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" letterSpacing="2" textAlign="center">
+          <p letterSpacing="2">
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">社团名称</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="136" topLeftX="614" topLeftY="361" rotation="0" type="ellipse">
+        <border color="rgba(216, 57, 49, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="105" height="105" topLeftX="629" topLeftY="376" rotation="0" type="ellipse">
+        <border color="rgba(242, 114, 175, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="71" height="71" topLeftX="646" topLeftY="394" rotation="0" type="ellipse">
+        <border color="rgba(230, 181, 19, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="38" height="38" topLeftX="661" topLeftY="410" rotation="0" type="ellipse">
+        <border color="rgba(82, 104, 220, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="76" height="147" topLeftX="605" topLeftY="355" rotation="0" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="129" height="129" topLeftX="215" topLeftY="37" rotation="270" type="ellipse">
+        <border color="rgba(230, 181, 19, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="99" height="97" topLeftX="230" topLeftY="54" rotation="270" type="ellipse">
+        <border color="rgba(82, 104, 220, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="66" height="67" topLeftX="247" topLeftY="69" rotation="270" type="ellipse">
+        <border color="rgba(242, 114, 175, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="36" height="36" topLeftX="262" topLeftY="86" rotation="270" type="ellipse">
+        <border color="rgba(216, 57, 49, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="75" height="140" topLeftX="242" topLeftY="70" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="83" height="83" topLeftX="841" topLeftY="311" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="31" topLeftX="846" topLeftY="304" rotation="45" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="79" topLeftX="854" topLeftY="293" rotation="45" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="105" topLeftX="866" topLeftY="289" rotation="45" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="120" topLeftX="878" topLeftY="293" rotation="45" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="105" topLeftX="887" topLeftY="312" rotation="45" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="79" topLeftX="896" topLeftY="340" rotation="45" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="31" topLeftX="911" topLeftY="370" rotation="45" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="21" height="61" topLeftX="49" topLeftY="168" rotation="315" type="ellipse">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="21" height="61" topLeftX="49" topLeftY="214" rotation="45" type="ellipse">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="55" height="55" topLeftX="37" topLeftY="447" type="rect">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="55" height="55" topLeftX="37" topLeftY="447" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+      </shape>
+      <shape width="55" height="55" topLeftX="92" topLeftY="447" type="rect">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="55" height="55" topLeftX="92" topLeftY="447" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="122" topLeftY="310" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="122" topLeftY="368" rotation="180" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="149" topLeftY="349" rotation="110" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="95" topLeftY="329" rotation="290" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="139" topLeftY="362" rotation="145" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="106" topLeftY="316" rotation="325" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="139" topLeftY="316" rotation="35" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="106" topLeftY="362" rotation="215" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="149" topLeftY="328" rotation="70" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="95" topLeftY="348" rotation="250" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="33" height="33" topLeftX="114" topLeftY="337" type="ellipse">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="51" height="51" topLeftX="598" topLeftY="37" type="pie">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="51" height="51" topLeftX="624" topLeftY="37" type="pie">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="51" height="51" topLeftX="649" topLeftY="37" type="pie">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="51" height="51" topLeftX="675" topLeftY="37" type="pie">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+      </shape>
+      <shape width="98" height="98" topLeftX="676" topLeftY="167" rotation="270" type="ellipse">
+        <border color="rgba(82, 104, 220, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="115" height="59" topLeftX="700" topLeftY="185" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <line startX="727" startY="265" endX="727" endY="166">
+        <border color="rgba(82, 104, 220, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="19" height="55" topLeftX="895" topLeftY="31" rotation="45" type="ellipse">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="55" topLeftX="853" topLeftY="31" rotation="315" type="ellipse">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="55" topLeftX="895" topLeftY="72" rotation="315" type="ellipse">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="55" topLeftX="853" topLeftY="72" rotation="45" type="ellipse">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="44" topLeftX="877" topLeftY="482" rotation="90" type="ellipse">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+        <border color="rgba(216, 57, 49, 1)" width="11" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="29" height="82" topLeftX="885" topLeftY="477" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="83" height="83" topLeftX="35" topLeftY="37" type="rect">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="31" topLeftX="40" topLeftY="96" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="79" topLeftX="52" topLeftY="64" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="105" topLeftX="62" topLeftY="39" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="120" topLeftX="73" topLeftY="19" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="105" topLeftX="85" topLeftY="18" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="79" topLeftX="99" topLeftY="21" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="32" topLeftX="105" topLeftY="29" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="11" height="11" topLeftX="320" topLeftY="480" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="11" height="63" topLeftX="283" topLeftY="465" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="11" height="24" topLeftX="338" topLeftY="485" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="374" topLeftY="163" rotation="90" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="384" topLeftY="163" rotation="90" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="395" topLeftY="163" rotation="90" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="405" topLeftY="163" rotation="90" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="415" topLeftY="163" rotation="90" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="426" topLeftY="163" rotation="90" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="579" topLeftY="163" rotation="270" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="569" topLeftY="163" rotation="270" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="558" topLeftY="163" rotation="270" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="548" topLeftY="163" rotation="270" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="538" topLeftY="163" rotation="270" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="527" topLeftY="163" rotation="270" alpha="0.5" type="triangle">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="556" topLeftY="325" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="613" topLeftY="325" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="594" topLeftY="298" rotation="20" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="575" topLeftY="352" rotation="200" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="608" topLeftY="308" rotation="55" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="561" topLeftY="341" rotation="235" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="561" topLeftY="308" rotation="305" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="608" topLeftY="341" rotation="125" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="574" topLeftY="298" rotation="340" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="33" topLeftX="593" topLeftY="352" rotation="160" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="33" height="33" topLeftX="575" topLeftY="325" rotation="270" type="ellipse">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="11" height="11" topLeftX="595" topLeftY="336" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="7" topLeftX="596" topLeftY="337" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="11" height="11" topLeftX="582" topLeftY="328" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="7" topLeftX="583" topLeftY="329" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="7" topLeftX="583" topLeftY="329" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="214" height="44" topLeftX="373" topLeftY="353" presetHandlers="22" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" bold="false" letterSpacing="4">
+          <p letterSpacing="4">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="undefined" bold="false">策划人: 小李</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="1" topLeftX="0" topLeftY="27" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="54" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="81" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="108" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="135" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="162" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="189" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="216" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="243" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="270" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="297" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="324" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="351" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="378" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="405" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="432" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="459" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="486" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="512" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-242" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-215" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-187" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-160" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-132" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-105" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-78" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-50" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-23" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="5" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="32" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="59" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="87" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="114" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="142" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="169" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="196" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="224" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="251" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="278" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="306" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="333" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="361" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="388" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="415" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="443" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="470" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="498" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="525" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="552" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="580" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="607" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="635" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="662" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="960" topLeftX="210" topLeftY="-210" rotation="90" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.55) 77%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="78" height="63" topLeftX="285" topLeftY="212" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="75" height="75" topLeftX="42" topLeftY="204" rotation="90" type="ellipse">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+        <border color="rgba(216, 57, 49, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="88" height="45" topLeftX="11" topLeftY="221" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="735" topLeftY="200" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="735" topLeftY="255" rotation="180" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="761" topLeftY="237" rotation="110" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="709" topLeftY="218" rotation="290" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="751" topLeftY="250" rotation="145" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="719" topLeftY="205" rotation="325" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="751" topLeftY="205" rotation="35" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="719" topLeftY="250" rotation="215" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="761" topLeftY="217" rotation="70" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="709" topLeftY="236" rotation="250" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="32" topLeftX="727" topLeftY="226" type="ellipse">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="70" height="70" topLeftX="491" topLeftY="204" rotation="270" type="pie">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="110" height="93" topLeftX="719" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="48" fontFamily="Arial Black">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="110" height="93" topLeftX="505" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="48" fontFamily="Arial Black">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="44" topLeftX="296" topLeftY="288" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">活动内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="110" height="93" topLeftX="80" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="48" fontFamily="Arial Black">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="44" topLeftX="85" topLeftY="288" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">活动介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="42" topLeftX="85" topLeftY="321" alpha="0.8" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">输入活动介绍的相关信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="42" topLeftX="296" topLeftY="321" alpha="0.8" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">输入活动内容的相关信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="110" height="93" topLeftX="294" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="48" fontFamily="Arial Black">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="44" topLeftX="508" topLeftY="288" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">活动安排</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="42" topLeftX="508" topLeftY="321" alpha="0.8" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">输入活动安排的相关信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="44" topLeftX="719" topLeftY="288" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">活动维护</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="42" topLeftX="719" topLeftY="321" alpha="0.8" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">输入活动维护的相关信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="312" height="41" topLeftX="65" topLeftY="108" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)">
+          <p>
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">Category</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="788" height="68" topLeftX="64" topLeftY="61" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">目录</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="41" topLeftX="761" topLeftY="67" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" letterSpacing="2" textAlign="right">
+          <p letterSpacing="2">
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">社团名称</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="1" topLeftX="0" topLeftY="669" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="696" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="723" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="750" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="777" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="804" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="831" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="858" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="885" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="912" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="939" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="966" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="993" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1020" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1047" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1074" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1101" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1128" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1154" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-242" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-215" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-187" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-160" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-132" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-105" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-78" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-50" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-23" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="5" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="32" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="59" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="87" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="114" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="142" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="169" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="196" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="224" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="251" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="278" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="306" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="333" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="361" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="388" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="415" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="443" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="470" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="498" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="525" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="552" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="580" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="607" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="635" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="662" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="960" topLeftX="210" topLeftY="-210" rotation="90" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.55) 62%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="144" height="144" topLeftX="113" topLeftY="201" type="ellipse">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+        <border color="rgba(216, 57, 49, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="169" height="87" topLeftX="103" topLeftY="277" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="117" height="117" topLeftX="325" topLeftY="202" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="64" fontFamily="Arial Black">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="44" topLeftX="433" topLeftY="286" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(168, 174, 181, 1)">
+          <p letterSpacing="2">
+            <span color="rgba(168, 174, 181, 1)" fontSize="16">Activity description</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="77" topLeftX="433" topLeftY="226" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="38">活动介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="312" height="41" topLeftX="65" topLeftY="108" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)">
+          <p>
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">Preparatory Preparations</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="788" height="68" topLeftX="64" topLeftY="61" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">前期筹备</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="262" height="298" topLeftX="68" topLeftY="166" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="236" height="47" topLeftX="82" topLeftY="330" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="18">主题策划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="82" topLeftY="371" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="55" height="56" topLeftX="86" topLeftY="192" rotation="45" type="donut">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="57" height="30" topLeftX="75" topLeftY="215" rotation="45" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="40" height="40" topLeftX="95" topLeftY="199" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="262" height="298" topLeftX="350" topLeftY="166" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="236" height="47" topLeftX="362" topLeftY="330" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="18">人员邀请</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="362" topLeftY="371" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="36" height="36" topLeftX="374" topLeftY="206" type="pie">
+        <fill>
+          <fillColor color="rgba(255, 198, 10, 1)"/>
+        </fill>
+      </shape>
+      <shape width="36" height="36" topLeftX="393" topLeftY="188" rotation="180" type="pie">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="262" height="298" topLeftX="632" topLeftY="166" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="236" height="47" topLeftX="645" topLeftY="330" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>现场布置</p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="645" topLeftY="371" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="49" height="49" topLeftX="655" topLeftY="191" type="ellipse">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="57" height="29" topLeftX="651" topLeftY="217" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <line startX="655" startY="216" endX="704" endY="216">
+        <border color="rgba(82, 104, 220, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="24" height="24" topLeftX="668" topLeftY="218" type="ellipse">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="27" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="54" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="81" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="108" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="134" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="161" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="188" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="215" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="242" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="269" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="295" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="322" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="349" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="376" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="403" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="430" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="457" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="483" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="509" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="0.16" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="0.99" topLeftX="0" topLeftY="537" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="-268" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="-241" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="-213" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="-186" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="-158" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="-131" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="-104" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="-76" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="-49" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="-21" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="6" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="33" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="61" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="88" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="116" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="143" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="170" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="198" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="225" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="253" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="280" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="307" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="335" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="362" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="390" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="417" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="444" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="472" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="499" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="527" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="554" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="581" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="609" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="636" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="664" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="537" height="1" topLeftX="691" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="419" height="961" topLeftX="270" topLeftY="-150" rotation="270" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="276" height="961" topLeftX="342" topLeftY="-343" rotation="90" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="70" height="70" topLeftX="417" topLeftY="380" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="26" topLeftX="477" topLeftY="430" rotation="225" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="67" topLeftX="470" topLeftY="399" rotation="225" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="89" topLeftX="460" topLeftY="380" rotation="225" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="101" topLeftX="450" topLeftY="365" rotation="225" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="89" topLeftX="442" topLeftY="361" rotation="225" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="67" topLeftX="434" topLeftY="360" rotation="225" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="27" topLeftX="421" topLeftY="374" rotation="225" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="14" height="14" topLeftX="84" topLeftY="167" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 198, 10, 1)"/>
+        </fill>
+      </shape>
+      <shape width="14" height="14" topLeftX="98" topLeftY="181" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 198, 10, 1)"/>
+        </fill>
+      </shape>
+      <shape width="14" height="14" topLeftX="112" topLeftY="195" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 198, 10, 1)"/>
+        </fill>
+      </shape>
+      <shape width="14" height="14" topLeftX="126" topLeftY="209" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 198, 10, 1)"/>
+        </fill>
+      </shape>
+      <shape width="14" height="14" topLeftX="84" topLeftY="195" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 198, 10, 1)"/>
+        </fill>
+      </shape>
+      <shape width="14" height="14" topLeftX="98" topLeftY="209" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 198, 10, 1)"/>
+        </fill>
+      </shape>
+      <shape width="14" height="14" topLeftX="112" topLeftY="167" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 198, 10, 1)"/>
+        </fill>
+      </shape>
+      <shape width="14" height="14" topLeftX="126" topLeftY="181" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 198, 10, 1)"/>
+        </fill>
+      </shape>
+      <shape width="70" height="70" topLeftX="743" topLeftY="318" rotation="135" type="rect">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="27" topLeftX="775" topLeftY="300" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="66" topLeftX="772" topLeftY="293" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="88" topLeftX="774" topLeftY="295" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="55" height="101" topLeftX="750" topLeftY="327" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="312" height="41" topLeftX="324" topLeftY="108" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" textAlign="center">
+          <p>
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">Activity budge</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="821" height="68" topLeftX="70" topLeftY="61" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">活动经费</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="44" topLeftX="782" topLeftY="348" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="16">其他支出</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="38" topLeftX="782" topLeftY="376" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">¥ 100</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="103" height="103" topLeftX="672" topLeftY="329" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <img src="EET5bSsCBoyek7xTYnxcMRxBnbe" width="91" height="90" topLeftX="678" topLeftY="336" exposure="11">
+        <crop type="ellipse" leftOffset="4" rightOffset="5" topOffset="6" bottomOffset="4"/>
+      </img>
+      <shape width="90" height="44" topLeftX="494" topLeftY="348" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="16">食品饮料</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="38" topLeftX="494" topLeftY="376" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">¥ 220</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="103" height="103" topLeftX="386" topLeftY="329" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <img src="BUGBb6jEeoBaJ2xBdWNc2dhynzd" width="91" height="90" topLeftX="392" topLeftY="336" exposure="11">
+        <crop type="ellipse" leftOffset="0" rightOffset="0" topOffset="0.14" bottomOffset="0.14"/>
+      </img>
+      <shape width="90" height="44" topLeftX="221" topLeftY="348" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="16">活动奖品</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="38" topLeftX="221" topLeftY="376" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">¥ 300</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="102" height="102" topLeftX="113" topLeftY="330" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <img src="LYPSbzk1LoIEFBxuYqsc1l62nRh" width="90" height="90" topLeftX="119" topLeftY="336" exposure="11">
+        <crop type="ellipse" leftOffset="0.18" rightOffset="0.18" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="90" height="44" topLeftX="219" topLeftY="208" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="16">酒店住宿</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="38" topLeftX="219" topLeftY="235" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">¥ 500</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="103" height="103" topLeftX="112" topLeftY="189" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <img src="AgAUbRkCMopriNxpLkecctn8nCg" width="90" height="90" topLeftX="119" topLeftY="196" exposure="11">
+        <crop type="ellipse" leftOffset="0" rightOffset="0" topOffset="0.14" bottomOffset="0.14"/>
+      </img>
+      <shape width="90" height="44" topLeftX="494" topLeftY="208" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="16">交通出行</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="38" topLeftX="494" topLeftY="235" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">¥ 150</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="103" height="103" topLeftX="386" topLeftY="189" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <img src="MNqnbVyJ8oQgbCxKyc7cC5KanNc" width="90" height="90" topLeftX="392" topLeftY="195" exposure="11">
+        <crop type="ellipse" leftOffset="30" rightOffset="35" topOffset="29" bottomOffset="36"/>
+      </img>
+      <shape width="90" height="44" topLeftX="782" topLeftY="208" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="16">医疗保险</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="38" topLeftX="782" topLeftY="235" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">¥ 90</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="103" height="103" topLeftX="672" topLeftY="189" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <img src="R51nbtXy5o304Wx8SOUcfYLmnlh" width="90" height="90" topLeftX="679" topLeftY="195" exposure="11">
+        <crop type="ellipse" leftOffset="0.18" rightOffset="0.18" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="1" topLeftX="0" topLeftY="669" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="696" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="723" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="750" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="777" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="804" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="831" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="858" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="885" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="912" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="939" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="966" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="993" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1020" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1047" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1074" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1101" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1128" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1154" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-242" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-215" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-187" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-160" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-132" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-105" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-78" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-50" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-23" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="5" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="32" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="59" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="87" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="114" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="142" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="169" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="196" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="224" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="251" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="278" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="306" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="333" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="361" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="388" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="415" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="443" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="470" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="498" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="525" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="552" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="580" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="607" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="635" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="662" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="960" topLeftX="210" topLeftY="-210" rotation="90" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.55) 62%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="114" height="91" topLeftX="320" topLeftY="207" rotation="0" type="triangle">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <shape width="117" height="117" topLeftX="325" topLeftY="202" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="218" height="44" topLeftX="433" topLeftY="286" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(168, 174, 181, 1)">
+          <p letterSpacing="2">
+            <span color="rgba(168, 174, 181, 1)" fontSize="16">Activity content</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="77" topLeftX="433" topLeftY="226" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="38">活动内容</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="312" height="41" topLeftX="324" topLeftY="108" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" textAlign="center">
+          <p>
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">Guests of Activity </span>
+          </p>
+        </content>
+      </shape>
+      <shape width="821" height="68" topLeftX="70" topLeftY="61" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">活动嘉宾</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="44" height="44" topLeftX="125" topLeftY="156" rotation="270" type="ellipse">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="52" height="27" topLeftX="135" topLeftY="164" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="44" topLeftX="155" topLeftY="156" rotation="270" type="ellipse">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+      </shape>
+      <shape width="52" height="27" topLeftX="166" topLeftY="164" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="112" height="112" topLeftX="540" topLeftY="326" rotation="180" type="ellipse">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="68" topLeftX="528" topLeftY="312" rotation="180" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="12" height="67" topLeftX="821" topLeftY="311" rotation="285" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="822" topLeftY="303" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="817" topLeftY="320" rotation="300" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="812" topLeftY="327" rotation="315" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="805" topLeftY="332" rotation="330" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="797" topLeftY="335" rotation="345" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="788" topLeftY="336" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="821" topLeftY="294" rotation="75" flipY="true" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="817" topLeftY="286" rotation="60" flipY="true" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="812" topLeftY="279" rotation="45" flipY="true" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="805" topLeftY="274" rotation="30" flipY="true" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="797" topLeftY="270" rotation="15" flipY="true" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="67" topLeftX="788" topLeftY="270" flipY="true" type="triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="132" height="243" topLeftX="328" topLeftY="168" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="102" height="102" topLeftX="343" topLeftY="185" type="ellipse">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+      <img src="N753bs5QComVeEx47QnclaSmnHf" width="89" height="89" topLeftX="349" topLeftY="190" exposure="11">
+        <crop type="ellipse" leftOffset="0" rightOffset="0" topOffset="0.14" bottomOffset="0.14"/>
+      </img>
+      <shape width="132" height="39" topLeftX="328" topLeftY="325" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6" textAlign="center">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">活动宣传负责人</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="44" topLeftX="328" topLeftY="297" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">王大</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="243" topLeftX="673" topLeftY="168" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="102" height="102" topLeftX="688" topLeftY="185" type="ellipse">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="39" topLeftX="673" topLeftY="325" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6" textAlign="center">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">文案负责人</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="44" topLeftX="673" topLeftY="297" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">李小画</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="P4p4bITwWos38xxtEQAc8zaCnTc" width="89" height="89" topLeftX="694" topLeftY="191" exposure="11">
+        <crop type="ellipse" leftOffset="0" rightOffset="0" topOffset="0.14" bottomOffset="0.14"/>
+      </img>
+      <shape width="132" height="243" topLeftX="500" topLeftY="168" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="102" height="102" topLeftX="515" topLeftY="185" type="ellipse">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="39" topLeftX="500" topLeftY="325" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6" textAlign="center">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">场地布置负责人</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="44" topLeftX="500" topLeftY="297" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">林克</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Cpogbga7RoRyF7xRXrEcq5Uanvh" width="89" height="89" topLeftX="522" topLeftY="191" exposure="11">
+        <crop type="ellipse" leftOffset="0" rightOffset="0" topOffset="0.14" bottomOffset="0.14"/>
+      </img>
+      <img src="NoKGbYUYBoX6jSxQRKOcPSh9n6c" width="327" height="327" topLeftX="0" topLeftY="213" alpha="0.35">
+        <crop type="rect" leftOffset="3" rightOffset="0" topOffset="0" bottomOffset="3" presetHandlers="0"/>
+      </img>
+      <img src="HDrKbCVtEojOu0xZxPTcpolQnLf" width="314" height="315" topLeftX="0" topLeftY="225" alpha="0.35">
+        <crop type="rect" leftOffset="4" rightOffset="0" topOffset="0" bottomOffset="3" presetHandlers="0"/>
+      </img>
+      <img src="KStZbxK4QocGN6x8YD4ciRYfnGc" width="300" height="301" topLeftX="0" topLeftY="239" alpha="0.35">
+        <crop type="rect" leftOffset="3" rightOffset="0" topOffset="0" bottomOffset="3" presetHandlers="0"/>
+      </img>
+      <img src="Ss1vbAypHoRJc4xZ0EXcee2OnuP" width="286" height="287" topLeftX="0" topLeftY="253" alpha="0.35">
+        <crop type="rect" leftOffset="4" rightOffset="0" topOffset="0" bottomOffset="3" presetHandlers="0"/>
+      </img>
+      <img src="VLRYbTeLIoL6bWx0Abkc7ePKn8b" width="272" height="273" topLeftX="0" topLeftY="267" alpha="0.35">
+        <crop type="rect" leftOffset="4" rightOffset="0" topOffset="0" bottomOffset="3" presetHandlers="0"/>
+      </img>
+      <shape width="132" height="243" topLeftX="155" topLeftY="168" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="102" height="102" topLeftX="170" topLeftY="185" type="ellipse">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+      </shape>
+      <img src="EbqLbN4EKoYFf1x1YBAcQbDQnae" width="89" height="89" topLeftX="177" topLeftY="190" exposure="11">
+        <crop type="ellipse" leftOffset="0" rightOffset="0" topOffset="0.14" bottomOffset="0.14"/>
+      </img>
+      <shape width="132" height="39" topLeftX="155" topLeftY="325" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6" textAlign="center">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">流程策划负责人</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="134" height="44" topLeftX="154" topLeftY="297" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">张小可</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="312" height="41" topLeftX="65" topLeftY="108" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)">
+          <p>
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">Activity projects</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="68" topLeftX="64" topLeftY="61" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">活动项目</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="41" height="41" topLeftX="74" topLeftY="422" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="41" height="41" topLeftX="115" topLeftY="422" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="168" height="154" topLeftX="64" topLeftY="169" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(216, 218, 220, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(216, 218, 220, 1)" fontSize="14">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="838" topLeftY="54" rotation="180" type="rect">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+      </shape>
+      <shape width="5" height="23" topLeftX="889" topLeftY="48" rotation="135" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="5" height="57" topLeftX="880" topLeftY="37" rotation="135" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="5" height="76" topLeftX="873" topLeftY="36" rotation="135" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="45" height="87" topLeftX="831" topLeftY="54" rotation="135" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="194" height="407" topLeftX="264" topLeftY="69" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="175" height="47" topLeftX="273" topLeftY="381" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <span fontSize="18">项目一</span>
+          </p>
+        </content>
+      </shape>
+      <img src="RgL4bQPeroai4gxFRFxc3YgWnfc" width="165" height="290" topLeftX="278" topLeftY="81" saturation="-30">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="3" bottomOffset="3" presetHandlers="12"/>
+      </img>
+      <shape width="175" height="39" topLeftX="273" topLeftY="412" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" bold="false" lineSpacing="multiple:1.6" textAlign="left">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12" bold="false">输入详细的活动内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="194" height="407" topLeftX="692" topLeftY="69" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="175" height="47" topLeftX="702" topLeftY="381" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="18">项目三</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Eb2bbOIfvojAEOxIH5TcZOkAnBd" width="165" height="290" topLeftX="707" topLeftY="81" flipX="true" saturation="-24">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="3" bottomOffset="3" presetHandlers="12"/>
+      </img>
+      <shape width="175" height="39" topLeftX="702" topLeftY="412" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" bold="false" lineSpacing="multiple:1.6" textAlign="left">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12" bold="false">输入详细的活动内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="194" height="407" topLeftX="478" topLeftY="69" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="175" height="47" topLeftX="487" topLeftY="381" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="18">项目二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Js3gbdrlDoUAyExGVYWceNq6nXA" width="165" height="290" topLeftX="492" topLeftY="81" contrast="-1" saturation="-18">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="3" bottomOffset="3" presetHandlers="12"/>
+      </img>
+      <shape width="175" height="39" topLeftX="488" topLeftY="412" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" bold="false" lineSpacing="multiple:1.6" textAlign="left">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12" bold="false">输入详细的活动内容</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="1" topLeftX="0" topLeftY="669" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="696" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="723" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="750" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="777" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="804" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="831" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="858" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="885" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="912" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="939" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="966" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="993" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1020" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1047" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1074" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1101" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1128" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1154" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-242" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-215" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-187" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-160" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-132" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-105" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-78" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-50" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-23" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="5" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="32" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="59" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="87" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="114" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="142" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="169" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="196" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="224" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="251" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="278" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="306" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="333" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="361" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="388" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="415" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="443" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="470" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="498" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="525" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="552" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="580" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="607" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="635" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="662" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="960" topLeftX="210" topLeftY="-210" rotation="90" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.55) 62%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="102" height="102" topLeftX="326" topLeftY="211" rotation="90" type="pie">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="117" height="117" topLeftX="325" topLeftY="202" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="218" height="44" topLeftX="433" topLeftY="286" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(168, 174, 181, 1)">
+          <p letterSpacing="2">
+            <span color="rgba(168, 174, 181, 1)" fontSize="16">Activity arrange</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="77" topLeftX="433" topLeftY="226" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="38">活动安排</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="1" topLeftX="0" topLeftY="26" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="53" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="80" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="107" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="134" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="161" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="188" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="215" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="242" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="269" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="296" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="322" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="349" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="376" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="403" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="430" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="457" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="484" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="510" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="-1" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="538" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="-269" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="-242" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="-214" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="-187" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="-159" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="-132" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="-105" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="-77" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="-50" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="-22" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="5" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="32" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="60" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="87" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="115" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="142" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="169" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="197" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="224" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="252" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="279" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="306" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="334" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="361" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="389" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="416" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="443" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="471" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="498" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="526" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="553" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="580" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="608" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="635" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="663" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="539" height="1" topLeftX="690" topLeftY="268" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="541" height="960" topLeftX="209" topLeftY="-211" rotation="90" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.6) 88%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="122" height="50" topLeftX="424" topLeftY="343" rotation="90" presetHandlers="24" type="rect">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="226" height="50" topLeftX="460" topLeftY="380" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="122" height="50" topLeftX="424" topLeftY="225" rotation="90" presetHandlers="24" type="rect">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+      </shape>
+      <shape width="256" height="50" topLeftX="254" topLeftY="189" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+      </shape>
+      <shape width="200" height="50" topLeftX="686" topLeftY="380" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="185" height="50" topLeftX="74" topLeftY="190" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(219, 168, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="70" height="70" topLeftX="234" topLeftY="179" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="32" height="27" topLeftX="254" topLeftY="201" alpha="0.6" type="right-arrow">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="70" height="70" topLeftX="449" topLeftY="275" rotation="90" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="32" height="27" topLeftX="468" topLeftY="298" rotation="90" alpha="0.6" type="right-arrow">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="70" height="70" topLeftX="652" topLeftY="368" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="32" height="27" topLeftX="672" topLeftY="390" alpha="0.6" type="right-arrow">
+        <fill>
+          <fillColor color="rgba(168, 174, 181, 1)"/>
+        </fill>
+      </shape>
+      <shape width="140" height="44" topLeftX="305" topLeftY="192" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="16">嘉宾颁奖</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="140" height="97" topLeftX="84" topLeftY="248" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6" textAlign="left">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="140" height="97" topLeftX="305" topLeftY="248" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6" textAlign="left">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="140" height="44" topLeftX="514" topLeftY="383" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="16">嘉宾分享</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="140" height="44" topLeftX="735" topLeftY="383" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="16">自由活动</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="140" height="97" topLeftX="518" topLeftY="276" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6" textAlign="left">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="140" height="97" topLeftX="735" topLeftY="276" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6" textAlign="left">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="140" height="44" topLeftX="84" topLeftY="193" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="16">登记入场</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="312" height="41" topLeftX="324" topLeftY="108" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" textAlign="center">
+          <p>
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">Execution flow</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="821" height="68" topLeftX="70" topLeftY="61" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">执行流程</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="312" height="41" topLeftX="65" topLeftY="108" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)">
+          <p>
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">Emergency response plan</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="788" height="68" topLeftX="64" topLeftY="61" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">应急预案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="83" height="83" topLeftX="769" topLeftY="150" type="rect">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="31" topLeftX="774" topLeftY="209" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="79" topLeftX="787" topLeftY="177" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="105" topLeftX="796" topLeftY="152" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="120" topLeftX="807" topLeftY="132" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="105" topLeftX="819" topLeftY="130" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="79" topLeftX="834" topLeftY="134" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="32" topLeftX="840" topLeftY="142" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="89" height="89" topLeftX="57" topLeftY="390" rotation="0" type="rect">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="7" height="34" topLeftX="62" topLeftY="453" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="8" height="84" topLeftX="75" topLeftY="419" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="8" height="112" topLeftX="85" topLeftY="392" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="70" height="128" topLeftX="88" topLeftY="349" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="206" height="85" topLeftX="68" topLeftY="168" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="206" height="85" topLeftX="68" topLeftY="274" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="206" height="85" topLeftX="68" topLeftY="379" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="145" height="50" topLeftX="99" topLeftY="186" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(245, 246, 247, 1)" textAlign="center">
+          <p>
+            <span fontSize="20">应急预案一</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="145" height="50" topLeftX="99" topLeftY="291" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(245, 246, 247, 1)" textAlign="center">
+          <p>
+            <span fontSize="20">应急预案二</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="145" height="50" topLeftX="99" topLeftY="396" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(245, 246, 247, 1)" textAlign="center">
+          <p>
+            <span fontSize="20">应急预案三</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="583" height="85" topLeftX="293" topLeftY="168" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="518" height="56" topLeftX="322" topLeftY="183" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="583" height="85" topLeftX="293" topLeftY="274" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="518" height="56" topLeftX="322" topLeftY="288" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="583" height="85" topLeftX="293" topLeftY="379" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="518" height="56" topLeftX="322" topLeftY="393" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="1" topLeftX="0" topLeftY="669" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="696" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="723" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="750" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="777" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="804" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="831" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="858" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="885" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="912" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="939" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="966" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="993" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1020" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1047" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1074" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1101" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1128" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="1154" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-242" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-215" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-187" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-160" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-132" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-105" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-78" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-50" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-23" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="5" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="32" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="59" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="87" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="114" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="142" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="169" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="196" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="224" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="251" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="278" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="306" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="333" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="361" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="388" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="415" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="443" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="470" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="498" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="525" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="552" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="580" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="607" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="635" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="662" topLeftY="911" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="960" topLeftX="210" topLeftY="-210" rotation="90" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.55) 62%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="59" height="59" topLeftX="507" topLeftY="-548" type="ellipse">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="77" topLeftX="1132" topLeftY="-235" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="77" topLeftX="1132" topLeftY="-101" rotation="180" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="77" topLeftX="-100" topLeftY="-56" rotation="220" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="77" topLeftX="-14" topLeftY="-159" rotation="40" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="77" topLeftX="-273" topLeftY="-540" rotation="290" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="77" topLeftX="-147" topLeftY="-494" rotation="110" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="77" topLeftX="862" topLeftY="92" rotation="70" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="77" topLeftX="736" topLeftY="138" rotation="250" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="77" topLeftX="409" topLeftY="205" rotation="140" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="77" topLeftX="323" topLeftY="102" rotation="320" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="117" height="117" topLeftX="325" topLeftY="202" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="218" height="44" topLeftX="433" topLeftY="286" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(168, 174, 181, 1)">
+          <p letterSpacing="2">
+            <span color="rgba(168, 174, 181, 1)" fontSize="16">Activity maintain</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="77" topLeftX="433" topLeftY="226" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="38">活动评估</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="312" height="41" topLeftX="65" topLeftY="108" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)">
+          <p>
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">Activity Results</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="788" height="68" topLeftX="64" topLeftY="61" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">活动成果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="18" height="32" topLeftX="66" topLeftY="355" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="66" topLeftY="411" rotation="180" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="92" topLeftY="392" rotation="110" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="40" topLeftY="374" rotation="290" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="82" topLeftY="406" rotation="145" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="50" topLeftY="360" rotation="325" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="82" topLeftY="360" rotation="35" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="50" topLeftY="406" rotation="215" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="92" topLeftY="373" rotation="70" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="32" topLeftX="40" topLeftY="391" rotation="250" type="triangle">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="32" topLeftX="58" topLeftY="381" type="ellipse">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <img src="BIwibSZamoxCEtxELtxcfUOgnmf" width="265" height="275" topLeftX="695" topLeftY="265" rotation="0" alpha="0.25">
+        <crop type="rect" leftOffset="0.52" rightOffset="24" topOffset="0" bottomOffset="48" presetHandlers="0"/>
+      </img>
+      <shape width="402" height="140" topLeftX="68" topLeftY="164" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="361" height="47" topLeftX="88" topLeftY="179" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>成果一</p>
+        </content>
+      </shape>
+      <shape width="356" height="56" topLeftX="89" topLeftY="220" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="402" height="140" topLeftX="490" topLeftY="164" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="361" height="47" topLeftX="509" topLeftY="179" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="18">成果二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="357" height="56" topLeftX="510" topLeftY="220" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="402" height="140" topLeftX="490" topLeftY="324" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="361" height="47" topLeftX="509" topLeftY="339" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="18">成果四</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="357" height="56" topLeftX="510" topLeftY="380" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="402" height="140" topLeftX="68" topLeftY="324" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="361" height="47" topLeftX="88" topLeftY="339" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="18">成果三</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="356" height="56" topLeftX="89" topLeftY="380" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(216, 218, 220, 1)" textAlign="left">
+          <p>
+            <span color="rgba(216, 218, 220, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="11" height="11" topLeftX="824" topLeftY="141" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="11" height="63" topLeftX="787" topLeftY="126" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="11" height="24" topLeftX="841" topLeftY="146" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(230, 181, 19, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Gpi9bSRJgovEj1xSIVtcFVnjnvf" width="327" height="327" topLeftX="0" topLeftY="213" alpha="0.35">
+        <crop type="rect" leftOffset="3" rightOffset="0" topOffset="0" bottomOffset="3" presetHandlers="0"/>
+      </img>
+      <img src="Cfh1bjIQGoaLC6x3zyjcKKohnyd" width="314" height="315" topLeftX="0" topLeftY="225" alpha="0.35">
+        <crop type="rect" leftOffset="4" rightOffset="0" topOffset="0" bottomOffset="3" presetHandlers="0"/>
+      </img>
+      <img src="OBaWbRYRPovtEBxpns2cUiYRnWc" width="300" height="301" topLeftX="0" topLeftY="239" alpha="0.35">
+        <crop type="rect" leftOffset="3" rightOffset="0" topOffset="0" bottomOffset="3" presetHandlers="0"/>
+      </img>
+      <img src="Rt7Cb7ADWoU63jxpAZ5ceJytnae" width="286" height="287" topLeftX="0" topLeftY="253" alpha="0.35">
+        <crop type="rect" leftOffset="4" rightOffset="0" topOffset="0" bottomOffset="3" presetHandlers="0"/>
+      </img>
+      <img src="NFhcbc0bootyLixWvzvcpAMlnZe" width="272" height="273" topLeftX="0" topLeftY="267" alpha="0.35">
+        <crop type="rect" leftOffset="4" rightOffset="0" topOffset="0" bottomOffset="3" presetHandlers="0"/>
+      </img>
+      <shape width="238" height="960" topLeftX="361" topLeftY="-361" rotation="90" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.55) 62%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="89" height="89" topLeftX="50" topLeftY="118" rotation="90" type="ellipse">
+        <border color="rgba(216, 57, 49, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="105" height="54" topLeftX="13" topLeftY="138" rotation="90" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <line startX="93" startY="118" endX="93" endY="209">
+        <border color="rgba(216, 57, 49, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="923" startY="324" endX="769" endY="324">
+        <border color="rgba(82, 104, 220, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="154" height="154" topLeftX="769" topLeftY="325" rotation="0" type="donut">
+        <border color="rgba(82, 104, 220, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="164" height="79" topLeftX="764" topLeftY="323" rotation="180" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <line startX="923" startY="402" endX="769" endY="402">
+        <border color="rgba(82, 104, 220, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="154" height="154" topLeftX="769" topLeftY="247" rotation="0" type="donut">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+        <border color="rgba(82, 104, 220, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="164" height="79" topLeftX="764" topLeftY="244" rotation="180" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="402" height="320" topLeftX="490" topLeftY="164" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="365" height="60" topLeftX="508" topLeftY="186" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="rgba(242, 114, 175, 1)"/>
+        </fill>
+      </shape>
+      <shape width="289" height="47" topLeftX="546" topLeftY="193" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(245, 246, 247, 1)" fontSize="18">总结二</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="353" height="110" topLeftX="514" topLeftY="259" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(216, 218, 220, 1)" lineSpacing="multiple:1.6" textAlign="left">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(216, 218, 220, 1)" fontSize="14">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。大多数时候，他们都是在观众面前。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="402" height="320" topLeftX="68" topLeftY="164" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="353" height="110" topLeftX="93" topLeftY="259" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(216, 218, 220, 1)" lineSpacing="multiple:1.6" textAlign="left">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(216, 218, 220, 1)" fontSize="14">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。大多数时候，他们都是在观众面前。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="365" height="60" topLeftX="87" topLeftY="186" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="rgba(82, 104, 220, 1)"/>
+        </fill>
+      </shape>
+      <shape width="289" height="47" topLeftX="125" topLeftY="193" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(245, 246, 247, 1)" fontSize="18">总结一</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="312" height="41" topLeftX="324" topLeftY="108" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" textAlign="center">
+          <p>
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">Summary</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="821" height="68" topLeftX="70" topLeftY="61" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">总结</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="1" topLeftX="0" topLeftY="27" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="54" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="81" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="108" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="135" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="162" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="189" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="216" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="243" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="270" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="297" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="324" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="351" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="378" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="405" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="432" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="459" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="486" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="960" height="1" topLeftX="0" topLeftY="512" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-242" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-215" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-187" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-160" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-132" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-105" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-78" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-50" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="-23" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="5" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="32" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="59" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="87" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="114" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="142" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="169" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="196" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="224" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="251" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="278" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="306" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="333" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="361" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="388" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="415" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="443" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="470" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="498" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="525" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="552" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="580" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="607" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="635" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="1" topLeftX="662" topLeftY="269" rotation="90" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="540" height="960" topLeftX="210" topLeftY="-214" rotation="90" alpha="0.8" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 1) 0%,rgba(0, 0, 0, 0.7) 73%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="129" height="128" topLeftX="415" topLeftY="183" rotation="270" type="ellipse">
+        <border color="rgba(230, 181, 19, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="99" height="99" topLeftX="431" topLeftY="198" rotation="270" type="ellipse">
+        <border color="rgba(82, 104, 220, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="66" height="66" topLeftX="447" topLeftY="214" rotation="270" type="ellipse">
+        <border color="rgba(242, 114, 175, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="36" height="36" topLeftX="462" topLeftY="230" rotation="270" type="ellipse">
+        <border color="rgba(216, 57, 49, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="73" height="139" topLeftX="443" topLeftY="215" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="213" height="68" topLeftX="373" topLeftY="256" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(245, 246, 247, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(245, 246, 247, 1)">谢谢观看</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="213" height="41" topLeftX="374" topLeftY="303" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" textAlign="center">
+          <p>
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">Thank you!</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/misc--student_career_plan.xml
+++ b/skills/lark-slides/references/templates/misc--student_career_plan.xml
@@ -1,0 +1,1854 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>学生职业生涯规划</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="296" height="296" topLeftX="125" topLeftY="122" type="ellipse">
+        <fill>
+          <fillColor color="rgba(248, 206, 56, 1)"/>
+        </fill>
+      </shape>
+      <shape width="259" height="260" topLeftX="-340" topLeftY="140" type="ellipse">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <shape width="130" height="130" topLeftX="-340" topLeftY="270" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <line startX="567" startY="-1" endX="462" endY="122" alpha="0.6">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="552" startY="34" endX="480" endY="118" alpha="0.6">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="468" startY="293" endX="316" endY="471" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="469" startY="312" endX="396" endY="399" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="404" height="68" topLeftX="129" topLeftY="276" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>Career Planning</p>
+        </content>
+        <shadow offset="4" angle="90" blur="20" color="rgba(0, 0, 0, 0.06)"/>
+      </shape>
+      <shape width="668" height="101" topLeftX="129" topLeftY="195" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>大学生职业发展规划</p>
+        </content>
+        <shadow offset="4" angle="90" blur="20" color="rgba(0, 0, 0, 0.06)"/>
+      </shape>
+      <shape width="355" height="44" topLeftX="41" topLeftY="46" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>XX大学学生发展中心</p>
+        </content>
+      </shape>
+      <shape width="130" height="44" topLeftX="41" topLeftY="450" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>主讲人：XXX</p>
+        </content>
+      </shape>
+      <shape width="73" height="44" topLeftX="834" topLeftY="46" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="false" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">LOGO</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="44" height="10" topLeftX="855" topLeftY="462" type="rect">
+        <fill>
+          <fillColor color="rgba(100, 237, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="44" height="10" topLeftX="855" topLeftY="462" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(100, 237, 255, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="546" height="460" topLeftX="376" topLeftY="40" presetHandlers="16" type="rect">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <shape width="72" height="68" topLeftX="456" topLeftY="90" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="284" height="53" topLeftX="517" topLeftY="98" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="22">自我认知</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="284" height="41" topLeftX="517" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(234, 234, 234, 1)" bold="false">
+          <p>
+            <span color="rgba(234, 234, 234, 1)" fontSize="14" bold="false">KNOW YOURSELF</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="68" topLeftX="456" topLeftY="182" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="284" height="53" topLeftX="517" topLeftY="189" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">行业认知</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="284" height="41" topLeftX="517" topLeftY="226" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(234, 234, 234, 1)" bold="false">
+          <p>
+            <span color="rgba(234, 234, 234, 1)" fontSize="14" bold="false">CAREER COGNITION</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="68" topLeftX="456" topLeftY="273" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="284" height="53" topLeftX="517" topLeftY="280" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">职业定位</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="284" height="41" topLeftX="517" topLeftY="317" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(234, 234, 234, 1)" bold="false">
+          <p>
+            <span color="rgba(234, 234, 234, 1)">Career positioning</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="68" topLeftX="456" topLeftY="365" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="284" height="53" topLeftX="517" topLeftY="372" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">实施计划</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="284" height="41" topLeftX="517" topLeftY="409" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(234, 234, 234, 1)" bold="false">
+          <p>
+            <span color="rgba(234, 234, 234, 1)" fontSize="14" bold="false">IMPLEMENT PLAN</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="28" topLeftX="180" topLeftY="147" rotation="30" type="triangle">
+        <border color="rgba(100, 237, 255, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="74" height="74" topLeftX="77" topLeftY="73" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(248, 206, 56, 1) 0%,rgba(248, 206, 56, 1) 23%,rgba(248, 206, 56, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="326" height="71" topLeftX="95" topLeftY="84" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="34" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">目录</span>
+          </p>
+        </content>
+        <shadow offset="4" angle="90" blur="12" color="rgba(0, 0, 0, 0.08)"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="64" height="385" topLeftX="760" topLeftY="324" type="rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <shape width="338" height="419" topLeftX="801" topLeftY="290" type="rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <shape width="262" height="131" topLeftX="404" topLeftY="169" presetHandlers="32" type="round-rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <line startX="83" startY="180" endX="14" endY="263" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="79" startY="198" endX="57" endY="224" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="416" startY="-190" endX="350" endY="-113" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="389" startY="-173" endX="363" endY="-143" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="64" height="432" topLeftX="875" topLeftY="182" type="rect">
+        <fill>
+          <fillColor color="rgba(215, 163, 201, 1)"/>
+        </fill>
+      </shape>
+      <shape width="338" height="466" topLeftX="916" topLeftY="148" type="rect">
+        <fill>
+          <fillColor color="rgba(215, 163, 201, 1)"/>
+        </fill>
+      </shape>
+      <shape width="262" height="131" topLeftX="486" topLeftY="74" presetHandlers="32" type="round-rect">
+        <fill>
+          <fillColor color="rgba(215, 163, 201, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="138" height="125" topLeftX="65" topLeftY="66" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="70" color="rgba(248, 206, 56, 1)" bold="true">
+          <p>01</p>
+        </content>
+      </shape>
+      <shape width="737" height="77" topLeftX="63" topLeftY="372" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="44" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3">
+          <p>自我认知</p>
+        </content>
+      </shape>
+      <shape width="328" height="46" topLeftX="65" topLeftY="436" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="17" color="rgba(145, 144, 168, 1)">
+          <p>KNOW YOURSELF</p>
+        </content>
+      </shape>
+      <img src="UANBb22iFo5JGuxZAO6cQ0LCnOh" width="441" height="412" topLeftX="519" topLeftY="128">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="5" bottomOffset="29" presetHandlers="15"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="55" height="55" topLeftX="46" topLeftY="58" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(248, 206, 56, 1) 0%,rgba(248, 206, 56, 1) 23%,rgba(248, 206, 56, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="167" height="44" topLeftX="755" topLeftY="53" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>LOGO</p>
+        </content>
+      </shape>
+      <shape width="367" height="71" topLeftX="63" topLeftY="61" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="34" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>个人背景</p>
+        </content>
+      </shape>
+      <shape width="885" height="327" topLeftX="38" topLeftY="173" presetHandlers="20" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(21, 20, 87, 1)"/>
+        </fill>
+      </shape>
+      <shape width="154" height="135" topLeftX="148" topLeftY="240" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)">现在就开始打字吧，写下任何你想表达的内容。用简洁明了的语言来传达你的想法，结合图像和图表，让你的观众更好地理解和记住你的演示。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="154" height="44" topLeftX="148" topLeftY="208" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(234, 234, 234, 1)" fontSize="16">专业技能</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="74" height="74" topLeftX="71" topLeftY="210" type="ellipse">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <icon width="42" height="42" topLeftX="87" topLeftY="226" iconType="iconpark/Base/tool.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </icon>
+      <shape width="154" height="135" topLeftX="441" topLeftY="240" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)">现在就开始打字吧，写下任何你想表达的内容。用简洁明了的语言来传达你的想法，结合图像和图表，让你的观众更好地理解和记住你的演示。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="154" height="44" topLeftX="441" topLeftY="208" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>
+            <span fontSize="16">教育背景</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="74" height="74" topLeftX="363" topLeftY="210" type="ellipse">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <icon width="42" height="42" topLeftX="379" topLeftY="226" iconType="iconpark/Office/book-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </icon>
+      <shape width="154" height="135" topLeftX="733" topLeftY="240" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)">现在就开始打字吧，写下任何你想表达的内容。用简洁明了的语言来传达你的想法，结合图像和图表，让你的观众更好地理解和记住你的演示。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="154" height="44" topLeftX="733" topLeftY="208" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>
+            <span fontSize="16">获奖经历</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="74" height="74" topLeftX="656" topLeftY="210" type="ellipse">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <icon width="42" height="42" topLeftX="672" topLeftY="226" iconType="iconpark/Base/config.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </icon>
+      <line startX="333" startY="201" endX="333" endY="472" alpha="0.4">
+        <border color="rgba(222, 224, 227, 0.8)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="625" startY="201" endX="625" endY="472" alpha="0.4">
+        <border color="rgba(222, 224, 227, 0.8)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="JXhjb7HM3oI3RpxUtYcc0EgnnEd" width="202" height="202" topLeftX="273" topLeftY="270">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="VbI1bwroaoADdcxxAK8cbHbVnue" width="202" height="202" topLeftX="475" topLeftY="68">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="185" height="56" topLeftX="290" topLeftY="150" type="rect">
+        <fill>
+          <fillColor color="rgba(100, 237, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="185" height="56" topLeftX="290" topLeftY="150" rotation="270" type="rect">
+        <fill>
+          <fillColor color="rgba(100, 237, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="51" topLeftX="460" topLeftY="342" rotation="315" type="rect">
+        <fill>
+          <fillColor color="rgba(100, 237, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="51" topLeftX="460" topLeftY="342" rotation="225" type="rect">
+        <fill>
+          <fillColor color="rgba(100, 237, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="54" height="54" topLeftX="78" topLeftY="428" type="donut">
+        <fill>
+          <fillColor color="rgba(248, 206, 56, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="28" topLeftX="846" topLeftY="64" rotation="40" type="triangle">
+        <border color="rgba(251, 142, 241, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="200" height="97" topLeftX="68" topLeftY="125" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示。所以，让我们开始吧，展示你的想法和知识吧！</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="116" height="42" topLeftX="68" topLeftY="73" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <shape width="116" height="44" topLeftX="68" topLeftY="73" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>个人性格</p>
+        </content>
+      </shape>
+      <shape width="200" height="97" topLeftX="700" topLeftY="382" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示。所以，让我们开始吧，展示你的想法和知识吧！</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="116" height="42" topLeftX="700" topLeftY="331" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <shape width="116" height="44" topLeftX="700" topLeftY="330" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>职业性格</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="64" height="385" topLeftX="760" topLeftY="324" type="rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <shape width="338" height="419" topLeftX="801" topLeftY="290" type="rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <shape width="262" height="131" topLeftX="404" topLeftY="169" presetHandlers="32" type="round-rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <line startX="83" startY="180" endX="14" endY="263" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="79" startY="198" endX="57" endY="224" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="416" startY="-190" endX="350" endY="-113" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="389" startY="-173" endX="363" endY="-143" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="64" height="432" topLeftX="875" topLeftY="182" type="rect">
+        <fill>
+          <fillColor color="rgba(251, 202, 227, 1)"/>
+        </fill>
+      </shape>
+      <shape width="338" height="466" topLeftX="916" topLeftY="148" type="rect">
+        <fill>
+          <fillColor color="rgba(251, 202, 227, 1)"/>
+        </fill>
+      </shape>
+      <shape width="262" height="131" topLeftX="486" topLeftY="74" presetHandlers="32" type="round-rect">
+        <fill>
+          <fillColor color="rgba(251, 202, 227, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="R6RabwEXIonZtUxf9U1c2s4qnVg" width="474" height="438" topLeftX="486" topLeftY="102">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="18" bottomOffset="18" presetHandlers="2"/>
+      </img>
+      <shape width="138" height="125" topLeftX="65" topLeftY="66" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="70" color="rgba(248, 206, 56, 1)" bold="true">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="737" height="77" topLeftX="63" topLeftY="372" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="44" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3">
+          <p>行业认知</p>
+        </content>
+      </shape>
+      <shape width="328" height="46" topLeftX="65" topLeftY="436" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="17" color="rgba(145, 144, 168, 1)">
+          <p>CAREER COGNITION</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="55" height="55" topLeftX="46" topLeftY="58" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(248, 206, 56, 1) 0%,rgba(248, 206, 56, 1) 23%,rgba(248, 206, 56, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="367" height="71" topLeftX="63" topLeftY="61" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="34" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>职业价值观</p>
+        </content>
+      </shape>
+      <shape width="452" height="115" topLeftX="446" topLeftY="365" presetHandlers="20" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(21, 20, 87, 1)"/>
+        </fill>
+      </shape>
+      <shape width="332" height="58" topLeftX="552" topLeftY="412" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)" fontSize="12">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="332" height="50" topLeftX="552" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>享受型</p>
+        </content>
+      </shape>
+      <shape width="80" height="80" topLeftX="460" topLeftY="382" type="ellipse">
+        <fill>
+          <fillColor color="rgba(66, 59, 152, 1)"/>
+        </fill>
+      </shape>
+      <icon width="42" height="42" topLeftX="479" topLeftY="401" iconType="iconpark/Game/game-handle.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </icon>
+      <shape width="452" height="115" topLeftX="446" topLeftY="73" presetHandlers="20" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(21, 20, 87, 1)"/>
+        </fill>
+      </shape>
+      <shape width="332" height="58" topLeftX="552" topLeftY="120" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)" fontSize="12">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="332" height="50" topLeftX="552" topLeftY="82" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>志愿型</p>
+        </content>
+      </shape>
+      <shape width="80" height="80" topLeftX="460" topLeftY="90" type="ellipse">
+        <fill>
+          <fillColor color="rgba(66, 59, 152, 1)"/>
+        </fill>
+      </shape>
+      <icon width="42" height="42" topLeftX="479" topLeftY="109" iconType="iconpark/Base/tips.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </icon>
+      <shape width="452" height="115" topLeftX="446" topLeftY="219" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <shape width="332" height="58" topLeftX="552" topLeftY="266" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="332" height="50" topLeftX="552" topLeftY="228" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">自由型</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="80" topLeftX="461" topLeftY="236" alpha="0.4" type="ellipse">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <icon width="42" height="42" topLeftX="480" topLeftY="255" iconType="iconpark/Others/magic.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </icon>
+      <shape width="6" height="6" topLeftX="146" topLeftY="434" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="165" topLeftY="434" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="127" topLeftY="434" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="108" topLeftY="434" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="89" topLeftY="434" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="71" topLeftY="434" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="71" topLeftY="454" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="71" topLeftY="473" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="89" topLeftY="454" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="89" topLeftY="473" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="108" topLeftY="454" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="108" topLeftY="473" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="127" topLeftY="454" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="127" topLeftY="473" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="165" topLeftY="454" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="165" topLeftY="473" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="146" topLeftY="454" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="146" topLeftY="473" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="55" height="55" topLeftX="46" topLeftY="58" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(248, 206, 56, 1) 0%,rgba(248, 206, 56, 1) 23%,rgba(248, 206, 56, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="167" height="44" topLeftX="755" topLeftY="53" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>LOGO</p>
+        </content>
+      </shape>
+      <shape width="367" height="71" topLeftX="63" topLeftY="61" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="34" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>环境分析</p>
+        </content>
+      </shape>
+      <shape width="404" height="115" topLeftX="63" topLeftY="362" presetHandlers="16" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(21, 20, 87, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="81" topLeftX="73" topLeftY="379" presetHandlers="3" type="rect">
+        <fill>
+          <fillColor color="rgba(100, 237, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="370" height="58" topLeftX="83" topLeftY="409" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)" fontSize="12">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="370" height="50" topLeftX="83" topLeftY="371" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>社会环境</p>
+        </content>
+      </shape>
+      <shape width="404" height="115" topLeftX="493" topLeftY="362" presetHandlers="16" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(21, 20, 87, 1)"/>
+        </fill>
+      </shape>
+      <shape width="370" height="58" topLeftX="513" topLeftY="409" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)" fontSize="12">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="370" height="50" topLeftX="513" topLeftY="371" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>职业环境</p>
+        </content>
+      </shape>
+      <shape width="6" height="81" topLeftX="503" topLeftY="379" presetHandlers="3" type="rect">
+        <fill>
+          <fillColor color="rgba(100, 237, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="404" height="115" topLeftX="63" topLeftY="217" presetHandlers="16" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(21, 20, 87, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="81" topLeftX="73" topLeftY="234" presetHandlers="3" type="rect">
+        <fill>
+          <fillColor color="rgba(100, 237, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="370" height="58" topLeftX="83" topLeftY="264" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)" fontSize="12">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="370" height="50" topLeftX="83" topLeftY="226" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>家庭环境</p>
+        </content>
+      </shape>
+      <shape width="404" height="115" topLeftX="493" topLeftY="217" presetHandlers="16" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(21, 20, 87, 1)"/>
+        </fill>
+      </shape>
+      <shape width="370" height="58" topLeftX="513" topLeftY="264" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)" fontSize="12">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="370" height="50" topLeftX="513" topLeftY="226" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>学校环境</p>
+        </content>
+      </shape>
+      <shape width="6" height="81" topLeftX="503" topLeftY="234" presetHandlers="3" type="rect">
+        <fill>
+          <fillColor color="rgba(100, 237, 255, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="64" height="385" topLeftX="760" topLeftY="324" type="rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <shape width="338" height="419" topLeftX="801" topLeftY="290" type="rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <shape width="262" height="131" topLeftX="404" topLeftY="169" presetHandlers="32" type="round-rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <line startX="83" startY="180" endX="14" endY="263" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="79" startY="198" endX="57" endY="224" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="416" startY="-190" endX="350" endY="-113" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="389" startY="-173" endX="363" endY="-143" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="64" height="432" topLeftX="875" topLeftY="182" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 187, 233, 1)"/>
+        </fill>
+      </shape>
+      <shape width="338" height="466" topLeftX="916" topLeftY="148" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 187, 233, 1)"/>
+        </fill>
+      </shape>
+      <shape width="262" height="131" topLeftX="486" topLeftY="74" presetHandlers="32" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 187, 233, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="APzubfYrBoCiqZxaqpxcZ6hnnXk" width="474" height="438" topLeftX="486" topLeftY="102" exposure="9" contrast="4" saturation="4" temperature="-11">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="18" bottomOffset="18" presetHandlers="2"/>
+      </img>
+      <shape width="138" height="125" topLeftX="65" topLeftY="66" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="70" color="rgba(248, 206, 56, 1)" bold="true">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="737" height="77" topLeftX="63" topLeftY="372" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="44" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3">
+          <p>职业定位</p>
+        </content>
+      </shape>
+      <shape width="328" height="46" topLeftX="65" topLeftY="436" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="17" color="rgba(145, 144, 168, 1)">
+          <p>Career positioning</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="55" height="55" topLeftX="46" topLeftY="58" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(248, 206, 56, 1) 0%,rgba(248, 206, 56, 1) 23%,rgba(248, 206, 56, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="167" height="44" topLeftX="755" topLeftY="53" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>LOGO</p>
+        </content>
+      </shape>
+      <shape width="367" height="71" topLeftX="63" topLeftY="61" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="34" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>优劣势分析</p>
+        </content>
+      </shape>
+      <shape width="404" height="295" topLeftX="63" topLeftY="182" presetHandlers="16" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(21, 20, 87, 1)"/>
+        </fill>
+      </shape>
+      <shape width="341" height="78" topLeftX="94" topLeftY="270" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">在这个幻灯片中，你可以描述相关的信息以解释你的标题。无论是介绍一个产品、提供数据分析、讲解一个概念，还是分享一段故事，都可以通过这个占位符来开始</p>
+        </content>
+      </shape>
+      <shape width="116" height="42" topLeftX="88" topLeftY="203" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <shape width="116" height="44" topLeftX="88" topLeftY="202" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">优势分析</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="295" topLeftX="494" topLeftY="182" presetHandlers="16" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(21, 20, 87, 1)"/>
+        </fill>
+      </shape>
+      <shape width="341" height="78" topLeftX="525" topLeftY="270" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">在这个幻灯片中，你可以描述相关的信息以解释你的标题。无论是介绍一个产品、提供数据分析、讲解一个概念，还是分享一段故事，都可以通过这个占位符来开始</p>
+        </content>
+      </shape>
+      <shape width="116" height="42" topLeftX="519" topLeftY="203" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <shape width="116" height="44" topLeftX="519" topLeftY="202" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>劣势分析</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="55" height="55" topLeftX="46" topLeftY="58" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(248, 206, 56, 1) 0%,rgba(248, 206, 56, 1) 23%,rgba(248, 206, 56, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="167" height="44" topLeftX="755" topLeftY="53" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>LOGO</p>
+        </content>
+      </shape>
+      <shape width="367" height="71" topLeftX="63" topLeftY="61" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="34" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>职业发展方向</p>
+        </content>
+      </shape>
+      <shape width="164" height="164" topLeftX="398" topLeftY="236" type="ellipse">
+        <border color="rgba(251, 142, 241, 1)" width="60" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="363" startY="318" endX="597" endY="318">
+        <border color="rgba(44, 41, 100, 1)" width="8" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="201" endX="480" endY="434">
+        <border color="rgba(44, 41, 100, 1)" width="8" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="80" height="80" topLeftX="362" topLeftY="202" type="ellipse">
+        <fill>
+          <fillColor color="rgba(70, 218, 238, 1)"/>
+        </fill>
+        <shadow offset="10" angle="90" blur="25" color="rgba(0, 0, 0, 0.15)"/>
+      </shape>
+      <icon width="42" height="42" topLeftX="381" topLeftY="221" iconType="iconpark/Abstract/six-points.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </icon>
+      <shape width="80" height="80" topLeftX="362" topLeftY="343" type="ellipse">
+        <fill>
+          <fillColor color="rgba(70, 218, 238, 1)"/>
+        </fill>
+        <shadow offset="10" angle="90" blur="25" color="rgba(0, 0, 0, 0.15)"/>
+      </shape>
+      <icon width="42" height="42" topLeftX="381" topLeftY="362" iconType="iconpark/Abstract/circle-three.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </icon>
+      <shape width="80" height="80" topLeftX="517" topLeftY="202" type="ellipse">
+        <fill>
+          <fillColor color="rgba(70, 218, 238, 1)"/>
+        </fill>
+        <shadow offset="10" angle="90" blur="25" color="rgba(0, 0, 0, 0.15)"/>
+      </shape>
+      <icon width="42" height="42" topLeftX="536" topLeftY="221" iconType="iconpark/Abstract/sales-report.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </icon>
+      <shape width="80" height="80" topLeftX="517" topLeftY="343" type="ellipse">
+        <fill>
+          <fillColor color="rgba(70, 218, 238, 1)"/>
+        </fill>
+        <shadow offset="10" angle="90" blur="25" color="rgba(0, 0, 0, 0.15)"/>
+      </shape>
+      <icon width="42" height="42" topLeftX="536" topLeftY="362" iconType="iconpark/Abstract/stereo-nesting.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90"/>
+      </icon>
+      <shape width="287" height="58" topLeftX="611" topLeftY="239" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)" fontSize="12">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="287" height="50" topLeftX="611" topLeftY="201" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>发展方向二</p>
+        </content>
+      </shape>
+      <shape width="287" height="58" topLeftX="611" topLeftY="381" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)" fontSize="12">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="287" height="50" topLeftX="611" topLeftY="343" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>发展方向四</p>
+        </content>
+      </shape>
+      <shape width="287" height="58" topLeftX="63" topLeftY="239" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)" fontSize="12">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="287" height="50" topLeftX="63" topLeftY="201" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>发展方向一</p>
+        </content>
+      </shape>
+      <shape width="287" height="58" topLeftX="63" topLeftY="381" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)" fontSize="12">通过精心设计的幻灯片模板，你可以制作出引人注目且具有影响力的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="287" height="50" topLeftX="63" topLeftY="343" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(234, 234, 234, 1)" bold="true">
+          <p>发展方向三</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="64" height="385" topLeftX="760" topLeftY="324" type="rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <shape width="338" height="419" topLeftX="801" topLeftY="290" type="rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <shape width="262" height="131" topLeftX="404" topLeftY="169" presetHandlers="32" type="round-rect">
+        <fill>
+          <fillColor color="rgba(208, 50, 193, 1)"/>
+        </fill>
+      </shape>
+      <line startX="83" startY="180" endX="14" endY="263" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="79" startY="198" endX="57" endY="224" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="416" startY="-190" endX="350" endY="-113" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="389" startY="-173" endX="363" endY="-143" alpha="0.5">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="64" height="432" topLeftX="875" topLeftY="182" type="rect">
+        <fill>
+          <fillColor color="rgba(249, 190, 213, 1)"/>
+        </fill>
+      </shape>
+      <shape width="338" height="466" topLeftX="916" topLeftY="148" type="rect">
+        <fill>
+          <fillColor color="rgba(249, 190, 213, 1)"/>
+        </fill>
+      </shape>
+      <shape width="262" height="131" topLeftX="486" topLeftY="74" presetHandlers="32" type="round-rect">
+        <fill>
+          <fillColor color="rgba(249, 190, 213, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-132" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="520" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="539" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="557" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="576" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="614" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-113" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="6" height="6" topLeftX="595" topLeftY="-93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="U07qbNriwojg4wxvawdce2vJnqh" width="286" height="343" topLeftX="596" topLeftY="154">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="138" height="125" topLeftX="65" topLeftY="66" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="70" color="rgba(248, 206, 56, 1)" bold="true">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="737" height="77" topLeftX="63" topLeftY="372" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="44" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3">
+          <p>实施计划</p>
+        </content>
+      </shape>
+      <shape width="328" height="46" topLeftX="65" topLeftY="436" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="17" color="rgba(145, 144, 168, 1)">
+          <p>CAREER DECISION-DECISION-MAKING</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="55" height="55" topLeftX="46" topLeftY="58" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(248, 206, 56, 1) 0%,rgba(248, 206, 56, 1) 23%,rgba(248, 206, 56, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="167" height="44" topLeftX="755" topLeftY="53" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>LOGO</p>
+        </content>
+      </shape>
+      <shape width="367" height="71" topLeftX="63" topLeftY="61" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="34" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>计划周期一览</p>
+        </content>
+      </shape>
+      <shape width="249" height="78" topLeftX="63" topLeftY="402" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)">用简洁明了的语言来传达你的想法，结合图像和图表，让你的观众更好地理解和记住你的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="835" height="29" topLeftX="63" topLeftY="357" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(21, 20, 87, 1)"/>
+        </fill>
+      </shape>
+      <shape width="29" height="29" topLeftX="386" topLeftY="357" type="ellipse">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <shape width="29" height="29" topLeftX="63" topLeftY="357" type="ellipse">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <shape width="324" height="29" topLeftX="77" topLeftY="357" type="rect">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <shape width="29" height="29" topLeftX="627" topLeftY="357" type="ellipse">
+        <fill>
+          <fillColor color="rgba(248, 206, 56, 1)"/>
+        </fill>
+      </shape>
+      <shape width="29" height="29" topLeftX="304" topLeftY="357" type="ellipse">
+        <fill>
+          <fillColor color="rgba(248, 206, 56, 1)"/>
+        </fill>
+      </shape>
+      <shape width="324" height="29" topLeftX="318" topLeftY="357" type="rect">
+        <fill>
+          <fillColor color="rgba(248, 206, 56, 1)"/>
+        </fill>
+      </shape>
+      <shape width="29" height="29" topLeftX="869" topLeftY="357" type="ellipse">
+        <fill>
+          <fillColor color="rgba(70, 218, 238, 1)"/>
+        </fill>
+      </shape>
+      <shape width="29" height="29" topLeftX="578" topLeftY="357" type="ellipse">
+        <fill>
+          <fillColor color="rgba(70, 218, 238, 1)"/>
+        </fill>
+      </shape>
+      <shape width="294" height="29" topLeftX="589" topLeftY="357" type="rect">
+        <fill>
+          <fillColor color="rgba(70, 218, 238, 1)"/>
+        </fill>
+      </shape>
+      <shape width="50" height="50" topLeftX="847" topLeftY="346" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 248, 254, 1)"/>
+        </fill>
+        <border color="rgba(70, 218, 238, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="25" height="25" topLeftX="860" topLeftY="359" iconType="iconpark/Base/radar.svg">
+        <border color="rgba(70, 218, 238, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="50" height="50" topLeftX="288" topLeftY="346" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 248, 254, 1)"/>
+        </fill>
+        <border color="rgba(251, 142, 241, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="25" height="25" topLeftX="300" topLeftY="359" iconType="iconpark/Base/aiming.svg">
+        <border color="rgba(251, 142, 241, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="50" height="50" topLeftX="567" topLeftY="346" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 248, 254, 1)"/>
+        </fill>
+        <border color="rgba(248, 206, 56, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="25" height="25" topLeftX="580" topLeftY="359" iconType="iconpark/Charts/chart-ring.svg">
+        <border color="rgba(248, 206, 56, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="187" height="41" topLeftX="90" topLeftY="349" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">短期目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="187" height="41" topLeftX="356" topLeftY="349" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">中期目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="187" height="41" topLeftX="643" topLeftY="349" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">长期目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="249" height="78" topLeftX="336" topLeftY="402" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)">用简洁明了的语言来传达你的想法，结合图像和图表，让你的观众更好地理解和记住你的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="249" height="78" topLeftX="612" topLeftY="402" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)">用简洁明了的语言来传达你的想法，结合图像和图表，让你的观众更好地理解和记住你的演示</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="525" height="58" topLeftX="63" topLeftY="140" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">在这个幻灯片中，你可以描述相关的信息以解释你的标题。无论是介绍一个产品、提供数据分析、讲解一个概念，还是分享一段故事，都可以通过这个占位符来开始</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="55" height="55" topLeftX="46" topLeftY="58" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(248, 206, 56, 1) 0%,rgba(248, 206, 56, 1) 23%,rgba(248, 206, 56, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="167" height="44" topLeftX="755" topLeftY="53" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>LOGO</p>
+        </content>
+      </shape>
+      <shape width="367" height="71" topLeftX="63" topLeftY="61" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="34" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>效果评估</p>
+        </content>
+      </shape>
+      <shape width="467" height="340" topLeftX="432" topLeftY="143" type="triangle">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <line startX="579" startY="260" endX="750" endY="260">
+        <border color="rgba(44, 41, 100, 1)" width="8" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="497" startY="372" endX="833" endY="372">
+        <border color="rgba(44, 41, 100, 1)" width="8" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="116" height="44" topLeftX="607" topLeftY="187" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">长期目标</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="116" height="44" topLeftX="607" topLeftY="297" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">中期目标</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="116" height="44" topLeftX="607" topLeftY="406" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">短期目标</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="602" startY="206" endX="382" endY="206" alpha="0.4">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="315" height="58" topLeftX="63" topLeftY="187" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)">无论是介绍一个产品、提供数据分析、讲解一个概念，还是分享一段故事，都可以通过这个占位符来开始</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="523" startY="318" endX="335" endY="318" alpha="0.4">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="257" height="78" topLeftX="63" topLeftY="279" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)">无论是介绍一个产品、提供数据分析、讲解一个概念，还是分享一段故事，都可以通过这个占位符来开始</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="446" startY="427" endX="293" endY="427" alpha="0.4">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="220" height="78" topLeftX="63" topLeftY="388" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(222, 224, 227, 0.8)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(222, 224, 227, 0.8)">无论是介绍一个产品、提供数据分析、讲解一个概念，还是分享一段故事，都可以通过这个占位符来开始</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(44, 41, 100, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="296" height="296" topLeftX="332" topLeftY="122" type="ellipse">
+        <fill>
+          <fillColor color="rgba(248, 206, 56, 1)"/>
+        </fill>
+      </shape>
+      <shape width="149" height="149" topLeftX="332" topLeftY="269" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(248, 206, 56, 1)"/>
+        </fill>
+      </shape>
+      <shape width="247" height="247" topLeftX="356" topLeftY="146" type="ellipse">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+      <shape width="525" height="101" topLeftX="218" topLeftY="202" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">谢谢!</span>
+          </p>
+        </content>
+        <shadow offset="4" angle="90" blur="12" color="rgba(0, 0, 0, 0.08)"/>
+      </shape>
+      <shape width="525" height="44" topLeftX="218" topLeftY="283" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">副标题信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="28" topLeftX="637" topLeftY="158" rotation="30" type="triangle">
+        <border color="rgba(100, 237, 255, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="42" height="42" topLeftX="263" topLeftY="347" type="donut">
+        <fill>
+          <fillColor color="rgba(251, 142, 241, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/office--dark_general.xml
+++ b/skills/lark-slides/references/templates/office--dark_general.xml
@@ -1,0 +1,3763 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>黑底通用模板</title>
+  <theme>
+    <background>
+      <fillColor color="rgba(31, 35, 41, 1)"/>
+    </background>
+    <textStyles>
+      <title fontColor="#000000FF"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="668" height="36" topLeftX="100" topLeftY="293" type="text">
+        <content textType="headline" fontSize="24" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>通用模板副标题</p>
+        </content>
+      </shape>
+      <shape width="668" height="66" topLeftX="100" topLeftY="229" type="text">
+        <content textType="headline" fontSize="44" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>通用模板</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="818" height="24" topLeftX="70" topLeftY="448" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>通用模板副标题</p>
+        </content>
+      </shape>
+      <shape width="818" height="48" topLeftX="70" topLeftY="397" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>通用模板</p>
+        </content>
+      </shape>
+      <shape width="818" height="21" topLeftX="70" topLeftY="98" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>日期：2026</p>
+        </content>
+      </shape>
+      <shape width="818" height="21" topLeftX="70" topLeftY="73" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>作者：XXX</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="200" height="260" topLeftX="41" topLeftY="181" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="200" height="260" topLeftX="267" topLeftY="181" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="200" height="260" topLeftX="493" topLeftY="181" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="200" height="260" topLeftX="719" topLeftY="181" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="164" height="48" topLeftX="59" topLeftY="215" type="text">
+        <content fontSize="32" fontFamily="Arial Black" color="rgba(78, 110, 253, 1)" italic="true">
+          <p>
+            <em>
+              <span color="rgba(78, 110, 253, 1)" fontSize="32" fontFamily="Arial Black">01.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="164" height="48" topLeftX="285" topLeftY="215" type="text">
+        <content fontSize="32" fontFamily="Arial Black" color="rgba(78, 110, 253, 1)" italic="true">
+          <p>
+            <em>
+              <span color="rgba(78, 110, 253, 1)" fontSize="32" fontFamily="Arial Black">02.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="164" height="48" topLeftX="511" topLeftY="215" type="text">
+        <content fontSize="32" fontFamily="Arial Black" color="rgba(78, 110, 253, 1)" italic="true">
+          <p>
+            <em>
+              <span color="rgba(78, 110, 253, 1)" fontSize="32" fontFamily="Arial Black">03.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="164" height="48" topLeftX="737" topLeftY="215" type="text">
+        <content fontSize="32" fontFamily="Arial Black" color="rgba(78, 110, 253, 1)" italic="true">
+          <p>
+            <em>
+              <span color="rgba(78, 110, 253, 1)" fontSize="32" fontFamily="Arial Black">04.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="164" height="105" topLeftX="737" topLeftY="311" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="164" height="24" topLeftX="737" topLeftY="278" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="164" height="105" topLeftX="511" topLeftY="311" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="164" height="24" topLeftX="511" topLeftY="278" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="164" height="105" topLeftX="285" topLeftY="311" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="164" height="24" topLeftX="285" topLeftY="278" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="164" height="105" topLeftX="59" topLeftY="311" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="164" height="24" topLeftX="59" topLeftY="278" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="818" height="48" topLeftX="70" topLeftY="88" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>目录</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="40" height="40" topLeftX="100" topLeftY="198" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16" fontFamily="Arial">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="505" topLeftY="198" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontFamily="Arial">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="100" topLeftY="287" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16" fontFamily="Arial">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="505" topLeftY="287" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontFamily="Arial">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="100" topLeftY="375" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16" fontFamily="Arial">05</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="505" topLeftY="375" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontFamily="Arial">06</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="155" topLeftY="382" type="text">
+        <content fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="155" topLeftY="293" type="text">
+        <content fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="560" topLeftY="382" type="text">
+        <content fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="560" topLeftY="293" type="text">
+        <content fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="560" topLeftY="205" type="text">
+        <content fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="155" topLeftY="205" type="text">
+        <content fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="760" height="48" topLeftX="100" topLeftY="108" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>目录</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="YarQbf2AvoVflHx9iYDcBA6Sn2f" width="450" height="540" topLeftX="510" topLeftY="0">
+        <crop type="rect" leftOffset="257" rightOffset="257" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="376" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>目录</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="411" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>06</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="411" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="358" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>05</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="358" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="306" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="306" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="253" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="253" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="201" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="201" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="149" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>01</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="149" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="480" startY="98" endX="890" endY="98" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="127" endX="890" endY="127" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="156" endX="890" endY="156" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="203" endX="890" endY="203" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="232" endX="890" endY="232" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="261" endX="890" endY="261" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="308" endX="890" endY="308" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="337" endX="890" endY="337" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="366" endX="890" endY="366" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="413" endX="890" endY="413" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="442" endX="890" endY="442" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="471" endX="890" endY="471" alpha="0.4">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="24" height="18" topLeftX="865" topLeftY="448" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(208, 211, 214, 1)" bold="false" textAlign="right">
+          <p>32</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="419" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(208, 211, 214, 1)" bold="false" textAlign="right">
+          <p>30</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="385" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>29</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="448" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="419" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="21" topLeftX="480" topLeftY="385" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="343" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(208, 211, 214, 1)" bold="false" textAlign="right">
+          <p>27</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="314" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(208, 211, 214, 1)" bold="false" textAlign="right">
+          <p>23</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="280" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>22</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="343" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="314" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="21" topLeftX="480" topLeftY="280" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="238" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(208, 211, 214, 1)" bold="false" textAlign="right">
+          <p>20</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="209" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(208, 211, 214, 1)" bold="false" textAlign="right">
+          <p>15</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="175" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>14</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="238" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="209" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="21" topLeftX="480" topLeftY="175" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="133" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(208, 211, 214, 1)" bold="false" textAlign="right">
+          <p>08</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="104" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(208, 211, 214, 1)" bold="false" textAlign="right">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="70" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="133" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="104" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="21" topLeftX="480" topLeftY="70" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="400" height="32" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p lineSpacing="multiple:1">目录</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="760" height="66" topLeftX="100" topLeftY="237" type="text">
+        <content textType="title" fontSize="44" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">通用模板标题</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="760" height="36" topLeftX="100" topLeftY="287" type="text">
+        <content textType="caption" fontSize="24" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>通用模板标题</p>
+        </content>
+      </shape>
+      <shape width="760" height="66" topLeftX="100" topLeftY="217" type="text">
+        <content textType="caption" fontSize="44" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>通用模板标题</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="760" height="72" topLeftX="100" topLeftY="352" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="760" height="72" topLeftX="100" topLeftY="262" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="760" height="54" topLeftX="100" topLeftY="190" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="760" height="48" topLeftX="100" topLeftY="100" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="390" height="90" topLeftX="500" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="30" topLeftX="500" topLeftY="240" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="390" height="30" topLeftX="70" topLeftY="240" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="390" height="90" topLeftX="70" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="760" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="240" height="30" topLeftX="360" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="240" height="90" topLeftX="360" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="650" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="240" height="90" topLeftX="650" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="70" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="240" height="90" topLeftX="70" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="180" height="30" topLeftX="497" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="180" height="90" topLeftX="497" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="180" height="30" topLeftX="283" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="180" height="90" topLeftX="283" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="180" height="30" topLeftX="710" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="180" height="90" topLeftX="710" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="180" height="30" topLeftX="70" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="180" height="90" topLeftX="70" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="360" topLeftY="320" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题五</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="360" topLeftY="360" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="650" topLeftY="320" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题六</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="650" topLeftY="360" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="70" topLeftY="320" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="70" topLeftY="360" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="650" topLeftY="169" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="650" topLeftY="210" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="360" topLeftY="169" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="360" topLeftY="210" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="70" topLeftY="168" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="70" topLeftY="210" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="470" height="30" topLeftX="420" topLeftY="350" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="470" height="54" topLeftX="420" topLeftY="393" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="470" height="30" topLeftX="420" topLeftY="227" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="470" height="54" topLeftX="420" topLeftY="270" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="470" height="30" topLeftX="420" topLeftY="104" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="470" height="54" topLeftX="420" topLeftY="147" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="300" height="48" topLeftX="70" topLeftY="246" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <icon width="32" height="32" topLeftX="337" topLeftY="102" iconType="iconpark/Base/camera.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="32" height="32" topLeftX="631" topLeftY="102" iconType="iconpark/Office/agreement.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="32" height="32" topLeftX="337" topLeftY="293" iconType="iconpark/Office/schedule.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="32" height="32" topLeftX="631" topLeftY="293" iconType="iconpark/Clothes/clothes-sweater.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="260" height="24" topLeftX="631" topLeftY="339" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="260" height="72" topLeftX="631" topLeftY="373" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="260" height="24" topLeftX="337" topLeftY="339" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="260" height="72" topLeftX="337" topLeftY="373" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="260" height="24" topLeftX="631" topLeftY="146" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="260" height="72" topLeftX="631" topLeftY="180" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="260" height="24" topLeftX="337" topLeftY="146" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="260" height="72" topLeftX="337" topLeftY="180" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="233" height="48" topLeftX="70" topLeftY="246" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="32" height="32" topLeftX="70" topLeftY="173" presetHandlers="4" type="round-rect">
+        <border color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" italic="false">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="Arial" italic="false">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="32" topLeftX="500" topLeftY="173" presetHandlers="4" type="round-rect">
+        <border color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" italic="false">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="Arial" italic="false">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="32" topLeftX="70" topLeftY="324" presetHandlers="4" type="round-rect">
+        <border color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" italic="false">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="Arial" italic="false">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="32" topLeftX="500" topLeftY="324" presetHandlers="4" type="round-rect">
+        <border color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" italic="false">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="Arial" italic="false">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="500" topLeftY="372" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="390" height="36" topLeftX="500" topLeftY="406" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="70" topLeftY="372" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="390" height="36" topLeftX="70" topLeftY="406" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="500" topLeftY="221" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="390" height="36" topLeftX="500" topLeftY="255" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="70" topLeftY="221" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="390" height="36" topLeftX="70" topLeftY="255" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="46" height="46" topLeftX="70" topLeftY="176" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="187" iconType="iconpark/Emoji/winking-face-with-open-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="176" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="187" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="70" topLeftY="322" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="333" iconType="iconpark/Emoji/smiling-face-with-squinting-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="322" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="333" iconType="iconpark/Emoji/grinning-face-with-tightly-closed-eyes-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="330" height="24" topLeftX="560" topLeftY="322" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="560" topLeftY="356" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="131" topLeftY="322" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="131" topLeftY="356" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="560" topLeftY="176" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="560" topLeftY="210" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="131" topLeftY="176" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="131" topLeftY="210" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="70" topLeftY="176" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="187" iconType="iconpark/Emoji/winking-face-with-open-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="176" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="187" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="70" topLeftY="322" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="333" iconType="iconpark/Emoji/smiling-face-with-squinting-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="322" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="333" iconType="iconpark/Emoji/grinning-face-with-tightly-closed-eyes-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="253" height="323" topLeftX="70" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="46" height="46" topLeftX="92" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="103" topLeftY="183" iconType="iconpark/Emoji/winking-face-with-open-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="253" height="323" topLeftX="353" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="46" height="46" topLeftX="375" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="386" topLeftY="183" iconType="iconpark/Emoji/smiling-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="253" height="323" topLeftX="637" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="46" height="46" topLeftX="659" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="670" topLeftY="183" iconType="iconpark/Emoji/distraught-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="210" height="24" topLeftX="659" topLeftY="247" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="210" height="144" topLeftX="659" topLeftY="281" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" lineSpacing="multiple:2" textAlign="left">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="375" topLeftY="247" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="210" height="144" topLeftX="375" topLeftY="281" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" lineSpacing="multiple:2" textAlign="left">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="91" topLeftY="247" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="210" height="144" topLeftX="91" topLeftY="281" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" lineSpacing="multiple:2" textAlign="left">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="92" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="103" topLeftY="183" iconType="iconpark/Emoji/winking-face-with-open-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="375" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="386" topLeftY="183" iconType="iconpark/Emoji/smiling-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="659" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="670" topLeftY="183" iconType="iconpark/Emoji/distraught-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="253" height="140" topLeftX="70" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="253" height="140" topLeftX="353" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="253" height="140" topLeftX="637" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="253" height="140" topLeftX="70" topLeftY="316" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="253" height="140" topLeftX="353" topLeftY="316" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="253" height="140" topLeftX="637" topLeftY="316" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(51, 51, 51, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="210" height="24" topLeftX="659" topLeftY="342" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题六</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="659" topLeftY="376" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="375" topLeftY="342" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题五</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="375" topLeftY="376" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="92" topLeftY="342" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="92" topLeftY="376" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="659" topLeftY="173" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="659" topLeftY="207" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="375" topLeftY="173" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="375" topLeftY="207" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="92" topLeftY="173" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="92" topLeftY="207" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="LtgrbELgNo0hlWxYYQFcEL9YnHg" width="961" height="395" topLeftX="0" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="72" bottomOffset="72"/>
+      </img>
+      <shape width="820" height="30" topLeftX="70" topLeftY="477" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>副标题</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="426" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KrmdbCCMPoc48mxrs9KcKxZrnIe" width="820" height="308" topLeftX="70" topLeftY="162">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="76" bottomOffset="76" presetHandlers="12"/>
+      </img>
+      <shape width="606" height="63" topLeftX="284" topLeftY="70" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="200" height="48" topLeftX="70" topLeftY="78" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KkEbbx8m2opiscxfQphcYYGrnVd" width="427" height="540" topLeftX="533" topLeftY="0">
+        <crop type="rect" leftOffset="268" rightOffset="268" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="390" height="72" topLeftX="70" topLeftY="395" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="36" topLeftX="70" topLeftY="339" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="72" topLeftX="70" topLeftY="247" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="30" topLeftX="70" topLeftY="122" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>副标题</p>
+        </content>
+      </shape>
+      <shape width="390" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PJjVblf6co4PRdxOtXmcPrwvnaf" width="360" height="400" topLeftX="530" topLeftY="70">
+        <crop type="rect" leftOffset="177" rightOffset="177" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="390" height="30" topLeftX="70" topLeftY="213" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题</p>
+        </content>
+      </shape>
+      <shape width="390" height="72" topLeftX="70" topLeftY="255" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="46" height="46" topLeftX="499" topLeftY="145" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="156" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="266" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="277" iconType="iconpark/Emoji/grinning-face-with-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="386" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="397" iconType="iconpark/Emoji/grinning-face-with-tightly-closed-eyes-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="UhIJbYObdovSqax9NStcKnSKnOh" width="427" height="540" topLeftX="0" topLeftY="0">
+        <crop type="rect" leftOffset="268" rightOffset="268" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="330" height="24" topLeftX="560" topLeftY="386" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="560" topLeftY="420" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="560" topLeftY="265" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="560" topLeftY="299" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="560" topLeftY="145" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="560" topLeftY="179" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="48" topLeftX="500" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="499" topLeftY="145" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="156" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="266" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="277" iconType="iconpark/Emoji/grinning-face-with-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="386" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="397" iconType="iconpark/Emoji/grinning-face-with-tightly-closed-eyes-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="46" height="46" topLeftX="70" topLeftY="145" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="70" topLeftY="228" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="70" topLeftY="311" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">03</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="70" topLeftY="394" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">04</span>
+          </p>
+        </content>
+      </shape>
+      <img src="AJqcbMYzJoOIrGxDMIpcgOdlnZg" width="360" height="400" topLeftX="530" topLeftY="70">
+        <crop type="rect" leftOffset="177" rightOffset="177" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="340" height="54" topLeftX="131" topLeftY="394" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="340" height="54" topLeftX="131" topLeftY="311" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="340" height="54" topLeftX="131" topLeftY="228" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="340" height="54" topLeftX="131" topLeftY="145" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="401" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="M4nIbPDwjocIkRxsRrNcOiv1nCh" width="160" height="312" topLeftX="422" topLeftY="151">
+        <crop type="rect" leftOffset="198" rightOffset="198" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="LKh1bppCgoGBV0xKokVc6y4jnhh" width="160" height="312" topLeftX="246" topLeftY="151">
+        <crop type="rect" leftOffset="198" rightOffset="198" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="TAIObSBvYofXZVxDnY5cg1CMn2d" width="160" height="312" topLeftX="70" topLeftY="151">
+        <crop type="rect" leftOffset="198" rightOffset="198" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="270" height="24" topLeftX="620" topLeftY="375" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="270" height="54" topLeftX="620" topLeftY="409" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="270" height="24" topLeftX="620" topLeftY="263" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="270" height="54" topLeftX="620" topLeftY="297" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="270" height="24" topLeftX="620" topLeftY="147" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="270" height="54" topLeftX="620" topLeftY="181" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="A2Qgb3aYxoq40Hx6VTQc8rL8ned" width="390" height="192" topLeftX="500" topLeftY="150">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="13" bottomOffset="13" presetHandlers="12"/>
+      </img>
+      <img src="KC3XbcNeBovcTLxj9axcDCcTnCd" width="390" height="192" topLeftX="70" topLeftY="150">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="13" bottomOffset="13" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="500" topLeftY="368" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="390" height="72" topLeftX="500" topLeftY="402" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="70" topLeftY="368" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="390" height="72" topLeftX="70" topLeftY="402" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PmJPb8FpCokRZLxgx2EctvRKnRe" width="240" height="120" topLeftX="650" topLeftY="187">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <img src="EWmBbqTrCogLx2xD5TMcCIPdnZg" width="240" height="120" topLeftX="360" topLeftY="187">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <img src="W2Zsbl8qmogHphxpGTJc8KvenMf" width="240" height="120" topLeftX="70" topLeftY="187">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="650" topLeftY="334" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="368" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="360" topLeftY="334" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="360" topLeftY="368" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="70" topLeftY="334" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="70" topLeftY="368" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="N9WVbos8OoAoT8xqk5ucsl8ynHd" width="240" height="120" topLeftX="70" topLeftY="281">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <img src="FKydbsW6MofyHBxT1EycVmzanfd" width="240" height="120" topLeftX="650" topLeftY="281">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <img src="Cd6GbYAdToXNxfxvfjMcR5SEnjc" width="240" height="120" topLeftX="360" topLeftY="281">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <shape width="240" height="24" topLeftX="650" topLeftY="174" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="208" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="360" topLeftY="174" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="360" topLeftY="208" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="70" topLeftY="174" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="70" topLeftY="208" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="ZsOybrTbroDcgDxWiAdcEM6Hnmh" width="190" height="190" topLeftX="70" topLeftY="280">
+        <crop type="rect" leftOffset="75" rightOffset="75" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="RkPlbqguIoSq5fxQJvncw6Spngc" width="190" height="190" topLeftX="280" topLeftY="280">
+        <crop type="rect" leftOffset="75" rightOffset="75" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="WC9ZbKdv7oj2y9xRwHOcOIP2nK5" width="190" height="190" topLeftX="70" topLeftY="70">
+        <crop type="rect" leftOffset="75" rightOffset="75" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="Lt7HbAz0mo4CxUxZjjGcTvvwn0d" width="190" height="190" topLeftX="280" topLeftY="70">
+        <crop type="rect" leftOffset="75" rightOffset="75" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="360" height="126" topLeftX="530" topLeftY="344" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="360" height="48" topLeftX="530" topLeftY="280" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="SD4bbB1gPoB8EgxDW2Dcswxun5O" width="175" height="249" topLeftX="715" topLeftY="380">
+        <crop type="rect" leftOffset="135" rightOffset="135" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="K39JbmhXlo71kHx4ie1cibcznle" width="175" height="140" topLeftX="715" topLeftY="223">
+        <crop type="rect" leftOffset="37" rightOffset="37" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="MHicbP8y4o3jGhxSzTYcDQ1lnkb" width="175" height="249" topLeftX="715" topLeftY="-43">
+        <crop type="rect" leftOffset="135" rightOffset="135" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="Qf0Vbu6cMoZDXBxRd7PcBnU1nph" width="175" height="140" topLeftX="523" topLeftY="-43">
+        <crop type="rect" leftOffset="37" rightOffset="37" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="ESdYbuvzooIdyoxsbsic9jisnMf" width="175" height="140" topLeftX="523" topLeftY="426">
+        <crop type="rect" leftOffset="37" rightOffset="37" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="NOmAbki55oibi6xtAgTcmCMPnTw" width="175" height="140" topLeftX="523" topLeftY="269">
+        <crop type="rect" leftOffset="37" rightOffset="37" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="AS1dbFEzIow665xyBjccQqD8nic" width="175" height="140" topLeftX="523" topLeftY="113">
+        <crop type="rect" leftOffset="37" rightOffset="37" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="400" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="400" height="24" topLeftX="70" topLeftY="379" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="400" height="36" topLeftX="70" topLeftY="413" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="400" height="24" topLeftX="70" topLeftY="269" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="400" height="36" topLeftX="70" topLeftY="303" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="400" height="24" topLeftX="70" topLeftY="161" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="400" height="36" topLeftX="70" topLeftY="195" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KzuVbZYPmocI8QxnkXmc033Pn1e" width="240" height="329" topLeftX="650" topLeftY="141">
+        <crop type="rect" leftOffset="173" rightOffset="173" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="WP4BbvA5oozzksxn6qSc8c8NnRd" width="240" height="329" topLeftX="360" topLeftY="141">
+        <crop type="rect" leftOffset="173" rightOffset="173" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="GCRNbznlvomPX1xe4iRcm62Knkd" width="240" height="329" topLeftX="70" topLeftY="141">
+        <crop type="rect" leftOffset="173" rightOffset="173" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KF2NbFxpUoKAlLxbB4yctjBZnXd" width="551" height="150" topLeftX="339" topLeftY="320">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="79" bottomOffset="79" presetHandlers="12"/>
+      </img>
+      <img src="QYZRbX6ppoAo5OxBr8UcZVjvnbb" width="551" height="150" topLeftX="339" topLeftY="141">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="79" bottomOffset="79" presetHandlers="12"/>
+      </img>
+      <img src="YsBYb5UNOoNo8TxNTHHcI6WDn0b" width="240" height="329" topLeftX="70" topLeftY="141">
+        <crop type="rect" leftOffset="173" rightOffset="173" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="ZIpMbverjo1wgGxVT6gccdDin0e" width="190" height="152" topLeftX="280" topLeftY="312">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="ZqxJbLWpnoN4cIx1h9Ycpl6rnXd" width="190" height="152" topLeftX="70" topLeftY="312">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="CsmnbZTLnoQnIixjXKPc4WKDnsg" width="190" height="152" topLeftX="700" topLeftY="312">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="FVJHbIjowoOUaVxC4h4cAQ4LnHb" width="190" height="152" topLeftX="490" topLeftY="312">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="CU0FbAXR9omdgPxX8gEcR346nRf" width="190" height="152" topLeftX="700" topLeftY="139">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="Vhimbmo9MoFZ59xJZZxcWyUonzg" width="190" height="152" topLeftX="490" topLeftY="139">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="DSw6b0kYjo0XE3xWpEhcNo8EnFg" width="190" height="152" topLeftX="280" topLeftY="141">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="Kk1IbFXHGoExjjxjTWRcYZUYnMf" width="190" height="152" topLeftX="70" topLeftY="141">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="838" height="28" topLeftX="51" topLeftY="295" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(271deg,rgba(35, 72, 197, 0.38) 0%,rgba(72, 239, 207, 0.11) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="12" height="12" topLeftX="86" topLeftY="303" type="ellipse">
+        <border color="rgba(78, 110, 253, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="249" startY="319" endX="249" endY="402">
+        <border color="rgba(78, 110, 253, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="12" height="12" topLeftX="400" topLeftY="303" type="ellipse">
+        <border color="rgba(78, 110, 253, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="16" height="16" topLeftX="551" topLeftY="301" type="ellipse">
+        <border color="rgba(78, 110, 253, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="12" topLeftX="685" topLeftY="303" type="ellipse">
+        <border color="rgba(78, 110, 253, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="559" startY="317" endX="559" endY="403">
+        <border color="rgba(78, 110, 253, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="16" height="16" topLeftX="241" topLeftY="301" type="ellipse">
+        <border color="rgba(78, 110, 253, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="406" startY="175" endX="406" endY="301">
+        <border color="rgba(78, 110, 253, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="691" startY="175" endX="691" endY="301">
+        <border color="rgba(78, 110, 253, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="91" startY="175" endX="91" endY="301">
+        <border color="rgba(78, 110, 253, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="215" height="24" topLeftX="268" topLeftY="360" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>时间点</p>
+        </content>
+      </shape>
+      <shape width="215" height="54" topLeftX="268" topLeftY="394" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="215" height="24" topLeftX="578" topLeftY="360" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>时间点</p>
+        </content>
+      </shape>
+      <shape width="215" height="54" topLeftX="578" topLeftY="394" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="215" height="24" topLeftX="710" topLeftY="162" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>时间点</p>
+        </content>
+      </shape>
+      <shape width="215" height="54" topLeftX="710" topLeftY="197" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="215" height="24" topLeftX="425" topLeftY="162" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>时间点</p>
+        </content>
+      </shape>
+      <shape width="215" height="54" topLeftX="425" topLeftY="197" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="215" height="24" topLeftX="110" topLeftY="162" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>时间点</p>
+        </content>
+      </shape>
+      <shape width="215" height="54" topLeftX="110" topLeftY="197" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>时间轴</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <undefined type="fallback"/>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">时间轴</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="160" height="41" topLeftX="211" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="480" height="104" topLeftX="410" topLeftY="371" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="160" height="41" topLeftX="211" topLeftY="292" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="480" height="104" topLeftX="410" topLeftY="277" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="480" height="104" topLeftX="410" topLeftY="183" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="160" height="41" topLeftX="211" topLeftY="198" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="820" height="77" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true">
+          <p>时间轴</p>
+        </content>
+      </shape>
+      <shape width="160" height="24" topLeftX="211" topLeftY="386" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="480" height="54" topLeftX="410" topLeftY="371" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="160" height="24" topLeftX="211" topLeftY="292" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="480" height="54" topLeftX="410" topLeftY="277" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="480" height="54" topLeftX="410" topLeftY="183" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="160" height="24" topLeftX="211" topLeftY="198" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>时间轴</p>
+        </content>
+      </shape>
+      <line startX="121" startY="160" endX="121" endY="456">
+        <border color="rgba(130, 167, 252, 1)" dashArray="dash" width="1"/>
+      </line>
+      <shape width="103" height="35" topLeftX="69" topLeftY="193" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="Arial">2022-2023</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="103" height="35" topLeftX="69" topLeftY="286" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="Arial">2024-2026</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="103" height="35" topLeftX="69" topLeftY="380" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="Arial">2026</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="380" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">标题和描述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="36" topLeftX="70" topLeftY="195" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontSize="12" bold="false">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="24" topLeftX="70" topLeftY="161" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16" fontFamily="思源黑体">主题标题一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="36" topLeftX="70" topLeftY="303" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontSize="12" bold="false">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="24" topLeftX="70" topLeftY="269" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16" fontFamily="思源黑体">主题标题二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="36" topLeftX="70" topLeftY="413" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontSize="12" bold="false">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="24" topLeftX="70" topLeftY="379" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16" fontFamily="思源黑体">主题标题三</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <undefined type="chart_refer_host_perm"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="188" height="24" topLeftX="516" topLeftY="144" type="text">
+        <content fontSize="16" color="rgba(208, 211, 214, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(208, 211, 214, 1)" fontSize="16">数据标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="374" height="27" topLeftX="516" topLeftY="175" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="274" height="20" topLeftX="519" topLeftY="178" presetHandlers="2" type="rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="24" topLeftX="825" topLeftY="144" type="text">
+        <content fontSize="16" color="rgba(78, 110, 253, 1)" bold="true" textAlign="right">
+          <p textAlign="right">
+            <strong>
+              <span color="rgba(78, 110, 253, 1)" fontSize="16">67%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="24" topLeftX="516" topLeftY="241" type="text">
+        <content fontSize="16" color="rgba(208, 211, 214, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(208, 211, 214, 1)">数据标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="374" height="27" topLeftX="516" topLeftY="272" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="357" height="20" topLeftX="519" topLeftY="275" presetHandlers="2" type="rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="25" topLeftX="825" topLeftY="241" type="text">
+        <content fontSize="17" color="rgba(78, 110, 253, 1)" bold="true" textAlign="right">
+          <p textAlign="right">
+            <strong>
+              <span color="rgba(78, 110, 253, 1)" fontSize="17">98%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="24" topLeftX="516" topLeftY="341" type="text">
+        <content fontSize="16" color="rgba(208, 211, 214, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(208, 211, 214, 1)">数据标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="374" height="27" topLeftX="516" topLeftY="372" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.08)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="174" height="20" topLeftX="519" topLeftY="375" presetHandlers="2" type="rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="25" topLeftX="825" topLeftY="341" type="text">
+        <content fontSize="17" color="rgba(78, 110, 253, 1)" bold="true" textAlign="right">
+          <p textAlign="right">
+            <strong>
+              <span color="rgba(78, 110, 253, 1)" fontSize="17">43%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="380" height="48" topLeftX="70" topLeftY="154" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">标题和描述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="380" height="54" topLeftX="70" topLeftY="222" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>
+            <span color="rgba(208, 211, 214, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="380" height="90" topLeftX="70" topLeftY="296" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>
+            <span color="rgba(208, 211, 214, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="32" fontFamily="思源黑体">标题和描述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="650" topLeftY="165" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">主题标题三</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="199" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>
+            <span color="rgba(208, 211, 214, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="360" topLeftY="165" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">主题标题二</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="360" topLeftY="199" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>
+            <span color="rgba(208, 211, 214, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="70" topLeftY="165" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">主题标题一</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="70" topLeftY="199" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>
+            <span color="rgba(208, 211, 214, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <undefined type="chart_refer_host_perm"/>
+      <undefined type="chart_refer_host_perm"/>
+      <undefined type="chart_refer_host_perm"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="330" height="24" topLeftX="131" topLeftY="386" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">主题标题三</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="131" topLeftY="420" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>
+            <span color="rgba(208, 211, 214, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="131" topLeftY="265" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">主题标题二</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="131" topLeftY="299" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>
+            <span color="rgba(208, 211, 214, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="131" topLeftY="145" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">主题标题一</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="131" topLeftY="179" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>
+            <span color="rgba(208, 211, 214, 1)">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="70" topLeftY="145" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="156" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="70" topLeftY="266" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="277" iconType="iconpark/Emoji/grinning-face-with-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="70" topLeftY="386" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="397" iconType="iconpark/Emoji/grinning-face-with-tightly-closed-eyes-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="391" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="32" fontFamily="思源黑体">标题和描述</span>
+          </p>
+        </content>
+      </shape>
+      <undefined type="chart_refer_host_perm"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <table topLeftX="70" topLeftY="152">
+        <colgroup>
+          <col span="4" width="205"/>
+        </colgroup>
+        <tr height="53">
+          <td>
+            <borderTop color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(78, 110, 253, 1)"/>
+            </fill>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="思源黑体">标题</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(78, 110, 253, 1)"/>
+            </fill>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="Arial">2025</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(78, 110, 253, 1)"/>
+            </fill>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="Arial">2026</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(78, 110, 253, 1)"/>
+            </fill>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="思源黑体">相关细节</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="60">
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="思源黑体">标题</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">30M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">32M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+              <p>
+                <span color="rgba(208, 211, 214, 1)" fontSize="12" fontFamily="思源黑体">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="60">
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontFamily="思源黑体">标题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">45M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">40M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+              <p>
+                <span color="rgba(208, 211, 214, 1)" fontSize="12" fontFamily="思源黑体">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="60">
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontFamily="思源黑体">标题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">15M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">30M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+              <p>
+                <span color="rgba(208, 211, 214, 1)" fontSize="12" fontFamily="思源黑体">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="60">
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontFamily="思源黑体">标题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">60M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">66M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.08)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)">
+              <p>
+                <span color="rgba(208, 211, 214, 1)" fontSize="12" fontFamily="思源黑体">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+      </table>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">标题和描述</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="390" height="68" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="32">标题和描述</span>
+          </p>
+        </content>
+      </shape>
+      <img src="S3T2bozEHor9A5xrFsVcG1kUnpe" width="427" height="540" topLeftX="533" topLeftY="0">
+        <crop type="rect" leftOffset="268" rightOffset="268" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="120" height="18" topLeftX="70" topLeftY="331" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontSize="12" bold="false">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="66" topLeftX="70" topLeftY="267" type="text">
+        <content textType="headline" fontSize="44" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="44" fontFamily="Arial">2,080</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="18" topLeftX="265" topLeftY="331" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontSize="12" bold="false">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="66" topLeftX="265" topLeftY="267" type="text">
+        <content textType="headline" fontSize="44" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">89</span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="18" topLeftX="70" topLeftY="444" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontSize="12" bold="false">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="66" topLeftX="70" topLeftY="380" type="text">
+        <content textType="headline" fontSize="44" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="44" fontFamily="Arial">1,562</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="18" topLeftX="265" topLeftY="444" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontSize="12" bold="false">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="66" topLeftX="265" topLeftY="380" type="text">
+        <content textType="headline" fontSize="44" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">76</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="105" height="90" topLeftX="70" topLeftY="209" type="text">
+        <content textType="sub-headline" fontSize="38" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="60" fontFamily="Arial">98</span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="38" fontFamily="Arial">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="18" topLeftX="70" topLeftY="194" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontFamily="思源黑体">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="18" topLeftX="70" topLeftY="343" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontFamily="思源黑体">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="57" topLeftX="70" topLeftY="358" type="text">
+        <content textType="sub-headline" fontSize="38" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">2,080</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="18" topLeftX="380" topLeftY="343" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontFamily="思源黑体">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="57" topLeftX="380" topLeftY="358" type="text">
+        <content textType="sub-headline" fontSize="38" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">6,098</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="18" topLeftX="690" topLeftY="343" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontFamily="思源黑体">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="57" topLeftX="690" topLeftY="358" type="text">
+        <content textType="sub-headline" fontSize="38" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">78</span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">%</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="890" startY="306" endX="70" endY="306">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="42" height="36" topLeftX="175" topLeftY="244" type="text">
+        <content fontSize="16" color="rgba(78, 110, 253, 1)" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(78, 110, 253, 1)" fontSize="24">↑</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">标题和描述</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="120" height="120" topLeftX="130" topLeftY="156" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">2,080</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="120" topLeftX="420" topLeftY="156" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">6,098</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="120" topLeftX="710" topLeftY="156" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">98%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="70" topLeftY="338" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(208, 211, 214, 1)" fontSize="12" fontFamily="思源黑体">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="70" topLeftY="300" type="text">
+        <content textType="sub-headline" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="360" topLeftY="338" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(208, 211, 214, 1)" fontSize="12" fontFamily="思源黑体">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="360" topLeftY="300" type="text">
+        <content textType="sub-headline" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="338" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(208, 211, 214, 1)" fontSize="12" fontFamily="思源黑体">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="650" topLeftY="300" type="text">
+        <content textType="sub-headline" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">标题和描述</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PwHLbaOOFoskGTxSGDzcqi1NnEr" width="194" height="389" topLeftX="609" topLeftY="76">
+        <crop type="rect" leftOffset="79" rightOffset="80" topOffset="11" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="IwxFbHzrHoY6F2xjRlEcIw9mnmb" width="162" height="353" topLeftX="626" topLeftY="89">
+        <crop type="rect" leftOffset="234" rightOffset="234" topOffset="0" bottomOffset="0" presetHandlers="22"/>
+      </img>
+      <shape width="472" height="30" topLeftX="70" topLeftY="205" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题</p>
+        </content>
+      </shape>
+      <shape width="472" height="72" topLeftX="70" topLeftY="245" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PwHLbaOOFoskGTxSGDzcqi1NnEr" width="316" height="633" topLeftX="529" topLeftY="76">
+        <crop type="rect" leftOffset="128" rightOffset="130" topOffset="18" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="D6Q4b7fdzoIfcWx4foWcLJMVnib" width="264" height="574" topLeftX="557" topLeftY="95">
+        <crop type="rect" leftOffset="381" rightOffset="381" topOffset="0" bottomOffset="0" presetHandlers="38"/>
+      </img>
+      <shape width="360" height="24" topLeftX="70" topLeftY="375" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.922)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="360" height="36" topLeftX="70" topLeftY="409" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="360" height="24" topLeftX="70" topLeftY="263" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.922)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="360" height="36" topLeftX="70" topLeftY="297" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="360" height="24" topLeftX="70" topLeftY="147" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.922)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="360" height="36" topLeftX="70" topLeftY="181" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="360" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.922)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="390" startY="166" endX="320" endY="166">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <line startX="390" startY="279" endX="320" endY="279">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <line startX="390" startY="392" endX="320" endY="392">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <line startX="573" startY="218" endX="643" endY="218">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <line startX="573" startY="320" endX="643" endY="320">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <img src="PwHLbaOOFoskGTxSGDzcqi1NnEr" width="194" height="389" topLeftX="383" topLeftY="83">
+        <crop type="rect" leftOffset="79" rightOffset="80" topOffset="11" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="DgzVb6tJboDNjcx436ScwRn9nFg" width="162" height="353" topLeftX="400" topLeftY="96">
+        <crop type="rect" leftOffset="234" rightOffset="234" topOffset="0" bottomOffset="0" presetHandlers="22"/>
+      </img>
+      <shape width="240" height="72" topLeftX="654" topLeftY="284" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="654" topLeftY="180" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="70" topLeftY="356" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="70" topLeftY="243" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="70" topLeftY="131" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PwHLbaOOFoskGTxSGDzcqi1NnEr" width="194" height="389" topLeftX="67" topLeftY="83">
+        <crop type="rect" leftOffset="79" rightOffset="80" topOffset="11" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="PwHLbaOOFoskGTxSGDzcqi1NnEr" width="194" height="389" topLeftX="276" topLeftY="83">
+        <crop type="rect" leftOffset="79" rightOffset="80" topOffset="11" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="46" height="46" topLeftX="517" topLeftY="211" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="528" topLeftY="222" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="517" topLeftY="331" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="528" topLeftY="342" iconType="iconpark/Emoji/grinning-face-with-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="HaMhbb8VWoAFgoxOfL1cknBUnNg" width="162" height="353" topLeftX="293" topLeftY="96">
+        <crop type="rect" leftOffset="234" rightOffset="234" topOffset="0" bottomOffset="0" presetHandlers="22"/>
+      </img>
+      <img src="Bc5jbqBr7oaYVlxGnMocTfAMngW" width="162" height="353" topLeftX="84" topLeftY="96">
+        <crop type="rect" leftOffset="234" rightOffset="234" topOffset="0" bottomOffset="0" presetHandlers="22"/>
+      </img>
+      <shape width="310" height="24" topLeftX="578" topLeftY="331" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="310" height="54" topLeftX="578" topLeftY="365" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="310" height="24" topLeftX="578" topLeftY="210" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="310" height="54" topLeftX="578" topLeftY="244" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="370" height="48" topLeftX="518" topLeftY="135" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="517" topLeftY="211" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="528" topLeftY="222" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="517" topLeftY="331" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="528" topLeftY="342" iconType="iconpark/Emoji/grinning-face-with-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="ISfIbGa4no1LVaxf7iccWDcznwd" width="151" height="302" topLeftX="115" topLeftY="70">
+        <crop type="rect" leftOffset="61" rightOffset="62" topOffset="9" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="ISfIbGa4no1LVaxf7iccWDcznwd" width="151" height="302" topLeftX="405" topLeftY="70">
+        <crop type="rect" leftOffset="61" rightOffset="62" topOffset="9" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="ISfIbGa4no1LVaxf7iccWDcznwd" width="151" height="302" topLeftX="694" topLeftY="70">
+        <crop type="rect" leftOffset="61" rightOffset="62" topOffset="9" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="UZyZbOPaToLJYwxCW3ScXvkBn8f" width="127" height="277" topLeftX="707" topLeftY="78">
+        <crop type="rect" leftOffset="183" rightOffset="183" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+      <img src="NfYwbc2dDovjxGxrdy8c4TXynSf" width="127" height="277" topLeftX="417" topLeftY="78">
+        <crop type="rect" leftOffset="183" rightOffset="183" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+      <img src="IB2TbVOTUoNcPvxxIHJct3jwn4b" width="127" height="277" topLeftX="127" topLeftY="78">
+        <crop type="rect" leftOffset="183" rightOffset="183" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+      <shape width="240" height="24" topLeftX="650" topLeftY="381" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="415" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="center">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="360" topLeftY="381" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="360" topLeftY="415" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="center">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="70" topLeftY="381" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="70" topLeftY="415" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="center">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="WCF2b1GBeoJXoDx1GFucTFyDnKb" width="595" height="359" topLeftX="182" topLeftY="95" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="GQo2bXF7LoWHlSxZQb2cJDvjnJf" width="477" height="321" topLeftX="242" topLeftY="104">
+        <crop type="rect" leftOffset="48" rightOffset="48" topOffset="0" bottomOffset="0" presetHandlers="10"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="WCF2b1GBeoJXoDx1GFucTFyDnKb" width="595" height="359" topLeftX="451" topLeftY="95" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="BINqbR9Kvoro12x8YSHcw68hnQg" width="477" height="321" topLeftX="511" topLeftY="104">
+        <crop type="rect" leftOffset="48" rightOffset="48" topOffset="0" bottomOffset="0" presetHandlers="10"/>
+      </img>
+      <shape width="390" height="30" topLeftX="70" topLeftY="210" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>主题标题</p>
+        </content>
+      </shape>
+      <shape width="390" height="72" topLeftX="70" topLeftY="250" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="820" height="36" topLeftX="70" topLeftY="110" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(208, 211, 214, 1)" fontSize="12" bold="false">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="820" height="30" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.922)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(255, 255, 255, 0.922)" fontSize="20" fontFamily="思源黑体">主题标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="WCF2b1GBeoJXoDx1GFucTFyDnKb" width="790" height="477" topLeftX="10" topLeftY="180" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="SH6ubsnOuogi1DxQ8IncbN4znud" width="633" height="426" topLeftX="88" topLeftY="190">
+        <crop type="rect" leftOffset="64" rightOffset="64" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="ISfIbGa4no1LVaxf7iccWDcznwd" width="205" height="412" topLeftX="667" topLeftY="283">
+        <crop type="rect" leftOffset="83" rightOffset="85" topOffset="12" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="YleVbfXs3oolUgxozWdccVzXnWh" width="172" height="374" topLeftX="685" topLeftY="296">
+        <crop type="rect" leftOffset="248" rightOffset="248" topOffset="0" bottomOffset="0" presetHandlers="24"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="400" height="90" topLeftX="70" topLeftY="371" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="400" height="54" topLeftX="70" topLeftY="294" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="400" height="30" topLeftX="70" topLeftY="118" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.922)" bold="true" textAlign="left">
+          <p>副标题</p>
+        </content>
+      </shape>
+      <shape width="400" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.922)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <img src="WCF2b1GBeoJXoDx1GFucTFyDnKb" width="595" height="359" topLeftX="544" topLeftY="95" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="C1zhbKMzgoJFLSxAN97c0LhGnkh" width="477" height="321" topLeftX="603" topLeftY="104">
+        <crop type="rect" leftOffset="48" rightOffset="48" topOffset="0" bottomOffset="0" presetHandlers="10"/>
+      </img>
+      <img src="ISfIbGa4no1LVaxf7iccWDcznwd" width="151" height="302" topLeftX="499" topLeftY="197">
+        <crop type="rect" leftOffset="61" rightOffset="62" topOffset="9" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="HYu3bZ2DPolY4yxpwZPcdFkBnWg" width="126" height="275" topLeftX="513" topLeftY="206">
+        <crop type="rect" leftOffset="182" rightOffset="182" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="VrBmbqW2BoHPunxOZi2carKsn8d" width="653" height="540" topLeftX="307" topLeftY="0">
+        <crop type="rect" leftOffset="155" rightOffset="155" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="180" height="48" topLeftX="70" topLeftY="423" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>谢谢观看</p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="70" topLeftY="270" type="text">
+        <content textType="caption" fontSize="18" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>湖北省 武汉市 洪山区</p>
+        </content>
+      </shape>
+      <shape width="180" height="18" topLeftX="70" topLeftY="252" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>联系地址</p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="70" topLeftY="192" type="text">
+        <content textType="caption" fontSize="18" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <a href="mailto:sherry@gmail.com">
+              <span color="rgba(20, 86, 240, 1)">Sherry@gmail.com</span>
+            </a>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="70" topLeftY="167" type="text">
+        <content textType="caption" fontSize="18" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>+132 9792 7108</p>
+        </content>
+      </shape>
+      <shape width="180" height="18" topLeftX="70" topLeftY="149" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>联系方式</p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="70" topLeftY="88" type="text">
+        <content textType="caption" fontSize="18" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>XXX</p>
+        </content>
+      </shape>
+      <shape width="180" height="18" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(208, 211, 214, 1)" bold="false" textAlign="left">
+          <p>联系人</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(31, 35, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Gh35b4dQ5o4egexxcEgcEv5Infg" width="960" height="540" topLeftX="0" topLeftY="0">
+        <crop type="rect" leftOffset="2" rightOffset="2" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="668" height="66" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="44" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>谢谢观看</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/office--dept_annual_report.xml
+++ b/skills/lark-slides/references/templates/office--dept_annual_report.xml
@@ -1,0 +1,1192 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>部门年度工作汇报</title>
+  <theme>
+    <background>
+      <fillColor color="rgba(0, 0, 0, 1)"/>
+    </background>
+    <textStyles>
+      <title fontColor="rgba(255, 255, 255, 1)"/>
+      <headline fontColor="rgba(255, 255, 255, 1)"/>
+      <sub-headline fontColor="rgba(255, 255, 255, 1)"/>
+      <body fontColor="rgba(255, 255, 255, 1)"/>
+      <caption fontColor="rgba(255, 255, 255, 1)" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="MHF4bfOmPoPVhcxIt1xcp2vnnWb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="234" height="44" topLeftX="350" topLeftY="294" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>汇报人：XXX</p>
+        </content>
+      </shape>
+      <shape width="172" height="101" topLeftX="347" topLeftY="184" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>2024</p>
+        </content>
+      </shape>
+      <shape width="261" height="182" topLeftX="63" topLeftY="179" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>部门年度工作汇报</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HrflbvupMo6hHsxWxZNcKip5nXd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="680" height="540" topLeftX="280" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 0.54) 0%,rgba(0, 0, 0, 0.2) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="680" height="540" topLeftX="280" topLeftY="0" alpha="0.45" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 22, 81, 1)"/>
+        </fill>
+      </shape>
+      <shape width="280" height="540" topLeftX="0" topLeftY="0" alpha="0.84" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="200" height="47" topLeftX="686" topLeftY="166" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>工作成果展示</p>
+        </content>
+      </shape>
+      <shape width="200" height="47" topLeftX="686" topLeftY="250" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>现况复盘总结</p>
+        </content>
+      </shape>
+      <shape width="200" height="47" topLeftX="388" topLeftY="334" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>未来发展计划</p>
+        </content>
+      </shape>
+      <shape width="200" height="47" topLeftX="387" topLeftY="250" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>工作数据分析</p>
+        </content>
+      </shape>
+      <shape width="200" height="47" topLeftX="388" topLeftY="166" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>年度工作概述</p>
+        </content>
+      </shape>
+      <shape width="192" height="80" topLeftX="48" topLeftY="148" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" bold="true">
+          <p>目录</p>
+        </content>
+      </shape>
+      <shape width="232" height="56" topLeftX="48" topLeftY="207" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span fontSize="24">CONTENTS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="68" height="69" topLeftX="628" topLeftY="239" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="Trebuchet MS" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="68" height="69" topLeftX="628" topLeftY="156" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="Trebuchet MS" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="68" height="69" topLeftX="328" topLeftY="322" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="Trebuchet MS" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>05</p>
+        </content>
+      </shape>
+      <shape width="68" height="69" topLeftX="328" topLeftY="239" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="Trebuchet MS" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="68" height="69" topLeftX="328" topLeftY="155" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="Trebuchet MS" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>01</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="K183bP2GcoB1qTxZH5FcbKQSnzh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="3" height="98" topLeftX="75" topLeftY="370" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="790" height="44" topLeftX="86" topLeftY="430" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>描述相关的信息以解释你的标题</p>
+        </content>
+      </shape>
+      <shape width="790" height="101" topLeftX="86" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>年度工作概述</p>
+        </content>
+      </shape>
+      <shape width="192" height="202" topLeftX="55" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="120" fontFamily="Trebuchet MS" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" bold="true">
+          <p>01</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DBQnbuIuEom29SxUDjLcOK8Wn0g" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="315" height="74" topLeftX="52" topLeftY="59" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span bold="false">重点工作内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="56" height="56" topLeftX="509" topLeftY="80" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)">
+          <p>
+            <strong>
+              <span color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" fontSize="24">1</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="56" height="56" topLeftX="726" topLeftY="80" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)">
+          <p>
+            <strong>
+              <span color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" fontSize="24">2</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="56" height="56" topLeftX="509" topLeftY="294" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(21, 211, 237, 1)">
+          <p>
+            <strong>
+              <span color="rgba(21, 211, 237, 1)" fontSize="24">3</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="56" height="56" topLeftX="726" topLeftY="294" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(21, 211, 237, 1)">
+          <p>
+            <strong>
+              <span color="rgba(21, 211, 237, 1)" fontSize="24">4</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="202" height="62" topLeftX="502" topLeftY="395" alpha="0.8" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" bold="false">
+          <p>演示文稿是实用工具，可以是演示、演讲、报告等等。</p>
+        </content>
+      </shape>
+      <shape width="202" height="62" topLeftX="719" topLeftY="395" alpha="0.8" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" bold="false">
+          <p>演示文稿是实用工具，可以是演示、演讲、报告等等。</p>
+        </content>
+      </shape>
+      <shape width="202" height="62" topLeftX="719" topLeftY="182" alpha="0.8" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" bold="false">
+          <p>演示文稿是实用工具，可以是演示、演讲、报告等等。</p>
+        </content>
+      </shape>
+      <shape width="202" height="62" topLeftX="502" topLeftY="182" alpha="0.8" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" bold="false">
+          <p>演示文稿是实用工具，可以是演示、演讲、报告等等。</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="502" topLeftY="361" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">项目推进</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="719" topLeftY="361" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">产品销售额</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="719" topLeftY="148" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">企业宣传</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="502" topLeftY="148" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">成员招新</span>
+          </p>
+        </content>
+      </shape>
+      <img src="DVHSbuS3xowvubxBiQzcsE0SnOc" width="378" height="187" topLeftX="50" topLeftY="293" saturation="-8" temperature="-43">
+        <crop type="rect" leftOffset="24" rightOffset="158" topOffset="0" bottomOffset="322" presetHandlers="12"/>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DBQnbuIuEom29SxUDjLcOK8Wn0g" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="262" height="307" topLeftX="68" topLeftY="162" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 243, 243, 0.58) 17%,rgba(180, 140, 247, 0.73) 50%,rgba(139, 163, 245, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="262" height="307" topLeftX="350" topLeftY="162" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="262" height="307" topLeftX="632" topLeftY="162" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 243, 243, 0.58) 17%,rgba(180, 140, 247, 0.73) 50%,rgba(139, 163, 245, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="636" height="74" topLeftX="52" topLeftY="59" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span bold="false">项目成果</span>
+          </p>
+        </content>
+      </shape>
+      <img src="BLxrbI0xIo61P9xDfgpcMilQnih" width="240" height="153" topLeftX="78" topLeftY="174">
+        <crop type="rect" leftOffset="8" rightOffset="8" topOffset="107" bottomOffset="81" presetHandlers="6"/>
+        <border color="linear-gradient(320deg,rgba(203, 116, 228, 1) 0%,rgba(104, 65, 201, 1) 33%,rgba(76, 169, 223, 0.31) 67%,rgba(61, 84, 213, 0.5) 100%)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="236" height="47" topLeftX="645" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(222, 224, 227, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(222, 224, 227, 1)">成果三</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="645" topLeftY="377" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="47" topLeftX="362" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(222, 224, 227, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(222, 224, 227, 1)">成果二</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="362" topLeftY="377" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="47" topLeftX="82" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(222, 224, 227, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(222, 224, 227, 1)" fontSize="18">成果一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="82" topLeftY="377" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Wax6bldALoYdutxgtonceksRnQf" width="240" height="153" topLeftX="361" topLeftY="174">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="75" bottomOffset="13" presetHandlers="6"/>
+        <border color="linear-gradient(354deg,rgba(165, 18, 255, 1) 0%,rgba(108, 56, 255, 1) 22%,rgba(28, 229, 255, 1) 100%)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="Sq5bbcmtjoLt6Rx0P4WcK8QAnSg" width="240" height="153" topLeftX="641" topLeftY="174">
+        <crop type="rect" leftOffset="3" rightOffset="5" topOffset="66" bottomOffset="29" presetHandlers="6"/>
+        <border color="linear-gradient(320deg,rgba(203, 116, 228, 1) 0%,rgba(104, 65, 201, 1) 33%,rgba(76, 169, 223, 0.31) 67%,rgba(61, 84, 213, 0.5) 100%)" lineJoin="miter" miterLimit="10"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="K183bP2GcoB1qTxZH5FcbKQSnzh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="3" height="98" topLeftX="75" topLeftY="370" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="790" height="44" topLeftX="86" topLeftY="436" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>描述相关的信息以解释你的标题</p>
+        </content>
+      </shape>
+      <shape width="790" height="101" topLeftX="86" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>工作成果展示</p>
+        </content>
+      </shape>
+      <shape width="192" height="202" topLeftX="55" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="120" fontFamily="Trebuchet MS" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" bold="true">
+          <p>02</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DBQnbuIuEom29SxUDjLcOK8Wn0g" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="636" height="74" topLeftX="52" topLeftY="59" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span bold="false">目标达成情况</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="47" topLeftX="332" topLeftY="261" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Trebuchet MS" color="rgba(255, 255, 255, 1)" bold="true" letterSpacing="2">
+          <p letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Trebuchet MS">100%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="165" height="165" topLeftX="739" topLeftY="202" rotation="90" type="slides-full-round-rect">
+        <border color="linear-gradient(20deg,rgba(203, 116, 228, 1) 0%,rgba(104, 65, 201, 1) 33%,rgba(76, 169, 223, 0.31) 67%,rgba(61, 84, 213, 0.5) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="156" height="44" topLeftX="744" topLeftY="366" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">产品销售额</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="138" height="138" topLeftX="753" topLeftY="215" alpha="0.2" type="donut">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="138" height="138" topLeftX="753" topLeftY="215" flipX="true" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="75" height="47" topLeftX="787" topLeftY="261" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Trebuchet MS" color="rgba(255, 255, 255, 1)" bold="true" letterSpacing="2">
+          <p letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Trebuchet MS">100%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="165" height="165" topLeftX="512" topLeftY="202" rotation="90" type="slides-full-round-rect">
+        <border color="linear-gradient(20deg,rgba(203, 116, 228, 1) 0%,rgba(104, 65, 201, 1) 33%,rgba(76, 169, 223, 0.31) 67%,rgba(61, 84, 213, 0.5) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="156" height="44" topLeftX="516" topLeftY="366" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">项目推进</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="138" height="138" topLeftX="525" topLeftY="215" alpha="0.2" type="donut">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="138" height="138" topLeftX="525" topLeftY="215" flipX="true" type="slides-block-arc">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="71" height="47" topLeftX="565" topLeftY="261" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Trebuchet MS" color="rgba(255, 255, 255, 1)" bold="true" letterSpacing="2">
+          <p letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Trebuchet MS">75%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="165" height="165" topLeftX="284" topLeftY="202" rotation="90" type="slides-full-round-rect">
+        <border color="linear-gradient(20deg,rgba(196, 97, 223, 1) 0%,rgba(121, 83, 219, 1) 33%,rgba(101, 199, 255, 0.43) 67%,rgba(69, 96, 245, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="156" height="44" topLeftX="288" topLeftY="366" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">企业宣传</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="138" height="138" topLeftX="297" topLeftY="215" alpha="0.2" type="donut">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="138" height="138" topLeftX="297" topLeftY="215" flipX="true" type="donut">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="165" height="165" topLeftX="56" topLeftY="202" rotation="90" type="slides-full-round-rect">
+        <border color="linear-gradient(20deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 0.2) 67%,rgba(69, 96, 245, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="156" height="44" topLeftX="60" topLeftY="366" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">成员招新</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="138" height="138" topLeftX="70" topLeftY="215" alpha="0.2" type="donut">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="138" height="138" topLeftX="69" topLeftY="215" flipX="true" type="slides-block-arc">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="71" height="47" topLeftX="109" topLeftY="261" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Trebuchet MS" color="rgba(255, 255, 255, 1)" bold="true" letterSpacing="2">
+          <p letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Trebuchet MS">75%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DBQnbuIuEom29SxUDjLcOK8Wn0g" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="322" height="74" topLeftX="52" topLeftY="59" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span bold="false">销售成果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="322" height="83" topLeftX="52" topLeftY="144" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(168, 174, 181, 1)" bold="false">
+          <p>
+            <span color="rgba(168, 174, 181, 1)" fontSize="14">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="355" height="44" topLeftX="555" topLeftY="88" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="16">成果一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="355" height="58" topLeftX="555" topLeftY="124" alpha="0.8" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="110" height="110" topLeftX="426" topLeftY="80" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="48" height="48" topLeftX="457" topLeftY="109" iconType="iconpark/Charts/chart-proportion.svg">
+        <border color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="110" height="110" topLeftX="426" topLeftY="215" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="48" height="48" topLeftX="457" topLeftY="246" iconType="iconpark/Charts/data-one.svg">
+        <border color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="110" height="110" topLeftX="426" topLeftY="361" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="48" height="48" topLeftX="457" topLeftY="392" iconType="iconpark/Charts/positive-dynamics.svg">
+        <border color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="355" height="44" topLeftX="555" topLeftY="223" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="16">成果二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="355" height="58" topLeftX="555" topLeftY="259" alpha="0.8" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="355" height="44" topLeftX="555" topLeftY="368" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="16">成果三</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="355" height="58" topLeftX="555" topLeftY="405" alpha="0.8" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="K183bP2GcoB1qTxZH5FcbKQSnzh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="3" height="98" topLeftX="75" topLeftY="370" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="790" height="44" topLeftX="86" topLeftY="436" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>描述相关的信息以解释你的标题</p>
+        </content>
+      </shape>
+      <shape width="790" height="101" topLeftX="86" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>工作数据分析</p>
+        </content>
+      </shape>
+      <shape width="192" height="202" topLeftX="55" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="120" fontFamily="Trebuchet MS" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" bold="true">
+          <p>03</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DBQnbuIuEom29SxUDjLcOK8Wn0g" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="856" height="74" topLeftX="52" topLeftY="59" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p>
+            <span bold="false">项目投标率</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="2" height="197" topLeftX="328" topLeftY="190" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="179" height="187" topLeftX="385" topLeftY="178" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="110" fontFamily="Trebuchet MS" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" bold="false">
+          <p>
+            <span color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" fontSize="110" fontFamily="Trebuchet MS" bold="false">62</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="81" topLeftX="516" topLeftY="258" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" fontFamily="Sans Serif" color="rgba(21, 211, 237, 1)">
+          <p>
+            <span color="rgba(21, 211, 237, 1)" fontSize="40" fontFamily="Sans Serif">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="148" height="44" topLeftX="387" topLeftY="343" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(168, 174, 181, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(168, 174, 181, 1)">全年累计开展项目</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="179" height="187" topLeftX="70" topLeftY="178" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="110" fontFamily="Trebuchet MS" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" bold="false">
+          <p>
+            <span color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" fontSize="110" fontFamily="Trebuchet MS" bold="false">40</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="81" topLeftX="202" topLeftY="258" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" fontFamily="Sans Serif" color="rgba(21, 211, 237, 1)">
+          <p>
+            <span color="rgba(21, 211, 237, 1)" fontSize="40" fontFamily="Sans Serif">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="122" height="44" topLeftX="80" topLeftY="343" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(168, 174, 181, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(168, 174, 181, 1)">投标达率</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="2" height="197" topLeftX="652" topLeftY="190" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="179" height="187" topLeftX="709" topLeftY="178" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="110" fontFamily="Trebuchet MS" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" bold="false">
+          <p>
+            <span color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" fontSize="110" fontFamily="Trebuchet MS" bold="false">80</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="81" topLeftX="841" topLeftY="258" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" fontFamily="Sans Serif" color="rgba(21, 211, 237, 1)">
+          <p>
+            <span color="rgba(21, 211, 237, 1)" fontSize="40" fontFamily="Sans Serif">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="122" height="44" topLeftX="719" topLeftY="343" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(168, 174, 181, 1)" bold="true" textAlign="center">
+          <p>项目覆盖达率</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DBQnbuIuEom29SxUDjLcOK8Wn0g" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="856" height="74" topLeftX="52" topLeftY="59" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p>
+            <span bold="false">宣传覆盖率</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="2" height="197" topLeftX="479" topLeftY="190" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0) 0%,rgba(150, 219, 219, 0.58) 17%,rgba(172, 122, 255, 0.73) 50%,rgba(168, 187, 253, 0.62) 85%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="179" height="187" topLeftX="576" topLeftY="178" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="110" fontFamily="Trebuchet MS" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" bold="false">
+          <p>
+            <span color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" fontSize="110" fontFamily="Trebuchet MS" bold="false">90</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="81" topLeftX="707" topLeftY="258" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" fontFamily="Sans Serif" color="rgba(21, 211, 237, 1)">
+          <p>
+            <span color="rgba(21, 211, 237, 1)" fontSize="40" fontFamily="Sans Serif">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="148" height="44" topLeftX="578" topLeftY="343" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(168, 174, 181, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(168, 174, 181, 1)">媒体平台覆盖率</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="179" height="187" topLeftX="191" topLeftY="178" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="110" fontFamily="Trebuchet MS" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" bold="false">
+          <p>
+            <span color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" fontSize="110" fontFamily="Trebuchet MS" bold="false">70</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="81" topLeftX="323" topLeftY="258" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" fontFamily="Sans Serif" color="rgba(21, 211, 237, 1)">
+          <p>
+            <span color="rgba(21, 211, 237, 1)" fontSize="40" fontFamily="Sans Serif">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="201" height="44" topLeftX="162" topLeftY="343" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(168, 174, 181, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(168, 174, 181, 1)">全年合作媒体平台增长率</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="K183bP2GcoB1qTxZH5FcbKQSnzh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="3" height="98" topLeftX="75" topLeftY="370" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="790" height="44" topLeftX="86" topLeftY="436" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>描述相关的信息以解释你的标题</p>
+        </content>
+      </shape>
+      <shape width="790" height="101" topLeftX="86" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>现况复盘总结</p>
+        </content>
+      </shape>
+      <shape width="192" height="202" topLeftX="55" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="120" fontFamily="Trebuchet MS" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" bold="true">
+          <p>04</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DBQnbuIuEom29SxUDjLcOK8Wn0g" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="636" height="74" topLeftX="52" topLeftY="59" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>项目执行过程</p>
+        </content>
+      </shape>
+      <shape width="459" height="62" topLeftX="432" topLeftY="67" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(222, 224, 227, 1)" bold="false">
+          <p>
+            <span color="rgba(222, 224, 227, 1)" fontSize="14">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="843" height="26" topLeftX="62" topLeftY="318" presetHandlers="120" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="17" topLeftX="66" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="17" topLeftX="374" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="17" topLeftX="680" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="27" height="26" topLeftX="192" topLeftY="318" alpha="0.57" iconType="iconpark/Arrows/right.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="27" height="26" topLeftX="497" topLeftY="318" alpha="0.57" iconType="iconpark/Arrows/right.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="236" height="47" topLeftX="62" topLeftY="359" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="18">过程一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="62" topLeftY="395" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="47" topLeftX="362" topLeftY="359" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="18">过程二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="362" topLeftY="395" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="47" topLeftX="669" topLeftY="359" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="18">过程三</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="669" topLeftY="395" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DBQnbuIuEom29SxUDjLcOK8Wn0g" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="636" height="74" topLeftX="52" topLeftY="59" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>风险与问题分析</p>
+        </content>
+      </shape>
+      <shape width="402" height="307" topLeftX="68" topLeftY="162" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(133deg,rgba(224, 239, 244, 0) 0%,rgba(150, 243, 243, 0.58) 17%,rgba(180, 140, 247, 0.73) 50%,rgba(139, 163, 245, 0.62) 85%,rgba(240, 249, 254, 0) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="362" height="47" topLeftX="90" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(222, 224, 227, 1)" bold="true" textAlign="left">
+          <p>风险一</p>
+        </content>
+      </shape>
+      <shape width="362" height="58" topLeftX="89" topLeftY="384" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</p>
+        </content>
+      </shape>
+      <shape width="402" height="307" topLeftX="487" topLeftY="162" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 0.15)"/>
+        </fill>
+        <border color="linear-gradient(20deg,rgba(210, 132, 232, 1) 0%,rgba(146, 108, 242, 1) 33%,rgba(106, 196, 248, 0.52) 67%,rgba(69, 96, 245, 0.48) 100%)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="362" height="47" topLeftX="508" topLeftY="340" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(222, 224, 227, 1)" bold="true" textAlign="left">
+          <p>风险二</p>
+        </content>
+      </shape>
+      <shape width="362" height="58" topLeftX="508" topLeftY="384" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="58" height="58" topLeftX="90" topLeftY="183" iconType="iconpark/Abstract/open-one.svg">
+        <border color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="58" height="58" topLeftX="508" topLeftY="183" iconType="iconpark/Abstract/category-management.svg">
+        <border color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="K183bP2GcoB1qTxZH5FcbKQSnzh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="3" height="98" topLeftX="75" topLeftY="370" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="790" height="44" topLeftX="86" topLeftY="436" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>描述相关的信息以解释你的标题</p>
+        </content>
+      </shape>
+      <shape width="790" height="101" topLeftX="86" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>未来发展计划</p>
+        </content>
+      </shape>
+      <shape width="192" height="202" topLeftX="55" topLeftY="59" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="120" fontFamily="Trebuchet MS" color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)" bold="true">
+          <p>05</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DBQnbuIuEom29SxUDjLcOK8Wn0g" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="636" height="74" topLeftX="52" topLeftY="59" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>计划步骤</p>
+        </content>
+      </shape>
+      <shape width="459" height="62" topLeftX="432" topLeftY="67" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(222, 224, 227, 1)" bold="false">
+          <p>
+            <span color="rgba(222, 224, 227, 1)" fontSize="14">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="843" height="26" topLeftX="62" topLeftY="318" presetHandlers="120" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(100, 232, 214, 1) 0%,rgba(115, 187, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="17" topLeftX="66" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="17" topLeftX="374" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="17" topLeftX="680" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="27" height="26" topLeftX="192" topLeftY="318" alpha="0.57" iconType="iconpark/Arrows/right.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="27" height="26" topLeftX="497" topLeftY="318" alpha="0.57" iconType="iconpark/Arrows/right.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="236" height="47" topLeftX="62" topLeftY="359" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(245, 246, 247, 1)" fontSize="18">步骤一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="62" topLeftY="395" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="47" topLeftX="362" topLeftY="359" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>步骤二</p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="362" topLeftY="395" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="47" topLeftX="669" topLeftY="359" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(245, 246, 247, 1)" bold="true" textAlign="left">
+          <p>步骤三</p>
+        </content>
+      </shape>
+      <shape width="236" height="78" topLeftX="669" topLeftY="395" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(168, 174, 181, 1)" lineSpacing="multiple:1.6">
+          <p lineSpacing="multiple:1.6">
+            <span color="rgba(168, 174, 181, 1)" fontSize="12">演示文稿是实用工具，可以是演示、演讲、报告等等。他们有各种各样的目的，使他们成为令人信服和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XH3RbSsOloN7GBxPOnocSJDznEc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" rotation="180" alpha="0.75" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(0, 0, 0, 0.5) 0%,rgba(0, 0, 0, 0.3) 22%,rgba(0, 0, 0, 0.65) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="261" height="101" topLeftX="267" topLeftY="220" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="58" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p lineSpacing="multiple:1.4">谢谢观看</p>
+        </content>
+        <shadow offset="8" angle="90" blur="10" color="rgba(0, 0, 0, 0.05)"/>
+      </shape>
+      <shape width="139" height="47" topLeftX="554" topLeftY="247" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">汇报人：XXX</span>
+          </p>
+        </content>
+        <shadow offset="8" angle="90" blur="10" color="rgba(0, 0, 0, 0.05)"/>
+      </shape>
+      <shape width="2" height="80" topLeftX="534" topLeftY="230" alpha="0.6" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0) 0%,rgba(236, 255, 255, 0.8) 17%,rgba(233, 219, 255, 0.9) 50%,rgba(216, 225, 255, 0.8) 85%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/office--light_general.xml
+++ b/skills/lark-slides/references/templates/office--light_general.xml
@@ -1,0 +1,3378 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>白底通用模板</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style/>
+    <data>
+      <shape width="668" height="36" topLeftX="100" topLeftY="293" type="text">
+        <content textType="headline" fontSize="24" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>通用模板副标题</p>
+        </content>
+      </shape>
+      <shape width="668" height="66" topLeftX="100" topLeftY="229" type="text">
+        <content textType="headline" fontSize="44" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>通用模板</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="OpAVbV1zhoQbSQx1DCCcVYypnDb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="818" height="24" topLeftX="70" topLeftY="448" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>通用模板副标题</p>
+        </content>
+      </shape>
+      <shape width="818" height="48" topLeftX="70" topLeftY="397" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>通用模板</p>
+        </content>
+      </shape>
+      <shape width="818" height="21" topLeftX="70" topLeftY="98" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>日期：XX.XX</p>
+        </content>
+      </shape>
+      <shape width="818" height="21" topLeftX="70" topLeftY="73" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>作者：XXX</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(244, 245, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="200" height="260" topLeftX="41" topLeftY="181" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="200" height="260" topLeftX="267" topLeftY="181" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="200" height="260" topLeftX="493" topLeftY="181" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="200" height="260" topLeftX="719" topLeftY="181" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="164" height="52" topLeftX="59" topLeftY="215" type="text">
+        <content paddingTop="10" paddingBottom="10" fontSize="32" fontFamily="Arial Black" color="rgba(78, 110, 253, 1)" italic="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(78, 110, 253, 1)" fontSize="32" fontFamily="Arial Black">01.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="164" height="52" topLeftX="285" topLeftY="215" type="text">
+        <content paddingTop="10" paddingBottom="10" fontSize="32" fontFamily="Arial Black" color="rgba(78, 110, 253, 1)" italic="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(78, 110, 253, 1)" fontSize="32" fontFamily="Arial Black">02.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="164" height="52" topLeftX="511" topLeftY="215" type="text">
+        <content paddingTop="10" paddingBottom="10" fontSize="32" fontFamily="Arial Black" color="rgba(78, 110, 253, 1)" italic="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(78, 110, 253, 1)" fontSize="32" fontFamily="Arial Black">03.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="164" height="52" topLeftX="737" topLeftY="215" type="text">
+        <content paddingTop="10" paddingBottom="10" fontSize="32" fontFamily="Arial Black" color="rgba(78, 110, 253, 1)" italic="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(78, 110, 253, 1)" fontSize="32" fontFamily="Arial Black">04.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="164" height="105" topLeftX="737" topLeftY="311" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="164" height="24" topLeftX="737" topLeftY="278" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="164" height="105" topLeftX="511" topLeftY="311" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="164" height="24" topLeftX="511" topLeftY="278" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="164" height="105" topLeftX="285" topLeftY="311" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="164" height="24" topLeftX="285" topLeftY="278" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="164" height="105" topLeftX="59" topLeftY="311" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="164" height="24" topLeftX="59" topLeftY="278" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="818" height="48" topLeftX="70" topLeftY="88" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>目录</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="40" height="40" topLeftX="100" topLeftY="198" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 0.922)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.922)" fontSize="14" fontFamily="Arial">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="505" topLeftY="198" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 0.922)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.922)" fontFamily="Arial">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="100" topLeftY="287" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 0.922)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.922)" fontFamily="Arial">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="505" topLeftY="287" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 0.922)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.922)" fontFamily="Arial">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="100" topLeftY="375" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 0.922)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.922)" fontFamily="Arial">05</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="505" topLeftY="375" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 0.922)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.922)" fontFamily="Arial">06</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="155" topLeftY="382" type="text">
+        <content fontSize="18" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="155" topLeftY="293" type="text">
+        <content fontSize="18" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="560" topLeftY="382" type="text">
+        <content fontSize="18" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="560" topLeftY="293" type="text">
+        <content fontSize="18" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="560" topLeftY="205" type="text">
+        <content fontSize="18" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="300" height="27" topLeftX="155" topLeftY="205" type="text">
+        <content fontSize="18" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="760" height="48" topLeftX="100" topLeftY="108" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>目录</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="MhPNbCRWsoCTBvxtoRzc4VrYnse" width="450" height="540" topLeftX="510" topLeftY="0">
+        <crop type="rect" leftOffset="257" rightOffset="257" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="376" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>目录</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="411" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>06</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="411" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="358" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>05</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="358" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="306" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="306" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="253" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="253" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="201" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="201" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="27" topLeftX="70" topLeftY="149" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>01</p>
+        </content>
+      </shape>
+      <shape width="330" height="27" topLeftX="116" topLeftY="149" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <line startX="480" startY="98" endX="890" endY="98" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="127" endX="890" endY="127" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="156" endX="890" endY="156" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="203" endX="890" endY="203" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="232" endX="890" endY="232" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="261" endX="890" endY="261" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="308" endX="890" endY="308" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="337" endX="890" endY="337" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="366" endX="890" endY="366" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="413" endX="890" endY="413" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="442" endX="890" endY="442" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="471" endX="890" endY="471" alpha="0.4">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="24" height="18" topLeftX="865" topLeftY="448" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(100, 102, 107, 1)" bold="false" textAlign="right">
+          <p>32</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="419" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(100, 102, 107, 1)" bold="false" textAlign="right">
+          <p>30</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="385" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p>29</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="448" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="419" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="21" topLeftX="480" topLeftY="385" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="343" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(100, 102, 107, 1)" bold="false" textAlign="right">
+          <p>27</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="314" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(100, 102, 107, 1)" bold="false" textAlign="right">
+          <p>23</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="280" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p>22</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="343" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="314" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="21" topLeftX="480" topLeftY="280" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="238" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(100, 102, 107, 1)" bold="false" textAlign="right">
+          <p>20</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="209" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(100, 102, 107, 1)" bold="false" textAlign="right">
+          <p>15</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="175" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p>14</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="238" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="209" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="21" topLeftX="480" topLeftY="175" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="133" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(100, 102, 107, 1)" bold="false" textAlign="right">
+          <p>08</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="104" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(100, 102, 107, 1)" bold="false" textAlign="right">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="24" height="18" topLeftX="865" topLeftY="70" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="133" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="18" topLeftX="480" topLeftY="104" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>子目录</p>
+        </content>
+      </shape>
+      <shape width="380" height="21" topLeftX="480" topLeftY="70" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>目录标题</p>
+        </content>
+      </shape>
+      <shape width="400" height="32" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p lineSpacing="multiple:1">目录</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="760" height="86" topLeftX="100" topLeftY="227" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="44" color="rgba(48, 48, 48, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(48, 48, 48, 1)">通用模板标题</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="760" height="36" topLeftX="100" topLeftY="287" type="text">
+        <content textType="caption" fontSize="24" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>通用模板标题</p>
+        </content>
+      </shape>
+      <shape width="760" height="66" topLeftX="100" topLeftY="217" type="text">
+        <content textType="caption" fontSize="44" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>通用模板标题</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="760" height="72" topLeftX="100" topLeftY="352" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="760" height="72" topLeftX="100" topLeftY="262" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="760" height="54" topLeftX="100" topLeftY="190" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="760" height="48" topLeftX="100" topLeftY="100" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="390" height="90" topLeftX="500" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="30" topLeftX="500" topLeftY="240" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="390" height="30" topLeftX="70" topLeftY="240" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="390" height="90" topLeftX="70" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="760" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="240" height="30" topLeftX="360" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="240" height="90" topLeftX="360" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="650" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="240" height="90" topLeftX="650" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="70" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="240" height="90" topLeftX="70" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="180" height="30" topLeftX="497" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="180" height="90" topLeftX="497" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="180" height="30" topLeftX="283" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="180" height="90" topLeftX="283" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="180" height="30" topLeftX="710" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="180" height="90" topLeftX="710" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="180" height="30" topLeftX="70" topLeftY="240" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="180" height="90" topLeftX="70" topLeftY="280" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="360" topLeftY="320" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题五</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="360" topLeftY="360" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="650" topLeftY="320" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题六</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="650" topLeftY="360" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="70" topLeftY="320" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="70" topLeftY="360" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="650" topLeftY="169" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="650" topLeftY="210" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="360" topLeftY="169" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="360" topLeftY="210" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="30" topLeftX="70" topLeftY="168" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="70" topLeftY="210" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="470" height="30" topLeftX="420" topLeftY="350" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="470" height="54" topLeftX="420" topLeftY="393" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="470" height="30" topLeftX="420" topLeftY="227" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="470" height="54" topLeftX="420" topLeftY="270" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="470" height="30" topLeftX="420" topLeftY="104" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="470" height="54" topLeftX="420" topLeftY="147" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="300" height="48" topLeftX="70" topLeftY="246" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <icon width="32" height="32" topLeftX="337" topLeftY="102" iconType="iconpark/Base/camera.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="32" height="32" topLeftX="631" topLeftY="102" iconType="iconpark/Office/agreement.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="32" height="32" topLeftX="337" topLeftY="293" iconType="iconpark/Office/schedule.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="32" height="32" topLeftX="631" topLeftY="293" iconType="iconpark/Clothes/clothes-sweater.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="260" height="24" topLeftX="631" topLeftY="339" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="260" height="72" topLeftX="631" topLeftY="373" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="260" height="24" topLeftX="337" topLeftY="339" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="260" height="72" topLeftX="337" topLeftY="373" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="260" height="24" topLeftX="631" topLeftY="146" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="260" height="72" topLeftX="631" topLeftY="180" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="260" height="24" topLeftX="337" topLeftY="146" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="260" height="72" topLeftX="337" topLeftY="180" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="233" height="48" topLeftX="70" topLeftY="246" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="32" height="32" topLeftX="70" topLeftY="173" presetHandlers="4" type="round-rect">
+        <border color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true" italic="false">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="14" fontFamily="Arial" italic="false">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="32" topLeftX="500" topLeftY="173" presetHandlers="4" type="round-rect">
+        <border color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true" italic="false">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="14" fontFamily="Arial" italic="false">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="32" topLeftX="70" topLeftY="324" presetHandlers="4" type="round-rect">
+        <border color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true" italic="false">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="14" fontFamily="Arial" italic="false">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="32" topLeftX="500" topLeftY="324" presetHandlers="4" type="round-rect">
+        <border color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true" italic="false">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="14" fontFamily="Arial" italic="false">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="500" topLeftY="372" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="390" height="36" topLeftX="500" topLeftY="406" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="70" topLeftY="372" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="390" height="36" topLeftX="70" topLeftY="406" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="500" topLeftY="221" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="390" height="36" topLeftX="500" topLeftY="255" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="70" topLeftY="221" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="390" height="36" topLeftX="70" topLeftY="255" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="46" height="46" topLeftX="70" topLeftY="176" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="187" iconType="iconpark/Emoji/winking-face-with-open-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="176" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="187" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="70" topLeftY="322" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="333" iconType="iconpark/Emoji/smiling-face-with-squinting-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="322" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="333" iconType="iconpark/Emoji/grinning-face-with-tightly-closed-eyes-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="330" height="24" topLeftX="560" topLeftY="322" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="560" topLeftY="356" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="131" topLeftY="322" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="131" topLeftY="356" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="560" topLeftY="176" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="560" topLeftY="210" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="131" topLeftY="176" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="131" topLeftY="210" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="70" topLeftY="176" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="187" iconType="iconpark/Emoji/winking-face-with-open-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="176" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="187" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="70" topLeftY="322" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="333" iconType="iconpark/Emoji/smiling-face-with-squinting-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="322" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="333" iconType="iconpark/Emoji/grinning-face-with-tightly-closed-eyes-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(244, 245, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="253" height="323" topLeftX="70" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="46" height="46" topLeftX="92" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="103" topLeftY="183" iconType="iconpark/Emoji/winking-face-with-open-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="253" height="323" topLeftX="353" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="46" height="46" topLeftX="375" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="386" topLeftY="183" iconType="iconpark/Emoji/smiling-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="253" height="323" topLeftX="637" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="46" height="46" topLeftX="659" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="670" topLeftY="183" iconType="iconpark/Emoji/distraught-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="210" height="24" topLeftX="659" topLeftY="247" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="210" height="144" topLeftX="659" topLeftY="281" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" lineSpacing="multiple:2" textAlign="left">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="375" topLeftY="247" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="210" height="144" topLeftX="375" topLeftY="281" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" lineSpacing="multiple:2" textAlign="left">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="91" topLeftY="247" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="210" height="144" topLeftX="91" topLeftY="281" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" lineSpacing="multiple:2" textAlign="left">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息以解释你的标题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="92" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="103" topLeftY="183" iconType="iconpark/Emoji/winking-face-with-open-eyes.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="375" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="386" topLeftY="183" iconType="iconpark/Emoji/smiling-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="659" topLeftY="172" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="670" topLeftY="183" iconType="iconpark/Emoji/distraught-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(244, 245, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="253" height="140" topLeftX="70" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="253" height="140" topLeftX="353" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="253" height="140" topLeftX="637" topLeftY="147" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="253" height="140" topLeftX="70" topLeftY="316" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="253" height="140" topLeftX="353" topLeftY="316" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="253" height="140" topLeftX="637" topLeftY="316" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.84)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(147, 150, 156, 0.2)"/>
+      </shape>
+      <shape width="210" height="24" topLeftX="659" topLeftY="342" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题六</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="659" topLeftY="376" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="375" topLeftY="342" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题五</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="375" topLeftY="376" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="92" topLeftY="342" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题四</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="92" topLeftY="376" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="659" topLeftY="173" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="659" topLeftY="207" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="375" topLeftY="173" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="375" topLeftY="207" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="210" height="24" topLeftX="92" topLeftY="173" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="210" height="54" topLeftX="92" topLeftY="207" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="UdtdbZbpKoaEEexUz07c9OHVnMd" width="961" height="395" topLeftX="0" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="72" bottomOffset="72"/>
+      </img>
+      <shape width="820" height="30" topLeftX="70" topLeftY="477" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" bold="true" textAlign="center">
+          <p>副标题</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="426" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" bold="true" textAlign="center">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="RUV0bZ37YouKpjxf4VKckdjhn6e" width="820" height="308" topLeftX="70" topLeftY="162">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="76" bottomOffset="76" presetHandlers="12"/>
+      </img>
+      <shape width="606" height="63" topLeftX="284" topLeftY="70" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="200" height="48" topLeftX="70" topLeftY="78" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="N61xbdsLro9jPzxFdaNcTyCjnNe" width="427" height="540" topLeftX="533" topLeftY="0">
+        <crop type="rect" leftOffset="268" rightOffset="268" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="390" height="72" topLeftX="70" topLeftY="395" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="36" topLeftX="70" topLeftY="339" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="72" topLeftX="70" topLeftY="247" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="30" topLeftX="70" topLeftY="122" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>副标题</p>
+        </content>
+      </shape>
+      <shape width="390" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="B1fHbkd1voF2iGxyg0mc66LGnDb" width="360" height="400" topLeftX="530" topLeftY="70">
+        <crop type="rect" leftOffset="177" rightOffset="177" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="390" height="30" topLeftX="70" topLeftY="213" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题</p>
+        </content>
+      </shape>
+      <shape width="390" height="72" topLeftX="70" topLeftY="255" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="46" height="46" topLeftX="499" topLeftY="145" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="156" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="266" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="277" iconType="iconpark/Emoji/grinning-face-with-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="386" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="397" iconType="iconpark/Emoji/grinning-face-with-tightly-closed-eyes-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="NK3ObUBQqocaMkxlLt2cr5C1nNf" width="427" height="540" topLeftX="0" topLeftY="0">
+        <crop type="rect" leftOffset="268" rightOffset="268" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="330" height="24" topLeftX="560" topLeftY="386" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="560" topLeftY="420" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="560" topLeftY="265" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="560" topLeftY="299" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="560" topLeftY="145" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="560" topLeftY="179" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="48" topLeftX="500" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="499" topLeftY="145" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="156" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="266" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="277" iconType="iconpark/Emoji/grinning-face-with-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="499" topLeftY="386" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="510" topLeftY="397" iconType="iconpark/Emoji/grinning-face-with-tightly-closed-eyes-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="46" height="46" topLeftX="70" topLeftY="145" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="70" topLeftY="228" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="70" topLeftY="311" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">03</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="70" topLeftY="394" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">04</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Cpjjb7QKFohJzixFmudcveLanec" width="360" height="400" topLeftX="530" topLeftY="70">
+        <crop type="rect" leftOffset="177" rightOffset="177" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="340" height="54" topLeftX="131" topLeftY="394" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="340" height="54" topLeftX="131" topLeftY="311" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="340" height="54" topLeftX="131" topLeftY="228" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="340" height="54" topLeftX="131" topLeftY="145" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="401" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="UrinbB8Q4oj0LkxoOkfcJ1KinVc" width="160" height="312" topLeftX="422" topLeftY="151">
+        <crop type="rect" leftOffset="198" rightOffset="198" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="XFbNbpyKtouApzx0zevcG7txnhf" width="160" height="312" topLeftX="246" topLeftY="151">
+        <crop type="rect" leftOffset="198" rightOffset="198" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="HWkXbtsmuoiDjpxPJDTcLH7Hnsc" width="160" height="312" topLeftX="70" topLeftY="151">
+        <crop type="rect" leftOffset="198" rightOffset="198" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="270" height="24" topLeftX="620" topLeftY="375" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="270" height="54" topLeftX="620" topLeftY="409" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="270" height="24" topLeftX="620" topLeftY="263" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="270" height="54" topLeftX="620" topLeftY="297" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="270" height="24" topLeftX="620" topLeftY="147" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="270" height="54" topLeftX="620" topLeftY="181" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="Ndgob5bcsoqoMTxOmz1c6z0vnYc" width="390" height="192" topLeftX="500" topLeftY="150">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="13" bottomOffset="13" presetHandlers="12"/>
+      </img>
+      <img src="MUwyb6SnjoQTwuxiOB1cL6MYnTp" width="390" height="192" topLeftX="70" topLeftY="150">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="13" bottomOffset="13" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="500" topLeftY="368" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="390" height="72" topLeftX="500" topLeftY="402" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="390" height="24" topLeftX="70" topLeftY="368" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="390" height="72" topLeftX="70" topLeftY="402" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="JWmUbcsENoCPNgxmG61cOXArnTb" width="240" height="120" topLeftX="650" topLeftY="187">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <img src="CeeobQbgaoWXlkxOhXYcu0rgnhd" width="240" height="120" topLeftX="360" topLeftY="187">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <img src="DMsebV7EnoQocLxkLz3cyl9jned" width="240" height="120" topLeftX="70" topLeftY="187">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="650" topLeftY="334" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="368" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="360" topLeftY="334" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="360" topLeftY="368" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="70" topLeftY="334" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="70" topLeftY="368" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="AAOvbGpghofRb3xgLUscy8kJnHb" width="240" height="120" topLeftX="70" topLeftY="281">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <img src="HpHabXmYbo3v7YxIybRcGBqmn9K" width="240" height="120" topLeftX="650" topLeftY="281">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <img src="QnC9b6Au9owetoxxL1bcLxk7nlc" width="240" height="120" topLeftX="360" topLeftY="281">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="7" bottomOffset="7" presetHandlers="12"/>
+      </img>
+      <shape width="240" height="24" topLeftX="650" topLeftY="174" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="208" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="360" topLeftY="174" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="360" topLeftY="208" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="70" topLeftY="174" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="70" topLeftY="208" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="LaQAbab0ToMFZHx2vcFcekoDnfj" width="190" height="190" topLeftX="70" topLeftY="280">
+        <crop type="rect" leftOffset="75" rightOffset="75" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="VZIib07cQojdKyxxadWcg1EOn4f" width="190" height="190" topLeftX="280" topLeftY="280">
+        <crop type="rect" leftOffset="75" rightOffset="75" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="RwdhbPR67orsSQxUItvcZ1GDn9g" width="190" height="190" topLeftX="70" topLeftY="70">
+        <crop type="rect" leftOffset="75" rightOffset="75" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="IBgNbWYZdoW4cvxJ7KOczv96npc" width="190" height="190" topLeftX="280" topLeftY="70">
+        <crop type="rect" leftOffset="75" rightOffset="75" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="360" height="126" topLeftX="530" topLeftY="344" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="360" height="48" topLeftX="530" topLeftY="280" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="KMPwbZANDoM8VtxikwbcdgtYn6e" width="175" height="249" topLeftX="715" topLeftY="380">
+        <crop type="rect" leftOffset="135" rightOffset="135" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="QZLubWOb5ou0jGxHuK8cvyovnuU" width="175" height="140" topLeftX="715" topLeftY="223">
+        <crop type="rect" leftOffset="37" rightOffset="37" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="EOA1bzkFOodgKJxRt32cGkiPn5b" width="175" height="249" topLeftX="715" topLeftY="-43">
+        <crop type="rect" leftOffset="135" rightOffset="135" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="Qv1eb4EBRoTyBtxYhWScsA9pnUe" width="175" height="140" topLeftX="523" topLeftY="-43">
+        <crop type="rect" leftOffset="37" rightOffset="37" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="DaV6bjvbooZq39xWX6CcD5I8nFh" width="175" height="140" topLeftX="523" topLeftY="426">
+        <crop type="rect" leftOffset="37" rightOffset="37" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="OE5nb3nAgoEZPCxtAzycCV03ns4" width="175" height="140" topLeftX="523" topLeftY="269">
+        <crop type="rect" leftOffset="37" rightOffset="37" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="Eg5Ob6bqZoXa2cxL1sYcUjXZnnh" width="175" height="140" topLeftX="523" topLeftY="113">
+        <crop type="rect" leftOffset="37" rightOffset="37" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="400" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="400" height="24" topLeftX="70" topLeftY="379" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="400" height="36" topLeftX="70" topLeftY="413" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="400" height="24" topLeftX="70" topLeftY="269" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="400" height="36" topLeftX="70" topLeftY="303" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="400" height="24" topLeftX="70" topLeftY="161" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="400" height="36" topLeftX="70" topLeftY="195" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="CVlxbnjeXoXmyvxizbIcyhEAnkc" width="240" height="329" topLeftX="650" topLeftY="141">
+        <crop type="rect" leftOffset="173" rightOffset="173" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="BGQQbKBsxoZ6a9xwCUzcfvsinSJ" width="240" height="329" topLeftX="360" topLeftY="141">
+        <crop type="rect" leftOffset="173" rightOffset="173" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="NAo6bVZokosccOxFzWic0xdEnWe" width="240" height="329" topLeftX="70" topLeftY="141">
+        <crop type="rect" leftOffset="173" rightOffset="173" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="CUMbbcVlnoM4sfxUEC1cHXCRn5e" width="551" height="150" topLeftX="339" topLeftY="320">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="79" bottomOffset="79" presetHandlers="12"/>
+      </img>
+      <img src="JTi1binYYoah0fxefx2cw73Rnuf" width="551" height="150" topLeftX="339" topLeftY="141">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="79" bottomOffset="79" presetHandlers="12"/>
+      </img>
+      <img src="Ic1UbbFDroNj15xyXrFc13jvnPf" width="240" height="329" topLeftX="70" topLeftY="141">
+        <crop type="rect" leftOffset="173" rightOffset="173" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="TOsLbMBi6olv5txLhV8cxP83nbi" width="190" height="152" topLeftX="280" topLeftY="312">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="FlAcbO793o38sCxU9GrcmIyxnbd" width="190" height="152" topLeftX="70" topLeftY="312">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="YS8AbcHFNoetRkxihPcc4s5Dnte" width="190" height="152" topLeftX="700" topLeftY="312">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="V67bb63eYox1eHxtKmPcHF7FnFh" width="190" height="152" topLeftX="490" topLeftY="312">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="TV3DbPu8loC75UxSlQIcHleznVe" width="190" height="152" topLeftX="700" topLeftY="139">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="TtcYba7nLoI5cexx4DDcsVuHnsd" width="190" height="152" topLeftX="490" topLeftY="139">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="KdSsbBljKocygSxfL1EcIF7Mnog" width="190" height="152" topLeftX="280" topLeftY="141">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="L3Gsb31ZAogVLVx2HCtcunn9n1X" width="190" height="152" topLeftX="70" topLeftY="141">
+        <crop type="rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="838" height="28" topLeftX="51" topLeftY="295" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(271deg,rgba(35, 72, 197, 0.38) 0%,rgba(72, 239, 207, 0.11) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="12" height="12" topLeftX="86" topLeftY="303" type="ellipse">
+        <border color="rgba(78, 110, 253, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="249" startY="319" endX="249" endY="402">
+        <border color="rgba(78, 110, 253, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="12" height="12" topLeftX="400" topLeftY="303" type="ellipse">
+        <border color="rgba(78, 110, 253, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="16" height="16" topLeftX="551" topLeftY="301" type="ellipse">
+        <border color="rgba(78, 110, 253, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="12" topLeftX="685" topLeftY="303" type="ellipse">
+        <border color="rgba(78, 110, 253, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="559" startY="317" endX="559" endY="403">
+        <border color="rgba(78, 110, 253, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="16" height="16" topLeftX="241" topLeftY="301" type="ellipse">
+        <border color="rgba(78, 110, 253, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="406" startY="175" endX="406" endY="301">
+        <border color="rgba(78, 110, 253, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="691" startY="175" endX="691" endY="301">
+        <border color="rgba(78, 110, 253, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="91" startY="175" endX="91" endY="301">
+        <border color="rgba(78, 110, 253, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="215" height="24" topLeftX="268" topLeftY="360" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>时间点</p>
+        </content>
+      </shape>
+      <shape width="215" height="54" topLeftX="268" topLeftY="394" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="215" height="24" topLeftX="578" topLeftY="360" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>时间点</p>
+        </content>
+      </shape>
+      <shape width="215" height="54" topLeftX="578" topLeftY="394" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="215" height="24" topLeftX="710" topLeftY="162" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>时间点</p>
+        </content>
+      </shape>
+      <shape width="215" height="54" topLeftX="710" topLeftY="197" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="215" height="24" topLeftX="425" topLeftY="162" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>时间点</p>
+        </content>
+      </shape>
+      <shape width="215" height="54" topLeftX="425" topLeftY="197" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="215" height="24" topLeftX="110" topLeftY="162" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>时间点</p>
+        </content>
+      </shape>
+      <shape width="215" height="54" topLeftX="110" topLeftY="197" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>时间轴</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <undefined type="fallback"/>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" bold="true" textAlign="left">
+          <p>时间轴</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <line startX="120" startY="159" endX="120" endY="451" alpha="0.4">
+        <border color="rgba(78, 110, 253, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="100" height="34" topLeftX="70" topLeftY="381" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>2024-2026</p>
+        </content>
+      </shape>
+      <shape width="100" height="34" topLeftX="70" topLeftY="287" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>2022-2023</p>
+        </content>
+      </shape>
+      <shape width="100" height="34" topLeftX="70" topLeftY="193" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>2020-2021</p>
+        </content>
+      </shape>
+      <shape width="160" height="24" topLeftX="211" topLeftY="386" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="480" height="54" topLeftX="410" topLeftY="371" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="160" height="24" topLeftX="211" topLeftY="292" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="480" height="54" topLeftX="410" topLeftY="277" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="480" height="54" topLeftX="410" topLeftY="183" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="160" height="24" topLeftX="211" topLeftY="198" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>时间轴</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="188" height="24" topLeftX="516" topLeftY="144" type="text">
+        <content fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">数据标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="374" height="27" topLeftX="516" topLeftY="175" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="274" height="20" topLeftX="519" topLeftY="178" presetHandlers="2" type="rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="24" topLeftX="825" topLeftY="144" type="text">
+        <content fontSize="16" color="rgba(78, 110, 253, 1)" bold="true" textAlign="right">
+          <p textAlign="right">
+            <strong>
+              <span color="rgba(78, 110, 253, 1)" fontSize="16">67%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="24" topLeftX="516" topLeftY="241" type="text">
+        <content fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">数据标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="374" height="27" topLeftX="516" topLeftY="272" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="357" height="20" topLeftX="519" topLeftY="275" presetHandlers="2" type="rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="26" topLeftX="825" topLeftY="241" type="text">
+        <content fontSize="17" color="rgba(78, 110, 253, 1)" bold="true" textAlign="right">
+          <p textAlign="right">
+            <strong>
+              <span color="rgba(78, 110, 253, 1)" fontSize="17">98%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="24" topLeftX="516" topLeftY="341" type="text">
+        <content fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">数据标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="374" height="27" topLeftX="516" topLeftY="372" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="174" height="20" topLeftX="519" topLeftY="375" presetHandlers="2" type="rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="26" topLeftX="825" topLeftY="341" type="text">
+        <content fontSize="17" color="rgba(78, 110, 253, 1)" bold="true" textAlign="right">
+          <p textAlign="right">
+            <strong>
+              <span color="rgba(78, 110, 253, 1)" fontSize="17">43%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="380" height="48" topLeftX="70" topLeftY="154" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" bold="true" textAlign="left">
+          <p textAlign="left">标题和描述</p>
+        </content>
+      </shape>
+      <shape width="380" height="54" topLeftX="70" topLeftY="222" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="380" height="90" topLeftX="70" topLeftY="296" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(48, 48, 48, 1)" bold="true">
+          <p>
+            <span fontSize="32" fontFamily="思源黑体">标题和描述</span>
+          </p>
+        </content>
+      </shape>
+      <undefined type="chart_refer_host_perm"/>
+      <undefined type="chart_refer_host_perm"/>
+      <undefined type="chart_refer_host_perm"/>
+      <shape width="240" height="24" topLeftX="650" topLeftY="165" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="199" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="360" topLeftY="165" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="360" topLeftY="199" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="70" topLeftY="165" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="70" topLeftY="199" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <undefined type="chart_refer_host_perm"/>
+      <shape width="330" height="24" topLeftX="131" topLeftY="386" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="131" topLeftY="420" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="131" topLeftY="265" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="131" topLeftY="299" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="330" height="24" topLeftX="131" topLeftY="145" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="330" height="54" topLeftX="131" topLeftY="179" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="70" topLeftY="145" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="156" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="70" topLeftY="266" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="277" iconType="iconpark/Emoji/grinning-face-with-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="70" topLeftY="386" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="81" topLeftY="397" iconType="iconpark/Emoji/grinning-face-with-tightly-closed-eyes-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="391" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(48, 48, 48, 1)" bold="true">
+          <p>
+            <span fontSize="32" fontFamily="思源黑体">标题和描述</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <table topLeftX="70" topLeftY="152">
+        <colgroup>
+          <col span="4" width="205"/>
+        </colgroup>
+        <tr height="53">
+          <td>
+            <borderTop color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(78, 110, 253, 1)"/>
+            </fill>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="思源黑体">标题</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(78, 110, 253, 1)"/>
+            </fill>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>项目一</p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(78, 110, 253, 1)"/>
+            </fill>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="Arial">项目二</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(78, 110, 253, 1)"/>
+            </fill>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14" fontFamily="思源黑体">相关细节</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="60">
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="14" fontFamily="思源黑体">标题</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12" fontFamily="Arial">30M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12" fontFamily="Arial">32M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+              <p>
+                <span color="rgba(100, 102, 107, 1)" fontSize="12" fontFamily="思源黑体">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="60">
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" bold="true">
+              <p>
+                <span fontFamily="思源黑体">标题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12" fontFamily="Arial">45M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12" fontFamily="Arial">40M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+              <p>
+                <span color="rgba(100, 102, 107, 1)" fontSize="12" fontFamily="思源黑体">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="60">
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" bold="true">
+              <p>
+                <span fontFamily="思源黑体">标题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12" fontFamily="Arial">15M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12" fontFamily="Arial">30M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+              <p>
+                <span color="rgba(100, 102, 107, 1)" fontSize="12" fontFamily="思源黑体">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="60">
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" bold="true">
+              <p>
+                <span fontFamily="思源黑体">标题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12" fontFamily="Arial">60M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="Arial" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12" fontFamily="Arial">66M</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(78, 110, 253, 1)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="0" paddingBottom="0" paddingLeft="0" paddingRight="0" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+              <p>
+                <span color="rgba(100, 102, 107, 1)" fontSize="12" fontFamily="思源黑体">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+      </table>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="390" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(48, 48, 48, 1)" bold="true">
+          <p>
+            <span color="rgba(48, 48, 48, 1)" fontSize="32" fontFamily="思源黑体">标题和描述</span>
+          </p>
+        </content>
+      </shape>
+      <img src="BhwkbrUYDoICFDxn2bYcuCpGnsd" width="427" height="540" topLeftX="533" topLeftY="0">
+        <crop type="rect" leftOffset="268" rightOffset="268" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="120" height="18" topLeftX="70" topLeftY="331" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12" bold="false">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="66" topLeftX="70" topLeftY="267" type="text">
+        <content textType="headline" fontSize="44" fontFamily="Arial" color="rgba(48, 48, 48, 1)" bold="true">
+          <p>
+            <span fontSize="44" fontFamily="Arial">2,080</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="18" topLeftX="265" topLeftY="331" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12" bold="false">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="66" topLeftX="265" topLeftY="267" type="text">
+        <content textType="headline" fontSize="44" fontFamily="Arial" color="rgba(48, 48, 48, 1)" bold="true">
+          <p>
+            89
+            <span fontSize="24">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="18" topLeftX="70" topLeftY="444" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12" bold="false">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="66" topLeftX="70" topLeftY="380" type="text">
+        <content textType="headline" fontSize="44" fontFamily="Arial" color="rgba(48, 48, 48, 1)" bold="true">
+          <p>
+            <span fontSize="44" fontFamily="Arial">1,562</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="18" topLeftX="265" topLeftY="444" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12" bold="false">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="66" topLeftX="265" topLeftY="380" type="text">
+        <content textType="headline" fontSize="44" fontFamily="Arial" color="rgba(48, 48, 48, 1)" bold="true">
+          <p>76</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="105" height="90" topLeftX="70" topLeftY="209" type="text">
+        <content textType="sub-headline" fontSize="38" fontFamily="Arial" color="rgba(48, 48, 48, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="60" fontFamily="Arial">98</span>
+            <span fontSize="38" fontFamily="Arial">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="18" topLeftX="70" topLeftY="194" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontFamily="思源黑体">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="18" topLeftX="70" topLeftY="343" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontFamily="思源黑体">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="57" topLeftX="70" topLeftY="358" type="text">
+        <content textType="sub-headline" fontSize="38" fontFamily="Arial" color="rgba(48, 48, 48, 1)" bold="true" textAlign="left">
+          <p textAlign="left">2,080</p>
+        </content>
+      </shape>
+      <shape width="200" height="18" topLeftX="380" topLeftY="343" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontFamily="思源黑体">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="57" topLeftX="380" topLeftY="358" type="text">
+        <content textType="sub-headline" fontSize="38" fontFamily="Arial" color="rgba(48, 48, 48, 1)" bold="true" textAlign="left">
+          <p textAlign="left">6,098</p>
+        </content>
+      </shape>
+      <shape width="200" height="18" topLeftX="690" topLeftY="343" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontFamily="思源黑体">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="57" topLeftX="690" topLeftY="358" type="text">
+        <content textType="sub-headline" fontSize="38" fontFamily="Arial" color="rgba(48, 48, 48, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            78
+            <span fontSize="24">%</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="890" startY="306" endX="70" endY="306">
+        <border color="rgba(208, 211, 214, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="42" height="36" topLeftX="175" topLeftY="244" type="text">
+        <content fontSize="16" color="rgba(78, 110, 253, 1)" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(78, 110, 253, 1)" fontSize="24">↑</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="120" height="120" topLeftX="130" topLeftY="156" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">2,080</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="120" topLeftX="420" topLeftY="156" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">6,098</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="120" topLeftX="710" topLeftY="156" type="ellipse">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">98%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="70" topLeftY="338" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12" fontFamily="思源黑体">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="70" topLeftY="300" type="text">
+        <content textType="sub-headline" fontSize="16" color="rgba(48, 48, 48, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(48, 48, 48, 1)" fontSize="16">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="360" topLeftY="338" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12" fontFamily="思源黑体">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="360" topLeftY="300" type="text">
+        <content textType="sub-headline" fontSize="16" color="rgba(48, 48, 48, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="16">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="338" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12" fontFamily="思源黑体">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="650" topLeftY="300" type="text">
+        <content textType="sub-headline" fontSize="16" color="rgba(48, 48, 48, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="16">关键数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="TS3obuM9uoiDLLxgxw7cdpVRnDb" width="194" height="389" topLeftX="609" topLeftY="76">
+        <crop type="rect" leftOffset="79" rightOffset="80" topOffset="11" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="UHSabFVFBoL8PzxboqFc1wIine9" width="162" height="353" topLeftX="626" topLeftY="89">
+        <crop type="rect" leftOffset="234" rightOffset="234" topOffset="0" bottomOffset="0" presetHandlers="22"/>
+      </img>
+      <shape width="472" height="30" topLeftX="70" topLeftY="205" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题</p>
+        </content>
+      </shape>
+      <shape width="472" height="72" topLeftX="70" topLeftY="245" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="TS3obuM9uoiDLLxgxw7cdpVRnDb" width="316" height="633" topLeftX="529" topLeftY="76">
+        <crop type="rect" leftOffset="128" rightOffset="130" topOffset="18" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="WTL3bP2ZYo7hcexcplTczqrXn3b" width="264" height="574" topLeftX="557" topLeftY="95">
+        <crop type="rect" leftOffset="381" rightOffset="381" topOffset="0" bottomOffset="0" presetHandlers="38"/>
+      </img>
+      <shape width="360" height="24" topLeftX="70" topLeftY="375" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="360" height="36" topLeftX="70" topLeftY="409" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="360" height="24" topLeftX="70" topLeftY="263" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="360" height="36" topLeftX="70" topLeftY="297" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="360" height="24" topLeftX="70" topLeftY="147" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="360" height="36" topLeftX="70" topLeftY="181" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="360" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <line startX="390" startY="166" endX="320" endY="166">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <line startX="390" startY="279" endX="320" endY="279">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <line startX="390" startY="392" endX="320" endY="392">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <line startX="573" startY="218" endX="643" endY="218">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <line startX="573" startY="320" endX="643" endY="320">
+        <border color="rgba(100, 102, 107, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <startArrow type="solid-circle"/>
+      </line>
+      <img src="TS3obuM9uoiDLLxgxw7cdpVRnDb" width="194" height="389" topLeftX="383" topLeftY="83">
+        <crop type="rect" leftOffset="79" rightOffset="80" topOffset="11" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="OYjWbO3vzo5RXLxneqxcGkcrnog" width="162" height="353" topLeftX="400" topLeftY="96">
+        <crop type="rect" leftOffset="234" rightOffset="234" topOffset="0" bottomOffset="0" presetHandlers="22"/>
+      </img>
+      <shape width="240" height="72" topLeftX="654" topLeftY="284" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="654" topLeftY="180" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="70" topLeftY="356" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="70" topLeftY="243" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="72" topLeftX="70" topLeftY="131" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="TS3obuM9uoiDLLxgxw7cdpVRnDb" width="194" height="389" topLeftX="67" topLeftY="83">
+        <crop type="rect" leftOffset="79" rightOffset="80" topOffset="11" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="TS3obuM9uoiDLLxgxw7cdpVRnDb" width="194" height="389" topLeftX="276" topLeftY="83">
+        <crop type="rect" leftOffset="79" rightOffset="80" topOffset="11" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="46" height="46" topLeftX="517" topLeftY="211" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="528" topLeftY="222" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="517" topLeftY="331" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="528" topLeftY="342" iconType="iconpark/Emoji/grinning-face-with-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="Q2FybbJISoe4gJxBqCZcdcGLnt7" width="162" height="353" topLeftX="293" topLeftY="96">
+        <crop type="rect" leftOffset="234" rightOffset="234" topOffset="0" bottomOffset="0" presetHandlers="22"/>
+      </img>
+      <img src="Io74bsywQorRoYxblTecisEgnlg" width="162" height="353" topLeftX="84" topLeftY="96">
+        <crop type="rect" leftOffset="234" rightOffset="234" topOffset="0" bottomOffset="0" presetHandlers="22"/>
+      </img>
+      <shape width="310" height="24" topLeftX="578" topLeftY="331" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="310" height="54" topLeftX="578" topLeftY="365" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="310" height="24" topLeftX="578" topLeftY="210" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="310" height="54" topLeftX="578" topLeftY="244" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="370" height="48" topLeftX="518" topLeftY="135" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="517" topLeftY="211" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="528" topLeftY="222" iconType="iconpark/Emoji/relieved-face.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="46" height="46" topLeftX="517" topLeftY="331" presetHandlers="23" type="round-rect">
+        <fill>
+          <fillColor color="rgba(78, 110, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="528" topLeftY="342" iconType="iconpark/Emoji/grinning-face-with-open-mouth.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="Rhy4b1ms1oQzsJx1OiicAr7HnNh" width="151" height="302" topLeftX="115" topLeftY="70">
+        <crop type="rect" leftOffset="61" rightOffset="62" topOffset="9" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="Rhy4b1ms1oQzsJx1OiicAr7HnNh" width="151" height="302" topLeftX="405" topLeftY="70">
+        <crop type="rect" leftOffset="61" rightOffset="62" topOffset="9" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="Rhy4b1ms1oQzsJx1OiicAr7HnNh" width="151" height="302" topLeftX="694" topLeftY="70">
+        <crop type="rect" leftOffset="61" rightOffset="62" topOffset="9" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="IkNBba1tKov0OcxMu7pcottvnLf" width="127" height="277" topLeftX="707" topLeftY="78">
+        <crop type="rect" leftOffset="183" rightOffset="183" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+      <img src="BzuMbFf9SoFq5Zx1R0wcIJZznFh" width="127" height="277" topLeftX="417" topLeftY="78">
+        <crop type="rect" leftOffset="183" rightOffset="183" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+      <img src="QKaEb8jPBo2oRjxJtgvcD6gVndd" width="127" height="277" topLeftX="127" topLeftY="78">
+        <crop type="rect" leftOffset="183" rightOffset="183" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+      <shape width="240" height="24" topLeftX="650" topLeftY="381" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>主题标题三</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="415" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="center">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="360" topLeftY="381" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>主题标题二</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="360" topLeftY="415" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="center">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="70" topLeftY="381" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>主题标题一</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="70" topLeftY="415" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="center">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="JiksbRvHYoWRPxxBUYNcSuGZnjc" width="595" height="359" topLeftX="182" topLeftY="95" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="KCLSbcQRPojNiIxEZNncl3bxnQc" width="477" height="321" topLeftX="242" topLeftY="104">
+        <crop type="rect" leftOffset="48" rightOffset="48" topOffset="0" bottomOffset="0" presetHandlers="10"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="JiksbRvHYoWRPxxBUYNcSuGZnjc" width="595" height="359" topLeftX="451" topLeftY="95" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="T4o1bdSsuo4rXRxygYfc73h6nbe" width="477" height="321" topLeftX="511" topLeftY="104">
+        <crop type="rect" leftOffset="48" rightOffset="48" topOffset="0" bottomOffset="0" presetHandlers="10"/>
+      </img>
+      <shape width="390" height="30" topLeftX="70" topLeftY="210" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题</p>
+        </content>
+      </shape>
+      <shape width="390" height="72" topLeftX="70" topLeftY="250" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="JiksbRvHYoWRPxxBUYNcSuGZnjc" width="790" height="477" topLeftX="10" topLeftY="180" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="820" height="30" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>主题标题</p>
+        </content>
+      </shape>
+      <shape width="820" height="36" topLeftX="70" topLeftY="110" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <img src="VpaZbZ7K9oKUdCxODBVcIZ7ln5b" width="633" height="426" topLeftX="88" topLeftY="190">
+        <crop type="rect" leftOffset="64" rightOffset="64" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="Rhy4b1ms1oQzsJx1OiicAr7HnNh" width="205" height="412" topLeftX="667" topLeftY="283">
+        <crop type="rect" leftOffset="83" rightOffset="85" topOffset="12" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="ADcsbOc5xoAjRxx4RbLchlm7nsg" width="172" height="374" topLeftX="685" topLeftY="296">
+        <crop type="rect" leftOffset="248" rightOffset="248" topOffset="0" bottomOffset="0" presetHandlers="24"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="400" height="90" topLeftX="70" topLeftY="371" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="400" height="54" topLeftX="70" topLeftY="294" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="400" height="30" topLeftX="70" topLeftY="118" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>副标题</p>
+        </content>
+      </shape>
+      <shape width="400" height="48" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>标题和描述</p>
+        </content>
+      </shape>
+      <img src="JiksbRvHYoWRPxxBUYNcSuGZnjc" width="595" height="359" topLeftX="544" topLeftY="95" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="TacibFO8eoOOhqxBubBchT75nTd" width="477" height="321" topLeftX="603" topLeftY="104">
+        <crop type="rect" leftOffset="48" rightOffset="48" topOffset="0" bottomOffset="0" presetHandlers="10"/>
+      </img>
+      <img src="Rhy4b1ms1oQzsJx1OiicAr7HnNh" width="151" height="302" topLeftX="499" topLeftY="197">
+        <crop type="rect" leftOffset="61" rightOffset="62" topOffset="9" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="BMJpb7YAvoeKgdxBAoQcsX6Gn6e" width="126" height="275" topLeftX="513" topLeftY="206">
+        <crop type="rect" leftOffset="182" rightOffset="182" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="CPicb3HffodDqFxKjLmcD6ubnuh" width="653" height="540" topLeftX="307" topLeftY="0">
+        <crop type="rect" leftOffset="155" rightOffset="155" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="180" height="48" topLeftX="70" topLeftY="423" type="text">
+        <content textType="caption" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>谢谢观看</p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="70" topLeftY="270" type="text">
+        <content textType="caption" fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>湖北省 武汉市 洪山区</p>
+        </content>
+      </shape>
+      <shape width="180" height="18" topLeftX="70" topLeftY="252" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>联系地址</p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="70" topLeftY="192" type="text">
+        <content textType="caption" fontSize="18" fontFamily="思源黑体" color="rgba(78, 110, 253, 1)" bold="true" textAlign="left">
+          <p>
+            <a href="mailto:sherry@gmail.com">
+              <span color="rgba(78, 110, 253, 1)">Sherry@gmail.com</span>
+            </a>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="70" topLeftY="167" type="text">
+        <content textType="caption" fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>+132 9792 710X</p>
+        </content>
+      </shape>
+      <shape width="180" height="18" topLeftX="70" topLeftY="149" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>联系方式</p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="70" topLeftY="88" type="text">
+        <content textType="caption" fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>XXX</p>
+        </content>
+      </shape>
+      <shape width="180" height="18" topLeftX="70" topLeftY="70" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false" textAlign="left">
+          <p>联系人</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/office--project_kickoff.xml
+++ b/skills/lark-slides/references/templates/office--project_kickoff.xml
@@ -1,0 +1,3152 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>项目启动宣讲</title>
+  <theme>
+    <textStyles>
+      <headline fontColor="rgba(31, 35, 41, 1)"/>
+      <sub-headline fontColor="rgba(31, 35, 41, 1)"/>
+      <body fontColor="rgba(31, 35, 41, 1)"/>
+      <caption fontColor="rgba(155, 158, 162, 1)" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <img src="YmDFb5Rklo4jylxqtWWce9KNn0b" width="355" height="350" topLeftX="524" topLeftY="141">
+        <crop type="rect" leftOffset="74" rightOffset="90" topOffset="21" bottomOffset="19" presetHandlers="0"/>
+      </img>
+      <line startX="122" startY="390" endX="122" endY="404">
+        <border color="rgba(221, 222, 223, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(31, 35, 41, 1)">背景同步</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="center">
+          <p textAlign="center">项目方案</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="center">
+          <p textAlign="center">成本预估</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="center">
+          <p textAlign="center">产品线路图</p>
+        </content>
+      </shape>
+      <shape width="420" height="80" topLeftX="68" topLeftY="140" type="text">
+        <content textType="headline" fontSize="40" fontFamily="Arial Black" color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" fontSize="40" fontFamily="Arial Black">Project Kickoff Presentation</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="420" height="81" topLeftX="68" topLeftY="220" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="54" fontFamily="思源黑体">项目启动宣讲</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="420" height="54" topLeftX="68" topLeftY="308" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>
+            <span color="rgba(102, 102, 102, 1)">输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="420" height="18" topLeftX="68" topLeftY="388" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(33, 56, 253, 1)" bold="false">
+          <p>
+            <span color="rgba(33, 56, 253, 1)">某某团队     某某某</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <img src="M0BEbvy17oWtboxK4fNcK2EHnyh" width="268" height="345" topLeftX="49" topLeftY="106">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EAhgbgzOQoANx2xqOuJcWzt9nvc" width="37" height="48" topLeftX="672" topLeftY="86" rotation="325" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="IMmubGNPvo6UPLx8UAlcjmmknWc" width="50" height="75" topLeftX="855" topLeftY="435">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="IMmubGNPvo6UPLx8UAlcjmmknWc" width="40" height="59" topLeftX="835" topLeftY="451">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="256" height="75" topLeftX="335" topLeftY="234" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="350" topLeftY="247" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontFamily="Arial Black">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="75" topLeftX="624" topLeftY="234" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="639" topLeftY="247" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontFamily="Arial Black">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="75" topLeftX="335" topLeftY="343" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="350" topLeftY="355" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="256" height="75" topLeftX="624" topLeftY="343" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="639" topLeftY="355" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="546" height="75" topLeftX="335" topLeftY="110" type="text">
+        <content textType="headline" fontSize="50" fontFamily="Arial Black" color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" bold="true">
+          <p>CONTENTS</p>
+        </content>
+      </shape>
+      <shape width="170" height="27" topLeftX="408" topLeftY="247" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="18">背景同步</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="170" height="18" topLeftX="408" topLeftY="274" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>
+            <span color="rgba(102, 102, 102, 1)" bold="false">Background Synchronization</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="170" height="27" topLeftX="697" topLeftY="247" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="18">项目方案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="170" height="18" topLeftX="697" topLeftY="274" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Project Proposal</p>
+        </content>
+      </shape>
+      <shape width="170" height="27" topLeftX="408" topLeftY="360" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>成本预估</p>
+        </content>
+      </shape>
+      <shape width="170" height="18" topLeftX="408" topLeftY="387" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Cost Estimate</p>
+        </content>
+      </shape>
+      <shape width="170" height="27" topLeftX="697" topLeftY="357" type="text">
+        <content fontSize="18" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>产品线路图</p>
+        </content>
+      </shape>
+      <shape width="170" height="18" topLeftX="697" topLeftY="384" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Roadmap</p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="420" height="54" topLeftX="69" topLeftY="330" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="420" height="60" topLeftX="69" topLeftY="262" type="text">
+        <content textType="headline" fontSize="40" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>背景同步</p>
+        </content>
+      </shape>
+      <shape width="420" height="60" topLeftX="69" topLeftY="195" type="text">
+        <content textType="headline" fontSize="60" fontFamily="Arial Black" color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" bold="true" lineSpacing="multiple:1">
+          <p>01</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">产品线路图</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">项目方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="28" topLeftX="508" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">背景同步</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="XeAVba5Wyo9UMSxPMCKcZcRdn1b" width="384" height="323" topLeftX="501" topLeftY="143">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <img src="LgTxbgFsgo9apQxoLn5cm56qnpc" width="359" height="248" topLeftX="52" topLeftY="207">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="256" height="172" topLeftX="200" topLeftY="150" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="40" height="40" topLeftX="508" topLeftY="216" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="40" height="40" topLeftX="508" topLeftY="305" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="40" height="40" topLeftX="508" topLeftY="392" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="220" height="24" topLeftX="218" topLeftY="173" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(33, 56, 253, 1)" bold="true">
+          <p>上下文</p>
+        </content>
+      </shape>
+      <shape width="220" height="90" topLeftX="218" topLeftY="205" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="324" height="24" topLeftX="565" topLeftY="392" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>背景三</p>
+        </content>
+      </shape>
+      <shape width="324" height="36" topLeftX="565" topLeftY="422" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="324" height="24" topLeftX="565" topLeftY="305" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>背景二</p>
+        </content>
+      </shape>
+      <shape width="324" height="36" topLeftX="565" topLeftY="335" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="324" height="24" topLeftX="565" topLeftY="210" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>背景一</p>
+        </content>
+      </shape>
+      <shape width="324" height="36" topLeftX="565" topLeftY="240" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="382" height="48" topLeftX="508" topLeftY="140" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>背景同步</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">产品线路图</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">项目方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="28" topLeftX="508" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">背景同步</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="25" height="25" topLeftX="516" topLeftY="222" iconType="iconpark/Office/ticket.svg">
+        <border color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="25" height="25" topLeftX="516" topLeftY="313" iconType="iconpark/Office/compression.svg">
+        <border color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="25" height="25" topLeftX="516" topLeftY="399" iconType="iconpark/Charts/form.svg">
+        <border color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <img src="RvPhbhTxhoJTOxx0x4AcmXiPnAh" width="103" height="136" topLeftX="823" topLeftY="384">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="XlI2bVkr8osFqmx9hyJcIV0Nnnm" width="123" height="192" topLeftX="6" topLeftY="336">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="167" height="256" topLeftX="129" topLeftY="183" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="167" height="256" topLeftX="312" topLeftY="183" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="167" height="256" topLeftX="496" topLeftY="183" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="167" height="256" topLeftX="680" topLeftY="183" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="32" height="54" topLeftX="140" topLeftY="238" alpha="0.25" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(102, 102, 102, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="54" fontFamily="Arial">“</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="54" topLeftX="327" topLeftY="238" alpha="0.25" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(102, 102, 102, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="54" fontFamily="Arial">“</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="54" topLeftX="508" topLeftY="238" alpha="0.25" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(102, 102, 102, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="54" fontFamily="Arial">“</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="54" topLeftX="694" topLeftY="238" alpha="0.25" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(102, 102, 102, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="54" fontFamily="Arial">“</span>
+          </p>
+        </content>
+      </shape>
+      <img src="VrLib60oFo2hhlxy0OecLd02ndf" width="37" height="37" topLeftX="745" topLeftY="206">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="16"/>
+      </img>
+      <img src="QX8SbykBioZ0CPxlf3DcQBmanKf" width="37" height="37" topLeftX="561" topLeftY="206">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="16"/>
+      </img>
+      <img src="FJQJbjinVo3yClxuZWnczq4Snpb" width="37" height="37" topLeftX="378" topLeftY="206">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="16"/>
+      </img>
+      <img src="MJz8bCPWGo8V7xxQ4ZOcdvP9n7b" width="37" height="37" topLeftX="194" topLeftY="206">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="16"/>
+      </img>
+      <shape width="134" height="144" topLeftX="697" topLeftY="266" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="134" height="144" topLeftX="512" topLeftY="266" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="134" height="144" topLeftX="329" topLeftY="266" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="134" height="144" topLeftX="145" topLeftY="266" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="420" height="48" topLeftX="277" topLeftY="111" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>用户诉求</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">产品线路图</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">项目方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="28" topLeftX="508" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">背景同步</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <img src="Bi5Jbj7kPo25eHxtc6FcmNTFnyd" width="228" height="262" topLeftX="357" topLeftY="218">
+        <crop type="rect" leftOffset="65" rightOffset="82" topOffset="9" bottomOffset="10" presetHandlers="0"/>
+      </img>
+      <line startX="66" startY="200" endX="886" endY="200">
+        <border color="rgba(221, 222, 223, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="308" height="54" topLeftX="578" topLeftY="397" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="308" height="54" topLeftX="66" topLeftY="397" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="308" height="54" topLeftX="578" topLeftY="278" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="308" height="54" topLeftX="66" topLeftY="278" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="568" height="54" topLeftX="312" topLeftY="118" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="228" height="48" topLeftX="70" topLeftY="121" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>项目价值</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">产品线路图</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">项目方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="28" topLeftX="508" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">背景同步</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="112" height="28" topLeftX="261" topLeftY="241" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">项目价值一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="112" height="28" topLeftX="579" topLeftY="241" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">项目价值二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="112" height="28" topLeftX="261" topLeftY="360" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">项目价值三</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="112" height="28" topLeftX="579" topLeftY="360" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">项目价值四</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="503" height="100" topLeftX="388" topLeftY="125" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="415" topLeftY="150" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" width="1"/>
+      </shape>
+      <shape width="503" height="100" topLeftX="388" topLeftY="247" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="415" topLeftY="273" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="503" height="100" topLeftX="388" topLeftY="370" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="415" topLeftY="395" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" width="1"/>
+      </shape>
+      <img src="Nvazbp8HkosHJWx68vKcRMYZndf" width="231" height="218" topLeftX="72" topLeftY="270" flipX="true">
+        <crop type="rect" leftOffset="25" rightOffset="50" topOffset="12" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <line startX="176" startY="195" endX="176" endY="240">
+        <border color="rgba(221, 222, 223, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="100" height="18" topLeftX="210" topLeftY="188" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>指标 B 增长</p>
+        </content>
+      </shape>
+      <shape width="100" height="18" topLeftX="72" topLeftY="188" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>指标 A 增长</p>
+        </content>
+      </shape>
+      <shape width="279" height="48" topLeftX="72" topLeftY="126" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>项目目标</p>
+        </content>
+      </shape>
+      <shape width="374" height="72" topLeftX="490" topLeftY="384" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="374" height="72" topLeftX="490" topLeftY="262" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="374" height="72" topLeftX="490" topLeftY="138" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息描述上述主题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="100" height="32" topLeftX="210" topLeftY="214" type="text">
+        <content textType="headline" fontSize="32" fontFamily="Arial" color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" bold="true" lineSpacing="multiple:1">
+          <p>820</p>
+        </content>
+      </shape>
+      <shape width="100" height="32" topLeftX="72" topLeftY="214" type="text">
+        <content textType="headline" fontSize="32" fontFamily="Arial" color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" bold="true" lineSpacing="multiple:1">
+          <p>1290</p>
+        </content>
+      </shape>
+      <icon width="25" height="25" topLeftX="427" topLeftY="163" iconType="iconpark/Office/compression.svg">
+        <border color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="25" height="25" topLeftX="427" topLeftY="285" iconType="iconpark/Charts/chart-line.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="25" height="25" topLeftX="427" topLeftY="408" iconType="iconpark/Music/signal-strength.svg">
+        <border color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">产品线路图</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">项目方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="28" topLeftX="508" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">背景同步</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="420" height="54" topLeftX="460" topLeftY="330" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="420" height="60" topLeftX="460" topLeftY="262" type="text">
+        <content textType="headline" fontSize="40" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>项目方案</p>
+        </content>
+      </shape>
+      <shape width="420" height="60" topLeftX="460" topLeftY="195" type="text">
+        <content textType="headline" fontSize="60" fontFamily="Arial Black" color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" bold="true" lineSpacing="multiple:1">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">产品线路图</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="28" topLeftX="608" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14" bold="false">背景同步</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">项目方案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="XeAVba5Wyo9UMSxPMCKcZcRdn1b" width="384" height="323" topLeftX="57" topLeftY="143" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <img src="LgTxbgFsgo9apQxoLn5cm56qnpc" width="320" height="220" topLeftX="107" topLeftY="255" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="40" height="40" topLeftX="480" topLeftY="132" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="40" height="40" topLeftX="687" topLeftY="132" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="40" height="40" topLeftX="480" topLeftY="323" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="40" height="40" topLeftX="687" topLeftY="323" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="190" height="24" topLeftX="687" topLeftY="379" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>关键决策四</p>
+        </content>
+      </shape>
+      <shape width="190" height="72" topLeftX="687" topLeftY="409" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="190" height="24" topLeftX="480" topLeftY="379" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>关键决策三</p>
+        </content>
+      </shape>
+      <shape width="190" height="72" topLeftX="480" topLeftY="409" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="190" height="24" topLeftX="687" topLeftY="188" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>关键决策二</p>
+        </content>
+      </shape>
+      <shape width="190" height="72" topLeftX="687" topLeftY="218" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="190" height="24" topLeftX="480" topLeftY="188" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>关键决策一</p>
+        </content>
+      </shape>
+      <shape width="190" height="72" topLeftX="480" topLeftY="218" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="238" height="126" topLeftX="70" topLeftY="193" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+            </li>
+            <li>
+              <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="238" height="48" topLeftX="70" topLeftY="132" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>关键决策</p>
+        </content>
+      </shape>
+      <icon width="25" height="25" topLeftX="487" topLeftY="138" iconType="iconpark/Base/pic.svg">
+        <border color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="25" height="25" topLeftX="694" topLeftY="139" iconType="iconpark/Office/compression.svg">
+        <border color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="25" height="25" topLeftX="487" topLeftY="330" iconType="iconpark/Character/success.svg">
+        <border color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="25" height="25" topLeftX="694" topLeftY="331" iconType="iconpark/Music/movie-board.svg">
+        <border color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="86" height="21" topLeftX="824" topLeftY="83" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">产品线路图</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="727" topLeftY="83" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="28" topLeftX="628" topLeftY="79" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="532" topLeftY="83" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14" bold="false">背景同步</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="630" topLeftY="83" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">项目方案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="240" height="24" topLeftX="646" topLeftY="201" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>产品设计方案</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="646" topLeftY="235" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="356" topLeftY="201" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>产品设计方案</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="356" topLeftY="235" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="240" height="24" topLeftX="66" topLeftY="203" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>产品设计方案</p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="66" topLeftY="237" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="820" height="48" topLeftX="66" topLeftY="132" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>产品设计方案</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">产品线路图</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="28" topLeftX="608" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14" bold="false">背景同步</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">项目方案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Tw9vbhGNhoVNR8xaVPCcDxEPn3d" width="240" height="160" topLeftX="66" topLeftY="310">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="40" bottomOffset="40" presetHandlers="12"/>
+      </img>
+      <img src="Ar7bbnW1Go26kpxuRWhcbF7tnYg" width="240" height="160" topLeftX="356" topLeftY="310">
+        <crop type="rect" leftOffset="23" rightOffset="23" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="GUExbtM1OoXzFwxrcgqcgCutnWe" width="240" height="160" topLeftX="646" topLeftY="310">
+        <crop type="rect" leftOffset="23" rightOffset="23" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="420" height="54" topLeftX="69" topLeftY="330" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="420" height="60" topLeftX="69" topLeftY="262" type="text">
+        <content textType="headline" fontSize="40" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>成本预估</p>
+        </content>
+      </shape>
+      <shape width="420" height="60" topLeftX="69" topLeftY="195" type="text">
+        <content textType="headline" fontSize="60" fontFamily="Arial Black" color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" bold="true" lineSpacing="multiple:1">
+          <p>03</p>
+        </content>
+      </shape>
+      <img src="YED6bNyt8ocZ8dxBbIGcR6V4nuj" width="274" height="353" topLeftX="585" topLeftY="129" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">产品线路图</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">项目方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="28" topLeftX="703" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14" bold="false">背景同步</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <img src="ErpRbpfTCoiZq1xyAW1cAdctneW" width="277" height="319" topLeftX="62" topLeftY="140">
+        <crop type="rect" leftOffset="79" rightOffset="100" topOffset="10" bottomOffset="12" presetHandlers="0"/>
+      </img>
+      <shape width="112" height="28" topLeftX="381" topLeftY="194" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content paddingLeft="20" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">产品</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="172" height="28" topLeftX="449" topLeftY="194" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content paddingLeft="20" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">26 人天</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">产品线路图</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">项目方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="28" topLeftX="703" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14" bold="false">背景同步</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="242" height="32" topLeftX="381" topLeftY="132" type="text">
+        <content fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">成本预估</p>
+        </content>
+      </shape>
+      <shape width="242" height="72" topLeftX="381" topLeftY="240" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p/>
+            </li>
+            <li>
+              <p/>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="112" height="28" topLeftX="653" topLeftY="194" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content paddingLeft="20" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">设计</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="172" height="28" topLeftX="721" topLeftY="194" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content paddingLeft="20" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">18 人天</p>
+        </content>
+      </shape>
+      <shape width="242" height="72" topLeftX="653" topLeftY="240" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p/>
+            </li>
+            <li>
+              <p/>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="112" height="28" topLeftX="381" topLeftY="340" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content paddingLeft="20" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">研发</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="172" height="28" topLeftX="449" topLeftY="340" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content paddingLeft="20" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">120 人天</p>
+        </content>
+      </shape>
+      <shape width="242" height="72" topLeftX="381" topLeftY="387" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p/>
+            </li>
+            <li>
+              <p/>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="112" height="28" topLeftX="653" topLeftY="340" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content paddingLeft="20" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">测试</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="172" height="28" topLeftX="721" topLeftY="340" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content paddingLeft="20" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">16 人天</p>
+        </content>
+      </shape>
+      <shape width="242" height="72" topLeftX="653" topLeftY="387" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+            </li>
+            <li>
+              <p/>
+            </li>
+            <li>
+              <p/>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">产品线路图</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">项目方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="90" height="28" topLeftX="703" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14" bold="false">背景同步</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="242" height="32" topLeftX="69" topLeftY="119" type="text">
+        <content fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">优先级</p>
+        </content>
+      </shape>
+      <table topLeftX="69" topLeftY="174">
+        <colgroup>
+          <col span="1" width="215"/>
+          <col span="1" width="269"/>
+          <col span="1" width="143"/>
+          <col span="1" width="105"/>
+          <col span="1" width="85"/>
+        </colgroup>
+        <tr height="31">
+          <td>
+            <borderTop lineJoin="miter" miterLimit="10"/>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <borderLeft lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(33, 56, 253, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">产品能力</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop lineJoin="miter" miterLimit="10"/>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(33, 56, 253, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">项目拆解</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop lineJoin="miter" miterLimit="10"/>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(33, 56, 253, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p>负责人</p>
+            </content>
+          </td>
+          <td>
+            <borderTop lineJoin="miter" miterLimit="10"/>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(33, 56, 253, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p lineSpacing="multiple:1.2">
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">时间节点</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop lineJoin="miter" miterLimit="10"/>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(33, 56, 253, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" paddingRight="6" fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">优先级</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="35">
+          <td rowspan="2">
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <borderLeft lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" italic="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p>
+                <em>输入“@+人名”</em>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">25 年 1 月</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" paddingRight="6" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">P0</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="32">
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" italic="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p>
+                <em>输入“@+人名”</em>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">25 年 3 月</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" paddingRight="6" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">P0</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="31">
+          <td rowspan="3">
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <borderLeft lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span fontSize="12">输入相关的描述信息描述上述主题,输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" italic="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p>
+                <em>输入“@+人名”</em>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">25 年 3 月</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" paddingRight="6" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">P0</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="31">
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" italic="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p>
+                <em>输入“@+人名”</em>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">25 年 4 月</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" paddingRight="6" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">P1</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="31">
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" italic="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p>
+                <em>输入“@+人名”</em>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">25 年 4 月</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" paddingRight="6" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">P2</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="32">
+          <td rowspan="3">
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <borderLeft lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span fontSize="12">输入相关的描述信息描述上述主题,输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" italic="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p>
+                <em>输入“@+人名”</em>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">25 年 5 月</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" paddingRight="6" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">P0</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="32">
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" italic="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p>
+                <em>输入“@+人名”</em>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">25 年 5 月</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" paddingRight="6" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">P0</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="32">
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p textAlign="left" lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" italic="true" lineSpacing="multiple:1.2" textAlign="left">
+              <p>
+                <em>输入“@+人名”</em>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">25 年 6 月</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight lineJoin="miter" miterLimit="10"/>
+            <borderBottom lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(244, 244, 244, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingLeft="16" paddingRight="6" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+              <p lineSpacing="multiple:1.2">
+                <span color="rgba(43, 47, 54, 1)" fontSize="12">p2</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+      </table>
+      <shape width="209" height="18" topLeftX="82" topLeftY="235" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)">
+          <p/>
+        </content>
+      </shape>
+      <shape width="209" height="18" topLeftX="82" topLeftY="320" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)">
+          <p/>
+        </content>
+      </shape>
+      <shape width="209" height="18" topLeftX="82" topLeftY="422" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)">
+          <p/>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="420" height="54" topLeftX="460" topLeftY="330" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="420" height="60" topLeftX="460" topLeftY="262" type="text">
+        <content textType="headline" fontSize="40" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>产品路线图</p>
+        </content>
+      </shape>
+      <shape width="420" height="60" topLeftX="460" topLeftY="195" type="text">
+        <content textType="headline" fontSize="60" fontFamily="Arial Black" color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" bold="true" lineSpacing="multiple:1">
+          <p>04</p>
+        </content>
+      </shape>
+      <img src="Kbvhb5ggcow7GBxKnAccI4VJnNg" width="355" height="350" topLeftX="54" topLeftY="129">
+        <crop type="rect" leftOffset="74" rightOffset="90" topOffset="21" bottomOffset="19" presetHandlers="0"/>
+      </img>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <line startX="587" startY="131" endX="587" endY="467">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="409" startY="131" endX="409" endY="467">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="764" startY="131" endX="764" endY="467">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="160" height="21" topLeftX="241" topLeftY="120" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">1-2 月</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="21" topLeftX="418" topLeftY="120" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">2-3 月</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="21" topLeftX="595" topLeftY="120" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">3-4 月</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="21" topLeftX="773" topLeftY="120" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">5-6 月</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="51" startY="254" endX="909" endY="254">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="51" startY="364" endX="909" endY="364">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="234" startY="131" endX="234" endY="467">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="174" height="42" topLeftX="51" topLeftY="177" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">主线任务描述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="174" height="21" topLeftX="51" topLeftY="405" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">主线任务描述</p>
+        </content>
+      </shape>
+      <shape width="174" height="21" topLeftX="51" topLeftY="299" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">主线任务描述</p>
+        </content>
+      </shape>
+      <shape width="240" height="20" topLeftX="243" topLeftY="156" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="思源黑体" bold="false">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="20" topLeftX="448" topLeftY="180" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="300" height="20" topLeftX="609" topLeftY="228" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="18" topLeftX="257" topLeftY="260" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(23, 182, 156, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="18" topLeftX="482" topLeftY="285" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(23, 182, 156, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="265" height="18" topLeftX="363" topLeftY="310" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(23, 182, 156, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="20" topLeftX="279" topLeftY="370" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(173, 130, 247, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="20" topLeftX="591" topLeftY="395" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(173, 130, 247, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="20" topLeftX="701" topLeftY="420" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(173, 130, 247, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="20" topLeftX="375" topLeftY="445" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(173, 130, 247, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="20" topLeftX="633" topLeftY="337" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(23, 182, 156, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="280" height="20" topLeftX="418" topLeftY="204" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="98" height="28" topLeftX="799" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14" bold="false">背景同步</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">产品线路图</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">项目方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="193" height="256" topLeftX="69" topLeftY="213" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="193" height="256" topLeftX="281" topLeftY="213" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="193" height="256" topLeftX="492" topLeftY="213" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <shape width="193" height="256" topLeftX="704" topLeftY="213" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+      </shape>
+      <img src="XeAVba5Wyo9UMSxPMCKcZcRdn1b" width="115" height="97" topLeftX="320" topLeftY="372" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="ErpRbpfTCoiZq1xyAW1cAdctneW" width="98" height="112" topLeftX="117" topLeftY="357">
+        <crop type="rect" leftOffset="28" rightOffset="35" topOffset="4" bottomOffset="4" presetHandlers="0"/>
+      </img>
+      <img src="YED6bNyt8ocZ8dxBbIGcR6V4nuj" width="86" height="111" topLeftX="599" topLeftY="356" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Tqdub9JKEorQnaxZPDZcHkX9nVd" width="111" height="110" topLeftX="752" topLeftY="360">
+        <crop type="rect" leftOffset="23" rightOffset="28" topOffset="7" bottomOffset="6" presetHandlers="0"/>
+      </img>
+      <shape width="154" height="24" topLeftX="724" topLeftY="228" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>🧑‍💻 测试</p>
+        </content>
+      </shape>
+      <shape width="154" height="36" topLeftX="724" topLeftY="264" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" italic="true" list="bullet">
+          <ul>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="154" height="24" topLeftX="512" topLeftY="228" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>🧑‍💻 研发</p>
+        </content>
+      </shape>
+      <shape width="154" height="90" topLeftX="512" topLeftY="264" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" italic="true" list="bullet">
+          <ul>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="154" height="24" topLeftX="300" topLeftY="228" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>🧑‍🎨 设计师</p>
+        </content>
+      </shape>
+      <shape width="154" height="54" topLeftX="300" topLeftY="264" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" italic="true" list="bullet">
+          <ul>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="154" height="24" topLeftX="88" topLeftY="230" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>🧑‍💼 产品经理</p>
+        </content>
+      </shape>
+      <shape width="154" height="72" topLeftX="88" topLeftY="266" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" italic="true" list="bullet">
+          <ul>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+            <li>
+              <p>输入“@+人名”</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="828" height="24" topLeftX="69" topLeftY="168" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(51, 51, 51, 1)" bold="true">
+          <p>
+            整体 Owner：
+            <em>
+              <span fontSize="12" bold="false">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="828" height="48" topLeftX="69" topLeftY="109" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>项目成员</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="98" height="28" topLeftX="799" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14" bold="false">背景同步</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">产品线路图</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">项目方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">成本预估</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="98" height="28" topLeftX="799" topLeftY="59" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14" bold="false">背景同步</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">产品线路图</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14" bold="false">项目方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="242" height="32" topLeftX="69" topLeftY="119" type="text">
+        <content fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">历史经验</p>
+        </content>
+      </shape>
+      <shape width="278" height="266" topLeftX="341" topLeftY="173" type="ellipse">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+      </shape>
+      <img src="Kbvhb5ggcow7GBxKnAccI4VJnNg" width="225" height="221" topLeftX="374" topLeftY="202">
+        <crop type="rect" leftOffset="47" rightOffset="57" topOffset="13" bottomOffset="12" presetHandlers="0"/>
+      </img>
+      <shape width="112" height="28" topLeftX="199" topLeftY="186" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>历史文档</p>
+        </content>
+      </shape>
+      <shape width="112" height="28" topLeftX="650" topLeftY="186" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">风险点</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="230" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <ul>
+            <li>
+              <p textAlign="left">
+                <strong>
+                  <span color="rgba(0, 0, 0, 1)" fontSize="12">风险点1</span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left" level="2">
+                <span color="rgba(102, 102, 102, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left" level="2">
+                <span color="rgba(102, 102, 102, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="301" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <ul>
+            <li>
+              <p textAlign="left">
+                <strong>
+                  <span color="rgba(0, 0, 0, 1)" fontSize="12">风险点2</span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left" level="2">
+                <span color="rgba(102, 102, 102, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left" level="2">
+                <span color="rgba(102, 102, 102, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="240" height="54" topLeftX="650" topLeftY="371" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <ul>
+            <li>
+              <p textAlign="left">
+                <strong>
+                  <span color="rgba(0, 0, 0, 1)" fontSize="12">风险点3</span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left" level="2">
+                <span color="rgba(102, 102, 102, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left" level="2">
+                <span color="rgba(102, 102, 102, 1)" fontSize="12">输入相关的描述信息描述上述主题</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="240" height="18" topLeftX="71" topLeftY="230" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p textAlign="right"/>
+        </content>
+      </shape>
+      <shape width="240" height="18" topLeftX="71" topLeftY="260" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p textAlign="right"/>
+        </content>
+      </shape>
+      <shape width="240" height="18" topLeftX="71" topLeftY="289" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p textAlign="right"/>
+        </content>
+      </shape>
+      <shape width="240" height="18" topLeftX="71" topLeftY="319" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p textAlign="right"/>
+        </content>
+      </shape>
+      <shape width="240" height="18" topLeftX="71" topLeftY="348" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p textAlign="right"/>
+        </content>
+      </shape>
+      <shape width="240" height="18" topLeftX="71" topLeftY="378" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p textAlign="right"/>
+        </content>
+      </shape>
+      <shape width="240" height="18" topLeftX="71" topLeftY="407" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="right">
+          <p textAlign="right"/>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="909" height="488" topLeftX="32" topLeftY="21" type="round1rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 244, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <shape width="909" height="488" topLeftX="20" topLeftY="34" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="3"/>
+      </shape>
+      <line startX="122" startY="390" endX="122" endY="404">
+        <border color="rgba(221, 222, 223, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <img src="YED6bNyt8ocZ8dxBbIGcR6V4nuj" width="274" height="353" topLeftX="585" topLeftY="129" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="86" height="21" topLeftX="804" topLeftY="63" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="center">
+          <p>产品线路图</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="707" topLeftY="63" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="center">
+          <p>成本预估</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="610" topLeftY="63" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="center">
+          <p>项目方案</p>
+        </content>
+      </shape>
+      <shape width="86" height="21" topLeftX="512" topLeftY="63" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" textAlign="center">
+          <p>背景同步</p>
+        </content>
+      </shape>
+      <shape width="420" height="54" topLeftX="68" topLeftY="330" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="420" height="81" topLeftX="68" topLeftY="242" type="text">
+        <content textType="headline" fontSize="54" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>感谢观看</p>
+        </content>
+      </shape>
+      <shape width="420" height="40" topLeftX="68" topLeftY="194" type="text">
+        <content textType="headline" fontSize="50" fontFamily="Arial Black" color="linear-gradient(90deg,rgba(75, 92, 245, 1) 0%,rgba(35, 58, 251, 1) 100%)" bold="true" lineSpacing="multiple:1">
+          <p>Thanks</p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="96" topLeftY="64" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(51, 51, 51, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 51, 51, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="68" topLeftY="62" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(31, 35, 41, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/office--quarterly_review.xml
+++ b/skills/lark-slides/references/templates/office--quarterly_review.xml
@@ -1,0 +1,1253 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>季度复盘</title>
+  <theme>
+    <fill alpha="1">
+      <fillImg src="CcdZb7zBbovgU3xDjvxcpvRtnng" alpha="1" rotateWithShape="false"/>
+    </fill>
+    <textStyles>
+      <title fontColor="rgba(67, 86, 113, 1)" fontSize="90"/>
+      <headline fontColor="rgba(67, 86, 113, 1)" fontSize="64"/>
+      <sub-headline fontColor="rgba(67, 86, 113, 1)" fontSize="24"/>
+      <body fontColor="rgba(67, 86, 113, 1)" fontSize="14"/>
+      <caption fontColor="rgba(67, 86, 113, 1)"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CcdZb7zBbovgU3xDjvxcpvRtnng" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="268" height="41" topLeftX="40" topLeftY="24" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="14">你的团队</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="2" height="20" topLeftX="37" topLeftY="34" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(67, 86, 113, 1)"/>
+        </fill>
+      </shape>
+      <shape width="646" height="116" topLeftX="48" topLeftY="149" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(67, 86, 113, 1)" bold="true">
+          <p>季度复盘总结</p>
+        </content>
+      </shape>
+      <shape width="642" height="41" topLeftX="52" topLeftY="244" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>Departmental Work Summary</p>
+        </content>
+      </shape>
+      <shape width="140" height="36" topLeftX="58" topLeftY="295" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(67, 86, 113, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">2026 Q1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="926" startY="8" endX="926" endY="378" alpha="0.2">
+        <border color="rgba(67, 86, 113, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="90" height="38" topLeftX="491" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>季度概述</p>
+        </content>
+      </shape>
+      <shape width="90" height="38" topLeftX="701" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>工作成果</p>
+        </content>
+      </shape>
+      <shape width="90" height="38" topLeftX="596" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>目标复盘</p>
+        </content>
+      </shape>
+      <shape width="90" height="38" topLeftX="807" topLeftY="24" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>未来规划</p>
+        </content>
+      </shape>
+      <img src="GH2XbzpA4okl6rxlGUIcHq9pnyb" width="551" height="347" topLeftX="438" topLeftY="193" exposure="1" contrast="41" saturation="-59" temperature="-18">
+        <crop type="rect" leftOffset="72" rightOffset="63" topOffset="0" bottomOffset="197" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NrnIbEr91oOuxFx653xc9P7tn6e" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="443" height="92" topLeftX="37" topLeftY="160" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="48">目录 CONTENTS</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="223" height="41" topLeftX="40" topLeftY="24" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.6)" fontSize="14">你的团队</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="2" height="20" topLeftX="37" topLeftY="34" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+      </shape>
+      <shape width="345" height="44" topLeftX="40" topLeftY="440" presetHandlers="26" alpha="0.29" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="257" height="41" topLeftX="58" topLeftY="442" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">未来规划 Future Planning</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="345" height="44" topLeftX="40" topLeftY="266" presetHandlers="26" alpha="0.29" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="18" color="rgba(16, 50, 98, 0.4)"/>
+      </shape>
+      <shape width="282" height="41" topLeftX="58" topLeftY="268" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">季度概述 Quarterly Overview</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="345" height="44" topLeftX="40" topLeftY="324" presetHandlers="26" alpha="0.29" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="18" color="rgba(16, 50, 98, 0.4)"/>
+      </shape>
+      <shape width="295" height="41" topLeftX="58" topLeftY="326" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">目标复盘 OKR Review</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="345" height="44" topLeftX="40" topLeftY="382" presetHandlers="26" alpha="0.29" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="257" height="41" topLeftX="58" topLeftY="384" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">工作成果 Work Results</span>
+          </p>
+        </content>
+      </shape>
+      <img src="KUrhbGGF8o5qaixDNQ4claw3nKb" width="404" height="540" topLeftX="556" topLeftY="0" saturation="-70">
+        <crop type="rect" leftOffset="136" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="FIQ7bmN4HomZJ4xw5Jdc2VQXnuf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="712" height="146" topLeftX="124" topLeftY="156" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="28" bold="false">请用一句话简要概括一下这个季度的状况。根据需要编辑和完善文本，以确保有效传达您的信息，并吸引受众的注意力</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="4" height="120" topLeftX="109" topLeftY="169" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CcdZb7zBbovgU3xDjvxcpvRtnng" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <undefined type="fallback"/>
+      <shape width="395" height="41" topLeftX="283" topLeftY="74" alpha="0.6" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="14">Quarterly Overview</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="56" topLeftX="283" topLeftY="38" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(67, 86, 113, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="24">季度概述</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IOKkbQRAroyuDPxVzXucSJ9Lnfb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="395" height="77" topLeftX="59" topLeftY="49" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true" textAlign="left">
+          <p>数据状况</p>
+        </content>
+      </shape>
+      <shape width="126" height="68" topLeftX="64" topLeftY="258" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(67, 86, 113, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(67, 86, 113, 1)">68%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="44" topLeftX="64" topLeftY="313" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(16, 50, 98, 0.4)" textAlign="left">
+          <p>
+            <span color="rgba(16, 50, 98, 0.4)">用户留存率</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="126" height="68" topLeftX="64" topLeftY="377" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(67, 86, 113, 1)" bold="true" textAlign="left">
+          <p>56%</p>
+        </content>
+      </shape>
+      <shape width="144" height="44" topLeftX="64" topLeftY="429" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(16, 50, 98, 0.4)" textAlign="left">
+          <p>
+            <span color="rgba(16, 50, 98, 0.4)">预计市场占有率</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="12" topLeftX="792" topLeftY="87" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="120" height="38" topLeftX="804" topLeftY="74" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(37, 43, 51, 1)" textAlign="left">
+          <p>你的产品</p>
+        </content>
+      </shape>
+      <shape width="12" height="12" topLeftX="792" topLeftY="134" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 50, 98, 0.4)"/>
+        </fill>
+      </shape>
+      <shape width="120" height="38" topLeftX="805" topLeftY="121" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(37, 43, 51, 1)" textAlign="left">
+          <p>
+            <span color="rgba(37, 43, 51, 1)" fontSize="12">竞品 A</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="363" height="62" topLeftX="59" topLeftY="116" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(16, 50, 98, 0.4)">
+          <p>
+            <span color="rgba(16, 50, 98, 0.4)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="348" startY="243" endX="906" endY="242" alpha="0.38">
+        <border color="rgba(143, 149, 158, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="348" startY="314" endX="906" endY="313" alpha="0.38">
+        <border color="rgba(143, 149, 158, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="348" startY="387" endX="906" endY="386" alpha="0.38">
+        <border color="rgba(143, 149, 158, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="348" startY="458" endX="906" endY="457" alpha="0.38">
+        <border color="rgba(143, 149, 158, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="51" height="44" topLeftX="280" topLeftY="437" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(16, 50, 98, 0.4)" textAlign="center">
+          <p>
+            <span color="rgba(16, 50, 98, 0.4)">0</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="44" topLeftX="280" topLeftY="366" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(16, 50, 98, 0.4)" textAlign="center">
+          <p>
+            <span color="rgba(16, 50, 98, 0.4)">20</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="44" topLeftX="280" topLeftY="293" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(16, 50, 98, 0.4)" textAlign="center">
+          <p>
+            <span color="rgba(16, 50, 98, 0.4)">40</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="44" topLeftX="280" topLeftY="222" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(16, 50, 98, 0.4)" textAlign="center">
+          <p>
+            <span color="rgba(16, 50, 98, 0.4)">60</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="44" topLeftX="421" topLeftY="457" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>
+            <span color="rgba(67, 86, 113, 1)">Q1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="44" topLeftX="550" topLeftY="457" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>
+            <span color="rgba(67, 86, 113, 1)">Q2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="44" topLeftX="680" topLeftY="457" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>
+            <span color="rgba(67, 86, 113, 1)">Q3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="44" topLeftX="810" topLeftY="457" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>
+            <span color="rgba(67, 86, 113, 1)">Q4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="16" height="97" topLeftX="428" topLeftY="360" type="rect">
+        <fill>
+          <fillColor color="rgba(16, 50, 98, 0.4)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="51" topLeftX="449" topLeftY="407" type="rect">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="116" topLeftX="558" topLeftY="341" type="rect">
+        <fill>
+          <fillColor color="rgba(16, 50, 98, 0.4)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="116" topLeftX="578" topLeftY="341" type="rect">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="116" topLeftX="688" topLeftY="341" type="rect">
+        <fill>
+          <fillColor color="rgba(16, 50, 98, 0.4)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="164" topLeftX="708" topLeftY="293" type="rect">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="120" topLeftX="817" topLeftY="337" type="rect">
+        <fill>
+          <fillColor color="rgba(16, 50, 98, 0.4)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="179" topLeftX="837" topLeftY="278" type="rect">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CcdZb7zBbovgU3xDjvxcpvRtnng" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="220" height="260" topLeftX="608" topLeftY="160" presetHandlers="0" alpha="0.5" type="round-rect">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="220" height="260" topLeftX="370" topLeftY="160" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(39, 49, 62, 1)"/>
+        </fill>
+      </shape>
+      <shape width="220" height="260" topLeftX="132" topLeftY="160" presetHandlers="0" alpha="0.5" type="round-rect">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="200" height="41" topLeftX="142" topLeftY="287" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="false" textAlign="center">
+          <p>
+            <span bold="false">关键数据 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="74" topLeftX="142" topLeftY="330" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 0.502)" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 0.502)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="41" topLeftX="380" topLeftY="287" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="false" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" bold="false">关键数据 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="74" topLeftX="380" topLeftY="330" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="74" topLeftX="618" topLeftY="330" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 0.502)" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 0.502)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="41" topLeftX="618" topLeftY="287" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="false" textAlign="center">
+          <p>
+            <span bold="false">关键数据 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="70" topLeftX="142" topLeftY="196" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="42">2,048</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="70" topLeftX="380" topLeftY="196" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="42">6,068</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="70" topLeftX="618" topLeftY="196" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="42">24%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="396" height="56" topLeftX="282" topLeftY="38" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(67, 86, 113, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="24">数据状况</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="396" height="41" topLeftX="282" topLeftY="74" alpha="0.6" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="14">Data status</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CeT7bMsMSoDAobx3VOgcluxNnac" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="466" height="77" topLeftX="247" topLeftY="212" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(67, 86, 113, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="38">目标复盘 OKR Review</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IOKkbQRAroyuDPxVzXucSJ9Lnfb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="152" height="56" topLeftX="40" topLeftY="40" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="24">Q1 目标复盘</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="56" height="40" topLeftX="40" topLeftY="349" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(67, 86, 113, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="20">O4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="708" height="52" topLeftX="94" topLeftY="343" presetHandlers="26" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="18" color="rgba(16, 50, 98, 0.1)"/>
+      </shape>
+      <shape width="603" height="41" topLeftX="108" topLeftY="349" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="14">单击此处输入你的正文，文字是您思想的提炼为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="36" topLeftX="817" topLeftY="351" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">M</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="56" height="40" topLeftX="40" topLeftY="287" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(67, 86, 113, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="20">O3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="708" height="52" topLeftX="94" topLeftY="281" presetHandlers="26" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="18" color="rgba(16, 50, 98, 0.1)"/>
+      </shape>
+      <shape width="603" height="41" topLeftX="108" topLeftY="286" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="14">单击此处输入你的正文，文字是您思想的提炼为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="36" topLeftX="817" topLeftY="289" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">M-</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="56" height="40" topLeftX="40" topLeftY="224" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(67, 86, 113, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="20">O2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="708" height="52" topLeftX="94" topLeftY="218" presetHandlers="26" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="18" color="rgba(16, 50, 98, 0.1)"/>
+      </shape>
+      <shape width="603" height="41" topLeftX="108" topLeftY="224" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="14">单击此处输入你的正文，文字是您思想的提炼为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="36" topLeftX="817" topLeftY="226" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">M</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="56" height="40" topLeftX="40" topLeftY="162" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(67, 86, 113, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="20">O1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="708" height="52" topLeftX="94" topLeftY="156" presetHandlers="26" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="18" color="rgba(16, 50, 98, 0.1)"/>
+      </shape>
+      <shape width="603" height="41" topLeftX="108" topLeftY="162" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="14">单击此处输入你的正文，文字是您思想的提炼为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="36" topLeftX="817" topLeftY="164" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">M+</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IOKkbQRAroyuDPxVzXucSJ9Lnfb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="395" height="68" topLeftX="48" topLeftY="83" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" textAlign="left">
+          <p>如何完成目标 HOW</p>
+        </content>
+      </shape>
+      <shape width="225" height="44" topLeftX="-217" topLeftY="39" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p/>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+      <shape width="305" height="62" topLeftX="48" topLeftY="139" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(16, 50, 98, 0.4)">
+          <p>
+            <span color="rgba(16, 50, 98, 0.4)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CeT7bMsMSoDAobx3VOgcluxNnac" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="466" height="77" topLeftX="247" topLeftY="212" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(67, 86, 113, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="38">工作成果 Work Results</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CcdZb7zBbovgU3xDjvxcpvRtnng" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="395" height="44" topLeftX="31" topLeftY="30" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <strong>
+              <span color="rgba(37, 43, 51, 1)" fontSize="16">工作结果 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="492" height="36" topLeftX="31" topLeftY="68" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(67, 86, 113, 1)" bold="false">
+          <p lineSpacing="multiple:1.3">
+            <span color="rgba(67, 86, 113, 1)" fontSize="12" bold="false">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Fx44bLHhEo2M5fxnkxbciHg1n0d" width="355" height="459" topLeftX="572" topLeftY="38" saturation="61" temperature="-47">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="83" bottomOffset="83" presetHandlers="0"/>
+      </img>
+      <shape width="261" height="92" topLeftX="135" topLeftY="384" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" textAlign="left">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="34" topLeftX="135" topLeftY="355" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="14">关键</span>
+            </strong>
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="14">点 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="92" topLeftX="135" topLeftY="225" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" textAlign="left">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="34" topLeftX="135" topLeftY="196" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="14">关键</span>
+            </strong>
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="14">点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="76" height="76" topLeftX="45" topLeftY="195" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="76" height="76" topLeftX="45" topLeftY="354" type="ellipse">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CcdZb7zBbovgU3xDjvxcpvRtnng" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="395" height="44" topLeftX="31" topLeftY="30" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <strong>
+              <span color="rgba(37, 43, 51, 1)" fontSize="16">工作结果 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="492" height="36" topLeftX="31" topLeftY="68" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="false">
+          <p lineSpacing="multiple:1.3">
+            <span color="rgba(67, 86, 113, 1)" fontSize="12" bold="false">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <img src="KOeRbHNF0ooGkGxNePNcqeblnf7" width="428" height="241" topLeftX="493" topLeftY="124" exposure="3" saturation="-28" temperature="-100">
+        <crop type="rect" leftOffset="49" rightOffset="37" topOffset="0" bottomOffset="48" presetHandlers="0"/>
+      </img>
+      <img src="KEglbi17LosUiRxiWINcwLM8nCd" width="428" height="241" topLeftX="39" topLeftY="124" exposure="32" saturation="-76" temperature="-100">
+        <crop type="rect" leftOffset="0.79" rightOffset="0.79" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="428" height="74" topLeftX="39" topLeftY="413" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="34" topLeftX="152" topLeftY="376" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="14">关键</span>
+            </strong>
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="14">点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="428" height="74" topLeftX="493" topLeftY="413" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="34" topLeftX="606" topLeftY="376" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="14">关键</span>
+            </strong>
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="14">点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CcdZb7zBbovgU3xDjvxcpvRtnng" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="395" height="44" topLeftX="31" topLeftY="30" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <strong>
+              <span color="rgba(37, 43, 51, 1)" fontSize="16">工作结果 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="267" height="56" topLeftX="39" topLeftY="408" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(67, 86, 113, 1)" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="39" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true">
+          <p>关键结果 #1</p>
+        </content>
+      </shape>
+      <shape width="267" height="56" topLeftX="336" topLeftY="408" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(67, 86, 113, 1)" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="336" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true">
+          <p>关键结果 #2</p>
+        </content>
+      </shape>
+      <shape width="267" height="56" topLeftX="634" topLeftY="408" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(67, 86, 113, 1)" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="634" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true">
+          <p>关键结果 #3</p>
+        </content>
+      </shape>
+      <img src="OSQCbZBZGoVP1Qx1WXKcrM8JnCc" width="882" height="241" topLeftX="39" topLeftY="94" exposure="32" saturation="-76" temperature="-100">
+        <crop type="rect" leftOffset="7" rightOffset="0" topOffset="37" bottomOffset="221" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CcdZb7zBbovgU3xDjvxcpvRtnng" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="395" height="44" topLeftX="31" topLeftY="30" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <p>
+            <strong>
+              <span color="rgba(37, 43, 51, 1)" fontSize="16">结果复盘</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="148" height="36" topLeftX="46" topLeftY="113" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">做的好的</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="148" height="36" topLeftX="448" topLeftY="113" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(37, 43, 51, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">可以更好的</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="376" height="342" topLeftX="46" topLeftY="164" presetHandlers="12" type="round-rect">
+        <border color="linear-gradient(180deg,rgba(48, 70, 99, 0.34) 0%,rgba(37, 43, 51, 0) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(67, 86, 113, 1)" lineSpacing="multiple:1.8" textAlign="left">
+          <ul>
+            <li>
+              <p lineSpacing="multiple:1.8">
+                <span color="rgba(67, 86, 113, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:1.8">
+                <span color="rgba(67, 86, 113, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:1.8">
+                <span color="rgba(67, 86, 113, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="376" height="342" topLeftX="448" topLeftY="164" presetHandlers="12" type="round-rect">
+        <border color="linear-gradient(180deg,rgba(48, 70, 99, 0.34) 0%,rgba(37, 43, 51, 0) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(67, 86, 113, 1)" lineSpacing="multiple:1.8" textAlign="left">
+          <ul>
+            <li>
+              <p lineSpacing="multiple:1.8">
+                <span color="rgba(67, 86, 113, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:1.8">
+                <span color="rgba(67, 86, 113, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:1.8">
+                <span color="rgba(67, 86, 113, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CeT7bMsMSoDAobx3VOgcluxNnac" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="466" height="77" topLeftX="247" topLeftY="212" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(67, 86, 113, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="38">未来规划 Future Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CcdZb7zBbovgU3xDjvxcpvRtnng" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="708" height="116" topLeftX="167" topLeftY="193" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <ul>
+            <li>
+              <p lineSpacing="multiple:2">
+                <strong>
+                  <span color="rgba(37, 43, 51, 1)" fontSize="12">KR1</span>
+                </strong>
+                <span color="rgba(37, 43, 51, 1)" fontSize="12"> - 描述相关的信息以解释你的标题。</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <strong>
+                  <span color="rgba(37, 43, 51, 1)" fontSize="12">KR2 </span>
+                </strong>
+                <span color="rgba(37, 43, 51, 1)" fontSize="12" bold="false">- 描述相关的信息以解释你的标题。</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <strong>
+                  <span color="rgba(37, 43, 51, 1)" fontSize="12">KR3</span>
+                </strong>
+                <span color="rgba(37, 43, 51, 1)" fontSize="12" bold="false"> - 描述相关的信息以解释你的标题。</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <strong>
+                  <span color="rgba(37, 43, 51, 1)" fontSize="12">KR4 </span>
+                </strong>
+                <span color="rgba(37, 43, 51, 1)" fontSize="12" bold="false">- 描述相关的信息以解释你的标题。</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="708" height="116" topLeftX="167" topLeftY="386" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)">
+          <ul>
+            <li>
+              <p lineSpacing="multiple:2">
+                <strong>
+                  <span color="rgba(37, 43, 51, 1)" fontSize="12">KR1</span>
+                </strong>
+                <span color="rgba(37, 43, 51, 1)" fontSize="12"> - 描述相关的信息以解释你的标题。</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <strong>
+                  <span color="rgba(37, 43, 51, 1)" fontSize="12">KR2 </span>
+                </strong>
+                <span color="rgba(37, 43, 51, 1)" fontSize="12" bold="false">- 描述相关的信息以解释你的标题。</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <strong>
+                  <span color="rgba(37, 43, 51, 1)" fontSize="12">KR3</span>
+                </strong>
+                <span color="rgba(37, 43, 51, 1)" fontSize="12" bold="false"> - 描述相关的信息以解释你的标题。</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <strong>
+                  <span color="rgba(37, 43, 51, 1)" fontSize="12">KR4 </span>
+                </strong>
+                <span color="rgba(37, 43, 51, 1)" fontSize="12" bold="false">- 描述相关的信息以解释你的标题。</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="56" height="40" topLeftX="103" topLeftY="139" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="20">O1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="708" height="52" topLeftX="157" topLeftY="133" presetHandlers="26" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="18" color="rgba(16, 50, 98, 0.1)"/>
+      </shape>
+      <shape width="603" height="41" topLeftX="172" topLeftY="138" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="14">单击此处输入你的正文，文字是您思想的提炼为了最终演示发布的良好效果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="56" height="40" topLeftX="106" topLeftY="331" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="20">O2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="708" height="52" topLeftX="160" topLeftY="325" presetHandlers="26" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" angle="90" blur="18" color="rgba(16, 50, 98, 0.1)"/>
+      </shape>
+      <shape width="603" height="41" topLeftX="175" topLeftY="331" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="14">单击此处输入你的正文，文字是您思想的提炼为了最终演示发布的良好效果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="41" topLeftX="283" topLeftY="74" alpha="0.6" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(67, 86, 113, 1)" textAlign="center">
+          <p>
+            <span color="rgba(67, 86, 113, 1)" fontSize="14">Future Planning</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="56" topLeftX="283" topLeftY="38" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(67, 86, 113, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(67, 86, 113, 1)" fontSize="24">未来规划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="FIQ7bmN4HomZJ4xw5Jdc2VQXnuf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="566" height="77" topLeftX="197" topLeftY="212" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">Thank you</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/office--work_report.xml
+++ b/skills/lark-slides/references/templates/office--work_report.xml
@@ -1,0 +1,1099 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>工作汇报</title>
+  <theme>
+    <fill alpha="1">
+      <fillImg src="NTWGbjziqoG2vZxAoBrc9p3znbd" alpha="1" rotateWithShape="false"/>
+    </fill>
+    <textStyles>
+      <title fontColor="#000000FF"/>
+      <headline fontColor="#000000FF" fontSize="32"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="V1yybjKJoovlTixLUGUcyyU0nwf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="350" height="47" topLeftX="349" topLeftY="286" alpha="0.48" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="false" textAlign="left">
+          <p>
+            <span fontSize="18" bold="false">汇报人: XXXX</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="350" height="47" topLeftX="349" topLeftY="179" alpha="0.48" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="false" textAlign="left">
+          <p>
+            <span fontSize="18" bold="false">WORK SUMMARY</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="350" height="88" topLeftX="349" topLeftY="206" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(53, 49, 58, 1)" bold="true" lineSpacing="multiple:1.4" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(53, 49, 58, 1)" fontSize="48">工作汇报</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NTWGbjziqoG2vZxAoBrc9p3znbd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="327" height="62" topLeftX="45" topLeftY="106" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="488" height="64" topLeftX="42" topLeftY="54" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(31, 35, 41, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="32">汇报流程</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="206" height="83" topLeftX="730" topLeftY="374" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="206" height="44" topLeftX="730" topLeftY="336" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>下一步规划</p>
+        </content>
+      </shape>
+      <shape width="206" height="83" topLeftX="503" topLeftY="374" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="206" height="44" topLeftX="503" topLeftY="336" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>经验与成长</p>
+        </content>
+      </shape>
+      <shape width="206" height="83" topLeftX="276" topLeftY="374" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="206" height="44" topLeftX="276" topLeftY="336" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>进展更新</p>
+        </content>
+      </shape>
+      <shape width="206" height="83" topLeftX="46" topLeftY="374" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="206" height="44" topLeftX="46" topLeftY="336" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>目标复盘</p>
+        </content>
+      </shape>
+      <shape width="105" height="105" topLeftX="513" topLeftY="218" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="105" height="105" topLeftX="286" topLeftY="218" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="105" height="105" topLeftX="56" topLeftY="218" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="105" height="105" topLeftX="740" topLeftY="218" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <img src="X7Kvbtl9CobayrxUfNacKQ0nnqT" width="105" height="105" topLeftX="740" topLeftY="218">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="14"/>
+      </img>
+      <img src="SfKkb2wb9o4k3rxRi1IcQkUxnDh" width="105" height="105" topLeftX="56" topLeftY="218">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="14"/>
+      </img>
+      <img src="B2robKlpXoGzNTxNDvxcT67LnKf" width="105" height="105" topLeftX="286" topLeftY="218">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="14"/>
+      </img>
+      <img src="CjRfb9zhTokbWlxArWzcTUQbnOb" width="105" height="105" topLeftX="513" topLeftY="218">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="14"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NTWGbjziqoG2vZxAoBrc9p3znbd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="327" height="62" topLeftX="45" topLeftY="106" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="488" height="64" topLeftX="42" topLeftY="54" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(31, 35, 41, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="32">目标复盘</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="366" height="44" topLeftX="534" topLeftY="63" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>提升用户满意度</p>
+        </content>
+      </shape>
+      <shape width="366" height="62" topLeftX="534" topLeftY="98" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(147, 150, 156, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="366" height="62" topLeftX="534" topLeftY="213" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(147, 150, 156, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="366" height="44" topLeftX="534" topLeftY="178" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>提升用户留存</p>
+        </content>
+      </shape>
+      <shape width="366" height="62" topLeftX="534" topLeftY="328" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(147, 150, 156, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="366" height="44" topLeftX="534" topLeftY="293" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>扩展用户基数</p>
+        </content>
+      </shape>
+      <shape width="366" height="62" topLeftX="534" topLeftY="443" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(147, 150, 156, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="366" height="44" topLeftX="534" topLeftY="407" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>增加产品利润率</p>
+        </content>
+      </shape>
+      <shape width="90" height="52" topLeftX="450" topLeftY="407" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(127, 59, 245, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="right">
+          <p>70%</p>
+        </content>
+      </shape>
+      <shape width="90" height="52" topLeftX="450" topLeftY="291" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(245, 74, 69, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="right">
+          <p>100%</p>
+        </content>
+      </shape>
+      <shape width="90" height="52" topLeftX="450" topLeftY="178" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(51, 112, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="right">
+          <p>60%</p>
+        </content>
+      </shape>
+      <shape width="90" height="52" topLeftX="450" topLeftY="63" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 136, 0, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="right">
+          <p>90%</p>
+        </content>
+      </shape>
+      <line startX="478" startY="159" endX="900" endY="159">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="478" startY="274" endX="900" endY="274">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="478" startY="389" endX="900" endY="388">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NTWGbjziqoG2vZxAoBrc9p3znbd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="327" height="62" topLeftX="45" topLeftY="106" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="488" height="64" topLeftX="42" topLeftY="54" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(31, 35, 41, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" lineSpacing="multiple:1.35" textAlign="left">
+          <p>
+            <strong>
+              <span fontSize="32">进展更新</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="56" height="56" topLeftX="509" topLeftY="80" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.51)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24">
+          <p>
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="24">1</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="56" height="56" topLeftX="726" topLeftY="80" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.51)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 136, 0, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 136, 0, 1)" fontSize="24">2</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="56" height="56" topLeftX="509" topLeftY="294" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.51)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(245, 74, 69, 1)">
+          <p>
+            <strong>
+              <span color="rgba(245, 74, 69, 1)" fontSize="24">3</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="56" height="56" topLeftX="726" topLeftY="294" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.51)" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(127, 59, 245, 1)">
+          <p>
+            <strong>
+              <span color="rgba(127, 59, 245, 1)" fontSize="24">4</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="202" height="83" topLeftX="502" topLeftY="395" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="83" topLeftX="719" topLeftY="395" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="83" topLeftX="719" topLeftY="182" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="83" topLeftX="502" topLeftY="182" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="502" topLeftY="361" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>关键结果 #3</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="719" topLeftY="361" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>关键结果 #4</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="719" topLeftY="148" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>关键结果 #2</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="502" topLeftY="148" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>关键结果 #1</p>
+        </content>
+      </shape>
+      <shape width="390" height="198" topLeftX="44" topLeftY="288" presetHandlers="12" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <img src="AhcMbGEh4ozikoxpZS5cSJDlnxh" width="378" height="187" topLeftX="50" topLeftY="294" alpha="0.8" exposure="16" saturation="-15">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="13" bottomOffset="13" presetHandlers="10"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Hs6Vb0DcDooIyPx4DRLcUn9QnHc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="217" height="449" topLeftX="358" topLeftY="45" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <img src="QGM6bOHEGoSpXexp8kPcmQDmnpc" width="202" height="437" topLeftX="365" topLeftY="52">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="279" height="116" topLeftX="42" topLeftY="45" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="left">
+          <p lineSpacing="multiple:1.2" letterSpacing="8">
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="80">0</span>
+            </strong>
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="80">1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="299" height="63" topLeftX="42" topLeftY="345" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="36">关键结果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="279" height="62" topLeftX="42" topLeftY="406" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="319" height="167" topLeftX="611" topLeftY="301" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">这是一个模板模块，你可以介绍我们的产品功能</span>
+          </p>
+          <p/>
+          <p>
+            <span fontSize="14">把我们的产品抽象的界面展示功能放在右边</span>
+          </p>
+          <p/>
+          <p>
+            <span fontSize="14">右边的产品界面图片也是分层的。你可以删除这个界面，保留底部的装饰图片，然后用你想用的产品界面代替它。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="299" height="44" topLeftX="611" topLeftY="171" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="16">用户满意度</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="299" height="84" topLeftX="611" topLeftY="204" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(51, 112, 255, 1)" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="64">60</span>
+            </strong>
+            <strong>
+              <span color="rgba(51, 112, 255, 1)" fontSize="36">%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DtsKblm5koUbwKxUNrgcvihHnhh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="202" height="116" topLeftX="728" topLeftY="388" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 136, 0, 1)" textAlign="right">
+          <p lineSpacing="multiple:1.2" letterSpacing="8">
+            <strong>
+              <span color="rgba(255, 136, 0, 1)" fontSize="80">0</span>
+            </strong>
+            <strong>
+              <span color="rgba(255, 136, 0, 1)" fontSize="80">2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="299" height="63" topLeftX="44" topLeftY="53" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="36">关键结果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="358" height="62" topLeftX="361" topLeftY="53" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="267" height="62" topLeftX="44" topLeftY="279" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="44" topLeftY="244" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>关键结果 #1</p>
+        </content>
+      </shape>
+      <shape width="267" height="62" topLeftX="361" topLeftY="279" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="361" topLeftY="244" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>关键结果 #2</p>
+        </content>
+      </shape>
+      <shape width="267" height="62" topLeftX="44" topLeftY="408" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="44" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>关键结果 #3</p>
+        </content>
+      </shape>
+      <shape width="267" height="62" topLeftX="361" topLeftY="408" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="361" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>关键结果 #4</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HZmVby7pHoCsGyxYBricPrZonqh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="522" height="450" topLeftX="387" topLeftY="45" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="374" height="116" topLeftX="42" topLeftY="175" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(127, 59, 245, 1)" textAlign="left">
+          <p lineSpacing="multiple:1.2" letterSpacing="8">
+            <strong>
+              <span color="rgba(127, 59, 245, 1)" fontSize="80">0</span>
+            </strong>
+            <strong>
+              <span color="rgba(127, 59, 245, 1)" fontSize="80">3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="434" startY="434" endX="889" endY="435" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="434" startY="134" endX="889" endY="135" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="434" startY="194" endX="889" endY="195" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="435" startY="251" endX="890" endY="252" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="434" startY="314" endX="889" endY="315" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="435" startY="375" endX="890" endY="376" alpha="0.15">
+        <border color="rgba(31, 35, 41, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="299" height="64" topLeftX="42" topLeftY="302" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="36">关键结果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="279" height="62" topLeftX="42" topLeftY="357" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="12" topLeftX="55" topLeftY="466" type="ellipse">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="120" height="38" topLeftX="67" topLeftY="453" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">所有用户</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="12" topLeftX="159" topLeftY="466" alpha="0.25" type="ellipse">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="120" height="38" topLeftX="171" topLeftY="453" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">留存用户</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="38" topLeftX="435" topLeftY="433" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2020</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="38" topLeftX="381" topLeftY="115" alpha="0.3" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">100</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="38" topLeftX="381" topLeftY="171" alpha="0.3" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">80</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="38" topLeftX="381" topLeftY="232" alpha="0.3" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">60</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="38" topLeftX="382" topLeftY="295" alpha="0.3" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">40</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="38" topLeftX="381" topLeftY="356" alpha="0.3" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">20</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="38" topLeftX="514" topLeftY="433" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2021</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="38" topLeftX="593" topLeftY="433" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2022</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="38" topLeftX="673" topLeftY="433" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2023</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="38" topLeftX="752" topLeftY="433" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2024</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="53" height="38" topLeftX="831" topLeftY="433" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">2025</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="18" height="252" topLeftX="849" topLeftY="182" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="156" topLeftX="849" topLeftY="278" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="274" topLeftX="769" topLeftY="160" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="170" topLeftX="769" topLeftY="263" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="215" topLeftX="690" topLeftY="219" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="93" topLeftX="690" topLeftY="341" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="149" topLeftX="611" topLeftY="284" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="120" topLeftX="611" topLeftY="314" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="215" topLeftX="532" topLeftY="219" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="143" topLeftX="532" topLeftY="291" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="94" topLeftX="452" topLeftY="340" presetHandlers="19" alpha="0.15" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="77" topLeftX="452" topLeftY="356" presetHandlers="19" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NTWGbjziqoG2vZxAoBrc9p3znbd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="858" height="314" topLeftX="50" topLeftY="53" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="299" height="63" topLeftX="50" topLeftY="410" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="36">关键结果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="279" height="62" topLeftX="280" topLeftY="410" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="263" startY="413" endX="264" endY="470">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="173" height="116" topLeftX="758" topLeftY="388" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(245, 74, 69, 1)" textAlign="right">
+          <p lineSpacing="multiple:1.2" letterSpacing="8">
+            <strong>
+              <span color="rgba(245, 74, 69, 1)" fontSize="80">0</span>
+            </strong>
+            <strong>
+              <span color="rgba(245, 74, 69, 1)" fontSize="80">4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="E1mGbNkwBoqbpzxuGJVcF4hpnrd" width="842" height="301" topLeftX="58" topLeftY="60" alpha="0.85" exposure="35" saturation="-26" temperature="5">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="46" bottomOffset="46" presetHandlers="12"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NTWGbjziqoG2vZxAoBrc9p3znbd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="327" height="62" topLeftX="45" topLeftY="136" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="488" height="64" topLeftX="42" topLeftY="84" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(31, 35, 41, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" lineSpacing="multiple:1.35" textAlign="left">
+          <p>经验成长</p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NTWGbjziqoG2vZxAoBrc9p3znbd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="197" height="83" topLeftX="45" topLeftY="146" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="229" height="64" topLeftX="42" topLeftY="94" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(31, 35, 41, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" lineSpacing="multiple:1.35" textAlign="left">
+          <p>方法论总结</p>
+        </content>
+      </shape>
+      <shape width="214" height="382" topLeftX="258" topLeftY="79" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="202" height="83" topLeftX="264" topLeftY="374" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="264" topLeftY="342" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>方法论 #1</p>
+        </content>
+      </shape>
+      <shape width="214" height="382" topLeftX="489" topLeftY="79" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="202" height="83" topLeftX="495" topLeftY="374" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="495" topLeftY="342" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>方法论 #2</p>
+        </content>
+      </shape>
+      <shape width="214" height="382" topLeftX="719" topLeftY="79" presetHandlers="14" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="202" height="83" topLeftX="725" topLeftY="374" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="202" height="44" topLeftX="725" topLeftY="342" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>方法论 #3</p>
+        </content>
+      </shape>
+      <img src="OOmEb343jolp58xrDnacYN18ncb" width="200" height="252" topLeftX="727" topLeftY="86">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.18" bottomOffset="0.18" presetHandlers="12"/>
+      </img>
+      <img src="HGb6bju5molc3gxT9ecccuHYnxd" width="200" height="252" topLeftX="495" topLeftY="86">
+        <crop type="rect" leftOffset="0.03" rightOffset="0.03" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <img src="UOtKbgGgboAqGrxx8cPcwbEMnFb" width="200" height="252" topLeftX="265" topLeftY="86">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.18" bottomOffset="0.18" presetHandlers="12"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NTWGbjziqoG2vZxAoBrc9p3znbd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="327" height="62" topLeftX="45" topLeftY="106" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="488" height="64" topLeftX="42" topLeftY="54" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(31, 35, 41, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" lineSpacing="multiple:1.35" textAlign="left">
+          <p>下一步规划</p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NTWGbjziqoG2vZxAoBrc9p3znbd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="81" startY="450" endX="80" endY="90" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="214" startY="450" endX="213" endY="90" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="347" startY="450" endX="346" endY="90" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="480" startY="450" endX="480" endY="90" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="614" startY="450" endX="613" endY="90" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="880" startY="450" endX="879" endY="90" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="747" startY="450" endX="746" endY="90" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="399" height="48" topLeftX="214" topLeftY="101" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">调查研究</span>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="229" height="56" topLeftX="208" topLeftY="153" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="337" height="48" topLeftX="480" topLeftY="161" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(127, 59, 245, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">研发执行</span>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(127, 59, 245, 0.2)"/>
+      </shape>
+      <shape width="400" height="48" topLeftX="80" topLeftY="280" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(245, 74, 69, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">制定策略</span>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(245, 74, 69, 0.15)"/>
+      </shape>
+      <shape width="133" height="48" topLeftX="480" topLeftY="221" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">设计执行</span>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="267" height="56" topLeftX="80" topLeftY="333" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="267" height="56" topLeftX="613" topLeftY="399" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="267" height="48" topLeftX="613" topLeftY="343" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">质量测试</span>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="TICCbnOL2ob8axxsXIychojDnhd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="350" height="87" topLeftX="305" topLeftY="206" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(53, 49, 58, 1)" bold="true" lineSpacing="multiple:1.4" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(53, 49, 58, 1)" fontSize="48">谢谢观赏</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/office--work_summary.xml
+++ b/skills/lark-slides/references/templates/office--work_summary.xml
@@ -1,0 +1,4420 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>工作总结</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(34, 38, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="211" height="270" topLeftX="749" topLeftY="270" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="470" height="470" topLeftX="520" topLeftY="0" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="410" height="410" topLeftX="550" topLeftY="30" type="pie">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <img src="JNIDbOa9roxVVfxojZkcAW3XnPd" width="346" height="346" topLeftX="582" topLeftY="62">
+        <crop type="rect" leftOffset="136" rightOffset="136" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="37" height="37" topLeftX="466" topLeftY="58" type="ellipse">
+        <border color="rgba(102, 102, 102, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="QsFDbyJTOobre4x5WAZcrLF3npf" width="46" height="77" topLeftX="503" topLeftY="418" alpha="0.7">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="10" height="10" topLeftX="486" topLeftY="87" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <img src="Fb4FbjKWCo130dxrMgQcdpBxnTg" width="86" height="10" topLeftX="31" topLeftY="271">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="MoiqbBVA1oXix5xxcvhcQLk3nAb" width="46" height="16" topLeftX="31" topLeftY="524">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="37" height="37" topLeftX="836" topLeftY="470" type="ellipse">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="10" height="10" topLeftX="831" topLeftY="479" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="407" height="42" topLeftX="31" topLeftY="448" type="text">
+        <content textType="title" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>2026 Q1 </p>
+          <p>By 姓名</p>
+        </content>
+      </shape>
+      <shape width="407" height="63" topLeftX="31" topLeftY="305" type="text">
+        <content textType="title" fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="408" height="48" topLeftX="31" topLeftY="224" type="text">
+        <content textType="title" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>某某团队</p>
+        </content>
+      </shape>
+      <shape width="408" height="90" topLeftX="31" topLeftY="134" type="text">
+        <content textType="title" fontSize="60" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>工作总结</p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="68" topLeftY="40" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="SJrybASt7oIAmKxh6Xac4NYhnxh" width="24" height="24" topLeftX="31" topLeftY="37" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="298" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="47" height="46" topLeftX="516" topLeftY="101" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontFamily="Arial">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="46" topLeftX="516" topLeftY="194" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontFamily="Arial">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="46" topLeftX="516" topLeftY="290" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontFamily="Arial">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="46" topLeftX="516" topLeftY="384" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontFamily="Arial">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="404" topLeftX="95" topLeftY="80" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="353" height="353" topLeftX="121" topLeftY="105" type="pie">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <img src="F9pLbUiZiohvrSxwtyzcf6dfnQK" width="298" height="298" topLeftX="149" topLeftY="133">
+        <crop type="rect" leftOffset="117" rightOffset="117" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="233" height="60" topLeftX="52" topLeftY="45" type="text">
+        <content textType="headline" fontSize="40" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="40" fontFamily="思源黑体">目录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="233" height="30" topLeftX="52" topLeftY="102" type="text">
+        <content textType="headline" fontSize="20" fontFamily="Arial" color="rgba(255, 224, 136, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 224, 136, 1)" fontSize="20" fontFamily="Arial">CONTENTS</span>
+          </p>
+        </content>
+      </shape>
+      <img src="GcEOb8DiHogACrxPz3KcQZomnGg" width="86" height="10" topLeftX="825" topLeftY="491">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="851" topLeftY="-29" rotation="270">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="47" height="46" topLeftX="514" topLeftY="99" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontFamily="Arial">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="46" topLeftX="514" topLeftY="192" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontFamily="Arial">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="46" topLeftX="514" topLeftY="288" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontFamily="Arial">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="46" topLeftX="514" topLeftY="382" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontFamily="Arial">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="37" height="37" topLeftX="52" topLeftY="470" type="ellipse">
+        <border color="rgba(102, 102, 102, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="10" height="10" topLeftX="79" topLeftY="474" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="332" height="42" topLeftX="579" topLeftY="412" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p textAlign="left">输入相关的描述信息以解释标题，输入相关的描述信息以解释标题</p>
+        </content>
+      </shape>
+      <shape width="332" height="30" topLeftX="579" topLeftY="376" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">后续计划</p>
+        </content>
+      </shape>
+      <shape width="332" height="42" topLeftX="579" topLeftY="318" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p textAlign="left">输入相关的描述信息以解释标题，输入相关的描述信息以解释标题</p>
+        </content>
+      </shape>
+      <shape width="332" height="30" topLeftX="579" topLeftY="282" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">经验反思</p>
+        </content>
+      </shape>
+      <shape width="332" height="42" topLeftX="579" topLeftY="224" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p textAlign="left">输入相关的描述信息以解释标题，输入相关的描述信息以解释标题</p>
+        </content>
+      </shape>
+      <shape width="332" height="30" topLeftX="579" topLeftY="188" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">完成情况</p>
+        </content>
+      </shape>
+      <shape width="332" height="42" topLeftX="579" topLeftY="130" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p textAlign="left">输入相关的描述信息以解释标题，输入相关的描述信息以解释标题</p>
+        </content>
+      </shape>
+      <shape width="332" height="30" topLeftX="579" topLeftY="94" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">工作概况</p>
+        </content>
+      </shape>
+      <img src="F9pLbUiZiohvrSxwtyzcf6dfnQK" width="298" height="298" topLeftX="149" topLeftY="133">
+        <crop type="rect" leftOffset="117" rightOffset="117" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(34, 38, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="BbgxbapUsowgUxxvPq1cc2TJnYd" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.5">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="GYslbhG0AoRPLbxG4QPcbTpunTc" width="960" height="540" topLeftX="0" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="75" bottomOffset="116" presetHandlers="0"/>
+      </img>
+      <img src="FnAFboETEoDtHdxsLZIcto8nnYc" width="103" height="12" topLeftX="809" topLeftY="489">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="100" height="99" topLeftX="196" topLeftY="223" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="132" height="132" topLeftX="769" topLeftY="-17" type="ellipse">
+        <border color="rgba(102, 102, 102, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="12" topLeftX="769" topLeftY="74" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="99" topLeftX="191" topLeftY="218" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="72" height="18" topLeftX="68" topLeftY="40" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="OvVIbXxqioTTT8xXAckcWzYBnYg" width="24" height="24" topLeftX="31" topLeftY="37" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="BiE0bg77Poe1ZTxonW1ckyVBnfg" width="12" height="32" topLeftX="31" topLeftY="479">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="100" height="30" topLeftX="191" topLeftY="275" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="Arial" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">PART 1</p>
+        </content>
+      </shape>
+      <shape width="407" height="63" topLeftX="335" topLeftY="284" type="text">
+        <content textType="title" fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="407" height="72" topLeftX="334" topLeftY="199" type="text">
+        <content textType="title" fontSize="48" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>工作概况</p>
+        </content>
+      </shape>
+      <icon width="40" height="40" topLeftX="221" topLeftY="232" iconType="iconpark/Office/compression.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="15" height="15" topLeftX="531" topLeftY="205" type="ellipse">
+        <border color="rgba(102, 102, 102, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="963" height="540" topLeftX="-3" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 242, 1)"/>
+        </fill>
+      </shape>
+      <shape width="963" height="540" topLeftX="-1" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="851" topLeftY="-29" rotation="270">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Project Background</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">项目背景</p>
+        </content>
+      </shape>
+      <img src="JbFjbAlFNootaExzwGzcaS1anQx" width="103" height="12" topLeftX="215" topLeftY="71">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Apqqb1aFfoxZUQxeoUXc5Wgnn8b" width="163" height="378" topLeftX="577" topLeftY="120">
+        <crop type="round1rect" leftOffset="256" rightOffset="256" topOffset="0" bottomOffset="0" presetHandlers="21"/>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="VN8wbAk7EoYO0Nxe5NjclG1bn7g" width="163" height="378" topLeftX="390" topLeftY="120">
+        <crop type="round1rect" leftOffset="256" rightOffset="256" topOffset="0" bottomOffset="0" presetHandlers="21"/>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="283" height="168" topLeftX="57" topLeftY="326" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="283" height="168" topLeftX="55" topLeftY="324" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="283" height="168" topLeftX="56" topLeftY="122" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="283" height="168" topLeftX="54" topLeftY="120" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="230" height="24" topLeftX="91" topLeftY="141" type="text">
+        <content textType="headline" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="16">项目背景</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="230" height="84" topLeftX="91" topLeftY="177" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题，输入相关的描述信息以解释标题，输入相关的描述信息以解释标题，输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="LOi9b6WueojLw8xFM6Scuq1vnCb" width="163" height="378" topLeftX="765" topLeftY="120">
+        <crop type="round1rect" leftOffset="256" rightOffset="256" topOffset="0" bottomOffset="0" presetHandlers="21"/>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <icon width="20" height="20" topLeftX="67" topLeftY="144" iconType="iconpark/Office/table.svg">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="230" height="24" topLeftX="91" topLeftY="348" type="text">
+        <content textType="headline" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="16">项目目标</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="20" height="20" topLeftX="67" topLeftY="351" iconType="iconpark/Base/bookmark-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="Kgh0b2HQroD3CDx2WBecvrD1nYv" width="40" height="12" topLeftX="298" topLeftY="114">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Kgh0b2HQroD3CDx2WBecvrD1nYv" width="40" height="12" topLeftX="298" topLeftY="318">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="230" height="84" topLeftX="91" topLeftY="384" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题，输入相关的描述信息以解释标题，输入相关的描述信息以解释标题，输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(221, 239, 247, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PZwgbRQYEohPXzxJeNkcTBqDnUb" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="GOIIbzQj8ojJ0YxXVO4cvaGMn7b" width="80" height="139" topLeftX="851" topLeftY="-29" rotation="270">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Team Members</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">团队成员</p>
+        </content>
+      </shape>
+      <shape width="128" height="144" topLeftX="73" topLeftY="129" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="128" height="144" topLeftX="73" topLeftY="128" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="NagwbhT1UoRHSAxoKNQcXsEMngg" width="63" height="63" topLeftX="106" topLeftY="145">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="114" height="21" topLeftX="80" topLeftY="217" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">姓名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="18" topLeftX="80" topLeftY="241" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">职能</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="144" topLeftX="242" topLeftY="129" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="128" height="144" topLeftX="242" topLeftY="128" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="Lv7cbt82ZoJ6baxmadfczk7Enze" width="63" height="63" topLeftX="274" topLeftY="145">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="114" height="21" topLeftX="249" topLeftY="217" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">姓名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="18" topLeftX="249" topLeftY="241" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">职能</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="144" topLeftX="409" topLeftY="129" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="128" height="144" topLeftX="409" topLeftY="128" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="V2dYbtxU9oMorhxRmqncilzQnQe" width="63" height="63" topLeftX="442" topLeftY="145">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="114" height="21" topLeftX="416" topLeftY="217" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">姓名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="18" topLeftX="416" topLeftY="241" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">职能</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="144" topLeftX="585" topLeftY="129" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="128" height="144" topLeftX="585" topLeftY="128" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="BS1MbloA4oGLVExMBsXcJ9G2ngg" width="63" height="63" topLeftX="617" topLeftY="145">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="114" height="21" topLeftX="592" topLeftY="217" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">姓名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="18" topLeftX="592" topLeftY="241" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">职能</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="144" topLeftX="750" topLeftY="129" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="128" height="144" topLeftX="750" topLeftY="128" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="Vpepbbwz4oxM7RxYNc6ckhHMnMb" width="63" height="63" topLeftX="782" topLeftY="145">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="114" height="21" topLeftX="756" topLeftY="217" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">姓名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="18" topLeftX="756" topLeftY="241" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">职能</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="144" topLeftX="73" topLeftY="311" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="128" height="144" topLeftX="73" topLeftY="309" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="F8Hrb0kCpoEb3DxYimocy5qxnUe" width="63" height="63" topLeftX="106" topLeftY="326">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="114" height="21" topLeftX="80" topLeftY="397" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">姓名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="18" topLeftX="80" topLeftY="422" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">职能</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="144" topLeftX="242" topLeftY="311" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="128" height="144" topLeftX="242" topLeftY="309" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="Vo3obQJMOopPLTxtdK4cSYXVnrf" width="63" height="63" topLeftX="274" topLeftY="326">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="114" height="21" topLeftX="249" topLeftY="397" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">姓名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="18" topLeftX="249" topLeftY="422" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">职能</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="144" topLeftX="409" topLeftY="311" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="128" height="144" topLeftX="409" topLeftY="309" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="QQ67by8a0oaYk9xephYc6gAAnUb" width="63" height="63" topLeftX="442" topLeftY="326">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="114" height="21" topLeftX="416" topLeftY="397" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">姓名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="18" topLeftX="416" topLeftY="422" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">职能</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="144" topLeftX="585" topLeftY="311" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="128" height="144" topLeftX="585" topLeftY="309" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="XURgb0FxIow7VnxlJw0c2U5RnGd" width="63" height="63" topLeftX="617" topLeftY="326">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="114" height="21" topLeftX="592" topLeftY="397" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">姓名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="18" topLeftX="592" topLeftY="422" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">职能</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="144" topLeftX="750" topLeftY="311" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="128" height="144" topLeftX="750" topLeftY="309" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="UNDMbqjOzo02bPxl4eMcBP41nmc" width="63" height="63" topLeftX="782" topLeftY="326">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="114" height="21" topLeftX="756" topLeftY="397" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">姓名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="114" height="18" topLeftX="756" topLeftY="422" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">职能</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Nz2Bbvq9joLfAxxjnA1c2d2dnyc" width="38" height="40" topLeftX="163" topLeftY="231" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Nz2Bbvq9joLfAxxjnA1c2d2dnyc" width="38" height="40" topLeftX="331" topLeftY="127" rotation="270" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Nz2Bbvq9joLfAxxjnA1c2d2dnyc" width="38" height="40" topLeftX="409" topLeftY="232" rotation="90" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Nz2Bbvq9joLfAxxjnA1c2d2dnyc" width="38" height="40" topLeftX="674" topLeftY="127" rotation="270" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Nz2Bbvq9joLfAxxjnA1c2d2dnyc" width="38" height="40" topLeftX="750" topLeftY="233" rotation="90" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="KljObYVJUoEkGnx7C3qcENPknHb" width="38" height="40" topLeftX="164" topLeftY="308" rotation="270" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="KljObYVJUoEkGnx7C3qcENPknHb" width="38" height="40" topLeftX="241" topLeftY="413" rotation="90" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="KljObYVJUoEkGnx7C3qcENPknHb" width="38" height="40" topLeftX="497" topLeftY="308" rotation="270" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="KljObYVJUoEkGnx7C3qcENPknHb" width="38" height="40" topLeftX="678" topLeftY="413" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="KljObYVJUoEkGnx7C3qcENPknHb" width="38" height="40" topLeftX="750" topLeftY="413" rotation="90" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OnEabmzmnoWL07xAWancWJhun3f" width="103" height="12" topLeftX="186" topLeftY="71">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="963" height="540" topLeftX="-3" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 242, 1)"/>
+        </fill>
+      </shape>
+      <shape width="963" height="540" topLeftX="-1" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="851" topLeftY="-29" rotation="270">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Business Objective</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">业务目标</p>
+        </content>
+      </shape>
+      <img src="RElNb64QeopwDaxjD6CcK0FGnwv" width="103" height="12" topLeftX="215" topLeftY="71">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="261" height="362" topLeftX="51" topLeftY="123" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="261" height="362" topLeftX="49" topLeftY="120" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="230" height="42" topLeftX="66" topLeftY="137" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(19, 147, 207, 1)" fontSize="14">O1:</span>
+            </strong>
+            <span color="rgba(19, 147, 207, 1)" fontSize="14"> </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的业务目标，输入相关的业务目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="67" topLeftY="197" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="68" topLeftY="198" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="67" topLeftY="292" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="68" topLeftY="293" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="67" topLeftY="388" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="68" topLeftY="389" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR3</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="83" startY="213" endX="83" endY="386">
+        <border color="rgba(141, 201, 236, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="183" height="54" topLeftX="108" topLeftY="192" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="250" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="108" topLeftY="288" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="346" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="108" topLeftY="384" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="441" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="362" topLeftX="351" topLeftY="123" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="261" height="362" topLeftX="349" topLeftY="120" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="230" height="42" topLeftX="366" topLeftY="137" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(247, 193, 95, 1)" fontSize="14">O2:</span>
+            </strong>
+            <span color="rgba(247, 193, 95, 1)" fontSize="14"> </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的业务目标，输入相关的业务目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="367" topLeftY="197" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="368" topLeftY="198" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" fontFamily="Arial">KR1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="367" topLeftY="292" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="20" topLeftX="367" topLeftY="388" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <line startX="383" startY="213" endX="383" endY="386">
+        <border color="rgba(255, 224, 136, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="183" height="54" topLeftX="408" topLeftY="192" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="250" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="408" topLeftY="288" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="346" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="408" topLeftY="384" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="441" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="362" topLeftX="651" topLeftY="123" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="261" height="362" topLeftX="649" topLeftY="120" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="230" height="42" topLeftX="666" topLeftY="137" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(84, 213, 217, 1)" fontSize="14">O3:</span>
+            </strong>
+            <span color="rgba(35, 195, 192, 1)" fontSize="14"> </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的业务目标，输入相关的业务目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="667" topLeftY="197" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(35, 195, 192, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="20" topLeftX="667" topLeftY="292" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(35, 195, 192, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="20" topLeftX="667" topLeftY="388" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(35, 195, 192, 1)"/>
+        </fill>
+      </shape>
+      <line startX="683" startY="213" endX="683" endY="386">
+        <border color="rgba(35, 195, 192, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="183" height="54" topLeftX="708" topLeftY="192" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="708" topLeftY="250" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="708" topLeftY="288" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="708" topLeftY="346" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名</span>
+            </em>
+            <span fontSize="12">”</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="708" topLeftY="384" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="708" topLeftY="441" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="368" topLeftY="293" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" fontFamily="Arial">KR2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="368" topLeftY="389" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" fontFamily="Arial">KR3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="668" topLeftY="198" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="668" topLeftY="293" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="668" topLeftY="389" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR3</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 246, 220, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="AZbNbhTvDo08gzx2zmTc5jfwnMg" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EP1JbjIGzoTdKHx0hNFclSWjnpd" width="135" height="77" topLeftX="828" topLeftY="0" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EP1JbjIGzoTdKHx0hNFclSWjnpd" width="135" height="77" topLeftX="0" topLeftY="463" rotation="180" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Business Decomposition</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>业务拆解</p>
+        </content>
+      </shape>
+      <shape width="193" height="257" topLeftX="52" topLeftY="170" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="193" height="257" topLeftX="51" topLeftY="167" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="193" height="257" topLeftX="275" topLeftY="170" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="193" height="257" topLeftX="273" topLeftY="167" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="193" height="257" topLeftX="497" topLeftY="170" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="193" height="257" topLeftX="496" topLeftY="167" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="193" height="257" topLeftX="720" topLeftY="170" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="193" height="257" topLeftX="718" topLeftY="167" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="152" height="42" topLeftX="78" topLeftY="207" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">业务拆解一标题，业务拆解一标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="152" height="54" topLeftX="78" topLeftY="262" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="8" topLeftX="63" topLeftY="268" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(247, 193, 95, 1)"/>
+        </fill>
+      </shape>
+      <shape width="152" height="54" topLeftX="78" topLeftY="330" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="8" topLeftX="63" topLeftY="335" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(247, 193, 95, 1)"/>
+        </fill>
+      </shape>
+      <shape width="152" height="42" topLeftX="299" topLeftY="207" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">业务拆解一标题，业务拆解一标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="152" height="42" topLeftX="522" topLeftY="207" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">业务拆解一标题，业务拆解一标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="152" height="54" topLeftX="522" topLeftY="262" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="8" topLeftX="507" topLeftY="268" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(247, 193, 95, 1)"/>
+        </fill>
+      </shape>
+      <shape width="152" height="54" topLeftX="522" topLeftY="330" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="8" topLeftX="507" topLeftY="335" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(247, 193, 95, 1)"/>
+        </fill>
+      </shape>
+      <shape width="152" height="42" topLeftX="742" topLeftY="207" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">业务拆解一标题，业务拆解一标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="152" height="36" topLeftX="742" topLeftY="262" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="8" topLeftX="727" topLeftY="268" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(247, 193, 95, 1)"/>
+        </fill>
+      </shape>
+      <shape width="152" height="36" topLeftX="742" topLeftY="308" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="8" topLeftX="727" topLeftY="314" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(247, 193, 95, 1)"/>
+        </fill>
+      </shape>
+      <shape width="60" height="60" topLeftX="119" topLeftY="137" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="124" topLeftY="142" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="137" topLeftY="154" iconType="iconpark/Office/compression.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="60" height="60" topLeftX="342" topLeftY="137" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="347" topLeftY="142" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="360" topLeftY="154" iconType="iconpark/Base/save-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="60" height="60" topLeftX="564" topLeftY="137" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="569" topLeftY="142" type="ellipse">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="582" topLeftY="154" iconType="iconpark/Office/file-cabinet.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="60" height="60" topLeftX="787" topLeftY="137" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="792" topLeftY="142" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="805" topLeftY="154" iconType="iconpark/Office/folder-code.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="152" height="36" topLeftX="742" topLeftY="356" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="8" topLeftX="727" topLeftY="361" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(247, 193, 95, 1)"/>
+        </fill>
+      </shape>
+      <shape width="152" height="36" topLeftX="299" topLeftY="262" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="8" topLeftX="284" topLeftY="268" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(247, 193, 95, 1)"/>
+        </fill>
+      </shape>
+      <shape width="152" height="36" topLeftX="299" topLeftY="308" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="8" topLeftX="284" topLeftY="314" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(247, 193, 95, 1)"/>
+        </fill>
+      </shape>
+      <shape width="152" height="36" topLeftX="299" topLeftY="356" type="text">
+        <content textType="headline" fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="8" topLeftX="284" topLeftY="361" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(247, 193, 95, 1)"/>
+        </fill>
+      </shape>
+      <img src="CjHhbWKFfowop0xU6lycd2r8nFf" width="103" height="12" topLeftX="248" topLeftY="71">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(34, 38, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="BbgxbapUsowgUxxvPq1cc2TJnYd" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.5">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="GYslbhG0AoRPLbxG4QPcbTpunTc" width="960" height="540" topLeftX="0" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="75" bottomOffset="116" presetHandlers="0"/>
+      </img>
+      <img src="FnAFboETEoDtHdxsLZIcto8nnYc" width="103" height="12" topLeftX="809" topLeftY="489">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="100" height="99" topLeftX="196" topLeftY="223" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="132" height="132" topLeftX="769" topLeftY="-17" type="ellipse">
+        <border color="rgba(102, 102, 102, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="12" topLeftX="769" topLeftY="74" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="99" topLeftX="191" topLeftY="218" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="72" height="18" topLeftX="68" topLeftY="40" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="OvVIbXxqioTTT8xXAckcWzYBnYg" width="24" height="24" topLeftX="31" topLeftY="37" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="BiE0bg77Poe1ZTxonW1ckyVBnfg" width="12" height="32" topLeftX="31" topLeftY="479">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="100" height="30" topLeftX="191" topLeftY="275" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="Arial" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">PART 2</p>
+        </content>
+      </shape>
+      <shape width="407" height="63" topLeftX="335" topLeftY="284" type="text">
+        <content textType="title" fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="407" height="72" topLeftX="334" topLeftY="199" type="text">
+        <content textType="title" fontSize="48" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>完成情况</p>
+        </content>
+      </shape>
+      <icon width="40" height="40" topLeftX="221" topLeftY="232" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="963" height="540" topLeftX="-3" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 242, 1)"/>
+        </fill>
+      </shape>
+      <shape width="963" height="540" topLeftX="-1" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="851" topLeftY="-29" rotation="270">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Task Achievement</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">完成情况</p>
+        </content>
+      </shape>
+      <img src="RElNb64QeopwDaxjD6CcK0FGnwv" width="103" height="12" topLeftX="209" topLeftY="72">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="51" startY="254" endX="909" endY="254">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="51" startY="364" endX="909" endY="364">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="694" startY="131" endX="694" endY="467">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="464" startY="131" endX="464" endY="467">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="234" startY="131" endX="234" endY="467">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="174" height="42" topLeftX="51" topLeftY="177" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)" fontSize="14">O1:</span>
+            <span color="rgba(41, 71, 152, 1)" fontSize="14"> </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="174" height="42" topLeftX="51" topLeftY="394" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(35, 195, 192, 1)" fontSize="14">O3: </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="174" height="42" topLeftX="51" topLeftY="289" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(247, 193, 95, 1)" fontSize="14">O2: </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="24" topLeftX="249" topLeftY="128" type="text">
+        <content textType="headline" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="16">6 月</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="24" topLeftX="479" topLeftY="128" type="text">
+        <content textType="headline" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="16">7月</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="24" topLeftX="709" topLeftY="128" type="text">
+        <content textType="headline" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="16">8月</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="20" topLeftX="243" topLeftY="172" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" fontFamily="思源黑体" bold="false">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="20" topLeftX="379" topLeftY="198" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="300" height="20" topLeftX="609" topLeftY="224" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="18" topLeftX="343" topLeftY="263" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="18" topLeftX="482" topLeftY="288" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="265" height="18" topLeftX="458" topLeftY="313" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="20" topLeftX="408" topLeftY="370" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="20" topLeftX="591" topLeftY="395" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="20" topLeftX="729" topLeftY="420" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="20" topLeftX="375" topLeftY="445" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="20" topLeftX="633" topLeftY="340" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="963" height="540" topLeftX="-3" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 242, 1)"/>
+        </fill>
+      </shape>
+      <shape width="963" height="540" topLeftX="-1" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="851" topLeftY="-29" rotation="270">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Task Achievement</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">完成情况</p>
+        </content>
+      </shape>
+      <img src="C8c6bWxJFo1IPXxoIyfc70XYnzS" width="103" height="12" topLeftX="209" topLeftY="72">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="261" height="362" topLeftX="51" topLeftY="123" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="261" height="362" topLeftX="49" topLeftY="120" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="83" startY="213" endX="83" endY="386">
+        <border color="rgba(141, 201, 236, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="183" height="36" topLeftX="108" topLeftY="192" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="233" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 90%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="115" height="6" topLeftX="175" topLeftY="240" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="100" height="6" topLeftX="175" topLeftY="240" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="255" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="36" topLeftX="108" topLeftY="288" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="329" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 100%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="115" height="6" topLeftX="175" topLeftY="336" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="115" height="6" topLeftX="175" topLeftY="336" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="351" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="36" topLeftX="108" topLeftY="384" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="425" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 100%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="115" height="6" topLeftX="175" topLeftY="432" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="115" height="6" topLeftX="175" topLeftY="432" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="447" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="362" topLeftX="351" topLeftY="123" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="261" height="362" topLeftX="349" topLeftY="120" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="32" height="20" topLeftX="367" topLeftY="197" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="368" topLeftY="198" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" fontFamily="Arial">KR1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="367" topLeftY="292" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="20" topLeftX="367" topLeftY="388" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <line startX="383" startY="213" endX="383" endY="386">
+        <border color="rgba(247, 193, 95, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="183" height="36" topLeftX="408" topLeftY="192" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="233" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 85%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="115" height="6" topLeftX="475" topLeftY="240" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="80" height="6" topLeftX="475" topLeftY="240" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="255" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="36" topLeftX="408" topLeftY="288" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="329" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 80%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="115" height="6" topLeftX="475" topLeftY="336" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="80" height="6" topLeftX="475" topLeftY="336" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="351" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="36" topLeftX="408" topLeftY="384" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="425" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 100%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="115" height="6" topLeftX="475" topLeftY="432" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="115" height="6" topLeftX="475" topLeftY="432" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="447" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="368" topLeftY="293" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" fontFamily="Arial">KR2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="368" topLeftY="389" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" fontFamily="Arial">KR3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="67" topLeftY="197" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="68" topLeftY="198" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="67" topLeftY="292" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="68" topLeftY="293" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="67" topLeftY="388" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="68" topLeftY="389" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="362" topLeftX="645" topLeftY="123" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="261" height="362" topLeftX="642" topLeftY="120" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="32" height="20" topLeftX="661" topLeftY="197" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="662" topLeftY="198" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="661" topLeftY="292" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="20" topLeftX="661" topLeftY="388" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <line startX="677" startY="213" endX="677" endY="386">
+        <border color="rgba(84, 213, 217, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="183" height="36" topLeftX="701" topLeftY="192" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="701" topLeftY="233" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 100%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="115" height="6" topLeftX="768" topLeftY="240" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="115" height="6" topLeftX="768" topLeftY="240" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <shape width="183" height="18" topLeftX="701" topLeftY="255" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="36" topLeftX="701" topLeftY="288" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="701" topLeftY="329" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 86%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="115" height="6" topLeftX="768" topLeftY="336" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="90" height="6" topLeftX="768" topLeftY="336" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <shape width="183" height="18" topLeftX="701" topLeftY="351" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="36" topLeftX="701" topLeftY="384" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="701" topLeftY="425" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 100%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="115" height="6" topLeftX="768" topLeftY="432" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="115" height="6" topLeftX="768" topLeftY="432" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <shape width="183" height="18" topLeftX="701" topLeftY="447" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="662" topLeftY="293" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="662" topLeftY="389" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="230" height="42" topLeftX="66" topLeftY="137" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(19, 147, 207, 1)" fontSize="14">O1:</span>
+            </strong>
+            <span color="rgba(19, 147, 207, 1)" fontSize="14"> </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的业务目标，输入相关的业务目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="230" height="42" topLeftX="366" topLeftY="137" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(247, 193, 95, 1)" fontSize="14">O2:</span>
+            </strong>
+            <span color="rgba(247, 193, 95, 1)" fontSize="14"> </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的业务目标，输入相关的业务目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="230" height="42" topLeftX="666" topLeftY="137" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(84, 213, 217, 1)" fontSize="14">O3:</span>
+            </strong>
+            <span color="rgba(35, 195, 192, 1)" fontSize="14"> </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的业务目标，输入相关的业务目标</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(221, 239, 247, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PZwgbRQYEohPXzxJeNkcTBqDnUb" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="GOIIbzQj8ojJ0YxXVO4cvaGMn7b" width="80" height="139" topLeftX="851" topLeftY="-29" rotation="270">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Task Achievement</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">完成情况</p>
+        </content>
+      </shape>
+      <shape width="283" height="98" topLeftX="53" topLeftY="148" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="283" height="98" topLeftX="51" topLeftY="149" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="568" height="36" topLeftX="356" topLeftY="148" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">进展 1:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12"> </span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <line startX="344" startY="252" endX="909" endY="252">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="553" height="18" topLeftX="356" topLeftY="195" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">进展 2:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12"> </span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="553" height="18" topLeftX="356" topLeftY="221" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">进展 3:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12"> </span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="283" height="98" topLeftX="53" topLeftY="270" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="283" height="98" topLeftX="51" topLeftY="270" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="243" height="36" topLeftX="71" topLeftY="287" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">KR2:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="552" height="36" topLeftX="356" topLeftY="270" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">进展 1:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="344" startY="374" endX="909" endY="374">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="553" height="18" topLeftX="356" topLeftY="317" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)">进展 2:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="553" height="18" topLeftX="356" topLeftY="344" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)">进展 3:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="283" height="98" topLeftX="53" topLeftY="393" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="283" height="98" topLeftX="51" topLeftY="393" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="243" height="36" topLeftX="71" topLeftY="411" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">KR3:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="552" height="36" topLeftX="356" topLeftY="393" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">进展 1:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="344" startY="496" endX="909" endY="496">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="553" height="18" topLeftX="356" topLeftY="440" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)">进展 2:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="553" height="18" topLeftX="356" topLeftY="467" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)">进展 3:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="243" height="36" topLeftX="71" topLeftY="165" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">KR1:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="868" height="30" topLeftX="51" topLeftY="101" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)">O1: </span>
+            <span color="rgba(43, 47, 54, 1)">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="71" topLeftY="213" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 90%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="6" topLeftX="138" topLeftY="220" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="183" height="18" topLeftX="71" topLeftY="332" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 100%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="115" height="6" topLeftX="138" topLeftY="339" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="247" height="18" topLeftX="71" topLeftY="458" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">进度: 100%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="115" height="6" topLeftX="138" topLeftY="465" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <img src="SLMUb0IB4ohwq2xY9lBcR5KTnWd" width="38" height="40" topLeftX="295" topLeftY="328" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="SLMUb0IB4ohwq2xY9lBcR5KTnWd" width="38" height="40" topLeftX="295" topLeftY="207" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="SLMUb0IB4ohwq2xY9lBcR5KTnWd" width="38" height="40" topLeftX="295" topLeftY="451" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="160" height="6" topLeftX="138" topLeftY="220" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="180" height="6" topLeftX="138" topLeftY="339" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="180" height="6" topLeftX="138" topLeftY="465" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <img src="KFarbLFdZoZUyQxszvxc4jmFnYg" width="103" height="12" topLeftX="209" topLeftY="72">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 246, 220, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="AZbNbhTvDo08gzx2zmTc5jfwnMg" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EP1JbjIGzoTdKHx0hNFclSWjnpd" width="135" height="77" topLeftX="828" topLeftY="0" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EP1JbjIGzoTdKHx0hNFclSWjnpd" width="135" height="77" topLeftX="0" topLeftY="463" rotation="180" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Task Achievement</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">完成情况</p>
+        </content>
+      </shape>
+      <shape width="260" height="323" topLeftX="644" topLeftY="181" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="260" height="323" topLeftX="644" topLeftY="178" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="260" height="323" topLeftX="50" topLeftY="181" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="260" height="323" topLeftX="51" topLeftY="178" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="240" height="42" topLeftX="61" topLeftY="260" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)">进展 1:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="323" topLeftX="348" topLeftY="181" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="260" height="323" topLeftX="347" topLeftY="178" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="240" height="42" topLeftX="357" topLeftY="260" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)">进展 2:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="42" topLeftX="654" topLeftY="260" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)">进展 3:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="CYN0bNVzJoNkE6xrzygcvi4zndh" width="240" height="170" topLeftX="61" topLeftY="319">
+        <crop type="round-rect" leftOffset="32" rightOffset="32" topOffset="0" bottomOffset="0" presetHandlers="4"/>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="V5cDb09NbomVpexuCDycvZuinBe" width="240" height="170" topLeftX="357" topLeftY="319">
+        <crop type="round-rect" leftOffset="32" rightOffset="32" topOffset="0" bottomOffset="0" presetHandlers="4"/>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="UERRbDVXkoFMX5x7Jidca4Lsnzf" width="240" height="170" topLeftX="654" topLeftY="319">
+        <crop type="round-rect" leftOffset="32" rightOffset="32" topOffset="0" bottomOffset="0" presetHandlers="4"/>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="60" height="60" topLeftX="744" topLeftY="192" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="749" topLeftY="197" type="ellipse">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="762" topLeftY="210" iconType="iconpark/Office/folder-focus.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="60" height="60" topLeftX="447" topLeftY="192" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="452" topLeftY="197" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="465" topLeftY="210" iconType="iconpark/Office/file-cabinet.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="60" height="60" topLeftX="151" topLeftY="192" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="50" height="50" topLeftX="156" topLeftY="197" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <icon width="24" height="24" topLeftX="169" topLeftY="210" iconType="iconpark/Office/file-conversion.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="859" height="30" topLeftX="51" topLeftY="101" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)">O1: </span>
+            <span color="rgba(43, 47, 54, 1)">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="859" height="21" topLeftX="51" topLeftY="135" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="14">KR1:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Vxtbbvy1SoHnhPxqu5jcO1CmnEb" width="103" height="12" topLeftX="209" topLeftY="72">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="963" height="540" topLeftX="-3" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 242, 1)"/>
+        </fill>
+      </shape>
+      <shape width="963" height="540" topLeftX="-1" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="851" topLeftY="-29" rotation="270">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Task Achievement</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">完成情况</p>
+        </content>
+      </shape>
+      <img src="WUA5bK6EuoiZ9dxYr92cHormnLd" width="103" height="12" topLeftX="209" topLeftY="72">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="868" height="30" topLeftX="49" topLeftY="101" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)">某数据同步增长近五成</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="870" height="21" topLeftX="49" topLeftY="136" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="336" height="284" topLeftX="53" topLeftY="180" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="335" height="284" topLeftX="51" topLeftY="180" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="91" startY="223" endX="362" endY="223">
+        <border color="rgba(155, 158, 162, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="91" startY="265" endX="362" endY="265">
+        <border color="rgba(155, 158, 162, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="91" startY="348" endX="362" endY="348">
+        <border color="rgba(155, 158, 162, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="91" startY="306" endX="362" endY="306">
+        <border color="rgba(155, 158, 162, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="91" startY="389" endX="362" endY="389">
+        <border color="rgba(155, 158, 162, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="319" height="21" topLeftX="61" topLeftY="191" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)">标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="20" height="18" topLeftX="65" topLeftY="375" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="right">
+          <p textAlign="right">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">0</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="20" height="18" topLeftX="65" topLeftY="334" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="right">
+          <p textAlign="right">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">10</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="20" height="18" topLeftX="65" topLeftY="293" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="right">
+          <p textAlign="right">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">20</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="20" height="18" topLeftX="65" topLeftY="252" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="right">
+          <p textAlign="right">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">30</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="20" height="18" topLeftX="65" topLeftY="210" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="right">
+          <p textAlign="right">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">40</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="10" height="98" topLeftX="99" topLeftY="292" type="rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="50" topLeftX="116" topLeftY="339" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="160" topLeftX="134" topLeftY="229" type="rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="84" topLeftX="171" topLeftY="306" type="rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="100" topLeftX="189" topLeftY="289" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="137" topLeftX="207" topLeftY="252" type="rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="113" topLeftX="244" topLeftY="276" type="rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="58" topLeftX="262" topLeftY="331" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="120" topLeftX="280" topLeftY="269" type="rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="120" topLeftX="317" topLeftY="269" type="rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="80" topLeftX="334" topLeftY="309" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="120" topLeftX="352" topLeftY="269" type="rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <shape width="50" height="18" topLeftX="95" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="18" topLeftX="168" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="18" topLeftX="241" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="18" topLeftX="315" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="10" height="10" topLeftX="72" topLeftY="422" type="rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="50" height="18" topLeftX="89" topLeftY="417" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="18" topLeftX="199" topLeftY="417" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="18" topLeftX="309" topLeftY="417" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="12">数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="10" height="10" topLeftX="185" topLeftY="422" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="10" topLeftX="291" topLeftY="422" type="rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+      </shape>
+      <shape width="233" height="80" topLeftX="418" topLeftY="179" type="round1rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 0.1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="88" height="36" topLeftX="433" topLeftY="201" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">订单量同步去年增长近</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="25" topLeftX="522" topLeftY="206" rotation="270" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 255, 253, 1) 0%,rgba(144, 201, 236, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="103" height="60" topLeftX="562" topLeftY="189" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(19, 147, 207, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)" fontSize="40" fontFamily="Arial">160</span>
+            <span color="rgba(19, 147, 207, 1)" fontSize="12" fontFamily="Arial">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="233" height="80" topLeftX="676" topLeftY="179" type="round1rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 0.1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="88" height="36" topLeftX="691" topLeftY="201" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">订单量同步去年增长近</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="25" topLeftX="779" topLeftY="207" rotation="270" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 255, 253, 1) 0%,rgba(144, 201, 236, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="103" height="60" topLeftX="820" topLeftY="189" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(19, 147, 207, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)" fontSize="40" fontFamily="Arial">90</span>
+            <span color="rgba(19, 147, 207, 1)" fontSize="12" fontFamily="Arial">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="233" height="80" topLeftX="418" topLeftY="286" type="round1rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 0.1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="88" height="36" topLeftX="433" topLeftY="308" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">订单量同步去年增长近</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="25" topLeftX="522" topLeftY="313" rotation="270" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 255, 253, 1) 0%,rgba(144, 201, 236, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="103" height="60" topLeftX="562" topLeftY="296" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(19, 147, 207, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)" fontSize="40" fontFamily="Arial">120</span>
+            <span color="rgba(19, 147, 207, 1)" fontSize="12" fontFamily="Arial">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="233" height="80" topLeftX="418" topLeftY="390" type="round1rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 0.1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="88" height="36" topLeftX="433" topLeftY="412" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">订单量同步去年增长近</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="25" topLeftX="522" topLeftY="417" rotation="270" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 255, 253, 1) 0%,rgba(144, 201, 236, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="103" height="60" topLeftX="562" topLeftY="400" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(19, 147, 207, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)" fontSize="40" fontFamily="Arial">280</span>
+            <span color="rgba(19, 147, 207, 1)" fontSize="12" fontFamily="Arial">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="233" height="80" topLeftX="676" topLeftY="390" type="round1rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 0.1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="88" height="36" topLeftX="691" topLeftY="412" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">订单量同步去年增长近</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="25" topLeftX="779" topLeftY="418" rotation="270" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 255, 253, 1) 0%,rgba(144, 201, 236, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="103" height="60" topLeftX="820" topLeftY="400" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(19, 147, 207, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)" fontSize="40" fontFamily="Arial">20</span>
+            <span color="rgba(19, 147, 207, 1)" fontSize="12" fontFamily="Arial">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="233" height="80" topLeftX="676" topLeftY="286" type="round1rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 0.1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="88" height="36" topLeftX="691" topLeftY="308" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">订单量同步去年增长近</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="25" topLeftX="779" topLeftY="313" rotation="270" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(255, 255, 253, 1) 0%,rgba(144, 201, 236, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="103" height="60" topLeftX="820" topLeftY="296" type="text">
+        <content fontSize="12" fontFamily="Arial" color="rgba(19, 147, 207, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)" fontSize="40" fontFamily="Arial">170</span>
+            <span color="rgba(19, 147, 207, 1)" fontSize="12" fontFamily="Arial">%</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Brebbm81boxxu9x7lNScnFUqndh" width="40" height="12" topLeftX="200" topLeftY="173">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(34, 38, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="BbgxbapUsowgUxxvPq1cc2TJnYd" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.5">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="GYslbhG0AoRPLbxG4QPcbTpunTc" width="960" height="540" topLeftX="0" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="75" bottomOffset="116" presetHandlers="0"/>
+      </img>
+      <img src="FnAFboETEoDtHdxsLZIcto8nnYc" width="103" height="12" topLeftX="809" topLeftY="489">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="100" height="99" topLeftX="196" topLeftY="223" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="132" height="132" topLeftX="769" topLeftY="-17" type="ellipse">
+        <border color="rgba(102, 102, 102, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="12" topLeftX="769" topLeftY="74" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="99" topLeftX="191" topLeftY="218" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="72" height="18" topLeftX="68" topLeftY="40" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="OvVIbXxqioTTT8xXAckcWzYBnYg" width="24" height="24" topLeftX="31" topLeftY="37" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="BiE0bg77Poe1ZTxonW1ckyVBnfg" width="12" height="32" topLeftX="31" topLeftY="479">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="100" height="30" topLeftX="191" topLeftY="275" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="Arial" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">PART 3</p>
+        </content>
+      </shape>
+      <shape width="407" height="63" topLeftX="335" topLeftY="284" type="text">
+        <content textType="title" fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="407" height="72" topLeftX="334" topLeftY="199" type="text">
+        <content textType="title" fontSize="48" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>经验反思</p>
+        </content>
+      </shape>
+      <icon width="40" height="40" topLeftX="221" topLeftY="232" iconType="iconpark/Base/tips.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 246, 220, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="AZbNbhTvDo08gzx2zmTc5jfwnMg" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EP1JbjIGzoTdKHx0hNFclSWjnpd" width="135" height="77" topLeftX="828" topLeftY="0" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EP1JbjIGzoTdKHx0hNFclSWjnpd" width="135" height="77" topLeftX="0" topLeftY="463" rotation="180" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Review And Summary</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">业务复盘</p>
+        </content>
+      </shape>
+      <shape width="868" height="30" topLeftX="51" topLeftY="101" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)">O1: </span>
+            <span color="rgba(43, 47, 54, 1)">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="864" height="21" topLeftX="51" topLeftY="135" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="14">KR1:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="524" height="140" topLeftX="53" topLeftY="174" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="524" height="140" topLeftX="51" topLeftY="172" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="470" height="24" topLeftX="87" topLeftY="190" type="text">
+        <content textType="headline" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="16">做的好的</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="491" height="63" topLeftX="67" topLeftY="227" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <ul>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="524" height="140" topLeftX="387" topLeftY="343" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="524" height="140" topLeftX="385" topLeftY="341" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="470" height="24" topLeftX="421" topLeftY="359" type="text">
+        <content textType="headline" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="16">待改进点</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="491" height="63" topLeftX="401" topLeftY="396" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <ul>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <img src="KPu8b7LzBoWDKlxVPhTcOpexndd" width="306" height="144" topLeftX="609" topLeftY="172">
+        <crop type="round1rect" leftOffset="0" rightOffset="0" topOffset="12" bottomOffset="12" presetHandlers="21"/>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="JKqHbAW8aoe0HQxplScc7RFTn9b" width="306" height="144" topLeftX="51" topLeftY="341">
+        <crop type="round1rect" leftOffset="0" rightOffset="0" topOffset="12" bottomOffset="12" presetHandlers="21"/>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="NrvbbvoUIoLyqVxG4cbcYt4inNb" width="40" height="12" topLeftX="536" topLeftY="166">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="NrvbbvoUIoLyqVxG4cbcYt4inNb" width="40" height="12" topLeftX="869" topLeftY="335">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <icon width="20" height="20" topLeftX="63" topLeftY="193" iconType="iconpark/Hands/good-two.svg">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="20" height="20" topLeftX="396" topLeftY="362" iconType="iconpark/Charts/data-arrival.svg">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="WRLPbnASJoO8KixZpffcmaGanTe" width="103" height="12" topLeftX="232" topLeftY="72">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(221, 239, 247, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PZwgbRQYEohPXzxJeNkcTBqDnUb" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="GOIIbzQj8ojJ0YxXVO4cvaGMn7b" width="80" height="139" topLeftX="851" topLeftY="-29" rotation="270">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Review And Summary</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p textAlign="left">业务复盘</p>
+        </content>
+      </shape>
+      <shape width="868" height="30" topLeftX="51" topLeftY="101" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)">O1:</span>
+            <span color="rgba(41, 71, 152, 1)"> </span>
+            <span color="rgba(43, 47, 54, 1)">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="828" height="21" topLeftX="51" topLeftY="135" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(102, 102, 102, 1)" fontSize="14">KR1:输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="401" height="308" topLeftX="59" topLeftY="187" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="401" height="316" topLeftX="59" topLeftY="176" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="352" height="24" topLeftX="99" topLeftY="192" type="text">
+        <content textType="headline" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="16">遇到问题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="352" height="105" topLeftX="84" topLeftY="228" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <ul>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <img src="GNFJb9cTnoQ7eExha71cQJ7wnDb" width="386" height="128" topLeftX="66" topLeftY="356">
+        <crop type="round-rect" leftOffset="0" rightOffset="0" topOffset="44" bottomOffset="44" presetHandlers="4"/>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="401" height="308" topLeftX="499" topLeftY="187" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="401" height="316" topLeftX="499" topLeftY="176" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="344" height="24" topLeftX="547" topLeftY="192" type="text">
+        <content textType="headline" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="16">改进措施</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="344" height="105" topLeftX="532" topLeftY="228" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <ul>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left">
+                <span color="rgba(102, 102, 102, 1)" fontSize="14">输入相关的描述信息以解释标题</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <img src="Ao2dbDGVco9V2wxLKS9cFtWynzb" width="386" height="128" topLeftX="506" topLeftY="356">
+        <crop type="round-rect" leftOffset="0" rightOffset="0" topOffset="44" bottomOffset="44" presetHandlers="4"/>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <icon width="20" height="20" topLeftX="72" topLeftY="195" iconType="iconpark/Others/thinking-problem.svg">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="20" height="20" topLeftX="517" topLeftY="195" iconType="iconpark/Office/level.svg">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="BKLubjyl2ocINoxtwo8cQehinKg" width="103" height="12" topLeftX="232" topLeftY="72">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="F9ysbSCvVo4CWFxjdhXcp9Gxndb" width="40" height="12" topLeftX="860" topLeftY="170">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="F9ysbSCvVo4CWFxjdhXcp9Gxndb" width="40" height="12" topLeftX="421" topLeftY="170">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(34, 38, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="BbgxbapUsowgUxxvPq1cc2TJnYd" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.5">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="GYslbhG0AoRPLbxG4QPcbTpunTc" width="960" height="540" topLeftX="0" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="75" bottomOffset="116" presetHandlers="0"/>
+      </img>
+      <img src="FnAFboETEoDtHdxsLZIcto8nnYc" width="103" height="12" topLeftX="809" topLeftY="489">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="100" height="99" topLeftX="196" topLeftY="223" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="132" height="132" topLeftX="769" topLeftY="-17" type="ellipse">
+        <border color="rgba(102, 102, 102, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="12" topLeftX="769" topLeftY="74" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="99" topLeftX="191" topLeftY="218" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(31, 35, 41, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="72" height="18" topLeftX="68" topLeftY="40" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="OvVIbXxqioTTT8xXAckcWzYBnYg" width="24" height="24" topLeftX="31" topLeftY="37" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="BiE0bg77Poe1ZTxonW1ckyVBnfg" width="12" height="32" topLeftX="31" topLeftY="479">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="100" height="30" topLeftX="191" topLeftY="275" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="Arial" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p textAlign="center">PART 4</p>
+        </content>
+      </shape>
+      <shape width="407" height="63" topLeftX="335" topLeftY="284" type="text">
+        <content textType="title" fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="407" height="72" topLeftX="334" topLeftY="199" type="text">
+        <content textType="title" fontSize="48" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>后续计划</p>
+        </content>
+      </shape>
+      <icon width="40" height="40" topLeftX="221" topLeftY="232" iconType="iconpark/Office/doc-detail.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="963" height="540" topLeftX="-3" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 242, 1)"/>
+        </fill>
+      </shape>
+      <shape width="963" height="540" topLeftX="-1" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="851" topLeftY="-29" rotation="270">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Short-Term Objective</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>短期目标</p>
+        </content>
+      </shape>
+      <img src="FcRsb15VFojqK6xzvkNco7Vin3f" width="103" height="12" topLeftX="224" topLeftY="71">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="261" height="362" topLeftX="51" topLeftY="123" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="261" height="362" topLeftX="49" topLeftY="120" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="230" height="42" topLeftX="66" topLeftY="137" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(19, 147, 207, 1)" fontSize="14">O1:</span>
+            </strong>
+            <span color="rgba(19, 147, 207, 1)" fontSize="14"> </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的业务目标，输入相关的业务目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="67" topLeftY="197" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="68" topLeftY="198" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="67" topLeftY="292" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="68" topLeftY="293" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="67" topLeftY="388" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="68" topLeftY="389" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR3</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="83" startY="213" endX="83" endY="386">
+        <border color="rgba(141, 201, 236, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="183" height="54" topLeftX="108" topLeftY="192" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="250" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="108" topLeftY="288" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="346" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="108" topLeftY="384" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="108" topLeftY="441" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="362" topLeftX="351" topLeftY="123" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="261" height="362" topLeftX="349" topLeftY="120" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="230" height="42" topLeftX="366" topLeftY="137" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(247, 193, 95, 1)" fontSize="14">O2:</span>
+            </strong>
+            <span color="rgba(247, 193, 95, 1)" fontSize="14"> </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的业务目标，输入相关的业务目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="367" topLeftY="197" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="30" height="18" topLeftX="368" topLeftY="198" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" fontFamily="Arial">KR1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="367" topLeftY="292" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="20" topLeftX="367" topLeftY="388" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+      </shape>
+      <line startX="383" startY="213" endX="383" endY="386">
+        <border color="rgba(255, 224, 136, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="183" height="54" topLeftX="408" topLeftY="192" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="250" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="408" topLeftY="288" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="346" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="408" topLeftY="384" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="408" topLeftY="441" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="362" topLeftX="651" topLeftY="123" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="261" height="362" topLeftX="649" topLeftY="120" flipX="true" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="230" height="42" topLeftX="666" topLeftY="137" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(84, 213, 217, 1)" fontSize="14">O3:</span>
+            </strong>
+            <span color="rgba(35, 195, 192, 1)" fontSize="14"> </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的业务目标，输入相关的业务目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="20" topLeftX="667" topLeftY="197" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(35, 195, 192, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="20" topLeftX="667" topLeftY="292" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(35, 195, 192, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="20" topLeftX="667" topLeftY="388" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(35, 195, 192, 1)"/>
+        </fill>
+      </shape>
+      <line startX="683" startY="213" endX="683" endY="386">
+        <border color="rgba(35, 195, 192, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="183" height="54" topLeftX="708" topLeftY="192" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="708" topLeftY="250" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="708" topLeftY="288" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="708" topLeftY="346" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名</span>
+            </em>
+            <span fontSize="12">”</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="54" topLeftX="708" topLeftY="384" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">输入相关的描述信息以解释标题；输入相关的描述信息以解释标题；输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="183" height="18" topLeftX="708" topLeftY="441" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">负责人：</span>
+            <em>
+              <span color="rgba(155, 158, 162, 1)" fontSize="12">输入“@+人名”</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="368" topLeftY="293" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" fontFamily="Arial">KR2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="368" topLeftY="389" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" fontFamily="Arial">KR3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="668" topLeftY="198" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="668" topLeftY="293" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="18" topLeftX="668" topLeftY="389" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="12" fontFamily="Arial">KR3</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="963" height="540" topLeftX="-3" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 244, 242, 1)"/>
+        </fill>
+      </shape>
+      <shape width="963" height="540" topLeftX="-1" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="29" topLeftY="431" rotation="90">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="HFdYbDeNvosW0BxcRdBcxRPonsh" width="80" height="139" topLeftX="851" topLeftY="-29" rotation="270">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="E3p7boCbJoZiGsxZ98ucT5DbnRf" width="24" height="12" topLeftX="816" topLeftY="30">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OaLab1wvOo648bxy3ejcT72inIe" width="14" height="41" topLeftX="55" topLeftY="39">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="587" startY="131" endX="587" endY="467">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="409" startY="131" endX="409" endY="467">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="764" startY="131" endX="764" endY="467">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="160" height="21" topLeftX="241" topLeftY="120" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">Q1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="21" topLeftX="418" topLeftY="120" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">Q2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="21" topLeftX="595" topLeftY="120" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">Q3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="21" topLeftX="773" topLeftY="120" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">Q4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="403" height="21" topLeftX="77" topLeftY="67" type="text">
+        <content textType="sub-headline" fontSize="14" fontFamily="思源黑体" color="rgba(102, 102, 102, 1)" bold="false">
+          <p>Long-Term Objectives</p>
+        </content>
+      </shape>
+      <shape width="403" height="36" topLeftX="77" topLeftY="30" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>长期目标</p>
+        </content>
+      </shape>
+      <img src="FcRsb15VFojqK6xzvkNco7Vin3f" width="103" height="12" topLeftX="224" topLeftY="71">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="51" startY="254" endX="909" endY="254">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="51" startY="364" endX="909" endY="364">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="234" startY="131" endX="234" endY="467">
+        <border color="rgba(155, 158, 162, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="174" height="42" topLeftX="51" topLeftY="177" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(19, 147, 207, 1)" fontSize="14">O1:</span>
+            <span color="rgba(41, 71, 152, 1)" fontSize="14"> </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="174" height="42" topLeftX="51" topLeftY="394" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(35, 195, 192, 1)" fontSize="14">O3: </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="174" height="42" topLeftX="51" topLeftY="289" type="text">
+        <content textType="headline" fontSize="14" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(247, 193, 95, 1)" fontSize="14">O2: </span>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="20" topLeftX="243" topLeftY="156" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" fontFamily="思源黑体" bold="false">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="160" height="20" topLeftX="448" topLeftY="180" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="300" height="20" topLeftX="609" topLeftY="228" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="18" topLeftX="257" topLeftY="260" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="212" height="18" topLeftX="482" topLeftY="285" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="265" height="18" topLeftX="363" topLeftY="310" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="20" topLeftX="279" topLeftY="370" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="20" topLeftX="591" topLeftY="395" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="20" topLeftX="701" topLeftY="420" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="20" topLeftX="375" topLeftY="445" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(84, 213, 217, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="20" topLeftX="633" topLeftY="337" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 224, 136, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="false">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="280" height="20" topLeftX="418" topLeftY="204" presetHandlers="4" type="round-rect">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">子任务</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(34, 38, 41, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="245" height="321" topLeftX="-18" topLeftY="219" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="470" height="470" topLeftX="-242" topLeftY="0" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="410" height="410" topLeftX="-212" topLeftY="30" type="slides-block-arc">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <img src="CHIvb1lRHoFw5PxLzlwc29OVnx1" width="346" height="346" topLeftX="-180" topLeftY="62">
+        <crop type="rect" leftOffset="136" rightOffset="136" topOffset="0" bottomOffset="0" presetHandlers="200"/>
+      </img>
+      <shape width="37" height="37" topLeftX="286" topLeftY="58" type="ellipse">
+        <border color="rgba(102, 102, 102, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="12" topLeftX="306" topLeftY="87" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <img src="Vt4Vbmu6gourQ6xmTUqc0ZSgnIb" width="86" height="10" topLeftX="349" topLeftY="281">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="KzXbbB6C0opXSZxxBvwcNZvJnNg" width="46" height="77" topLeftX="780" topLeftY="408" alpha="0.7">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="LHgHbwvKUo3nWKxW65XccGhenSD" width="46" height="16" topLeftX="874" topLeftY="524">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="37" height="37" topLeftX="86" topLeftY="464" type="ellipse">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="12" height="12" topLeftX="111" topLeftY="464" type="ellipse">
+        <fill>
+          <fillColor color="rgba(141, 201, 236, 1)"/>
+        </fill>
+      </shape>
+      <shape width="407" height="63" topLeftX="349" topLeftY="353" type="text">
+        <content textType="title" fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false">
+          <p>
+            <span color="rgba(222, 224, 227, 1)">输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="407" height="36" topLeftX="349" topLeftY="248" type="text">
+        <content textType="title" fontSize="24" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span fontFamily="Arial">For Your Attention</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="408" height="90" topLeftX="349" topLeftY="158" type="text">
+        <content textType="title" fontSize="60" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span fontFamily="Arial">Thank You</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="863" topLeftY="40" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="SJrybASt7oIAmKxh6Xac4NYhnxh" width="28" height="28" topLeftX="826" topLeftY="35" rotation="90">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/office--work_summary_report.xml
+++ b/skills/lark-slides/references/templates/office--work_summary_report.xml
@@ -1,0 +1,1523 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>工作总结报告</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="60"/>
+      <headline fontColor="#000000FF" fontSize="36"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style/>
+    <data>
+      <img src="BA1QbwpWMo58RExmiiAcWEHhnOf" width="251" height="251" topLeftX="532" topLeftY="83" rotation="45" alpha="0.1">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="292" height="292" topLeftX="456" topLeftY="152" type="ellipse">
+        <fill>
+          <fillColor color="rgba(58, 108, 234, 1)"/>
+        </fill>
+      </shape>
+      <shape width="408" height="97" topLeftX="67" topLeftY="66" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="51">工作总结规划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="262" height="56" topLeftX="67" topLeftY="147" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="24">WORK SUMMARY</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="216" height="45" topLeftX="72" topLeftY="364" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(58, 108, 234, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">报告人: 马克</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="225" height="44" topLeftX="67" topLeftY="413" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">汇报时间：2026.XX.XX</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="60" topLeftX="57" topLeftY="84" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <img src="BsM1b7VS6o7egBxNroTcunE6njh" width="454" height="381" topLeftX="456" topLeftY="108">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="346" height="66" topLeftX="510" topLeftY="119" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="51" height="51" topLeftX="517" topLeftY="126" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="65" topLeftX="510" topLeftY="119" type="ellipse">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="346" height="66" topLeftX="510" topLeftY="198" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="51" height="51" topLeftX="517" topLeftY="205" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="65" topLeftX="510" topLeftY="198" type="ellipse">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="346" height="66" topLeftX="510" topLeftY="277" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="51" height="51" topLeftX="517" topLeftY="284" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="65" topLeftX="510" topLeftY="277" type="ellipse">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="346" height="66" topLeftX="510" topLeftY="356" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="51" height="51" topLeftX="517" topLeftY="363" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="65" topLeftX="510" topLeftY="356" type="ellipse">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="280" height="47" topLeftX="576" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p>
+            <span fontSize="18">工作概述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="280" height="47" topLeftX="576" topLeftY="207" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p>
+            <span fontSize="18">完成情况</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="280" height="47" topLeftX="576" topLeftY="286" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p>
+            <span fontSize="18">经验反思</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="280" height="47" topLeftX="576" topLeftY="365" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18">
+          <p>
+            <span fontSize="18">工作计划</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="292" height="292" topLeftX="57" topLeftY="111" type="ellipse">
+        <fill>
+          <fillColor color="rgba(58, 108, 234, 1)"/>
+        </fill>
+      </shape>
+      <img src="PvU5bCCjCop7hCxDgYAc1G9jnxd" width="288" height="206" topLeftX="130" topLeftY="247">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="242" height="68" topLeftX="143" topLeftY="140" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">目录</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="232" height="68" topLeftX="218" topLeftY="140" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="32">CONTENTS</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(58, 108, 234, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="416" height="64" topLeftX="392" topLeftY="282" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">JOB OVERVIEW</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Bs0GbbM4LoKrcPxZpSHc9h9dnLe" width="116" height="132" topLeftX="224" topLeftY="191">
+        <crop type="rect" leftOffset="0.39" rightOffset="0.39" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="544" height="110" topLeftX="385" topLeftY="187" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="60">01 工作概述</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="302" height="56" topLeftX="174" topLeftY="64" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="24" bold="false">WORK CONTENT</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="56" topLeftX="70" topLeftY="64" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(58, 108, 234, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(58, 108, 234, 1)" fontSize="24">工作内容</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="44" topLeftX="69" topLeftY="345" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="16">项目进展问题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="134" height="134" topLeftX="92" topLeftY="201" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="180" height="92" topLeftX="69" topLeftY="380" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="44" topLeftX="295" topLeftY="345" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="16">客户反馈我问题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="134" height="134" topLeftX="318" topLeftY="201" type="ellipse">
+        <fill>
+          <fillColor color="rgba(58, 108, 234, 1)"/>
+        </fill>
+      </shape>
+      <shape width="180" height="92" topLeftX="295" topLeftY="380" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(44, 40, 64, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="center" autoFit="shape-auto-fit">
+          <p list="none" textAlign="center">
+            <span color="rgba(44, 40, 64, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="12" fontFamily="undefined" bold="false" italic="false" strikethrough="false" underline="false">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="44" topLeftX="520" topLeftY="345" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="16">公关处理问题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="134" height="134" topLeftX="544" topLeftY="201" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="180" height="92" topLeftX="520" topLeftY="380" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(44, 40, 64, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="center" autoFit="shape-auto-fit">
+          <p list="none" textAlign="center">
+            <span color="rgba(44, 40, 64, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="12" fontFamily="undefined" bold="false" italic="false" strikethrough="false" underline="false">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="44" topLeftX="746" topLeftY="345" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="16">工作业绩回顾</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="134" height="134" topLeftX="769" topLeftY="201" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="180" height="92" topLeftX="746" topLeftY="379" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" textAlign="center">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="60" height="60" topLeftX="355" topLeftY="238" iconType="iconpark/Abstract/cylinder.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="60" height="60" topLeftX="580" topLeftY="238" iconType="iconpark/Abstract/game-emoji.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="60" height="60" topLeftX="806" topLeftY="238" iconType="iconpark/Abstract/oval-love-two.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="60" height="60" topLeftX="129" topLeftY="238" iconType="iconpark/Abstract/six-points.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="5" height="30" topLeftX="58" topLeftY="77" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="302" height="56" topLeftX="174" topLeftY="64" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>WORK CONTENT</p>
+        </content>
+      </shape>
+      <shape width="118" height="56" topLeftX="70" topLeftY="64" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(58, 108, 234, 1)" bold="true">
+          <p>工作内容</p>
+        </content>
+      </shape>
+      <shape width="373" height="167" topLeftX="119" topLeftY="156" presetHandlers="16" alpha="0.85" type="round-rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="373" height="167" topLeftX="509" topLeftY="156" presetHandlers="16" alpha="0.85" type="round-rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="373" height="167" topLeftX="118" topLeftY="336" presetHandlers="16" alpha="0.85" type="round-rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="373" height="167" topLeftX="508" topLeftY="336" presetHandlers="16" alpha="0.85" type="round-rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="60" height="60" topLeftX="528" topLeftY="357" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="38" topLeftX="593" topLeftY="352" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">工作内容 #4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="83" topLeftX="593" topLeftY="382" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="138" topLeftY="357" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="38" topLeftX="203" topLeftY="352" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">工作内容 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="83" topLeftX="203" topLeftY="382" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="529" topLeftY="176" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="38" topLeftX="594" topLeftY="171" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">工作内容 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="83" topLeftX="594" topLeftY="201" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="139" topLeftY="176" type="ellipse">
+        <fill>
+          <fillColor color="rgba(14, 94, 253, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">0</span>
+            </strong>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="38" topLeftX="205" topLeftY="171" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">工作内容 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="83" topLeftX="205" topLeftY="201" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="5" height="30" topLeftX="58" topLeftY="77" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(58, 108, 234, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="886" height="464" topLeftX="37" topLeftY="38" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="J8gLbpIy4o8aiTxCutkc0feNnoc" width="183" height="149" topLeftX="708" topLeftY="76">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="256" height="68" topLeftX="85" topLeftY="88" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="32">工作总结</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="230" height="56" topLeftX="226" topLeftY="94" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="24">SUMMARY</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="225" height="44" topLeftX="85" topLeftY="241" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">内容总结详情</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="619" height="92" topLeftX="85" topLeftY="285" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="216" height="45" topLeftX="90" topLeftY="418" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">总结点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="216" height="45" topLeftX="357" topLeftY="418" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">总结点 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(58, 108, 234, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="416" height="64" topLeftX="392" topLeftY="282" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">COMPLETION</span>
+          </p>
+        </content>
+      </shape>
+      <img src="LzSZbMIn1oU2yOxNT8ocDmyhndc" width="116" height="132" topLeftX="224" topLeftY="191">
+        <crop type="rect" leftOffset="0.21" rightOffset="0.21" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="544" height="110" topLeftX="385" topLeftY="187" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="60">02 完成情况</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="302" height="57" topLeftX="154" topLeftY="44" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" fontFamily="undefined" color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="left" autoFit="shape-auto-fit">
+          <p list="none" textAlign="left">
+            <span color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="24" fontFamily="undefined" bold="false" italic="false" strikethrough="false" underline="false">WORK PROGRESS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="56" topLeftX="50" topLeftY="44" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(58, 108, 234, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(58, 108, 234, 1)" fontSize="24">工作进度</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="38" topLeftX="40" topLeftY="145" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">工作内容 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="279" height="62" topLeftX="40" topLeftY="175" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="374" height="27" topLeftX="45" topLeftY="239" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="226" height="20" topLeftX="49" topLeftY="243" presetHandlers="2" type="rect">
+        <fill>
+          <fillColor color="rgba(14, 94, 253, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="38" topLeftX="424" topLeftY="234" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(14, 94, 253, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(14, 94, 253, 1)" fontSize="18">67%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="38" topLeftX="40" topLeftY="318" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">工作内容 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="279" height="62" topLeftX="40" topLeftY="348" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="374" height="27" topLeftX="45" topLeftY="412" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="226" height="20" topLeftX="49" topLeftY="416" presetHandlers="2" type="rect">
+        <fill>
+          <fillColor color="rgba(14, 94, 253, 1)"/>
+        </fill>
+      </shape>
+      <shape width="65" height="38" topLeftX="424" topLeftY="407" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(14, 94, 253, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(14, 94, 253, 1)" fontSize="18">67%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="HzRFb9Spso7U0Qx5aa3cZLPenDr" width="381" height="381" topLeftX="579" topLeftY="155">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="5" height="30" topLeftX="45" topLeftY="57" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="302" height="56" topLeftX="154" topLeftY="44" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>WORK PROGRESS</p>
+        </content>
+      </shape>
+      <shape width="118" height="56" topLeftX="50" topLeftY="44" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(58, 108, 234, 1)" bold="true">
+          <p>工作进度</p>
+        </content>
+      </shape>
+      <shape width="210" height="264" topLeftX="697" topLeftY="181" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="210" height="264" topLeftX="482" topLeftY="181" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="210" height="264" topLeftX="268" topLeftY="181" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="210" height="264" topLeftX="54" topLeftY="181" presetHandlers="18" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="180" height="44" topLeftX="707" topLeftY="310" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="16">项目内容 #4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="92" topLeftX="707" topLeftY="344" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="712" topLeftY="201" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="33" height="33" topLeftX="732" topLeftY="221" iconType="iconpark/Abstract/oval-love-two.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="180" height="44" topLeftX="493" topLeftY="311" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="16">项目内容 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="92" topLeftX="493" topLeftY="345" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="498" topLeftY="201" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="33" height="33" topLeftX="517" topLeftY="221" iconType="iconpark/Abstract/game-emoji.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="180" height="44" topLeftX="278" topLeftY="311" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="16">项目内容 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="92" topLeftX="278" topLeftY="345" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="283" topLeftY="201" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="33" height="33" topLeftX="303" topLeftY="221" iconType="iconpark/Abstract/cylinder.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="180" height="44" topLeftX="64" topLeftY="311" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="16">项目内容 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="92" topLeftX="64" topLeftY="345" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="69" topLeftY="201" type="ellipse">
+        <fill>
+          <fillColor color="rgba(14, 94, 253, 1)"/>
+        </fill>
+      </shape>
+      <icon width="32" height="32" topLeftX="89" topLeftY="221" iconType="iconpark/Abstract/six-points.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="99" height="68" topLeftX="151" topLeftY="202" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(14, 94, 253, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(14, 94, 253, 1)" fontSize="32">60%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="68" topLeftX="365" topLeftY="202" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="32">30%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="68" topLeftX="579" topLeftY="202" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="32">80%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="99" height="68" topLeftX="793" topLeftY="202" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(44, 40, 64, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(44, 40, 64, 1)" fontSize="32">60%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="5" height="30" topLeftX="45" topLeftY="57" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(58, 108, 234, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="886" height="464" topLeftX="37" topLeftY="38" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="256" height="68" topLeftX="85" topLeftY="88" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="32">工作进度</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="230" height="56" topLeftX="226" topLeftY="94" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="24">WORK PROGRESS</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Ip5mbB0MUoJhTFxVsmEcrEnjnrd" width="259" height="199" topLeftX="361" topLeftY="190">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="242" height="44" topLeftX="95" topLeftY="227" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span fontSize="16">工作态度和敬业方面</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="242" height="92" topLeftX="95" topLeftY="261" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="225" height="44" topLeftX="630" topLeftY="227" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">工作质量，绩效和贡献</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="242" height="92" topLeftX="630" topLeftY="261" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="216" height="45" topLeftX="110" topLeftY="373" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">XX 项目</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="216" height="45" topLeftX="635" topLeftY="159" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">XX 项目</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(58, 108, 234, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="416" height="64" topLeftX="392" topLeftY="282" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">EXPERIENCE REFLECTION</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Latfb65aEorji9xRzgFcuS3un3g" width="116" height="132" topLeftX="224" topLeftY="191">
+        <crop type="rect" leftOffset="0.22" rightOffset="0.22" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="544" height="110" topLeftX="385" topLeftY="187" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="60">03 经验反思</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="302" height="56" topLeftX="154" topLeftY="44" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="24" bold="false">EXPERIENCE REFLECTION</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="56" topLeftX="50" topLeftY="44" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(58, 108, 234, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(58, 108, 234, 1)" fontSize="24">经验反思</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+      <img src="ZrQrbKVo4oQAijxeFqIcZ4Xhnnd" width="271" height="271" topLeftX="623" topLeftY="234" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="5" height="30" topLeftX="45" topLeftY="57" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(58, 108, 234, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="416" height="64" topLeftX="392" topLeftY="282" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">WORK PLAN</span>
+          </p>
+        </content>
+      </shape>
+      <img src="ECiab3ZDpomRJaxjYTBcpxWpnDf" width="116" height="132" topLeftX="224" topLeftY="191">
+        <crop type="rect" leftOffset="0.39" rightOffset="0.39" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="544" height="110" topLeftX="385" topLeftY="187" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="60">04  工作计划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="302" height="56" topLeftX="154" topLeftY="44" alpha="0.5" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="24" bold="false">WORK PLAN</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="56" topLeftX="50" topLeftY="44" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(58, 108, 234, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(58, 108, 234, 1)" fontSize="24">工作计划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="RY2XbimMGowUaix1Op4c45plnkf" width="202" height="331" topLeftX="376" topLeftY="138">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="161" height="38" topLeftX="186" topLeftY="150" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="18">完善招聘流程</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="288" height="62" topLeftX="59" topLeftY="180" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="right">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="38" topLeftX="186" topLeftY="382" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">完善培训体系</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="288" height="62" topLeftX="59" topLeftY="412" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="right">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="38" topLeftX="186" topLeftY="266" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">优化绩效方法</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="288" height="62" topLeftX="59" topLeftY="296" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="right">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="366" topLeftY="155" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="366" topLeftY="271" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="366" topLeftY="387" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="38" topLeftX="607" topLeftY="150" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="18">加强行政管理</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="288" height="62" topLeftX="607" topLeftY="180" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="38" topLeftX="607" topLeftY="382" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">加强培训</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="288" height="62" topLeftX="607" topLeftY="412" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="38" topLeftX="607" topLeftY="266" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">拓宽招聘渠道</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="288" height="62" topLeftX="607" topLeftY="296" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="530" topLeftY="155" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">06</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="530" topLeftY="271" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">05</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="530" topLeftY="387" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(58, 108, 234, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="886" height="464" topLeftX="37" topLeftY="38" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="256" height="68" topLeftX="352" topLeftY="51" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="32">工作计划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="840" height="335" topLeftX="60" topLeftY="129" presetHandlers="0" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="382" startY="465" endX="381" endY="174" alpha="0.2">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="468" startY="465" endX="468" endY="174" alpha="0.2">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="554" startY="465" endX="553" endY="129" alpha="0.2">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="641" startY="465" endX="641" endY="174" alpha="0.2">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="727" startY="465" endX="727" endY="174" alpha="0.2">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="900" startY="465" endX="900" endY="174" alpha="0.2">
+        <border lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="814" startY="465" endX="813" endY="174" alpha="0.2">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="295" startY="465" endX="295" endY="174" alpha="0.2">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="207" startY="465" endX="206" endY="129" alpha="0.2">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="840" height="45" topLeftX="60" topLeftY="129" presetHandlers="0" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="rgba(244, 245, 246, 1)"/>
+        </fill>
+        <border color="rgba(43, 47, 54, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="87" height="47" topLeftX="338" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">Q1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="87" height="47" topLeftX="684" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">Q2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="139" height="47" topLeftX="60" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">事项规划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="139" height="41" topLeftX="60" topLeftY="185" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">事项 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="139" height="41" topLeftX="60" topLeftY="241" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">事项 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="139" height="41" topLeftX="60" topLeftY="297" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">事项 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="139" height="41" topLeftX="60" topLeftY="353" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">事项 #4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="139" height="41" topLeftX="60" topLeftY="409" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">事项 #5</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="45" topLeftX="216" topLeftY="183" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(58, 108, 234, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">3/1 - 3/3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="174" height="45" topLeftX="305" topLeftY="239" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">3/1 - 3/8</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="45" topLeftX="477" topLeftY="295" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(58, 108, 234, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">3/12</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="45" topLeftX="564" topLeftY="409" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(58, 108, 234, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">3/10 - 3/24</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="45" topLeftX="391" topLeftY="352" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">3/8 - 3/10</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="408" height="97" topLeftX="276" topLeftY="155" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="51">感谢观看</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="262" height="56" topLeftX="349" topLeftY="227" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="center">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="24">THANKS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="216" height="45" topLeftX="368" topLeftY="293" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(58, 108, 234, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">报告人: 马克</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="225" height="44" topLeftX="368" topLeftY="347" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span fontSize="16">汇报时间：2026.XX.XX</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/operations--brand_logo_design.xml
+++ b/skills/lark-slides/references/templates/operations--brand_logo_design.xml
@@ -1,0 +1,1347 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>品牌标志设计</title>
+  <theme>
+    <textStyles>
+      <title/>
+      <headline/>
+      <sub-headline/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="rgba(155, 157, 160, 1)" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Nz5gb0JwQoKtbWxj6vScCVdlnDg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="206" height="62" topLeftX="60" topLeftY="413" type="slides-full-round-rect">
+        <border color="rgba(0, 0, 0, 1)" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="124" height="41" topLeftX="82" topLeftY="424" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="14">April XX, 2026</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="215" startY="445" endX="245" endY="445">
+        <border lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <endArrow type="arrow"/>
+      </line>
+      <shape width="157" height="42" topLeftX="60" topLeftY="170" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(203, 205, 208, 1)">
+          <p letterSpacing="1">
+            <span color="rgba(203, 205, 208, 1)">XX 品牌</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="454" height="110" topLeftX="46" topLeftY="211" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="60" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="60">品牌标志设计</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="41" topLeftX="85" topLeftY="54" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="false">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="14" bold="false">YOUR LOGO</span>
+          </p>
+        </content>
+      </shape>
+      <img src="DD33b3w3XovpT9xFZpqco0TynEe" width="12" height="25" topLeftX="60" topLeftY="62" alpha="0.9">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="DD33b3w3XovpT9xFZpqco0TynEe" width="12" height="25" topLeftX="74" topLeftY="62" alpha="0.9">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="124" height="38" topLeftX="787" topLeftY="57" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(0, 0, 0, 1)" bold="false" textAlign="right">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12" bold="false">YOUR TEAM</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(28, 102, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="DYM4b6dzCoMD5gx4sn4cdPYlnxg" width="312" height="402" topLeftX="0" topLeftY="0" rotation="180">
+        <crop type="rect" leftOffset="0" rightOffset="86" topOffset="0" bottomOffset="186" presetHandlers="0"/>
+      </img>
+      <img src="ILOUbaURToeRBCx5VxicLMsKnsb" width="432" height="203" topLeftX="528" topLeftY="0">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="K8w1bqqEzoTR1bxSqC2cZaQKnmM" width="216" height="337" topLeftX="744" topLeftY="203">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="95" presetHandlers="0"/>
+      </img>
+      <shape width="357" height="44" topLeftX="471" topLeftY="371" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="16">品牌标志方案二</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="357" height="44" topLeftX="471" topLeftY="308" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="16">品牌标志方案一</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="357" height="44" topLeftX="471" topLeftY="246" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="16">设计目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="357" height="44" topLeftX="471" topLeftY="181" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="16">品牌背景</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="57" height="56" topLeftX="414" topLeftY="365" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="57" height="56" topLeftX="414" topLeftY="302" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="57" height="56" topLeftX="414" topLeftY="240" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="57" height="56" topLeftX="414" topLeftY="175" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>01</p>
+        </content>
+      </shape>
+      <shape width="355" height="83" topLeftX="47" topLeftY="163" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.949)" fontSize="42">目录</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(251, 251, 251, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(306deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 26%,rgba(230, 241, 255, 0.1) 63%,rgba(8, 120, 255, 0.11) 100%)"/>
+        </fill>
+      </shape>
+      <img src="CfGzbrtZQogLbGxoQ6NcBVgTnud" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="311" height="291" topLeftX="-10" topLeftY="239" rotation="270" alpha="0.4" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(19, 123, 255, 0) 0%,rgba(173, 230, 253, 0.4) 100%)"/>
+        </fill>
+      </shape>
+      <img src="FW7dbP5C1ol5nXxuNxEcNewknTd" width="210" height="295" topLeftX="250" topLeftY="-43" rotation="90" alpha="0.12">
+        <crop type="rect" leftOffset="50" rightOffset="0" topOffset="0" bottomOffset="87" presetHandlers="0"/>
+      </img>
+      <img src="I8dFbBRi4o5BJCx4XgycfspKnxI" width="362" height="540" topLeftX="0" topLeftY="0" exposure="12" contrast="-11" saturation="22" temperature="-82">
+        <crop type="rect" leftOffset="13" rightOffset="31" topOffset="7" bottomOffset="62" presetHandlers="0"/>
+      </img>
+      <shape width="106" height="106" topLeftX="302" topLeftY="105" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="64" height="64" topLeftX="322" topLeftY="126" iconType="iconpark/Abstract/graphic-stitching.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="235" height="77" topLeftX="451" topLeftY="118" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="38">品牌背景</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="332" height="44" topLeftX="453" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">背景一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="332" height="62" topLeftX="453" topLeftY="233" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(155, 157, 160, 1)" textAlign="left">
+          <p>
+            <span color="rgba(155, 157, 160, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="332" height="44" topLeftX="453" topLeftY="313" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">背景二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="332" height="62" topLeftX="453" topLeftY="343" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(155, 157, 160, 1)" textAlign="left">
+          <p>
+            <span color="rgba(155, 157, 160, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(251, 251, 251, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="V3PFbTK7oo0k82x2N1Rcu5x0nBc" width="344" height="412" topLeftX="0" topLeftY="0" alpha="0.15">
+        <crop type="rect" leftOffset="81" rightOffset="0" topOffset="172" bottomOffset="43" presetHandlers="0"/>
+      </img>
+      <img src="X9O3bMXTQoPTsSxLF9XciJtwnAf" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <img src="PT8Vb5020oH4AjxP0hacPvwDnhq" width="540" height="960" topLeftX="455" topLeftY="510" rotation="270" alpha="0.5">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="249" height="77" topLeftX="47" topLeftY="150" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="38">设计目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="244" height="83" topLeftX="52" topLeftY="227" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)" textAlign="left">
+          <p>
+            <span color="rgba(121, 124, 129, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="44" topLeftX="683" topLeftY="174" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">目标二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="74" topLeftX="684" topLeftY="207" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)">
+          <p>
+            <span color="rgba(121, 124, 129, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="78" topLeftX="683" topLeftY="91" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="40" height="40" topLeftX="702" topLeftY="110" iconType="iconpark/Charts/chart-proportion.svg">
+        <border color="linear-gradient(141deg,rgba(243, 249, 255, 1) 0%,rgba(244, 248, 253, 1) 27%,rgba(245, 246, 246, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="236" height="44" topLeftX="683" topLeftY="401" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">目标四</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="74" topLeftX="684" topLeftY="434" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)">
+          <p>
+            <span color="rgba(121, 124, 129, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="78" topLeftX="683" topLeftY="318" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 117, 239, 1)"/>
+        </fill>
+      </shape>
+      <icon width="40" height="40" topLeftX="702" topLeftY="337" iconType="iconpark/Abstract/triangular-pyramid.svg">
+        <border color="linear-gradient(141deg,rgba(243, 249, 255, 1) 0%,rgba(244, 248, 253, 1) 27%,rgba(245, 246, 246, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="236" height="44" topLeftX="396" topLeftY="401" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">目标三</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="74" topLeftX="397" topLeftY="434" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)">
+          <p>
+            <span color="rgba(121, 124, 129, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="78" topLeftX="396" topLeftY="318" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="40" height="40" topLeftX="415" topLeftY="337" iconType="iconpark/Operate/color-filter.svg">
+        <border color="linear-gradient(141deg,rgba(243, 249, 255, 1) 0%,rgba(244, 248, 253, 1) 27%,rgba(245, 246, 246, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <line startX="653" startY="91" endX="653" endY="502">
+        <border color="rgba(203, 205, 208, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="370" startY="292" endX="905" endY="292">
+        <border color="rgba(203, 205, 208, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="236" height="44" topLeftX="396" topLeftY="174" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">目标一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="236" height="74" topLeftX="397" topLeftY="207" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)">
+          <p>
+            <span color="rgba(121, 124, 129, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="78" topLeftX="396" topLeftY="91" type="ellipse">
+        <fill>
+          <fillColor color="rgba(16, 117, 239, 1)"/>
+        </fill>
+      </shape>
+      <icon width="40" height="40" topLeftX="415" topLeftY="110" iconType="iconpark/Base/system.svg">
+        <border color="linear-gradient(141deg,rgba(243, 249, 255, 1) 0%,rgba(244, 248, 253, 1) 27%,rgba(245, 246, 246, 1) 100%)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="BsaXbZFhXosMIaxe1q3cwVGinxh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="318" startY="298" endX="642" endY="298">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="879" height="41" topLeftX="40" topLeftY="308" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(78, 86, 102, 1)" textAlign="center">
+          <p letterSpacing="1">
+            <span color="rgba(78, 86, 102, 1)" fontSize="14">副标题信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="879" height="83" topLeftX="40" topLeftY="210" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="42">品牌标志方案一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="U9PNbCv3Loi5WNxYxvjclLXmn3e" width="241" height="540" topLeftX="-2" topLeftY="0" flipY="true" exposure="18" contrast="-7" saturation="14" temperature="-69">
+        <crop type="rect" leftOffset="15" rightOffset="14" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="-2" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="21" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="-2" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0.8) 0%,rgba(255, 255, 255, 0.4) 59%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="21" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="31" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="21" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(0, 0, 0, 1)">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="GRNXbSx7OoO9Lhx1YEBctcvunKc" width="241" height="540" topLeftX="480" topLeftY="0" rotation="180" exposure="9" temperature="-42">
+        <crop type="rect" leftOffset="150" rightOffset="150" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="480" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="503" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="480" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0.8) 0%,rgba(255, 255, 255, 0.4) 59%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="503" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="513" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="503" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(0, 0, 0, 1)">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Jys9bL5AYoTbL7xxuGFcddJvnzz" width="241" height="540" topLeftX="719" topLeftY="0" exposure="14" contrast="-5" saturation="11" temperature="-26">
+        <crop type="rect" leftOffset="15" rightOffset="14" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="719" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="742" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="719" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(0, 0, 0, 0.8) 0%,rgba(0, 0, 0, 0.4) 59%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="742" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="751" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(243, 244, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="742" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="HNMDbk5Afo4U9cx6RFec78s4npm" width="241" height="540" topLeftX="239" topLeftY="0" exposure="20" contrast="5" saturation="11" temperature="-20">
+        <crop type="rect" leftOffset="15" rightOffset="14" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="194" height="56" topLeftX="263" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="56" topLeftX="262" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="105" topLeftX="239" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="194" height="56" topLeftX="263" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="239" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(0, 0, 0, 0.8) 0%,rgba(0, 0, 0, 0.4) 59%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="262" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="271" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(243, 244, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="262" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="192" height="44" topLeftX="852" topLeftY="717" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="480" height="540" topLeftX="480" topLeftY="0" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="218" height="218" topLeftX="611" topLeftY="161" type="ellipse">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="218" height="218" topLeftX="611" topLeftY="161" presetHandlers="16" type="round-rect">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="161" height="161" topLeftX="639" topLeftY="189" presetHandlers="16" type="round-rect">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="551" startY="270" endX="889" endY="270">
+        <border color="rgba(203, 205, 208, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="720" startY="127" endX="720" endY="413">
+        <border color="rgba(203, 205, 208, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="183" height="183" topLeftX="629" topLeftY="179" iconType="iconpark/Abstract/two-ellipses.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(251, 251, 251, 1)" width="9" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="480" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="217" height="217" topLeftX="130" topLeftY="163" type="ellipse">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="217" height="217" topLeftX="130" topLeftY="163" presetHandlers="16" type="round-rect">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="161" height="161" topLeftX="158" topLeftY="191" presetHandlers="16" type="round-rect">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="70" startY="271" endX="408" endY="271">
+        <border color="rgba(129, 132, 135, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="239" startY="128" endX="239" endY="414">
+        <border color="rgba(129, 132, 135, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="182" height="182" topLeftX="148" topLeftY="180" iconType="iconpark/Abstract/two-ellipses.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="9" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="389" height="56" topLeftX="522" topLeftY="445" rotation="360" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)" textAlign="left">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="389" height="53" topLeftX="45" topLeftY="445" rotation="360" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(243, 244, 246, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="22">设计方案一</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="V4dIb4GvwoHVZ3xEqMmcvcMfnPc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="303" height="83" topLeftX="52" topLeftY="229" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(251, 251, 251, 1)" textAlign="left">
+          <p>
+            <span color="rgba(251, 251, 251, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="V3PFbTK7oo0k82x2N1Rcu5x0nBc" width="344" height="412" topLeftX="0" topLeftY="0" alpha="0.15">
+        <crop type="rect" leftOffset="81" rightOffset="0" topOffset="172" bottomOffset="43" presetHandlers="0"/>
+      </img>
+      <img src="X9O3bMXTQoPTsSxLF9XciJtwnAf" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="864" height="62" topLeftX="47" topLeftY="411" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)" textAlign="left">
+          <p>
+            <span color="rgba(121, 124, 129, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中展现内容，可以选择多种可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="296" height="263" topLeftX="47" topLeftY="125" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="160" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="160" fontFamily="Arial Black" bold="false">Aa</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="492" height="51" topLeftX="415" topLeftY="192" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Arial Black" bold="false">Aa Bb Cc Dd Ee Ff Gg Hh Ii Jj Kk Ll Mm Nn</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="492" height="51" topLeftX="415" topLeftY="239" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="false" letterSpacing="8">
+          <p letterSpacing="8">
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Arial Black" bold="false">1234567890</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="492" height="51" topLeftX="415" topLeftY="286" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="false" letterSpacing="8">
+          <p letterSpacing="8">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Arial Black">(&lt;!</span>
+            </strong>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Arial Black" bold="false">#$&amp;?]}</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="355" startY="191" endX="355" endY="338">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="V3PFbTK7oo0k82x2N1Rcu5x0nBc" width="344" height="412" topLeftX="0" topLeftY="0" alpha="0.15">
+        <crop type="rect" leftOffset="81" rightOffset="0" topOffset="172" bottomOffset="43" presetHandlers="0"/>
+      </img>
+      <img src="X9O3bMXTQoPTsSxLF9XciJtwnAf" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="146" height="146" topLeftX="717" topLeftY="103" type="ellipse">
+        <fill>
+          <fillColor color="rgba(134, 219, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.949)" fontSize="28">25%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="717" topLeftY="249" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#86DBFF</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="717" topLeftY="314" type="ellipse">
+        <fill>
+          <fillColor color="rgba(198, 231, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="28">5%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="717" topLeftY="460" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#C6E7FF</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="509" topLeftY="103" type="ellipse">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" color="rgba(251, 251, 251, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(251, 251, 251, 1)" fontSize="30">60%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="509" topLeftY="249" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#1C66F6</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="509" topLeftY="314" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.949)" fontSize="28">10%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="509" topLeftY="460" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#000000</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="249" height="77" topLeftX="47" topLeftY="150" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="38">色彩方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="360" height="104" topLeftX="52" topLeftY="227" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)" textAlign="left">
+          <p>
+            <span color="rgba(121, 124, 129, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中展现内容，可以选择多种可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="W9b6bRk6xoEMZJxK9SicuaaLnKp" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="318" startY="298" endX="642" endY="298">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="879" height="41" topLeftX="40" topLeftY="308" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(78, 86, 102, 1)" textAlign="center">
+          <p letterSpacing="1">
+            <span color="rgba(78, 86, 102, 1)" fontSize="14">副标题信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="879" height="83" topLeftX="40" topLeftY="210" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="42" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="42">品牌标志方案二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="KXVybTHCGoY3Gjxsnb5clEdbnud" width="241" height="540" topLeftX="0" topLeftY="0" exposure="18" temperature="-100">
+        <crop type="rect" leftOffset="15" rightOffset="26" topOffset="23" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="0" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="23" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="0" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0.8) 0%,rgba(255, 255, 255, 0.4) 59%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="23" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="33" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="23" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(0, 0, 0, 1)">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="AyzzbZ5KUoncRaxxMwecWRHAnOd" width="241" height="540" topLeftX="480" topLeftY="0" exposure="-7" contrast="-12" saturation="15" temperature="-16">
+        <crop type="rect" leftOffset="15" rightOffset="14" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="480" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="503" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="480" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(255, 255, 255, 0.8) 0%,rgba(255, 255, 255, 0.4) 59%,rgba(255, 255, 255, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="503" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="513" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="503" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(0, 0, 0, 1)">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="EiPVblC7pomjKlxdqo1cXl89nBg" width="241" height="540" topLeftX="239" topLeftY="0" rotation="180" flipX="true" flipY="true" saturation="-22">
+        <crop type="rect" leftOffset="31" rightOffset="31" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="194" height="56" topLeftX="262" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="56" topLeftX="262" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="105" topLeftX="239" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="194" height="56" topLeftX="263" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="239" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(0, 0, 0, 0.8) 0%,rgba(0, 0, 0, 0.4) 59%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="262" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="271" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(243, 244, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="262" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="G3sIb7p4Qounv7xEwkMcuqfRnid" width="241" height="540" topLeftX="719" topLeftY="0" rotation="180" exposure="38" contrast="-8" saturation="9" temperature="-80">
+        <crop type="rect" leftOffset="31" rightOffset="31" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="241" height="105" topLeftX="719" topLeftY="435" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="56" topLeftX="742" topLeftY="459" alpha="0.9" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="248" topLeftX="719" topLeftY="0" alpha="0.5" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(0, 0, 0, 0.8) 0%,rgba(0, 0, 0, 0.4) 59%,rgba(0, 0, 0, 0) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="59" topLeftX="742" topLeftY="78" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="26">风格语言</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="42" height="6" topLeftX="751" topLeftY="66" type="rect">
+        <fill>
+          <fillColor color="rgba(243, 244, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="195" height="38" topLeftX="742" topLeftY="128" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 0.949)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.949)" fontSize="12">演示文稿是一种实用的工具。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="480" height="540" topLeftX="480" topLeftY="0" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(28, 102, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="218" height="218" topLeftX="611" topLeftY="161" type="ellipse">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="218" height="218" topLeftX="611" topLeftY="161" presetHandlers="16" type="round-rect">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="161" height="161" topLeftX="639" topLeftY="189" presetHandlers="16" type="round-rect">
+        <border color="rgba(143, 156, 180, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="551" startY="270" endX="889" endY="270">
+        <border color="rgba(203, 205, 208, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="720" startY="127" endX="720" endY="413">
+        <border color="rgba(203, 205, 208, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="183" height="183" topLeftX="629" topLeftY="179" iconType="iconpark/Abstract/api-app.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(251, 251, 251, 1)" width="9" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="480" height="540" topLeftX="0" topLeftY="0" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <shape width="217" height="217" topLeftX="130" topLeftY="163" type="ellipse">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="217" height="217" topLeftX="130" topLeftY="163" presetHandlers="16" type="round-rect">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="161" height="161" topLeftX="158" topLeftY="191" presetHandlers="16" type="round-rect">
+        <border color="rgba(62, 63, 65, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="70" startY="271" endX="408" endY="271">
+        <border color="rgba(129, 132, 135, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="239" startY="128" endX="239" endY="414">
+        <border color="rgba(129, 132, 135, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="182" height="182" topLeftX="148" topLeftY="180" iconType="iconpark/Abstract/api-app.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="9" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="389" height="56" topLeftX="522" topLeftY="445" rotation="360" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(243, 244, 246, 1)" textAlign="left">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="12">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="389" height="53" topLeftX="45" topLeftY="445" rotation="360" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" color="rgba(243, 244, 246, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(243, 244, 246, 1)" fontSize="22">设计方案二</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="41" topLeftX="85" topLeftY="54" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" bold="false">YOUR LOGO</span>
+          </p>
+        </content>
+      </shape>
+      <img src="KQ6ubZ4VJoHxRSxjPGecHsdHnNb" width="12" height="25" topLeftX="60" topLeftY="62">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Zte9b4vHRo6CjpxVGRvceHwtnWf" width="12" height="25" topLeftX="74" topLeftY="62">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="124" height="38" topLeftX="787" topLeftY="57" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(251, 251, 251, 1)" bold="false" textAlign="right">
+          <p>
+            <span color="rgba(251, 251, 251, 1)" fontSize="12" bold="false">YOUR TEAM</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="V3PFbTK7oo0k82x2N1Rcu5x0nBc" width="344" height="412" topLeftX="0" topLeftY="0" alpha="0.15">
+        <crop type="rect" leftOffset="81" rightOffset="0" topOffset="172" bottomOffset="43" presetHandlers="0"/>
+      </img>
+      <img src="X9O3bMXTQoPTsSxLF9XciJtwnAf" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="864" height="62" topLeftX="47" topLeftY="411" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)" textAlign="left">
+          <p>
+            <span color="rgba(121, 124, 129, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中展现内容，可以选择多种可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="296" height="263" topLeftX="47" topLeftY="125" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="160" fontFamily="Trebuchet MS" color="rgba(43, 47, 54, 1)" bold="false" letterSpacing="8">
+          <p letterSpacing="8">
+            <span color="rgba(43, 47, 54, 1)" fontSize="160" fontFamily="Trebuchet MS" bold="false">Aa</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="407" height="51" topLeftX="506" topLeftY="192" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Trebuchet MS" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Trebuchet MS" bold="false">Aa Bb Cc Dd Ee Ff Gg Hh Ii Jj Kk Ll Mm Nn</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="407" height="51" topLeftX="506" topLeftY="239" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Trebuchet MS" color="rgba(43, 47, 54, 1)" bold="false" letterSpacing="8">
+          <p letterSpacing="8">
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Trebuchet MS" bold="false">1234567890</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="407" height="51" topLeftX="506" topLeftY="286" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" fontFamily="Trebuchet MS" color="rgba(43, 47, 54, 1)" bold="false" letterSpacing="8">
+          <p letterSpacing="8">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Trebuchet MS">(&lt;!</span>
+            </strong>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20" fontFamily="Trebuchet MS" bold="false">#$&amp;?]}</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="374" startY="197" endX="374" endY="343">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="V3PFbTK7oo0k82x2N1Rcu5x0nBc" width="344" height="412" topLeftX="0" topLeftY="0" alpha="0.15">
+        <crop type="rect" leftOffset="81" rightOffset="0" topOffset="172" bottomOffset="43" presetHandlers="0"/>
+      </img>
+      <img src="X9O3bMXTQoPTsSxLF9XciJtwnAf" width="219" height="219" topLeftX="741" topLeftY="321" alpha="0.25">
+        <crop type="rect" leftOffset="63" rightOffset="149" topOffset="38" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="146" height="146" topLeftX="717" topLeftY="103" type="ellipse">
+        <fill>
+          <fillColor color="rgba(41, 185, 246, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.949)" fontSize="28">25%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="717" topLeftY="249" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#86DBFF</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="717" topLeftY="314" type="ellipse">
+        <fill>
+          <fillColor color="rgba(225, 234, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="28">5%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="717" topLeftY="460" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#C6E7FF</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="509" topLeftY="103" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 145, 227, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30" color="rgba(251, 251, 251, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(251, 251, 251, 1)" fontSize="30">60%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="509" topLeftY="249" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#1C66F6</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="509" topLeftY="314" type="ellipse">
+        <fill>
+          <fillColor color="rgba(0, 0, 0, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 0.949)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 0.949)" fontSize="28">10%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="44" topLeftX="509" topLeftY="460" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">#000000</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="360" height="77" topLeftX="47" topLeftY="150" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="38">色彩方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="360" height="104" topLeftX="52" topLeftY="227" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(121, 124, 129, 1)" textAlign="left">
+          <p>
+            <span color="rgba(121, 124, 129, 1)">演示文稿是一种实用的工具，可以是演示，演讲，报告等。大部分时间，它们都是在为观众服务。它们有多种用途，是演讲和教学的有力工具。如果您想在演示文稿中展现内容，可以选择多种可以选择多种方式。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WsnNbo3j8oXqnWxynaZcVz6knrd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="132" height="41" topLeftX="85" topLeftY="54" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14" bold="false">YOUR LOGO</span>
+          </p>
+        </content>
+      </shape>
+      <img src="CCJxbunFoosXKRxZiSwcrHKNnXe" width="12" height="25" topLeftX="60" topLeftY="62">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Um3Qb2dr1of3Swxw73Ec5hGlnyb" width="12" height="25" topLeftX="74" topLeftY="62">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="124" height="38" topLeftX="787" topLeftY="57" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(251, 251, 251, 1)" bold="false" textAlign="right">
+          <p>
+            <span color="rgba(251, 251, 251, 1)" fontSize="12" bold="false">YOUR TEAM</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/operations--brand_operations_plan.xml
+++ b/skills/lark-slides/references/templates/operations--brand_operations_plan.xml
@@ -1,0 +1,1309 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>品牌运营计划-裂图重新上传</title>
+  <theme>
+    <textStyles>
+      <title fontColor="rgba(43, 47, 54, 1)" fontSize="80"/>
+      <headline fontColor="rgba(43, 47, 54, 1)" fontSize="48"/>
+      <sub-headline fontColor="rgba(43, 47, 54, 1)"/>
+      <body fontColor="rgba(43, 47, 54, 1)" fontSize="14"/>
+      <caption fontColor="rgba(43, 47, 54, 1)"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="542" height="116" topLeftX="26" topLeftY="375" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)">品牌提案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="464" height="62" topLeftX="33" topLeftY="326" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">Brand proposal</span>
+          </p>
+        </content>
+      </shape>
+      <img src="XLyZb9phHo2eqMxA4TFcsriAnYg" width="459" height="464" topLeftX="501" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="22" topOffset="160" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="73" height="38" topLeftX="59" topLeftY="24" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="40" topLeftY="31" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(239, 242, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="175" height="92" topLeftX="54" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">目录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="68" topLeftX="60" topLeftY="165" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">Contents</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="59" height="50" topLeftX="484" topLeftY="113" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(60, 111, 229, 1)" fontSize="20">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="50" topLeftX="551" topLeftY="113" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(60, 111, 229, 1)" fontSize="20">品牌介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="59" height="50" topLeftX="484" topLeftY="170" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="50" topLeftX="551" topLeftY="170" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20">产品介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="59" height="50" topLeftX="484" topLeftY="226" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="50" topLeftX="551" topLeftY="226" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20">市场分析</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="59" height="50" topLeftX="484" topLeftY="282" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="50" topLeftX="551" topLeftY="282" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20">活动思路</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="59" height="50" topLeftX="484" topLeftY="338" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="20">05</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="50" topLeftX="551" topLeftY="338" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="20">营销推广</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="5" height="32" topLeftX="468" topLeftY="123" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <shape width="5" height="32" topLeftX="468" topLeftY="179" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="5" height="32" topLeftX="468" topLeftY="235" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="5" height="32" topLeftX="468" topLeftY="291" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="5" height="32" topLeftX="468" topLeftY="347" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PBaBbVkouoPSSDxKzfDcg0pFn3d" width="810" height="504" topLeftX="150" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="160" topOffset="309" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="150" height="163" topLeftX="151" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="96" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="96">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="67" topLeftX="289" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="31" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="31">品牌介绍</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Brand Story</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="225" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>
+            <span color="rgba(60, 111, 229, 1)">品牌故事</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Ob67bcca3obkWzxh5LtcdaEYnQh" width="248" height="361" topLeftX="350" topLeftY="89">
+        <crop type="rect" leftOffset="0" rightOffset="347" topOffset="127" bottomOffset="107" presetHandlers="0"/>
+      </img>
+      <img src="GsGwbhbE0oRA2pxH46BcHtBZnOp" width="225" height="361" topLeftX="610" topLeftY="89">
+        <crop type="rect" leftOffset="270" rightOffset="100" topOffset="128" bottomOffset="106" presetHandlers="0"/>
+      </img>
+      <img src="GYwAbOu11ofIfYxkiSlcX00bnvl" width="93" height="361" topLeftX="848" topLeftY="89">
+        <crop type="rect" leftOffset="502" rightOffset="0" topOffset="128" bottomOffset="105" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Milestone</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="246" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>发展回顾</p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PBaBbVkouoPSSDxKzfDcg0pFn3d" width="810" height="504" topLeftX="150" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="160" topOffset="309" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="150" height="164" topLeftX="151" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="96" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="96">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="67" topLeftX="289" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="31" color="rgba(255, 255, 255, 1)">
+          <p>产品介绍</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Product Line</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="246" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>产品线</p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="248" height="371" topLeftX="619" topLeftY="78" type="rect">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="248" height="371" topLeftX="351" topLeftY="79" type="rect">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Highlights</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="246" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>产品亮点</p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="644" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">亮点 </span>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">#2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="92" topLeftX="644" topLeftY="240" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="649" topLeftY="115" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="33" height="33" topLeftX="669" topLeftY="135" iconType="iconpark/Abstract/cylinder.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="180" height="41" topLeftX="370" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">亮点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="92" topLeftX="370" topLeftY="240" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="375" topLeftY="115" type="ellipse">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <icon width="32" height="32" topLeftX="395" topLeftY="135" iconType="iconpark/Abstract/six-points.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="205" height="74" topLeftX="370" topLeftY="332" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <ul>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="205" height="74" topLeftX="644" topLeftY="332" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <ul>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span fontSize="12">要点描述</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PBaBbVkouoPSSDxKzfDcg0pFn3d" width="810" height="504" topLeftX="150" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="160" topOffset="309" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="150" height="163" topLeftX="151" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="96" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="96">03</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="67" topLeftX="289" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="31" color="rgba(255, 255, 255, 1)">
+          <p>市场分析</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Market Environment</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="308" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>市场环境</p>
+        </content>
+      </shape>
+      <shape width="310" height="310" topLeftX="334" topLeftY="110" type="ellipse">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="310" height="310" topLeftX="605" topLeftY="111" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="180" height="44" topLeftX="387" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">国内市场</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="92" topLeftX="387" topLeftY="240" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="44" topLeftX="657" topLeftY="205" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">国际市场</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="92" topLeftX="657" topLeftY="240" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Consumer Group</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="308" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>消费人群</p>
+        </content>
+      </shape>
+      <shape width="79" height="32" topLeftX="415" topLeftY="257" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="12">18</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="32" topLeftX="415" topLeftY="289" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="12">18-25</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="32" topLeftX="414" topLeftY="321" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="12">25-35</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="79" height="32" topLeftX="414" topLeftY="351" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1" textAlign="right">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="12">35 以上</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="307" height="12" topLeftX="513" topLeftY="267" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="188" height="12" topLeftX="513" topLeftY="267" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <shape width="307" height="12" topLeftX="513" topLeftY="299" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="92" height="12" topLeftX="513" topLeftY="299" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <shape width="307" height="12" topLeftX="513" topLeftY="331" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="256" height="12" topLeftX="513" topLeftY="331" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <shape width="307" height="12" topLeftX="513" topLeftY="361" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="188" height="12" topLeftX="513" topLeftY="361" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+      </shape>
+      <shape width="38" height="32" topLeftX="513" topLeftY="381" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" bold="false">0</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="38" height="32" topLeftX="603" topLeftY="381" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" bold="false">10</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="38" height="32" topLeftX="693" topLeftY="381" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" bold="false">20</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="38" height="32" topLeftX="782" topLeftY="381" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(43, 47, 54, 1)" fontSize="12" bold="false">30</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="386" height="74" topLeftX="448" topLeftY="141" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="448" topLeftY="107" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">洞察分析</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p>Competition Analysis</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="269" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>竞对分析</p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="559" topLeftY="79" type="ellipse">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="20">竞品 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="559" topLeftY="194" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20">
+          <p>
+            <span fontSize="20">竞品 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="146" topLeftX="559" topLeftY="315" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="20">竞品 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="41" topLeftX="374" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>优势</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="374" topLeftY="120" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="374" topLeftY="233" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="374" topLeftY="354" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="41" topLeftX="745" topLeftY="79" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>劣势</p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="745" topLeftY="120" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="745" topLeftY="233" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="146" height="74" topLeftX="745" topLeftY="354" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)" textAlign="center">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="352" startY="208" endX="542" endY="208">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="352" startY="332" endX="542" endY="332">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="722" startY="208" endX="913" endY="208">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="722" startY="331" endX="913" endY="331">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PBaBbVkouoPSSDxKzfDcg0pFn3d" width="810" height="504" topLeftX="150" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="160" topOffset="309" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="150" height="164" topLeftX="151" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="96" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="96">04</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="67" topLeftX="289" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="31" color="rgba(255, 255, 255, 1)">
+          <p>活动思路</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p> Activity Ideas</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="308" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>活动思路</p>
+        </content>
+      </shape>
+      <img src="CZOnbA1troRlwZxlAtPcPnZynJh" width="244" height="150" topLeftX="366" topLeftY="120">
+        <crop type="rect" leftOffset="46" rightOffset="0" topOffset="64" bottomOffset="77" presetHandlers="0"/>
+      </img>
+      <img src="Dwj0bfLj6oNOvfxDDTPcXP38nQg" width="244" height="158" topLeftX="649" topLeftY="270">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="29" bottomOffset="57" presetHandlers="0"/>
+      </img>
+      <shape width="261" height="74" topLeftX="641" topLeftY="175" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="641" topLeftY="141" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>促销活动</p>
+        </content>
+      </shape>
+      <shape width="261" height="74" topLeftX="358" topLeftY="329" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">。</span>
+            <span color="rgba(124, 125, 126, 1)" fontSize="12">描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="358" topLeftY="294" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true">
+          <p> 试用活动</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="PBaBbVkouoPSSDxKzfDcg0pFn3d" width="810" height="504" topLeftX="150" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="160" topOffset="309" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="150" height="164" topLeftX="151" topLeftY="134" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="96" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="96">05</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="175" height="67" topLeftX="289" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="31" color="rgba(255, 255, 255, 1)">
+          <p>营销推广</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p> Activity Ideas</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="270" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>活动思路</p>
+        </content>
+      </shape>
+      <shape width="563" height="132" topLeftX="335" topLeftY="205" type="slides-full-round-rect">
+        <border color="rgba(60, 111, 229, 1)" width="24" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="191" height="200" topLeftX="321" topLeftY="259" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="119" height="282" topLeftX="304" topLeftY="98" flipX="true" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="78" height="78" topLeftX="365" topLeftY="168" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="78" height="78" topLeftX="568" topLeftY="168" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="180" height="41" topLeftX="570" topLeftY="67" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>主视觉设计</p>
+        </content>
+      </shape>
+      <shape width="167" height="56" topLeftX="570" topLeftY="101" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="365" topLeftY="67" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>产品定位</p>
+        </content>
+      </shape>
+      <shape width="167" height="56" topLeftX="365" topLeftY="101" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="478" topLeftY="383" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>营销活动</p>
+        </content>
+      </shape>
+      <shape width="167" height="56" topLeftX="478" topLeftY="417" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="78" topLeftX="478" topLeftY="297" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="78" height="78" topLeftX="678" topLeftY="297" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="180" height="41" topLeftX="678" topLeftY="383" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>广告投放</p>
+        </content>
+      </shape>
+      <shape width="167" height="56" topLeftX="678" topLeftY="417" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="42" height="42" topLeftX="383" topLeftY="187" iconType="iconpark/Base/home.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="42" height="42" topLeftX="586" topLeftY="187" iconType="iconpark/Base/pic.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="42" height="42" topLeftX="696" topLeftY="317" iconType="iconpark/Office/envelope-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="42" height="42" topLeftX="496" topLeftY="317" iconType="iconpark/Office/newspaper-folding.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="543" topLeftX="0" topLeftY="-3" type="rect">
+        <fill>
+          <fillColor color="rgba(239, 242, 246, 1)"/>
+        </fill>
+      </shape>
+      <shape width="225" height="41" topLeftX="32" topLeftY="167" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="false">
+          <p> Activity Ideas</p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="239" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="207" height="74" topLeftX="32" topLeftY="317" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(124, 125, 126, 1)">
+          <p>
+            <span color="rgba(124, 125, 126, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="267" height="92" topLeftX="27" topLeftY="93" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(60, 111, 229, 1)" bold="true">
+          <p>活动思路</p>
+        </content>
+      </shape>
+      <line startX="362" startY="440" endX="362" endY="173" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="536" startY="440" endX="535" endY="173" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="722" startY="440" endX="722" endY="173" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="895" startY="440" endX="895" endY="173" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="399" height="48" topLeftX="495" topLeftY="191" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">事项 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="337" height="48" topLeftX="450" topLeftY="252" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">事项 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="48" topLeftX="362" topLeftY="313" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(60, 111, 229, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">事项 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="267" height="48" topLeftX="583" topLeftY="373" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>事项 #4</p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="362" topLeftY="84" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>前期筹备</p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="538" topLeftY="84" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>执行期</p>
+        </content>
+      </shape>
+      <shape width="180" height="41" topLeftX="715" topLeftY="84" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)" bold="true" textAlign="center">
+          <p>总结复盘</p>
+        </content>
+      </shape>
+      <line startX="362" startY="136" endX="895" endY="136">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <endArrow type="solid-triangle"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(60, 111, 229, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="542" height="116" topLeftX="26" topLeftY="375" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)">感谢观看</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="464" height="62" topLeftX="33" topLeftY="326" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">Thank You</span>
+          </p>
+        </content>
+      </shape>
+      <img src="CaPpbVUruoFDoBxsOS2cpAOFnBe" width="459" height="464" topLeftX="501" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="22" topOffset="160" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="73" height="38" topLeftX="59" topLeftY="24" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="40" topLeftY="31" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/operations--marketing_plan.xml
+++ b/skills/lark-slides/references/templates/operations--marketing_plan.xml
@@ -1,0 +1,1469 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>营销策划方案-裂图重新上传</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XfIfbc1tYoFJ1sx5FWxcsCoBn0f" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="191" height="202" topLeftX="587" topLeftY="184" presetHandlers="8" alpha="0.9" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="545" height="101" topLeftX="207" topLeftY="204" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" bold="true" textAlign="center">
+          <p>营销策划模板</p>
+        </content>
+      </shape>
+      <line startX="142" startY="47" endX="910" endY="47" alpha="0.29">
+        <border color="rgba(147, 150, 156, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="615" height="44" topLeftX="172" topLeftY="290" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(147, 150, 156, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="16">MARKETING PLANNING </span>
+            </strong>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="16">TEMPLATE</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="92" height="116" topLeftX="295" topLeftY="26" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="161" height="77" topLeftX="319" topLeftY="71" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true" textAlign="center">
+          <p>目录</p>
+        </content>
+      </shape>
+      <line startX="907" startY="119" endX="907" endY="515">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="908" startY="0" endX="908" endY="142">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="904" topLeftY="144" rotation="0" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="785" topLeftY="367" rotation="270" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="43" topLeftX="369" topLeftY="207" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="15" bold="true">
+          <p>
+            <strong>
+              <span fontSize="15">活动总体思路</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="38" topLeftX="369" topLeftY="229" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 219, 29, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="12">General Idea</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="203" height="56" topLeftX="369" topLeftY="254" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(66, 66, 66, 1)">
+          <p>
+            <span color="rgba(66, 66, 66, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="43" topLeftX="614" topLeftY="207" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="15" bold="true">
+          <p>
+            <strong>
+              <span fontSize="15">活动执行方案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="38" topLeftX="614" topLeftY="229" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 219, 29, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="12">Program of Activities</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="203" height="56" topLeftX="614" topLeftY="254" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(66, 66, 66, 1)">
+          <p>
+            <span color="rgba(66, 66, 66, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <img src="NUtabqkWpohkfCxb523ckUYfnIf" width="254" height="489" topLeftX="26" topLeftY="26" exposure="16" contrast="-46" saturation="-93" temperature="-14">
+        <crop type="rect" leftOffset="80" rightOffset="34" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="136" height="43" topLeftX="369" topLeftY="327" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="15" bold="true">
+          <p>
+            <strong>
+              <span fontSize="15">活动经费预算</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="38" topLeftX="369" topLeftY="349" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 219, 29, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="12">Budget</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="203" height="56" topLeftX="369" topLeftY="374" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(66, 66, 66, 1)">
+          <p>
+            <span color="rgba(66, 66, 66, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="136" height="43" topLeftX="614" topLeftY="327" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="15" bold="true">
+          <p>
+            <strong>
+              <span fontSize="15">活动预期效果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="38" topLeftX="614" topLeftY="349" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 219, 29, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="12">Expected Results</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="203" height="56" topLeftX="614" topLeftY="374" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(66, 66, 66, 1)">
+          <p>
+            <span color="rgba(66, 66, 66, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 219, 29, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Ha3Cbaf8PobZMvxI6VZcV7uznZc" width="480" height="540" topLeftX="480" topLeftY="0" exposure="14" contrast="-55" saturation="-92" temperature="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="261" height="74" topLeftX="27" topLeftY="434" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(24, 24, 26, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(24, 24, 26, 1)" fontSize="36">活动总体思路</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="47" topLeftX="31" topLeftY="407" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">General Idea</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="142" startY="47" endX="676" endY="47">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="481" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <line startX="142" startY="47" endX="910" endY="47">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="101" height="90" topLeftX="41" topLeftY="88" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="407" height="62" topLeftX="77" topLeftY="118" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" bold="true" textAlign="left">
+          <p>
+            <span fontSize="28">活动总体思路</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="41" topLeftY="232" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="41" topLeftX="41" topLeftY="204" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="41" topLeftY="326" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="41" topLeftX="41" topLeftY="298" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="56" topLeftX="41" topLeftY="420" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="41" topLeftX="41" topLeftY="392" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Yb3sbX2Vooj3HyxQfB3cH9ErnOb" width="240" height="403" topLeftX="331" topLeftY="88" exposure="4" contrast="-51" saturation="-91" temperature="20">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="MhGabCLEBoKmRox0Q7dc6txbnhg" width="152" height="403" topLeftX="589" topLeftY="88" exposure="22" contrast="-35" saturation="-92" temperature="26">
+        <crop type="rect" leftOffset="411" rightOffset="155" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="H8q1bdnT8o7bXAxIKIHc9IGLnUh" width="152" height="403" topLeftX="758" topLeftY="88" exposure="26" contrast="-35" saturation="-91" temperature="31">
+        <crop type="rect" leftOffset="4" rightOffset="4" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="49" height="56" topLeftX="38" topLeftY="74" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <line startX="142" startY="47" endX="910" endY="47">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">5</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="74" topLeftX="38" topLeftY="194" alpha="0.88" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="38" topLeftX="38" topLeftY="388" presetHandlers="45" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">第一阶段</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="407" height="56" topLeftX="47" topLeftY="82" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true" textAlign="left">
+          <p>
+            <span fontSize="24">活动时间轴</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="250" startY="194" endX="250" endY="426" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="195" height="74" topLeftX="267" topLeftY="194" alpha="0.88" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="38" topLeftX="267" topLeftY="388" presetHandlers="45" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">第二阶段</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="479" startY="194" endX="479" endY="426" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="195" height="74" topLeftX="498" topLeftY="194" alpha="0.88" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="38" topLeftX="498" topLeftY="388" presetHandlers="45" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">第三阶段</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="710" startY="194" endX="710" endY="426" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="195" height="74" topLeftX="727" topLeftY="194" alpha="0.88" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="195" height="38" topLeftX="727" topLeftY="388" presetHandlers="45" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">第四阶段</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 219, 29, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="JezPbVNsHopdNuxR7ZecFO7Xnhf" width="480" height="540" topLeftX="480" topLeftY="0" exposure="14" contrast="-55" saturation="-92" temperature="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="261" height="74" topLeftX="27" topLeftY="434" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(24, 24, 26, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(24, 24, 26, 1)" fontSize="36">活动执行方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="47" topLeftX="31" topLeftY="407" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">Program of Activities</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="142" startY="47" endX="676" endY="47">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">6</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="481" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <line startX="282" startY="250" endX="90" endY="250" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="907" startY="119" endX="907" endY="515">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="908" startY="0" endX="908" endY="142">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="904" topLeftY="144" rotation="0" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">7</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="785" topLeftY="367" rotation="270" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q3 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="261" height="68" topLeftX="30" topLeftY="64" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(24, 24, 26, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(24, 24, 26, 1)" fontSize="32">活动执行方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="44" topLeftX="34" topLeftY="41" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 219, 29, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="16">Program of Activities</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="34" height="34" topLeftX="46" topLeftY="233" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="53" topLeftY="240" iconType="iconpark/Base/all-application.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="34" height="34" topLeftX="294" topLeftY="233" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="301" topLeftY="240" iconType="iconpark/Office/transform.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="34" height="34" topLeftX="542" topLeftY="233" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="549" topLeftY="240" iconType="iconpark/Travel/airplane.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <line startX="530" startY="250" endX="337" endY="250" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="240" height="41" topLeftX="42" topLeftY="277" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="192" height="56" topLeftX="62" topLeftY="314" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="53" topLeftY="332" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="192" height="38" topLeftX="62" topLeftY="360" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="53" topLeftY="378" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="240" height="41" topLeftX="294" topLeftY="277" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="192" height="56" topLeftX="313" topLeftY="314" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="305" topLeftY="332" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="192" height="38" topLeftX="313" topLeftY="360" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="305" topLeftY="378" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="192" height="74" topLeftX="313" topLeftY="391" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="305" topLeftY="408" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="240" height="41" topLeftX="542" topLeftY="277" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="192" height="56" topLeftX="561" topLeftY="314" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文此处添加正文</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="2" topLeftX="553" topLeftY="332" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <line startX="907" startY="119" endX="907" endY="515">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="908" startY="0" endX="908" endY="142">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="904" topLeftY="144" rotation="0" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">8</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="785" topLeftY="367" rotation="270" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12"> European Market Q1 Planning</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="W2oebPLuVoS3XzxoJc7cz2xtnxf" width="243" height="466" topLeftX="35" topLeftY="37" exposure="16" contrast="-46" saturation="-93" temperature="-14">
+        <crop type="rect" leftOffset="8" rightOffset="8" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="60" height="64" topLeftX="341" topLeftY="163" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="177" height="59" topLeftX="361" topLeftY="179" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" bold="true" textAlign="left">
+          <p>
+            <span fontSize="26">活动执行方案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="38" topLeftX="363" topLeftY="221" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 219, 29, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="12">Program of Activities</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="188" height="254" topLeftX="363" topLeftY="252" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文，此处添加正文。</span>
+          </p>
+          <p/>
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文，此处添加正文。此处添加正文此处添加正文，此处添加正文。此处添加正文此处添加正文，此处添加正文。</span>
+          </p>
+          <p/>
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="41" topLeftX="616" topLeftY="163" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题或更多内容</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="77" topLeftX="616" topLeftY="183" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 219, 29, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="38">1,891+</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="817" startY="252" endX="624" endY="252" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="240" height="41" topLeftX="616" topLeftY="286" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题或更多内容</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="77" topLeftX="616" topLeftY="307" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 219, 29, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="38">60+</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="817" startY="375" endX="624" endY="375" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="240" height="41" topLeftX="616" topLeftY="411" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题或更多内容</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="77" topLeftX="616" topLeftY="432" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 219, 29, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 219, 29, 1)" fontSize="38">13,762+</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="816" startY="500" endX="624" endY="500" alpha="0.7">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 219, 29, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KSLDbAtVTowNhQxnPfUcK4s2nzc" width="480" height="540" topLeftX="0" topLeftY="0" exposure="14" contrast="-55" saturation="-92" temperature="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="261" height="74" topLeftX="672" topLeftY="434" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(24, 24, 26, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(24, 24, 26, 1)" fontSize="36">活动经费预算</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="47" topLeftX="699" topLeftY="407" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">Budget</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="142" startY="47" endX="676" endY="47">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">9</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="481" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="49" height="56" topLeftX="58" topLeftY="84" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <line startX="142" startY="47" endX="910" endY="47">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">10</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+      <shape width="407" height="56" topLeftX="67" topLeftY="92" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true" textAlign="left">
+          <p>
+            <span fontSize="24">活动经费预算</span>
+          </p>
+        </content>
+      </shape>
+      <img src="IrLPbZFuSok7kHxnOvFciHi9nPA" width="145" height="145" topLeftX="58" topLeftY="198" exposure="12" saturation="-91" temperature="23">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="GO5pblEDSo03uExEIlEc9xXdnyd" width="145" height="145" topLeftX="267" topLeftY="198" exposure="12" saturation="-91" temperature="23">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="EzCabT0y8o65r8xgM2Jcf25zncb" width="145" height="145" topLeftX="476" topLeftY="198" exposure="12" saturation="-91" temperature="23">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="CULmb2XWmouit4xzxbKc3U7ynxg" width="145" height="145" topLeftX="685" topLeftY="198" exposure="12" saturation="-91" temperature="23">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="24" height="2" topLeftX="66" topLeftY="360" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="2" topLeftX="275" topLeftY="360" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="2" topLeftX="484" topLeftY="360" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="24" height="2" topLeftX="693" topLeftY="360" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="144" height="41" topLeftX="58" topLeftY="357" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="41" topLeftX="267" topLeftY="357" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="41" topLeftX="476" topLeftY="357" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="41" topLeftX="685" topLeftY="357" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(66, 66, 66, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(66, 66, 66, 1)" fontSize="14">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="145" height="74" topLeftX="58" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="145" height="74" topLeftX="266" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="145" height="74" topLeftX="476" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="145" height="74" topLeftX="685" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="W9OibVJ7cooFpyxooUpcU5Jfnfd" width="527" height="361" topLeftX="433" topLeftY="96" exposure="62" contrast="12" saturation="-92" temperature="1">
+        <crop type="rect" leftOffset="59" rightOffset="59" topOffset="0" bottomOffset="0" presetHandlers="4"/>
+      </img>
+      <line startX="142" startY="47" endX="910" endY="47">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">11</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+      <img src="IcRMb9tt6ony53x6QO6cUxAknne" width="587" height="407" topLeftX="373" topLeftY="91" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="88" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="63" height="64" topLeftX="32" topLeftY="91" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="177" height="59" topLeftX="52" topLeftY="107" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="26" bold="true" textAlign="left">
+          <p>
+            <span fontSize="26">活动经费预算</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="34" height="34" topLeftX="63" topLeftY="201" alpha="0.6" type="ellipse">
+        <fill>
+          <fillColor color="rgba(66, 66, 66, 1)"/>
+        </fill>
+        <border color="rgba(147, 150, 156, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="20" height="20" topLeftX="70" topLeftY="208" alpha="0.6" iconType="iconpark/Money/paper-money-two.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="34" height="34" topLeftX="63" topLeftY="302" alpha="0.6" type="ellipse">
+        <fill>
+          <fillColor color="rgba(66, 66, 66, 1)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="70" topLeftY="309" alpha="0.6" iconType="iconpark/Money/financing-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="144" height="44" topLeftX="101" topLeftY="195" alpha="0.7" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="44" topLeftX="101" topLeftY="297" alpha="0.7" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">此处添加小标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="232" height="56" topLeftX="101" topLeftY="228" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文，此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="232" height="56" topLeftX="101" topLeftY="329" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">此处添加正文此处添加正文，此处添加正文此处添加正文，此处添加正文。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 219, 29, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="UnojbYZiZoljtNxOh8AcvjpGnck" width="480" height="540" topLeftX="0" topLeftY="0" exposure="14" contrast="-55" saturation="-92" temperature="31">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="261" height="74" topLeftX="672" topLeftY="434" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" color="rgba(24, 24, 26, 1)" bold="true" textAlign="right">
+          <p>
+            <span color="rgba(24, 24, 26, 1)" fontSize="36">活动预期效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="47" topLeftX="699" topLeftY="407" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">Expected Results</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="142" startY="47" endX="676" endY="47">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">12</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="481" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="FtzebenNwoDtQoxtmggceadnn1d" width="961" height="539" topLeftX="0" topLeftY="0" exposure="16" saturation="-91" temperature="12">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="674" height="476" topLeftX="217" topLeftY="22" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="300" fontFamily="Trebuchet MS" color="rgba(255, 219, 29, 1)" bold="true" textAlign="center">
+          <p>
+            <span color="rgba(255, 219, 29, 1)" fontSize="300" fontFamily="Trebuchet MS">40%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="165" height="122" topLeftX="100" topLeftY="97" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="35" height="157" topLeftX="165" topLeftY="213" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <img src="HJQ4bD96zoxB41xEmHncaqUVnrc" width="771" height="202" topLeftX="73" topLeftY="318" exposure="16" saturation="-91" temperature="12">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="20" presetHandlers="0"/>
+      </img>
+      <line startX="142" startY="47" endX="910" endY="47" alpha="0.29">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">13</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="49" height="56" topLeftX="58" topLeftY="84" presetHandlers="8" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 219, 29, 1)"/>
+        </fill>
+      </shape>
+      <line startX="142" startY="47" endX="910" endY="47">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 219, 29, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(147, 150, 156, 1)" fontSize="12">14</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="640" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)" bold="true" textAlign="right">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+      <shape width="407" height="56" topLeftX="67" topLeftY="92" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true" textAlign="left">
+          <p>
+            <span fontSize="24">活动预期效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="213" height="74" topLeftX="707" topLeftY="382" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="707" topLeftY="338" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #6</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="656" topLeftY="338" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="26" height="26" topLeftX="666" topLeftY="348" iconType="iconpark/Base/tag-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="213" height="74" topLeftX="707" topLeftY="244" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="707" topLeftY="200" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="656" topLeftY="199" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="30" height="30" topLeftX="664" topLeftY="206" iconType="iconpark/Base/hourglass-null.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="213" height="74" topLeftX="408" topLeftY="382" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="408" topLeftY="338" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #5</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="357" topLeftY="338" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="26" height="26" topLeftX="367" topLeftY="348" iconType="iconpark/Base/lightning.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="213" height="74" topLeftX="408" topLeftY="244" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="408" topLeftY="200" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="357" topLeftY="199" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="30" height="30" topLeftX="365" topLeftY="206" iconType="iconpark/Base/aiming.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="213" height="74" topLeftX="108" topLeftY="382" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="108" topLeftY="338" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="58" topLeftY="338" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="26" height="26" topLeftX="68" topLeftY="348" iconType="iconpark/Abstract/game-emoji.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="213" height="74" topLeftX="108" topLeftY="244" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(147, 150, 156, 1)">
+          <p>
+            <span color="rgba(147, 150, 156, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="41" topLeftX="108" topLeftY="200" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+          <p>
+            <span fontSize="14">预期效果 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="58" topLeftY="199" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+      </shape>
+      <icon width="30" height="30" topLeftX="66" topLeftY="206" iconType="iconpark/Travel/mountain.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 219, 29, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="337" height="78" topLeftX="600" topLeftY="417" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" bold="true" lineSpacing="multiple:1.2" textAlign="right">
+          <p lineSpacing="multiple:1.2">
+            <span fontSize="48">谢谢观看</span>
+          </p>
+        </content>
+      </shape>
+      <img src="C7EfbhI7PoHav4xydHsc789rnsf" width="534" height="540" topLeftX="0" topLeftY="0" exposure="14" contrast="-55" saturation="-92" temperature="31">
+        <crop type="rect" leftOffset="0" rightOffset="6" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <line startX="142" startY="47" endX="726" endY="47">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="0" startY="46" endX="142" endY="46">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="49" height="38" topLeftX="158" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">15</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="276" height="38" topLeftX="534" topLeftY="16" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p> European Market Q1 Planning</p>
+        </content>
+      </shape>
+      <shape width="231" height="50" topLeftX="699" topLeftY="385" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">Thank you</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/operations--product_promotion.xml
+++ b/skills/lark-slides/references/templates/operations--product_promotion.xml
@@ -1,0 +1,687 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>产品推广方案-裂图重新上传</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="64"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF" fontSize="14"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style/>
+    <data>
+      <img src="KQ11bto5XoGHbCxBHmMchsYOn9e" width="251" height="425" topLeftX="578" topLeftY="65">
+        <crop type="rect" leftOffset="6" rightOffset="169" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="39" height="425" topLeftX="578" topLeftY="65" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="536" height="180" topLeftX="84" topLeftY="85" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">DIGITAL</span>
+          </p>
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">MARKETING</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="325" height="68" topLeftX="84" topLeftY="257" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>产品推广计划</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="250" height="77" topLeftX="56" topLeftY="85" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true">
+          <p>CONTENTS</p>
+        </content>
+      </shape>
+      <shape width="250" height="68" topLeftX="56" topLeftY="142" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="false" textAlign="left">
+          <p>
+            <span bold="false">目录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="102" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="113" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18">关于我们</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="114" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="189" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="200" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18">愿景&amp;目标</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="201" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="275" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="287" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18">品牌策略</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="288" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="372" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="384" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">核心产品</p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="385" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="24">关于我们</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="450" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KFOtbv5TUoKxm8x9dDfcfb6snEd" width="202" height="128" topLeftX="257" topLeftY="75" exposure="5" contrast="-12" saturation="-24" temperature="-65">
+        <crop type="rect" leftOffset="126" rightOffset="29" topOffset="212" bottomOffset="18" presetHandlers="0"/>
+      </img>
+      <img src="KFOtbv5TUoKxm8x9dDfcfb6snEd" width="202" height="128" topLeftX="38" topLeftY="75" flipY="true" exposure="5" contrast="-12" saturation="-24" temperature="-73">
+        <crop type="rect" leftOffset="0" rightOffset="202" topOffset="101" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="250" height="140" topLeftX="28" topLeftY="323" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" bold="true">
+          <p>
+            <span fontSize="80">Hello</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="68" topLeftX="32" topLeftY="293" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="false" textAlign="left">
+          <p>
+            <span bold="false">你好</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="56" topLeftX="34" topLeftY="215" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="74" topLeftX="507" topLeftY="99" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="230" topLeftX="507" topLeftY="229" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <img src="TE9RblFGdowyVexgIYIc2GEonJd" width="395" height="230" topLeftX="507" topLeftY="229" saturation="-43" temperature="-100">
+        <crop type="rect" leftOffset="20" rightOffset="17" topOffset="88" bottomOffset="113" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="372" height="116" topLeftX="28" topLeftY="130" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true">
+          <p>About us</p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="32" topLeftY="103" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">关于我们</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="74" topLeftX="32" topLeftY="235" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="TDYmbbCrPoAAz0xgXVwcbblrn4f" width="395" height="415" topLeftX="507" topLeftY="44" saturation="-100" temperature="-100">
+        <crop type="rect" leftOffset="26" rightOffset="68" topOffset="30" bottomOffset="45" presetHandlers="0"/>
+      </img>
+      <shape width="39" height="415" topLeftX="863" topLeftY="44" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <span color="rgba(255, 255, 255, 1)">愿景&amp;目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="460" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="250" height="92" topLeftX="65" topLeftY="100" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" bold="true">
+          <p>
+            <span fontSize="48">Vision</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="56" topLeftX="65" topLeftY="168" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="92" topLeftX="482" topLeftY="100" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" bold="true">
+          <p>
+            <span fontSize="48">Mission</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="65" topLeftY="72" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">愿景</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="482" topLeftY="72" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="56" topLeftX="482" topLeftY="168" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="189" topLeftX="74" topLeftY="240" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <img src="EnkQbyTJKouv4bx15ezccGjinXc" width="395" height="189" topLeftX="74" topLeftY="240">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="206" presetHandlers="0"/>
+      </img>
+      <img src="ProZbJDy5omwBlxreCgcPqA9nOc" width="395" height="189" topLeftX="491" topLeftY="240" exposure="5" contrast="-23" saturation="-30" temperature="-42">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="118" bottomOffset="88" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <span color="rgba(255, 255, 255, 1)">品牌策略</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="450" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="372" height="116" topLeftX="28" topLeftY="130" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true">
+          <p>Strategy</p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="32" topLeftY="103" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">推广策略</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="74" topLeftX="32" topLeftY="245" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <span color="rgba(255, 255, 255, 1)" bold="false">核心项目</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="450" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18" bold="false">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="196" height="50" topLeftX="95" topLeftY="77" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">Project 01 - XXX</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="49" topLeftX="81" topLeftY="393" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 0.502)" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">描述相关的信息以解释你的标题。现在就开始打字吧。</p>
+        </content>
+      </shape>
+      <shape width="231" height="42" topLeftX="81" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="18">关键点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="164" topLeftX="98" topLeftY="172" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="231" height="49" topLeftX="365" topLeftY="393" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 0.502)" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">描述相关的信息以解释你的标题。现在就开始打字吧。</p>
+        </content>
+      </shape>
+      <shape width="231" height="42" topLeftX="365" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="18">关键点 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="164" topLeftX="382" topLeftY="172" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="231" height="49" topLeftX="648" topLeftY="393" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 0.502)" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">描述相关的信息以解释你的标题。现在就开始打字吧。</p>
+        </content>
+      </shape>
+      <shape width="231" height="42" topLeftX="648" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="18">关键点 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="164" topLeftX="666" topLeftY="172" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="66" height="66" topLeftX="163" topLeftY="221" iconType="iconpark/Base/bookmark.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="66" height="66" topLeftX="447" topLeftY="221" iconType="iconpark/Base/camera.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="66" height="66" topLeftX="731" topLeftY="221" iconType="iconpark/Office/list-view.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="554" height="56" topLeftX="291" topLeftY="77" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="318" height="74" topLeftX="32" topLeftY="271" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="465" topLeftX="379" topLeftY="37" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="196" height="50" topLeftX="32" topLeftY="221" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">Project 02 - XXX</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="74" topLeftX="610" topLeftY="93" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="226" topLeftX="610" topLeftY="276" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <img src="GGuFbd8azoDXASxtmdRcCjG0nrf" width="202" height="465" topLeftX="379" topLeftY="37" saturation="-73" temperature="-57">
+        <crop type="rect" leftOffset="132" rightOffset="132" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="LYMEbK4ZroZq9pxhlNfcdHignHe" width="201" height="226" topLeftX="610" topLeftY="276" exposure="-4" contrast="-19" saturation="-23" temperature="-32">
+        <crop type="rect" leftOffset="200" rightOffset="0" topOffset="64" bottomOffset="111" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="KQ11bto5XoGHbCxBHmMchsYOn9e" width="251" height="425" topLeftX="578" topLeftY="65">
+        <crop type="rect" leftOffset="6" rightOffset="169" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="39" height="425" topLeftX="578" topLeftY="65" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="536" height="180" topLeftX="84" topLeftY="85" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">THANK</span>
+          </p>
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">YOU</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="325" height="68" topLeftX="84" topLeftY="257" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>感谢观看</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/personal--experience_sharing.xml
+++ b/skills/lark-slides/references/templates/personal--experience_sharing.xml
@@ -1,0 +1,2242 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>经验分享</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Y9h2btHFWojmQvx3CGTcAn4Lnvf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Agrob4Jlbo7prnxeL9vcb2xmnoe" width="548" height="262" topLeftX="-14" topLeftY="263" rotation="9" alpha="0.4">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="400" height="63" topLeftX="50" topLeftY="293" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="400" height="81" topLeftX="50" topLeftY="189" type="text">
+        <content textType="title" fontSize="54" fontFamily="思源黑体" bold="true">
+          <p>工作经验分享</p>
+        </content>
+      </shape>
+      <shape width="120" height="25" topLeftX="50" topLeftY="375" presetHandlers="4" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(113, 170, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)"/>
+        </fill>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>
+            <span color="rgba(222, 224, 227, 1)" fontSize="12">分享者：某某某</span>
+          </p>
+        </content>
+      </shape>
+      <img src="RXoWbeLjlo2n38xxqDtcLxF8nZb" width="439" height="434" topLeftX="521" topLeftY="58">
+        <crop type="rect" leftOffset="0" rightOffset="279" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="CDVMbQVUgoLxd2x40YzcXXfDnBg" width="376" height="388" topLeftX="585" topLeftY="68">
+        <crop type="rect" leftOffset="0" rightOffset="289" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="Pjoyb78Rdof062xhu6dcnwoenTh" width="141" height="306" topLeftX="474" topLeftY="199">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="VmOyb6JmSog3xsxyArpce0npnVd" width="156" height="316" topLeftX="467" topLeftY="194" rotation="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="72" height="18" topLeftX="78" topLeftY="40" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="50" topLeftY="38" iconType="iconpark/Abstract/api-app.svg">
+        <border width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NpNDb60f2onXI3xw9oVcH2sdnCb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="AMdDb4GlsomFakxifhVcH6TenNh" width="612" height="361" topLeftX="245" topLeftY="179" alpha="0.4">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="46" presetHandlers="0"/>
+      </img>
+      <shape width="192" height="274" topLeftX="50" topLeftY="153" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="192" height="274" topLeftX="274" topLeftY="153" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="192" height="274" topLeftX="498" topLeftY="153" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="192" height="274" topLeftX="721" topLeftY="153" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="170" height="42" topLeftX="61" topLeftY="358" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="170" height="30" topLeftX="61" topLeftY="318" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>自我介绍</p>
+        </content>
+      </shape>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>目录</p>
+        </content>
+      </shape>
+      <shape width="170" height="42" topLeftX="285" topLeftY="358" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="170" height="30" topLeftX="285" topLeftY="318" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>项目流程</p>
+        </content>
+      </shape>
+      <shape width="170" height="42" topLeftX="509" topLeftY="358" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="170" height="30" topLeftX="509" topLeftY="318" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>经验教训</p>
+        </content>
+      </shape>
+      <img src="WWlWbVpJ0oqnyKx9C6ucI0T8nEh" width="170" height="130" topLeftX="733" topLeftY="164">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="UN4bbySoHoksyNxiUWdcKLNtnjf" width="170" height="130" topLeftX="509" topLeftY="164">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="WWlWbVpJ0oqnyKx9C6ucI0T8nEh" width="170" height="130" topLeftX="285" topLeftY="164">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="M08cbzJIPo8nOHxVSQ8ce5BqnFb" width="170" height="130" topLeftX="61" topLeftY="164">
+        <crop type="rect" leftOffset="3" rightOffset="3" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="170" height="42" topLeftX="733" topLeftY="358" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="170" height="30" topLeftX="733" topLeftY="318" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>工作技巧</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(92, 127, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="I097brAnnoQ7MPxog13cyvYrnLd" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.4">
+        <crop type="rect" leftOffset="658" rightOffset="572" topOffset="828" bottomOffset="180" presetHandlers="0"/>
+      </img>
+      <img src="SBTYbKGAHomWYcxxZwjcFtM9npA" width="507" height="414" topLeftX="-5" topLeftY="63" rotation="62" alpha="0.06">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="370" height="84" topLeftX="416" topLeftY="270" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="370" height="81" topLeftX="419" topLeftY="178" type="text">
+        <content textType="title" fontSize="54" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">自我介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="300" topLeftX="174" topLeftY="120" type="text">
+        <content textType="title" fontSize="200" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>01</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="G8hUbZ1OjosIxixVk2ocRARRnWh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="HGkubS7Quo0oEZxJ0VZcAX2JnVg" width="376" height="540" topLeftX="584" topLeftY="0">
+        <crop type="rect" leftOffset="300" rightOffset="135" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="378" height="120" topLeftX="50" topLeftY="69" type="text">
+        <content textType="title" fontSize="40" fontFamily="思源黑体" color="rgba(53, 49, 58, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" fontSize="40">Hi</span>
+            </strong>
+            <strong>
+              <span color="rgba(73, 125, 245, 1)" fontSize="40"> </span>
+            </strong>
+          </p>
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="40">I'M 某某某</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="125" startY="203" endX="125" endY="223">
+        <border color="rgba(221, 222, 223, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="63" height="30" topLeftX="50" topLeftY="198" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20">某公司</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="50" topLeftY="329" iconType="iconpark/Base/config.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="108" height="30" topLeftX="137" topLeftY="198" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)">产品总监</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="491" height="42" topLeftX="50" topLeftY="256" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(0, 0, 0, 1)">输入相关的描述信息描述主讲人背景，输入相关的描述信息描述主讲人背景，输入相关的描述信息描述主讲人背景</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="452" height="21" topLeftX="89" topLeftY="330" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述主讲人信息</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="50" topLeftY="365" iconType="iconpark/Charts/data-screen.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="452" height="21" topLeftX="89" topLeftY="366" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述主讲人信息</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="50" topLeftY="399" iconType="iconpark/Game/trophy.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="452" height="21" topLeftX="89" topLeftY="400" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述主讲人奖项</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="50" topLeftY="435" iconType="iconpark/Game/trophy.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="452" height="21" topLeftX="89" topLeftY="436" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述主讲人奖项</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="182" height="21" topLeftX="50" topLeftY="293" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="left" autoFit="shape-auto-fit"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="960" height="224" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(92, 127, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="I097brAnnoQ7MPxog13cyvYrnLd" width="960" height="224" topLeftX="0" topLeftY="0" alpha="0.4">
+        <crop type="rect" leftOffset="658" rightOffset="572" topOffset="1144" bottomOffset="180" presetHandlers="0"/>
+      </img>
+      <shape width="960" height="351" topLeftX="0" topLeftY="189" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow offset="0" angle="270" blur="16" color="rgba(0, 0, 0, 0.13)"/>
+      </shape>
+      <img src="Z2w3bF8aBov0F6xKMVPc1nqUnId" width="960" height="351" topLeftX="0" topLeftY="189" alpha="0.3">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="16"/>
+      </img>
+      <img src="AMdDb4GlsomFakxifhVcH6TenNh" width="480" height="319" topLeftX="456" topLeftY="-17" rotation="313" alpha="0.1">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="42" startY="325" endX="919" endY="325">
+        <border color="rgba(222, 224, 227, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="16" height="16" topLeftX="42" topLeftY="318" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(248, 248, 248, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" blur="36"/>
+      </shape>
+      <shape width="8" height="8" topLeftX="46" topLeftY="322" type="ellipse">
+        <fill>
+          <fillColor color="rgba(52, 113, 252, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="16" topLeftX="268" topLeftY="318" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(248, 248, 248, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" blur="36"/>
+      </shape>
+      <shape width="8" height="8" topLeftX="272" topLeftY="322" type="ellipse">
+        <fill>
+          <fillColor color="rgba(52, 113, 252, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="16" topLeftX="493" topLeftY="318" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(248, 248, 248, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" blur="36"/>
+      </shape>
+      <shape width="8" height="8" topLeftX="497" topLeftY="322" type="ellipse">
+        <fill>
+          <fillColor color="rgba(52, 113, 252, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="16" topLeftX="719" topLeftY="318" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(248, 248, 248, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="0" blur="36"/>
+      </shape>
+      <shape width="8" height="8" topLeftX="723" topLeftY="322" type="ellipse">
+        <fill>
+          <fillColor color="rgba(52, 113, 252, 1)"/>
+        </fill>
+      </shape>
+      <shape width="490" height="42" topLeftX="42" topLeftY="106" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题</p>
+        </content>
+      </shape>
+      <shape width="490" height="48" topLeftX="42" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>个人经验和成就</p>
+        </content>
+      </shape>
+      <shape width="200" height="63" topLeftX="42" topLeftY="397" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="200" height="30" topLeftX="42" topLeftY="357" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" bold="true">
+          <p>经验和成就</p>
+        </content>
+      </shape>
+      <shape width="200" height="30" topLeftX="719" topLeftY="272" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="Arial" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true">
+          <p>2026</p>
+        </content>
+      </shape>
+      <shape width="200" height="30" topLeftX="493" topLeftY="272" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="Arial" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true">
+          <p>2025</p>
+        </content>
+      </shape>
+      <shape width="200" height="30" topLeftX="268" topLeftY="272" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="Arial" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true">
+          <p>2024</p>
+        </content>
+      </shape>
+      <shape width="200" height="30" topLeftX="42" topLeftY="272" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="Arial" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true">
+          <p>2023</p>
+        </content>
+      </shape>
+      <shape width="200" height="63" topLeftX="268" topLeftY="397" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="200" height="30" topLeftX="268" topLeftY="357" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" bold="true">
+          <p>经验和成就</p>
+        </content>
+      </shape>
+      <shape width="200" height="63" topLeftX="493" topLeftY="397" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="200" height="30" topLeftX="493" topLeftY="357" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" bold="true">
+          <p>经验和成就</p>
+        </content>
+      </shape>
+      <shape width="200" height="63" topLeftX="719" topLeftY="397" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="200" height="30" topLeftX="719" topLeftY="357" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" bold="true">
+          <p>经验和成就</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(92, 127, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="I097brAnnoQ7MPxog13cyvYrnLd" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.4">
+        <crop type="rect" leftOffset="658" rightOffset="572" topOffset="828" bottomOffset="180" presetHandlers="0"/>
+      </img>
+      <img src="SBTYbKGAHomWYcxxZwjcFtM9npA" width="507" height="414" topLeftX="-5" topLeftY="63" rotation="62" alpha="0.06">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="370" height="84" topLeftX="416" topLeftY="270" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="370" height="81" topLeftX="416" topLeftY="178" type="text">
+        <content textType="title" fontSize="54" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">项目流程</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="300" topLeftX="174" topLeftY="120" type="text">
+        <content textType="title" fontSize="200" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>02</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Ip4ubagmtoY28TxMEObc9qiBnyf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" bold="true">
+          <p>项目背景</p>
+        </content>
+      </shape>
+      <shape width="214" height="30" topLeftX="439" topLeftY="77" type="text">
+        <content fontSize="20" fontFamily="Arial" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="20" fontFamily="Arial">Before</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="214" height="30" topLeftX="692" topLeftY="77" type="text">
+        <content fontSize="20" fontFamily="Arial" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="20" fontFamily="Arial">After</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="HrMwbLZVlohWW4xBV59cqGcUnTc" width="167" height="361" topLeftX="462" topLeftY="126">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="TDlsbLTkTo1k4exdmbYcQx5Bnac" width="185" height="374" topLeftX="454" topLeftY="120">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="GwVhbztihoqbHrxfDdVcYHNCnYb" width="167" height="361" topLeftX="715" topLeftY="126">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="NfYLbrlfjo8tVUxH38hc28jInGf" width="185" height="374" topLeftX="707" topLeftY="120">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="314" height="30" topLeftX="87" topLeftY="147" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>项目背景</p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="50" topLeftY="151" iconType="iconpark/Office/newspaper-folding.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="314" height="30" topLeftX="87" topLeftY="258" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>难点</p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="50" topLeftY="262" iconType="iconpark/Office/book-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="314" height="30" topLeftX="87" topLeftY="365" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>策略</p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="50" topLeftY="369" iconType="iconpark/Base/save.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="314" height="42" topLeftX="87" topLeftY="186" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="314" height="42" topLeftX="87" topLeftY="294" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="314" height="42" topLeftX="87" topLeftY="403" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Ip4ubagmtoY28TxMEObc9qiBnyf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" bold="true">
+          <p>项目流程</p>
+        </content>
+      </shape>
+      <shape width="269" height="32" topLeftX="198" topLeftY="50" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true">
+          <p>
+            <span color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" fontSize="20" fontFamily="Arial">STEP 1 </span>
+            <span color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" fontSize="20">标题</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="295" startY="174" endX="358" endY="174">
+        <border color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <endArrow type="arrow"/>
+      </line>
+      <line startX="602" startY="174" endX="668" endY="174">
+        <border color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <endArrow type="arrow"/>
+      </line>
+      <shape width="244" height="216" topLeftX="50" topLeftY="215" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="244" height="99" topLeftX="358" topLeftY="215" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="244" height="99" topLeftX="358" topLeftY="332" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="244" height="216" topLeftX="670" topLeftY="215" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="209" height="24" topLeftX="70" topLeftY="225" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="16">标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="48" topLeftX="66" topLeftY="260" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20"> </span>
+            <span color="rgba(0, 0, 0, 1)" fontSize="32" fontFamily="Arial">75</span>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20" fontFamily="Arial">w</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="21" topLeftX="66" topLeftY="304" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" list="none" textAlign="left">
+          <p list="none" textAlign="left">
+            <span color="rgba(85, 85, 85, 1)">活跃</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="48" topLeftX="185" topLeftY="261" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20"> </span>
+            <span color="rgba(0, 0, 0, 1)" fontSize="32" fontFamily="Arial">90</span>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20" fontFamily="Arial">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="21" topLeftX="185" topLeftY="305" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" list="none" textAlign="left">
+          <p list="none" textAlign="left">
+            <span color="rgba(85, 85, 85, 1)">分发</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="48" topLeftX="66" topLeftY="340" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20"> </span>
+            <span color="rgba(0, 0, 0, 1)" fontSize="32" fontFamily="Arial">18</span>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20" fontFamily="Arial">平方</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="21" topLeftX="66" topLeftY="384" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" list="none" textAlign="left">
+          <p list="none" textAlign="left">
+            <span color="rgba(85, 85, 85, 1)">数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="48" topLeftX="185" topLeftY="342" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20"> </span>
+            <span color="rgba(0, 0, 0, 1)" fontSize="32" fontFamily="Arial">912</span>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20" fontFamily="Arial">w</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="21" topLeftX="185" topLeftY="385" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" list="none" textAlign="left">
+          <p list="none" textAlign="left">
+            <span color="rgba(85, 85, 85, 1)">数据</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="214" height="24" topLeftX="374" topLeftY="225" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)">用户诉求</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="214" height="24" topLeftX="374" topLeftY="346" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="16">用户诉求</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="214" height="24" topLeftX="686" topLeftY="225" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)">产品策略</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="214" height="42" topLeftX="374" topLeftY="258" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="214" height="42" topLeftX="374" topLeftY="375" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="214" height="42" topLeftX="686" topLeftY="258" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" list="bullet" listStyle="circle-hollow-square">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>
+                <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="214" height="42" topLeftX="686" topLeftY="316" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" list="bullet" listStyle="circle-hollow-square">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>
+                <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="214" height="42" topLeftX="686" topLeftY="375" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" list="bullet" listStyle="circle-hollow-square">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>
+                <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="244" height="48" topLeftX="358" topLeftY="149" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20" fontFamily="思源黑体">用户诉求</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" blur="34" color="rgba(0, 0, 0, 0.06)"/>
+      </shape>
+      <shape width="244" height="48" topLeftX="50" topLeftY="149" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">数据情况</span>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" blur="34" color="rgba(0, 0, 0, 0.06)"/>
+      </shape>
+      <shape width="244" height="48" topLeftX="670" topLeftY="149" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20" fontFamily="思源黑体">产品策略</span>
+            </strong>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" blur="34" color="rgba(0, 0, 0, 0.06)"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HoQvb28y6ojQXxx1LRbcr79Rnmg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="268" height="352" topLeftX="50" topLeftY="127" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="268" height="352" topLeftX="350" topLeftY="127" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="268" height="352" topLeftX="645" topLeftY="127" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="244" height="84" topLeftX="62" topLeftY="358" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="244" height="30" topLeftX="62" topLeftY="318" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>优化方案</p>
+        </content>
+      </shape>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>项目流程</p>
+        </content>
+      </shape>
+      <shape width="244" height="84" topLeftX="362" topLeftY="358" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="244" height="30" topLeftX="362" topLeftY="318" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>优化方案</p>
+        </content>
+      </shape>
+      <img src="XaZdbFuAcoHxhoxe8mectkBfnmg" width="244" height="156" topLeftX="657" topLeftY="141">
+        <crop type="rect" leftOffset="0.31" rightOffset="0.31" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="MhrybIwZZoz2Gbx4Jf0ceiC1nwe" width="244" height="156" topLeftX="362" topLeftY="141">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="70" bottomOffset="70" presetHandlers="8"/>
+      </img>
+      <img src="HgrsbPrsLoDwS0xsybucFUy8nZg" width="244" height="156" topLeftX="62" topLeftY="141">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.51" bottomOffset="0.51" presetHandlers="8"/>
+      </img>
+      <shape width="244" height="84" topLeftX="657" topLeftY="358" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="244" height="30" topLeftX="657" topLeftY="318" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>优化方案</p>
+        </content>
+      </shape>
+      <shape width="269" height="32" topLeftX="198" topLeftY="50" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true">
+          <p>
+            <span color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" fontSize="20" fontFamily="Arial">STEP 2 </span>
+            <span color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" fontSize="20">标题</span>
+          </p>
+        </content>
+      </shape>
+      <img src="MhrybIwZZoz2Gbx4Jf0ceiC1nwe" width="244" height="156" topLeftX="362" topLeftY="141">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="137" bottomOffset="2" presetHandlers="8"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Ip4ubagmtoY28TxMEObc9qiBnyf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" bold="true">
+          <p>项目流程</p>
+        </content>
+      </shape>
+      <shape width="269" height="32" topLeftX="198" topLeftY="50" type="text">
+        <content textType="headline" fontSize="20" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true">
+          <p>
+            <span color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" fontSize="20" fontFamily="Arial">STEP 3 </span>
+            <span color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" fontSize="20">标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="294" height="367" topLeftX="608" topLeftY="125" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(92, 127, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="Mcv6bIdsOolSpmxS3Vsct7mcnwc" width="295" height="367" topLeftX="607" topLeftY="125" alpha="0.4">
+        <shadow offset="13" blur="45" color="rgba(30, 47, 88, 0.35)"/>
+        <crop type="rect" leftOffset="202" rightOffset="176" topOffset="563" bottomOffset="123" presetHandlers="12"/>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="VNIGbqkVgoLiefx8Cmocw8vKnrc" width="278" height="155" topLeftX="616" topLeftY="337" rotation="360" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="72" presetHandlers="0"/>
+      </img>
+      <shape width="254" height="30" topLeftX="625" topLeftY="143" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>标题</p>
+        </content>
+      </shape>
+      <shape width="254" height="147" topLeftX="627" topLeftY="186" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" list="bullet" listStyle="circle-hollow-square" textAlign="left">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p textAlign="left">输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p textAlign="left">输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <line startX="882" startY="365" endX="627" endY="365">
+        <border color="rgba(221, 222, 223, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="252" height="60" topLeftX="627" topLeftY="380" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="20">提效 </span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="40" fontFamily="Arial">75 </span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="20">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="252" height="21" topLeftX="627" topLeftY="440" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" list="none" textAlign="left">
+          <p list="none" textAlign="left">平均流转耗时缩减为 1/4</p>
+        </content>
+      </shape>
+      <img src="QqDWb0utco37ztxvUZscG0Btnqh" width="167" height="361" topLeftX="397" topLeftY="126">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="NfYLbrlfjo8tVUxH38hc28jInGf" width="185" height="374" topLeftX="389" topLeftY="120">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="269" height="30" topLeftX="87" topLeftY="147" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20">标题</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="50" topLeftY="151" iconType="iconpark/Office/newspaper-folding.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="269" height="30" topLeftX="87" topLeftY="258" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)">标题</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="50" topLeftY="262" iconType="iconpark/Office/book-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="269" height="30" topLeftX="87" topLeftY="365" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)">标题</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="50" topLeftY="369" iconType="iconpark/Base/save.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="269" height="42" topLeftX="87" topLeftY="186" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="269" height="42" topLeftX="87" topLeftY="294" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="269" height="42" topLeftX="87" topLeftY="403" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Ip4ubagmtoY28TxMEObc9qiBnyf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" bold="true">
+          <p>项目结果</p>
+        </content>
+      </shape>
+      <shape width="423" height="385" topLeftX="499" topLeftY="107" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <undefined type="chart_refer_host_perm"/>
+      <shape width="400" height="60" topLeftX="50" topLeftY="250" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(52, 113, 252, 1)" bold="true" list="none">
+          <p list="none">
+            <strong>
+              <span color="rgba(52, 113, 252, 1)" fontSize="20">输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="82" height="48" topLeftX="50" topLeftY="166" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)">1290</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="21" height="21" topLeftX="132" topLeftY="178" iconType="iconpark/Charts/chart-line.svg">
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="110" height="21" topLeftX="50" topLeftY="141" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>指标 A 增长</p>
+        </content>
+      </shape>
+      <shape width="67" height="48" topLeftX="239" topLeftY="166" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)">820</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="21" height="21" topLeftX="306" topLeftY="178" iconType="iconpark/Charts/chart-line.svg">
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="110" height="21" topLeftX="239" topLeftY="141" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>指标 B 增长</p>
+        </content>
+      </shape>
+      <shape width="400" height="42" topLeftX="50" topLeftY="328" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="400" height="63" topLeftX="50" topLeftY="389" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Ip4ubagmtoY28TxMEObc9qiBnyf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" bold="true">
+          <p>项目结果</p>
+        </content>
+      </shape>
+      <shape width="870" height="308" topLeftX="47" topLeftY="146" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <table topLeftX="59" topLeftY="159">
+        <colgroup>
+          <col span="1" width="59"/>
+          <col span="1" width="252"/>
+          <col span="1" width="335"/>
+          <col span="1" width="199"/>
+        </colgroup>
+        <tr height="38">
+          <td>
+            <borderTop color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(52, 113, 252, 1)"/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+              <p textAlign="left"/>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(52, 113, 252, 1)"/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+              <p textAlign="left">
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)">名称</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(52, 113, 252, 1)"/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+              <p textAlign="left">
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)">描述</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(52, 113, 252, 1)"/>
+            </fill>
+            <content paddingRight="6" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+              <p textAlign="left">
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)">结果</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="54">
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">1</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content paddingRight="6" fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">结果</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="48">
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(248, 248, 248, 1)"/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">2</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(248, 248, 248, 1)"/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(248, 248, 248, 1)"/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(248, 248, 248, 1)"/>
+            </fill>
+            <content paddingRight="6" fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">结果</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="48">
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">3</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content paddingRight="6" fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">结果</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="48">
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(248, 248, 248, 1)"/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">4</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(248, 248, 248, 1)"/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(248, 248, 248, 1)"/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(248, 248, 248, 1)"/>
+            </fill>
+            <content paddingRight="6" fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">结果</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="48">
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">5</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">输入相关的描述信息描述上述主题</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(248, 248, 248, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content paddingRight="6" fontSize="14" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" textAlign="left">
+              <p textAlign="left">
+                <span color="rgba(0, 0, 0, 1)">结果</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+      </table>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(92, 127, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="I097brAnnoQ7MPxog13cyvYrnLd" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.4">
+        <crop type="rect" leftOffset="658" rightOffset="572" topOffset="828" bottomOffset="180" presetHandlers="0"/>
+      </img>
+      <img src="SBTYbKGAHomWYcxxZwjcFtM9npA" width="507" height="414" topLeftX="-5" topLeftY="63" rotation="62" alpha="0.06">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="370" height="84" topLeftX="416" topLeftY="270" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="370" height="81" topLeftX="416" topLeftY="178" type="text">
+        <content textType="title" fontSize="54" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">经验教训</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="300" topLeftX="174" topLeftY="120" type="text">
+        <content textType="title" fontSize="200" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>03</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Ip4ubagmtoY28TxMEObc9qiBnyf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" bold="true">
+          <p>如何应对挑战</p>
+        </content>
+      </shape>
+      <shape width="268" height="367" topLeftX="361" topLeftY="121" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="268" height="367" topLeftX="647" topLeftY="121" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="218" height="30" topLeftX="386" topLeftY="142" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">Before</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="30" topLeftX="672" topLeftY="142" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true" textAlign="left">
+          <p>
+            <span color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)">Now</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="30" topLeftX="672" topLeftY="200" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true" textAlign="left">
+          <p>
+            <span color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" fontSize="20">标题</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="20" height="20" topLeftX="672" topLeftY="326" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(52, 113, 252, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="20" height="20" topLeftX="672" topLeftY="355" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(52, 113, 252, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="20" height="20" topLeftX="672" topLeftY="387" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(52, 113, 252, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="20" height="20" topLeftX="672" topLeftY="416" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(52, 113, 252, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="194" height="21" topLeftX="702" topLeftY="325" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="194" height="21" topLeftX="702" topLeftY="355" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="194" height="21" topLeftX="702" topLeftY="386" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="194" height="21" topLeftX="702" topLeftY="416" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="30" topLeftX="386" topLeftY="336" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20">标题</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="20" height="20" topLeftX="384" topLeftY="375" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="20" height="20" topLeftX="384" topLeftY="407" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="20" height="20" topLeftX="384" topLeftY="437" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="194" height="21" topLeftX="411" topLeftY="375" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="194" height="21" topLeftX="411" topLeftY="406" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="194" height="21" topLeftX="411" topLeftY="437" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="30" topLeftX="386" topLeftY="200" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(0, 0, 0, 1)" fontSize="20">标题</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="20" height="20" topLeftX="384" topLeftY="240" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="20" height="20" topLeftX="384" topLeftY="271" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="20" height="20" topLeftX="384" topLeftY="301" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="194" height="21" topLeftX="411" topLeftY="240" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="194" height="21" topLeftX="411" topLeftY="271" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="194" height="21" topLeftX="411" topLeftY="301" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="63" topLeftX="672" topLeftY="241" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(52, 113, 252, 1)">
+          <p>
+            <span color="rgba(52, 113, 252, 1)">输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="294" height="367" topLeftX="50" topLeftY="121" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(92, 127, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="Mcv6bIdsOolSpmxS3Vsct7mcnwc" width="295" height="367" topLeftX="50" topLeftY="121" alpha="0.4">
+        <shadow offset="13" blur="45" color="rgba(30, 47, 88, 0.35)"/>
+        <crop type="rect" leftOffset="202" rightOffset="176" topOffset="563" bottomOffset="123" presetHandlers="12"/>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="VNIGbqkVgoLiefx8Cmocw8vKnrc" width="295" height="103" topLeftX="51" topLeftY="385" rotation="0" alpha="0.1">
+        <crop type="rect" leftOffset="49" rightOffset="0" topOffset="0" bottomOffset="177" presetHandlers="0"/>
+      </img>
+      <shape width="254" height="30" topLeftX="68" topLeftY="142" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>挑战</p>
+        </content>
+      </shape>
+      <shape width="254" height="147" topLeftX="68" topLeftY="291" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" list="bullet" listStyle="circle-hollow-square" textAlign="left">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p textAlign="left">输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p textAlign="left">输入相关的描述信息以解释你的标题</p>
+            </li>
+            <li>
+              <p textAlign="left">输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="88" height="21" topLeftX="101" topLeftY="196" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span fontSize="14">响应慢</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="70" topLeftY="195" iconType="iconpark/Base/save.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="88" height="21" topLeftX="234" topLeftY="196" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span fontSize="14">成本高</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="203" topLeftY="195" iconType="iconpark/Money/coupon.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="88" height="21" topLeftX="101" topLeftY="237" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span fontSize="14">运维难</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="70" topLeftY="236" iconType="iconpark/Charts/pivot-table.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="88" height="21" topLeftX="234" topLeftY="237" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span fontSize="14">收益低</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="203" topLeftY="236" iconType="iconpark/Money/consume.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Pt9Kb8mKLo519qxEArtcydiln7d" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="410" height="257" topLeftX="498" topLeftY="232" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="8" angle="90" blur="24" color="rgba(30, 47, 88, 0.07)"/>
+      </shape>
+      <shape width="410" height="257" topLeftX="51" topLeftY="233" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="8" angle="90" blur="24" color="rgba(30, 47, 88, 0.07)"/>
+      </shape>
+      <shape width="410" height="63" topLeftX="51" topLeftY="153" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="410" height="30" topLeftX="51" topLeftY="113" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true">
+          <p list="none">成功案例</p>
+        </content>
+      </shape>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>成功案例和学习方法</p>
+        </content>
+      </shape>
+      <img src="K84wbnVu3oY73bxBwt4ckMzdnmh" width="393" height="239" topLeftX="507" topLeftY="241">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="8" bottomOffset="8" presetHandlers="8"/>
+      </img>
+      <img src="Ojvpb0MTNoiGXnxlHwjc7yCXnjc" width="393" height="239" topLeftX="60" topLeftY="242">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="9" bottomOffset="9" presetHandlers="8"/>
+      </img>
+      <shape width="410" height="63" topLeftX="498" topLeftY="153" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="410" height="30" topLeftX="498" topLeftY="113" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true">
+          <p list="none">成功案例</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Ip4ubagmtoY28TxMEObc9qiBnyf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" bold="true">
+          <p>失败案例和反思</p>
+        </content>
+      </shape>
+      <img src="ENS4bZEMVooy2dxzkoLc5ymEnyh" width="320" height="352" topLeftX="45" topLeftY="116" exposure="14" contrast="-5" saturation="11" temperature="-26">
+        <crop type="rect" leftOffset="73" rightOffset="108" topOffset="0" bottomOffset="0" presetHandlers="12"/>
+      </img>
+      <shape width="320" height="140" topLeftX="252" topLeftY="305" rotation="0" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(92, 127, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="XX2LbjLyfooYrax1mGzc0Oe1nxg" width="321" height="140" topLeftX="251" topLeftY="305" rotation="0" alpha="0.4">
+        <shadow offset="13" blur="45" color="rgba(30, 47, 88, 0.35)"/>
+        <crop type="rect" leftOffset="220" rightOffset="191" topOffset="215" bottomOffset="47" presetHandlers="12"/>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="WLOIbethsoI8PPxtKLtcEppdnZQ" width="195" height="120" topLeftX="377" topLeftY="314" alpha="0.1">
+        <crop type="rect" leftOffset="0" rightOffset="37" topOffset="0" bottomOffset="69" presetHandlers="0"/>
+      </img>
+      <shape width="256" height="30" topLeftX="297" topLeftY="325" rotation="0" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>反思一</p>
+        </content>
+      </shape>
+      <shape width="256" height="63" topLeftX="297" topLeftY="362" rotation="0" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" list="none" listStyle="circle-hollow-square" textAlign="left">
+          <p list="none" textAlign="left">输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题</p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="266" topLeftY="331" rotation="0" iconType="iconpark/Office/notes.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="320" height="140" topLeftX="596" topLeftY="305" rotation="0" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(92, 127, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="XX2LbjLyfooYrax1mGzc0Oe1nxg" width="321" height="140" topLeftX="595" topLeftY="305" rotation="0" alpha="0.4">
+        <shadow offset="13" blur="45" color="rgba(30, 47, 88, 0.35)"/>
+        <crop type="rect" leftOffset="220" rightOffset="191" topOffset="215" bottomOffset="47" presetHandlers="12"/>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="664" height="134" topLeftX="252" topLeftY="147" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <icon width="24" height="24" topLeftX="609" topLeftY="342" rotation="0" iconType="iconpark/Office/doc-success.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="605" height="30" topLeftX="297" topLeftY="163" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" bold="true" textAlign="left">
+          <p>
+            <span color="linear-gradient(135deg,rgba(113, 153, 255, 1) 0%,rgba(75, 85, 255, 1) 100%)" fontSize="20">失败案例</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="605" height="63" topLeftX="297" topLeftY="199" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>
+            <span color="rgba(85, 85, 85, 1)">输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="256" height="30" topLeftX="641" topLeftY="336" rotation="0" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>反思二</p>
+        </content>
+      </shape>
+      <shape width="256" height="63" topLeftX="641" topLeftY="373" rotation="0" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" list="none" listStyle="circle-hollow-square" textAlign="left">
+          <p list="none" textAlign="left">输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题</p>
+        </content>
+      </shape>
+      <icon width="24" height="24" topLeftX="266" topLeftY="166" rotation="0" iconType="iconpark/Office/doc-fail.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="960" height="540" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(92, 127, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="I097brAnnoQ7MPxog13cyvYrnLd" width="960" height="540" topLeftX="0" topLeftY="0" alpha="0.4">
+        <crop type="rect" leftOffset="658" rightOffset="572" topOffset="828" bottomOffset="180" presetHandlers="0"/>
+      </img>
+      <img src="SBTYbKGAHomWYcxxZwjcFtM9npA" width="507" height="414" topLeftX="-5" topLeftY="63" rotation="62" alpha="0.06">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="370" height="84" topLeftX="416" topLeftY="270" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)">输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题，输入相关的描述信息以解释你的标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="370" height="81" topLeftX="416" topLeftY="178" type="text">
+        <content textType="title" fontSize="54" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">工作技巧</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="241" height="300" topLeftX="174" topLeftY="120" type="text">
+        <content textType="title" fontSize="200" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>04</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Yz7KbkMIJoEAo0xxl4ecouP2nje" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="877" height="238" topLeftX="46" topLeftY="338" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <line startX="336" startY="160" endX="336" endY="262">
+        <border color="rgba(221, 222, 223, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="635" startY="160" endX="635" endY="262">
+        <border color="rgba(221, 222, 223, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="220" height="84" topLeftX="100" topLeftY="190" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="220" height="30" topLeftX="100" topLeftY="150" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" bold="true">
+          <p>标题</p>
+        </content>
+      </shape>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>工作技巧</p>
+        </content>
+      </shape>
+      <shape width="220" height="84" topLeftX="403" topLeftY="191" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="220" height="30" topLeftX="403" topLeftY="151" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" bold="true">
+          <p>标题</p>
+        </content>
+      </shape>
+      <img src="Ml8kbWqPLoKmiIx1gXPcoPPAn4e" width="852" height="214" topLeftX="59" topLeftY="351" exposure="14" contrast="-5" saturation="11" temperature="-26">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="131" bottomOffset="131" presetHandlers="12"/>
+      </img>
+      <shape width="220" height="84" topLeftX="703" topLeftY="191" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="220" height="30" topLeftX="703" topLeftY="151" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" bold="true">
+          <p>标题</p>
+        </content>
+      </shape>
+      <icon width="34" height="34" topLeftX="58" topLeftY="154" iconType="iconpark/Base/config.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="34" height="34" topLeftX="353" topLeftY="154" iconType="iconpark/Base/camera.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="34" height="34" topLeftX="648" topLeftY="154" iconType="iconpark/Base/home.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 85, 85, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EZCTbfrC0o1LRJxbhhHc2wBvndd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="404" height="128" topLeftX="499" topLeftY="308" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="404" height="128" topLeftX="499" topLeftY="148" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="404" height="128" topLeftX="50" topLeftY="308" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="404" height="128" topLeftX="50" topLeftY="148" presetHandlers="12" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.51)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="14" angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="270" height="42" topLeftX="148" topLeftY="212" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="270" height="30" topLeftX="148" topLeftY="172" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" bold="true">
+          <p>标题</p>
+        </content>
+      </shape>
+      <shape width="418" height="48" topLeftX="50" topLeftY="40" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>对大家的建议</p>
+        </content>
+      </shape>
+      <shape width="270" height="42" topLeftX="596" topLeftY="212" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="270" height="30" topLeftX="596" topLeftY="172" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" bold="true">
+          <p>标题</p>
+        </content>
+      </shape>
+      <shape width="270" height="42" topLeftX="148" topLeftY="371" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="270" height="30" topLeftX="148" topLeftY="331" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" bold="true">
+          <p>标题</p>
+        </content>
+      </shape>
+      <img src="YZUbbdVbBoTB9Xx67IUcgTQFngb" width="58" height="58" topLeftX="523" topLeftY="175">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="KKjtb4sckoQmQixkjUHcozl1nqg" width="58" height="58" topLeftX="77" topLeftY="175">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Q8wdbuRH3oFJvOxo9YpcqqSznpd" width="58" height="58" topLeftX="523" topLeftY="334">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="WmfBbHWTWoOomyxLj9OcRPZnnIH" width="58" height="58" topLeftX="77" topLeftY="334">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="270" height="42" topLeftX="596" topLeftY="371" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(85, 85, 85, 1)">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="270" height="30" topLeftX="596" topLeftY="331" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" bold="true">
+          <p>标题</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="FZOUbnaFqojl08x6hu6cWHCbnMe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="IMzZbUGphoDASYx63swcZfHgnCc" width="421" height="262" topLeftX="0" topLeftY="285" rotation="360" alpha="0.4">
+        <crop type="rect" leftOffset="127" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="421" height="63" topLeftX="50" topLeftY="376" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体">
+          <p>输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题，输入相关的描述信息描述上述主题</p>
+        </content>
+      </shape>
+      <shape width="421" height="81" topLeftX="50" topLeftY="190" type="text">
+        <content textType="title" fontSize="54" fontFamily="思源黑体" bold="true">
+          <p>Thanks</p>
+        </content>
+      </shape>
+      <img src="IuJdbjz8KoNoBmx3sOIcsxwCnZe" width="454" height="437" topLeftX="510" topLeftY="57">
+        <crop type="rect" leftOffset="0" rightOffset="178" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="JwMcbM5AToPVujxvnCScMMprn0f" width="436" height="401" topLeftX="528" topLeftY="73">
+        <crop type="rect" leftOffset="0" rightOffset="252" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="72" height="18" topLeftX="78" topLeftY="40" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="50" topLeftY="38" iconType="iconpark/Abstract/api-app.svg">
+        <border width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/personal--personal_resume.xml
+++ b/skills/lark-slides/references/templates/personal--personal_resume.xml
@@ -1,0 +1,2047 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>个人简历</title>
+  <theme>
+    <textStyles>
+      <headline fontColor="rgba(31, 35, 41, 1)"/>
+      <sub-headline fontColor="rgba(31, 35, 41, 1)"/>
+      <body fontColor="rgba(31, 35, 41, 1)"/>
+      <caption fontColor="rgba(155, 158, 162, 1)" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="VLg4b8LG6oAAVqxswv0cLf8znAg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="LZI4bTrYNouYsQxtF56c7vT9nw5" width="960" height="540" topLeftX="0" topLeftY="0">
+        <crop type="rect" leftOffset="10" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="Xm9Tb2nsfomTfixcGh6cZrHZnsQ" width="224" height="255" topLeftX="790" topLeftY="363">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="900" startY="234" endX="900" endY="306">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="217" height="24" topLeftX="272" topLeftY="475" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(222, 224, 227, 1)" bold="false">
+          <p>
+            <span fontFamily="Arial" bold="false">Tel：123456789</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="217" height="24" topLeftX="494" topLeftY="475" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(222, 224, 227, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontFamily="Arial">Mail：</span>
+            <span fontFamily="Arial">xxx.com</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="484" height="120" topLeftX="50" topLeftY="18" type="text">
+        <content fontSize="80" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="80" fontFamily="Arial Black">PERSONAL</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="381" height="120" topLeftX="50" topLeftY="106" type="text">
+        <content fontSize="80" fontFamily="Arial Black" color="rgba(253, 151, 51, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(253, 151, 51, 1)" fontSize="80" fontFamily="Arial Black">PROFILE</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="24" topLeftX="55" topLeftY="240" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">我｜的｜个｜人｜简｜历</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="279" height="63" topLeftX="55" topLeftY="316" alpha="0.8" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">关于你的一些介绍文案，关于你的一些介绍文案，关于你的一些介绍文案，关于你的一些介绍文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="20" height="6" topLeftX="48" topLeftY="286" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="56" topLeftY="286" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="64" topLeftY="286" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="71" topLeftY="286" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" textAlign="right">
+          <p textAlign="right">
+            <span color="rgba(255, 255, 255, 1)" fontFamily="Arial Black">2026</span>
+          </p>
+          <p textAlign="right">
+            <span color="rgba(255, 255, 255, 1)" fontFamily="Arial Black">/</span>
+          </p>
+          <p textAlign="right">
+            <span color="rgba(255, 255, 255, 1)" fontFamily="Arial Black">2027</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="20" height="6" topLeftX="890" topLeftY="188" rotation="360" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="890" topLeftY="181" rotation="360" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="890" topLeftY="173" rotation="360" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="890" topLeftY="165" rotation="360" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="217" height="24" topLeftX="50" topLeftY="475" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(222, 224, 227, 1)" bold="false">
+          <p>
+            <span fontFamily="Arial" bold="false">Name：xx</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WTIwbyyhZoAL6RxFm6mckAAlnlb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="900" startY="234" endX="900" endY="490">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="20" height="6" topLeftX="793" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="785" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="777" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="769" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="25" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="33" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="41" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="49" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="94" height="16" topLeftX="437" topLeftY="81" type="rect">
+        <fill>
+          <fillColor color="rgba(253, 151, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="85" height="90" topLeftX="437" topLeftY="26" type="text">
+        <content textType="title" fontSize="60" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="60" fontFamily="Arial Black">01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="16" topLeftX="437" topLeftY="314" type="rect">
+        <fill>
+          <fillColor color="rgba(76, 241, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="85" height="90" topLeftX="437" topLeftY="258" type="text">
+        <content textType="title" fontSize="60" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="60" fontFamily="Arial Black">02</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="16" topLeftX="658" topLeftY="140" type="rect">
+        <fill>
+          <fillColor color="rgba(76, 241, 29, 1)"/>
+        </fill>
+      </shape>
+      <shape width="85" height="90" topLeftX="658" topLeftY="84" type="text">
+        <content textType="title" fontSize="60" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="60" fontFamily="Arial Black">03</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="16" topLeftX="658" topLeftY="370" type="rect">
+        <fill>
+          <fillColor color="rgba(253, 151, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="85" height="90" topLeftX="658" topLeftY="314" type="text">
+        <content textType="title" fontSize="60" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="60" fontFamily="Arial Black">04</span>
+          </p>
+        </content>
+      </shape>
+      <img src="M0uxbwv11orsaax0bA8c1SNMnKb" width="263" height="310" topLeftX="349" topLeftY="431" rotation="180" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="L4sqbDAenogCR5xfASCcOrvqn1f" width="27" height="27" topLeftX="516" topLeftY="363" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="NNTrbhULToQzu8xONlKcHmIHnm1" width="15" height="15" topLeftX="429" topLeftY="268" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="CGYmb49F8oObx6xE4pKcsDmanXb" width="21" height="21" topLeftX="459" topLeftY="192" rotation="180" flipX="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+      <shape width="180" height="54" topLeftX="658" topLeftY="440" type="text">
+        <content textType="sub-headline" fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.659)" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="658" topLeftY="404" type="text">
+        <content textType="sub-headline" fontSize="18" fontFamily="思源黑体" color="rgba(253, 151, 51, 1)" bold="true">
+          <p>未来规划</p>
+        </content>
+      </shape>
+      <shape width="180" height="54" topLeftX="658" topLeftY="211" type="text">
+        <content textType="sub-headline" fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.659)" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="658" topLeftY="174" type="text">
+        <content textType="sub-headline" fontSize="18" fontFamily="思源黑体" color="rgba(76, 241, 29, 1)" bold="true">
+          <p>项目展示</p>
+        </content>
+      </shape>
+      <shape width="180" height="54" topLeftX="437" topLeftY="384" type="text">
+        <content textType="sub-headline" fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.659)" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="437" topLeftY="348" type="text">
+        <content textType="sub-headline" fontSize="18" fontFamily="思源黑体" color="rgba(76, 241, 29, 1)" bold="true">
+          <p>个人经历</p>
+        </content>
+      </shape>
+      <shape width="180" height="54" topLeftX="437" topLeftY="153" type="text">
+        <content textType="sub-headline" fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.659)" bold="false">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="180" height="27" topLeftX="437" topLeftY="116" type="text">
+        <content textType="sub-headline" fontSize="18" fontFamily="思源黑体" color="rgba(253, 151, 51, 1)" bold="true">
+          <p>自我介绍</p>
+        </content>
+      </shape>
+      <shape width="350" height="75" topLeftX="50" topLeftY="232" type="text">
+        <content textType="sub-headline" fontSize="50" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>CONTENTS</p>
+        </content>
+      </shape>
+      <shape width="350" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>PERSONAL PROFILE</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="UYmobcl7foXr7RxaLbec8v2OnZe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KPZbbHtkCofl0Hxkewwc0DZVnFL" width="263" height="310" topLeftX="349" topLeftY="115">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="WMG5baPsbobtsFxIRSKcdA2dnbf" width="27" height="27" topLeftX="592" topLeftY="355">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="IiyNbgOoEo2eUIxtVFxcKAVYn0d" width="15" height="15" topLeftX="691" topLeftY="261">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="ExZJbF4OVoDiRlxdp8Zc7mfOnZe" width="21" height="21" topLeftX="459" topLeftY="165">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="900" startY="234" endX="900" endY="490">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="20" height="6" topLeftX="793" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="785" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="777" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="769" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="190" height="12" topLeftX="385" topLeftY="301" type="rect">
+        <fill>
+          <fillColor color="rgba(253, 151, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="25" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="33" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="41" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="49" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="334" height="75" topLeftX="313" topLeftY="226" type="text">
+        <content textType="sub-headline" fontSize="50" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p list="none">自我介绍</p>
+        </content>
+      </shape>
+      <shape width="145" height="90" topLeftX="50" topLeftY="107" type="text">
+        <content textType="sub-headline" fontSize="60" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>01</p>
+        </content>
+      </shape>
+      <shape width="350" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>PERSONAL PROFILE</p>
+        </content>
+      </shape>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Jtx3bkWIsoJdL6xDWyFccXxYnIc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="XZb8bUstMoBM9mx5JVcchZCenf5" width="598" height="682" topLeftX="292" topLeftY="-281" alpha="0.04">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="XkfjbCezMouz9AxHCtLcHCjJnLf" width="152" height="152" topLeftX="42" topLeftY="0" exposure="1" contrast="100">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="900" startY="234" endX="900" endY="490">
+        <border width="1"/>
+      </line>
+      <shape width="20" height="6" topLeftX="793" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="785" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="777" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="769" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="200" height="45" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="30" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>自我介绍</p>
+        </content>
+      </shape>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+      <img src="GutOb3qzSokIDzxbHk5c3fnknTe" width="221" height="294" topLeftX="594" topLeftY="48">
+        <shadow angle="90"/>
+        <crop type="round-rect" leftOffset="37" rightOffset="37" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <shape width="144" height="84" topLeftX="50" topLeftY="238" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>
+                <span color="rgba(119, 119, 119, 1)" fontSize="14">性别：女</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span color="rgba(119, 119, 119, 1)" fontSize="14">年龄：24</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span color="rgba(119, 119, 119, 1)" fontSize="14">学历：硕士</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span color="rgba(119, 119, 119, 1)" fontSize="14">毕业学校：某大学</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="124" height="30" topLeftX="50" topLeftY="198" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" textAlign="left">
+          <p list="none" textAlign="left">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="20" fontFamily="思源黑体" italic="false" strikethrough="false" underline="false">基本信息</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="IpZQbujV4oa5OwxXcM5cNd1dnwe" width="18" height="20" topLeftX="133" topLeftY="203">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="184" height="120" topLeftX="613" topLeftY="367" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" list="bullet" textAlign="left">
+          <ul>
+            <li>
+              <p textAlign="left">
+                <strong>
+                  <span color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="20">Tel：123456789</span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left">
+                <strong>
+                  <span color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="20">Mail：</span>
+                </strong>
+                <strong>
+                  <span color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="20">xxx.com</span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left">
+                <strong>
+                  <span color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="20">Blog：</span>
+                </strong>
+                <strong>
+                  <span color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="20">xxx.com</span>
+                </strong>
+              </p>
+            </li>
+            <li>
+              <p textAlign="left">
+                <strong>
+                  <span color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="20">GitHub：xxx.com</span>
+                </strong>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="207" height="84" topLeftX="281" topLeftY="238" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>求职意向：工程师</p>
+            </li>
+            <li>
+              <p>到岗时间：随时</p>
+            </li>
+            <li>
+              <p>
+                <span color="rgba(119, 119, 119, 1)" fontSize="14">工作地点：北京</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span color="rgba(119, 119, 119, 1)" fontSize="14">期望薪资：面议</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="124" height="30" topLeftX="281" topLeftY="198" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" textAlign="left">
+          <p list="none" textAlign="left">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="20" fontFamily="思源黑体" italic="false" strikethrough="false" underline="false">求职意向</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="VJQSbxmOGoG98Jxjqrsc48lrnjl" width="18" height="20" topLeftX="364" topLeftY="203">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="311" height="84" topLeftX="50" topLeftY="406" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)">
+          <ul>
+            <li>
+              <p>2020.09 - 2024.06 某大学 xxx专业（本科）</p>
+            </li>
+            <li>
+              <p>2020.09 - 2024.06 某大学 xxx专业（本科）</p>
+            </li>
+            <li>
+              <p>2020.09 - 2024.06 某大学 xxx专业（本科）</p>
+            </li>
+            <li>
+              <p>2020.09 - 2024.06 某大学 xxx专业（本科）</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="124" height="30" topLeftX="50" topLeftY="363" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" textAlign="left">
+          <p list="none" textAlign="left">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="20" fontFamily="思源黑体" italic="false" strikethrough="false" underline="false">教育背景</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Wo2MbuFNFohbVCxte7ocbYtpnNb" width="18" height="20" topLeftX="133" topLeftY="368">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Qbugb1tgZoJrHGxGBjxcm4MgnWd" width="53" height="53" topLeftX="786" topLeftY="402" alpha="0.4">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="G4Y9bCaUMo8hb5xfjm0cnmVanyc" width="22" height="22" topLeftX="822" topLeftY="400" alpha="0.4">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="GAB9bdkZyoYxaHxAOPHcACiYnqg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="I633bhMJko1nrvxlqGyc51g3nzh" width="152" height="152" topLeftX="42" topLeftY="0" exposure="1" contrast="100">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="UAHXbev8FoCTEsxB47Bc8kEAnyf" width="224" height="255" topLeftX="790" topLeftY="363" alpha="0.12">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="273" height="167" topLeftX="44" topLeftY="152" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(52, 195, 125, 1) 0%,rgba(113, 230, 147, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="29" height="84" topLeftX="79" topLeftY="175" type="text">
+        <content textType="title" fontSize="56" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="56" fontFamily="Arial Black">“</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="273" height="167" topLeftX="344" topLeftY="152" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(43, 47, 54, 1) 0%,rgba(114, 116, 124, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="29" height="84" topLeftX="378" topLeftY="175" type="text">
+        <content textType="title" fontSize="56" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="56" fontFamily="Arial Black">“</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="273" height="167" topLeftX="643" topLeftY="152" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(251, 152, 60, 1) 0%,rgba(255, 214, 140, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="29" height="84" topLeftX="678" topLeftY="175" type="text">
+        <content textType="title" fontSize="56" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="56" fontFamily="Arial Black">“</span>
+          </p>
+        </content>
+      </shape>
+      <img src="IwzgbRPPjoUtGWxHy7rc7hm5nVh" width="30" height="30" topLeftX="39" topLeftY="95" rotation="343">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EasnbONnvoJoFyxiueicEm3Zn6d" width="16" height="16" topLeftX="164" topLeftY="25" rotation="16">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="273" height="126" topLeftX="644" topLeftY="343" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="273" height="126" topLeftX="344" topLeftY="343" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="273" height="126" topLeftX="44" topLeftY="343" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="200" height="36" topLeftX="678" topLeftY="241" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>技能关键词三</p>
+        </content>
+      </shape>
+      <shape width="200" height="36" topLeftX="378" topLeftY="241" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>技能关键词二</p>
+        </content>
+      </shape>
+      <shape width="200" height="36" topLeftX="75" topLeftY="241" type="text">
+        <content textType="sub-headline" fontSize="24" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>技能关键词一</p>
+        </content>
+      </shape>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+      <shape width="200" height="45" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="30" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>个人技能</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="UYmobcl7foXr7RxaLbec8v2OnZe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KPZbbHtkCofl0Hxkewwc0DZVnFL" width="263" height="310" topLeftX="349" topLeftY="115">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="WMG5baPsbobtsFxIRSKcdA2dnbf" width="27" height="27" topLeftX="592" topLeftY="355">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="IiyNbgOoEo2eUIxtVFxcKAVYn0d" width="15" height="15" topLeftX="691" topLeftY="261">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="ExZJbF4OVoDiRlxdp8Zc7mfOnZe" width="21" height="21" topLeftX="459" topLeftY="165">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="900" startY="234" endX="900" endY="490">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="20" height="6" topLeftX="793" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="785" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="777" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="769" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="190" height="12" topLeftX="385" topLeftY="301" type="rect">
+        <fill>
+          <fillColor color="rgba(253, 151, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="25" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="33" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="41" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="49" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="334" height="75" topLeftX="313" topLeftY="226" type="text">
+        <content textType="sub-headline" fontSize="50" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p list="none">个人经历</p>
+        </content>
+      </shape>
+      <shape width="145" height="90" topLeftX="50" topLeftY="107" type="text">
+        <content textType="sub-headline" fontSize="60" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="350" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>PERSONAL PROFILE</p>
+        </content>
+      </shape>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="ZTceb4CE7oVUtAxFCz5cvEBunxb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="JTgybQsAwoWvcUxxe98c7vqkn0e" width="152" height="152" topLeftX="42" topLeftY="0" exposure="1" contrast="100">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="900" startY="234" endX="900" endY="490">
+        <border width="1"/>
+      </line>
+      <shape width="20" height="6" topLeftX="793" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="785" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="777" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="769" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <img src="PKp8bNRQKoml6Ux0Iz2crvH2nob" width="207" height="207" topLeftX="-1195" topLeftY="522" alpha="0.12">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Moqabl7gcobNToxT6spc87zNn1d" width="85" height="85" topLeftX="-1054" topLeftY="517" alpha="0.12">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="UPlbbHBpro0zCPxEEjFcx1p4nWc" width="30" height="30" topLeftX="39" topLeftY="95" rotation="343">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Fo9KbWEgwoB0uwxorjAcXMDYnPf" width="16" height="16" topLeftX="164" topLeftY="25" rotation="16">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+      <shape width="200" height="45" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="30" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>项目经历</p>
+        </content>
+      </shape>
+      <shape width="277" height="30" topLeftX="496" topLeftY="115" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" textAlign="left">
+          <p list="none" textAlign="left">项目名称一（2025.8-至今）</p>
+        </content>
+      </shape>
+      <img src="Z0jIbii4BobqVzx8OLtciVvRnYb" width="21" height="20" topLeftX="764" topLeftY="120">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="339" height="105" topLeftX="496" topLeftY="156" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>
+                <span fontSize="14">项目简介：描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span fontSize="14">岗位职责：描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <img src="YBV3b2lT4o7Nbyx3CjUc00Kcnfd" width="227" height="340" topLeftX="49" topLeftY="152">
+        <shadow angle="90"/>
+        <crop type="round-rect" leftOffset="57" rightOffset="57" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <img src="UTBlbxUvXoihA3x7AuBcLcaQn2b" width="163" height="245" topLeftX="297" topLeftY="67">
+        <shadow angle="90"/>
+        <crop type="round-rect" leftOffset="41" rightOffset="41" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <img src="IVGxbX90PoZ85kxWZ4UcoiJ4nrh" width="160" height="160" topLeftX="299" topLeftY="332">
+        <shadow angle="90"/>
+        <crop type="round-rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="30"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <shape width="276" height="30" topLeftX="496" topLeftY="295" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" textAlign="left">
+          <p list="none" textAlign="left">项目名称二（2025.8-至今）</p>
+        </content>
+      </shape>
+      <img src="XtoHbm650o1iZfxaqbxcadwHnRd" width="21" height="20" topLeftX="764" topLeftY="300">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="339" height="105" topLeftX="496" topLeftY="336" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="bullet">
+          <ul>
+            <li>
+              <p>项目简介：描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</p>
+            </li>
+            <li>
+              <p>岗位职责：描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EXctb1E3doblDDxpeZucW82xn4c" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="TlJWbC3XwoshRyxkCj1cFVVJn9g" width="598" height="682" topLeftX="181" topLeftY="40" alpha="0.04">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EM1Vb7GgkoN5CPxZ4MIc08abnGd" width="224" height="255" topLeftX="368" topLeftY="367" alpha="0.2">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="20" height="6" topLeftX="25" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="33" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="41" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="49" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <img src="TeKmbVm1oocRMCx9E72cisgXnHf" width="152" height="152" topLeftX="42" topLeftY="0" exposure="1" contrast="100">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="JT9Wb6wZvoJAdnxVQcUcSqkPnAd" width="30" height="30" topLeftX="39" topLeftY="95" rotation="343">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="CF9UbZRICoH54PxagP9cRzysnnh" width="16" height="16" topLeftX="164" topLeftY="25" rotation="16">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="WsXOba2PeoVwaixv6FKcx9Z7nCg" width="190" height="135" topLeftX="720" topLeftY="189">
+        <shadow angle="90"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="28" bottomOffset="27" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <img src="Fqz9bTwPJoFAh4xpI1Jcr4Iynkh" width="190" height="135" topLeftX="496" topLeftY="95">
+        <shadow angle="90"/>
+        <crop type="rect" leftOffset="25" rightOffset="25" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <img src="Id3mbksxxolZndxSwtJcgG8qnxe" width="190" height="135" topLeftX="273" topLeftY="95">
+        <shadow angle="90"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="28" bottomOffset="27" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <img src="ZjWYba6q0oYPuWxW9DocYbSgnoc" width="190" height="135" topLeftX="50" topLeftY="189">
+        <shadow angle="90"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="28" bottomOffset="27" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+      <shape width="200" height="48" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="32" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>证书荣誉</p>
+        </content>
+      </shape>
+      <shape width="190" height="30" topLeftX="720" topLeftY="342" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="center">
+          <p list="none">《xx荣誉》</p>
+        </content>
+      </shape>
+      <shape width="190" height="63" topLeftX="720" topLeftY="378" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="center">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</p>
+        </content>
+      </shape>
+      <shape width="190" height="30" topLeftX="496" topLeftY="248" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="center">
+          <p list="none">《xx荣誉》</p>
+        </content>
+      </shape>
+      <shape width="190" height="63" topLeftX="496" topLeftY="285" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="center">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</p>
+        </content>
+      </shape>
+      <shape width="190" height="30" topLeftX="273" topLeftY="248" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="center">
+          <p list="none">《xx荣誉》</p>
+        </content>
+      </shape>
+      <shape width="190" height="63" topLeftX="273" topLeftY="285" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="center">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</p>
+        </content>
+      </shape>
+      <shape width="190" height="30" topLeftX="50" topLeftY="342" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="center">
+          <p list="none">《xx荣誉》</p>
+        </content>
+      </shape>
+      <shape width="190" height="63" topLeftX="50" topLeftY="378" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="center">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="UYmobcl7foXr7RxaLbec8v2OnZe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KPZbbHtkCofl0Hxkewwc0DZVnFL" width="263" height="310" topLeftX="349" topLeftY="115">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="WMG5baPsbobtsFxIRSKcdA2dnbf" width="27" height="27" topLeftX="592" topLeftY="355">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="IiyNbgOoEo2eUIxtVFxcKAVYn0d" width="15" height="15" topLeftX="691" topLeftY="261">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="ExZJbF4OVoDiRlxdp8Zc7mfOnZe" width="21" height="21" topLeftX="459" topLeftY="165">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="900" startY="234" endX="900" endY="490">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="20" height="6" topLeftX="793" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="785" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="777" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="769" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="190" height="12" topLeftX="385" topLeftY="301" type="rect">
+        <fill>
+          <fillColor color="rgba(253, 151, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="25" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="33" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="41" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="49" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="334" height="75" topLeftX="313" topLeftY="226" type="text">
+        <content textType="sub-headline" fontSize="50" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>项目展示</p>
+        </content>
+      </shape>
+      <shape width="145" height="90" topLeftX="50" topLeftY="107" type="text">
+        <content textType="sub-headline" fontSize="60" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>03</p>
+        </content>
+      </shape>
+      <shape width="350" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>PERSONAL PROFILE</p>
+        </content>
+      </shape>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CzsObYpFnoNfFnx0RM2cxmdGnld" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="WBJeb9LKyoTjpmx2wricpFGynsd" width="152" height="152" topLeftX="42" topLeftY="0" exposure="1" contrast="100">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="RaDTbEM21omyGIxvDRPcoYOMnkf" width="30" height="30" topLeftX="39" topLeftY="95" rotation="343">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="NogYb7AoZoimsjxF2O2cuiMsnNg" width="16" height="16" topLeftX="164" topLeftY="25" rotation="16">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="20" height="6" topLeftX="25" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="33" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="41" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="49" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <img src="R0vjbPKQkoywSLxW1ZNcbtmGn4g" width="40" height="40" topLeftX="288" topLeftY="199" rotation="180" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="308" startY="190" endX="308" endY="98" alpha="0.6">
+        <border color="rgba(76, 241, 29, 1)" width="1"/>
+      </line>
+      <img src="K7DNbxxPCoHGS6xoLkscnNoEnKb" width="40" height="40" topLeftX="637" topLeftY="-118" rotation="360" flipX="true" flipY="true" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="657" startY="-127" endX="657" endY="-219" alpha="0.6">
+        <border color="rgba(76, 241, 29, 1)" width="1"/>
+      </line>
+      <img src="Tgu1bLjYyoQH6nxnjIZcfwWwn9b" width="40" height="40" topLeftX="460" topLeftY="270" rotation="270" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="CutfbrBcAomkoRxrmGecyW9mnFg" width="178" height="178" topLeftX="489" topLeftY="302">
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+        <crop type="rect" leftOffset="69" rightOffset="69" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <img src="LTEUbgzHvovRDJx8v34c3gs7nQd" width="178" height="178" topLeftX="293" topLeftY="302">
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <img src="V7EKbEXNxoct8ExCpFFcobLWnWg" width="178" height="178" topLeftX="489" topLeftY="106">
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <img src="IPv9bTtjIonQnfxXWsscEcc3nFd" width="178" height="178" topLeftX="293" topLeftY="106">
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <shape width="200" height="45" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="30" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>项目背景</p>
+        </content>
+      </shape>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+      <shape width="190" height="30" topLeftX="694" topLeftY="341" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="left">
+          <p list="none">背景关键词四</p>
+        </content>
+      </shape>
+      <shape width="190" height="63" topLeftX="694" topLeftY="378" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="left"/>
+      </shape>
+      <shape width="190" height="30" topLeftX="694" topLeftY="139" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="left">
+          <p list="none">背景关键词三</p>
+        </content>
+      </shape>
+      <shape width="190" height="63" topLeftX="694" topLeftY="176" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="left"/>
+      </shape>
+      <shape width="190" height="30" topLeftX="81" topLeftY="341" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="right">
+          <p list="none">背景关键词二</p>
+        </content>
+      </shape>
+      <shape width="190" height="63" topLeftX="81" topLeftY="378" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="right"/>
+      </shape>
+      <shape width="190" height="30" topLeftX="81" topLeftY="139" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="right">
+          <p list="none">背景关键词一</p>
+        </content>
+      </shape>
+      <shape width="190" height="63" topLeftX="81" topLeftY="176" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="right"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Q5igbqt1qo67nbxfcRPckrSAnpg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="HIWWbgfi1olsujxZs0McOWizndh" width="152" height="152" topLeftX="42" topLeftY="0" exposure="1" contrast="100">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="MaYebg87ko0Zl1xFzVdcVigInjh" width="30" height="30" topLeftX="39" topLeftY="95" rotation="343">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="U7ImbFEjioZC5LxTSrEcXVR0nMf" width="16" height="16" topLeftX="164" topLeftY="25" rotation="16">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Uk98bzc8mohu6QxAE7hcl8lVnmh" width="172" height="196" topLeftX="679" topLeftY="-97" alpha="0.12">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="273" height="365" topLeftX="44" topLeftY="137" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(52, 195, 125, 1) 0%,rgba(113, 230, 147, 1) 100%)"/>
+        </fill>
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="235" height="84" topLeftX="63" topLeftY="202" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="235" height="84" topLeftX="63" topLeftY="298" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="235" height="84" topLeftX="63" topLeftY="395" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="273" height="365" topLeftX="344" topLeftY="137" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(43, 47, 54, 1) 0%,rgba(114, 116, 124, 1) 100%)"/>
+        </fill>
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="235" height="84" topLeftX="363" topLeftY="202" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="235" height="84" topLeftX="363" topLeftY="298" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="235" height="84" topLeftX="363" topLeftY="395" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="273" height="365" topLeftX="643" topLeftY="137" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(251, 152, 60, 1) 0%,rgba(255, 214, 140, 1) 100%)"/>
+        </fill>
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="235" height="84" topLeftX="663" topLeftY="202" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="235" height="84" topLeftX="663" topLeftY="298" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="235" height="84" topLeftX="663" topLeftY="395" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.6)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </shape>
+      <shape width="205" height="24" topLeftX="679" topLeftY="414" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="left">
+          <p list="none">关键词</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="679" topLeftY="442" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" list="none" textAlign="left">
+          <p list="none">描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="205" height="24" topLeftX="679" topLeftY="317" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="left">
+          <p list="none">关键词</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="679" topLeftY="346" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" list="none" textAlign="left">
+          <p list="none">描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="205" height="24" topLeftX="679" topLeftY="219" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="left">
+          <p list="none">关键词</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="679" topLeftY="248" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" list="none" textAlign="left">
+          <p list="none">描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="205" height="24" topLeftX="378" topLeftY="414" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="left">
+          <p list="none">关键词</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="378" topLeftY="442" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" list="none" textAlign="left">
+          <p list="none">描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="205" height="24" topLeftX="378" topLeftY="317" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="left">
+          <p list="none">关键词</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="378" topLeftY="346" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" list="none" textAlign="left">
+          <p list="none">描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="205" height="24" topLeftX="378" topLeftY="219" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="left">
+          <p list="none">关键词</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="378" topLeftY="248" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" list="none" textAlign="left">
+          <p list="none">描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="205" height="24" topLeftX="76" topLeftY="414" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="left">
+          <p list="none">关键词</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="76" topLeftY="442" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" list="none" textAlign="left">
+          <p list="none">描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="205" height="24" topLeftX="76" topLeftY="317" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="left">
+          <p list="none">关键词</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="76" topLeftY="346" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" list="none" textAlign="left">
+          <p list="none">描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="205" height="24" topLeftX="76" topLeftY="219" type="text">
+        <content textType="caption" fontSize="16" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="left">
+          <p list="none">关键词</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="76" topLeftY="248" type="text">
+        <content textType="caption" fontSize="12" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" list="none" textAlign="left">
+          <p list="none">描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="235" height="30" topLeftX="663" topLeftY="157" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>策略关键词三</p>
+        </content>
+      </shape>
+      <shape width="235" height="30" topLeftX="363" topLeftY="156" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>策略关键词二</p>
+        </content>
+      </shape>
+      <shape width="235" height="30" topLeftX="63" topLeftY="156" type="text">
+        <content textType="sub-headline" fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>策略关键词一</p>
+        </content>
+      </shape>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+      <shape width="200" height="45" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="30" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>产品策略</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="YOgtbfnnDoX66hxfgbAcPYeKnHc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="M6CcbFTL1odX3KxkQfmcIAsOnRf" width="598" height="682" topLeftX="181" topLeftY="-71" alpha="0.04">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Tg3BbzQUloT17Mxvu7PcTwbznwf" width="152" height="152" topLeftX="42" topLeftY="0" exposure="1" contrast="100">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="FwqAbLi01oiccaxc23HcWwjjnnh" width="16" height="16" topLeftX="164" topLeftY="25" rotation="16">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="TUNwbNNKuoRfeNxLF9TcebITnmb" width="40" height="40" topLeftX="318" topLeftY="354" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="338" startY="404" endX="338" endY="495" alpha="0.6">
+        <border color="rgba(76, 241, 29, 1)" width="1"/>
+      </line>
+      <img src="X84Gbvu6kohOR3xeplDcBEWEnpd" width="40" height="40" topLeftX="918" topLeftY="354" alpha="0.6">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="938" startY="404" endX="938" endY="495" alpha="0.6">
+        <border color="rgba(76, 241, 29, 1)" width="1"/>
+      </line>
+      <img src="Nf0DbwIOVoGyU4xwF85cVUL7nsd" width="30" height="30" topLeftX="39" topLeftY="95" rotation="343">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Cfoqb14pXo5y2Yxj8HHcfNICnNd" width="266" height="200" topLeftX="644" topLeftY="162">
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="33" bottomOffset="33" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <img src="DbHqbMfyZondyPxWHYccndNUnDe" width="266" height="200" topLeftX="347" topLeftY="162">
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="33" bottomOffset="33" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <img src="ZhBkbvabAoPqFgxQsmVc6wyNn9h" width="266" height="200" topLeftX="50" topLeftY="162">
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="33" bottomOffset="33" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+      <shape width="200" height="45" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="30" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p list="none">产品展示</p>
+        </content>
+      </shape>
+      <shape width="266" height="30" topLeftX="646" topLeftY="388" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="center">
+          <p list="none">关键词三</p>
+        </content>
+      </shape>
+      <shape width="266" height="42" topLeftX="646" topLeftY="425" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="center">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</p>
+        </content>
+      </shape>
+      <shape width="266" height="30" topLeftX="347" topLeftY="388" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="center">
+          <p list="none">关键词二</p>
+        </content>
+      </shape>
+      <shape width="266" height="42" topLeftX="347" topLeftY="425" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="center">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</p>
+        </content>
+      </shape>
+      <shape width="266" height="30" topLeftX="50" topLeftY="388" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" list="none" textAlign="center">
+          <p list="none">关键词一</p>
+        </content>
+      </shape>
+      <shape width="266" height="42" topLeftX="50" topLeftY="425" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="center">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Ekprb2YuOoA1bQxuWUEcFMeSnSg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="A3ssbXoSEoHUmsxzqAxc698lnSg" width="152" height="152" topLeftX="42" topLeftY="0" exposure="1" contrast="100">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Qe59bSBDBoMGFcx66yQcLtA1ntc" width="16" height="16" topLeftX="164" topLeftY="25" rotation="16">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="900" startY="234" endX="900" endY="490">
+        <border width="1"/>
+      </line>
+      <shape width="20" height="6" topLeftX="793" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="785" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="777" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="769" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <img src="UAfrbn5LjoJEYyxWjFBcgpDvnih" width="40" height="40" topLeftX="605" topLeftY="-87" rotation="360" flipX="true" flipY="true">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="625" startY="-96" endX="625" endY="-233">
+        <border color="rgba(76, 241, 29, 1)" width="1"/>
+      </line>
+      <img src="FQhGb35zeoCrxxxPOUiceWnined" width="30" height="30" topLeftX="39" topLeftY="95" rotation="343">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+      <shape width="200" height="45" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="30" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>产品数据</p>
+        </content>
+      </shape>
+      <shape width="190" height="21" topLeftX="674" topLeftY="227" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="center">
+          <p>数据字段名称</p>
+        </content>
+      </shape>
+      <shape width="190" height="75" topLeftX="674" topLeftY="152" type="text">
+        <content textType="title" fontSize="50" fontFamily="Arial Black" color="linear-gradient(180deg,rgba(52, 195, 125, 1) 0%,rgba(113, 230, 147, 1) 100%)" bold="true" textAlign="center">
+          <p>90%</p>
+        </content>
+      </shape>
+      <img src="UVg5bbsWdoWpZFxtu7scEehInif" width="280" height="331" topLeftX="356" topLeftY="152">
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+        <crop type="rect" leftOffset="26" rightOffset="25" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <img src="VnE5bMFHNoLCxqxlkaIcXBrbnHc" width="280" height="331" topLeftX="50" topLeftY="152">
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+        <crop type="rect" leftOffset="25" rightOffset="25" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" width="1"/>
+      </img>
+      <shape width="190" height="21" topLeftX="674" topLeftY="409" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)" list="none" textAlign="center">
+          <p>数据字段名称</p>
+        </content>
+      </shape>
+      <shape width="190" height="75" topLeftX="674" topLeftY="337" type="text">
+        <content textType="title" fontSize="50" fontFamily="Arial Black" color="linear-gradient(180deg,rgba(251, 152, 60, 1) 0%,rgba(255, 214, 140, 1) 100%)" bold="true" textAlign="center">
+          <p>116%</p>
+        </content>
+      </shape>
+      <shape width="280" height="119" topLeftX="50" topLeftY="364" presetHandlers="20" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(43, 47, 54, 1) 0%,rgba(114, 116, 124, 1) 100%)"/>
+        </fill>
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="226" height="63" topLeftX="77" topLeftY="388" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="280" height="119" topLeftX="356" topLeftY="364" presetHandlers="20" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(52, 195, 125, 1) 0%,rgba(113, 230, 147, 1) 100%)"/>
+        </fill>
+        <shadow angle="90" color="rgba(0, 0, 0, 0.1)"/>
+      </shape>
+      <shape width="226" height="63" topLeftX="383" topLeftY="388" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="UYmobcl7foXr7RxaLbec8v2OnZe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KPZbbHtkCofl0Hxkewwc0DZVnFL" width="263" height="310" topLeftX="349" topLeftY="115">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="WMG5baPsbobtsFxIRSKcdA2dnbf" width="27" height="27" topLeftX="592" topLeftY="355">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="IiyNbgOoEo2eUIxtVFxcKAVYn0d" width="15" height="15" topLeftX="691" topLeftY="261">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="ExZJbF4OVoDiRlxdp8Zc7mfOnZe" width="21" height="21" topLeftX="459" topLeftY="165">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="900" startY="234" endX="900" endY="490">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="20" height="6" topLeftX="793" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="785" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="777" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="769" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="190" height="12" topLeftX="385" topLeftY="301" type="rect">
+        <fill>
+          <fillColor color="rgba(253, 151, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="25" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="33" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="41" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="49" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="334" height="75" topLeftX="313" topLeftY="226" type="text">
+        <content textType="sub-headline" fontSize="50" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>未来规划</p>
+        </content>
+      </shape>
+      <shape width="145" height="90" topLeftX="50" topLeftY="107" type="text">
+        <content textType="sub-headline" fontSize="60" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>04</p>
+        </content>
+      </shape>
+      <shape width="350" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>PERSONAL PROFILE</p>
+        </content>
+      </shape>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="QdnybQoaeojCkhxeEBZcFV8onYc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="900" startY="234" endX="900" endY="490">
+        <border width="1"/>
+      </line>
+      <shape width="20" height="6" topLeftX="793" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="785" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="777" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="769" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <img src="LLsTbxb76oFs7QxyclzcvKU4n4f" width="152" height="152" topLeftX="42" topLeftY="0" exposure="1" contrast="100">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EOyCbbTFIoQztcxzvVCcxJXynRh" width="16" height="16" topLeftX="164" topLeftY="25" rotation="16">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="IE21boNvroeuxlxomPYcIwOvnIf" width="30" height="30" topLeftX="39" topLeftY="95" rotation="343">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="20" height="6" topLeftX="25" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="33" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="41" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="49" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <img src="PU2CbQlNyomLN7xGkHCcPBZLnbf" width="771" height="315" topLeftX="38" topLeftY="103" alpha="0.2">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="90" height="30" topLeftX="254" topLeftY="674" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" textAlign="left">
+          <p list="none" textAlign="left">
+            <span color="rgba(43, 47, 54, 1)">短期规划</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Quk7brbdMoOrTbxhsA8cbVk5nHg" width="21" height="20" topLeftX="347" topLeftY="680">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="166" startY="416" endX="166" endY="203">
+        <border color="rgba(76, 241, 29, 1)" width="1"/>
+        <startArrow type="solid-circle"/>
+        <endArrow type="solid-triangle"/>
+      </line>
+      <shape width="90" height="30" topLeftX="1007" topLeftY="492" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" textAlign="left">
+          <p list="none" textAlign="left">长期规划</p>
+        </content>
+      </shape>
+      <img src="GWO8bQA7UoDlfpxzzDhcnaCsnCd" width="21" height="20" topLeftX="1100" topLeftY="498">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="524" startY="319" endX="524" endY="86">
+        <border color="rgba(76, 241, 29, 1)" width="1"/>
+        <startArrow type="solid-circle"/>
+        <endArrow type="solid-triangle"/>
+      </line>
+      <img src="Y3jpbG3ltoo8sEx3RWgcBQc0n3L" width="203" height="203" topLeftX="565" topLeftY="350" alpha="0.12">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="KufOb8DJAoRPbGxgV1WcdXiRndd" width="83" height="83" topLeftX="703" topLeftY="345" alpha="0.12">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="236" height="21" topLeftX="543" topLeftY="95" type="text">
+        <content textType="caption" fontSize="14" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" list="none" textAlign="left">
+          <p>2027</p>
+        </content>
+      </shape>
+      <shape width="236" height="126" topLeftX="543" topLeftY="122" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="236" height="21" topLeftX="187" topLeftY="203" type="text">
+        <content textType="caption" fontSize="14" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" list="none" textAlign="left">
+          <p>2026</p>
+        </content>
+      </shape>
+      <shape width="236" height="126" topLeftX="187" topLeftY="230" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(119, 119, 119, 1)">
+          <ul listStyle="circle-hollow-square">
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+            <li>
+              <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="200" height="45" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="30" fontFamily="思源黑体" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>未来规划</p>
+        </content>
+      </shape>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(43, 47, 54, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="OcZob9NETo0U3gxTRnVcgmuunkd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="VP5SbRgmFoUKWjxu2Phca6XmnBQ" width="263" height="310" topLeftX="349" topLeftY="115">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Oihcbc4ZuoG6tGx3T8hc4bMQnCh" width="27" height="27" topLeftX="592" topLeftY="355">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="WYFRbJuHhoWl1Ox3qPPcNvUcnve" width="15" height="15" topLeftX="691" topLeftY="261">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="JUrlbMoLMoycNux01CZcFLCinOe" width="21" height="21" topLeftX="459" topLeftY="165">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <line startX="900" startY="234" endX="900" endY="490">
+        <border color="rgba(222, 224, 227, 1)" width="1"/>
+      </line>
+      <shape width="20" height="6" topLeftX="793" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="785" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="777" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="769" topLeftY="-641" rotation="270" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="308" height="12" topLeftX="326" topLeftY="301" type="rect">
+        <fill>
+          <fillColor color="rgba(253, 151, 51, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="25" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="33" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="41" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="20" height="6" topLeftX="49" topLeftY="668" rotation="90" type="triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="334" height="75" topLeftX="313" topLeftY="226" type="text">
+        <content textType="sub-headline" fontSize="50" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>Thank You</p>
+        </content>
+      </shape>
+      <shape width="350" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>PERSONAL PROFILE</p>
+        </content>
+      </shape>
+      <shape width="52" height="72" topLeftX="858" topLeftY="50" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>2026</p>
+          <p>/</p>
+          <p>2027</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/personal--promotion_defense.xml
+++ b/skills/lark-slides/references/templates/personal--promotion_defense.xml
@@ -1,0 +1,1099 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>晋级答辩</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="48"/>
+      <headline fontColor="#000000FF" fontSize="36"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(85, 70, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="324" height="208" topLeftX="36" topLeftY="249" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="75" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.1" textAlign="left">
+          <p lineSpacing="multiple:1.1">
+            <span color="rgba(255, 255, 255, 1)" fontSize="75" bold="false">晋升</span>
+          </p>
+          <p lineSpacing="multiple:1.1">
+            <span color="rgba(255, 255, 255, 1)" fontSize="75" bold="false">答辩报告</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="253" height="56" topLeftX="41" topLeftY="448" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">PROMOTION REPORT</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="216" height="38" topLeftX="36" topLeftY="35" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">演讲人：李天</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="216" height="38" topLeftX="264" topLeftY="35" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">目标岗位：XXX</span>
+          </p>
+        </content>
+      </shape>
+      <img src="UOS9brd20oEbUSxjPpbcdzTMnhg" width="324" height="540" topLeftX="636" topLeftY="0">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content>
+        <p/>
+      </content>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="OOiyb931ToebAWxB5ytcbmgvnTg" width="216" height="540" topLeftX="0" topLeftY="0">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="133" height="80" topLeftX="318" topLeftY="121" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(74, 58, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(74, 58, 255, 1)" fontSize="40">目录</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="426" height="80" topLeftX="428" topLeftY="121" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="40">CONTENT</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="248" height="62" topLeftX="335" topLeftY="271" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span fontSize="14">请在此处编辑文字请在此处编辑文字请在此处编辑</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="248" height="47" topLeftX="335" topLeftY="235" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">01  个人简介</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="248" height="62" topLeftX="620" topLeftY="271" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span fontSize="14">请在此处编辑文字请在此处编辑文字请在此处编辑</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="248" height="47" topLeftX="620" topLeftY="235" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">02  工作经验</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="248" height="62" topLeftX="335" topLeftY="393" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span fontSize="14">请在此处编辑文字请在此处编辑文字请在此处编辑</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="248" height="47" topLeftX="335" topLeftY="357" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">03  认知与评价</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="248" height="62" topLeftX="620" topLeftY="393" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <span fontSize="14">请在此处编辑文字请在此处编辑文字请在此处编辑</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="248" height="47" topLeftX="620" topLeftY="357" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="18">04 未来规划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="135" height="81" topLeftX="318" topLeftY="121" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" fontFamily="undefined" color="rgba(74, 58, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="center" autoFit="shape-auto-fit">
+          <p>目录</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="296" height="113" topLeftX="664" topLeftY="427" type="rect">
+        <fill>
+          <fillColor color="rgba(85, 70, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="80" height="37" topLeftX="87" topLeftY="275" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">年龄</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="37" topLeftX="87" topLeftY="314" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">民族</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="140" height="37" topLeftX="298" topLeftY="275" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">最高学历</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="48" topLeftX="87" topLeftY="345" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">籍贯</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="140" height="37" topLeftX="298" topLeftY="314" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="14">毕业学校</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="296" height="430" topLeftX="664" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="rgba(74, 58, 255, 1)"/>
+        </fill>
+      </shape>
+      <img src="InFdbMXOeo5VHCx1BYYcHBzZnTf" width="296" height="430" topLeftX="664" topLeftY="0" exposure="24" temperature="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="5" bottomOffset="5"/>
+      </img>
+      <shape width="120" height="37" topLeftX="393" topLeftY="314" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" lineSpacing="multiple:1.2">
+          <p>XXX 大学</p>
+        </content>
+      </shape>
+      <shape width="120" height="37" topLeftX="393" topLeftY="275" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" lineSpacing="multiple:1.2">
+          <p>硕士</p>
+        </content>
+      </shape>
+      <shape width="120" height="37" topLeftX="156" topLeftY="351" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" lineSpacing="multiple:1.2">
+          <p>山东</p>
+        </content>
+      </shape>
+      <shape width="120" height="37" topLeftX="156" topLeftY="314" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" lineSpacing="multiple:1.2">
+          <p>汉族</p>
+        </content>
+      </shape>
+      <shape width="120" height="37" topLeftX="156" topLeftY="275" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" lineSpacing="multiple:1.2">
+          <p>36岁</p>
+        </content>
+      </shape>
+      <shape width="393" height="56" topLeftX="87" topLeftY="182" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="69" topLeftX="87" topLeftY="116" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="36">李天</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="T8zebebNSocayLxKjYicyzNFnLc" width="224" height="223" topLeftX="552" topLeftY="316" rotation="270">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="114" height="44" topLeftX="26" topLeftY="25" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" fontFamily="undefined" color="rgba(31, 35, 41, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="true" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="left" autoFit="shape-auto-fit">
+          <p>个人简介</p>
+        </content>
+      </shape>
+      <shape width="129" height="44" topLeftX="101" topLeftY="25" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" fontFamily="undefined" color="rgba(31, 35, 41, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="left" autoFit="shape-auto-fit" wrap="false">
+          <p>PersonalProfile</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="450" height="44" topLeftX="98" topLeftY="26" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">Work Experience</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="88" height="44" topLeftX="26" topLeftY="26" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">工作经验</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="388" height="83" topLeftX="56" topLeftY="162" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="68" topLeftX="55" topLeftY="98" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="32">工作经历</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="44" topLeftX="58" topLeftY="355" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="16">工作单位 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="62" topLeftX="58" topLeftY="384" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="44" topLeftX="365" topLeftY="355" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="16">工作单位 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="62" topLeftX="365" topLeftY="384" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="671" topLeftY="355" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="16">工作单位 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="210" height="62" topLeftX="671" topLeftY="384" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(43, 47, 54, 1)">
+          <p>
+            <span color="rgba(43, 47, 54, 1)" fontSize="14">描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="843" height="26" topLeftX="62" topLeftY="318" presetHandlers="120" type="round-rect">
+        <fill>
+          <fillColor color="rgba(74, 58, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="17" topLeftX="68" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="17" topLeftX="374" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="18" height="17" topLeftX="680" topLeftY="323" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="27" height="26" topLeftX="192" topLeftY="318" alpha="0.57" iconType="iconpark/Arrows/right.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="27" height="26" topLeftX="497" topLeftY="318" alpha="0.57" iconType="iconpark/Arrows/right.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="9" height="9" topLeftX="250" topLeftY="96" rotation="90" alpha="0.25" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(74, 58, 255, 1)" width="48" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="51" height="3" topLeftX="399" topLeftY="167" rotation="90" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(85, 70, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="2" height="2" topLeftX="424" topLeftY="142" rotation="90" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 70, 255, 1)" width="6" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="HprTbjNtso2te1x1aeTcPX20nf3" width="6" height="16" topLeftX="365" topLeftY="153">
+        <crop type="rect" leftOffset="5" rightOffset="5" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="RobvbBHEuoLeC0xykEOcZLyxnvc" width="12" height="32" topLeftX="249" topLeftY="234">
+        <crop type="rect" leftOffset="10" rightOffset="10" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OnGsbbL9WoJEaXxSC2fcAbe0ntd" width="45" height="45" topLeftX="-137" topLeftY="450" rotation="90">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="D6xzbqzsPoerzOxZ4LScWdqqnqh" width="45" height="45" topLeftX="-183" topLeftY="495" rotation="180">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="OEVabGAm4ovOkBxVEm2crnGonsf" width="45" height="45" topLeftX="-137" topLeftY="495" rotation="180">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="TAtRbqzKRo7KDdxxKUQclqpgnHc" width="330" height="330" topLeftX="69" topLeftY="118">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="165"/>
+        <border color="rgba(85, 70, 255, 1)" width="6" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="450" height="44" topLeftX="98" topLeftY="26" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">Work Experience</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="88" height="44" topLeftX="26" topLeftY="26" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">工作经验</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="346" height="74" topLeftX="521" topLeftY="248" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="346" height="74" topLeftX="521" topLeftY="352" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="521" topLeftY="321" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">工作成果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="521" topLeftY="214" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">工作内容</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="521" topLeftY="108" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">20</span>
+            <span fontSize="16">XX.</span>
+            <span fontSize="16">06 - 20</span>
+            <span fontSize="16">XX</span>
+            <span fontSize="16">.09</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="265" height="64" topLeftX="521" topLeftY="140" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">XXX 公司</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="229" height="58" topLeftX="677" topLeftY="145" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(85, 70, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(85, 70, 255, 1)" fontSize="28">XXX 职位</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="NBfrbjlPPowUJDxiOgdcEopnn1e" width="45" height="45" topLeftX="0" topLeftY="225" rotation="270">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="N017bZZUqorDelxO9Etc9SZan02" width="45" height="45" topLeftX="45" topLeftY="225" rotation="90">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="TeoNbF4dSop7Dwxf3tTcb9yenOc" width="45" height="45" topLeftX="0" topLeftY="181">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="9" height="9" topLeftX="232" topLeftY="62" rotation="90" alpha="0.25" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(74, 58, 255, 1)" width="48" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="68" height="3" topLeftX="371" topLeftY="32" rotation="90" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(85, 70, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="4" height="4" topLeftX="403" topLeftY="15" rotation="90" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 70, 255, 1)" width="10" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="T5p7bfT95ohYBNxH2F6c72QKnWf" width="6" height="16" topLeftX="346" topLeftY="57">
+        <crop type="rect" leftOffset="5" rightOffset="5" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="AfoObqdupob16RxMaJRcyo6Inic" width="12" height="22" topLeftX="231" topLeftY="0.17">
+        <crop type="rect" leftOffset="10" rightOffset="10" topOffset="10" bottomOffset="0"/>
+      </img>
+      <img src="UWCjblpwzoiSndxEu2xccMosnBe" width="12" height="32" topLeftX="231" topLeftY="219">
+        <crop type="rect" leftOffset="10" rightOffset="10" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="YzOebhxZCobLClxUYs6c5HQvn3f" width="330" height="330" topLeftX="69" topLeftY="118" exposure="18" contrast="9" saturation="1" temperature="-38">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="82" bottomOffset="83" presetHandlers="165"/>
+        <border color="rgba(85, 70, 255, 1)" width="6" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="450" height="44" topLeftX="98" topLeftY="26" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">Work Experience</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="88" height="44" topLeftX="26" topLeftY="26" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">工作经验</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="346" height="74" topLeftX="521" topLeftY="248" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="346" height="74" topLeftX="521" topLeftY="352" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="521" topLeftY="321" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">工作成果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="521" topLeftY="214" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">工作内容</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="521" topLeftY="108" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>20XX.06 - 20XX.09</p>
+        </content>
+      </shape>
+      <shape width="265" height="64" topLeftX="521" topLeftY="140" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">XXX 公司</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="229" height="58" topLeftX="677" topLeftY="145" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(85, 70, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(85, 70, 255, 1)" fontSize="28">XXX 职位</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="9" height="9" topLeftX="701" topLeftY="60" rotation="90" alpha="0.25" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(74, 58, 255, 1)" width="48" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="33" height="6" topLeftX="802" topLeftY="12" rotation="90" presetHandlers="0" type="round-rect">
+        <fill>
+          <fillColor color="rgba(85, 70, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="4" height="4" topLeftX="816" topLeftY="29" rotation="90" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(85, 70, 255, 1)" width="6" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="DZlkbobKUogw8HxRQmrc3fx3nKN" width="24" height="44" topLeftX="466" topLeftY="-1">
+        <crop type="rect" leftOffset="19" rightOffset="21" topOffset="19" bottomOffset="0"/>
+      </img>
+      <img src="MUTvbkuy6oR7PExbw62c2pHGnNf" width="45" height="45" topLeftX="316" topLeftY="360" rotation="90">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="YQ5tbnfcnodAd8xhrTccqFNBnyc" width="45" height="45" topLeftX="271" topLeftY="404" rotation="180">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="XlOwbR4F9o6uNRxM4CXcy1Tlnoh" width="45" height="45" topLeftX="271" topLeftY="360" rotation="270">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="GbJzbWMtLo6Gk7x5L7bc1EK9nPe" width="330" height="330" topLeftX="69" topLeftY="118">
+        <crop type="rect" leftOffset="42" rightOffset="15" topOffset="57" bottomOffset="0" presetHandlers="165"/>
+        <border color="rgba(85, 70, 255, 1)" width="6" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="450" height="44" topLeftX="98" topLeftY="26" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">Work Experience</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="88" height="44" topLeftX="26" topLeftY="26" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">工作经验</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="346" height="74" topLeftX="521" topLeftY="248" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="346" height="74" topLeftX="521" topLeftY="352" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="521" topLeftY="321" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">工作成果</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="521" topLeftY="214" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">工作内容</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="44" topLeftX="521" topLeftY="108" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>20XX.06 - 20XX.09</p>
+        </content>
+      </shape>
+      <shape width="265" height="64" topLeftX="521" topLeftY="140" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span fontSize="32">XXX 公司</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="229" height="58" topLeftX="677" topLeftY="145" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(85, 70, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(85, 70, 255, 1)" fontSize="28">XXX 职位</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(85, 70, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="450" height="44" topLeftX="112" topLeftY="26" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">Cognition and Evaluation</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="102" height="44" topLeftX="26" topLeftY="26" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">认知与评价</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="392" height="68" topLeftX="23" topLeftY="75" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">岗位认知</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="380" height="56" topLeftX="187" topLeftY="84" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="150" height="150" topLeftX="346" topLeftY="195" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="60" height="60" topLeftX="391" topLeftY="240" iconType="iconpark/Charts/chart-proportion.svg">
+        <border color="rgba(74, 58, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="150" height="150" topLeftX="69" topLeftY="195" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="60" height="60" topLeftX="114" topLeftY="240" iconType="iconpark/Office/book-one.svg">
+        <border color="rgba(74, 58, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="150" height="150" topLeftX="623" topLeftY="195" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="60" height="60" topLeftX="668" topLeftY="240" iconType="iconpark/Office/new-picture.svg">
+        <border color="rgba(74, 58, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="202" height="110" topLeftX="43" topLeftY="398" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="38" topLeftX="43" topLeftY="361" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">关键</span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">点 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="110" topLeftX="320" topLeftY="398" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="38" topLeftX="320" topLeftY="361" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">关键</span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">点 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="110" topLeftX="597" topLeftY="398" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="38" topLeftX="597" topLeftY="361" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">关键</span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">点 #1</span>
+          </p>
+        </content>
+      </shape>
+      <img src="JVa3bMiqCojIrsx4F56cJwNBn9f" width="90" height="90" topLeftX="870" topLeftY="0.5">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="Dgz0bsmonob9Jfxp1Xwc2z1knMg" width="90" height="90" topLeftX="870" topLeftY="180" rotation="0">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="SBgQbcnR2o7vi5x5xDNclCaqnJb" width="90" height="90" topLeftX="870" topLeftY="90">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="H4w5b6KcxosvwuxlLGCcL7AlnXd" width="90" height="90" topLeftX="780" topLeftY="0" rotation="180">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(85, 70, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="450" height="44" topLeftX="112" topLeftY="26" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">Cognition and Evaluation</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="102" height="44" topLeftX="26" topLeftY="26" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">认知与评价</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="392" height="68" topLeftX="23" topLeftY="75" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">自我评价</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="TTQdbNekhoZ8SLxDaZdcgjmXnmc" width="416" height="428" topLeftX="544" topLeftY="112">
+        <crop type="rect" leftOffset="134" rightOffset="134" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="XRuDbxFzto8F4Ax1xG2cJMiDnBc" width="224" height="223" topLeftX="432" topLeftY="0.26" rotation="270">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="KzLUb3wtqoTeVYxMr2ic86lYnTe" width="112" height="112" topLeftX="848" topLeftY="0">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="374" height="92" topLeftX="26" topLeftY="143" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="42" topLeftX="38" topLeftY="349" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(74, 58, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(74, 58, 255, 1)" fontSize="16">标签 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="42" topLeftX="185" topLeftY="349" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(74, 58, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(74, 58, 255, 1)" fontSize="16">标签 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="374" height="92" topLeftX="26" topLeftY="238" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="450" height="44" topLeftX="98" topLeftY="26" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="16">Future Planning</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="88" height="44" topLeftX="26" topLeftY="26" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="16">未来规划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="365" startY="206" endX="699" endY="204" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="365" startY="362" endX="699" endY="362" alpha="0.15">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="343" height="74" topLeftX="360" topLeftY="414" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="351" height="44" topLeftX="360" topLeftY="380" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">发挥兴趣与长处，提升团队氛围</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="249" topLeftY="398" type="slides-block-arc">
+        <fill>
+          <fillColor color="rgba(74, 58, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="72" height="68" topLeftX="282" topLeftY="380" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="32">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="343" height="74" topLeftX="360" topLeftY="268" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="215" height="44" topLeftX="360" topLeftY="237" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">提升沟通效率</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="71" height="74" topLeftX="249" topLeftY="257" type="slides-block-arc">
+        <fill>
+          <fillColor color="rgba(74, 58, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="72" height="68" topLeftX="282" topLeftY="237" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="32">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="351" height="74" topLeftX="355" topLeftY="114" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(43, 47, 54, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="351" height="44" topLeftX="355" topLeftY="84" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(31, 35, 41, 1)" fontSize="16">积累经验，形成沉淀</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="74" topLeftX="249" topLeftY="100" type="slides-block-arc">
+        <fill>
+          <fillColor color="rgba(74, 58, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="69" height="68" topLeftX="285" topLeftY="84" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true">
+          <p>
+            <strong>
+              <span fontSize="32">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="JNbobxKzsoiQydxNwSocCGGXn61" width="433" height="541" topLeftX="0" topLeftY="0">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="433" height="140" topLeftX="527" topLeftY="352" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(74, 58, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(74, 58, 255, 1)" fontSize="80">谢谢观赏</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="386" height="56" topLeftX="574" topLeftY="309" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>
+            <span fontSize="24">THANK YOU</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/personal--promotion_report.xml
+++ b/skills/lark-slides/references/templates/personal--promotion_report.xml
@@ -1,0 +1,1039 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>职位晋升汇报</title>
+  <theme>
+    <background>
+      <fillColor color="rgba(3, 3, 1, 1)"/>
+    </background>
+    <textStyles>
+      <title fontColor="rgba(255, 255, 255, 1)" fontSize="72"/>
+      <headline fontColor="rgba(255, 255, 255, 1)"/>
+      <sub-headline fontColor="rgba(255, 255, 255, 1)" fontSize="16"/>
+      <body fontColor="rgba(255, 255, 255, 1)" fontSize="14"/>
+      <caption fontColor="rgba(255, 255, 255, 1)"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="152" height="386" topLeftX="673" topLeftY="85" rotation="45" alpha="0.5" type="slides-full-round-rect">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="Pjxfb38TMocH5exF6NhctB9cneg" width="281" height="280" topLeftX="638" topLeftY="221" rotation="69">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="OCyQbv6jsozDmNxxLP3coVWBnJh" width="258" height="260" topLeftX="565" topLeftY="27" rotation="8">
+        <crop type="rect" leftOffset="2" rightOffset="2" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="Kj1Abq2yOoc4mVxI73Hc2DsVno0" width="131" height="131" topLeftX="814" topLeftY="376" rotation="285">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.36" bottomOffset="0.36" presetHandlers="0"/>
+      </img>
+      <img src="CkSDbsItwooxnSxkx9dcGcOinTe" width="131" height="128" topLeftX="787" topLeftY="45" rotation="344">
+        <crop type="rect" leftOffset="20" rightOffset="27" topOffset="36" bottomOffset="13" presetHandlers="0"/>
+      </img>
+      <img src="Gtuybw38moZuM1xew9kcFwDVnde" width="92" height="91" topLeftX="582" topLeftY="387">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="SbyJb8XExolUZpxTlVVcXJtnncr" width="59" height="59" topLeftX="826" topLeftY="196">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="LGThb65tmoqfJExzmZEciVaDnUc" width="131" height="131" topLeftX="567" topLeftY="222" rotation="250">
+        <crop type="rect" leftOffset="0.19" rightOffset="0.19" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="F1hobT5rOoXjgAxmK1sc3zm7nGe" width="74" height="74" topLeftX="736" topLeftY="11" rotation="330">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="470" height="128" topLeftX="53" topLeftY="328" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="72" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span fontSize="72">职位</span>
+            <span color="linear-gradient(90deg,rgba(121, 162, 255, 1) 0%,rgba(222, 189, 255, 1) 100%)" fontSize="72">晋升</span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="72">汇报</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="470" height="47" topLeftX="53" topLeftY="304" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">Promotion Report</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="470" height="47" topLeftX="53" topLeftY="432" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">2026-07-12</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="152" height="38" topLeftX="53" topLeftY="47" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">演讲人：李天</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="152" height="38" topLeftX="205" topLeftY="47" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">目标岗位：XXX</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="CkSDbsItwooxnSxkx9dcGcOinTe" width="282" height="177" topLeftX="678" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="105" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="Kj1Abq2yOoc4mVxI73Hc2DsVno0" width="257" height="168" topLeftX="0" topLeftY="372">
+        <crop type="rect" leftOffset="11" rightOffset="0" topOffset="0.74" bottomOffset="99" presetHandlers="0"/>
+      </img>
+      <shape width="125" height="77" topLeftX="165" topLeftY="100" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="linear-gradient(90deg,rgba(121, 162, 255, 1) 0%,rgba(222, 189, 255, 1) 100%)" bold="true">
+          <p>
+            <span color="linear-gradient(90deg,rgba(121, 162, 255, 1) 0%,rgba(222, 189, 255, 1) 100%)">目录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="328" height="77" topLeftX="257" topLeftY="100" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">CONTENTS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="125" height="41" topLeftX="201" topLeftY="203" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">基本情况</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="125" height="41" topLeftX="201" topLeftY="254" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">晋升优势</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="140" height="41" topLeftX="201" topLeftY="305" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">岗位认知</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="158" height="41" topLeftX="201" topLeftY="356" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">未来规划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="385" height="41" topLeftX="332" topLeftY="359" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>单击此处输入关于主题的简单介绍，为了更好的演示效果</p>
+        </content>
+      </shape>
+      <shape width="11" height="11" topLeftX="184" topLeftY="372" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <border color="linear-gradient(90deg,rgba(121, 162, 255, 1) 0%,rgba(222, 189, 255, 1) 100%)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="385" height="41" topLeftX="332" topLeftY="308" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>单击此处输入关于主题的简单介绍，为了更好的演示效果</p>
+        </content>
+      </shape>
+      <shape width="11" height="11" topLeftX="184" topLeftY="321" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <border color="linear-gradient(90deg,rgba(121, 162, 255, 1) 0%,rgba(222, 189, 255, 1) 100%)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="385" height="41" topLeftX="332" topLeftY="257" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>单击此处输入关于主题的简单介绍，为了更好的演示效果</p>
+        </content>
+      </shape>
+      <shape width="11" height="11" topLeftX="184" topLeftY="271" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <border color="linear-gradient(90deg,rgba(121, 162, 255, 1) 0%,rgba(222, 189, 255, 1) 100%)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="385" height="41" topLeftX="332" topLeftY="206" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>单击此处输入关于主题的简单介绍，为了更好的演示效果</p>
+        </content>
+      </shape>
+      <shape width="11" height="11" topLeftX="184" topLeftY="220" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <border color="linear-gradient(90deg,rgba(121, 162, 255, 1) 0%,rgba(222, 189, 255, 1) 100%)" width="4" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="624" startY="139" endX="499" endY="139" alpha="0.6">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="716" height="230" topLeftX="125" topLeftY="148" alpha="0.5" type="slides-full-round-rect">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="Gtuybw38moZuM1xew9kcFwDVnde" width="285" height="284" topLeftX="97" topLeftY="121">
+        <crop type="rect" leftOffset="0.29" rightOffset="0.29" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="404" height="68" topLeftX="382" topLeftY="260" alpha="0.6" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">单击此处输入你的正文，文字是您思想的提炼为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="77" topLeftX="382" topLeftY="193" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="38">基本情况</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="124" height="128" topLeftX="178" topLeftY="200" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="72" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>01</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="456" startY="48" endX="208" endY="48" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="110" height="41" topLeftX="98" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.651)" fontSize="14">Basic Status</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="87" height="41" topLeftX="26" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">基本情况</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Kj1Abq2yOoc4mVxI73Hc2DsVno0" width="164" height="92" topLeftX="709" topLeftY="448">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="72" presetHandlers="0"/>
+      </img>
+      <shape width="120" height="37" topLeftX="360" topLeftY="339" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">XXX 大学</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="37" topLeftX="360" topLeftY="301" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">硕士</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="37" topLeftX="143" topLeftY="376" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">山东</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="37" topLeftX="143" topLeftY="339" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">汉族</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="37" topLeftX="143" topLeftY="301" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">36岁</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="325" height="74" topLeftX="75" topLeftY="197" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。现在就开始打字吧。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="416" height="74" topLeftX="75" topLeftY="131" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="36">李天</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="37" topLeftX="75" topLeftY="301" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">年龄</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="37" topLeftX="75" topLeftY="339" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">民族</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="37" topLeftX="265" topLeftY="301" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">最高学历</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="48" topLeftX="75" topLeftY="371" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">籍贯</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="37" topLeftX="265" topLeftY="339" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">毕业学校</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="UcZQbVek7ojuEGx4PBtcKh2Knpf" width="310" height="310" topLeftX="525" topLeftY="115">
+        <crop type="rect" leftOffset="0.66" rightOffset="0.66" topOffset="0" bottomOffset="0" presetHandlers="216"/>
+      </img>
+      <img src="DviYbH0NJoReMUxZralchw1FnGd" width="284" height="141" topLeftX="567" topLeftY="0" flipX="true">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="141" bottomOffset="0" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="456" startY="48" endX="208" endY="48" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="110" height="41" topLeftX="90" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.651)" fontSize="14">Basic Status</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="41" topLeftX="26" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">基本情况</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+      <img src="Kj1Abq2yOoc4mVxI73Hc2DsVno0" width="164" height="81" topLeftX="748" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="82" bottomOffset="0.45" presetHandlers="0"/>
+      </img>
+      <img src="DviYbH0NJoReMUxZralchw1FnGd" width="238" height="118" topLeftX="50" topLeftY="422" flipY="true">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="118" bottomOffset="0" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="716" height="230" topLeftX="125" topLeftY="148" alpha="0.5" type="slides-full-round-rect">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="Gtuybw38moZuM1xew9kcFwDVnde" width="285" height="284" topLeftX="97" topLeftY="121">
+        <crop type="rect" leftOffset="0.29" rightOffset="0.29" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="404" height="68" topLeftX="382" topLeftY="260" alpha="0.6" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">单击此处输入你的正文，文字是您思想的提炼为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="77" topLeftX="382" topLeftY="193" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="38">晋升优势</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="124" height="128" topLeftX="178" topLeftY="200" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="72" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>02</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="456" startY="48" endX="208" endY="48" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="110" height="41" topLeftX="90" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.651)" fontSize="14">Advantages</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="41" topLeftX="26" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">晋升优势</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+      <shape width="333" height="62" topLeftX="35" topLeftY="176" alpha="0.6" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>单击此处输入你的正文，文字是您思想的提炼为了最终演示发布的良好效果</p>
+        </content>
+      </shape>
+      <shape width="404" height="77" topLeftX="35" topLeftY="109" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>核心能力</p>
+        </content>
+      </shape>
+      <img src="DPwGba8nVoEKBMx66cfc3ueindd" width="98" height="97" topLeftX="828" topLeftY="321" rotation="336">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="EmvubDGNHo8DPTxUGzTc7RNnnu5" width="147" height="92" topLeftX="840" topLeftY="28" rotation="270">
+        <crop type="rect" leftOffset="0" rightOffset="16" topOffset="0" bottomOffset="72" presetHandlers="0"/>
+      </img>
+      <img src="LvjMbSBWyoJAWbxLfx7cMd9snMh" width="264" height="175" topLeftX="-44" topLeftY="320" rotation="90" flipX="true" flipY="true">
+        <crop type="rect" leftOffset="20" rightOffset="0" topOffset="99" bottomOffset="8" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="456" startY="48" endX="208" endY="48" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="110" height="41" topLeftX="90" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.651)" fontSize="14">Advantages</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="41" topLeftX="26" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">晋升优势</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="884" height="411" topLeftX="38" topLeftY="84" presetHandlers="16" alpha="0.4" type="round-rect">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="Iu39bQRg9odR29xxCn0ceyoanph" width="278" height="368" topLeftX="60" topLeftY="106">
+        <crop type="rect" leftOffset="45" rightOffset="45" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="482" height="62" topLeftX="382" topLeftY="114" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p lineSpacing="multiple:1" letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="42">业务能力</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="176" height="41" topLeftX="382" topLeftY="191" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">Business capability</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="430" height="142" topLeftX="382" topLeftY="237" alpha="0.65" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1.7" letterSpacing="1">
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</span>
+          </p>
+          <p lineSpacing="multiple:1.7" letterSpacing="1"/>
+          <p lineSpacing="multiple:1.7" letterSpacing="1">
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Kj1Abq2yOoc4mVxI73Hc2DsVno0" width="164" height="81" topLeftX="748" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="82" bottomOffset="0.45" presetHandlers="0"/>
+      </img>
+      <img src="DviYbH0NJoReMUxZralchw1FnGd" width="223" height="111" topLeftX="381" topLeftY="429" flipY="true">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="111" bottomOffset="0" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="456" startY="48" endX="208" endY="48" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="132" height="41" topLeftX="90" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.651)" fontSize="14">Advantages</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="41" topLeftX="26" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">晋升优势</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="232" height="74" topLeftX="76" topLeftY="174" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 0.651)" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 0.651)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="44" topLeftX="164" topLeftY="134" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="right">
+          <p>关键点 #1</p>
+        </content>
+      </shape>
+      <shape width="144" height="44" topLeftX="408" topLeftY="371" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>关键点 #2</p>
+        </content>
+      </shape>
+      <shape width="232" height="74" topLeftX="636" topLeftY="174" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 0.651)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 0.651)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="44" topLeftX="636" topLeftY="134" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>关键点 #3</p>
+        </content>
+      </shape>
+      <shape width="285" height="74" topLeftX="337" topLeftY="406" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 0.651)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 0.651)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="205" topLeftX="376" topLeftY="124" alpha="0.4" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="72" height="72" topLeftX="350" topLeftY="134" presetHandlers="37" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(216, 216, 255, 1) 0%,rgba(171, 194, 255, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(29, 64, 126, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(29, 64, 126, 1)" fontSize="18">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="442" topLeftY="282" presetHandlers="37" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(216, 216, 255, 1) 0%,rgba(171, 194, 255, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(29, 64, 126, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(29, 64, 126, 1)" fontSize="18">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="538" topLeftY="137" presetHandlers="37" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(216, 216, 255, 1) 0%,rgba(171, 194, 255, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(29, 64, 126, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(29, 64, 126, 1)" fontSize="18">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="144" height="44" topLeftX="406" topLeftY="204" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>团队建设</p>
+        </content>
+      </shape>
+      <icon width="64" height="64" topLeftX="263" topLeftY="299" rotation="60" iconType="iconpark/Arrows/double-right.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="64" height="64" topLeftX="634" topLeftY="299" rotation="300" iconType="iconpark/Arrows/double-right.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="716" height="230" topLeftX="125" topLeftY="148" alpha="0.5" type="slides-full-round-rect">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="Gtuybw38moZuM1xew9kcFwDVnde" width="285" height="284" topLeftX="97" topLeftY="121">
+        <crop type="rect" leftOffset="0.29" rightOffset="0.29" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="404" height="68" topLeftX="382" topLeftY="260" alpha="0.6" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">单击此处输入你的正文，文字是您思想的提炼为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="77" topLeftX="382" topLeftY="193" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="38">岗位认知</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="124" height="128" topLeftX="178" topLeftY="200" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="72" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>03</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="456" startY="48" endX="208" endY="48" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="132" height="41" topLeftX="90" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.651)" fontSize="14">Job Awareness</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="41" topLeftX="26" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">岗位认知</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="456" startY="48" endX="208" endY="48" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="132" height="41" topLeftX="90" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.651)" fontSize="14">Job Awareness</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="41" topLeftX="26" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">岗位认知</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="SsUpbqOl3oLIkHxFZrLcciA3nze" width="278" height="368" topLeftX="265" topLeftY="104">
+        <crop type="rect" leftOffset="45" rightOffset="45" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="211" height="58" topLeftX="26" topLeftY="104" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="linear-gradient(135deg,rgba(216, 216, 255, 1) 0%,rgba(171, 194, 255, 1) 100%)" bold="true">
+          <p lineSpacing="multiple:1" letterSpacing="2">角色理解</p>
+        </content>
+      </shape>
+      <shape width="211" height="41" topLeftX="26" topLeftY="430" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>副标题说明</p>
+        </content>
+      </shape>
+      <shape width="330" height="163" topLeftX="583" topLeftY="117" alpha="0.65" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p lineSpacing="multiple:1.7" letterSpacing="1">
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</span>
+          </p>
+          <p lineSpacing="multiple:1.7" letterSpacing="1"/>
+          <p lineSpacing="multiple:1.7" letterSpacing="1">
+            <span fontSize="12">请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。请在此输入功能的亮点、价值等信息。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="Kj1Abq2yOoc4mVxI73Hc2DsVno0" width="164" height="81" topLeftX="518" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="82" bottomOffset="0.45" presetHandlers="0"/>
+      </img>
+      <img src="DviYbH0NJoReMUxZralchw1FnGd" width="223" height="111" topLeftX="748" topLeftY="429" flipY="true">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="111" bottomOffset="0" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="716" height="230" topLeftX="125" topLeftY="148" alpha="0.5" type="slides-full-round-rect">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="Gtuybw38moZuM1xew9kcFwDVnde" width="285" height="284" topLeftX="97" topLeftY="121">
+        <crop type="rect" leftOffset="0.29" rightOffset="0.29" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="404" height="68" topLeftX="382" topLeftY="260" alpha="0.6" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">单击此处输入你的正文，文字是您思想的提炼为了最终演示发布的良好效果</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="404" height="77" topLeftX="382" topLeftY="193" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="38">未来规划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="124" height="128" topLeftX="178" topLeftY="200" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="72" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>04</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="456" startY="48" endX="208" endY="48" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="132" height="41" topLeftX="90" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 0.651)" fontSize="14">Future Plan</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="81" height="41" topLeftX="26" topLeftY="27" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">未来规划</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="150" height="150" topLeftX="405" topLeftY="139" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(216, 216, 255, 1) 0%,rgba(171, 194, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="150" height="150" topLeftX="128" topLeftY="139" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(216, 216, 255, 1) 0%,rgba(171, 194, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="150" height="150" topLeftX="682" topLeftY="139" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(216, 216, 255, 1) 0%,rgba(171, 194, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="60" height="60" topLeftX="727" topLeftY="184" iconType="iconpark/Office/new-picture.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="60" height="60" topLeftX="173" topLeftY="184" iconType="iconpark/Office/book-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="60" height="60" topLeftX="450" topLeftY="184" iconType="iconpark/Charts/chart-proportion.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="202" height="110" topLeftX="102" topLeftY="342" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="38" topLeftX="102" topLeftY="305" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">关键</span>
+            </strong>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="110" topLeftX="379" topLeftY="342" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="38" topLeftX="379" topLeftY="305" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">关键</span>
+            </strong>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="110" topLeftX="656" topLeftY="342" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容描述相关的信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="38" topLeftX="656" topLeftY="305" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">关键</span>
+            </strong>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(3, 3, 1, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="152" height="386" topLeftX="673" topLeftY="85" rotation="45" alpha="0.5" type="slides-full-round-rect">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <img src="Pjxfb38TMocH5exF6NhctB9cneg" width="281" height="280" topLeftX="638" topLeftY="221" rotation="69">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="OCyQbv6jsozDmNxxLP3coVWBnJh" width="258" height="260" topLeftX="565" topLeftY="27" rotation="8">
+        <crop type="rect" leftOffset="2" rightOffset="2" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="Kj1Abq2yOoc4mVxI73Hc2DsVno0" width="131" height="131" topLeftX="814" topLeftY="376" rotation="285">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.36" bottomOffset="0.36" presetHandlers="0"/>
+      </img>
+      <img src="CkSDbsItwooxnSxkx9dcGcOinTe" width="131" height="128" topLeftX="787" topLeftY="45" rotation="344">
+        <crop type="rect" leftOffset="20" rightOffset="27" topOffset="36" bottomOffset="13" presetHandlers="0"/>
+      </img>
+      <img src="Gtuybw38moZuM1xew9kcFwDVnde" width="92" height="91" topLeftX="582" topLeftY="387">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="SbyJb8XExolUZpxTlVVcXJtnncr" width="59" height="59" topLeftX="826" topLeftY="196">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="LGThb65tmoqfJExzmZEciVaDnUc" width="131" height="131" topLeftX="567" topLeftY="222" rotation="250">
+        <crop type="rect" leftOffset="0.19" rightOffset="0.19" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="F1hobT5rOoXjgAxmK1sc3zm7nGe" width="74" height="74" topLeftX="736" topLeftY="11" rotation="330">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="470" height="128" topLeftX="53" topLeftY="328" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="72" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <span fontSize="72">感谢您的观看</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="470" height="47" topLeftX="53" topLeftY="304" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">Thanks For Your Time</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="470" height="47" topLeftX="53" topLeftY="432" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">2026-07-12</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/personal--self_intro.xml
+++ b/skills/lark-slides/references/templates/personal--self_intro.xml
@@ -1,0 +1,696 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>个人介绍-裂图重新上传</title>
+  <theme>
+    <background>
+      <fillColor color="rgba(248, 247, 246, 1)"/>
+    </background>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="80"/>
+      <headline fontColor="#000000FF" fontSize="28"/>
+      <sub-headline fontColor="#000000FF" fontSize="22"/>
+      <body fontColor="#000000FF"/>
+      <caption fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(248, 247, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="494" height="180" topLeftX="39" topLeftY="111" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(236, 145, 78, 1)">Self</span>
+          </p>
+          <p lineSpacing="multiple:1">Introduction</p>
+        </content>
+      </shape>
+      <shape width="250" height="62" topLeftX="39" topLeftY="289" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" bold="false">
+          <p>
+            <span bold="false">个人介绍</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="54" height="98" topLeftX="805" topLeftY="47" rotation="270" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(51, 71, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="98" height="98" topLeftX="534" topLeftY="398" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(23, 182, 156, 1)"/>
+        </fill>
+      </shape>
+      <shape width="98" height="98" topLeftX="534" topLeftY="300" rotation="270" type="round1rect">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+      </shape>
+      <img src="PwZDbqSihocHdFxyqlycMrfVnEc" width="250" height="373" topLeftX="631" topLeftY="122">
+        <crop type="round2diag-rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="290" height="41" topLeftX="39" topLeftY="455" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(128, 128, 128, 1)">
+          <p>关于你的一些小介绍文案</p>
+        </content>
+      </shape>
+      <shape width="180" height="180" topLeftX="541" topLeftY="32" type="donut">
+        <fill>
+          <fillColor color="rgba(250, 211, 85, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(51, 71, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="494" height="84" topLeftX="39" topLeftY="101" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(250, 211, 85, 1)" fontSize="64">Hello，</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="494" height="84" topLeftX="39" topLeftY="179" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(248, 247, 246, 1)" fontSize="64">我是 Monica</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="98" height="98" topLeftX="237" topLeftY="399" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(23, 182, 156, 1)"/>
+        </fill>
+      </shape>
+      <shape width="184" height="98" topLeftX="335" topLeftY="399" rotation="0" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(236, 145, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="196" height="196" topLeftX="41" topLeftY="301" type="donut">
+        <fill>
+          <fillColor color="rgba(250, 211, 85, 1)"/>
+        </fill>
+      </shape>
+      <shape width="72" height="72" topLeftX="433" topLeftY="412" type="pie">
+        <fill>
+          <fillColor color="rgba(248, 247, 246, 1)"/>
+        </fill>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(248, 247, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="612" height="92" topLeftX="174" topLeftY="291" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(128, 128, 128, 1)" textAlign="center">
+          <p>单击此处输入你的正文，文字是您思想的提炼，为了最终演示发布的良好效果，请尽量言简意赅的阐述观点；根据需要可酌情增减文字，以便观者可以准确理解您所传达的信息。</p>
+        </content>
+      </shape>
+      <shape width="612" height="116" topLeftX="174" topLeftY="176" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(236, 145, 78, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>职业设计师</p>
+        </content>
+      </shape>
+      <shape width="612" height="53" topLeftX="174" topLeftY="142" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true" textAlign="center">
+          <p>我是一个</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(248, 247, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <undefined type="fallback"/>
+      <shape width="612" height="53" topLeftX="174" topLeftY="70" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="22" bold="true" textAlign="center">
+          <p>我的作品</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(51, 71, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="494" height="84" topLeftX="39" topLeftY="97" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(248, 247, 246, 1)" fontSize="64">我的职业生涯</span>
+          </p>
+        </content>
+      </shape>
+      <table topLeftX="50" topLeftY="307">
+        <colgroup>
+          <col span="3" width="290"/>
+        </colgroup>
+        <tr height="62">
+          <td>
+            <borderTop color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="28">01</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="28">02</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="28">03</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="43">
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="16">关键节点 #1</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+              <p>关键节点 #2</p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+              <p>关键节点 #3</p>
+            </content>
+          </td>
+        </tr>
+        <tr height="62">
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 0.659)" textAlign="left">
+              <p>
+                <span color="rgba(255, 255, 255, 0.659)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 0.659)" textAlign="left">
+              <p>
+                <span color="rgba(255, 255, 255, 0.659)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+            <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 0.659)" textAlign="left">
+              <p>
+                <span color="rgba(255, 255, 255, 0.659)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+      </table>
+      <shape width="60" height="60" topLeftX="660" topLeftY="190" rotation="270" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="98" height="98" topLeftX="724" topLeftY="54" type="donut">
+        <fill>
+          <fillColor color="rgba(236, 145, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="201" height="98" topLeftX="720" topLeftY="151" rotation="0" presetHandlers="49" type="round-rect">
+        <fill>
+          <fillColor color="rgba(23, 182, 156, 1)"/>
+        </fill>
+      </shape>
+      <shape width="98" height="98" topLeftX="822" topLeftY="54" rotation="0" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(250, 211, 85, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(248, 247, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="465" height="85" topLeftX="39" topLeftY="95" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(31, 35, 41, 1)" fontSize="54">我获得的</span>
+            <span fontSize="54"> </span>
+            <span color="rgba(236, 145, 78, 1)" fontSize="54">XXX</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="361" height="104" topLeftX="39" topLeftY="180" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(128, 128, 128, 1)" textAlign="left">
+          <p>单击此处输入你的正文，文字是您思想的提炼，为了最终演示发布的良好效果，请尽量言简意赅的阐述观点；根据需要可酌情增减文字，以便观者可以准确理解您所传达的信息。</p>
+        </content>
+      </shape>
+      <img src="AwuPblzvMoG7Huxr1HdcqoeFn5c" width="338" height="393" topLeftX="578" topLeftY="87" contrast="-20" saturation="-14">
+        <crop type="round2diag-rect" leftOffset="23" rightOffset="3" topOffset="85" bottomOffset="67"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(248, 247, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="98" height="98" topLeftX="601" topLeftY="403" rotation="270" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(23, 182, 156, 1)"/>
+        </fill>
+      </shape>
+      <shape width="196" height="196" topLeftX="699" topLeftY="305" type="slides-block-arc">
+        <fill>
+          <fillColor color="rgba(250, 211, 85, 1)"/>
+        </fill>
+      </shape>
+      <shape width="98" height="98" topLeftX="810" topLeftY="293" rotation="270" type="ellipse">
+        <fill>
+          <fillColor color="rgba(216, 57, 49, 1)"/>
+        </fill>
+      </shape>
+      <shape width="98" height="98" topLeftX="601" topLeftY="305" rotation="180" type="round1rect">
+        <fill>
+          <fillColor color="rgba(51, 71, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="465" height="150" topLeftX="39" topLeftY="347" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(31, 35, 41, 1)" fontSize="54">除了是个设计师，</span>
+          </p>
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(31, 35, 41, 1)" fontSize="54">我还是</span>
+            <span fontSize="54"> </span>
+            <span color="rgba(236, 145, 78, 1)" fontSize="54">XXX</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="262" height="160" topLeftX="58" topLeftY="94" type="rect">
+        <border color="rgba(128, 128, 128, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="171" height="42" topLeftX="133" topLeftY="112" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="18">职业技能 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="83" topLeftX="70" topLeftY="156" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(128, 128, 128, 1)" textAlign="left">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="60" height="62" topLeftX="78" topLeftY="102" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" bold="true" textAlign="left">
+          <p>01</p>
+        </content>
+      </shape>
+      <shape width="262" height="160" topLeftX="339" topLeftY="94" type="rect">
+        <border color="rgba(128, 128, 128, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="171" height="42" topLeftX="413" topLeftY="112" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">职业技能 #2</p>
+        </content>
+      </shape>
+      <shape width="231" height="83" topLeftX="350" topLeftY="156" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(128, 128, 128, 1)" textAlign="left">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="60" height="62" topLeftX="358" topLeftY="102" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" bold="true" textAlign="left">
+          <p>02</p>
+        </content>
+      </shape>
+      <shape width="262" height="160" topLeftX="619" topLeftY="94" type="rect">
+        <border color="rgba(128, 128, 128, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="171" height="42" topLeftX="693" topLeftY="112" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">职业技能 #3</p>
+        </content>
+      </shape>
+      <shape width="231" height="83" topLeftX="630" topLeftY="156" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(128, 128, 128, 1)" textAlign="left">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="60" height="62" topLeftX="638" topLeftY="102" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(31, 35, 41, 1)" bold="true" textAlign="left">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">03</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(51, 71, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="300" height="135" topLeftX="39" topLeftY="104" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)" fontSize="48">如何与客户进行相处</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="98" height="98" topLeftX="53" topLeftY="389" rotation="270" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(23, 182, 156, 1)"/>
+        </fill>
+      </shape>
+      <shape width="166" height="166" topLeftX="151" topLeftY="293" rotation="90" type="slides-block-arc">
+        <fill>
+          <fillColor color="rgba(250, 211, 85, 1)"/>
+        </fill>
+      </shape>
+      <shape width="98" height="98" topLeftX="248" topLeftY="389" rotation="270" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="98" height="98" topLeftX="248" topLeftY="389" rotation="270" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(236, 145, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="64" height="64" topLeftX="423" topLeftY="130" presetHandlers="32" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="45" height="45" topLeftX="432" topLeftY="140" iconType="iconpark/Office/application-effect.svg">
+        <border width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="171" height="42" topLeftX="506" topLeftY="142" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">步骤 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="83" topLeftX="414" topLeftY="202" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 0.659)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 0.659)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="64" height="64" topLeftX="679" topLeftY="130" type="rect">
+        <fill>
+          <fillColor color="rgba(250, 211, 85, 1)"/>
+        </fill>
+      </shape>
+      <icon width="45" height="45" topLeftX="689" topLeftY="140" iconType="iconpark/Base/home.svg">
+        <border width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="171" height="42" topLeftX="762" topLeftY="142" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">步骤 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="83" topLeftX="670" topLeftY="202" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 0.659)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 0.659)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="64" height="64" topLeftX="426" topLeftY="305" type="rect">
+        <fill>
+          <fillColor color="rgba(250, 211, 85, 1)"/>
+        </fill>
+      </shape>
+      <icon width="45" height="45" topLeftX="436" topLeftY="314" iconType="iconpark/Charts/chart-line.svg">
+        <border width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="171" height="42" topLeftX="509" topLeftY="316" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">步骤 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="83" topLeftX="417" topLeftY="376" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 0.659)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 0.659)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="64" height="64" topLeftX="683" topLeftY="305" presetHandlers="32" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="45" height="45" topLeftX="692" topLeftY="314" iconType="iconpark/Office/mail-open.svg">
+        <border width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="171" height="42" topLeftX="765" topLeftY="316" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">步骤 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="83" topLeftX="673" topLeftY="376" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 0.659)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 0.659)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(51, 71, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="297" height="135" topLeftX="39" topLeftY="104" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)" fontSize="48">承担对客户的相关责任</span>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+      <shape width="98" height="98" topLeftX="53" topLeftY="389" rotation="270" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(23, 182, 156, 1)"/>
+        </fill>
+      </shape>
+      <shape width="166" height="166" topLeftX="151" topLeftY="293" rotation="90" type="slides-block-arc">
+        <fill>
+          <fillColor color="rgba(250, 211, 85, 1)"/>
+        </fill>
+      </shape>
+      <shape width="98" height="98" topLeftX="248" topLeftY="389" rotation="270" type="round1rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="98" height="98" topLeftX="248" topLeftY="389" rotation="270" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(236, 145, 78, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(248, 247, 246, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="465" height="150" topLeftX="32" topLeftY="88" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(31, 35, 41, 1)" fontSize="54">与我合作客户的</span>
+          </p>
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(236, 145, 78, 1)" fontSize="54">成功案例</span>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+      <shape width="361" height="41" topLeftX="42" topLeftY="233" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(128, 128, 128, 1)" textAlign="left">
+          <p>描述相关的信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="465" height="198" topLeftX="462" topLeftY="297" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <img src="UIgDbcJqPolTRvx8sh3czFBvnWg" width="465" height="198" topLeftX="462" topLeftY="297">
+        <crop type="rect" leftOffset="20" rightOffset="0" topOffset="267" bottomOffset="20" presetHandlers="0"/>
+      </img>
+      <img src="QdDebJmlloLN54xhKPac2WGrngb" width="465" height="198" topLeftX="462" topLeftY="81">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="133" bottomOffset="133" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(51, 71, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="494" height="84" topLeftX="39" topLeftY="101" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(250, 211, 85, 1)" fontSize="64">Thanks</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="494" height="84" topLeftX="39" topLeftY="179" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(255, 255, 255, 1)">感谢你的观看</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="98" height="98" topLeftX="237" topLeftY="399" type="rt-triangle">
+        <fill>
+          <fillColor color="rgba(23, 182, 156, 1)"/>
+        </fill>
+      </shape>
+      <shape width="184" height="98" topLeftX="335" topLeftY="399" rotation="0" type="round2diag-rect">
+        <fill>
+          <fillColor color="rgba(236, 145, 78, 1)"/>
+        </fill>
+      </shape>
+      <shape width="196" height="196" topLeftX="41" topLeftY="301" type="donut">
+        <fill>
+          <fillColor color="rgba(250, 211, 85, 1)"/>
+        </fill>
+      </shape>
+      <shape width="72" height="72" topLeftX="433" topLeftY="412" type="pie">
+        <fill>
+          <fillColor color="rgba(248, 247, 246, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/personal--teaching_sharing.xml
+++ b/skills/lark-slides/references/templates/personal--teaching_sharing.xml
@@ -1,0 +1,3013 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>分享教学</title>
+  <theme>
+    <textStyles>
+      <headline fontColor="rgba(31, 35, 41, 1)"/>
+      <sub-headline fontColor="rgba(31, 35, 41, 1)"/>
+      <body fontColor="rgba(31, 35, 41, 1)"/>
+      <caption fontColor="rgba(155, 158, 162, 1)" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="SwAKbuO1eo4Ji0xidOaczphQnYe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Qa68bQwVwovvwuxshKXcZY5hnYe" width="16" height="16" topLeftX="50" topLeftY="331">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="O0QYbtA2fohO9zxctNNcuKGpnoh" width="16" height="16" topLeftX="50" topLeftY="364">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="435" height="22" topLeftX="74" topLeftY="362" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>
+            分享时间：
+            <span fontFamily="Arial">2026.XX.XX</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="435" height="21" topLeftX="74" topLeftY="328" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>分享人：XX</p>
+        </content>
+      </shape>
+      <shape width="436" height="102" topLeftX="50" topLeftY="200" type="text">
+        <content textType="title" fontSize="68" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true">
+          <p>分享教学课件</p>
+        </content>
+      </shape>
+      <shape width="182" height="36" topLeftX="50" topLeftY="159" type="text">
+        <content textType="title" fontSize="36" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="36" fontFamily="思源黑体">市场研究</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="207" startY="165" endX="207" endY="189">
+        <border color="linear-gradient(180deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="215" height="39" topLeftX="219" topLeftY="158" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(26, 26, 27, 1)" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span fontFamily="Arial">Market </span>
+            <span color="rgba(26, 26, 27, 1)" fontFamily="Arial"> Research</span>
+          </p>
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(26, 26, 27, 1)" fontFamily="Arial">Sharing Teaching Courseware</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="20" height="20" topLeftX="50" topLeftY="52" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(55, 93, 224, 1) 0%,rgba(130, 148, 238, 1) 47%,rgba(209, 164, 147, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="104" height="24" topLeftX="79" topLeftY="50" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(26, 26, 27, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(26, 26, 27, 1)" fontFamily="Arial">YOUR LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="FLkJbMHBwolKvIxgyGZc5LLXnVV" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="154" height="32" topLeftX="403" topLeftY="137" type="text">
+        <content textType="title" fontSize="32" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(26, 26, 27, 1)" fontSize="32" fontFamily="思源黑体">目录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="154" height="24" topLeftX="403" topLeftY="106" alpha="0.4" type="text">
+        <content textType="title" fontSize="24" fontFamily="Inter" color="rgba(35, 72, 197, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p>
+            <span color="rgba(35, 72, 197, 1)" fontSize="24" fontFamily="Inter" bold="false">Content</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="260" topLeftX="41" topLeftY="193" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="112" height="32" topLeftX="59" topLeftY="209" type="text">
+        <content fontSize="32" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" italic="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(35, 72, 197, 1)" fontSize="32" fontFamily="Arial Black">01.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <line startX="219" startY="258" endX="63" endY="258">
+        <border color="linear-gradient(271deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 0.11) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="200" height="260" topLeftX="267" topLeftY="193" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="112" height="32" topLeftX="285" topLeftY="209" type="text">
+        <content fontSize="32" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" italic="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(35, 72, 197, 1)" fontSize="32" fontFamily="Arial Black">02.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <line startX="445" startY="258" endX="289" endY="258">
+        <border color="linear-gradient(271deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 0.11) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="200" height="260" topLeftX="493" topLeftY="193" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="112" height="32" topLeftX="511" topLeftY="209" type="text">
+        <content fontSize="32" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" italic="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(35, 72, 197, 1)" fontSize="32" fontFamily="Arial Black">03.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <line startX="671" startY="258" endX="515" endY="258">
+        <border color="linear-gradient(271deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 0.11) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="200" height="260" topLeftX="719" topLeftY="193" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="112" height="32" topLeftX="737" topLeftY="209" type="text">
+        <content fontSize="32" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" italic="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(35, 72, 197, 1)" fontSize="32" fontFamily="Arial Black">04.</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <line startX="897" startY="258" endX="741" endY="258">
+        <border color="linear-gradient(271deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 0.11) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="156" height="105" topLeftX="741" topLeftY="328" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="154" height="24" topLeftX="741" topLeftY="294" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>内容总结</p>
+        </content>
+      </shape>
+      <shape width="156" height="105" topLeftX="515" topLeftY="328" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="154" height="24" topLeftX="515" topLeftY="294" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>流程经验</p>
+        </content>
+      </shape>
+      <shape width="156" height="105" topLeftX="289" topLeftY="328" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="154" height="24" topLeftX="289" topLeftY="294" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>案例分析</p>
+        </content>
+      </shape>
+      <shape width="156" height="105" topLeftX="63" topLeftY="328" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="154" height="24" topLeftX="63" topLeftY="294" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="思源黑体" color="rgba(31, 35, 41, 1)" bold="true">
+          <p textAlign="left">基本介绍</p>
+        </content>
+      </shape>
+      <shape width="112" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="24" fontFamily="思源黑体">市场研究</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="157" startY="54" endX="157" endY="70">
+        <border color="linear-gradient(180deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="121" height="24" topLeftX="168" topLeftY="50" type="text">
+        <content fontSize="8" fontFamily="Arial" color="rgba(26, 26, 27, 1)">
+          <p>
+            <span fontFamily="Arial">Market  Research</span>
+          </p>
+          <p>
+            <span color="rgba(26, 26, 27, 1)" fontSize="8" fontFamily="Arial">Sharing Teaching Courseware</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Evgybt8w4ozD5rxJxCHcRmVunLc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="63" topLeftX="319" topLeftY="329" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="328" height="54" topLeftX="317" topLeftY="258" type="text">
+        <content textType="title" fontSize="36" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p textAlign="center">基本介绍</p>
+        </content>
+      </shape>
+      <shape width="200" height="120" topLeftX="380" topLeftY="128" type="text">
+        <content textType="title" fontSize="80" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" bold="true" italic="true">
+          <p textAlign="center">01.</p>
+        </content>
+      </shape>
+      <shape width="328" height="24" topLeftX="316" topLeftY="240" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)">
+          <p textAlign="center">Basic Introduction</p>
+        </content>
+      </shape>
+      <shape width="112" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="24" fontFamily="思源黑体">市场研究</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="157" startY="54" endX="157" endY="70">
+        <border color="linear-gradient(180deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="121" height="24" topLeftX="168" topLeftY="50" type="text">
+        <content fontSize="8" fontFamily="Arial" color="rgba(26, 26, 27, 1)">
+          <p>
+            <span fontFamily="Arial">Market  Research</span>
+          </p>
+          <p>
+            <span color="rgba(26, 26, 27, 1)" fontSize="8" fontFamily="Arial">Sharing Teaching Courseware</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IDpGbp2oloFzylx8CGTcRSI6ngb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="24" topLeftX="50" topLeftY="47" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="left">
+          <p>What Are We</p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="50" topLeftY="68" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p textAlign="left">我们是什么</p>
+        </content>
+      </shape>
+      <img src="HjMZbCWw0o9BbYxX7AZctHLeny5" width="876" height="252" topLeftX="44" topLeftY="262">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <reflection alpha="0.28" offset="7" size="0.31"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="124" bottomOffset="124" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="231" height="96" topLeftX="106" topLeftY="139" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="81" height="16" topLeftX="181" topLeftY="155" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="思源黑体" italic="false">标题文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="189" height="42" topLeftX="127" topLeftY="181" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="96" topLeftX="365" topLeftY="139" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="81" height="16" topLeftX="439" topLeftY="155" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="思源黑体" italic="false">标题文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="189" height="42" topLeftX="385" topLeftY="181" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="96" topLeftX="623" topLeftY="139" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="81" height="16" topLeftX="698" topLeftY="155" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="思源黑体" italic="false">标题文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="189" height="42" topLeftX="644" topLeftY="181" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IDpGbp2oloFzylx8CGTcRSI6ngb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="24" topLeftX="50" topLeftY="47" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="left">
+          <p>Study Goals</p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="50" topLeftY="68" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p textAlign="left">学习目标</p>
+        </content>
+      </shape>
+      <shape width="202" height="16" topLeftX="45" topLeftY="360" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span fontSize="16" fontFamily="思源黑体" italic="false">目标文案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="63" topLeftX="45" topLeftY="390" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="146" startY="299" endX="146" endY="348">
+        <border color="rgba(130, 167, 252, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <endArrow type="solid-circle"/>
+      </line>
+      <shape width="202" height="16" topLeftX="268" topLeftY="360" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span fontSize="16" fontFamily="思源黑体" italic="false">目标文案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="63" topLeftX="268" topLeftY="390" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="368" startY="299" endX="368" endY="348">
+        <border color="rgba(130, 167, 252, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <endArrow type="solid-circle"/>
+      </line>
+      <shape width="202" height="16" topLeftX="491" topLeftY="360" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span fontSize="16" fontFamily="思源黑体" italic="false">目标文案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="63" topLeftX="491" topLeftY="390" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="592" startY="299" endX="592" endY="348">
+        <border color="rgba(130, 167, 252, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <endArrow type="solid-circle"/>
+      </line>
+      <shape width="202" height="16" topLeftX="714" topLeftY="360" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span fontSize="16" fontFamily="思源黑体" italic="false">目标文案</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="63" topLeftX="714" topLeftY="390" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="815" startY="299" endX="815" endY="348">
+        <border color="rgba(130, 167, 252, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+        <endArrow type="solid-circle"/>
+      </line>
+      <shape width="150" height="150" topLeftX="71" topLeftY="149" presetHandlers="75" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <img src="Iirfb1UeFoR60MxjcleckDULn4e" width="136" height="137" topLeftX="78" topLeftY="155" exposure="7" contrast="24" saturation="19" temperature="-100">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0.48" rightOffset="0.48" topOffset="0" bottomOffset="0" presetHandlers="68"/>
+      </img>
+      <shape width="150" height="150" topLeftX="293" topLeftY="149" presetHandlers="75" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <img src="MQvTbj4EUowgJhxplRNcMVZEnPc" width="137" height="137" topLeftX="300" topLeftY="155" exposure="7" contrast="24" saturation="19" temperature="-100">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="69"/>
+      </img>
+      <shape width="150" height="150" topLeftX="517" topLeftY="149" presetHandlers="75" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <img src="NNJfbaMo8obRtxx8aMQcTNeRnZb" width="137" height="137" topLeftX="523" topLeftY="155" exposure="7" contrast="24" saturation="19" temperature="-100">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="69"/>
+      </img>
+      <shape width="150" height="150" topLeftX="740" topLeftY="149" presetHandlers="75" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <img src="UYtmbLfaQoeHPXxo0kccpbsKn2f" width="137" height="137" topLeftX="746" topLeftY="155" exposure="7" contrast="24" saturation="19" temperature="-100">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="69"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="SLs4b5CQvon6gMx1SSicNX4Mnaf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="CAHfbEIULowDeWxKr9kc1XIknGf" width="732" height="624" topLeftX="260" topLeftY="-42">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="26" bottomOffset="26" presetHandlers="30"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="440" height="129" topLeftX="40" topLeftY="50" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.92)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="154" height="16" topLeftX="59" topLeftY="72" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">
+            案例故事
+            <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="思源黑体" italic="false">标题文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="402" height="63" topLeftX="59" topLeftY="95" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="440" height="129" topLeftX="40" topLeftY="205" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.92)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="154" height="16" topLeftX="59" topLeftY="227" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">案例故事标题文案</p>
+        </content>
+      </shape>
+      <shape width="402" height="63" topLeftX="59" topLeftY="250" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="105" topLeftX="40" topLeftY="385" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="20" height="20" topLeftX="786" topLeftY="52" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(55, 93, 224, 1) 0%,rgba(130, 148, 238, 1) 47%,rgba(209, 164, 147, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="104" height="24" topLeftX="815" topLeftY="50" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(26, 26, 27, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(26, 26, 27, 1)" fontFamily="Arial">YOUR LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="591" topLeftY="463" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="right">
+          <p textAlign="right">案例故事</p>
+        </content>
+      </shape>
+      <shape width="328" height="24" topLeftX="591" topLeftY="443" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="right">
+          <p textAlign="right">Case Stories</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IDpGbp2oloFzylx8CGTcRSI6ngb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="24" topLeftX="50" topLeftY="47" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="left">
+          <p>General Introduction</p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="50" topLeftY="68" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p textAlign="left">基本介绍</p>
+        </content>
+      </shape>
+      <shape width="185" height="84" topLeftX="316" topLeftY="117" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="112" height="21" topLeftX="334" topLeftY="134" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">公司已完成</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="112" height="30" topLeftX="334" topLeftY="155" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(35, 72, 197, 1)" fontSize="20">F 轮融资</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="185" height="84" topLeftX="526" topLeftY="117" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="112" height="21" topLeftX="544" topLeftY="134" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">总融资金额</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="112" height="30" topLeftX="544" topLeftY="155" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(35, 72, 197, 1)" fontSize="20">超 3 亿元</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="185" height="84" topLeftX="735" topLeftY="117" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="112" height="21" topLeftX="753" topLeftY="134" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">公司估值</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="112" height="30" topLeftX="753" topLeftY="155" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true">
+          <p>
+            <span color="rgba(35, 72, 197, 1)">超 10 亿元</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="882" height="267" topLeftX="39" topLeftY="228" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.88)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="32" angle="90" blur="42" color="rgba(19, 42, 119, 0.12)"/>
+      </shape>
+      <shape width="846" height="45" topLeftX="58" topLeftY="246" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="846" height="45" topLeftX="58" topLeftY="292" presetHandlers="0" type="round-rect"/>
+      <shape width="846" height="45" topLeftX="58" topLeftY="337" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(222, 224, 227, 0.21)"/>
+        </fill>
+      </shape>
+      <shape width="846" height="45" topLeftX="58" topLeftY="382" presetHandlers="0" type="round-rect"/>
+      <shape width="846" height="45" topLeftX="58" topLeftY="428" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(222, 224, 227, 0.21)"/>
+        </fill>
+      </shape>
+      <shape width="80" height="21" topLeftX="197" topLeftY="257" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">A轮</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="197" topLeftY="302" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(26, 26, 27, 1)" fontSize="14" bold="false">2012.12</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="197" topLeftY="348" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(26, 26, 27, 1)" fontSize="14" bold="false">500万元</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="197" topLeftY="393" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">xx</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="197" topLeftY="438" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(26, 26, 27, 1)" fontSize="14" bold="false">--</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="318" topLeftY="257" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">B轮</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="318" topLeftY="302" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">2015.08</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="318" topLeftY="348" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">1000万元</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="318" topLeftY="393" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">xx</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="318" topLeftY="438" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">2000万元</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="438" topLeftY="257" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">C轮</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="438" topLeftY="302" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(26, 26, 27, 1)" fontSize="14" bold="false">2016.11</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="438" topLeftY="348" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">2000万元</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="438" topLeftY="393" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">xx</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="438" topLeftY="438" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">5000万元</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="558" topLeftY="257" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">D轮</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="558" topLeftY="302" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(26, 26, 27, 1)" fontSize="14" bold="false">2020.01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="558" topLeftY="348" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">5000万元</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="558" topLeftY="393" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">xx</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="558" topLeftY="438" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(26, 26, 27, 1)" fontSize="14" bold="false">--</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="679" topLeftY="257" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">E轮</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="679" topLeftY="302" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(26, 26, 27, 1)" fontSize="14" bold="false">2021.09</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="679" topLeftY="348" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">8000万元</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="679" topLeftY="393" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">xx</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="679" topLeftY="438" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(26, 26, 27, 1)" fontSize="14" bold="false">--</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="799" topLeftY="257" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">F轮</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="799" topLeftY="302" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(26, 26, 27, 1)" fontSize="14" bold="false">2024.01</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="799" topLeftY="348" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(26, 26, 27, 1)" fontSize="14" bold="false">&gt;亿元</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="799" topLeftY="393" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="14">xx</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="799" topLeftY="438" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(26, 26, 27, 1)" fontSize="14" bold="false">10 亿</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="84" topLeftY="302" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">融资时间</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="84" topLeftY="348" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">融资金额</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="84" topLeftY="393" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">投资机构</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="21" topLeftX="84" topLeftY="438" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="14">估值金额</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="122" height="281" topLeftX="782" topLeftY="214" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(55, 93, 224, 1) 0%,rgba(130, 148, 238, 1) 47%,rgba(209, 164, 147, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="80" height="24" topLeftX="803" topLeftY="253" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">F轮</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="24" topLeftX="803" topLeftY="299" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">2024.01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="24" topLeftX="803" topLeftY="344" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">&gt;亿元</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="24" topLeftX="803" topLeftY="389" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">xx</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="80" height="24" topLeftX="803" topLeftY="435" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">10 亿</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Evgybt8w4ozD5rxJxCHcRmVunLc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="63" topLeftX="319" topLeftY="329" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="328" height="54" topLeftX="317" topLeftY="258" type="text">
+        <content textType="title" fontSize="36" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p textAlign="center">案例分析</p>
+        </content>
+      </shape>
+      <shape width="200" height="120" topLeftX="380" topLeftY="128" type="text">
+        <content textType="title" fontSize="80" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" bold="true" italic="true">
+          <p textAlign="center">02.</p>
+        </content>
+      </shape>
+      <shape width="328" height="24" topLeftX="316" topLeftY="240" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)">
+          <p textAlign="center">Case Analysis</p>
+        </content>
+      </shape>
+      <shape width="112" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="24" fontFamily="思源黑体">市场研究</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="157" startY="54" endX="157" endY="70">
+        <border color="linear-gradient(180deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="121" height="24" topLeftX="168" topLeftY="50" type="text">
+        <content fontSize="8" fontFamily="Arial" color="rgba(26, 26, 27, 1)">
+          <p>
+            <span fontFamily="Arial">Market  Research</span>
+          </p>
+          <p>
+            <span color="rgba(26, 26, 27, 1)" fontSize="8" fontFamily="Arial">Sharing Teaching Courseware</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="HAcGbNfAhobfpVxdV91cf8d0nah" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="304" height="352" topLeftX="328" topLeftY="154" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <img src="APHJbhO1QoRybgxqFamcyaBanjg" width="258" height="222" topLeftX="351" topLeftY="118">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="18" bottomOffset="18" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="154" height="16" topLeftX="351" topLeftY="371" type="text">
+        <content textType="title" fontSize="16" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" bold="true" italic="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">
+            <em>
+              <span fontFamily="Arial Black">Demo.2</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="226" height="300" topLeftX="65" topLeftY="206" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <img src="MVkCbeCutokf19xwlRRcMD1Jneh" width="180" height="162" topLeftX="89" topLeftY="178">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="9" bottomOffset="9" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="154" height="16" topLeftX="88" topLeftY="371" type="text">
+        <content textType="title" fontSize="16" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" bold="true" italic="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="Arial Black">Demo.1</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="226" height="300" topLeftX="668" topLeftY="206" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <img src="N86xbBulgoWWAFxI5wicNkMlnM9" width="180" height="162" topLeftX="692" topLeftY="178">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="9" bottomOffset="9" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="154" height="16" topLeftX="691" topLeftY="371" type="text">
+        <content textType="title" fontSize="16" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" bold="true" italic="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">
+            <em>
+              <span fontFamily="Arial Black">Demo.3</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="184" height="84" topLeftX="690" topLeftY="394" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="258" height="84" topLeftX="351" topLeftY="394" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="184" height="84" topLeftX="88" topLeftY="394" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <img src="PAFpb6Awlo4bUfxaGzZcxiKOn2d" width="180" height="162" topLeftX="692" topLeftY="178">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="9" bottomOffset="9" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 0.92)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="H9NCbs1BJoU2bSxc43YcPusknfc" width="258" height="222" topLeftX="351" topLeftY="118">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="18" bottomOffset="18" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 0.92)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="A2cVbieYkokSWExDGuwcjQtMndd" width="180" height="162" topLeftX="89" topLeftY="178">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="9" bottomOffset="9" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 0.92)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="328" height="24" topLeftX="316" topLeftY="47" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="center">
+          <p textAlign="center">Case Presentation</p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="316" topLeftY="68" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p textAlign="center">案例展示</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IDpGbp2oloFzylx8CGTcRSI6ngb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="24" topLeftX="50" topLeftY="47" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="left">
+          <p textAlign="left">Case Background</p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="50" topLeftY="68" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p textAlign="left">案例背景</p>
+        </content>
+      </shape>
+      <shape width="800" height="800" topLeftX="80" topLeftY="97" rotation="360" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.57)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="11" angle="90" blur="16" color="rgba(52, 76, 157, 0.08)"/>
+      </shape>
+      <shape width="656" height="656" topLeftX="152" topLeftY="169" rotation="360" type="ellipse">
+        <fill>
+          <fillColor color="rgba(225, 234, 255, 1)"/>
+        </fill>
+        <border color="rgba(225, 234, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="11" angle="90" blur="16" color="rgba(52, 76, 157, 0.08)"/>
+      </shape>
+      <shape width="500" height="500" topLeftX="230" topLeftY="247" rotation="360" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.57)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow offset="11" angle="90" blur="16" color="rgba(52, 76, 157, 0.08)"/>
+      </shape>
+      <img src="QiUDb6vj1olqaVxoDr7cXWXFnPf" width="216" height="216" topLeftX="371" topLeftY="389" rotation="360">
+        <shadow offset="27" angle="90" blur="34" color="rgba(13, 34, 104, 0.26)"/>
+        <crop type="rect" leftOffset="14" rightOffset="14" topOffset="0" bottomOffset="0" presetHandlers="150"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="180" height="16" topLeftX="390" topLeftY="323" type="text">
+        <content textType="title" fontSize="16" fontFamily="Arial" color="rgba(130, 167, 252, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(130, 167, 252, 1)" fontFamily="Arial">Pain Point</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="131" height="16" topLeftX="415" topLeftY="346" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span fontSize="16">数据研发过程痛点</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="240" topLeftY="332" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true">
+          <p>
+            <em>
+              <span color="rgba(255, 255, 255, 1)" fontFamily="Arial Black">01</span>
+            </em>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" blur="25" color="rgba(18, 45, 137, 0.18)"/>
+      </shape>
+      <shape width="60" height="60" topLeftX="660" topLeftY="332" type="ellipse">
+        <fill>
+          <fillColor color="rgba(242, 170, 104, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true">
+          <p>
+            <em>
+              <span color="rgba(255, 255, 255, 1)" fontFamily="Arial Black">04</span>
+            </em>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" blur="25" color="rgba(18, 45, 137, 0.18)"/>
+      </shape>
+      <shape width="60" height="60" topLeftX="359" topLeftY="235" type="ellipse">
+        <fill>
+          <fillColor color="rgba(197, 162, 237, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true">
+          <p>
+            <em>
+              <span color="rgba(255, 255, 255, 1)" fontFamily="Arial Black">02</span>
+            </em>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" blur="25" color="rgba(18, 45, 137, 0.18)"/>
+      </shape>
+      <shape width="60" height="60" topLeftX="541" topLeftY="235" type="ellipse">
+        <fill>
+          <fillColor color="rgba(128, 145, 239, 1)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true">
+          <p>
+            <em>
+              <span color="rgba(255, 255, 255, 1)" fontFamily="Arial Black">03</span>
+            </em>
+          </p>
+        </content>
+        <shadow offset="14" angle="90" blur="25" color="rgba(18, 45, 137, 0.18)"/>
+      </shape>
+      <shape width="180" height="113" topLeftX="44" topLeftY="306" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.92)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="124" height="16" topLeftX="79" topLeftY="327" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="right">
+          <p textAlign="right" lineSpacing="multiple:1">痛点一</p>
+        </content>
+      </shape>
+      <shape width="136" height="42" topLeftX="66" topLeftY="357" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="right">
+          <p textAlign="right">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="113" topLeftX="736" topLeftY="306" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.92)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="124" height="16" topLeftX="762" topLeftY="327" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">痛点四</p>
+        </content>
+      </shape>
+      <shape width="136" height="42" topLeftX="762" topLeftY="357" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="113" topLeftX="176" topLeftY="113" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.92)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="124" height="16" topLeftX="211" topLeftY="134" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="right">
+          <p textAlign="right" lineSpacing="multiple:1">痛点二</p>
+        </content>
+      </shape>
+      <shape width="136" height="42" topLeftX="199" topLeftY="163" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="right">
+          <p textAlign="right">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="113" topLeftX="603" topLeftY="113" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.92)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="124" height="16" topLeftX="629" topLeftY="134" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">痛点三</p>
+        </content>
+      </shape>
+      <shape width="136" height="42" topLeftX="629" topLeftY="163" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IDpGbp2oloFzylx8CGTcRSI6ngb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="24" topLeftX="50" topLeftY="47" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="left">
+          <p textAlign="left">Case Analysis</p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="50" topLeftY="68" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p textAlign="left">具体案例分析</p>
+        </content>
+      </shape>
+      <shape width="860" height="71" topLeftX="32" topLeftY="50" type="triangle">
+        <fill>
+          <fillColor color="rgba(225, 234, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="223" height="143" topLeftX="420" topLeftY="354" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.77)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="42" height="24" topLeftX="438" topLeftY="375" type="text">
+        <content textType="title" fontSize="24" fontFamily="Arial Black" color="rgba(130, 167, 252, 1)" bold="true" italic="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(130, 167, 252, 1)" fontSize="24" fontFamily="Arial Black">02</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="187" height="54" topLeftX="438" topLeftY="416" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="64" height="32" topLeftX="561" topLeftY="371" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(197, 162, 237, 1)"/>
+        </fill>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">关键词</span>
+            </strong>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="223" height="100" topLeftX="178" topLeftY="232" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.77)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="37" height="100" topLeftX="364" topLeftY="232" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(128, 145, 239, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">关键词</span>
+            </strong>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="132" height="18" topLeftX="223" topLeftY="244" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="205" topLeftY="250" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="18" topLeftX="223" topLeftY="272" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="205" topLeftY="278" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="18" topLeftX="223" topLeftY="300" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="205" topLeftY="305" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="223" height="100" topLeftX="420" topLeftY="232" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.77)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="37" height="100" topLeftX="605" topLeftY="232" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(128, 145, 239, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>关键词</p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="240" height="66" topLeftX="170" topLeftY="143" type="slides-chevron">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.77)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="156" height="21" topLeftX="212" topLeftY="154" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" textAlign="left">
+          <p textAlign="left">关键词</p>
+        </content>
+      </shape>
+      <shape width="169" height="18" topLeftX="212" topLeftY="178" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="66" topLeftX="411" topLeftY="143" type="slides-chevron">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.77)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="156" height="21" topLeftX="454" topLeftY="154" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" textAlign="left">
+          <p textAlign="left">关键词</p>
+        </content>
+      </shape>
+      <shape width="169" height="18" topLeftX="454" topLeftY="178" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="240" height="66" topLeftX="652" topLeftY="143" type="slides-chevron">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.77)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="156" height="21" topLeftX="695" topLeftY="154" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" textAlign="left">
+          <p textAlign="left">关键词</p>
+        </content>
+      </shape>
+      <shape width="169" height="18" topLeftX="695" topLeftY="178" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="124" height="66" topLeftX="32" topLeftY="143" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="124" height="24" topLeftX="32" topLeftY="153" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.922)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 0.922)" fontSize="16">标题 01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="124" height="13" topLeftX="32" topLeftY="183" alpha="0.4" type="text">
+        <content textType="title" fontSize="13" fontFamily="Inter" color="rgba(255, 255, 255, 0.922)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 0.922)" fontSize="13">Title</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="124" height="100" topLeftX="32" topLeftY="232" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(128, 145, 239, 1)"/>
+        </fill>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="124" height="24" topLeftX="32" topLeftY="260" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.922)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 0.922)" fontSize="16">标题 02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="124" height="14" topLeftX="32" topLeftY="290" alpha="0.4" type="text">
+        <content textType="title" fontSize="14" fontFamily="Inter" color="rgba(255, 255, 255, 0.922)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 0.922)" fontSize="14">Title</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="124" height="143" topLeftX="32" topLeftY="354" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(197, 162, 237, 1)"/>
+        </fill>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="124" height="24" topLeftX="32" topLeftY="403" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 0.922)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 0.922)" fontSize="16">标题 03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="124" height="14" topLeftX="32" topLeftY="433" alpha="0.4" type="text">
+        <content textType="title" fontSize="14" fontFamily="Inter" color="rgba(255, 255, 255, 0.922)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 0.922)" fontSize="14">Title</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="223" height="143" topLeftX="178" topLeftY="354" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.77)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="42" height="24" topLeftX="196" topLeftY="375" type="text">
+        <content textType="title" fontSize="24" fontFamily="Arial Black" color="rgba(130, 167, 252, 1)" bold="true" italic="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(130, 167, 252, 1)" fontSize="24" fontFamily="Arial Black">01</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="64" height="32" topLeftX="319" topLeftY="371" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(197, 162, 237, 1)"/>
+        </fill>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">关键词</span>
+            </strong>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="187" height="32" topLeftX="196" topLeftY="409" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(13, 34, 104, 0.07)"/>
+        </fill>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)">输入相关的描述信息</span>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="187" height="32" topLeftX="196" topLeftY="450" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(13, 34, 104, 0.07)"/>
+        </fill>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)">输入相关的描述信息</span>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="223" height="143" topLeftX="661" topLeftY="354" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.77)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="42" height="24" topLeftX="679" topLeftY="375" type="text">
+        <content textType="title" fontSize="24" fontFamily="Arial Black" color="rgba(130, 167, 252, 1)" bold="true" italic="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">
+            <em>
+              <span color="rgba(130, 167, 252, 1)" fontSize="24" fontFamily="Arial Black">03</span>
+            </em>
+          </p>
+        </content>
+      </shape>
+      <shape width="64" height="32" topLeftX="802" topLeftY="371" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(197, 162, 237, 1)"/>
+        </fill>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12">关键词</span>
+            </strong>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="90" height="32" topLeftX="679" topLeftY="409" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(13, 34, 104, 0.07)"/>
+        </fill>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)">描述信息</span>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="187" height="32" topLeftX="679" topLeftY="450" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(13, 34, 104, 0.07)"/>
+        </fill>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)">输入相关的描述信息</span>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="90" height="32" topLeftX="775" topLeftY="409" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(13, 34, 104, 0.07)"/>
+        </fill>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)">描述信息</span>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="158" height="32" topLeftX="435" topLeftY="245" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(13, 34, 104, 0.07)"/>
+        </fill>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)">输入相关的描述信息</span>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="158" height="32" topLeftX="435" topLeftY="287" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="rgba(13, 34, 104, 0.07)"/>
+        </fill>
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" bold="false">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)">输入相关的描述信息</span>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="223" height="100" topLeftX="661" topLeftY="232" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.77)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="37" height="100" topLeftX="847" topLeftY="232" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(128, 145, 239, 1)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">关键词</span>
+            </strong>
+          </p>
+        </content>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="132" height="18" topLeftX="705" topLeftY="244" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="688" topLeftY="250" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="18" topLeftX="705" topLeftY="272" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="688" topLeftY="278" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="18" topLeftX="705" topLeftY="300" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="688" topLeftY="305" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="377" height="35" topLeftX="732" topLeftY="291" rotation="270" presetHandlers="50000,50000" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(270deg,rgba(55, 93, 224, 1) 0%,rgba(130, 148, 238, 0.64) 47%,rgba(198, 163, 235, 0) 100%)"/>
+        </fill>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="180" height="16" topLeftX="372" topLeftY="91" type="text">
+        <content textType="title" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(128, 145, 239, 1)" fontFamily="Arial">Process Description</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="131" height="16" topLeftX="397" topLeftY="69" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span fontSize="16">数据研发过程</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IDpGbp2oloFzylx8CGTcRSI6ngb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="24" topLeftX="50" topLeftY="47" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="left">
+          <p textAlign="left">Case Title</p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="50" topLeftY="68" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p textAlign="left">案例题目</p>
+        </content>
+      </shape>
+      <img src="OXimbv5GKomdkixiUs2c5L3Qnjb" width="520" height="270" topLeftX="50" topLeftY="166">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="19" bottomOffset="19" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="388" height="392" topLeftX="522" topLeftY="106" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.92)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="154" height="29" topLeftX="551" topLeftY="138" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1.2" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1.2">
+            <span fontSize="24">案例题目名称</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="325" height="105" topLeftX="551" topLeftY="182" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="R1Z5baTcaozlHFxAm7Uctsk1nWf" width="100" height="150" topLeftX="551" topLeftY="313">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="13" bottomOffset="13" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="MKMab0MnKofbO2xslnXcXaovnA6" width="200" height="150" topLeftX="676" topLeftY="313">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="10" rightOffset="10" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IDpGbp2oloFzylx8CGTcRSI6ngb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="24" topLeftX="50" topLeftY="47" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="left">
+          <p textAlign="left">Answer Question</p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="50" topLeftY="68" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p textAlign="left">题目答案</p>
+        </content>
+      </shape>
+      <img src="YdDlbHbdRo8mZxxADfZcn9RUncg" width="300" height="300" topLeftX="610" topLeftY="110">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <img src="Lxx5bRHMMoxvLMxaNefcXn7Vnag" width="200" height="200" topLeftX="472" topLeftY="290">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="174" height="16" topLeftX="50" topLeftY="165" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">解答思路 01</p>
+        </content>
+      </shape>
+      <shape width="371" height="63" topLeftX="50" topLeftY="197" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="174" height="16" topLeftX="50" topLeftY="320" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">解答思路 02</p>
+        </content>
+      </shape>
+      <shape width="371" height="63" topLeftX="50" topLeftY="352" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="50" startY="290" endX="421" endY="290">
+        <border color="linear-gradient(180deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 1) 100%)" dashArray="round-dot" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Evgybt8w4ozD5rxJxCHcRmVunLc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="63" topLeftX="319" topLeftY="329" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="328" height="54" topLeftX="317" topLeftY="258" type="text">
+        <content textType="title" fontSize="36" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p textAlign="center">流程经验</p>
+        </content>
+      </shape>
+      <shape width="200" height="120" topLeftX="380" topLeftY="128" type="text">
+        <content textType="title" fontSize="80" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" bold="true" italic="true">
+          <p textAlign="center">03.</p>
+        </content>
+      </shape>
+      <shape width="328" height="24" topLeftX="316" topLeftY="240" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)">
+          <p textAlign="center">Process experience</p>
+        </content>
+      </shape>
+      <shape width="112" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="24" fontFamily="思源黑体">市场研究</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="157" startY="54" endX="157" endY="70">
+        <border color="linear-gradient(180deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="121" height="24" topLeftX="168" topLeftY="50" type="text">
+        <content fontSize="8" fontFamily="Arial" color="rgba(26, 26, 27, 1)">
+          <p>
+            <span fontFamily="Arial">Market  Research</span>
+          </p>
+          <p>
+            <span color="rgba(26, 26, 27, 1)" fontSize="8" fontFamily="Arial">Sharing Teaching Courseware</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IDpGbp2oloFzylx8CGTcRSI6ngb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="24" topLeftX="50" topLeftY="47" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="left">
+          <p textAlign="left">Process Steps</p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="50" topLeftY="68" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p textAlign="left">流程步骤</p>
+        </content>
+      </shape>
+      <shape width="180" height="333" topLeftX="50" topLeftY="148" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="154" height="16" topLeftX="63" topLeftY="185" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="思源黑体" italic="false">标题文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="150" height="147" topLeftX="67" topLeftY="318" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="109" height="40" topLeftX="85" topLeftY="128" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="83" height="16" topLeftX="98" topLeftY="140" type="text">
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">Step.1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="21" topLeftX="83" topLeftY="215" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="65" topLeftY="222" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="21" topLeftX="83" topLeftY="243" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="65" topLeftY="249" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="21" topLeftX="83" topLeftY="270" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="65" topLeftY="277" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="180" height="333" topLeftX="277" topLeftY="148" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="154" height="16" topLeftX="290" topLeftY="185" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="思源黑体" italic="false">标题文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="150" height="147" topLeftX="294" topLeftY="318" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="109" height="40" topLeftX="312" topLeftY="128" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(197, 162, 237, 1)"/>
+        </fill>
+      </shape>
+      <shape width="83" height="16" topLeftX="325" topLeftY="140" type="text">
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">Step.2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="21" topLeftX="309" topLeftY="215" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="292" topLeftY="222" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="21" topLeftX="309" topLeftY="243" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="292" topLeftY="249" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="21" topLeftX="309" topLeftY="270" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="292" topLeftY="277" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="180" height="333" topLeftX="503" topLeftY="148" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="154" height="16" topLeftX="516" topLeftY="185" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="思源黑体" italic="false">标题文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="150" height="147" topLeftX="521" topLeftY="318" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="109" height="40" topLeftX="539" topLeftY="128" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(242, 170, 104, 1)"/>
+        </fill>
+      </shape>
+      <shape width="83" height="16" topLeftX="552" topLeftY="140" type="text">
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">Step.3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="21" topLeftX="536" topLeftY="215" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="519" topLeftY="222" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="21" topLeftX="536" topLeftY="243" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="519" topLeftY="249" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="21" topLeftX="536" topLeftY="270" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="519" topLeftY="277" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="180" height="333" topLeftX="730" topLeftY="148" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="154" height="16" topLeftX="743" topLeftY="185" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="思源黑体" italic="false">标题文案</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="150" height="147" topLeftX="747" topLeftY="318" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="109" height="40" topLeftX="766" topLeftY="128" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(128, 145, 239, 1)"/>
+        </fill>
+      </shape>
+      <shape width="83" height="16" topLeftX="778" topLeftY="140" type="text">
+        <content fontSize="16" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="16">Step.4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="132" height="21" topLeftX="763" topLeftY="215" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="745" topLeftY="222" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="21" topLeftX="763" topLeftY="243" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="745" topLeftY="249" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="132" height="21" topLeftX="763" topLeftY="270" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="745" topLeftY="277" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="74" height="47" topLeftX="216" topLeftY="282" presetHandlers="50000,50000" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(168, 194, 255, 1) 0%,rgba(216, 216, 255, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="74" height="47" topLeftX="443" topLeftY="282" presetHandlers="50000,50000" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(168, 194, 255, 1) 0%,rgba(216, 216, 255, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="74" height="47" topLeftX="670" topLeftY="282" presetHandlers="50000,50000" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(168, 194, 255, 1) 0%,rgba(216, 216, 255, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.4)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <line startX="197" startY="307" endX="83" endY="307">
+        <border color="rgba(35, 72, 197, 1)" dashArray="dot" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="423" startY="304" endX="310" endY="304">
+        <border color="rgba(35, 72, 197, 1)" dashArray="dot" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="650" startY="304" endX="537" endY="304">
+        <border color="rgba(35, 72, 197, 1)" dashArray="dot" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="877" startY="307" endX="763" endY="307">
+        <border color="rgba(35, 72, 197, 1)" dashArray="dot" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Fo4Mbtt7ToaJIJxEGqkcTyFpngx" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="374" height="164" topLeftX="86" topLeftY="131" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="374" height="164" topLeftX="501" topLeftY="131" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="374" height="164" topLeftX="86" topLeftY="337" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="374" height="164" topLeftX="501" topLeftY="337" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.7)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="56" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="328" height="63" topLeftX="111" topLeftY="404" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="154" height="16" topLeftX="111" topLeftY="372" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" lineSpacing="multiple:1">
+          <p textAlign="left">重点经验标题文案</p>
+        </content>
+      </shape>
+      <shape width="328" height="63" topLeftX="526" topLeftY="404" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="154" height="16" topLeftX="526" topLeftY="372" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" lineSpacing="multiple:1">
+          <p textAlign="left">重点经验标题文案</p>
+        </content>
+      </shape>
+      <shape width="328" height="63" topLeftX="526" topLeftY="197" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="154" height="16" topLeftX="526" topLeftY="165" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" lineSpacing="multiple:1">
+          <p textAlign="left">重点经验标题文案</p>
+        </content>
+      </shape>
+      <shape width="328" height="63" topLeftX="111" topLeftY="197" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="154" height="16" topLeftX="111" topLeftY="165" type="text">
+        <content textType="sub-headline" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" lineSpacing="multiple:1">
+          <p textAlign="left">重点经验标题文案</p>
+        </content>
+      </shape>
+      <shape width="328" height="24" topLeftX="50" topLeftY="47" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="left">
+          <p textAlign="left">Key Experience</p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="50" topLeftY="68" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p textAlign="left">重点经验</p>
+        </content>
+      </shape>
+      <shape width="109" height="38" topLeftX="100" topLeftY="112" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="109" height="20" topLeftX="100" topLeftY="121" type="text">
+        <content fontSize="20" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="20">Key.1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="109" height="38" topLeftX="515" topLeftY="112" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(197, 162, 237, 1)"/>
+        </fill>
+      </shape>
+      <shape width="109" height="20" topLeftX="515" topLeftY="121" type="text">
+        <content fontSize="20" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="20">Key.2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="109" height="38" topLeftX="100" topLeftY="318" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(242, 170, 104, 1)"/>
+        </fill>
+      </shape>
+      <shape width="109" height="20" topLeftX="100" topLeftY="327" type="text">
+        <content fontSize="20" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="20">Key.3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="109" height="38" topLeftX="515" topLeftY="330" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="rgba(128, 145, 239, 1)"/>
+        </fill>
+      </shape>
+      <shape width="109" height="20" topLeftX="515" topLeftY="339" type="text">
+        <content fontSize="20" fontFamily="Arial Black" color="rgba(255, 255, 255, 1)" italic="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="20">Key.4</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Evgybt8w4ozD5rxJxCHcRmVunLc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="63" topLeftX="319" topLeftY="329" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p textAlign="left">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="328" height="54" topLeftX="317" topLeftY="258" type="text">
+        <content textType="title" fontSize="36" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="center">
+          <p textAlign="center">内容总结</p>
+        </content>
+      </shape>
+      <shape width="200" height="120" topLeftX="380" topLeftY="128" type="text">
+        <content textType="title" fontSize="80" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" bold="true" italic="true">
+          <p textAlign="center">04.</p>
+        </content>
+      </shape>
+      <shape width="328" height="24" topLeftX="316" topLeftY="240" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)">
+          <p textAlign="center">Content summary</p>
+        </content>
+      </shape>
+      <shape width="112" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="24" fontFamily="思源黑体">市场研究</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="157" startY="54" endX="157" endY="70">
+        <border color="linear-gradient(180deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="121" height="24" topLeftX="168" topLeftY="50" type="text">
+        <content fontSize="8" fontFamily="Arial" color="rgba(26, 26, 27, 1)">
+          <p>
+            <span fontFamily="Arial">Market  Research</span>
+          </p>
+          <p>
+            <span color="rgba(26, 26, 27, 1)" fontSize="8" fontFamily="Arial">Sharing Teaching Courseware</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="KezGbZdkFoCGR8xoqWScyKFBnLe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="UenMb1HSpou6wZx0SbLczsf9ngb" width="369" height="186" topLeftX="40" topLeftY="37">
+        <shadow offset="19" angle="90" blur="39" color="rgba(35, 90, 197, 0.11)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="11" bottomOffset="11" presetHandlers="20"/>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="154" height="16" topLeftX="40" topLeftY="312" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">课程总结标题文案</p>
+        </content>
+      </shape>
+      <shape width="166" height="42" topLeftX="60" topLeftY="346" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="40" topLeftY="361" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="166" height="24" topLeftX="40" topLeftY="279" type="text">
+        <content fontSize="24" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" italic="true" lineSpacing="multiple:1" textAlign="left">
+          <p>
+            <span fontSize="24">Point.1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="166" height="42" topLeftX="60" topLeftY="399" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="40" topLeftY="414" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="166" height="42" topLeftX="60" topLeftY="452" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="40" topLeftY="467" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="154" height="16" topLeftX="271" topLeftY="312" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">课程总结标题文案</p>
+        </content>
+      </shape>
+      <shape width="166" height="42" topLeftX="291" topLeftY="346" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="271" topLeftY="361" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="173" height="24" topLeftX="271" topLeftY="279" type="text">
+        <content fontSize="24" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" italic="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="24">Point.2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="166" height="42" topLeftX="291" topLeftY="399" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="271" topLeftY="414" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="166" height="42" topLeftX="291" topLeftY="452" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="271" topLeftY="467" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="154" height="16" topLeftX="503" topLeftY="312" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">课程总结标题文案</p>
+        </content>
+      </shape>
+      <shape width="166" height="42" topLeftX="523" topLeftY="346" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="503" topLeftY="361" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="166" height="24" topLeftX="503" topLeftY="279" type="text">
+        <content fontSize="24" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" italic="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="24">Point.3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="166" height="42" topLeftX="523" topLeftY="399" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="503" topLeftY="414" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="166" height="42" topLeftX="523" topLeftY="452" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="503" topLeftY="467" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="154" height="16" topLeftX="734" topLeftY="312" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">课程总结标题文案</p>
+        </content>
+      </shape>
+      <shape width="166" height="42" topLeftX="754" topLeftY="346" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="734" topLeftY="361" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="156" height="24" topLeftX="734" topLeftY="279" type="text">
+        <content fontSize="24" fontFamily="Arial Black" color="rgba(35, 72, 197, 1)" italic="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="24">Point.4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="166" height="42" topLeftX="754" topLeftY="399" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="734" topLeftY="414" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <shape width="166" height="42" topLeftX="754" topLeftY="452" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="734" topLeftY="467" type="ellipse">
+        <fill>
+          <fillColor color="rgba(35, 72, 197, 1)"/>
+        </fill>
+      </shape>
+      <line startX="242" startY="494" endX="242" endY="270">
+        <border color="linear-gradient(180deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 1) 100%)" dashArray="round-dot" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="475" startY="494" endX="475" endY="270">
+        <border color="linear-gradient(180deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 1) 100%)" dashArray="round-dot" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="707" startY="494" endX="707" endY="270">
+        <border color="linear-gradient(180deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 1) 100%)" dashArray="round-dot" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="472" height="63" topLeftX="448" topLeftY="131" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)">
+          <p>
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="328" height="16" topLeftX="448" topLeftY="66" type="text">
+        <content textType="title" fontSize="16" fontFamily="Inter" color="rgba(128, 145, 239, 1)" bold="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(128, 145, 239, 1)">Course Summary</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="238" height="24" topLeftX="448" topLeftY="89" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left" lineSpacing="multiple:1">课程总结</p>
+        </content>
+      </shape>
+      <shape width="20" height="20" topLeftX="786" topLeftY="52" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(55, 93, 224, 1) 0%,rgba(130, 148, 238, 1) 47%,rgba(209, 164, 147, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="104" height="24" topLeftX="815" topLeftY="50" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(26, 26, 27, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(26, 26, 27, 1)" fontFamily="Arial">YOUR LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="IDpGbp2oloFzylx8CGTcRSI6ngb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="328" height="24" topLeftX="50" topLeftY="47" type="text">
+        <content textType="caption" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" textAlign="left">
+          <p textAlign="left">Recommended Books</p>
+        </content>
+      </shape>
+      <shape width="328" height="36" topLeftX="50" topLeftY="68" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(0, 0, 0, 1)" bold="true" textAlign="left">
+          <p textAlign="left">推荐书籍</p>
+        </content>
+      </shape>
+      <shape width="266" height="366" topLeftX="48" topLeftY="129" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="154" height="16" topLeftX="104" topLeftY="152" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="思源黑体" italic="false">《书籍名称》</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="184" height="14" topLeftX="89" topLeftY="179" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">作者名：xx</span>
+          </p>
+        </content>
+      </shape>
+      <img src="CTFCbe4GDoATGKxknZYcZrX4nrd" width="141" height="181" topLeftX="111" topLeftY="287">
+        <shadow offset="24" angle="90" blur="39" color="rgba(11, 28, 87, 0.1)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="16"/>
+        <border color="rgba(255, 255, 255, 0.36)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="184" height="63" topLeftX="89" topLeftY="207" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="266" height="366" topLeftX="347" topLeftY="129" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="154" height="16" topLeftX="403" topLeftY="152" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="思源黑体" italic="false">《书籍名称》</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="184" height="14" topLeftX="388" topLeftY="179" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">作者名：xx</span>
+          </p>
+        </content>
+      </shape>
+      <img src="IwzMb8kS2oLmvtxom0nc7yYCn2E" width="141" height="181" topLeftX="410" topLeftY="287">
+        <shadow offset="24" angle="90" blur="39" color="rgba(11, 28, 87, 0.1)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="16"/>
+        <border color="rgba(255, 255, 255, 0.36)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="184" height="63" topLeftX="388" topLeftY="207" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="266" height="366" topLeftX="646" topLeftY="129" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <shape width="154" height="16" topLeftX="702" topLeftY="152" type="text">
+        <content textType="title" fontSize="16" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" italic="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="16" fontFamily="思源黑体" italic="false">《书籍名称》</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="184" height="14" topLeftX="687" topLeftY="179" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">作者名：xx</span>
+          </p>
+        </content>
+      </shape>
+      <img src="CzzubCxiQoobaUxsJjZcCITDnvd" width="141" height="181" topLeftX="709" topLeftY="287">
+        <shadow offset="24" angle="90" blur="39" color="rgba(11, 28, 87, 0.1)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="16"/>
+        <border color="rgba(255, 255, 255, 0.36)" lineJoin="miter" miterLimit="10"/>
+      </img>
+      <shape width="184" height="63" topLeftX="687" topLeftY="207" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">输入相关的描述信息以解释你的标题。输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Rgs1bGtK1oijSXxXqhDcvw3Tn6b" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="20" height="20" topLeftX="786" topLeftY="52" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(55, 93, 224, 1) 0%,rgba(130, 148, 238, 1) 47%,rgba(209, 164, 147, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="104" height="24" topLeftX="815" topLeftY="50" type="text">
+        <content fontSize="16" fontFamily="Arial" color="rgba(26, 26, 27, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(26, 26, 27, 1)" fontFamily="Arial">YOUR LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="112" height="24" topLeftX="50" topLeftY="50" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(35, 72, 197, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span color="rgba(35, 72, 197, 1)" fontSize="24" fontFamily="思源黑体">市场研究</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="157" startY="54" endX="157" endY="70">
+        <border color="linear-gradient(180deg,rgba(35, 72, 197, 1) 0%,rgba(72, 239, 207, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="121" height="24" topLeftX="168" topLeftY="50" type="text">
+        <content fontSize="8" fontFamily="Arial" color="rgba(26, 26, 27, 1)">
+          <p>
+            <span fontFamily="Arial">Market  Research</span>
+          </p>
+          <p>
+            <span color="rgba(26, 26, 27, 1)" fontSize="8" fontFamily="Arial">Sharing Teaching Courseware</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="327" height="14" topLeftX="337" topLeftY="442" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(100, 102, 107, 1)" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">
+            <span color="rgba(100, 102, 107, 1)" fontSize="14">欢迎大家扫码反馈</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="250" topLeftX="375" topLeftY="165" presetHandlers="20" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.63)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+        <shadow angle="90" blur="40" color="rgba(52, 76, 157, 0.19)"/>
+      </shape>
+      <img src="BH00bDrD7oDmEMxqbCbcg7Kunjc" width="214" height="214" topLeftX="394" topLeftY="183">
+        <shadow angle="90" color="rgba(17, 39, 112, 0.15)"/>
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+      </img>
+      <shape width="328" height="16" topLeftX="336" topLeftY="70" type="text">
+        <content textType="title" fontSize="16" fontFamily="Arial" color="rgba(128, 145, 239, 1)" bold="false" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(128, 145, 239, 1)" fontFamily="Arial">Thank You For Listening</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="238" height="24" topLeftX="381" topLeftY="93" type="text">
+        <content textType="title" fontSize="24" fontFamily="思源黑体" color="rgba(26, 26, 27, 1)" bold="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center" lineSpacing="multiple:1">感谢聆听</p>
+        </content>
+      </shape>
+      <img src="FG0BbrpS6oHiHbxfmdUcAMwunWG" width="214" height="214" topLeftX="393" topLeftY="183">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="20"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/product--business_case_analysis.xml
+++ b/skills/lark-slides/references/templates/product--business_case_analysis.xml
@@ -1,0 +1,1341 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>商业案例分析</title>
+  <theme>
+    <fill alpha="1">
+      <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+    </fill>
+    <textStyles>
+      <title fontColor="rgba(255, 255, 255, 1)" fontSize="80"/>
+      <headline fontColor="rgba(255, 255, 255, 1)" fontSize="28"/>
+      <sub-headline fontColor="rgba(255, 255, 255, 1)"/>
+      <body fontColor="rgba(255, 255, 255, 1)"/>
+      <caption fontColor="rgba(255, 255, 255, 1)"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="V2JPb0EKrodGMbxy97ecqA83nIe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="547" height="116" topLeftX="42" topLeftY="373" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" fontFamily="undefined" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>商业案例分析</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="L8TTba7fBoMPFTxtouXcP12rnqd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="488" height="58" topLeftX="53" topLeftY="85" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>议程</p>
+        </content>
+      </shape>
+      <shape width="318" height="38" topLeftX="56" topLeftY="126" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在这里输入简要说明，为您的听众提供上下文。</p>
+        </content>
+      </shape>
+      <shape width="175" height="56" topLeftX="492" topLeftY="379" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在这里输入简要说明，为您的听众提供上下文。</p>
+        </content>
+      </shape>
+      <shape width="175" height="56" topLeftX="704" topLeftY="379" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在这里输入简要说明，为您的听众提供上下文。</p>
+        </content>
+      </shape>
+      <shape width="175" height="56" topLeftX="281" topLeftY="379" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在这里输入简要说明，为您的听众提供上下文。</p>
+        </content>
+      </shape>
+      <shape width="175" height="56" topLeftX="69" topLeftY="379" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在这里输入简要说明，为您的听众提供上下文。</p>
+        </content>
+      </shape>
+      <shape width="200" height="44" topLeftX="69" topLeftY="348" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>背景概述</p>
+        </content>
+      </shape>
+      <shape width="48" height="48" topLeftX="81" topLeftY="284" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="44" topLeftX="281" topLeftY="348" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>案例描述</p>
+        </content>
+      </shape>
+      <shape width="48" height="48" topLeftX="293" topLeftY="284" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="44" topLeftX="704" topLeftY="348" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>SUMMARY</p>
+        </content>
+      </shape>
+      <shape width="48" height="48" topLeftX="716" topLeftY="284" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">4</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="200" height="44" topLeftX="492" topLeftY="348" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>解决方案</p>
+        </content>
+      </shape>
+      <shape width="48" height="48" topLeftX="504" topLeftY="284" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18">3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="MeUnbQuR7on8Nvxi7BvctlyUn9b" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="391" height="97" topLeftX="82" topLeftY="280" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>背景概述</p>
+        </content>
+      </shape>
+      <shape width="139" height="140" topLeftX="82" topLeftY="140" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="100" color="rgba(255, 255, 255, 0.349)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 0.349)" fontSize="100">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="368" height="110" topLeftX="59" topLeftY="128" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在这个庞大而互联的全球市场中，企业面临着无数的机遇和挑战。拓展国际市场需要精心的规划，以及对不同文化、法规和消费者偏好的深入理解。适应不同的市场动态对于成功渗透新市场并建立全球影响力至关重要。企业必须进行深入的市场研究，以确定潜在竞争对手、目标受众和新兴趋势。</p>
+        </content>
+      </shape>
+      <shape width="423" height="74" topLeftX="59" topLeftY="48" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="linear-gradient(0deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>全球市场</p>
+        </content>
+      </shape>
+      <shape width="105" height="24" topLeftX="59" topLeftY="323" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>#1 好奇心</p>
+        </content>
+      </shape>
+      <shape width="146" height="24" topLeftX="175" topLeftY="323" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>#2 消费能力</p>
+        </content>
+      </shape>
+      <shape width="94" height="24" topLeftX="333" topLeftY="323" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>#3 影响</p>
+        </content>
+      </shape>
+      <shape width="109" height="38" topLeftX="59" topLeftY="360" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>属性</p>
+        </content>
+      </shape>
+      <shape width="146" height="38" topLeftX="260" topLeftY="415" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>消费能力</p>
+        </content>
+      </shape>
+      <shape width="185" height="7" topLeftX="64" topLeftY="430" alpha="0.2" type="slides-full-round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="78" height="7" topLeftX="64" topLeftY="430" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="94" height="38" topLeftX="260" topLeftY="390" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>好奇心</p>
+        </content>
+      </shape>
+      <shape width="185" height="7" topLeftX="64" topLeftY="405" alpha="0.2" type="slides-full-round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="109" height="7" topLeftX="64" topLeftY="405" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="38" topLeftX="260" topLeftY="441" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>影响力 </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="184" height="8" topLeftX="63" topLeftY="456" alpha="0.2" type="slides-full-round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="150" height="7" topLeftX="63" topLeftY="457" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <img src="SaukbeC3GofKMExRxULcvgcfnQf" width="343" height="447" topLeftX="474" topLeftY="48" saturation="-100">
+        <crop type="rect" leftOffset="52" rightOffset="52" topOffset="0" bottomOffset="0" presetHandlers="18"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="340" height="442" topLeftX="51" topLeftY="48" presetHandlers="36" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="105" height="24" topLeftX="445" topLeftY="337" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>#1 好奇心</p>
+        </content>
+      </shape>
+      <shape width="146" height="24" topLeftX="561" topLeftY="337" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>#2 消费能力</p>
+        </content>
+      </shape>
+      <shape width="94" height="24" topLeftX="719" topLeftY="337" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>#3 影响</p>
+        </content>
+      </shape>
+      <shape width="109" height="38" topLeftX="445" topLeftY="374" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>属性</p>
+        </content>
+      </shape>
+      <shape width="146" height="38" topLeftX="646" topLeftY="429" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>消费能力</p>
+        </content>
+      </shape>
+      <shape width="185" height="7" topLeftX="450" topLeftY="444" alpha="0.2" type="slides-full-round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="78" height="7" topLeftX="450" topLeftY="444" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="94" height="38" topLeftX="646" topLeftY="404" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>好奇心</p>
+        </content>
+      </shape>
+      <shape width="185" height="7" topLeftX="450" topLeftY="419" alpha="0.2" type="slides-full-round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="109" height="7" topLeftX="450" topLeftY="419" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="99" height="38" topLeftX="646" topLeftY="456" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>影响力 </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="184" height="8" topLeftX="449" topLeftY="470" alpha="0.2" type="slides-full-round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="150" height="7" topLeftX="449" topLeftY="471" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <img src="Ozhmb1LqwoH5tZxDJ28cXRzUnDb" width="343" height="447" topLeftX="50" topLeftY="46">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="83" bottomOffset="83" presetHandlers="18"/>
+      </img>
+      <shape width="368" height="128" topLeftX="445" topLeftY="143" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在国内市场这片充满活力的领域，企业面临着无数的挑战和机遇。随着消费者需求的不断变化和激烈的竞争，要想保持领先地位，就需要进行战略规划和具备适应性。建立强大的客户关系至关重要，因为满意的客户往往会成为忠实的品牌拥护者。此外，及时了解市场趋势和消费者喜好也是企业有效调整产品的必要条件。</p>
+        </content>
+      </shape>
+      <shape width="423" height="74" topLeftX="445" topLeftY="46" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="linear-gradient(0deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)" bold="true" lineSpacing="multiple:1.35">
+          <p>国内市场</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="197" height="56" topLeftX="51" topLeftY="385" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在此处输入简短说明，以便向受众提供上下文。</p>
+        </content>
+      </shape>
+      <shape width="285" height="58" topLeftX="51" topLeftY="341" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>市场趋势</p>
+        </content>
+      </shape>
+      <line startX="375" startY="357" endX="889" endY="358" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="375" startY="290" endX="889" endY="291" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="375" startY="222" endX="890" endY="223" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="375" startY="155" endX="889" endY="156" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="375" startY="88" endX="889" endY="89" alpha="0.3">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="22" height="282" topLeftX="842" topLeftY="144" presetHandlers="0" alpha="0.2" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="23" height="103" topLeftX="396" topLeftY="323" presetHandlers="0" alpha="0.2" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="244" topLeftX="488" topLeftY="182" presetHandlers="0" alpha="0.2" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="169" topLeftX="574" topLeftY="257" presetHandlers="0" alpha="0.2" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="247" topLeftX="666" topLeftY="179" presetHandlers="0" alpha="0.2" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="311" topLeftX="755" topLeftY="115" presetHandlers="0" alpha="0.2" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="50" height="38" topLeftX="381" topLeftY="430" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2021</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="474" topLeftY="430" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2022</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="560" topLeftY="430" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2023</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="652" topLeftY="429" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2024</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="741" topLeftY="430" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2025</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="827" topLeftY="430" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">2026</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="22" height="234" topLeftX="842" topLeftY="193" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="190" topLeftX="755" topLeftY="236" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="114" topLeftX="666" topLeftY="313" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="151" topLeftX="574" topLeftY="275" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="127" topLeftX="488" topLeftY="299" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="22" height="94" topLeftX="396" topLeftY="332" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="50" height="38" topLeftX="321" topLeftY="71" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(193, 193, 193, 1)" fontSize="12">100</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="320" topLeftY="134" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(193, 193, 193, 1)" fontSize="12">80</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="320" topLeftY="204" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(193, 193, 193, 1)" fontSize="12">60</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="321" topLeftY="274" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(193, 193, 193, 1)" fontSize="12">40</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="50" height="38" topLeftX="320" topLeftY="342" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="right">
+          <p>
+            <span color="rgba(193, 193, 193, 1)" fontSize="12">20</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="375" startY="425" endX="889" endY="426">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="391" height="97" topLeftX="59" topLeftY="306" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>案件描述</p>
+        </content>
+      </shape>
+      <shape width="391" height="140" topLeftX="59" topLeftY="182" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="100" color="rgba(255, 255, 255, 0.349)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 0.349)" fontSize="100">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="460" startY="184" endX="460" endY="390" alpha="0.3">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="326" height="110" topLeftX="508" topLeftY="249" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.4">
+          <p>制定计划是远远不够的。我们必须积极实施计划，并始终致力于实现我们的目标。只有那些能够有效地将计划和实施结合起来的人才会取得成功。</p>
+        </content>
+      </shape>
+      <shape width="326" height="110" topLeftX="54" topLeftY="249" alpha="0.5" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.4">
+          <p>定义目标受众包括确定组织或产品的目标市场，以及确定目标客户的特征和需求。它帮助组织更好地满足客户的需求，从而增加其市场份额和促进增长。</p>
+        </content>
+      </shape>
+      <shape width="360" height="44" topLeftX="508" topLeftY="174" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>2. 主要产品</p>
+        </content>
+      </shape>
+      <shape width="360" height="44" topLeftX="54" topLeftY="174" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+          <ol>
+            <li index="1">
+              <p>品牌介绍</p>
+            </li>
+          </ol>
+        </content>
+      </shape>
+      <shape width="574" height="58" topLeftX="54" topLeftY="56" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>品牌和产品介绍</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="255" height="74" topLeftX="582" topLeftY="161" alpha="0.65" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>价格指的是客户为购买一种产品所支付的金额，它是由生产成本、竞争情况和期望的利润率等因素决定的。</p>
+        </content>
+      </shape>
+      <shape width="254" height="56" topLeftX="154" topLeftY="161" alpha="0.65" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>公司向目标市场提供的有形或无形的产品，包括设计、功能、质量、包装和品牌。</p>
+        </content>
+      </shape>
+      <shape width="255" height="56" topLeftX="154" topLeftY="328" alpha="0.65" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>通过分销渠道将产品提供给客户，考虑直接销售、零售商和电子商务平台等选项。</p>
+        </content>
+      </shape>
+      <shape width="272" height="56" topLeftX="582" topLeftY="328" alpha="0.65" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>促销是指将产品推向目标市场的活动，包括广告，公关和促销。</p>
+        </content>
+      </shape>
+      <shape width="76" height="38" topLeftX="65" topLeftY="223" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>产品</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="63" height="63" topLeftX="72" topLeftY="153" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="36" height="36" topLeftX="85" topLeftY="166" iconType="iconpark/Makeups/lipstick.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="63" height="63" topLeftX="503" topLeftY="153" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="63" height="38" topLeftX="503" topLeftY="223" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>价格</p>
+        </content>
+      </shape>
+      <icon width="36" height="36" topLeftX="516" topLeftY="166" iconType="iconpark/Money/financing-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="88" height="38" topLeftX="493" topLeftY="391" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>晋升</p>
+        </content>
+      </shape>
+      <shape width="63" height="63" topLeftX="505" topLeftY="320" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="36" height="36" topLeftX="519" topLeftY="334" iconType="iconpark/Charts/positive-dynamics.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="63" height="38" topLeftX="72" topLeftY="391" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>地点</p>
+        </content>
+      </shape>
+      <shape width="63" height="63" topLeftX="72" topLeftY="320" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="36" height="36" topLeftX="86" topLeftY="334" iconType="iconpark/Travel/world.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="574" height="58" topLeftX="54" topLeftY="56" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>4P 分析</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <undefined type="fallback"/>
+      <shape width="574" height="58" topLeftX="54" topLeftY="56" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>波特五力模型</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="597" height="58" topLeftX="46" topLeftY="53" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>客户痛点</p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+      <img src="AeqAbKTpTo58c9xtKn2cljJAnQd" width="233" height="100" topLeftX="62" topLeftY="151" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="32" presetHandlers="8"/>
+      </img>
+      <img src="ThzbbJjWXol6PyxlMqpclAA7n7c" width="233" height="100" topLeftX="62" topLeftY="385" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="32" bottomOffset="0.75" presetHandlers="8"/>
+      </img>
+      <img src="LVPfbAlHkoTFEbxR9rPcw0xtnMg" width="233" height="100" topLeftX="62" topLeftY="268" saturation="-100">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="33" presetHandlers="8"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NGJmb0DV0oe6vgxJbsgcukxcnUe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="391" height="140" topLeftX="59" topLeftY="181" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="100" color="rgba(255, 255, 255, 0.349)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 0.349)" fontSize="100">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="391" height="97" topLeftX="59" topLeftY="305" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>解决方案</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="365" height="365" topLeftX="268" topLeftY="147" alpha="0.2" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="218" height="218" topLeftX="341" topLeftY="220" alpha="0.2" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="104" height="104" topLeftX="399" topLeftY="278" alpha="0.2" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <line startX="268" startY="329" endX="633" endY="330" alpha="0.2">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="451" startY="438" endX="450" endY="221" alpha="0.2">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="244" height="39" topLeftX="-26" topLeftY="306" rotation="270" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>经济的</p>
+        </content>
+      </shape>
+      <shape width="244" height="41" topLeftX="681" topLeftY="305" rotation="90" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="15" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>高端的</p>
+        </content>
+      </shape>
+      <shape width="244" height="39" topLeftX="327" topLeftY="482" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>市场依赖性</p>
+        </content>
+      </shape>
+      <shape width="244" height="39" topLeftX="327" topLeftY="115" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>市场统治力</p>
+        </content>
+      </shape>
+      <shape width="47" height="47" topLeftX="243" topLeftY="386" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">J</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="202" topLeftY="431" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="61" height="61" topLeftX="236" topLeftY="176" type="ellipse">
+        <fill>
+          <fillColor color="rgba(45, 49, 53, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">H</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="113" height="38" topLeftX="210" topLeftY="237" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="48" height="48" topLeftX="355" topLeftY="340" type="ellipse">
+        <fill>
+          <fillColor color="rgba(242, 243, 245, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>I</p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="315" topLeftY="386" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="44" height="44" topLeftX="375" topLeftY="238" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">F</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="105" height="38" topLeftX="345" topLeftY="277" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="503" topLeftY="226" type="ellipse">
+        <fill>
+          <fillColor color="rgba(242, 243, 245, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>C</p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="462" topLeftY="270" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="70" height="70" topLeftX="619" topLeftY="372" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(31, 35, 41, 1)">
+          <p>
+            <span color="rgba(31, 35, 41, 1)" fontSize="18">E</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="590" topLeftY="442" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="72" topLeftX="492" topLeftY="340" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24">D</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="113" height="38" topLeftX="471" topLeftY="412" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="70" height="70" topLeftX="646" topLeftY="211" type="ellipse">
+        <fill>
+          <fillColor color="rgba(45, 49, 53, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">B</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="617" topLeftY="281" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="44" height="44" topLeftX="569" topLeftY="144" type="ellipse">
+        <fill>
+          <fillColor color="rgba(45, 49, 53, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">A</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="38" topLeftX="528" topLeftY="187" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="691" height="58" topLeftX="54" topLeftY="38" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>方案 1：更具竞争力的产品</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="342" height="38" topLeftX="51" topLeftY="115" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在这里输入简要说明，为您的听众提供上下文。</p>
+        </content>
+      </shape>
+      <shape width="486" height="58" topLeftX="51" topLeftY="71" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>解决方案 2：更好的定价策略</p>
+        </content>
+      </shape>
+      <table topLeftX="59" topLeftY="226">
+        <colgroup>
+          <col span="3" width="269"/>
+        </colgroup>
+        <tr height="44">
+          <td>
+            <borderTop color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="linear-gradient(90deg,rgba(255, 255, 255, 1) 0%,rgba(255, 255, 255, 1) 100%)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+              <p>行动项目</p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>预算</p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(255, 255, 255, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(31, 35, 41, 1)" bold="true">
+              <p>经理</p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+              <p>跨平台宣传</p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(255, 255, 255, 0.149)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)">
+              <p>
+                <span color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)" fontSize="14">$ 20,000</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">@James Morris</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+              <p>与顶级影响者合作</p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(255, 255, 255, 0.149)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)">
+              <p>
+                <span color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)" fontSize="14">$ 50,000</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">@James Morris</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+              <p>
+                <span color="rgba(255, 255, 255, 1)" fontSize="14">SEO</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(255, 255, 255, 0.149)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)">
+              <p>
+                <span color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)" fontSize="14">$30,000</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">@James Morris</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+              <p>总共</p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(147, 150, 156, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(255, 255, 255, 0.149)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)">
+              <p>
+                <span color="linear-gradient(180deg,rgba(156, 156, 158, 1) 0%,rgba(192, 197, 211, 1) 100%)" fontSize="14">$ 100,000</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(193, 193, 193, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">@James Morris</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+      </table>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="176" height="56" topLeftX="707" topLeftY="179" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在这里输入简要说明，为您的听众提供上下文。</p>
+        </content>
+      </shape>
+      <shape width="176" height="56" topLeftX="505" topLeftY="179" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在这里输入简要说明，为您的听众提供上下文。</p>
+        </content>
+      </shape>
+      <shape width="176" height="56" topLeftX="284" topLeftY="179" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在这里输入简要说明，为您的听众提供上下文。</p>
+        </content>
+      </shape>
+      <shape width="176" height="56" topLeftX="44" topLeftY="179" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>在这里输入简要说明，为您的听众提供上下文。</p>
+        </content>
+      </shape>
+      <shape width="574" height="58" topLeftX="54" topLeftY="56" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>解决方案 3：提升品牌声誉</p>
+        </content>
+      </shape>
+      <shape width="209" height="30" topLeftX="48" topLeftY="331" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p>多平台宣传</p>
+        </content>
+      </shape>
+      <shape width="199" height="30" topLeftX="280" topLeftY="331" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p>与顶级影响者合作</p>
+        </content>
+      </shape>
+      <shape width="120" height="30" topLeftX="512" topLeftY="331" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="12"> SEO </span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="120" height="30" topLeftX="717" topLeftY="331" presetHandlers="30" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(43, 47, 54, 1) 0%,rgba(66, 71, 85, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p>用户推荐</p>
+        </content>
+      </shape>
+      <line startX="491" startY="175" endX="491" endY="360" alpha="0.3">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="269" startY="175" endX="269" endY="360" alpha="0.3">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="695" startY="175" endX="695" endY="360" alpha="0.3">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="34" startY="175" endX="34" endY="360" alpha="0.3">
+        <border color="rgba(143, 149, 158, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="LMSIbPjSEom7ekxw6g1ceS4SnVb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="391" height="97" topLeftX="59" topLeftY="302" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.2">
+          <p>总结</p>
+        </content>
+      </shape>
+      <shape width="391" height="140" topLeftX="59" topLeftY="178" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="100" color="rgba(255, 255, 255, 0.349)" bold="true" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 0.349)" fontSize="100">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="WROlbzmWGo7UP1xNkmPcRZ5MnHg" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="C7AYboTrdo4cP6x2onlczGOlnld" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="679" height="132" topLeftX="47" topLeftY="343" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p>谢谢！</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/product--market_analysis.xml
+++ b/skills/lark-slides/references/templates/product--market_analysis.xml
@@ -1,0 +1,898 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>市场分析报告</title>
+  <theme>
+    <background>
+      <fillColor color="rgba(0, 0, 0, 1)"/>
+    </background>
+    <textStyles>
+      <title fontColor="#000000FF"/>
+      <headline fontColor="#000000FF" fontSize="48"/>
+      <sub-headline fontColor="#000000FF" fontSize="24"/>
+      <body fontColor="#000000FF" fontSize="14"/>
+      <caption fontColor="#808080FF"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="SH0hbfYtUopLybxGlKLctZ7cnHc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="798" height="96" topLeftX="39" topLeftY="364" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p lineSpacing="multiple:1.4" letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="54">市场分析报告</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="DyxKbGBEeogZI6xH8TvcRTQwnsc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="44" startY="495" endX="926" endY="494" alpha="0.34">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="502" height="38" topLeftX="49" topLeftY="167" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="369" height="85" topLeftX="49" topLeftY="88" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="48">目录</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="116" topLeftX="480" topLeftY="339" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <ul>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">目标客户</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">客户画像</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">人口统计特征</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">心理和行为特征</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="231" height="92" topLeftX="49" topLeftY="339" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <ul>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">背景信息</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">市场规模</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span color="rgba(255, 255, 255, 1)" fontSize="12">市场趋势</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="356" height="53" topLeftX="49" topLeftY="270" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="24">市场分析</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="356" height="53" topLeftX="480" topLeftY="270" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>客户分析</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="Pkrjbk4e2oBx4ExptU6cxit7nic" width="387" height="540" topLeftX="575" topLeftY="0">
+        <crop type="rect" leftOffset="76" rightOffset="76" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="228" height="38" topLeftX="46" topLeftY="385" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="469" height="96" topLeftX="40" topLeftY="409" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p>市场分析</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="Kjh0bv8UAohccvxKC67c2EmLnle" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="343" height="343" topLeftX="83" topLeftY="108" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="257" height="257" topLeftX="126" topLeftY="194" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="146" height="146" topLeftX="182" topLeftY="306" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="78" height="41" topLeftX="215" topLeftY="134" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>低端市场</p>
+        </content>
+      </shape>
+      <shape width="78" height="41" topLeftX="215" topLeftY="246" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>中端市场</p>
+        </content>
+      </shape>
+      <shape width="78" height="41" topLeftX="215" topLeftY="358" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>高端市场</p>
+        </content>
+      </shape>
+      <line startX="371" startY="154" endX="416" endY="154">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="426" startY="266" endX="472" endY="266">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="394" startY="379" endX="440" endY="379">
+        <border color="rgba(255, 255, 255, 1)" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="297" height="56" topLeftX="509" topLeftY="159" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="52" topLeftX="433" topLeftY="129" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">60%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="165" height="41" topLeftX="509" topLeftY="129" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">低客单价、竞争激烈</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="297" height="56" topLeftX="558" topLeftY="270" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="52" topLeftX="482" topLeftY="240" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">30%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="165" height="41" topLeftX="558" topLeftY="240" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">稳定增长、高复购率</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="297" height="56" topLeftX="521" topLeftY="383" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="78" height="52" topLeftX="445" topLeftY="354" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="right">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">10%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="165" height="41" topLeftX="521" topLeftY="353" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)">高客单价、高用户粘性</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="DORCbvo8loYXudxUImpc8qxJnUc" width="635" height="426" topLeftX="275" topLeftY="68" alpha="0.5">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="278" height="56" topLeftX="50" topLeftY="396" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="311" height="85" topLeftX="50" topLeftY="327" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>主要城市</p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="348" topLeftY="228" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="12" topLeftX="344" topLeftY="211" rotation="180" type="triangle">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(13, 71, 219, 1) 0%,rgba(125, 0, 250, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="140" height="35" topLeftX="282" topLeftY="177" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(13, 71, 219, 1) 0%,rgba(125, 0, 250, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">城市 A</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="584" topLeftY="328" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="12" topLeftX="580" topLeftY="311" rotation="180" type="triangle">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(13, 71, 219, 1) 0%,rgba(125, 0, 250, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="140" height="35" topLeftX="518" topLeftY="277" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(13, 71, 219, 1) 0%,rgba(125, 0, 250, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">城市 B</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="810" topLeftY="255" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="12" topLeftX="806" topLeftY="238" rotation="180" type="triangle">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(13, 71, 219, 1) 0%,rgba(125, 0, 250, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="140" height="35" topLeftX="744" topLeftY="204" type="slides-full-round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(13, 71, 219, 1) 0%,rgba(125, 0, 250, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">城市 C</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="EtfBbjdtioRG0jxaIVZc2PH4n7g" width="82" height="82" topLeftX="51" topLeftY="231">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="79"/>
+      </img>
+      <img src="UrvkbSqqvoWi3rx0InicJttEnLd" width="82" height="82" topLeftX="51" topLeftY="366">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="80"/>
+      </img>
+      <img src="WHrJbggL9olprnxo52mcd8JXnbd" width="82" height="82" topLeftX="611" topLeftY="231">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="81"/>
+      </img>
+      <img src="JRTLb4j0VoEnYGxV3bRccy61nGg" width="82" height="82" topLeftX="331" topLeftY="366">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="81"/>
+      </img>
+      <img src="RWvwbf1tUo3v7xxl5kpcdPrEn5c" width="82" height="82" topLeftX="331" topLeftY="231">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0.15" bottomOffset="0.15" presetHandlers="81"/>
+      </img>
+      <shape width="224" height="41" topLeftX="144" topLeftY="237" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">竞争对手 #1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="38" topLeftX="144" topLeftY="268" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">规模 500 - 1,000</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="41" topLeftX="424" topLeftY="237" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">竞争对手 #2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="38" topLeftX="424" topLeftY="268" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">规模 500 - 1,000</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="41" topLeftX="144" topLeftY="372" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">竞争对手 #4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="38" topLeftX="144" topLeftY="403" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">规模 500 - 1,000</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="41" topLeftX="424" topLeftY="372" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">竞争对手 #5</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="38" topLeftX="424" topLeftY="403" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">规模 500 - 1,000</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="41" topLeftX="704" topLeftY="237" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">竞争对手 #3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="38" topLeftX="704" topLeftY="268" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">规模 500 - 1,000</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="41" topLeftX="704" topLeftY="372" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">竞争对手 #6</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="38" topLeftX="704" topLeftY="403" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">规模 500 - 1,000</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="305" height="56" topLeftX="331" topLeftY="103" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="238" height="85" topLeftX="49" topLeftY="88" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">竞争对手</span>
+          </p>
+        </content>
+      </shape>
+      <img src="OEb0bN9TXoDw7yxlPyWcrISqnXf" width="82" height="82" topLeftX="611" topLeftY="366">
+        <crop type="rect" leftOffset="5" rightOffset="5" topOffset="5" bottomOffset="5" presetHandlers="81"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="ICt2bHN2nouTrXxguMVc8ObJnHd" width="387" height="540" topLeftX="575" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="153" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="228" height="38" topLeftX="46" topLeftY="385" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="469" height="96" topLeftX="40" topLeftY="409" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.4">
+          <p>客户分析</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="228" height="56" topLeftX="639" topLeftY="433" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="228" height="41" topLeftX="639" topLeftY="402" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>新一线居民</p>
+        </content>
+      </shape>
+      <shape width="228" height="56" topLeftX="639" topLeftY="212" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="228" height="41" topLeftX="639" topLeftY="181" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>高学历</p>
+        </content>
+      </shape>
+      <shape width="197" height="74" topLeftX="44" topLeftY="268" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="369" height="52" topLeftX="44" topLeftY="218" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>用户画像</p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="639" topLeftY="116" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="24">1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="639" topLeftY="327" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(31, 35, 41, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="24">2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="QqUmbL49Po5gsnxNb34c4PEInbd" width="269" height="447" topLeftX="306" topLeftY="63">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="2" bottomOffset="2"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(0, 0, 0, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="305" height="56" topLeftX="443" topLeftY="72" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="342" height="85" topLeftX="49" topLeftY="58" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">人口特征分析</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="126" height="53" topLeftX="49" topLeftY="180" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">28M</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="126" height="41" topLeftX="49" topLeftY="212" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">人口规模</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="126" height="53" topLeftX="50" topLeftY="283" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>9</p>
+        </content>
+      </shape>
+      <shape width="126" height="41" topLeftX="50" topLeftY="314" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>年平均消费次数</p>
+        </content>
+      </shape>
+      <shape width="126" height="53" topLeftX="49" topLeftY="390" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35" textAlign="center">
+          <p>9</p>
+        </content>
+      </shape>
+      <shape width="126" height="41" topLeftX="49" topLeftY="422" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>预计市场占有率</p>
+        </content>
+      </shape>
+      <shape width="12" height="12" topLeftX="676" topLeftY="156" type="ellipse">
+        <fill>
+          <fillColor color="rgba(83, 23, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="120" height="38" topLeftX="688" topLeftY="143" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span fontSize="12">团队 A</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="12" height="12" topLeftX="779" topLeftY="156" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="120" height="38" topLeftX="791" topLeftY="143" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">团队 B</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="266" startY="212" endX="926" endY="212" alpha="0.38">
+        <border color="rgba(143, 149, 158, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="51" height="41" topLeftX="215" topLeftY="192" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">60</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="266" startY="283" endX="926" endY="283" alpha="0.38">
+        <border color="rgba(143, 149, 158, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="51" height="41" topLeftX="215" topLeftY="263" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">40</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="266" startY="356" endX="926" endY="356" alpha="0.38">
+        <border color="rgba(143, 149, 158, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="51" height="41" topLeftX="215" topLeftY="335" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">20</span>
+          </p>
+        </content>
+      </shape>
+      <line startX="266" startY="427" endX="926" endY="427" alpha="0.38">
+        <border color="rgba(143, 149, 158, 1)" dashArray="dash" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="51" height="41" topLeftX="215" topLeftY="406" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">0</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="41" topLeftX="311" topLeftY="427" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">Q4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="41" topLeftX="441" topLeftY="427" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">Q1</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="41" topLeftX="570" topLeftY="427" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">Q2</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="41" topLeftX="700" topLeftY="427" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">Q3</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="41" topLeftX="830" topLeftY="427" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" textAlign="center">
+          <p>
+            <span color="rgba(255, 255, 255, 1)">Q4</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="16" height="50" topLeftX="318" topLeftY="378" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="26" topLeftX="339" topLeftY="402" type="rect">
+        <fill>
+          <fillColor color="rgba(83, 23, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="97" topLeftX="448" topLeftY="330" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="51" topLeftX="469" topLeftY="376" type="rect">
+        <fill>
+          <fillColor color="rgba(83, 23, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="116" topLeftX="578" topLeftY="311" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="116" topLeftX="598" topLeftY="311" type="rect">
+        <fill>
+          <fillColor color="rgba(83, 23, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="116" topLeftX="708" topLeftY="311" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="164" topLeftX="728" topLeftY="263" type="rect">
+        <fill>
+          <fillColor color="rgba(83, 23, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="194" topLeftX="837" topLeftY="233" type="rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="16" height="179" topLeftX="857" topLeftY="248" type="rect">
+        <fill>
+          <fillColor color="rgba(83, 23, 255, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="SHObbS1FeoEAQExWHbpccnM6nxc" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="231" height="62" topLeftX="49" topLeftY="362" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="275" height="56" topLeftX="49" topLeftY="167" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="369" height="85" topLeftX="49" topLeftY="88" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.35">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="48">总结 &amp; 建议</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="62" topLeftX="365" topLeftY="362" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="49" topLeftY="336" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">聚焦中端市场 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="62" topLeftX="652" topLeftY="362" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="365" topLeftY="336" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">聚焦中端市场 #</span>
+            </strong>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="41" topLeftX="652" topLeftY="336" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">聚焦中端市场 #</span>
+            </strong>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="14">3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="BnCPbgKjioXfPDxXqgYc0Nenn4c" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="797" height="85" topLeftX="29" topLeftY="93" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="54" bold="true" lineSpacing="multiple:1.4">
+          <p lineSpacing="multiple:1.2" letterSpacing="2">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="54">感谢观看</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/product--product_analysis.xml
+++ b/skills/lark-slides/references/templates/product--product_analysis.xml
@@ -1,0 +1,1537 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>产品分析报告</title>
+  <theme>
+    <fill alpha="1">
+      <fillImg src="CeKhbKPBboW8zMxwnIsckRXjnwh" alpha="1" rotateWithShape="false"/>
+    </fill>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="60"/>
+      <headline fontColor="#000000FF" fontSize="36"/>
+      <sub-headline fontColor="#000000FF" fontSize="20"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CeKhbKPBboW8zMxwnIsckRXjnwh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="557" height="557" topLeftX="470" topLeftY="132" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="long-dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="514" height="514" topLeftX="646" topLeftY="-103" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="11" height="11" topLeftX="641" topLeftY="146" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="397" height="56" topLeftX="30" topLeftY="428" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(242, 243, 245, 1)">
+          <p>
+            <span color="rgba(242, 243, 245, 1)" fontSize="12">报告目的和背景：说明本次报告的目的，例如对特定产品进行详细分析，以评估其市场地位和潜在机会</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="640" height="110" topLeftX="30" topLeftY="320" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="90" color="rgba(242, 243, 245, 1)" bold="true" lineSpacing="multiple:1" letterSpacing="2">
+          <p>
+            <strong>
+              <span color="rgba(242, 243, 245, 1)" fontSize="90">产品分析报告</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="162" height="39" topLeftX="30" topLeftY="28" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="left" autoFit="shape-auto-fit">
+          <p list="none" textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="12" fontFamily="undefined" bold="false" italic="false" strikethrough="false" underline="false">你的团队</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="TWMbb5BUwoVGv2xyYwFcPJN0nfh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="449" height="449" topLeftX="532" topLeftY="88" alpha="0.15" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" dashArray="long-dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="514" height="514" topLeftX="626" topLeftY="-123" alpha="0.15" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="82" height="82" topLeftX="67" topLeftY="405" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="42" height="42" topLeftX="182" topLeftY="397" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="181" height="74" topLeftX="87" topLeftY="187" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="181" height="74" topLeftX="83" topLeftY="122" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span fontSize="45">目录</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="30" height="30" topLeftX="406" topLeftY="131" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(222, 235, 255, 1) 0%,rgba(255, 255, 255, 1) 0%,rgba(223, 236, 255, 1) 57%,rgba(215, 231, 255, 1) 100%,rgba(144, 188, 255, 1) 100%,rgba(182, 211, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="219" height="40" topLeftX="415" topLeftY="131" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>产品概述</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="222" height="74" topLeftX="412" topLeftY="169" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="30" height="30" topLeftX="663" topLeftY="131" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(222, 235, 255, 1) 0%,rgba(255, 255, 255, 1) 0%,rgba(223, 236, 255, 1) 57%,rgba(215, 231, 255, 1) 100%,rgba(144, 188, 255, 1) 100%,rgba(182, 211, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="219" height="40" topLeftX="672" topLeftY="131" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>市场分析</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="222" height="74" topLeftX="669" topLeftY="169" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="30" height="30" topLeftX="406" topLeftY="284" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(222, 235, 255, 1) 0%,rgba(255, 255, 255, 1) 0%,rgba(223, 236, 255, 1) 57%,rgba(215, 231, 255, 1) 100%,rgba(144, 188, 255, 1) 100%,rgba(182, 211, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="219" height="40" topLeftX="415" topLeftY="284" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>竞争分析</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="222" height="74" topLeftX="412" topLeftY="321" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="30" height="30" topLeftX="663" topLeftY="284" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(222, 235, 255, 1) 0%,rgba(255, 255, 255, 1) 0%,rgba(223, 236, 255, 1) 57%,rgba(215, 231, 255, 1) 100%,rgba(144, 188, 255, 1) 100%,rgba(182, 211, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="219" height="40" topLeftX="672" topLeftY="284" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>建议与措施</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="222" height="74" topLeftX="669" topLeftY="321" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CeKhbKPBboW8zMxwnIsckRXjnwh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="271" height="271" topLeftX="831" topLeftY="100" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="long-dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="619" height="619" topLeftX="411" topLeftY="247" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="11" height="11" topLeftX="832" topLeftY="265" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="200" height="74" topLeftX="70" topLeftY="150" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(242, 243, 245, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="692" height="92" topLeftX="70" topLeftY="62" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span color="rgba(242, 243, 245, 1)" fontSize="60">产品概述</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="291" height="160" topLeftX="647" topLeftY="362" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="140" color="rgba(242, 243, 245, 1)" bold="true" lineSpacing="multiple:1" letterSpacing="2" textAlign="right">
+          <p>01</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="H63mb66AvoxSqoxsg77cGpftnWO" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="589" height="589" topLeftX="-40" topLeftY="316" rotation="90" alpha="0.15" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="277" height="277" topLeftX="-21" topLeftY="168" rotation="90" alpha="0.15" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" dashArray="long-dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="10" height="10" topLeftX="28" topLeftY="411" rotation="90" alpha="0.93" type="ellipse">
+        <fill>
+          <fillColor color="rgba(226, 234, 249, 1)"/>
+        </fill>
+      </shape>
+      <shape width="43" height="49" topLeftX="490" topLeftY="315" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="linear-gradient(0deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="linear-gradient(0deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" fontSize="24">↑</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="43" height="49" topLeftX="687" topLeftY="315" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="linear-gradient(0deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" lineSpacing="multiple:1.2" textAlign="left">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span color="linear-gradient(0deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" fontSize="24">↑</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <img src="Tk6zbOJdRoVYW6xa5FvcVRnFneh" width="315" height="420" topLeftX="60" topLeftY="57">
+        <crop type="rect" leftOffset="0.68" rightOffset="0.68" topOffset="0" bottomOffset="0" presetHandlers="16"/>
+      </img>
+      <shape width="129" height="40" topLeftX="500" topLeftY="371" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span fontSize="16">增长</span>
+            </strong>
+            <strong>
+              <span fontSize="16">率</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="352" height="74" topLeftX="490" topLeftY="173" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">描述你的产品定位、使用场景、特点、功能等。描述你的产品定位、使用场景、特点、功能等。描述你的产品定位、使用场景、特点、功能等。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="432" height="64" topLeftX="490" topLeftY="113" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span fontSize="36">产品介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="38" topLeftX="686" topLeftY="397" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">相关细节信息描述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="130" height="38" topLeftX="500" topLeftY="397" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span fontSize="12">相关细节信息描述</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="78" topLeftX="714" topLeftY="293" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span color="linear-gradient(0deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" fontSize="48">120</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="128" height="78" topLeftX="517" topLeftY="293" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span color="linear-gradient(0deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" fontSize="48">80%</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="129" height="40" topLeftX="698" topLeftY="371" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" lineSpacing="multiple:1.2">
+          <p>增长量</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="GI0MbgUiqoP9hsxYaGjcMcrOnTf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="212" height="212" topLeftX="374" topLeftY="168" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" dashArray="dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="182" height="182" topLeftX="389" topLeftY="184" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)"/>
+        </fill>
+      </shape>
+      <line startX="335" startY="128" endX="405" endY="198">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="555" startY="350" endX="625" endY="420">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="405" startY="350" endX="335" endY="420">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="625" startY="128" endX="555" endY="198">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <icon width="135" height="135" topLeftX="67" topLeftY="75" alpha="0.38" iconType="iconpark/Abstract/cycle-one.svg">
+        <border color="rgba(226, 234, 249, 1)" width="6" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="140" height="140" topLeftX="63" topLeftY="294" alpha="0.38" iconType="iconpark/Abstract/two-ellipses.svg">
+        <border color="rgba(226, 234, 249, 1)" width="6" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="136" height="136" topLeftX="785" topLeftY="299" alpha="0.38" iconType="iconpark/Charts/data-all.svg">
+        <border color="rgba(226, 234, 249, 1)" width="6" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="134" height="134" topLeftX="786" topLeftY="75" alpha="0.38" iconType="iconpark/Office/application-effect.svg">
+        <border color="rgba(226, 234, 249, 1)" width="6" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="241" height="56" topLeftX="76" topLeftY="142" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="right">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="212" height="40" topLeftX="110" topLeftY="110" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" lineSpacing="multiple:1.2" textAlign="right">
+          <p>二级观点 #1</p>
+        </content>
+      </shape>
+      <shape width="91" height="97" topLeftX="434" topLeftY="221" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(242, 243, 245, 1)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>产品特点</p>
+        </content>
+      </shape>
+      <shape width="241" height="56" topLeftX="76" topLeftY="388" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="right">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="212" height="40" topLeftX="110" topLeftY="357" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" lineSpacing="multiple:1.2" textAlign="right">
+          <p>二级观点 #2</p>
+        </content>
+      </shape>
+      <shape width="241" height="56" topLeftX="644" topLeftY="142" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="212" height="40" topLeftX="644" topLeftY="110" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" lineSpacing="multiple:1.2" textAlign="left">
+          <p>二级观点 #3</p>
+        </content>
+      </shape>
+      <shape width="241" height="56" topLeftX="644" topLeftY="388" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="212" height="40" topLeftX="644" topLeftY="357" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" lineSpacing="multiple:1.2" textAlign="left">
+          <p>二级观点 #4</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="AJEbbuSXXouiGbx4bXNcouexn0g" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="QvCWbM5xqoVaJzxvKBXcIGiBnLf" width="367" height="540" topLeftX="593" topLeftY="0" saturation="-16" temperature="28">
+        <crop type="rect" leftOffset="21" rightOffset="26" topOffset="0" bottomOffset="74"/>
+      </img>
+      <shape width="269" height="56" topLeftX="85" topLeftY="170" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>确定产品的目标用户群体，并说明产品在市场中的定位和竞争优势。</p>
+        </content>
+      </shape>
+      <shape width="432" height="64" topLeftX="85" topLeftY="100" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.2">
+          <p>用户画像</p>
+        </content>
+      </shape>
+      <shape width="298" height="39" topLeftX="85" topLeftY="299" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" lineSpacing="multiple:1.2">
+          <p>用户画像</p>
+        </content>
+      </shape>
+      <shape width="298" height="94" topLeftX="85" topLeftY="343" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" lineSpacing="multiple:2">
+          <ul>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span fontSize="12">关键核心描述</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span fontSize="12">关键核心描述</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span fontSize="12">关键核心描述</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CeKhbKPBboW8zMxwnIsckRXjnwh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="271" height="271" topLeftX="831" topLeftY="100" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="long-dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="619" height="619" topLeftX="411" topLeftY="247" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="11" height="11" topLeftX="832" topLeftY="265" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="200" height="74" topLeftX="70" topLeftY="150" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(242, 243, 245, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="692" height="92" topLeftX="70" topLeftY="62" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span color="rgba(242, 243, 245, 1)" fontSize="60">市场分析</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="291" height="160" topLeftX="647" topLeftY="362" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="140" color="rgba(242, 243, 245, 1)" bold="true" lineSpacing="multiple:1" letterSpacing="2" textAlign="right">
+          <p>02</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="FooxbXPOJoYY0RxELmOcRJaEnNe" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="960" height="253" topLeftX="0" topLeftY="0" type="rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)"/>
+        </fill>
+      </shape>
+      <img src="NcsLb3VSRoeJEVxfOuTc1ISdnPf" width="960" height="253" topLeftX="0" topLeftY="0" alpha="0.5">
+        <crop type="rect" leftOffset="85" rightOffset="12" topOffset="25" bottomOffset="0"/>
+      </img>
+      <shape width="269" height="56" topLeftX="53" topLeftY="370" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="432" height="64" topLeftX="53" topLeftY="300" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.2">
+          <p>目标市场</p>
+        </content>
+      </shape>
+      <shape width="392" height="39" topLeftX="490" topLeftY="311" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" lineSpacing="multiple:1.2">
+          <p>描述的目标市场</p>
+        </content>
+      </shape>
+      <shape width="298" height="94" topLeftX="490" topLeftY="355" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" lineSpacing="multiple:2">
+          <ul>
+            <li>
+              <p lineSpacing="multiple:2">关键核心描述</p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span fontSize="12">关键核心描述</span>
+              </p>
+            </li>
+            <li>
+              <p lineSpacing="multiple:2">
+                <span fontSize="12">关键核心描述</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="QPp4bfbR9ocU43xZdn1cHZZxnYd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="570" height="570" topLeftX="-30" topLeftY="70" alpha="0.6" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="420" height="420" topLeftX="43" topLeftY="220" alpha="0.6" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="258" height="258" topLeftX="127" topLeftY="382" alpha="0.6" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="330" height="47" topLeftX="594" topLeftY="122" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true">
+          <p>关键结论 #1</p>
+        </content>
+      </shape>
+      <shape width="212" height="40" topLeftX="152" topLeftY="447" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" lineSpacing="multiple:1.2" textAlign="center">
+          <p>高端市场</p>
+        </content>
+      </shape>
+      <shape width="212" height="40" topLeftX="152" topLeftY="312" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" lineSpacing="multiple:1.2" textAlign="center">
+          <p>中端市场</p>
+        </content>
+      </shape>
+      <shape width="212" height="40" topLeftX="152" topLeftY="158" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" lineSpacing="multiple:1.2" textAlign="center">
+          <p>低端市场</p>
+        </content>
+      </shape>
+      <shape width="110" height="68" topLeftX="203" topLeftY="396" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="linear-gradient(0deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>10%</p>
+        </content>
+      </shape>
+      <shape width="110" height="68" topLeftX="203" topLeftY="260" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="linear-gradient(0deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>30%</p>
+        </content>
+      </shape>
+      <shape width="110" height="68" topLeftX="203" topLeftY="106" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="40" color="linear-gradient(0deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>60%</p>
+        </content>
+      </shape>
+      <shape width="309" height="56" topLeftX="594" topLeftY="295" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="594" topLeftY="263" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true">
+          <p>关键结论 #2</p>
+        </content>
+      </shape>
+      <shape width="309" height="56" topLeftX="594" topLeftY="153" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="309" height="56" topLeftX="594" topLeftY="442" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="594" topLeftY="410" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true">
+          <p>关键结论 #3</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="LeJHbiXkToox4uxb12Oc7AVUnqf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <line startX="933" startY="101" endX="29" endY="102" alpha="0.1">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="933" startY="326" endX="29" endY="327" alpha="0.1">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="933" startY="209" endX="29" endY="210" alpha="0.1">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="19" height="19" topLeftX="54" topLeftY="124" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="19" topLeftX="54" topLeftY="235" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="19" height="19" topLeftX="54" topLeftY="354" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)"/>
+        </fill>
+      </shape>
+      <line startX="924" startY="442" endX="20" endY="443" alpha="0.1">
+        <border width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="439" height="56" topLeftX="395" topLeftY="375" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <ul>
+            <li>
+              <p>
+                <span fontSize="12">这是指机器学习模型为其预测和决策提供解释的能力</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span fontSize="12">它可以提高人工智能系统的透明度和可信度，以及识别和纠正错误或偏见</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="439" height="56" topLeftX="395" topLeftY="257" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <ul>
+            <li>
+              <p>
+                <span fontSize="12">这是一个帮助程序员编写、调试和优化代码的工具</span>
+              </p>
+            </li>
+            <li>
+              <p>
+                <span fontSize="12">它可以提供诸如代码自动完成、纠错、性能改进、文档生成等功能。</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="439" height="56" topLeftX="395" topLeftY="145" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <ul>
+            <li>
+              <p>
+                <span fontSize="12">这是一种人工智能技术，可以创造新的内容，如文本、图像、视频或音频。它可用于文案写作、音乐、药物发现等任务。</span>
+              </p>
+            </li>
+          </ul>
+        </content>
+      </shape>
+      <shape width="218" height="40" topLeftX="184" topLeftY="374" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>
+            <strong>
+              <span fontSize="16">解释型 AI</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="40" topLeftX="184" topLeftY="257" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>
+            <strong>
+              <span fontSize="16">AI 编码助手</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="218" height="40" topLeftX="184" topLeftY="144" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>
+            <strong>
+              <span fontSize="16">生成式 AI</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="110" height="56" topLeftX="71" topLeftY="366" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true">
+          <p>
+            <strong>
+              <span fontSize="24">趋势 #</span>
+            </strong>
+            <strong>
+              <span fontSize="24">3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="110" height="56" topLeftX="71" topLeftY="248" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true">
+          <p>
+            <strong>
+              <span fontSize="24">趋势 #</span>
+            </strong>
+            <strong>
+              <span fontSize="24">2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="110" height="56" topLeftX="71" topLeftY="136" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="true">
+          <p>
+            <strong>
+              <span fontSize="24">趋势 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CeKhbKPBboW8zMxwnIsckRXjnwh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="271" height="271" topLeftX="831" topLeftY="100" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="long-dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="619" height="619" topLeftX="411" topLeftY="247" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="11" height="11" topLeftX="832" topLeftY="265" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="200" height="74" topLeftX="70" topLeftY="150" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(242, 243, 245, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="692" height="92" topLeftX="70" topLeftY="62" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span color="rgba(242, 243, 245, 1)" fontSize="60">竞争分析</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="291" height="160" topLeftX="647" topLeftY="362" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="140" color="rgba(242, 243, 245, 1)" bold="true" lineSpacing="multiple:1" letterSpacing="2" textAlign="right">
+          <p>03</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="ZQekbiWtbo1NMUxcr8NccVqdnDr" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="552" height="38" topLeftX="26" topLeftY="135" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>主要竞争对手和市场份额：列举产品的主要竞争对手，并分析他们在市场中的地位和市场份额。</p>
+        </content>
+      </shape>
+      <shape width="432" height="59" topLeftX="26" topLeftY="85" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" bold="true" lineSpacing="multiple:1.2">
+          <p>竞争对手</p>
+        </content>
+      </shape>
+      <table topLeftX="26" topLeftY="198">
+        <colgroup>
+          <col span="4" width="224"/>
+        </colgroup>
+        <tr height="41">
+          <td>
+            <borderTop color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(45, 78, 249, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">竞争对手</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(45, 78, 249, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">2025</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="rgba(45, 78, 249, 1)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">2026</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderTop color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderRight color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(45, 78, 249, 1)" lineJoin="miter" miterLimit="10"/>
+            <fill>
+              <fillColor color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)"/>
+            </fill>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" color="rgba(255, 255, 255, 1)" bold="true">
+              <p>
+                <strong>
+                  <span color="rgba(255, 255, 255, 1)" fontSize="14">相关细节</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12">竞争对手 A</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">30M</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">32M</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12">竞争对手 B</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">45M</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">40M</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12">竞争对手 C</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">15M</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">30M</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+        <tr height="46">
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderLeft color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" bold="true">
+              <p>
+                <strong>
+                  <span fontSize="12">竞争对手 D</span>
+                </strong>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">60M</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">66M</span>
+              </p>
+            </content>
+          </td>
+          <td>
+            <borderRight color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <borderBottom color="rgba(176, 194, 225, 1)" lineJoin="miter" miterLimit="10"/>
+            <content verticalAlign="top" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+              <p>
+                <span fontSize="12">更多细节描述</span>
+              </p>
+            </content>
+          </td>
+        </tr>
+      </table>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="824" height="416" topLeftX="68" topLeftY="62" presetHandlers="16" alpha="0.54" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(222, 235, 255, 1) 0%,rgba(229, 238, 253, 1) 0%,rgba(214, 226, 244, 1) 70%,rgba(144, 188, 255, 1) 100%,rgba(214, 230, 255, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="100" height="34" topLeftX="436" topLeftY="20" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(0, 0, 0, 1)" lineSpacing="multiple:1.2" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="12">容易使用</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="34" topLeftX="876" topLeftY="253" rotation="90" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(0, 0, 0, 1)" lineSpacing="multiple:1.2" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="12">高效率</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="100" height="34" topLeftX="436" topLeftY="483" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(0, 0, 0, 1)" lineSpacing="multiple:1.2" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="12">难以使用</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="94" height="34" topLeftX="-10" topLeftY="254" rotation="270" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(0, 0, 0, 1)" lineSpacing="multiple:1.2" textAlign="center">
+          <p>
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="12">低效率</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="90" startY="272" endX="870" endY="275" alpha="0.12">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="481" startY="462" endX="479" endY="78" alpha="0.12">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="67" height="67" topLeftX="652" topLeftY="94" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" color="rgba(242, 243, 245, 1)">
+          <p>
+            <span color="rgba(242, 243, 245, 1)">A</span>
+          </p>
+        </content>
+        <shadow offset="4" blur="26" color="rgba(45, 78, 249, 0.18)"/>
+      </shape>
+      <shape width="104" height="38" topLeftX="634" topLeftY="157" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">你的产品</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="56" height="56" topLeftX="800" topLeftY="143" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>B</p>
+        </content>
+        <shadow offset="7" blur="7" color="rgba(165, 178, 244, 0.17)"/>
+      </shape>
+      <shape width="104" height="38" topLeftX="778" topLeftY="196" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">竞争对手</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="32" topLeftX="544" topLeftY="183" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow offset="7" blur="7" color="rgba(165, 178, 244, 0.17)"/>
+      </shape>
+      <shape width="104" height="38" topLeftX="508" topLeftY="211" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">竞争对手</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="39" height="45" topLeftX="541" topLeftY="177" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span fontSize="16">C</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="64" height="64" topLeftX="267" topLeftY="90" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>D</p>
+        </content>
+        <shadow offset="7" blur="7" color="rgba(165, 178, 244, 0.17)"/>
+      </shape>
+      <shape width="104" height="38" topLeftX="247" topLeftY="149" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">竞争对手</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="104" height="38" topLeftX="332" topLeftY="244" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">竞争对手</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="32" topLeftX="368" topLeftY="220" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow offset="7" blur="7" color="rgba(165, 178, 244, 0.17)"/>
+      </shape>
+      <shape width="38" height="44" topLeftX="365" topLeftY="215" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>F</p>
+        </content>
+      </shape>
+      <shape width="67" height="67" topLeftX="139" topLeftY="164" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>E</p>
+        </content>
+        <shadow offset="7" blur="7" color="rgba(165, 178, 244, 0.17)"/>
+      </shape>
+      <shape width="104" height="38" topLeftX="121" topLeftY="226" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">竞争对手</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="74" height="74" topLeftX="708" topLeftY="344" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="30">
+          <p>
+            <span fontSize="30">J</span>
+          </p>
+        </content>
+        <shadow offset="7" blur="7" color="rgba(165, 178, 244, 0.17)"/>
+      </shape>
+      <shape width="104" height="38" topLeftX="693" topLeftY="414" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">竞争对手</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="56" height="56" topLeftX="562" topLeftY="306" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16">
+          <p>I</p>
+        </content>
+        <shadow offset="7" blur="7" color="rgba(165, 178, 244, 0.17)"/>
+      </shape>
+      <shape width="104" height="38" topLeftX="538" topLeftY="358" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">竞争对手</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="32" height="32" topLeftX="368" topLeftY="322" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <shadow offset="7" blur="7" color="rgba(165, 178, 244, 0.17)"/>
+      </shape>
+      <shape width="104" height="38" topLeftX="332" topLeftY="350" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">竞争对手</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="38" height="44" topLeftX="365" topLeftY="316" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="16" textAlign="center">
+          <p>
+            <span fontSize="16">H</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="44" height="44" topLeftX="226" topLeftY="359" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14">
+          <p>
+            <span fontSize="14">G</span>
+          </p>
+        </content>
+        <shadow offset="7" blur="7" color="rgba(165, 178, 244, 0.17)"/>
+      </shape>
+      <shape width="104" height="38" topLeftX="196" topLeftY="398" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>
+            <span color="rgba(31, 35, 41, 1)">竞争对手</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CeKhbKPBboW8zMxwnIsckRXjnwh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="271" height="271" topLeftX="831" topLeftY="100" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="long-dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="619" height="619" topLeftX="411" topLeftY="247" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="11" height="11" topLeftX="832" topLeftY="265" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="200" height="74" topLeftX="70" topLeftY="150" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>
+            <span color="rgba(242, 243, 245, 1)" fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="692" height="92" topLeftX="70" topLeftY="62" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.2">
+          <p>
+            <strong>
+              <span color="rgba(242, 243, 245, 1)" fontSize="60">建议与措施</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="291" height="160" topLeftX="647" topLeftY="362" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="140" color="rgba(242, 243, 245, 1)" bold="true" lineSpacing="multiple:1" letterSpacing="2" textAlign="right">
+          <p>04</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <shape width="468" height="56" topLeftX="246" topLeftY="86" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="center">
+          <p>（竞争对手的优势、劣势、机会和威胁）：对竞争对手进行SWOT分析，评估他们的优势、劣势、面临的机会和威胁。</p>
+        </content>
+      </shape>
+      <shape width="432" height="54" topLeftX="264" topLeftY="45" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="28" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p>
+            <span fontSize="28">SWOT 分析</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="173" topLeftX="333" topLeftY="177" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">S</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="173" topLeftX="454" topLeftY="177" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">W</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="173" topLeftX="454" topLeftY="301" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">O</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="173" height="173" topLeftX="333" topLeftY="301" flipX="true" type="ellipse">
+        <fill>
+          <fillColor color="rgba(31, 35, 41, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">T</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="295" height="47" topLeftX="9" topLeftY="200" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" textAlign="right">
+          <p>优势</p>
+        </content>
+      </shape>
+      <shape width="219" height="56" topLeftX="85" topLeftY="241" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="right">
+          <p>专有的技术平台。具有深厚行业知识的强大团队 .低管理成本</p>
+        </content>
+      </shape>
+      <shape width="295" height="47" topLeftX="9" topLeftY="347" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" textAlign="right">
+          <p>挑战</p>
+        </content>
+      </shape>
+      <shape width="219" height="74" topLeftX="85" topLeftY="388" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="right">
+          <p>来自老牌企业的激烈竞争。不可预见的市场和经济条件。网络安全风险和潜在违规行为</p>
+        </content>
+      </shape>
+      <shape width="295" height="47" topLeftX="656" topLeftY="200" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" textAlign="left">
+          <p>劣势</p>
+        </content>
+      </shape>
+      <shape width="219" height="74" topLeftX="656" topLeftY="241" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>拥挤的电子商务市场中的新进入者。品牌知名度有限。扩大经营规模的潜在问题</p>
+        </content>
+      </shape>
+      <shape width="295" height="47" topLeftX="656" topLeftY="347" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" textAlign="left">
+          <p>机遇</p>
+        </content>
+      </shape>
+      <shape width="219" height="56" topLeftX="656" topLeftY="388" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>不断增长的网上购物趋势。智能手机用户数量的增加。扩展到国际市场</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="PgVbbpypho2FaOxbrbmcPQpfnwh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="449" height="449" topLeftX="504" topLeftY="192" alpha="0.15" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" dashArray="long-dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="514" height="514" topLeftX="598" topLeftY="-19" alpha="0.15" type="ellipse">
+        <border color="linear-gradient(90deg,rgba(46, 78, 246, 1) 0%,rgba(33, 130, 244, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="13" height="13" topLeftX="593" topLeftY="227" alpha="0.8" type="ellipse">
+        <fill>
+          <fillColor color="rgba(226, 234, 249, 1)"/>
+        </fill>
+      </shape>
+      <shape width="581" height="56" topLeftX="43" topLeftY="120" alpha="0.5" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12">
+          <p>提出建议和策略：根据市场洞察和机会与挑战分析，提出具体的建议和策略，以帮助企业在电子商务行业中取得竞争优势。例如，加强供应链管理，提升用户体验，拓展新兴市场等。</p>
+        </content>
+      </shape>
+      <shape width="583" height="64" topLeftX="43" topLeftY="50" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" bold="true" lineSpacing="multiple:1.2">
+          <p>建议与措施</p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CeKhbKPBboW8zMxwnIsckRXjnwh" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="557" height="557" topLeftX="497" topLeftY="113" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" dashArray="long-dash" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="514" height="514" topLeftX="703" topLeftY="-204" alpha="0.51" type="ellipse">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="11" height="11" topLeftX="708" topLeftY="116" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="575" height="110" topLeftX="37" topLeftY="389" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="90" color="rgba(242, 243, 245, 1)" bold="true" lineSpacing="multiple:1" letterSpacing="2">
+          <p>感谢您的观赏</p>
+        </content>
+      </shape>
+      <shape width="162" height="39" topLeftX="30" topLeftY="28" type="text">
+        <content textType="caption" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" fontFamily="undefined" color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" bold="false" italic="false" underline="false" strikethrough="false" list="none" listStyle="circle-hollow-square" textAlign="left" autoFit="shape-auto-fit">
+          <p list="none" textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" backgroundColor="rgba(0, 0, 0, 0)" fontSize="12" fontFamily="undefined" bold="false" italic="false" strikethrough="false" underline="false">你的团队</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/product--product_intro.xml
+++ b/skills/lark-slides/references/templates/product--product_intro.xml
@@ -1,0 +1,2838 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>产品介绍</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="NfQpb6aAAoZAcMxsdPvccrL2nFb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="18" topLeftX="64" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="36" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="200" height="30" topLeftX="722" topLeftY="24" type="text">
+        <content textType="caption" fontSize="20" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true" italic="false">
+          <p textAlign="right">未来已至 感谢观看</p>
+        </content>
+      </shape>
+      <shape width="160" height="42" topLeftX="762" topLeftY="61" type="text">
+        <content textType="caption" fontSize="14" fontFamily="Arial" color="rgba(222, 224, 227, 1)" italic="true">
+          <p textAlign="right">The Future is Here. Thank you for Watching</p>
+        </content>
+      </shape>
+      <shape width="400" height="63" topLeftX="62" topLeftY="420" type="text">
+        <content textType="caption" fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="648" height="60" topLeftX="62" topLeftY="261" type="text">
+        <content textType="title" fontSize="40" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" italic="true">
+          <p>Product Introduction</p>
+        </content>
+      </shape>
+      <shape width="648" height="90" topLeftX="62" topLeftY="166" type="text">
+        <content textType="title" fontSize="60" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>产品介绍</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="CJRQbqIpcoDNJ6x6R8EcqhRMnAb" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="NIsYbsdhZoR2xJx1MBncO7kjnzd" width="687" height="406" topLeftX="42" topLeftY="0">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="121" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="531" height="54" topLeftX="214" topLeftY="136" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="center">
+          <p textAlign="center">
+            <span color="rgba(255, 255, 255, 1)" fontSize="54" fontFamily="Arial">CONTENTS</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="272" height="48" topLeftX="42" topLeftY="22" type="text">
+        <content textType="headline" fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="32">目录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <line startX="87" startY="317" endX="840" endY="317">
+        <border color="rgba(155, 158, 162, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="8" height="8" topLeftX="279" topLeftY="312" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="8" height="8" topLeftX="472" topLeftY="312" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="8" height="8" topLeftX="664" topLeftY="312" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="167" height="30" topLeftX="87" topLeftY="261" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">01 产品介绍</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="167" height="84" topLeftX="87" topLeftY="338" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>
+            <span color="rgba(222, 224, 227, 1)" fontSize="14">产品概述</span>
+          </p>
+          <p>
+            <span color="rgba(222, 224, 227, 1)" fontSize="14">核心能力</span>
+          </p>
+          <p>
+            <span color="rgba(222, 224, 227, 1)" fontSize="14">产品解决方案</span>
+          </p>
+          <p>
+            <span color="rgba(222, 224, 227, 1)" fontSize="14">产品发展历程</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="167" height="30" topLeftX="283" topLeftY="261" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">02 产品优势</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="167" height="63" topLeftX="283" topLeftY="338" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>
+            <span color="rgba(222, 224, 227, 1)" fontSize="14">产品优势</span>
+          </p>
+          <p>
+            <span color="rgba(222, 224, 227, 1)" fontSize="14">行业地位</span>
+          </p>
+          <p>
+            <span color="rgba(222, 224, 227, 1)" fontSize="14">最佳实践</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="167" height="30" topLeftX="472" topLeftY="261" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">03 产品费用</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="167" height="42" topLeftX="472" topLeftY="338" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>产品价格体系</p>
+          <p>客户评价</p>
+        </content>
+      </shape>
+      <shape width="167" height="30" topLeftX="664" topLeftY="261" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">04 未来展望</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="167" height="42" topLeftX="664" topLeftY="338" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>产品布局</p>
+          <p>未来展望</p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="87" topLeftY="312" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XZAxbIhLsok8UFxXIsvcb8r7nad" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="100" height="34" topLeftX="480" topLeftY="351" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">查看详情</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="G9dVbubk3offfzxETDFciwB5n8d" width="328" height="368" topLeftX="83" topLeftY="87" exposure="14" contrast="-5" saturation="11" temperature="-26">
+        <crop type="rect" leftOffset="20" rightOffset="20" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="431" height="42" topLeftX="480" topLeftY="270" type="text">
+        <content textType="title" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="431" height="40" topLeftX="480" topLeftY="202" type="text">
+        <content textType="title" fontSize="40" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p>产品介绍</p>
+        </content>
+      </shape>
+      <shape width="431" height="54" topLeftX="480" topLeftY="145" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p textAlign="left">PART 1</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EHSwbpJS0o0vOZxVKxTcc5yqnyd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="653" height="42" topLeftX="42" topLeftY="17" type="text">
+        <content textType="sub-headline" fontSize="28" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>核心能力</p>
+        </content>
+      </shape>
+      <shape width="269" height="114" topLeftX="46" topLeftY="88" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="235" height="24" topLeftX="63" topLeftY="102" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">01 核心能力</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="42" topLeftX="63" topLeftY="142" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述标题，输入相关的描述信息描述标题</p>
+        </content>
+      </shape>
+      <shape width="269" height="114" topLeftX="46" topLeftY="230" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="235" height="24" topLeftX="63" topLeftY="245" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">02 核心能力</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="42" topLeftX="63" topLeftY="284" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述标题，输入相关的描述信息描述标题</p>
+        </content>
+      </shape>
+      <shape width="269" height="114" topLeftX="46" topLeftY="372" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="235" height="24" topLeftX="63" topLeftY="387" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">03 核心能力</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="42" topLeftX="63" topLeftY="427" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述标题，输入相关的描述信息描述标题</p>
+        </content>
+      </shape>
+      <shape width="269" height="114" topLeftX="339" topLeftY="372" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="235" height="24" topLeftX="355" topLeftY="387" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">04 核心能力</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="42" topLeftX="355" topLeftY="427" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述标题，输入相关的描述信息描述标题</p>
+        </content>
+      </shape>
+      <shape width="269" height="114" topLeftX="632" topLeftY="88" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="235" height="24" topLeftX="649" topLeftY="102" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">07 核心能力</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="42" topLeftX="649" topLeftY="142" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述标题，输入相关的描述信息描述标题</p>
+        </content>
+      </shape>
+      <shape width="269" height="114" topLeftX="632" topLeftY="230" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="235" height="24" topLeftX="649" topLeftY="245" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">06 核心能力</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="42" topLeftX="649" topLeftY="284" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述标题，输入相关的描述信息描述标题</p>
+        </content>
+      </shape>
+      <shape width="269" height="114" topLeftX="632" topLeftY="372" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="235" height="24" topLeftX="649" topLeftY="387" type="text">
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="16">05 核心能力</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="42" topLeftX="649" topLeftY="427" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述标题，输入相关的描述信息描述标题</p>
+        </content>
+      </shape>
+      <shape width="160" height="160" topLeftX="393" topLeftY="131" presetHandlers="88" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="140" height="140" topLeftX="403" topLeftY="141" presetHandlers="73" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+        <shadow offset="11" angle="90" blur="28" color="rgba(75, 112, 226, 0.51)"/>
+      </shape>
+      <icon width="41" height="41" topLeftX="452" topLeftY="170" iconType="iconpark/Base/all-application.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="114" height="30" topLeftX="416" topLeftY="215" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">核心能力</p>
+        </content>
+      </shape>
+      <shape width="42" height="25" topLeftX="342" topLeftY="150" rotation="208" alpha="0.8" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0) 0%,rgba(74, 60, 243, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="42" height="25" topLeftX="347" topLeftY="265" rotation="149" alpha="0.8" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0) 0%,rgba(74, 60, 243, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="42" height="25" topLeftX="452" topLeftY="317" rotation="90" alpha="0.8" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0) 0%,rgba(74, 60, 243, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="39" height="25" topLeftX="566" topLeftY="150" rotation="149" flipX="true" alpha="0.8" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0) 0%,rgba(74, 60, 243, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="39" height="25" topLeftX="561" topLeftY="266" rotation="214" flipX="true" alpha="0.8" type="right-arrow">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0) 0%,rgba(74, 60, 243, 1) 100%)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EHSwbpJS0o0vOZxVKxTcc5yqnyd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="653" height="42" topLeftX="42" topLeftY="17" type="text">
+        <content textType="sub-headline" fontSize="28" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>解决方案</p>
+        </content>
+      </shape>
+      <shape width="269" height="383" topLeftX="389" topLeftY="99" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="269" height="383" topLeftX="46" topLeftY="99" presetHandlers="8" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="100" height="30" topLeftX="131" topLeftY="124" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">过去</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="21" topLeftX="63" topLeftY="158" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">输入相关的描述信息描述标题</p>
+        </content>
+      </shape>
+      <line startX="63" startY="141" endX="135" endY="141">
+        <border color="linear-gradient(90deg,rgba(0, 209, 240, 0) 0%,rgba(147, 151, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="298" startY="141" endX="221" endY="141">
+        <border color="linear-gradient(90deg,rgba(0, 209, 240, 0) 0%,rgba(147, 151, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="230" height="34" topLeftX="63" topLeftY="214" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">痛点一</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="230" height="34" topLeftX="63" topLeftY="275" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">痛点二</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="230" height="34" topLeftX="63" topLeftY="336" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">痛点三</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="230" height="34" topLeftX="63" topLeftY="397" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">痛点三</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="100" height="30" topLeftX="473" topLeftY="124" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" fontSize="20">现在</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="21" topLeftX="405" topLeftY="158" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">输入相关的描述信息描述标题</p>
+        </content>
+      </shape>
+      <line startX="405" startY="141" endX="477" endY="141">
+        <border color="linear-gradient(90deg,rgba(0, 209, 240, 0) 0%,rgba(147, 151, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="640" startY="141" endX="563" endY="141">
+        <border color="linear-gradient(90deg,rgba(0, 209, 240, 0) 0%,rgba(147, 151, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="230" height="34" topLeftX="405" topLeftY="214" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">卖点一</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="230" height="34" topLeftX="405" topLeftY="275" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>卖点二</p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="230" height="34" topLeftX="405" topLeftY="336" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>卖点三</p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="230" height="34" topLeftX="405" topLeftY="397" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>卖点四</p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="245" height="176" topLeftX="684" topLeftY="99" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="245" height="176" topLeftX="684" topLeftY="305" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <icon width="32" height="32" topLeftX="711" topLeftY="145" iconType="iconpark/Charts/chart-line.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="154" height="30" topLeftX="753" topLeftY="143" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="20">全球排名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="154" height="44" topLeftX="753" topLeftY="184" type="text">
+        <content textType="title" fontSize="44" fontFamily="Arial" color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" bold="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" fontSize="44" bold="false">3</span>
+          </p>
+        </content>
+      </shape>
+      <icon width="32" height="32" topLeftX="711" topLeftY="349" iconType="iconpark/Charts/chart-line.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="154" height="30" topLeftX="753" topLeftY="347" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="20">研发规模</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="154" height="44" topLeftX="753" topLeftY="388" type="text">
+        <content textType="title" fontSize="44" fontFamily="Arial" color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" bold="false" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" fontSize="44" bold="false">1000+</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="63" height="48" topLeftX="321" topLeftY="267" type="text">
+        <content fontSize="32" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="32">VS</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EHSwbpJS0o0vOZxVKxTcc5yqnyd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="653" height="42" topLeftX="42" topLeftY="17" type="text">
+        <content textType="sub-headline" fontSize="28" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p textAlign="left">产品发展历程</p>
+        </content>
+      </shape>
+      <line startX="-6" startY="149" endX="960" endY="149">
+        <border color="rgba(155, 158, 162, 1)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="8" height="8" topLeftX="307" topLeftY="145" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="8" height="8" topLeftX="479" topLeftY="145" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="8" height="8" topLeftX="652" topLeftY="145" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="51" height="30" topLeftX="801" topLeftY="99" type="text">
+        <content fontSize="20" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20" fontFamily="Arial">2026</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="8" height="8" topLeftX="134" topLeftY="145" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="8" height="8" topLeftX="823" topLeftY="145" type="ellipse">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="51" height="30" topLeftX="631" topLeftY="99" type="text">
+        <content fontSize="20" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20" fontFamily="Arial">2025</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="30" topLeftX="462" topLeftY="99" type="text">
+        <content fontSize="20" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20" fontFamily="Arial">2024</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="30" topLeftX="285" topLeftY="99" type="text">
+        <content fontSize="20" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20" fontFamily="Arial">2023</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="51" height="30" topLeftX="112" topLeftY="99" type="text">
+        <content fontSize="20" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" textAlign="left">
+          <p>2022</p>
+        </content>
+      </shape>
+      <shape width="136" height="34" topLeftX="70" topLeftY="176" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="243" topLeftY="176" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="415" topLeftY="176" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="588" topLeftY="176" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="761" topLeftY="176" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="70" topLeftY="230" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="243" topLeftY="230" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="415" topLeftY="230" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="588" topLeftY="230" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="761" topLeftY="230" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="243" topLeftY="287" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="415" topLeftY="287" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="588" topLeftY="287" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="761" topLeftY="287" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="588" topLeftY="344" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="761" topLeftY="344" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+      <shape width="136" height="34" topLeftX="588" topLeftY="403" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(208, 241, 247, 0.12) 0%,rgba(229, 228, 250, 0.2) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">产品能力</span>
+          </p>
+        </content>
+        <shadow offset="25" blur="26" color="rgba(33, 47, 64, 0.32)"/>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XZAxbIhLsok8UFxXIsvcb8r7nad" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="100" height="34" topLeftX="480" topLeftY="351" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">查看详情</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="C8zPbiwfJoUX2xxi8UpckM0mnDb" width="328" height="368" topLeftX="83" topLeftY="87" exposure="14" contrast="-5" saturation="11" temperature="-26">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="108" bottomOffset="108" presetHandlers="8"/>
+      </img>
+      <shape width="431" height="42" topLeftX="480" topLeftY="270" type="text">
+        <content textType="title" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="431" height="40" topLeftX="480" topLeftY="202" type="text">
+        <content textType="title" fontSize="40" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p>产品优势</p>
+        </content>
+      </shape>
+      <shape width="431" height="54" topLeftX="480" topLeftY="145" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p textAlign="left">PART 2</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EHSwbpJS0o0vOZxVKxTcc5yqnyd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="653" height="42" topLeftX="42" topLeftY="17" type="text">
+        <content textType="sub-headline" fontSize="28" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p textAlign="left">产品优势</p>
+        </content>
+      </shape>
+      <shape width="269" height="254" topLeftX="42" topLeftY="179" presetHandlers="8" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="100" height="30" topLeftX="126" topLeftY="124" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">优势一</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="21" topLeftX="59" topLeftY="207" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>输入相关的描述信息描述标题</strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="59" startY="141" endX="131" endY="141">
+        <border color="linear-gradient(90deg,rgba(0, 209, 240, 0) 0%,rgba(147, 151, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="294" startY="141" endX="217" endY="141">
+        <border color="linear-gradient(90deg,rgba(0, 209, 240, 0) 0%,rgba(147, 151, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="77" height="18" topLeftX="56" topLeftY="300" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="74" topLeftY="252" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="83" topLeftY="262" iconType="iconpark/Charts/chart-line.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="137" topLeftY="300" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="155" topLeftY="252" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="165" topLeftY="262" iconType="iconpark/Charts/histogram.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="219" topLeftY="300" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="237" topLeftY="252" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="247" topLeftY="262" iconType="iconpark/Charts/material-three.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="56" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="74" topLeftY="344" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="83" topLeftY="354" iconType="iconpark/Charts/viencharts.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="137" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="155" topLeftY="344" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="164" topLeftY="354" iconType="iconpark/Clothes/vest.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="219" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="237" topLeftY="344" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="246" topLeftY="354" iconType="iconpark/Travel/flight-safety.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="269" height="254" topLeftX="343" topLeftY="179" presetHandlers="8" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.1)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="100" height="30" topLeftX="427" topLeftY="124" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">优势二</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="21" topLeftX="360" topLeftY="207" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>输入相关的描述信息描述标题</strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="360" startY="141" endX="432" endY="141">
+        <border color="linear-gradient(90deg,rgba(0, 209, 240, 0) 0%,rgba(147, 151, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="595" startY="141" endX="518" endY="141">
+        <border color="linear-gradient(90deg,rgba(0, 209, 240, 0) 0%,rgba(147, 151, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="77" height="18" topLeftX="357" topLeftY="300" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="375" topLeftY="252" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="385" topLeftY="262" iconType="iconpark/Base/home.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="438" topLeftY="300" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="456" topLeftY="252" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="466" topLeftY="262" iconType="iconpark/Base/hourglass-full.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="520" topLeftY="300" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="538" topLeftY="252" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="548" topLeftY="262" iconType="iconpark/Base/more-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="357" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="375" topLeftY="344" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="385" topLeftY="354" iconType="iconpark/Base/pic.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="438" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="456" topLeftY="344" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="466" topLeftY="354" iconType="iconpark/Base/all-application.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="520" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="538" topLeftY="344" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="548" topLeftY="354" iconType="iconpark/Base/aiming.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="269" height="254" topLeftX="644" topLeftY="179" presetHandlers="8" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 0.1)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="100" height="30" topLeftX="728" topLeftY="124" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">优势三</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="235" height="21" topLeftX="661" topLeftY="207" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>输入相关的描述信息描述标题</strong>
+          </p>
+        </content>
+      </shape>
+      <line startX="661" startY="141" endX="733" endY="141">
+        <border color="linear-gradient(90deg,rgba(0, 209, 240, 0) 0%,rgba(147, 151, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <line startX="896" startY="141" endX="819" endY="141">
+        <border color="linear-gradient(90deg,rgba(0, 209, 240, 0) 0%,rgba(147, 151, 244, 1) 100%)" width="1" lineCap="square" lineJoin="miter" miterLimit="10"/>
+      </line>
+      <shape width="77" height="18" topLeftX="658" topLeftY="300" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="676" topLeftY="252" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="686" topLeftY="262" iconType="iconpark/Office/file-txt.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="739" topLeftY="300" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="757" topLeftY="252" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="767" topLeftY="262" iconType="iconpark/Office/file-editing.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="821" topLeftY="300" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="839" topLeftY="252" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="849" topLeftY="262" iconType="iconpark/Office/box.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="658" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="676" topLeftY="344" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="686" topLeftY="354" iconType="iconpark/Base/setting-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="739" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="757" topLeftY="344" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="767" topLeftY="354" iconType="iconpark/Office/compression.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="77" height="18" topLeftX="821" topLeftY="392" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="center">
+          <p textAlign="center">
+            <span fontSize="12">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="40" height="40" topLeftX="839" topLeftY="344" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="20" height="20" topLeftX="849" topLeftY="354" iconType="iconpark/Office/copy-one.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EHSwbpJS0o0vOZxVKxTcc5yqnyd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="653" height="42" topLeftX="42" topLeftY="17" type="text">
+        <content textType="sub-headline" fontSize="28" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p textAlign="left">行业地位</p>
+        </content>
+      </shape>
+      <shape width="434" height="42" topLeftX="42" topLeftY="91" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="199" height="254" topLeftX="42" topLeftY="179" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="161" height="54" topLeftX="61" topLeftY="252" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="54" fontFamily="Arial">80</span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" fontFamily="Arial">%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="63" topLeftX="61" topLeftY="324" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <icon width="73" height="73" topLeftX="158" topLeftY="191" alpha="0.2" iconType="iconpark/Charts/chart-line.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="199" height="254" topLeftX="268" topLeftY="179" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="170" height="54" topLeftX="287" topLeftY="252" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="54" fontFamily="Arial">18.5</span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" fontFamily="Arial">万方</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="63" topLeftX="287" topLeftY="324" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <icon width="73" height="73" topLeftX="384" topLeftY="191" alpha="0.2" iconType="iconpark/Travel/international.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="199" height="254" topLeftX="493" topLeftY="179" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="161" height="54" topLeftX="512" topLeftY="252" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="54" fontFamily="Arial">1000</span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" fontFamily="Arial">+</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="63" topLeftX="512" topLeftY="324" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <icon width="73" height="73" topLeftX="609" topLeftY="191" alpha="0.2" iconType="iconpark/Base/more-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="199" height="254" topLeftX="719" topLeftY="179" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="123" height="54" topLeftX="738" topLeftY="252" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="54" fontFamily="Arial">3</span>
+            <span color="rgba(255, 255, 255, 1)" fontSize="24" fontFamily="Arial">名</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="161" height="63" topLeftX="738" topLeftY="324" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <icon width="73" height="73" topLeftX="835" topLeftY="191" alpha="0.2" iconType="iconpark/Charts/chart-histogram-two.svg">
+        <border color="rgba(255, 255, 255, 1)" width="4" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EHSwbpJS0o0vOZxVKxTcc5yqnyd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="653" height="42" topLeftX="42" topLeftY="17" type="text">
+        <content textType="sub-headline" fontSize="28" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p textAlign="left">行业地位</p>
+        </content>
+      </shape>
+      <shape width="260" height="63" topLeftX="35" topLeftY="393" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <img src="VCNKb70k1oe0cnx188YcDSc0neg" width="177" height="317" topLeftX="737" topLeftY="139" exposure="14" contrast="-5" saturation="11" temperature="-26">
+        <crop type="rect" leftOffset="0.27" rightOffset="0.27" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="OvArbORrPod2quxk3DncfEFMnEg" width="177" height="317" topLeftX="543" topLeftY="139" exposure="14" contrast="-5" saturation="11" temperature="-26">
+        <crop type="rect" leftOffset="31" rightOffset="31" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <img src="OVKjbsCsFof2vdxs3V0csFisnaf" width="177" height="317" topLeftX="339" topLeftY="139" exposure="14" contrast="-5" saturation="11" temperature="-26">
+        <crop type="rect" leftOffset="0.27" rightOffset="0.27" topOffset="0" bottomOffset="0" presetHandlers="8"/>
+      </img>
+      <shape width="260" height="10" topLeftX="35" topLeftY="220" presetHandlers="16" alpha="0.1" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="200" height="10" topLeftX="35" topLeftY="220" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="177" height="21" topLeftX="35" topLeftY="193" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>数据</p>
+        </content>
+      </shape>
+      <shape width="60" height="21" topLeftX="235" topLeftY="193" type="text">
+        <content fontSize="14" fontFamily="Arial" color="rgba(222, 224, 227, 1)" textAlign="right">
+          <p textAlign="right">
+            <span fontFamily="Arial">77%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="10" topLeftX="35" topLeftY="287" presetHandlers="16" alpha="0.1" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="140" height="10" topLeftX="35" topLeftY="287" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="177" height="21" topLeftX="35" topLeftY="260" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>数据</p>
+        </content>
+      </shape>
+      <shape width="60" height="21" topLeftX="235" topLeftY="260" type="text">
+        <content fontSize="14" fontFamily="Arial" color="rgba(222, 224, 227, 1)" textAlign="right">
+          <p textAlign="right">
+            <span fontFamily="Arial">55%</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="260" height="10" topLeftX="35" topLeftY="355" presetHandlers="16" alpha="0.1" type="round-rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="220" height="10" topLeftX="35" topLeftY="355" presetHandlers="16" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="177" height="21" topLeftX="35" topLeftY="328" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>数据</p>
+        </content>
+      </shape>
+      <shape width="60" height="21" topLeftX="235" topLeftY="328" type="text">
+        <content fontSize="14" fontFamily="Arial" color="rgba(222, 224, 227, 1)" textAlign="right">
+          <p textAlign="right">
+            <span fontFamily="Arial">88%</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EHSwbpJS0o0vOZxVKxTcc5yqnyd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="653" height="42" topLeftX="42" topLeftY="17" type="text">
+        <content textType="sub-headline" fontSize="28" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p textAlign="left">最佳实践</p>
+        </content>
+      </shape>
+      <img src="XluEbobgOoQWwpxksqicuH8SnKb" width="287" height="179" topLeftX="331" topLeftY="287">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="72" height="18" topLeftX="455" topLeftY="303" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="427" topLeftY="301" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="60" height="60" topLeftX="331" topLeftY="195" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)">最佳实践</span>
+          </p>
+        </content>
+      </shape>
+      <img src="YgCMbbIkio2VjFxGAjYcpNYInDc" width="277" height="77" topLeftX="37" topLeftY="286">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <img src="LAMDbYeWToVWy6xzO7hc87e3nLg" width="284" height="82" topLeftX="636" topLeftY="282">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="224" height="30" topLeftX="42" topLeftY="225" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="21" topLeftX="42" topLeftY="261" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)">输入相关的描述信息描述标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="30" topLeftX="696" topLeftY="225" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="20">标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="224" height="21" topLeftX="696" topLeftY="261" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>
+              <span color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)">输入相关的描述信息描述标题</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="437" topLeftY="195" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)">最佳实践</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="543" topLeftY="195" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)">最佳实践</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="386" topLeftY="114" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)">最佳实践</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="60" height="60" topLeftX="492" topLeftY="114" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <content fontSize="16" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" lineSpacing="multiple:1.2">
+          <p lineSpacing="multiple:1.2">
+            <span color="rgba(255, 255, 255, 1)">最佳实践</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XZAxbIhLsok8UFxXIsvcb8r7nad" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="100" height="34" topLeftX="480" topLeftY="351" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">查看详情</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="IWHzb12C1oNer1xCqNmch9FunBc" width="328" height="368" topLeftX="83" topLeftY="87" exposure="14" contrast="-5" saturation="11" temperature="-26">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="34" bottomOffset="34" presetHandlers="8"/>
+      </img>
+      <shape width="431" height="42" topLeftX="480" topLeftY="270" type="text">
+        <content textType="title" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="431" height="40" topLeftX="480" topLeftY="202" type="text">
+        <content textType="title" fontSize="40" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p>产品价格</p>
+        </content>
+      </shape>
+      <shape width="431" height="54" topLeftX="480" topLeftY="145" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p textAlign="left">PART 3</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EHSwbpJS0o0vOZxVKxTcc5yqnyd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="653" height="42" topLeftX="42" topLeftY="17" type="text">
+        <content textType="sub-headline" fontSize="28" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>产品价格体系</p>
+        </content>
+      </shape>
+      <shape width="270" height="376" topLeftX="647" topLeftY="99" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="270" height="376" topLeftX="42" topLeftY="99" presetHandlers="8" type="round-rect">
+        <border color="rgba(255, 255, 255, 0.2)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="270" height="376" topLeftX="345" topLeftY="99" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </shape>
+      <shape width="238" height="21" topLeftX="362" topLeftY="123" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>高级版价格</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="395" topLeftY="210" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">描述信息描述信息描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="238" height="36" topLeftX="362" topLeftY="151" type="text">
+        <content fontSize="24" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="24">16,888</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="395" topLeftY="247" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="395" topLeftY="284" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="359" topLeftY="207" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="359" topLeftY="245" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="359" topLeftY="282" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="359" topLeftY="393" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 227, 227, 1)"/>
+        </fill>
+        <border color="rgba(216, 57, 49, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="359" topLeftY="430" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 227, 227, 1)"/>
+        </fill>
+        <border color="rgba(216, 57, 49, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="205" height="18" topLeftX="395" topLeftY="321" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">描述信息描述信息描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="395" topLeftY="358" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="395" topLeftY="395" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="395" topLeftY="433" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="554" topLeftY="121" alpha="0.1" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="32" topLeftX="561" topLeftY="129" alpha="0.2" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+      </shape>
+      <icon width="16" height="16" topLeftX="569" topLeftY="138" iconType="iconpark/Game/trophy.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="238" height="21" topLeftX="59" topLeftY="123" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>基础价格</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="92" topLeftY="210" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">描述信息描述信息描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="238" height="36" topLeftX="59" topLeftY="151" type="text">
+        <content fontSize="24" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" fontSize="24">12,888</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="92" topLeftY="247" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="92" topLeftY="284" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="57" topLeftY="319" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 227, 227, 1)"/>
+        </fill>
+        <border color="rgba(216, 57, 49, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="57" topLeftY="356" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 227, 227, 1)"/>
+        </fill>
+        <border color="rgba(216, 57, 49, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="57" topLeftY="207" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="57" topLeftY="245" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="57" topLeftY="282" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="57" topLeftY="393" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 227, 227, 1)"/>
+        </fill>
+        <border color="rgba(216, 57, 49, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="57" topLeftY="430" iconType="iconpark/Character/close-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 227, 227, 1)"/>
+        </fill>
+        <border color="rgba(216, 57, 49, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="205" height="18" topLeftX="92" topLeftY="321" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">描述信息描述信息描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="92" topLeftY="358" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="92" topLeftY="395" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="92" topLeftY="433" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="251" topLeftY="121" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(102, 51, 231, 1) 0%,rgba(145, 122, 215, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="32" topLeftX="258" topLeftY="129" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(102, 51, 231, 1) 0%,rgba(145, 122, 215, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="16" height="16" topLeftX="266" topLeftY="138" iconType="iconpark/Game/trophy.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="238" height="21" topLeftX="664" topLeftY="123" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>专业版价格</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="697" topLeftY="210" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">描述信息描述信息描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="238" height="36" topLeftX="664" topLeftY="151" type="text">
+        <content fontSize="24" fontFamily="思源黑体" color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" bold="true" textAlign="left">
+          <p textAlign="left">
+            <strong>
+              <span color="linear-gradient(135deg,rgba(193, 208, 250, 1) 0%,rgba(133, 167, 255, 1) 54%,rgba(166, 68, 255, 1) 100%)" fontSize="24">20,888</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="697" topLeftY="247" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="697" topLeftY="284" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="663" topLeftY="207" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="663" topLeftY="245" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="663" topLeftY="282" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="205" height="18" topLeftX="697" topLeftY="321" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">描述信息描述信息描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="697" topLeftY="358" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="697" topLeftY="395" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="205" height="18" topLeftX="697" topLeftY="433" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">描述信息描述信息描述信息</p>
+        </content>
+      </shape>
+      <shape width="46" height="46" topLeftX="856" topLeftY="121" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(102, 51, 231, 1) 0%,rgba(145, 122, 215, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="32" height="32" topLeftX="863" topLeftY="129" alpha="0.3" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(102, 51, 231, 1) 0%,rgba(145, 122, 215, 1) 100%)"/>
+        </fill>
+      </shape>
+      <icon width="16" height="16" topLeftX="871" topLeftY="138" iconType="iconpark/Game/trophy.svg">
+        <border color="rgba(255, 255, 255, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="359" topLeftY="316" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="359" topLeftY="355" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="663" topLeftY="319" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="663" topLeftY="356" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="663" topLeftY="393" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="23" height="23" topLeftX="663" topLeftY="430" iconType="iconpark/Character/check-one.svg">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <border color="rgba(46, 161, 33, 1)" width="1" lineJoin="miter" miterLimit="10"/>
+      </icon>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EHSwbpJS0o0vOZxVKxTcc5yqnyd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="653" height="42" topLeftX="42" topLeftY="17" type="text">
+        <content textType="sub-headline" fontSize="28" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>客户评价</p>
+        </content>
+      </shape>
+      <shape width="419" height="175" topLeftX="42" topLeftY="98" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(92, 135, 245, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </shape>
+      <shape width="72" height="21" topLeftX="106" topLeftY="213" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">姓名</p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="106" topLeftY="232" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">Title</span>
+          </p>
+        </content>
+      </shape>
+      <img src="AxddbMhlFoFVBrxBsi9cQfx1nTd" width="32" height="32" topLeftX="66" topLeftY="216">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="216"/>
+      </img>
+      <shape width="72" height="18" topLeftX="378" topLeftY="223" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="349" topLeftY="221" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="32" height="54" topLeftX="50" topLeftY="105" alpha="0.25" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="54" fontFamily="Arial">“</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="371" height="63" topLeftX="66" topLeftY="125" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价</p>
+        </content>
+      </shape>
+      <shape width="419" height="175" topLeftX="496" topLeftY="98" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </shape>
+      <shape width="72" height="21" topLeftX="560" topLeftY="213" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">姓名</p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="560" topLeftY="232" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">Title</span>
+          </p>
+        </content>
+      </shape>
+      <img src="AxddbMhlFoFVBrxBsi9cQfx1nTd" width="32" height="32" topLeftX="520" topLeftY="216">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="216"/>
+      </img>
+      <shape width="72" height="18" topLeftX="832" topLeftY="223" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="803" topLeftY="221" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="32" height="54" topLeftX="504" topLeftY="105" alpha="0.25" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="54" fontFamily="Arial">“</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="371" height="63" topLeftX="520" topLeftY="125" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价</p>
+        </content>
+      </shape>
+      <shape width="419" height="175" topLeftX="42" topLeftY="314" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </shape>
+      <shape width="72" height="21" topLeftX="106" topLeftY="430" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">姓名</p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="106" topLeftY="449" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">Title</span>
+          </p>
+        </content>
+      </shape>
+      <img src="AxddbMhlFoFVBrxBsi9cQfx1nTd" width="32" height="32" topLeftX="66" topLeftY="433">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="216"/>
+      </img>
+      <shape width="72" height="18" topLeftX="378" topLeftY="440" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="349" topLeftY="438" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="32" height="54" topLeftX="50" topLeftY="322" alpha="0.25" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="54" fontFamily="Arial">“</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="371" height="63" topLeftX="66" topLeftY="341" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价</p>
+        </content>
+      </shape>
+      <shape width="419" height="175" topLeftX="496" topLeftY="314" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </shape>
+      <shape width="72" height="21" topLeftX="560" topLeftY="430" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">姓名</p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="560" topLeftY="449" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">Title</span>
+          </p>
+        </content>
+      </shape>
+      <img src="AxddbMhlFoFVBrxBsi9cQfx1nTd" width="32" height="32" topLeftX="520" topLeftY="433">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0" presetHandlers="216"/>
+      </img>
+      <shape width="72" height="18" topLeftX="832" topLeftY="440" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="803" topLeftY="438" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="32" height="54" topLeftX="504" topLeftY="322" alpha="0.25" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="rgba(255, 255, 255, 1)" fontSize="54" fontFamily="Arial">“</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="371" height="63" topLeftX="520" topLeftY="341" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价，输入相关的描述信息描述客户评价</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="XZAxbIhLsok8UFxXIsvcb8r7nad" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="100" height="34" topLeftX="480" topLeftY="351" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="14">查看详情</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <img src="Ywdkb7xP8oZYI5xjy9lcnAaMn63" width="328" height="368" topLeftX="83" topLeftY="87" exposure="14" contrast="-5" saturation="11" temperature="-26">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="108" bottomOffset="108" presetHandlers="8"/>
+      </img>
+      <shape width="431" height="42" topLeftX="480" topLeftY="270" type="text">
+        <content textType="title" fontSize="14" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="false">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="431" height="40" topLeftX="480" topLeftY="202" type="text">
+        <content textType="title" fontSize="40" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p>未来展望</p>
+        </content>
+      </shape>
+      <shape width="431" height="54" topLeftX="480" topLeftY="145" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p textAlign="left">PART 4</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="EHSwbpJS0o0vOZxVKxTcc5yqnyd" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="653" height="42" topLeftX="42" topLeftY="17" type="text">
+        <content textType="sub-headline" fontSize="28" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>产品布局</p>
+        </content>
+      </shape>
+      <img src="IqXXbL1bJoyXO2xZnLgcAQYSn7d" width="768" height="375" topLeftX="96" topLeftY="82">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="180" height="80" topLeftX="73" topLeftY="192" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </shape>
+      <shape width="161" height="54" topLeftX="83" topLeftY="205" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>
+            <span fontSize="12">输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="80" topLeftX="253" topLeftY="394" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </shape>
+      <shape width="161" height="54" topLeftX="263" topLeftY="407" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>
+            <span fontSize="12">输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="80" topLeftX="419" topLeftY="63" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </shape>
+      <shape width="161" height="54" topLeftX="428" topLeftY="76" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>
+            <span fontSize="12">输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="180" height="80" topLeftX="630" topLeftY="304" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+        <border color="rgba(255, 255, 255, 0.3)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </shape>
+      <shape width="161" height="54" topLeftX="639" topLeftY="317" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>
+            <span fontSize="12">输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="179" height="155" topLeftX="35" topLeftY="348" presetHandlers="8" alpha="0.5" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 0.1) 0%,rgba(74, 60, 243, 0.1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+      </shape>
+      <shape width="155" height="21" topLeftX="45" topLeftY="363" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true">
+          <p>
+            <strong>说明</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="139" height="18" topLeftX="65" topLeftY="390" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="10" height="10" topLeftX="46" topLeftY="394" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="139" height="18" topLeftX="65" topLeftY="415" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="10" height="10" topLeftX="46" topLeftY="419" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="139" height="18" topLeftX="65" topLeftY="440" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="10" height="10" topLeftX="46" topLeftY="444" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="139" height="18" topLeftX="65" topLeftY="465" type="text">
+        <content fontSize="12" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" textAlign="left">
+          <p textAlign="left">
+            <span fontSize="12">输入相关的描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="10" height="10" topLeftX="46" topLeftY="469" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="10" topLeftX="163" topLeftY="170" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(14, 198, 215, 1) 0%,rgba(0, 137, 181, 1) 63%,rgba(17, 198, 154, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="10" topLeftX="516" topLeftY="149" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(231, 151, 30, 1) 0%,rgba(232, 81, 49, 1) 63%,rgba(240, 193, 123, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="10" topLeftX="338" topLeftY="371" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+      </shape>
+      <shape width="10" height="10" topLeftX="674" topLeftY="272" type="ellipse">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(55, 182, 207, 1) 0%,rgba(66, 62, 237, 1) 66%,rgba(56, 137, 234, 1) 100%)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="L76CbnVyxo5C2yxuas1csfaqn1c" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="GhNsbFJ2toyerNx34evcOKrDnkd" width="768" height="375" topLeftX="96" topLeftY="82" alpha="0.5">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="72" height="18" topLeftX="869" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="840" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="653" height="42" topLeftX="42" topLeftY="17" type="text">
+        <content textType="sub-headline" fontSize="28" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>未来展望</p>
+        </content>
+      </shape>
+      <shape width="885" height="269" topLeftX="38" topLeftY="234" presetHandlers="8" type="round-rect">
+        <fill>
+          <fillColor color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)"/>
+        </fill>
+        <border color="linear-gradient(135deg,rgba(116, 154, 253, 1) 0%,rgba(80, 86, 231, 1) 55%,rgba(153, 55, 242, 1) 100%)" width="1" lineJoin="miter" miterLimit="10"/>
+        <shadow/>
+      </shape>
+      <shape width="204" height="54" topLeftX="38" topLeftY="105" type="text">
+        <content textType="title" fontSize="54" fontFamily="Arial" color="linear-gradient(135deg,rgba(0, 209, 240, 1) 0%,rgba(95, 173, 243, 1) 55%,rgba(147, 151, 244, 1) 100%)" bold="true" lineSpacing="multiple:1" textAlign="left">
+          <p textAlign="left">
+            <span color="linear-gradient(135deg,rgba(0, 209, 240, 1) 0%,rgba(95, 173, 243, 1) 55%,rgba(147, 151, 244, 1) 100%)" fontSize="54" fontFamily="Arial">19,810</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="653" height="84" topLeftX="269" topLeftY="110" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)">
+          <p>输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题，输入相关的描述信息描述上述标题</p>
+        </content>
+      </shape>
+      <shape width="200" height="30" topLeftX="42" topLeftY="169" type="text">
+        <content fontSize="20" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">数据描述</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="830" height="48" topLeftX="65" topLeftY="273" presetHandlers="8" alpha="0.3" type="round-rect">
+        <fill>
+          <fillColor color="rgba(23, 29, 99, 1)"/>
+        </fill>
+      </shape>
+      <shape width="245" height="21" topLeftX="92" topLeftY="286" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>标题</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="245" height="21" topLeftX="355" topLeftY="286" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>标题</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="245" height="21" topLeftX="619" topLeftY="286" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="true" textAlign="center">
+          <p textAlign="center">
+            <strong>标题</strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="245" height="21" topLeftX="92" topLeftY="336" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span bold="false">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="245" height="21" topLeftX="355" topLeftY="336" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false" textAlign="center">
+          <p textAlign="center">描述信息</p>
+        </content>
+      </shape>
+      <shape width="245" height="21" topLeftX="619" topLeftY="336" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false" textAlign="center">
+          <p textAlign="center">描述信息</p>
+        </content>
+      </shape>
+      <shape width="245" height="21" topLeftX="92" topLeftY="388" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span bold="false">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="245" height="21" topLeftX="355" topLeftY="388" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false" textAlign="center">
+          <p textAlign="center">描述信息</p>
+        </content>
+      </shape>
+      <shape width="245" height="21" topLeftX="619" topLeftY="388" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false" textAlign="center">
+          <p textAlign="center">描述信息</p>
+        </content>
+      </shape>
+      <shape width="245" height="21" topLeftX="92" topLeftY="440" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false" textAlign="center">
+          <p textAlign="center">
+            <span bold="false">描述信息</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="245" height="21" topLeftX="355" topLeftY="440" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false" textAlign="center">
+          <p textAlign="center">描述信息</p>
+        </content>
+      </shape>
+      <shape width="245" height="21" topLeftX="619" topLeftY="440" type="text">
+        <content fontSize="14" fontFamily="思源黑体" color="rgba(222, 224, 227, 1)" bold="false" textAlign="center">
+          <p textAlign="center">描述信息</p>
+        </content>
+      </shape>
+      <shape width="830" height="48" topLeftX="65" topLeftY="374" presetHandlers="8" alpha="0.1" type="round-rect">
+        <fill>
+          <fillColor color="rgba(23, 29, 99, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillImg src="KYXNb7bSmoFNDvxOgNvcycZJnBf" alpha="1" rotateWithShape="false"/>
+      </fill>
+    </style>
+    <data>
+      <img src="FyQzbLdIRokiRZxiHdVcsbCcnog" width="1088" height="369" topLeftX="-59" topLeftY="85" rotation="180" alpha="0.8">
+        <crop leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="0"/>
+      </img>
+      <shape width="72" height="18" topLeftX="64" topLeftY="26" type="text">
+        <content fontSize="18" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Arial">LOGO</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <icon width="23" height="23" topLeftX="36" topLeftY="24" iconType="iconpark/Abstract/api-app.svg">
+        <border color="rgba(255, 255, 255, 1)" width="2" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="842" height="42" topLeftX="64" topLeftY="270" type="text">
+        <content textType="title" fontSize="28" fontFamily="Arial" color="rgba(255, 255, 255, 1)" bold="true" italic="true" textAlign="center">
+          <p textAlign="center">The Future is Here. Thank you for Watching</p>
+        </content>
+      </shape>
+      <shape width="842" height="90" topLeftX="64" topLeftY="177" type="text">
+        <content textType="title" fontSize="60" fontFamily="思源黑体" color="rgba(255, 255, 255, 1)" bold="true" textAlign="center">
+          <p textAlign="center">未来已至 感谢观看</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/product--product_promotion.xml
+++ b/skills/lark-slides/references/templates/product--product_promotion.xml
@@ -1,0 +1,687 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>产品推广方案-裂图重新上传</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="64"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF" fontSize="14"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style/>
+    <data>
+      <img src="KQ11bto5XoGHbCxBHmMchsYOn9e" width="251" height="425" topLeftX="578" topLeftY="65">
+        <crop type="rect" leftOffset="6" rightOffset="169" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="39" height="425" topLeftX="578" topLeftY="65" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="536" height="180" topLeftX="84" topLeftY="85" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">DIGITAL</span>
+          </p>
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">MARKETING</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="325" height="68" topLeftX="84" topLeftY="257" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>产品推广计划</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="250" height="77" topLeftX="56" topLeftY="85" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true">
+          <p>CONTENTS</p>
+        </content>
+      </shape>
+      <shape width="250" height="68" topLeftX="56" topLeftY="142" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="false" textAlign="left">
+          <p>
+            <span bold="false">目录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="102" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="113" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18">关于我们</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="114" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="189" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="200" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18">愿景&amp;目标</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="201" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="275" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="287" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18">品牌策略</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="288" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="372" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="384" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">核心产品</p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="385" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="24">关于我们</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="450" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KFOtbv5TUoKxm8x9dDfcfb6snEd" width="202" height="128" topLeftX="257" topLeftY="75" exposure="5" contrast="-12" saturation="-24" temperature="-65">
+        <crop type="rect" leftOffset="126" rightOffset="29" topOffset="212" bottomOffset="18" presetHandlers="0"/>
+      </img>
+      <img src="KFOtbv5TUoKxm8x9dDfcfb6snEd" width="202" height="128" topLeftX="38" topLeftY="75" flipY="true" exposure="5" contrast="-12" saturation="-24" temperature="-73">
+        <crop type="rect" leftOffset="0" rightOffset="202" topOffset="101" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="250" height="140" topLeftX="28" topLeftY="323" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" bold="true">
+          <p>
+            <span fontSize="80">Hello</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="68" topLeftX="32" topLeftY="293" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="false" textAlign="left">
+          <p>
+            <span bold="false">你好</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="56" topLeftX="34" topLeftY="215" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="74" topLeftX="507" topLeftY="99" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="230" topLeftX="507" topLeftY="229" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <img src="TE9RblFGdowyVexgIYIc2GEonJd" width="395" height="230" topLeftX="507" topLeftY="229" saturation="-43" temperature="-100">
+        <crop type="rect" leftOffset="20" rightOffset="17" topOffset="88" bottomOffset="113" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="372" height="116" topLeftX="28" topLeftY="130" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true">
+          <p>About us</p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="32" topLeftY="103" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">关于我们</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="74" topLeftX="32" topLeftY="235" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="TDYmbbCrPoAAz0xgXVwcbblrn4f" width="395" height="415" topLeftX="507" topLeftY="44" saturation="-100" temperature="-100">
+        <crop type="rect" leftOffset="26" rightOffset="68" topOffset="30" bottomOffset="45" presetHandlers="0"/>
+      </img>
+      <shape width="39" height="415" topLeftX="863" topLeftY="44" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <span color="rgba(255, 255, 255, 1)">愿景&amp;目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="460" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="250" height="92" topLeftX="65" topLeftY="100" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" bold="true">
+          <p>
+            <span fontSize="48">Vision</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="56" topLeftX="65" topLeftY="168" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="92" topLeftX="482" topLeftY="100" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" bold="true">
+          <p>
+            <span fontSize="48">Mission</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="65" topLeftY="72" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">愿景</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="482" topLeftY="72" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="56" topLeftX="482" topLeftY="168" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="189" topLeftX="74" topLeftY="240" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <img src="EnkQbyTJKouv4bx15ezccGjinXc" width="395" height="189" topLeftX="74" topLeftY="240">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="206" presetHandlers="0"/>
+      </img>
+      <img src="ProZbJDy5omwBlxreCgcPqA9nOc" width="395" height="189" topLeftX="491" topLeftY="240" exposure="5" contrast="-23" saturation="-30" temperature="-42">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="118" bottomOffset="88" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <span color="rgba(255, 255, 255, 1)">品牌策略</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="450" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="372" height="116" topLeftX="28" topLeftY="130" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true">
+          <p>Strategy</p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="32" topLeftY="103" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">推广策略</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="74" topLeftX="32" topLeftY="245" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <span color="rgba(255, 255, 255, 1)" bold="false">核心项目</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="450" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18" bold="false">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="196" height="50" topLeftX="95" topLeftY="77" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">Project 01 - XXX</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="49" topLeftX="81" topLeftY="393" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 0.502)" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">描述相关的信息以解释你的标题。现在就开始打字吧。</p>
+        </content>
+      </shape>
+      <shape width="231" height="42" topLeftX="81" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="18">关键点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="164" topLeftX="98" topLeftY="172" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="231" height="49" topLeftX="365" topLeftY="393" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 0.502)" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">描述相关的信息以解释你的标题。现在就开始打字吧。</p>
+        </content>
+      </shape>
+      <shape width="231" height="42" topLeftX="365" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="18">关键点 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="164" topLeftX="382" topLeftY="172" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="231" height="49" topLeftX="648" topLeftY="393" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 0.502)" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">描述相关的信息以解释你的标题。现在就开始打字吧。</p>
+        </content>
+      </shape>
+      <shape width="231" height="42" topLeftX="648" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="18">关键点 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="164" topLeftX="666" topLeftY="172" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="66" height="66" topLeftX="163" topLeftY="221" iconType="iconpark/Base/bookmark.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="66" height="66" topLeftX="447" topLeftY="221" iconType="iconpark/Base/camera.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="66" height="66" topLeftX="731" topLeftY="221" iconType="iconpark/Office/list-view.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="554" height="56" topLeftX="291" topLeftY="77" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="318" height="74" topLeftX="32" topLeftY="271" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="465" topLeftX="379" topLeftY="37" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="196" height="50" topLeftX="32" topLeftY="221" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">Project 02 - XXX</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="74" topLeftX="610" topLeftY="93" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="226" topLeftX="610" topLeftY="276" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <img src="GGuFbd8azoDXASxtmdRcCjG0nrf" width="202" height="465" topLeftX="379" topLeftY="37" saturation="-73" temperature="-57">
+        <crop type="rect" leftOffset="132" rightOffset="132" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="LYMEbK4ZroZq9pxhlNfcdHignHe" width="201" height="226" topLeftX="610" topLeftY="276" exposure="-4" contrast="-19" saturation="-23" temperature="-32">
+        <crop type="rect" leftOffset="200" rightOffset="0" topOffset="64" bottomOffset="111" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="KQ11bto5XoGHbCxBHmMchsYOn9e" width="251" height="425" topLeftX="578" topLeftY="65">
+        <crop type="rect" leftOffset="6" rightOffset="169" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="39" height="425" topLeftX="578" topLeftY="65" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="536" height="180" topLeftX="84" topLeftY="85" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">THANK</span>
+          </p>
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">YOU</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="325" height="68" topLeftX="84" topLeftY="257" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>感谢观看</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/references/templates/product--product_promotion_2.xml
+++ b/skills/lark-slides/references/templates/product--product_promotion_2.xml
@@ -1,0 +1,687 @@
+<presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+  <title>产品推广方案-裂图重新上传</title>
+  <theme>
+    <textStyles>
+      <title fontColor="#000000FF" fontSize="64"/>
+      <headline fontColor="#000000FF"/>
+      <sub-headline fontColor="#000000FF"/>
+      <body fontColor="#000000FF" fontSize="14"/>
+      <caption fontColor="#808080FF" fontSize="14"/>
+    </textStyles>
+  </theme>
+  <slide>
+    <style/>
+    <data>
+      <img src="KQ11bto5XoGHbCxBHmMchsYOn9e" width="251" height="425" topLeftX="578" topLeftY="65">
+        <crop type="rect" leftOffset="6" rightOffset="169" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="39" height="425" topLeftX="578" topLeftY="65" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="536" height="180" topLeftX="84" topLeftY="85" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">DIGITAL</span>
+          </p>
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">MARKETING</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="325" height="68" topLeftX="84" topLeftY="257" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>产品推广计划</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="250" height="77" topLeftX="56" topLeftY="85" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="38" bold="true">
+          <p>CONTENTS</p>
+        </content>
+      </shape>
+      <shape width="250" height="68" topLeftX="56" topLeftY="142" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="false" textAlign="left">
+          <p>
+            <span bold="false">目录</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="102" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="113" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18">关于我们</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="114" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="189" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="200" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18">愿景&amp;目标</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="201" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="275" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="287" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(0, 0, 0, 1)" fontSize="18">品牌策略</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="288" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+      <shape width="66" height="66" topLeftX="390" topLeftY="372" type="ellipse">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" fontFamily="Noto Sans" color="rgba(255, 255, 255, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="18" fontFamily="Noto Sans">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="43" topLeftX="463" topLeftY="384" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(0, 0, 0, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">核心产品</p>
+        </content>
+      </shape>
+      <shape width="330" height="41" topLeftX="581" topLeftY="385" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="14" textAlign="left">
+          <p>输入相关的描述信息以解释你的标题。</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">01</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="118" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <strong>
+              <span color="rgba(255, 255, 255, 1)" fontSize="24">关于我们</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="450" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <img src="KFOtbv5TUoKxm8x9dDfcfb6snEd" width="202" height="128" topLeftX="257" topLeftY="75" exposure="5" contrast="-12" saturation="-24" temperature="-65">
+        <crop type="rect" leftOffset="126" rightOffset="29" topOffset="212" bottomOffset="18" presetHandlers="0"/>
+      </img>
+      <img src="KFOtbv5TUoKxm8x9dDfcfb6snEd" width="202" height="128" topLeftX="38" topLeftY="75" flipY="true" exposure="5" contrast="-12" saturation="-24" temperature="-73">
+        <crop type="rect" leftOffset="0" rightOffset="202" topOffset="101" bottomOffset="175" presetHandlers="0"/>
+      </img>
+      <shape width="250" height="140" topLeftX="28" topLeftY="323" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" bold="true">
+          <p>
+            <span fontSize="80">Hello</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="68" topLeftX="32" topLeftY="293" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="false" textAlign="left">
+          <p>
+            <span bold="false">你好</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="56" topLeftX="34" topLeftY="215" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="74" topLeftX="507" topLeftY="99" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="230" topLeftX="507" topLeftY="229" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <img src="TE9RblFGdowyVexgIYIc2GEonJd" width="395" height="230" topLeftX="507" topLeftY="229" saturation="-43" temperature="-100">
+        <crop type="rect" leftOffset="20" rightOffset="17" topOffset="88" bottomOffset="113" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="372" height="116" topLeftX="28" topLeftY="130" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true">
+          <p>About us</p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="32" topLeftY="103" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">关于我们</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="74" topLeftX="32" topLeftY="235" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <img src="TDYmbbCrPoAAz0xgXVwcbblrn4f" width="395" height="415" topLeftX="507" topLeftY="44" saturation="-100" temperature="-100">
+        <crop type="rect" leftOffset="26" rightOffset="68" topOffset="30" bottomOffset="45" presetHandlers="0"/>
+      </img>
+      <shape width="39" height="415" topLeftX="863" topLeftY="44" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">02</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <span color="rgba(255, 255, 255, 1)">愿景&amp;目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="460" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="250" height="92" topLeftX="65" topLeftY="100" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" bold="true">
+          <p>
+            <span fontSize="48">Vision</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="56" topLeftX="65" topLeftY="168" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="92" topLeftX="482" topLeftY="100" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="48" bold="true">
+          <p>
+            <span fontSize="48">Mission</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="65" topLeftY="72" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">愿景</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="482" topLeftY="72" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">目标</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="56" topLeftX="482" topLeftY="168" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="395" height="189" topLeftX="74" topLeftY="240" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <img src="EnkQbyTJKouv4bx15ezccGjinXc" width="395" height="189" topLeftX="74" topLeftY="240">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="0" bottomOffset="206" presetHandlers="0"/>
+      </img>
+      <img src="ProZbJDy5omwBlxreCgcPqA9nOc" width="395" height="189" topLeftX="491" topLeftY="240" exposure="5" contrast="-23" saturation="-30" temperature="-42">
+        <crop type="rect" leftOffset="0" rightOffset="0" topOffset="118" bottomOffset="88" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">03</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="true" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <span color="rgba(255, 255, 255, 1)">品牌策略</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="450" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="372" height="116" topLeftX="28" topLeftY="130" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="64" bold="true">
+          <p>Strategy</p>
+        </content>
+      </shape>
+      <shape width="250" height="56" topLeftX="32" topLeftY="103" alpha="0.7" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" bold="false" textAlign="left">
+          <p>
+            <span fontSize="24" bold="false">推广策略</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="74" topLeftX="32" topLeftY="245" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <undefined type="fallback"/>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(43, 47, 54, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="118" height="118" topLeftX="182" topLeftY="193" type="ellipse">
+        <fill>
+          <fillColor color="rgba(255, 255, 255, 1)"/>
+        </fill>
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="36" fontFamily="Noto Sans" color="rgba(43, 47, 54, 1)" bold="true">
+          <p>
+            <strong>
+              <span color="rgba(43, 47, 54, 1)" fontSize="36" fontFamily="Noto Sans">04</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="141" height="51" topLeftX="316" topLeftY="227" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="24" color="rgba(255, 255, 255, 1)" bold="false" lineSpacing="multiple:1.3" textAlign="left">
+          <p lineSpacing="multiple:1.3">
+            <span color="rgba(255, 255, 255, 1)" bold="false">核心项目</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="330" height="47" topLeftX="450" topLeftY="229" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" color="rgba(255, 255, 255, 1)" bold="false" textAlign="left">
+          <p>
+            <span color="rgba(255, 255, 255, 1)" fontSize="18" bold="false">输入相关的描述信息以解释你的标题。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="196" height="50" topLeftX="95" topLeftY="77" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">Project 01 - XXX</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="231" height="49" topLeftX="81" topLeftY="393" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 0.502)" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">描述相关的信息以解释你的标题。现在就开始打字吧。</p>
+        </content>
+      </shape>
+      <shape width="231" height="42" topLeftX="81" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="18">关键点 #1</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="164" topLeftX="98" topLeftY="172" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="231" height="49" topLeftX="365" topLeftY="393" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 0.502)" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">描述相关的信息以解释你的标题。现在就开始打字吧。</p>
+        </content>
+      </shape>
+      <shape width="231" height="42" topLeftX="365" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="18">关键点 #2</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="164" topLeftX="382" topLeftY="172" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="231" height="49" topLeftX="648" topLeftY="393" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" color="rgba(43, 47, 54, 0.502)" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">描述相关的信息以解释你的标题。现在就开始打字吧。</p>
+        </content>
+      </shape>
+      <shape width="231" height="42" topLeftX="648" topLeftY="348" type="text">
+        <content textType="headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="18" bold="true" lineSpacing="multiple:1.2" textAlign="center">
+          <p lineSpacing="multiple:1.2">
+            <strong>
+              <span fontSize="18">关键点 #3</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="196" height="164" topLeftX="666" topLeftY="172" presetHandlers="0" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <icon width="66" height="66" topLeftX="163" topLeftY="221" iconType="iconpark/Base/bookmark.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="66" height="66" topLeftX="447" topLeftY="221" iconType="iconpark/Base/camera.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <icon width="66" height="66" topLeftX="731" topLeftY="221" iconType="iconpark/Office/list-view.svg">
+        <border color="rgba(255, 255, 255, 1)" width="3" lineJoin="miter" miterLimit="10"/>
+      </icon>
+      <shape width="554" height="56" topLeftX="291" topLeftY="77" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style>
+      <fill>
+        <fillColor color="rgba(255, 255, 255, 1)"/>
+      </fill>
+    </style>
+    <data>
+      <shape width="318" height="74" topLeftX="32" topLeftY="271" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="465" topLeftX="379" topLeftY="37" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <shape width="196" height="50" topLeftX="32" topLeftY="221" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="20" bold="true">
+          <p>
+            <strong>
+              <span fontSize="20">Project 02 - XXX</span>
+            </strong>
+          </p>
+        </content>
+      </shape>
+      <shape width="318" height="74" topLeftX="610" topLeftY="93" alpha="0.7" type="text">
+        <content paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="12" textAlign="left">
+          <p>
+            <span fontSize="12">描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。描述相关的信息以解释你的标题。现在就开始打字吧。写任何你想表达的内容。</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="202" height="226" topLeftX="610" topLeftY="276" type="rect">
+        <fill>
+          <fillColor/>
+        </fill>
+      </shape>
+      <img src="GGuFbd8azoDXASxtmdRcCjG0nrf" width="202" height="465" topLeftX="379" topLeftY="37" saturation="-73" temperature="-57">
+        <crop type="rect" leftOffset="132" rightOffset="132" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <img src="LYMEbK4ZroZq9pxhlNfcdHignHe" width="201" height="226" topLeftX="610" topLeftY="276" exposure="-4" contrast="-19" saturation="-23" temperature="-32">
+        <crop type="rect" leftOffset="200" rightOffset="0" topOffset="64" bottomOffset="111" presetHandlers="0"/>
+      </img>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+  <slide>
+    <style/>
+    <data>
+      <img src="KQ11bto5XoGHbCxBHmMchsYOn9e" width="251" height="425" topLeftX="578" topLeftY="65">
+        <crop type="rect" leftOffset="6" rightOffset="169" topOffset="0" bottomOffset="0" presetHandlers="0"/>
+      </img>
+      <shape width="39" height="425" topLeftX="578" topLeftY="65" type="rect">
+        <fill>
+          <fillColor color="rgba(43, 47, 54, 1)"/>
+        </fill>
+      </shape>
+      <shape width="536" height="180" topLeftX="84" topLeftY="85" type="text">
+        <content textType="title" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="80" color="rgba(43, 47, 54, 1)" bold="true" lineSpacing="multiple:1">
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">THANK</span>
+          </p>
+          <p lineSpacing="multiple:1">
+            <span fontSize="80">YOU</span>
+          </p>
+        </content>
+      </shape>
+      <shape width="325" height="68" topLeftX="84" topLeftY="257" type="text">
+        <content textType="sub-headline" paddingTop="10" paddingBottom="10" paddingLeft="10" paddingRight="10" fontSize="32" fontFamily="undefined" color="rgba(43, 47, 54, 1)" bold="true" textAlign="left">
+          <p>感谢观看</p>
+        </content>
+      </shape>
+    </data>
+    <note>
+      <content/>
+    </note>
+  </slide>
+</presentation>

--- a/skills/lark-slides/scripts/layout-lint.py
+++ b/skills/lark-slides/scripts/layout-lint.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+class LayoutLintError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise LayoutLintError(message)
+
+
+def read_file(file_path: str | Path) -> str:
+    return Path(file_path).read_text(encoding="utf-8")
+
+
+def parse_args(argv: list[str]) -> dict[str, Any]:
+    options: dict[str, Any] = {}
+    index = 0
+    while index < len(argv):
+        token = argv[index]
+        if not token.startswith("--"):
+            fail(f"unexpected argument: {token}")
+        key = token[2:]
+        next_token = argv[index + 1] if index + 1 < len(argv) else None
+        if next_token is None or next_token.startswith("--"):
+            options[key] = True
+            index += 1
+            continue
+        options[key] = next_token
+        index += 2
+    return options
+
+
+def extract_attribute(tag_source: str, name: str) -> str | None:
+    match = re.search(fr'{re.escape(name)}="([^"]+)"', tag_source)
+    return match.group(1) if match else None
+
+
+def extract_numeric_attribute(tag_source: str, name: str) -> int | float | None:
+    raw = extract_attribute(tag_source, name)
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except ValueError:
+        return None
+    return int(value) if value.is_integer() else value
+
+
+def strip_xml(value: str) -> str:
+    stripped = re.sub(r"<!\[CDATA\[([\s\S]*?)\]\]>", r"\1", value)
+    stripped = re.sub(r"<[^>]+>", " ", stripped)
+    stripped = stripped.replace("&nbsp;", " ")
+    stripped = stripped.replace("&amp;", "&")
+    stripped = stripped.replace("&lt;", "<")
+    stripped = stripped.replace("&gt;", ">")
+    stripped = stripped.replace("&quot;", '"')
+    stripped = stripped.replace("&#39;", "'")
+    return re.sub(r"\s+", " ", stripped).strip()
+
+
+def parse_presentation(xml: str) -> dict[str, Any]:
+    presentation_match = re.search(r"<presentation\b([^>]*)>", xml)
+    if presentation_match:
+        return {
+            "width": int(float(extract_attribute(presentation_match.group(1), "width") or 960)),
+            "height": int(float(extract_attribute(presentation_match.group(1), "height") or 540)),
+            "slides": re.findall(r"<slide\b[\s\S]*?</slide>", xml),
+        }
+    slide_match = re.findall(r"<slide\b[\s\S]*?</slide>", xml)
+    if slide_match:
+        return {"width": 960, "height": 540, "slides": slide_match}
+    fail("input must contain a <presentation> or <slide> root")
+
+
+def extract_elements(slide_xml: str) -> list[dict[str, Any]]:
+    elements: list[dict[str, Any]] = []
+    for match in re.finditer(r"<shape\b([^>]*)>([\s\S]*?)</shape>", slide_xml):
+        attrs, content = match.group(1), match.group(2)
+        x = extract_numeric_attribute(attrs, "topLeftX")
+        y = extract_numeric_attribute(attrs, "topLeftY")
+        width = extract_numeric_attribute(attrs, "width")
+        height = extract_numeric_attribute(attrs, "height")
+        if all(value is not None for value in [x, y, width, height]):
+            font_size = float(extract_attribute(content, "fontSize") or extract_attribute(attrs, "fontSize") or 16)
+            elements.append(
+                {
+                    "id": f"shape-{len(elements) + 1}",
+                    "kind": "shape",
+                    "type": extract_attribute(attrs, "type") or "shape",
+                    "textType": extract_attribute(content, "textType"),
+                    "x": x,
+                    "y": y,
+                    "width": width,
+                    "height": height,
+                    "fontSize": font_size,
+                    "text": strip_xml(content),
+                }
+            )
+
+    for match in re.finditer(r"<(img|table|chart)\b([^>]*)/?>", slide_xml):
+        attrs = match.group(2)
+        x = extract_numeric_attribute(attrs, "topLeftX")
+        y = extract_numeric_attribute(attrs, "topLeftY")
+        width = extract_numeric_attribute(attrs, "width")
+        height = extract_numeric_attribute(attrs, "height")
+        if all(value is not None for value in [x, y, width, height]):
+            elements.append(
+                {
+                    "id": f"{match.group(1)}-{len(elements) + 1}",
+                    "kind": match.group(1),
+                    "type": match.group(1),
+                    "x": x,
+                    "y": y,
+                    "width": width,
+                    "height": height,
+                }
+            )
+    return elements
+
+
+def intersects(left: dict[str, Any], right: dict[str, Any]) -> bool:
+    return (
+        left["x"] < right["x"] + right["width"]
+        and left["x"] + left["width"] > right["x"]
+        and left["y"] < right["y"] + right["height"]
+        and left["y"] + left["height"] > right["y"]
+    )
+
+
+def is_text_element(element: dict[str, Any]) -> bool:
+    return element["kind"] == "shape" and element["type"] == "text"
+
+
+def is_backgroundish(element: dict[str, Any], slide_area: int | float) -> bool:
+    if slide_area <= 0:
+        return False
+    area = element["width"] * element["height"]
+    if element["kind"] == "img":
+        return area >= slide_area * 0.45
+    if element["kind"] == "shape" and element["type"] != "text":
+        return area >= slide_area * 0.35
+    return False
+
+
+def should_flag_overlap(left: dict[str, Any], right: dict[str, Any], slide_area: int | float) -> bool:
+    if is_backgroundish(left, slide_area) or is_backgroundish(right, slide_area):
+        return False
+    if is_text_element(left) and is_text_element(right):
+        return True
+    allowed_companions = {"img", "table", "chart"}
+    return (
+        is_text_element(left) and right["kind"] in allowed_companions
+    ) or (
+        is_text_element(right) and left["kind"] in allowed_companions
+    )
+
+
+def estimate_text_height(element: dict[str, Any]) -> int | None:
+    if element["kind"] != "shape" or element["type"] != "text" or not element.get("text"):
+        return None
+    font_size = element["fontSize"] if isinstance(element["fontSize"], (int, float)) else 16
+    chars_per_line = max(1, int(element["width"] // max(font_size * 0.55, 1)))
+    paragraphs = [paragraph for paragraph in re.split(r"\n+", element["text"]) if paragraph]
+    line_count = 0
+    for paragraph in paragraphs:
+        logical_length = max(len(paragraph), 1)
+        line_count += max(1, -(-logical_length // chars_per_line))
+    return int((line_count * font_size * 1.35) + 12 + 0.999999)
+
+
+def lint_slide(slide_xml: str, slide_number: int, width: int, height: int) -> dict[str, Any]:
+    elements = extract_elements(slide_xml)
+    issues: list[dict[str, Any]] = []
+    slide_area = width * height
+
+    for element in elements:
+        if (
+            element["x"] < 0
+            or element["y"] < 0
+            or element["x"] + element["width"] > width
+            or element["y"] + element["height"] > height
+        ):
+            issues.append(
+                {
+                    "level": "error",
+                    "code": "out_of_bounds",
+                    "element": element["id"],
+                    "message": f'{element["id"]} exceeds slide bounds',
+                }
+            )
+        estimated_height = estimate_text_height(element)
+        if estimated_height is not None and estimated_height > element["height"]:
+            issues.append(
+                {
+                    "level": "warning",
+                    "code": "text_height_risk",
+                    "element": element["id"],
+                    "message": f'{element["id"]} may need {estimated_height}px height but only has {element["height"]}px',
+                }
+            )
+
+    for index, left in enumerate(elements):
+        for right in elements[index + 1 :]:
+            if not intersects(left, right) or not should_flag_overlap(left, right, slide_area):
+                continue
+            issues.append(
+                {
+                    "level": "error",
+                    "code": "bbox_overlap",
+                    "elements": [left["id"], right["id"]],
+                    "message": f'{left["id"]} overlaps {right["id"]}',
+                }
+            )
+
+    footer_candidates = [
+        element
+        for element in elements
+        if element["kind"] == "shape"
+        and element["type"] == "text"
+        and element["y"] >= height - 80
+        and element["height"] <= 60
+    ]
+    for footer in footer_candidates:
+        for element in elements:
+            if (
+                element["id"] == footer["id"]
+                or not intersects(footer, element)
+                or not should_flag_overlap(footer, element, slide_area)
+            ):
+                continue
+            issues.append(
+                {
+                    "level": "warning",
+                    "code": "footer_collision",
+                    "elements": [footer["id"], element["id"]],
+                    "message": f'{footer["id"]} is being crowded by {element["id"]}',
+                }
+            )
+
+    return {"slide_number": slide_number, "element_count": len(elements), "issues": issues}
+
+
+def lint_xml(xml: str, source_path: str | None = None) -> dict[str, Any]:
+    presentation = parse_presentation(xml)
+    slides = [
+        lint_slide(slide_xml, index + 1, presentation["width"], presentation["height"])
+        for index, slide_xml in enumerate(presentation["slides"])
+    ]
+    error_count = sum(1 for slide in slides for issue in slide["issues"] if issue["level"] == "error")
+    warning_count = sum(1 for slide in slides for issue in slide["issues"] if issue["level"] == "warning")
+    return {
+        "file": source_path,
+        "slide_size": {"width": presentation["width"], "height": presentation["height"]},
+        "summary": {"slide_count": len(slides), "error_count": error_count, "warning_count": warning_count},
+        "slides": slides,
+    }
+
+
+def print_usage() -> None:
+    print("Usage:\n  python3 layout-lint.py --input <presentation.xml>", file=sys.stderr)
+
+
+def run_cli(argv: list[str] | None = None) -> None:
+    options = parse_args(argv or sys.argv[1:])
+    if options.get("help") or options.get("--help"):
+        print_usage()
+        raise SystemExit(0)
+    if not options.get("input"):
+        print_usage()
+        fail("--input is required")
+    input_path = Path(options["input"]).resolve()
+    result = lint_xml(read_file(input_path), str(input_path))
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    if result["summary"]["error_count"] > 0:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    try:
+        run_cli()
+    except LayoutLintError as error:
+        print(f"layout-lint error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/skills/lark-slides/scripts/layout_lint_test.py
+++ b/skills/lark-slides/scripts/layout_lint_test.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LAYOUT_LINT_PATH = SCRIPT_DIR / "layout-lint.py"
+
+spec = importlib.util.spec_from_file_location("layout_lint", LAYOUT_LINT_PATH)
+layout_lint = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(layout_lint)
+
+
+class LayoutLintTest(unittest.TestCase):
+    def test_lint_xml_detects_overlapping_text_boxes(self) -> None:
+        result = layout_lint.lint_xml(
+            """
+            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                <data>
+                  <shape type="text" topLeftX="80" topLeftY="80" width="300" height="60">
+                    <content textType="title"><p>Title</p></content>
+                  </shape>
+                  <shape type="text" topLeftX="100" topLeftY="110" width="300" height="80">
+                    <content textType="body"><p>Body</p></content>
+                  </shape>
+                </data>
+              </slide>
+            </presentation>
+            """
+        )
+        self.assertEqual(result["summary"]["error_count"], 1)
+        self.assertEqual(result["slides"][0]["issues"][0]["code"], "bbox_overlap")
+
+    def test_lint_xml_detects_out_of_bounds_elements_and_text_height_risks(self) -> None:
+        result = layout_lint.lint_xml(
+            """
+            <presentation xmlns="http://www.larkoffice.com/sml/2.0" width="960" height="540">
+              <slide xmlns="http://www.larkoffice.com/sml/2.0">
+                <data>
+                  <shape type="text" topLeftX="80" topLeftY="80" width="180" height="20">
+                    <content textType="body" fontSize="18"><p>This paragraph is intentionally much longer than the box can safely contain.</p></content>
+                  </shape>
+                  <img src="tok" topLeftX="900" topLeftY="500" width="120" height="80"/>
+                </data>
+              </slide>
+            </presentation>
+            """
+        )
+        self.assertEqual(result["summary"]["error_count"], 1)
+        self.assertEqual(result["summary"]["warning_count"], 1)
+        self.assertTrue(any(issue["code"] == "out_of_bounds" for issue in result["slides"][0]["issues"]))
+        self.assertTrue(any(issue["code"] == "text_height_risk" for issue in result["slides"][0]["issues"]))

--- a/skills/lark-slides/scripts/template-tool.py
+++ b/skills/lark-slides/scripts/template-tool.py
@@ -1,0 +1,875 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+REFERENCES_DIR = SKILL_ROOT / "references"
+TEMPLATES_DIR = REFERENCES_DIR / "templates"
+CATALOG_PATH = REFERENCES_DIR / "template-catalog.md"
+DEFAULT_INDEX_PATH = REFERENCES_DIR / "template-index.json"
+
+
+class TemplateToolError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise TemplateToolError(message)
+
+
+def read_file(file_path: str | Path) -> str:
+    return Path(file_path).read_text(encoding="utf-8")
+
+
+def normalize_whitespace(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def strip_markdown(value: str) -> str:
+    return normalize_whitespace(
+        re.sub(r"^-\s*", "", re.sub(r"`([^`]+)`", r"\1", value.replace("**", "")))
+    )
+
+
+def strip_xml(value: str) -> str:
+    stripped = re.sub(r"<!\[CDATA\[([\s\S]*?)\]\]>", r"\1", value)
+    stripped = re.sub(r"<[^>]+>", " ", stripped)
+    stripped = stripped.replace("&nbsp;", " ")
+    stripped = stripped.replace("&amp;", "&")
+    stripped = stripped.replace("&lt;", "<")
+    stripped = stripped.replace("&gt;", ">")
+    stripped = stripped.replace("&quot;", '"')
+    stripped = stripped.replace("&#39;", "'")
+    return normalize_whitespace(stripped)
+
+
+def compact_object(value: dict[str, Any]) -> dict[str, Any]:
+    return {key: entry for key, entry in value.items() if entry is not None}
+
+
+def tokenize_query(value: str) -> list[str]:
+    normalized = normalize_whitespace(value.lower())
+    if not normalized:
+        return []
+    tokens = [item.strip() for item in re.split(r"[\s,/|]+", normalized) if item.strip()]
+    unique_tokens: list[str] = []
+    for token in tokens or [normalized]:
+        if token not in unique_tokens:
+            unique_tokens.append(token)
+    return unique_tokens
+
+
+def parse_range_spec(range_spec: str) -> list[int]:
+    if not range_spec or not range_spec.strip():
+        fail("range is required")
+    numbers: set[int] = set()
+    for part in range_spec.split(","):
+        trimmed = part.strip()
+        if not trimmed:
+            continue
+        match = re.fullmatch(r"(\d+)(?:-(\d+))?", trimmed)
+        if not match:
+            fail(f"invalid range token: {trimmed}")
+        start = int(match.group(1))
+        end = int(match.group(2) or match.group(1))
+        if start < 1 or end < start:
+            fail(f"invalid range token: {trimmed}")
+        for index in range(start, end + 1):
+            numbers.add(index)
+    return sorted(numbers)
+
+
+def compress_numbers(numbers: list[int]) -> str:
+    if not numbers:
+        return ""
+    parts: list[str] = []
+    start = numbers[0]
+    previous = numbers[0]
+    for current in numbers[1:]:
+        if current == previous + 1:
+            previous = current
+            continue
+        parts.append(f"{start}" if start == previous else f"{start}-{previous}")
+        start = current
+        previous = current
+    parts.append(f"{start}" if start == previous else f"{start}-{previous}")
+    return ",".join(parts)
+
+
+def slice_array(items: list[Any], limit: int) -> list[Any]:
+    return items[: max(limit, 0)]
+
+
+def count_tag(xml: str, tag_name: str) -> int:
+    return len(re.findall(fr"<{tag_name}\b", xml))
+
+
+def extract_attribute(tag_source: str, name: str) -> str | None:
+    match = re.search(fr'{re.escape(name)}="([^"]+)"', tag_source)
+    return match.group(1) if match else None
+
+
+def extract_numeric_attribute(tag_source: str, name: str) -> int | float | None:
+    raw = extract_attribute(tag_source, name)
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except ValueError:
+        return None
+    return int(value) if value.is_integer() else value
+
+
+def sort_regions(regions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(regions, key=lambda region: (region["y"], region["x"], region["kind"]))
+
+
+def extract_slide_regions(slide_xml: str) -> list[dict[str, Any]]:
+    regions: list[dict[str, Any]] = []
+    for match in re.finditer(r"<shape\b([^>]*)>([\s\S]*?)</shape>", slide_xml):
+        attrs, content = match.group(1), match.group(2)
+        x = extract_numeric_attribute(attrs, "topLeftX")
+        y = extract_numeric_attribute(attrs, "topLeftY")
+        width = extract_numeric_attribute(attrs, "width")
+        height = extract_numeric_attribute(attrs, "height")
+        if all(value is not None for value in [x, y, width, height]):
+            text_type_match = re.search(r'textType="([^"]+)"', content)
+            regions.append(
+                {
+                    "kind": "shape",
+                    "type": extract_attribute(attrs, "type") or "shape",
+                    "text_type": text_type_match.group(1) if text_type_match else None,
+                    "x": x,
+                    "y": y,
+                    "width": width,
+                    "height": height,
+                    "area": width * height,
+                }
+            )
+
+    for match in re.finditer(r"<(img|table|chart)\b([^>]*)/?>", slide_xml):
+        kind, attrs = match.group(1), match.group(2)
+        x = extract_numeric_attribute(attrs, "topLeftX")
+        y = extract_numeric_attribute(attrs, "topLeftY")
+        width = extract_numeric_attribute(attrs, "width")
+        height = extract_numeric_attribute(attrs, "height")
+        if all(value is not None for value in [x, y, width, height]):
+            regions.append(
+                {
+                    "kind": kind,
+                    "type": kind,
+                    "text_type": None,
+                    "x": x,
+                    "y": y,
+                    "width": width,
+                    "height": height,
+                    "area": width * height,
+                }
+            )
+    return sort_regions(regions)
+
+
+def build_bbox_summary(
+    regions: list[dict[str, Any]], slide_width: int | float | None, slide_height: int | float | None
+) -> dict[str, Any]:
+    if not regions:
+        return {
+            "region_count": 0,
+            "occupied_bounds": None,
+            "regions": [],
+            "canvas": compact_object({"width": slide_width, "height": slide_height}),
+        }
+
+    min_x = regions[0]["x"]
+    min_y = regions[0]["y"]
+    max_x = regions[0]["x"] + regions[0]["width"]
+    max_y = regions[0]["y"] + regions[0]["height"]
+    for region in regions:
+        min_x = min(min_x, region["x"])
+        min_y = min(min_y, region["y"])
+        max_x = max(max_x, region["x"] + region["width"])
+        max_y = max(max_y, region["y"] + region["height"])
+
+    return {
+        "region_count": len(regions),
+        "canvas": compact_object({"width": slide_width, "height": slide_height}),
+        "occupied_bounds": {
+            "x": min_x,
+            "y": min_y,
+            "width": max_x - min_x,
+            "height": max_y - min_y,
+        },
+        "regions": slice_array(
+            [
+                compact_object(
+                    {
+                        "id": f'{region["kind"]}-{index + 1}',
+                        "kind": region["kind"],
+                        "type": region["type"],
+                        "text_type": region.get("text_type"),
+                        "x": region["x"],
+                        "y": region["y"],
+                        "width": region["width"],
+                        "height": region["height"],
+                    }
+                )
+                for index, region in enumerate(regions)
+            ],
+            8,
+        ),
+    }
+
+
+def build_editable_regions(regions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    sorted_regions = sorted(regions, key=lambda region: region["area"], reverse=True)
+    return slice_array(
+        [
+            compact_object(
+                {
+                    "id": f'{region["kind"]}-{index + 1}',
+                    "kind": region["kind"],
+                    "role": "image"
+                    if region["kind"] == "img"
+                    else region.get("text_type") or region["type"] or region["kind"],
+                    "x": region["x"],
+                    "y": region["y"],
+                    "width": region["width"],
+                    "height": region["height"],
+                }
+            )
+            for index, region in enumerate(sorted_regions)
+        ],
+        8,
+    )
+
+
+def detect_slide_layout_tags(
+    slide_xml: str, regions: list[dict[str, Any]], slide_width: int | float | None, slide_height: int | float | None
+) -> list[str]:
+    tags: set[str] = set()
+    text_regions = [region for region in regions if region["kind"] == "shape" and region["type"] == "text"]
+    image_regions = [region for region in regions if region["kind"] == "img"]
+    table_regions = [region for region in regions if region["kind"] == "table"]
+
+    if table_regions:
+        tags.add("comparison-table")
+
+    if "<fillImg" in slide_xml:
+        tags.add("image-backed")
+        if text_regions:
+            tags.add("full-bleed-image-caption")
+
+    if text_regions and len(image_regions) == 1:
+        biggest_text = sorted(text_regions, key=lambda region: region["area"], reverse=True)[0]
+        biggest_image = image_regions[0]
+        if (
+            slide_width and biggest_image["width"] >= slide_width * 0.75
+        ) or (
+            slide_height and biggest_image["height"] >= slide_height * 0.75
+        ):
+            tags.add("full-bleed-image-caption")
+        elif biggest_text["x"] <= biggest_image["x"]:
+            tags.add("hero-text-left-image-right")
+        else:
+            tags.add("hero-image-left-text-right")
+
+    if len(text_regions) >= 4 and not image_regions:
+        distinct_x = len({round(region["x"] / 20) for region in text_regions})
+        distinct_y = len({round(region["y"] / 20) for region in text_regions})
+        if distinct_x >= 2 and distinct_y >= 2:
+            tags.add("2x2-metric-cards")
+
+    if len(text_regions) >= 2 and not image_regions:
+        width = slide_width or 960
+        left = any(region["x"] < width / 2 - 40 for region in text_regions)
+        right = any(region["x"] + region["width"] > width / 2 + 40 for region in text_regions)
+        if left and right:
+            tags.add("two-column-text")
+
+    if len(text_regions) <= 2 and not image_regions:
+        top_most = sorted(text_regions, key=lambda region: region["y"])[0] if text_regions else None
+        if top_most and top_most["y"] <= 120 and top_most["height"] <= 140:
+            tags.add("section-divider")
+
+    if not tags and text_regions:
+        tags.add("text-focused")
+
+    return sorted(tags)
+
+
+def parse_theme_summary(theme_xml: str | None) -> dict[str, Any]:
+    if not theme_xml:
+        return {"has_theme_node": False, "text_styles": []}
+
+    text_styles_block = re.search(r"<textStyles>([\s\S]*?)</textStyles>", theme_xml)
+    text_styles: list[dict[str, Any]] = []
+    if text_styles_block:
+        for match in re.finditer(r"<(title|headline|sub-headline|body|caption)\b([^>]*)/?>", text_styles_block.group(1)):
+            text_styles.append(
+                compact_object(
+                    {
+                        "text_type": match.group(1),
+                        "font_color": extract_attribute(match.group(2), "fontColor"),
+                        "font_size": extract_attribute(match.group(2), "fontSize"),
+                        "font_family": extract_attribute(match.group(2), "fontFamily"),
+                    }
+                )
+            )
+    return {"has_theme_node": True, "text_styles": text_styles}
+
+
+def extract_background_hint(slide_xml: str) -> str | None:
+    fill_color_match = re.search(r'<fillColor color="([^"]+)"', slide_xml)
+    if fill_color_match:
+        return fill_color_match.group(1)
+    fill_img_match = re.search(r'<fillImg src="([^"]+)"', slide_xml)
+    if fill_img_match:
+        return f"fillImg:{fill_img_match.group(1)}"
+    return None
+
+
+def extract_title_hint(slide_xml: str) -> dict[str, str] | None:
+    type_priority = {"title": 5, "headline": 4, "sub-headline": 3, "body": 2, "caption": 1}
+    content_pattern = re.compile(
+        r'<content\b([^>]*)textType="(title|headline|sub-headline|body|caption)"([^>]*)>([\s\S]*?)</content>'
+    )
+    candidates: list[dict[str, Any]] = []
+    for match in content_pattern.finditer(slide_xml):
+        attrs = f"{match.group(1)} {match.group(3)}"
+        text = strip_xml(match.group(4))
+        if text:
+            candidates.append(
+                {
+                    "text_type": match.group(2),
+                    "text": text[:80],
+                    "font_size": int(extract_attribute(attrs, "fontSize") or "0"),
+                    "priority": type_priority.get(match.group(2), 0),
+                }
+            )
+    candidates.sort(key=lambda item: (-item["priority"], -item["font_size"], -len(item["text"])))
+    if candidates:
+        return {"text_type": candidates[0]["text_type"], "text": candidates[0]["text"]}
+    return None
+
+
+def summarize_slide(slide_xml: str, slide_number: int, presentation_info: dict[str, Any] | None = None) -> dict[str, Any]:
+    presentation_info = presentation_info or {}
+    slide_width = int(float(presentation_info.get("width", 0))) or None
+    slide_height = int(float(presentation_info.get("height", 0))) or None
+    regions = extract_slide_regions(slide_xml)
+    return {
+        "slide_number": slide_number,
+        "title_hint": extract_title_hint(slide_xml),
+        "background_hint": extract_background_hint(slide_xml),
+        "layout_tags": detect_slide_layout_tags(slide_xml, regions, slide_width, slide_height),
+        "bbox_summary": build_bbox_summary(regions, slide_width, slide_height),
+        "editable_regions": build_editable_regions(regions),
+        "element_counts": {
+            "shape": count_tag(slide_xml, "shape"),
+            "img": count_tag(slide_xml, "img"),
+            "table": count_tag(slide_xml, "table"),
+            "chart": count_tag(slide_xml, "chart"),
+            "icon": count_tag(slide_xml, "icon"),
+            "line": count_tag(slide_xml, "line"),
+            "polyline": count_tag(slide_xml, "polyline"),
+        },
+    }
+
+
+def aggregate_slides(slide_summaries: list[dict[str, Any]]) -> dict[str, Any]:
+    totals = {"shape": 0, "img": 0, "table": 0, "chart": 0, "icon": 0, "line": 0, "polyline": 0}
+    title_hints: list[str] = []
+    background_hints: list[str] = []
+    layout_tags: list[str] = []
+    for slide in slide_summaries:
+        for key, value in slide["element_counts"].items():
+            totals[key] += value
+        if slide.get("title_hint") and slide["title_hint"]["text"] not in title_hints:
+            title_hints.append(slide["title_hint"]["text"])
+        if slide.get("background_hint") and slide["background_hint"] not in background_hints:
+            background_hints.append(slide["background_hint"])
+        for tag in slide.get("layout_tags") or []:
+            if tag not in layout_tags:
+                layout_tags.append(tag)
+    return {
+        "slide_count": len(slide_summaries),
+        "title_hints": slice_array(title_hints, 4),
+        "background_hints": slice_array(background_hints, 4),
+        "layout_tags": layout_tags,
+        "element_totals": totals,
+    }
+
+
+def parse_template_xml(template_path: str | Path) -> dict[str, Any]:
+    xml = read_file(template_path)
+    presentation_match = re.search(r"<presentation\b([^>]*)>", xml)
+    if not presentation_match:
+        fail(f"template missing presentation root: {template_path}")
+    opening_tag = presentation_match.group(0)
+    title_xml_match = re.search(r"<title>[\s\S]*?</title>", xml)
+    theme_xml_match = re.search(r"<theme>[\s\S]*?</theme>", xml)
+    slides = re.findall(r"<slide\b[\s\S]*?</slide>", xml)
+    slide_summaries = [
+        summarize_slide(
+            slide_xml,
+            index + 1,
+            {
+                "width": extract_attribute(presentation_match.group(1), "width"),
+                "height": extract_attribute(presentation_match.group(1), "height"),
+            },
+        )
+        for index, slide_xml in enumerate(slides)
+    ]
+    return {
+        "xml": xml,
+        "opening_tag": opening_tag,
+        "width": extract_attribute(presentation_match.group(1), "width"),
+        "height": extract_attribute(presentation_match.group(1), "height"),
+        "title_xml": title_xml_match.group(0) if title_xml_match else None,
+        "title_text": strip_xml(title_xml_match.group(0)) if title_xml_match else None,
+        "theme_xml": theme_xml_match.group(0) if theme_xml_match else None,
+        "theme_summary": parse_theme_summary(theme_xml_match.group(0) if theme_xml_match else None),
+        "slides": slides,
+        "slide_summaries": slide_summaries,
+    }
+
+
+def finalize_catalog_entry(entry: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not entry:
+        return None
+    filename_stem = re.sub(r"\.xml$", "", entry["filename"])
+    template_id = f'{entry["category"]}--{filename_stem}'
+    return {
+        "template_id": template_id,
+        "filename": f"{template_id}.xml",
+        "category": entry["category"],
+        "category_label": entry["category_label"],
+        "scene": entry["scene"],
+        "is_general_template": entry["is_general_template"],
+        "catalog_slide_count": entry["catalog_slide_count"],
+        "tone": entry["tone"],
+        "formality": entry["formality"],
+        "palette": entry["palette"],
+        "structure": entry["structure"],
+        "page_types": entry["page_types"],
+        "use_cases": entry["use_cases"],
+        "ranges": entry["ranges"],
+    }
+
+
+def parse_catalog(catalog_path: str | Path = CATALOG_PATH) -> list[dict[str, Any]]:
+    lines = read_file(catalog_path).splitlines()
+    entries: list[dict[str, Any]] = []
+    current_category: str | None = None
+    current_category_label: str | None = None
+    current_entry: dict[str, Any] | None = None
+
+    def push_current() -> None:
+        nonlocal current_entry
+        finalized = finalize_catalog_entry(current_entry)
+        if finalized:
+            entries.append(finalized)
+        current_entry = None
+
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        if line.startswith("## 快速匹配索引"):
+            break
+
+        category_match = re.match(r"^##\s+([a-z]+)\s+—\s+(.+)$", line)
+        if category_match:
+            push_current()
+            current_category = category_match.group(1)
+            current_category_label = category_match.group(2).strip()
+            continue
+
+        template_match = re.match(r"^###\s+(⭐\s+)?([^ ]+\.xml)\s+—\s+(.+)$", line)
+        if template_match:
+            push_current()
+            current_entry = {
+                "category": current_category,
+                "category_label": current_category_label,
+                "filename": template_match.group(2).strip(),
+                "scene": template_match.group(3).strip(),
+                "is_general_template": bool(template_match.group(1)),
+                "catalog_slide_count": None,
+                "tone": None,
+                "formality": None,
+                "palette": None,
+                "structure": None,
+                "page_types": None,
+                "use_cases": None,
+                "ranges": [],
+            }
+            continue
+
+        if not current_entry:
+            continue
+
+        plain = strip_markdown(line)
+        slide_count_match = re.search(r"(\d+)\s*页", plain)
+        if slide_count_match:
+            current_entry["catalog_slide_count"] = int(slide_count_match.group(1))
+
+        tone_match = re.search(r"色调：([^|]+)\|\s*正式度：(.+)$", plain)
+        if tone_match:
+            current_entry["tone"] = tone_match.group(1).strip()
+            current_entry["formality"] = tone_match.group(2).strip()
+            continue
+
+        if plain.startswith("配色："):
+            current_entry["palette"] = plain[len("配色：") :].strip()
+            continue
+
+        if plain.startswith("结构："):
+            current_entry["structure"] = plain[len("结构：") :].strip()
+            continue
+
+        if plain.startswith("页面类型："):
+            current_entry["page_types"] = plain[len("页面类型：") :].strip()
+            continue
+
+        if plain.startswith("页型索引"):
+            _, _, ranges_raw = plain.partition("：")
+            ranges: list[dict[str, Any]] = []
+            for item in [part.strip() for part in ranges_raw.split("|") if part.strip()]:
+                match = re.match(r"^(.+?)\s+([0-9,\-无]+)$", item)
+                if not match:
+                    ranges.append({"label": item, "range": "", "slide_numbers": []})
+                    continue
+                range_text = "" if match.group(2) == "无" else match.group(2)
+                ranges.append(
+                    {
+                        "label": match.group(1).strip(),
+                        "range": range_text,
+                        "slide_numbers": parse_range_spec(range_text) if range_text else [],
+                    }
+                )
+            current_entry["ranges"] = ranges
+            continue
+
+        if plain.startswith("适用："):
+            current_entry["use_cases"] = plain[len("适用：") :].strip()
+
+    push_current()
+    return entries
+
+
+def build_search_text(entry: dict[str, Any]) -> str:
+    values: list[str] = [
+        entry.get("template_id"),
+        entry.get("category"),
+        entry.get("category_label"),
+        entry.get("scene"),
+        entry.get("tone"),
+        entry.get("formality"),
+        entry.get("palette"),
+        entry.get("structure"),
+        entry.get("page_types"),
+        *(entry.get("layout_tags") or []),
+        entry.get("use_cases"),
+        *[f'{region["kind"]} {region["role"]}' for region in entry.get("editable_regions") or []],
+        *[f'{entry_range["label"]} {entry_range["range"]}' for entry_range in entry.get("ranges", [])],
+    ]
+    return " ".join(str(value) for value in values if value).lower()
+
+
+def build_index_data() -> dict[str, Any]:
+    catalog_entries = parse_catalog()
+    templates: list[dict[str, Any]] = []
+    for entry in catalog_entries:
+        template_path = TEMPLATES_DIR / entry["filename"]
+        xml_info = parse_template_xml(template_path)
+        layout_tags = sorted({tag for slide in xml_info["slide_summaries"] for tag in slide.get("layout_tags", [])})
+        editable_regions = [region for slide in xml_info["slide_summaries"] for region in slide.get("editable_regions", [])]
+        templates.append(
+            {
+                "template_id": entry["template_id"],
+                "category": entry["category"],
+                "category_label": entry["category_label"],
+                "scene": entry["scene"],
+                "tone": entry["tone"],
+                "formality": entry["formality"],
+                "is_general_template": entry["is_general_template"],
+                "slide_count": len(xml_info["slides"]),
+                "presentation_title": xml_info["title_text"],
+                "palette": entry["palette"],
+                "structure": entry["structure"],
+                "page_types": entry["page_types"],
+                "layout_tags": layout_tags,
+                "use_cases": entry["use_cases"],
+                "theme_summary": xml_info["theme_summary"],
+                "editable_regions": slice_array(editable_regions, 12),
+                "bbox_summary": {
+                    "slide_count": len(xml_info["slide_summaries"]),
+                    "slides": slice_array(
+                        [
+                            {"slide_number": slide["slide_number"], "bbox_summary": slide["bbox_summary"]}
+                            for slide in xml_info["slide_summaries"]
+                        ],
+                        6,
+                    ),
+                },
+                "ranges": [{"label": entry_range["label"], "range": entry_range["range"]} for entry_range in entry["ranges"]],
+            }
+        )
+
+    return {
+        "schema_version": "1.0.0",
+        "generated_at": datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "template_count": len(templates),
+        "templates": templates,
+    }
+
+
+def load_index(index_path: str | Path = DEFAULT_INDEX_PATH) -> dict[str, Any]:
+    index_path = Path(index_path)
+    if index_path.exists():
+        existing = json.loads(read_file(index_path))
+        first_template = existing.get("templates", [None])[0] if existing.get("templates") else None
+        if first_template and first_template.get("layout_tags") and first_template.get("bbox_summary"):
+            return existing
+    return build_index_data()
+
+
+def resolve_template_entry(index_data: dict[str, Any], template_selector: str) -> dict[str, Any]:
+    if not template_selector:
+        fail("template selector is required")
+    normalized = re.sub(r"\.xml$", "", template_selector)
+    for entry in index_data["templates"]:
+        if entry["template_id"] == normalized or f'{entry["template_id"]}.xml' == f"{normalized}.xml":
+            return entry
+
+    as_path = Path(template_selector)
+    if not as_path.is_absolute():
+        as_path = (Path.cwd() / as_path).resolve()
+    if not as_path.exists():
+        fail(f"template not found: {template_selector}")
+    filename = as_path.name
+    for entry in index_data["templates"]:
+        if f'{entry["template_id"]}.xml' == filename:
+            return entry
+    fail(f"template exists but is not indexed: {template_selector}")
+
+
+def resolve_range_selection(entry: dict[str, Any], options: dict[str, Any]) -> dict[str, Any]:
+    if options.get("label"):
+        matched_range = next((item for item in entry["ranges"] if item["label"] == options["label"]), None)
+        if not matched_range:
+            fail(f'range label not found: {options["label"]}')
+        slide_numbers = parse_range_spec(matched_range["range"]) if matched_range["range"] else []
+        if not slide_numbers:
+            fail(f'range label has no slides: {options["label"]}')
+        return {"label": matched_range["label"], "range": matched_range["range"], "slide_numbers": slide_numbers}
+
+    if not options.get("range"):
+        fail("either --range or --label is required")
+    slide_numbers = parse_range_spec(options["range"])
+    return {"label": None, "range": compress_numbers(slide_numbers), "slide_numbers": slide_numbers}
+
+
+def get_template_path(entry: dict[str, Any]) -> Path:
+    return TEMPLATES_DIR / f'{entry["template_id"]}.xml'
+
+
+def summarize_selection(index_data: dict[str, Any], template_selector: str, options: dict[str, Any]) -> dict[str, Any]:
+    entry = resolve_template_entry(index_data, template_selector)
+    selection = resolve_range_selection(entry, options)
+    xml_info = parse_template_xml(get_template_path(entry))
+    slide_summaries = [
+        xml_info["slide_summaries"][slide_number - 1]
+        for slide_number in selection["slide_numbers"]
+        if 0 < slide_number <= len(xml_info["slide_summaries"])
+    ]
+    return {
+        "template": {
+            "template_id": entry["template_id"],
+            "scene": entry["scene"],
+            "tone": entry["tone"],
+            "formality": entry["formality"],
+            "slide_count": entry["slide_count"],
+            "presentation_title": entry["presentation_title"],
+            "palette": entry["palette"],
+            "structure": entry["structure"],
+            "page_types": entry["page_types"],
+            "layout_tags": entry.get("layout_tags"),
+            "use_cases": entry["use_cases"],
+        },
+        "selection": selection,
+        "theme_summary": entry["theme_summary"],
+        "summary": aggregate_slides(slide_summaries),
+        "slides": slide_summaries,
+    }
+
+
+def extract_selection_xml(index_data: dict[str, Any], template_selector: str, options: dict[str, Any]) -> str:
+    entry = resolve_template_entry(index_data, template_selector)
+    selection = resolve_range_selection(entry, options)
+    xml_info = parse_template_xml(get_template_path(entry))
+    selected_slides: list[str] = []
+    for slide_number in selection["slide_numbers"]:
+        if slide_number - 1 >= len(xml_info["slides"]) or slide_number <= 0:
+            fail(f"slide {slide_number} is out of range for {entry['template_id']}")
+        selected_slides.append(xml_info["slides"][slide_number - 1])
+
+    chunks = [xml_info["opening_tag"]]
+    if xml_info["title_xml"]:
+        chunks.append(f'  {xml_info["title_xml"]}')
+    if xml_info["theme_xml"]:
+        chunks.append(f'  {xml_info["theme_xml"]}')
+    chunks.extend(selected_slides)
+    chunks.append("</presentation>")
+    return "\n".join(chunks)
+
+
+def search_templates(index_data: dict[str, Any], options: dict[str, Any]) -> list[dict[str, Any]]:
+    query = options.get("query", "") or ""
+    tokens = tokenize_query(query)
+    tone = options.get("tone")
+    formality = options.get("formality")
+    category = options.get("category")
+    layout_tag = options.get("layoutTag") or options.get("layout-tag")
+    limit = int(options.get("limit", 5))
+
+    ranked: list[dict[str, Any]] = []
+    for entry in index_data["templates"]:
+        if tone and entry["tone"] != tone:
+            continue
+        if formality and entry["formality"] != formality:
+            continue
+        if category and entry["category"] != category:
+            continue
+        if layout_tag and layout_tag not in (entry.get("layout_tags") or []):
+            continue
+
+        score = 0
+        if not query:
+            score = 1
+        else:
+            search_text = build_search_text(entry)
+            exact_id = entry["template_id"].lower() == query.lower()
+            if exact_id:
+                score += 100
+            for token in tokens:
+                if token in search_text:
+                    score += len(token) * 10
+            if entry.get("scene") and query in entry["scene"]:
+                score += 40
+            if entry.get("use_cases") and query in entry["use_cases"]:
+                score += 30
+            if score == 0:
+                continue
+
+        if entry.get("is_general_template"):
+            score -= 5
+        ranked.append(
+            {
+                "template_id": entry["template_id"],
+                "scene": entry["scene"],
+                "tone": entry["tone"],
+                "formality": entry["formality"],
+                "is_general_template": entry["is_general_template"],
+                "use_cases": entry["use_cases"],
+                "layout_tags": entry.get("layout_tags") or [],
+                "slide_count": entry["slide_count"],
+                "ranges": entry["ranges"],
+                "score": score,
+            }
+        )
+
+    ranked.sort(key=lambda item: (-item["score"], item["template_id"]))
+    return ranked[:limit]
+
+
+def parse_cli_args(argv: list[str]) -> tuple[str | None, dict[str, Any]]:
+    if not argv:
+        return None, {}
+    command, *rest = argv
+    options: dict[str, Any] = {}
+    index = 0
+    while index < len(rest):
+        token = rest[index]
+        if not token.startswith("--"):
+            fail(f"unexpected argument: {token}")
+        key = token[2:]
+        next_token = rest[index + 1] if index + 1 < len(rest) else None
+        if next_token is None or next_token.startswith("--"):
+            options[key] = True
+            index += 1
+            continue
+        options[key] = next_token
+        index += 2
+    return command, options
+
+
+def print_usage() -> None:
+    usage = [
+        "Usage:",
+        "  python3 template-tool.py build-index [--out <path>]",
+        "  python3 template-tool.py search --query <text> [--tone light|dark|colorful] [--formality formal|casual|creative] [--layout-tag <tag>] [--limit 3]",
+        "  python3 template-tool.py summarize --template <template-id|path> (--range 1-2,5 | --label 封面)",
+        "  python3 template-tool.py extract --template <template-id|path> (--range 1-2,5 | --label 封面) [--with-summary] [--out <path>]",
+    ]
+    print("\n".join(usage), file=sys.stderr)
+
+
+def write_json(value: Any) -> None:
+    print(json.dumps(value, ensure_ascii=False, indent=2))
+
+
+def run_cli(argv: list[str] | None = None) -> None:
+    command, options = parse_cli_args(argv or sys.argv[1:])
+    if not command or command in {"--help", "help"}:
+        print_usage()
+        raise SystemExit(0)
+
+    if command == "build-index":
+        index_data = build_index_data()
+        output_path = Path(options["out"]).resolve() if options.get("out") else DEFAULT_INDEX_PATH
+        output_path.write_text(f'{json.dumps(index_data, ensure_ascii=False, indent=2)}\n', encoding="utf-8")
+        print(output_path)
+        return
+
+    if command == "search":
+        write_json(search_templates(load_index(), options))
+        return
+
+    if command == "summarize":
+        write_json(summarize_selection(load_index(), options.get("template"), options))
+        return
+
+    if command == "extract":
+        index_data = load_index()
+        xml = extract_selection_xml(index_data, options.get("template"), options)
+        if options.get("with-summary"):
+            summary = summarize_selection(index_data, options.get("template"), options)
+            write_json({"xml": xml, "selection": summary["selection"], "summary": summary["summary"], "slides": summary["slides"]})
+            return
+        if options.get("out"):
+            output_path = Path(options["out"]).resolve()
+            output_path.write_text(f"{xml}\n", encoding="utf-8")
+            print(output_path)
+            return
+        sys.stdout.write(f"{xml}\n")
+        return
+
+    print_usage()
+    fail(f"unknown command: {command}")
+
+
+if __name__ == "__main__":
+    try:
+        run_cli()
+    except TemplateToolError as error:
+        print(f"template-tool error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/skills/lark-slides/scripts/template_tool_test.py
+++ b/skills/lark-slides/scripts/template_tool_test.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026 Lark Technologies Pte. Ltd.
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+TEMPLATE_TOOL_PATH = SCRIPT_DIR / "template-tool.py"
+
+spec = importlib.util.spec_from_file_location("template_tool", TEMPLATE_TOOL_PATH)
+template_tool = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(template_tool)
+
+
+class TemplateToolTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.index_data = template_tool.build_index_data()
+
+    def test_build_index_data_exposes_light_general_metadata(self) -> None:
+        template = next(
+            entry for entry in self.index_data["templates"] if entry["template_id"] == "office--light_general"
+        )
+        self.assertEqual(template["tone"], "light")
+        self.assertEqual(template["formality"], "formal")
+        self.assertEqual(template["slide_count"], 54)
+        self.assertEqual(template["presentation_title"], "白底通用模板")
+        self.assertTrue(template["theme_summary"]["has_theme_node"])
+        self.assertIsInstance(template["layout_tags"], list)
+        self.assertIn("bbox_summary", template)
+
+    def test_search_templates_keeps_work_report_templates_in_top_results(self) -> None:
+        results = template_tool.search_templates(self.index_data, {"query": "工作汇报", "limit": 3})
+        self.assertTrue(results)
+        self.assertTrue(any(entry["template_id"] == "office--work_report" for entry in results))
+
+    def test_extract_selection_xml_keeps_only_requested_slides_and_theme(self) -> None:
+        xml = template_tool.extract_selection_xml(self.index_data, "office--light_general", {"label": "封面"})
+        self.assertEqual(len(template_tool.re.findall(r"<slide\b", xml)), 2)
+        self.assertIn("<theme>", xml)
+        self.assertIn("<title>白底通用模板</title>", xml)
+
+    def test_summarize_selection_aggregates_slide_titles_and_counts(self) -> None:
+        summary = template_tool.summarize_selection(self.index_data, "office--light_general", {"label": "封面"})
+        self.assertEqual(summary["selection"]["range"], "1-2")
+        self.assertEqual(summary["summary"]["slide_count"], 2)
+        self.assertIn("通用模板", summary["summary"]["title_hints"])
+        self.assertGreater(summary["summary"]["element_totals"]["shape"], 0)
+        self.assertIsInstance(summary["slides"][0]["layout_tags"], list)
+        self.assertIn("bbox_summary", summary["slides"][0])
+
+    def test_search_templates_supports_layout_tag_filtering(self) -> None:
+        results = template_tool.search_templates(
+            self.index_data,
+            {"query": "", "layout-tag": "full-bleed-image-caption", "limit": 10},
+        )
+        self.assertTrue(results)
+        self.assertTrue(
+            any("full-bleed-image-caption" in entry["layout_tags"] for entry in results)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 ## Summary

  This PR expands the lark-slides workflow from template-first guidance into a fuller slide XML authoring toolkit. It adds a categorized template catalog, flat template references,
  helper scripts for template discovery/layout checks, and new slides shortcuts for composing presentations, bulk-uploading media, and replacing slides from XML.

  ## Changes

  - Add categorized lark-slides template catalog and machine-readable template index
  - Flatten slide template references under `references/templates/` for direct lookup and targeted XML reuse
  - Update `lark-slides` skill guidance for template-first creation, identity selection, XML validation, post-create verification, and safer edit workflows
  - Add `slides +compose` to create presentations from a slides directory or manifest, with local `@path` image placeholder upload support
  - Add `slides +bulk-media-upload` to upload multiple local images and return a stable filename-to-file-token map
  - Add `slides +replace-slide-xml` to replace an existing slide by creating a replacement before it and deleting the old slide
  - Add shared slides shortcut helpers for local asset validation, manifest parsing, placeholder replacement, and presentation reference handling
  - Add command-specific reference docs for create, compose, bulk media upload, replace slide XML, and XML presentation retrieval
  - Add `template-tool.py` and `layout-lint.py` helper scripts with focused tests

  ## Test Plan

  - Not run locally in this pass, per local AGENTS.md instruction to avoid build/test commands unless explicitly requested
  - Added unit test coverage for the new slides shortcuts and helper scripts

  ## Related Issues

  None
