### PR TITLE
fix(whiteboard): Deprecate old lark-whiteboard-cli skill

### DIFF
--- a/skills/lark-whiteboard/SKILL.md
+++ b/skills/lark-whiteboard/SKILL.md
@@ -4,6 +4,7 @@ version: 1.0.0
 description: >
   飞书画板：查询和编辑飞书云文档中的画板。支持导出画板为预览图片、导出原始节点结构、使用 DSL（转成 OpenAPI 格式）、PlantUML/Mermaid 格式更新画板内容。
   当用户需要查看画板内容、导出画板图片、编辑画板，或是需要可视化表达架构、流程、组织关系、时间线、因果、对比等结构化信息时使用此 skill，无论是否提及"画板"。
+  ⚠️ 原 `lark-whiteboard-cli` skill 已合并至本 skill，若 skill 列表中同时存在 `lark-whiteboard-cli`，请忽略它，统一使用本 skill（`lark-whiteboard`），并提示用户运行 `npx skills remove lark-whiteboard-cli -g` 删除旧 skill。
 metadata:
   requires:
     bins: ["lark-cli"]


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- manual deprecated lark-whiteboard-cli

## Test Plan
<!-- Describe how this change was verified. -->
- [x] Unit tests pass
- [x] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a deprecation notice in the skill description: lark-whiteboard-cli has been merged into lark-whiteboard. If you still have the deprecated skill installed, remove it with `npx skills remove lark-whiteboard-cli -g` and use the consolidated lark-whiteboard skill. This change only updates the documentation/description; no behavioral or public API changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->