### PR TITLE
fix(im): cap basic_batch user_ids at 10 per API limit

### DIFF
--- a/shortcuts/im/convert_lib/helpers.go
+++ b/shortcuts/im/convert_lib/helpers.go
@@ -152,8 +152,9 @@ func ResolveSenderNames(runtime *common.RuntimeContext, messages []map[string]in
 // This API has lighter permission requirements and works with user identity
 // even when the target user is not in the app's visible range.
 // Response uses "users" (not "items") and "user_id" (not "open_id").
+// The basic_batch endpoint caps user_ids at 10 per request.
 func batchResolveByBasicContact(runtime *common.RuntimeContext, missingIDs []string, nameMap map[string]string) {
-	const batchSize = 50
+	const batchSize = 10
 	for i := 0; i < len(missingIDs); i += batchSize {
 		end := i + batchSize
 		if end > len(missingIDs) {

--- a/shortcuts/im/convert_lib/helpers_test.go
+++ b/shortcuts/im/convert_lib/helpers_test.go
@@ -4,7 +4,9 @@
 package convertlib
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -167,6 +169,57 @@ func TestResolveSenderNames(t *testing.T) {
 	}
 	if got["ou_missing"] != "" {
 		t.Fatalf("missing sender = %#v, want empty", got["ou_missing"])
+	}
+}
+
+func TestBatchResolveByBasicContactRespectsAPILimit(t *testing.T) {
+	// basic_batch allows at most 10 user_ids per request. Given 25 missing IDs,
+	// expect three requests with sizes 10 / 10 / 5.
+	var batchSizes []int
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/open-apis/contact/v3/users/basic_batch") {
+			return nil, fmt.Errorf("unexpected path: %s", req.URL.Path)
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return nil, err
+		}
+		userIDs, _ := payload["user_ids"].([]interface{})
+		if len(userIDs) > 10 {
+			t.Fatalf("batch exceeded API limit: size = %d", len(userIDs))
+		}
+		batchSizes = append(batchSizes, len(userIDs))
+
+		users := make([]interface{}, 0, len(userIDs))
+		for _, raw := range userIDs {
+			id, _ := raw.(string)
+			users = append(users, map[string]interface{}{
+				"user_id": id,
+				"name":    "name-" + id,
+			})
+		}
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"users": users},
+		}), nil
+	}))
+
+	missingIDs := make([]string, 25)
+	for i := range missingIDs {
+		missingIDs[i] = fmt.Sprintf("ou_%02d", i)
+	}
+	nameMap := map[string]string{}
+	batchResolveByBasicContact(runtime, missingIDs, nameMap)
+
+	if want := []int{10, 10, 5}; !reflect.DeepEqual(batchSizes, want) {
+		t.Fatalf("batch sizes = %v, want %v", batchSizes, want)
+	}
+	if len(nameMap) != 25 {
+		t.Fatalf("resolved name count = %d, want 25", len(nameMap))
 	}
 }
 


### PR DESCRIPTION
## Summary

The `POST /contact/v3/users/basic_batch` endpoint accepts 1~10 `user_ids` per request ([doc](https://open.larkoffice.com/document/uAjLw4CM/ukTMukTMukTM/reference/contact-v3/user/basic_batch)). `batchResolveByBasicContact` in `shortcuts/im/convert_lib/helpers.go` was chunking by 50, so whenever the user-identity sender-name resolver had >10 unresolved IDs, the single oversized request was rejected and the whole batch was silently skipped — leaving sender names empty in the output of `im +chat-messages-list`, `+messages-search`, `+messages-mget`, `+threads-messages-list`, etc.

## Changes

- `shortcuts/im/convert_lib/helpers.go`: lower `batchSize` from 50 to 10 in `batchResolveByBasicContact` and add a comment citing the API limit. The sibling `batchResolveUsers` (calls the different `GET /contact/v3/users/batch` endpoint, cap 50) is untouched.
- `shortcuts/im/convert_lib/helpers_test.go`: add `TestBatchResolveByBasicContactRespectsAPILimit` that feeds 25 missing IDs and asserts the mock server sees three requests of size 10 / 10 / 5 and that every resolved name ends up in the name map.

## Test Plan

### Automated
- [x] `go test ./shortcuts/im/convert_lib/...` passes (new + existing tests)
- [x] `go vet ./...` and `go build ./...` clean

### End-to-end (built binary, live Feishu API)

Exercised the real `im +chat-messages-list` flow on two internal group chats (chat IDs and user identifiers redacted). Compared the number of unique user senders vs. how many ended up with their display name populated after `ResolveSenderNames` → `AttachSenderNames`.

| Case | Identity | `batchSize` | Unique user senders | Names resolved | Names missing |
|---|---|---|---|---|---|
| Positive — user identity, after fix | user | 10 | 31 | 31 | 0 |
| Positive — bot identity, after fix (unchanged `batchResolveUsers` path, different API) | bot | n/a | 4 | 4 | 0 |
| Negative — user identity, reverted `batchSize` to 50 (reproduces the bug) | user | 50 | 31 | **0** | **31** |

The negative run demonstrates the bug was real: with 31 unresolved IDs packed into a single oversized request, the server rejects it and the resolver's `break` leaves the whole name map empty. After the fix, the same 31 IDs are split across 4 batches (10/10/10/1) and every name comes back.

## Related Issues

- None