### PR TITLE
docs(mail): remove get_signatures from skill reference

### DIFF
--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -407,7 +407,6 @@ lark-cli mail <resource> <method> [flags] # 调用 API
 
 ### user_mailbox.settings
 
-  - `get_signatures` — 获取用户邮箱签名列表
   - `send_as` — 获取账号的所有可发信地址，包括主地址、别名地址、邮件组。可以使用用户地址访问该接口，也可以使用用户有权限的公共邮箱地址访问该接口。
 
 ### user_mailbox.threads
@@ -469,7 +468,6 @@ lark-cli mail <resource> <method> [flags] # 调用 API
 | `user_mailbox.rules.list` | `mail:user_mailbox.rule:read` |
 | `user_mailbox.rules.reorder` | `mail:user_mailbox.rule:write` |
 | `user_mailbox.rules.update` | `mail:user_mailbox.rule:write` |
-| `user_mailbox.settings.get_signatures` | `mail:user_mailbox:readonly` |
 | `user_mailbox.settings.send_as` | `mail:user_mailbox:readonly` |
 | `user_mailbox.threads.batch_modify` | `mail:user_mailbox.message:modify` |
 | `user_mailbox.threads.batch_trash` | `mail:user_mailbox.message:modify` |


### PR DESCRIPTION
## Summary

- `get_signatures` is not directly exposed as a CLI command — it's wrapped by `+signature`
- Remove the raw `get_signatures` entry from the shortcut reference list and the permissions table in `skills/lark-mail/SKILL.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the `get_signatures` API method documentation from lark-cli mail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->