### PR TITLE
Revert "Add client_secret to device authorization request (#517)"

### DIFF
--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -79,7 +79,6 @@ func RequestDeviceAuthorization(httpClient *http.Client, appId, appSecret string
 
 	form := url.Values{}
 	form.Set("client_id", appId)
-	form.Set("client_secret", appSecret)
 	form.Set("scope", scope)
 
 	req, err := http.NewRequest("POST", endpoints.DeviceAuthorization, strings.NewReader(form.Encode()))

--- a/internal/auth/device_flow_test.go
+++ b/internal/auth/device_flow_test.go
@@ -109,36 +109,6 @@ func TestFormatAuthCmdline_TruncatesExtraArgs(t *testing.T) {
 	}
 }
 
-// TestRequestDeviceAuthorization_ClientSecretInBody checks that client_secret is sent in the form body.
-func TestRequestDeviceAuthorization_ClientSecretInBody(t *testing.T) {
-	reg := &httpmock.Registry{}
-	t.Cleanup(func() { reg.Verify(t) })
-
-	stub := &httpmock.Stub{
-		Method: "POST",
-		URL:    PathDeviceAuthorization,
-		Body: map[string]interface{}{
-			"device_code":               "dc",
-			"user_code":                 "uc",
-			"verification_uri":          "https://example.com/verify",
-			"verification_uri_complete": "https://example.com/verify?code=123",
-			"expires_in":                240,
-			"interval":                  5,
-		},
-	}
-	reg.Register(stub)
-
-	_, err := RequestDeviceAuthorization(httpmock.NewClient(reg), "cli_a", "secret_b", core.BrandFeishu, "", nil)
-	if err != nil {
-		t.Fatalf("RequestDeviceAuthorization() error: %v", err)
-	}
-
-	body := string(stub.CapturedBody)
-	if !strings.Contains(body, "client_secret=secret_b") {
-		t.Errorf("expected client_secret in form body, got %q", body)
-	}
-}
-
 // TestLogAuthResponse_IgnoresTypedNilHTTPResponse tests that a typed nil HTTP response is ignored gracefully.
 func TestLogAuthResponse_IgnoresTypedNilHTTPResponse(t *testing.T) {
 	var buf bytes.Buffer


### PR DESCRIPTION
This reverts commit 663c24aadf7166ffb158270d25485b0d55d954b0.

## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Device authorization requests no longer include client_secret in the request body, ensuring compliance with device flow authentication standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->