### PR TITLE
feat(doc): adjust Markdown pipe-table column widths from cell content

### DIFF
--- a/shortcuts/doc/docs_create.go
+++ b/shortcuts/doc/docs_create.go
@@ -23,6 +23,7 @@ var DocsCreate = common.Shortcut{
 		{Name: "folder-token", Desc: "parent folder token"},
 		{Name: "wiki-node", Desc: "wiki node token"},
 		{Name: "wiki-space", Desc: "wiki space ID (use my_library for personal library)"},
+		{Name: "auto-table-widths", Type: "bool", Default: "true", Desc: "after create, adjust Markdown pipe-table column widths based on cell content (use --auto-table-widths=false to keep server default equal widths)"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		count := 0
@@ -61,6 +62,11 @@ var DocsCreate = common.Shortcut{
 		augmentDocsCreateResult(runtime, result)
 
 		normalizeDocsUpdateResult(result, runtime.Str("markdown"))
+		if runtime.Bool("auto-table-widths") {
+			if docID := strings.TrimSpace(common.GetString(result, "doc_id")); docID != "" {
+				applyMarkdownTableColumnWidths(runtime, docID, runtime.Str("markdown"))
+			}
+		}
 		runtime.Out(result, nil)
 		return nil
 	},

--- a/shortcuts/doc/docs_create.go
+++ b/shortcuts/doc/docs_create.go
@@ -63,7 +63,7 @@ var DocsCreate = common.Shortcut{
 
 		normalizeDocsUpdateResult(result, runtime.Str("markdown"))
 		if runtime.Bool("auto-table-widths") {
-			if docID := strings.TrimSpace(common.GetString(result, "doc_id")); docID != "" {
+			if docID, ok := resolveDocxTokenForCreateResult(runtime.CallAPI, result); ok {
 				applyMarkdownTableColumnWidths(runtime, docID, runtime.Str("markdown"))
 			}
 		}

--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -5,6 +5,7 @@ package doc
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/shortcuts/common"
@@ -116,6 +117,11 @@ var DocsUpdate = common.Shortcut{
 		if runtime.Str("mode") == "overwrite" && runtime.Bool("auto-table-widths") {
 			if docID, ok := docxTokenForUpdate(runtime.Str("doc")); ok {
 				applyMarkdownTableColumnWidths(runtime, docID, runtime.Str("markdown"))
+			} else {
+				fmt.Fprintln(
+					runtime.IO().ErrOut,
+					"auto-table-widths skipped: --doc is not a docx token/URL (wiki-backed docs require an extra resolve step that is not implemented yet)",
+				)
 			}
 		}
 		runtime.Out(result, nil)

--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -42,6 +42,7 @@ var DocsUpdate = common.Shortcut{
 		{Name: "selection-with-ellipsis", Desc: "content locator (e.g. 'start...end')"},
 		{Name: "selection-by-title", Desc: "title locator (e.g. '## Section')"},
 		{Name: "new-title", Desc: "also update document title"},
+		{Name: "auto-table-widths", Type: "bool", Default: "true", Desc: "for --mode overwrite, adjust Markdown pipe-table column widths based on cell content (use --auto-table-widths=false to keep equal widths; ignored for other modes)"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		mode := runtime.Str("mode")
@@ -112,6 +113,11 @@ var DocsUpdate = common.Shortcut{
 		}
 
 		normalizeDocsUpdateResult(result, runtime.Str("markdown"))
+		if runtime.Str("mode") == "overwrite" && runtime.Bool("auto-table-widths") {
+			if docID, ok := docxTokenForUpdate(runtime.Str("doc")); ok {
+				applyMarkdownTableColumnWidths(runtime, docID, runtime.Str("markdown"))
+			}
+		}
 		runtime.Out(result, nil)
 		return nil
 	},

--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -115,12 +115,12 @@ var DocsUpdate = common.Shortcut{
 
 		normalizeDocsUpdateResult(result, runtime.Str("markdown"))
 		if runtime.Str("mode") == "overwrite" && runtime.Bool("auto-table-widths") {
-			if docID, ok := docxTokenForUpdate(runtime.Str("doc")); ok {
+			if docID, ok := docxTokenForUpdate(runtime, runtime.Str("doc")); ok {
 				applyMarkdownTableColumnWidths(runtime, docID, runtime.Str("markdown"))
 			} else {
 				fmt.Fprintln(
 					runtime.IO().ErrOut,
-					"auto-table-widths skipped: --doc is not a docx token/URL (wiki-backed docs require an extra resolve step that is not implemented yet)",
+					"auto-table-widths skipped: could not resolve --doc to a docx token",
 				)
 			}
 		}

--- a/shortcuts/doc/table_widths.go
+++ b/shortcuts/doc/table_widths.go
@@ -1,0 +1,353 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// widthRatioTotal is the denominator used by Feishu's
+// update_grid_column_width_ratio API: width_ratios must sum to 100.
+const widthRatioTotal = 100
+
+// extractMarkdownTables parses GFM pipe tables from markdown text and returns
+// each table as a slice of rows, where each row is a slice of cell strings.
+// Header separator rows (e.g. |---|---|) are dropped. Tables inside fenced
+// code blocks are skipped so example snippets do not trigger column-width
+// patching.
+func extractMarkdownTables(md string) [][][]string {
+	var tables [][][]string
+	var current [][]string
+	inFence := false
+	for _, raw := range strings.Split(md, "\n") {
+		line := strings.TrimRight(raw, "\r")
+		trimmed := strings.TrimSpace(line)
+
+		// Track fenced code blocks (```, ~~~) so we don't parse tables inside.
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			if current != nil {
+				tables = append(tables, current)
+				current = nil
+			}
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+
+		if isPipeTableRow(trimmed) {
+			if isPipeSeparatorRow(trimmed) {
+				continue
+			}
+			current = append(current, splitPipeRow(trimmed))
+			continue
+		}
+
+		if current != nil {
+			tables = append(tables, current)
+			current = nil
+		}
+	}
+	if current != nil {
+		tables = append(tables, current)
+	}
+	return tables
+}
+
+func isPipeTableRow(line string) bool {
+	return strings.HasPrefix(line, "|") && strings.HasSuffix(line, "|") && len(line) >= 2
+}
+
+var pipeSeparatorCellRE = regexp.MustCompile(`^\s*:?-{3,}:?\s*$`)
+
+func isPipeSeparatorRow(line string) bool {
+	if !isPipeTableRow(line) {
+		return false
+	}
+	for _, cell := range splitPipeRow(line) {
+		if !pipeSeparatorCellRE.MatchString(cell) {
+			return false
+		}
+	}
+	return true
+}
+
+// splitPipeRow splits a pipe table row into cells, handling escaped \| inside
+// cells by substituting a placeholder before splitting.
+func splitPipeRow(line string) []string {
+	inner := strings.TrimPrefix(strings.TrimSuffix(line, "|"), "|")
+	// Protect escaped pipes.
+	const placeholder = "\x00PIPE\x00"
+	inner = strings.ReplaceAll(inner, `\|`, placeholder)
+	parts := strings.Split(inner, "|")
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = strings.ReplaceAll(strings.TrimSpace(p), placeholder, "|")
+	}
+	return out
+}
+
+// computeWidthRatios returns column-width ratios that sum to widthRatioTotal.
+// Each column's weight is the maximum visual width across its cells (first row
+// included, header separator already removed). Empty tables or single-column
+// tables return nil to signal "nothing to patch".
+func computeWidthRatios(rows [][]string) []int {
+	if len(rows) == 0 {
+		return nil
+	}
+	cols := 0
+	for _, r := range rows {
+		if len(r) > cols {
+			cols = len(r)
+		}
+	}
+	if cols < 2 {
+		return nil
+	}
+
+	weights := make([]int, cols)
+	for _, r := range rows {
+		for i := 0; i < cols; i++ {
+			if i >= len(r) {
+				continue
+			}
+			w := visualWidth(r[i])
+			if w > weights[i] {
+				weights[i] = w
+			}
+		}
+	}
+
+	// Ensure every column has at least weight 1 so zero-width columns still
+	// receive a non-zero ratio.
+	total := 0
+	for i, w := range weights {
+		if w <= 0 {
+			weights[i] = 1
+			w = 1
+		}
+		total += w
+	}
+	if total <= 0 {
+		return nil
+	}
+
+	ratios := make([]int, cols)
+	allocated := 0
+	// Integer apportionment with rounding; remaining error goes to the widest
+	// column so the array sums to exactly widthRatioTotal.
+	for i, w := range weights {
+		ratios[i] = w * widthRatioTotal / total
+		if ratios[i] < 1 {
+			ratios[i] = 1
+		}
+		allocated += ratios[i]
+	}
+	if diff := widthRatioTotal - allocated; diff != 0 {
+		widest := 0
+		for i := 1; i < cols; i++ {
+			if weights[i] > weights[widest] {
+				widest = i
+			}
+		}
+		ratios[widest] += diff
+		if ratios[widest] < 1 {
+			ratios[widest] = 1
+		}
+	}
+	return ratios
+}
+
+// visualWidth estimates the display width of s by counting each rune as 2 when
+// it is East Asian Wide/Full (CJK, full-width punctuation) and 1 otherwise.
+// Control characters and zero-width joiners contribute 0.
+func visualWidth(s string) int {
+	w := 0
+	for _, r := range s {
+		switch {
+		case r == 0 || r == '\t':
+			// Tabs and NULs do not reliably contribute visual width.
+			continue
+		case unicode.IsControl(r):
+			continue
+		case isWideRune(r):
+			w += 2
+		default:
+			w++
+		}
+	}
+	return w
+}
+
+// isWideRune returns true for runes that occupy two columns in a monospace
+// grid (CJK ideographs, full-width forms, Hiragana/Katakana, common emoji).
+func isWideRune(r rune) bool {
+	switch {
+	case r >= 0x1100 && r <= 0x115F: // Hangul Jamo
+		return true
+	case r >= 0x2E80 && r <= 0x303E: // CJK Radicals & punctuation
+		return true
+	case r >= 0x3041 && r <= 0x33FF: // Hiragana/Katakana/CJK symbols
+		return true
+	case r >= 0x3400 && r <= 0x4DBF: // CJK Ext A
+		return true
+	case r >= 0x4E00 && r <= 0x9FFF: // CJK unified ideographs
+		return true
+	case r >= 0xA000 && r <= 0xA4CF: // Yi
+		return true
+	case r >= 0xAC00 && r <= 0xD7A3: // Hangul syllables
+		return true
+	case r >= 0xF900 && r <= 0xFAFF: // CJK compatibility ideographs
+		return true
+	case r >= 0xFE30 && r <= 0xFE4F: // CJK compatibility forms
+		return true
+	case r >= 0xFF00 && r <= 0xFF60: // Full-width ASCII
+		return true
+	case r >= 0xFFE0 && r <= 0xFFE6: // Full-width signs
+		return true
+	case r >= 0x1F300 && r <= 0x1FAFF: // Emoji & pictographs
+		return true
+	case r >= 0x20000 && r <= 0x3FFFD: // CJK Ext B-G
+		return true
+	}
+	return false
+}
+
+// applyMarkdownTableColumnWidths calculates per-column width ratios for each
+// pipe table in the supplied markdown and PATCHes matching table blocks in the
+// given document with update_grid_column_width_ratio. Failures are logged and
+// treated as non-fatal because the main content has already been created.
+//
+// Only tables whose local column count equals the remote table's column_size
+// are patched; mismatches are skipped. Tables are matched to remote table
+// blocks by document-order index.
+func applyMarkdownTableColumnWidths(runtime *common.RuntimeContext, documentID, markdown string) {
+	if documentID == "" || strings.TrimSpace(markdown) == "" {
+		return
+	}
+	tables := extractMarkdownTables(markdown)
+	if len(tables) == 0 {
+		return
+	}
+
+	remote, err := fetchDocumentTableBlocks(runtime, documentID)
+	if err != nil {
+		fmt.Fprintf(runtime.IO().ErrOut, "column-width adjustment skipped: %v\n", err)
+		return
+	}
+	limit := len(remote)
+	if len(tables) < limit {
+		limit = len(tables)
+	}
+	patched := 0
+	for i := 0; i < limit; i++ {
+		ratios := computeWidthRatios(tables[i])
+		if ratios == nil {
+			continue
+		}
+		if remote[i].ColumnSize != len(ratios) {
+			continue
+		}
+		body := map[string]interface{}{
+			"update_grid_column_width_ratio": map[string]interface{}{
+				"width_ratios": ratios,
+			},
+		}
+		url := fmt.Sprintf(
+			"/open-apis/docx/v1/documents/%s/blocks/%s",
+			validate.EncodePathSegment(documentID),
+			validate.EncodePathSegment(remote[i].BlockID),
+		)
+		if _, err := runtime.CallAPI("PATCH", url, nil, body); err != nil {
+			fmt.Fprintf(
+				runtime.IO().ErrOut,
+				"column-width PATCH failed for block %s: %v\n",
+				remote[i].BlockID, err,
+			)
+			continue
+		}
+		patched++
+	}
+	if patched > 0 {
+		fmt.Fprintf(runtime.IO().ErrOut, "column widths applied to %d/%d tables\n", patched, limit)
+	}
+}
+
+// docxTokenForUpdate returns the docx token for the supplied --doc input,
+// if it can be determined without a network call. Wiki inputs return false
+// because resolving them requires an extra API call; callers should skip
+// column-width application in that case rather than block the main flow.
+func docxTokenForUpdate(doc string) (string, bool) {
+	ref, err := parseDocumentRef(doc)
+	if err != nil {
+		return "", false
+	}
+	if ref.Kind == "docx" {
+		return ref.Token, true
+	}
+	return "", false
+}
+
+// remoteTable describes the minimal fields we need about a docx table block.
+type remoteTable struct {
+	BlockID    string
+	ColumnSize int
+}
+
+// fetchDocumentTableBlocks returns all table blocks (block_type == 31) in the
+// given docx document, in document order. The function walks the paginated
+// /blocks endpoint.
+func fetchDocumentTableBlocks(runtime *common.RuntimeContext, documentID string) ([]remoteTable, error) {
+	var out []remoteTable
+	pageToken := ""
+	for {
+		params := map[string]interface{}{"page_size": float64(500)}
+		if pageToken != "" {
+			params["page_token"] = pageToken
+		}
+		resp, err := runtime.CallAPI(
+			"GET",
+			fmt.Sprintf("/open-apis/docx/v1/documents/%s/blocks", validate.EncodePathSegment(documentID)),
+			params,
+			nil,
+		)
+		if err != nil {
+			return nil, output.Errorf(output.ExitAPI, "api_error", "fetch blocks: %v", err)
+		}
+		items, _ := resp["items"].([]interface{})
+		for _, item := range items {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			bt, _ := m["block_type"].(float64)
+			if int(bt) != 31 {
+				continue
+			}
+			blockID, _ := m["block_id"].(string)
+			table, _ := m["table"].(map[string]interface{})
+			prop, _ := table["property"].(map[string]interface{})
+			cs, _ := prop["column_size"].(float64)
+			if blockID == "" || cs == 0 {
+				continue
+			}
+			out = append(out, remoteTable{BlockID: blockID, ColumnSize: int(cs)})
+		}
+		hasMore, _ := resp["has_more"].(bool)
+		next, _ := resp["page_token"].(string)
+		if !hasMore || next == "" || next == pageToken {
+			break
+		}
+		pageToken = next
+	}
+	return out, nil
+}

--- a/shortcuts/doc/table_widths.go
+++ b/shortcuts/doc/table_widths.go
@@ -18,6 +18,10 @@ import (
 // update_grid_column_width_ratio API: width_ratios must sum to 100.
 const widthRatioTotal = 100
 
+// docxBlockTypeTable is the block_type value returned by
+// /open-apis/docx/v1/documents/{id}/blocks for a docx table block.
+const docxBlockTypeTable = 31
+
 // extractMarkdownTables parses GFM pipe tables from markdown text and returns
 // each table as a slice of rows, where each row is a slice of cell strings.
 // Header separator rows (e.g. |---|---|) are dropped. Tables inside fenced
@@ -169,7 +173,8 @@ func computeWidthRatios(rows [][]string) []int {
 
 // visualWidth estimates the display width of s by counting each rune as 2 when
 // it is East Asian Wide/Full (CJK, full-width punctuation) and 1 otherwise.
-// Control characters and zero-width joiners contribute 0.
+// Zero-width runes (control chars, format chars like ZWJ, non-spacing/enclosing
+// marks such as combining accents and emoji variation selectors) contribute 0.
 func visualWidth(s string) int {
 	w := 0
 	for _, r := range s {
@@ -177,7 +182,11 @@ func visualWidth(s string) int {
 		case r == 0 || r == '\t':
 			// Tabs and NULs do not reliably contribute visual width.
 			continue
-		case unicode.IsControl(r):
+		case unicode.IsControl(r),
+			unicode.In(r, unicode.Cf, unicode.Mn, unicode.Me):
+			// Format (Cf: ZWJ, LRM, ...), non-spacing marks (Mn: combining
+			// accents, emoji variation selectors U+FE0F), and enclosing marks
+			// (Me) do not advance the cursor.
 			continue
 		case isWideRune(r):
 			w += 2
@@ -244,12 +253,23 @@ func applyMarkdownTableColumnWidths(runtime *common.RuntimeContext, documentID, 
 		fmt.Fprintf(runtime.IO().ErrOut, "column-width adjustment skipped: %v\n", err)
 		return
 	}
-	limit := len(remote)
-	if len(tables) < limit {
-		limit = len(tables)
+	// Strict precondition: index-based pairing is only safe when the local
+	// markdown and the remote document expose the same number of tables.
+	// Diverging counts can happen when the extractor misses a form the server
+	// accepts (tables nested in blockquotes, non-conforming separator rows),
+	// or when the target doc was not fully overwritten. In either case,
+	// proceeding would silently shift every subsequent pair and write wrong
+	// ratios to tables that happen to match on column count.
+	if len(remote) != len(tables) {
+		fmt.Fprintf(
+			runtime.IO().ErrOut,
+			"column-width adjustment skipped: remote has %d table block(s) but local markdown has %d; skipping to avoid misaligned ratios\n",
+			len(remote), len(tables),
+		)
+		return
 	}
 	patched := 0
-	for i := 0; i < limit; i++ {
+	for i := range tables {
 		ratios := computeWidthRatios(tables[i])
 		if ratios == nil {
 			continue
@@ -278,7 +298,7 @@ func applyMarkdownTableColumnWidths(runtime *common.RuntimeContext, documentID, 
 		patched++
 	}
 	if patched > 0 {
-		fmt.Fprintf(runtime.IO().ErrOut, "column widths applied to %d/%d tables\n", patched, limit)
+		fmt.Fprintf(runtime.IO().ErrOut, "column widths applied to %d/%d tables\n", patched, len(tables))
 	}
 }
 
@@ -330,7 +350,7 @@ func fetchDocumentTableBlocks(runtime *common.RuntimeContext, documentID string)
 				continue
 			}
 			bt, _ := m["block_type"].(float64)
-			if int(bt) != 31 {
+			if int(bt) != docxBlockTypeTable {
 				continue
 			}
 			blockID, _ := m["block_id"].(string)

--- a/shortcuts/doc/table_widths.go
+++ b/shortcuts/doc/table_widths.go
@@ -24,23 +24,37 @@ const docxBlockTypeTable = 31
 
 // extractMarkdownTables parses GFM pipe tables from markdown text and returns
 // each table as a slice of rows, where each row is a slice of cell strings.
-// Header separator rows (e.g. |---|---|) are dropped. Tables inside fenced
-// code blocks are skipped so example snippets do not trigger column-width
-// patching.
+// Only sequences that follow the GFM shape — a header row immediately followed
+// by a separator row (e.g. |---|---|) — are recognised as tables. This matches
+// the Lark renderer's behaviour and avoids false positives on stray prose that
+// happens to contain pipes (quoted snippets, log excerpts, tables in
+// blockquotes, etc.). Tables inside fenced code blocks are skipped so example
+// snippets do not trigger column-width patching.
 func extractMarkdownTables(md string) [][][]string {
 	var tables [][][]string
+	// Parser states:
+	//   nil header, nil current  → scanning prose
+	//   non-nil header, nil current → saw candidate header, awaiting separator
+	//   nil header, non-nil current → inside a confirmed table, accumulating rows
+	var header []string
 	var current [][]string
 	inFence := false
+
+	flushCurrent := func() {
+		if current != nil {
+			tables = append(tables, current)
+			current = nil
+		}
+	}
+
 	for _, raw := range strings.Split(md, "\n") {
 		line := strings.TrimRight(raw, "\r")
 		trimmed := strings.TrimSpace(line)
 
 		// Track fenced code blocks (```, ~~~) so we don't parse tables inside.
 		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
-			if current != nil {
-				tables = append(tables, current)
-				current = nil
-			}
+			flushCurrent()
+			header = nil
 			inFence = !inFence
 			continue
 		}
@@ -48,22 +62,45 @@ func extractMarkdownTables(md string) [][][]string {
 			continue
 		}
 
-		if isPipeTableRow(trimmed) {
-			if isPipeSeparatorRow(trimmed) {
-				continue
-			}
-			current = append(current, splitPipeRow(trimmed))
+		if !isPipeTableRow(trimmed) {
+			// Any non-pipe line flushes the current table and discards a
+			// pending header candidate (the header was never confirmed).
+			flushCurrent()
+			header = nil
 			continue
 		}
 
-		if current != nil {
-			tables = append(tables, current)
-			current = nil
+		// Line is a pipe row. Route by parser state.
+		switch {
+		case header != nil:
+			// Awaiting separator. If this is one, the table is confirmed.
+			if isPipeSeparatorRow(trimmed) {
+				current = [][]string{header}
+				header = nil
+				continue
+			}
+			// Two consecutive data rows without a separator don't form a
+			// GFM table; drop the pending header candidate but treat the
+			// current line as a new candidate (it might still be a header
+			// for a table that follows).
+			header = splitPipeRow(trimmed)
+		case current != nil:
+			// Inside a confirmed table.
+			if isPipeSeparatorRow(trimmed) {
+				// Separator rows after the confirmed one are unusual; drop.
+				continue
+			}
+			current = append(current, splitPipeRow(trimmed))
+		default:
+			// Scanning prose and saw a pipe row: candidate header.
+			if isPipeSeparatorRow(trimmed) {
+				// A separator row with no preceding header is not a table.
+				continue
+			}
+			header = splitPipeRow(trimmed)
 		}
 	}
-	if current != nil {
-		tables = append(tables, current)
-	}
+	flushCurrent()
 	return tables
 }
 
@@ -198,10 +235,15 @@ func visualWidth(s string) int {
 }
 
 // isWideRune returns true for runes that occupy two columns in a monospace
-// grid (CJK ideographs, full-width forms, Hiragana/Katakana, common emoji).
+// grid (CJK ideographs, full-width forms, Hiragana/Katakana, emoji, and common
+// double-width symbol blocks used in emoji-text content).
 func isWideRune(r rune) bool {
 	switch {
 	case r >= 0x1100 && r <= 0x115F: // Hangul Jamo
+		return true
+	case r >= 0x2600 && r <= 0x26FF: // Misc Symbols (☀ ☁ ⚡ ⭐ ♻ …)
+		return true
+	case r >= 0x2700 && r <= 0x27BF: // Dingbats (✅ ✈ ✂ ✏ …)
 		return true
 	case r >= 0x2E80 && r <= 0x303E: // CJK Radicals & punctuation
 		return true
@@ -223,7 +265,11 @@ func isWideRune(r rune) bool {
 		return true
 	case r >= 0xFFE0 && r <= 0xFFE6: // Full-width signs
 		return true
+	case r >= 0x1F000 && r <= 0x1F2FF: // Mahjong/Domino/Playing Cards/Enclosed Alphanumeric (🀄 🃏 🅰 🆗 …)
+		return true
 	case r >= 0x1F300 && r <= 0x1FAFF: // Emoji & pictographs
+		return true
+	case r >= 0x1F1E6 && r <= 0x1F1FF: // Regional Indicator Symbols (flag halves 🇺🇸 🇯🇵 …)
 		return true
 	case r >= 0x20000 && r <= 0x3FFFD: // CJK Ext B-G
 		return true
@@ -275,6 +321,11 @@ func applyMarkdownTableColumnWidths(runtime *common.RuntimeContext, documentID, 
 			continue
 		}
 		if remote[i].ColumnSize != len(ratios) {
+			fmt.Fprintf(
+				runtime.IO().ErrOut,
+				"column-width skipped for table %d (block %s): local has %d columns, remote has %d\n",
+				i+1, remote[i].BlockID, len(ratios), remote[i].ColumnSize,
+			)
 			continue
 		}
 		body := map[string]interface{}{

--- a/shortcuts/doc/table_widths.go
+++ b/shortcuts/doc/table_widths.go
@@ -40,7 +40,7 @@ func extractMarkdownTables(md string) [][][]string {
 	//   nil header, non-nil current → inside a confirmed table, accumulating rows
 	var header []string
 	var current [][]string
-	inFence := false
+	fenceChar, fenceMinLen := byte(0), 0
 
 	flushCurrent := func() {
 		if current != nil {
@@ -53,14 +53,32 @@ func extractMarkdownTables(md string) [][][]string {
 		line := strings.TrimRight(raw, "\r")
 		trimmed := strings.TrimSpace(line)
 
-		// Track fenced code blocks (```, ~~~) so we don't parse tables inside.
-		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
-			flushCurrent()
-			header = nil
-			inFence = !inFence
-			continue
-		}
-		if inFence {
+		// Track fenced code blocks so we don't parse tables inside.
+		// A fence opened with a given character run closes only on a matching
+		// character run of equal or greater length; mismatched markers (e.g.
+		// ~~~ inside ```) or shorter runs (e.g. ``` inside `````) are ignored.
+		if fenceChar == 0 {
+			if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+				c := trimmed[0]
+				cnt := 0
+				for cnt < len(trimmed) && trimmed[cnt] == c {
+					cnt++
+				}
+				fenceChar, fenceMinLen = c, cnt
+				flushCurrent()
+				header = nil
+				continue
+			}
+		} else {
+			if len(trimmed) > 0 && trimmed[0] == fenceChar {
+				cnt := 0
+				for cnt < len(trimmed) && trimmed[cnt] == fenceChar {
+					cnt++
+				}
+				if cnt >= fenceMinLen {
+					fenceChar, fenceMinLen = 0, 0
+				}
+			}
 			continue
 		}
 
@@ -154,6 +172,12 @@ func computeWidthRatios(rows [][]string) []int {
 		}
 	}
 	if cols < 2 {
+		return nil
+	}
+	// With more columns than widthRatioTotal, each column must receive at
+	// least ratio 1, making the sum exceed 100. Return nil so the caller
+	// skips patching rather than writing an invalid ratio slice.
+	if cols > widthRatioTotal {
 		return nil
 	}
 

--- a/shortcuts/doc/table_widths.go
+++ b/shortcuts/doc/table_widths.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"unicode"
 
+	"golang.org/x/text/width"
+
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -235,43 +237,25 @@ func visualWidth(s string) int {
 }
 
 // isWideRune returns true for runes that occupy two columns in a monospace
-// grid (CJK ideographs, full-width forms, Hiragana/Katakana, emoji, and common
-// double-width symbol blocks used in emoji-text content).
+// grid. Classification is delegated to golang.org/x/text/width for the Unicode
+// East Asian Width property (covers CJK, Hangul, full-width forms, etc.), with
+// explicit ranges added for emoji and common symbol blocks that Unicode marks
+// as "neutral" but most terminals and the Lark renderer show at 2 columns.
 func isWideRune(r rune) bool {
-	switch {
-	case r >= 0x1100 && r <= 0x115F: // Hangul Jamo
+	switch width.LookupRune(r).Kind() {
+	case width.EastAsianWide, width.EastAsianFullwidth:
 		return true
-	case r >= 0x2600 && r <= 0x26FF: // Misc Symbols (☀ ☁ ⚡ ⭐ ♻ …)
+	}
+	switch {
+	case r >= 0x2600 && r <= 0x26FF: // Misc Symbols (☀ ☁ ⚡ ♻ …)
 		return true
 	case r >= 0x2700 && r <= 0x27BF: // Dingbats (✅ ✈ ✂ ✏ …)
 		return true
-	case r >= 0x2E80 && r <= 0x303E: // CJK Radicals & punctuation
-		return true
-	case r >= 0x3041 && r <= 0x33FF: // Hiragana/Katakana/CJK symbols
-		return true
-	case r >= 0x3400 && r <= 0x4DBF: // CJK Ext A
-		return true
-	case r >= 0x4E00 && r <= 0x9FFF: // CJK unified ideographs
-		return true
-	case r >= 0xA000 && r <= 0xA4CF: // Yi
-		return true
-	case r >= 0xAC00 && r <= 0xD7A3: // Hangul syllables
-		return true
-	case r >= 0xF900 && r <= 0xFAFF: // CJK compatibility ideographs
-		return true
-	case r >= 0xFE30 && r <= 0xFE4F: // CJK compatibility forms
-		return true
-	case r >= 0xFF00 && r <= 0xFF60: // Full-width ASCII
-		return true
-	case r >= 0xFFE0 && r <= 0xFFE6: // Full-width signs
-		return true
-	case r >= 0x1F000 && r <= 0x1F2FF: // Mahjong/Domino/Playing Cards/Enclosed Alphanumeric (🀄 🃏 🅰 🆗 …)
+	case r >= 0x1F000 && r <= 0x1F2FF: // Mahjong / Playing Cards / Enclosed Alphanumeric (🀄 🃏 🅰 🆗 …)
 		return true
 	case r >= 0x1F300 && r <= 0x1FAFF: // Emoji & pictographs
 		return true
-	case r >= 0x1F1E6 && r <= 0x1F1FF: // Regional Indicator Symbols (flag halves 🇺🇸 🇯🇵 …)
-		return true
-	case r >= 0x20000 && r <= 0x3FFFD: // CJK Ext B-G
+	case r >= 0x1F1E6 && r <= 0x1F1FF: // Regional Indicator Symbols (flag halves)
 		return true
 	}
 	return false

--- a/shortcuts/doc/table_widths.go
+++ b/shortcuts/doc/table_widths.go
@@ -5,6 +5,7 @@ package doc
 
 import (
 	"fmt"
+	"io"
 	"regexp"
 	"strings"
 	"unicode"
@@ -15,6 +16,11 @@ import (
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
+
+// apiCaller is the subset of *common.RuntimeContext used by the table-width
+// orchestration. Exposing it as a function type keeps this package testable
+// without a fake for the whole runtime surface.
+type apiCaller func(method, url string, params map[string]interface{}, data interface{}) (map[string]interface{}, error)
 
 // widthRatioTotal is the denominator used by Feishu's
 // update_grid_column_width_ratio API: width_ratios must sum to 100.
@@ -27,11 +33,18 @@ const docxBlockTypeTable = 31
 // extractMarkdownTables parses GFM pipe tables from markdown text and returns
 // each table as a slice of rows, where each row is a slice of cell strings.
 // Only sequences that follow the GFM shape — a header row immediately followed
-// by a separator row (e.g. |---|---|) — are recognised as tables. This matches
-// the Lark renderer's behaviour and avoids false positives on stray prose that
-// happens to contain pipes (quoted snippets, log excerpts, tables in
-// blockquotes, etc.). Tables inside fenced code blocks are skipped so example
-// snippets do not trigger column-width patching.
+// by a separator row whose cell count matches the header — are recognised as
+// tables. This matches the Lark renderer's behaviour and avoids false
+// positives on stray prose that happens to contain pipes.
+//
+// Body rows are normalised to the confirmed column count so extra or missing
+// cells do not produce a ratio list that disagrees with the rendered table's
+// column_size (which would otherwise cause the subsequent PATCH to be skipped).
+//
+// Fenced code blocks are skipped. Fence tracking honours the CommonMark rule
+// that a fence only closes on a matching fence character (backtick vs tilde)
+// of equal-or-longer length; shorter fence markers inside a longer fence do
+// not terminate it.
 func extractMarkdownTables(md string) [][][]string {
 	var tables [][][]string
 	// Parser states:
@@ -40,45 +53,53 @@ func extractMarkdownTables(md string) [][][]string {
 	//   nil header, non-nil current → inside a confirmed table, accumulating rows
 	var header []string
 	var current [][]string
-	fenceChar, fenceMinLen := byte(0), 0
+	tableCols := 0
+
+	var fenceChar byte // 0 when not in a fence; '`' or '~' while inside
+	var fenceLen int
 
 	flushCurrent := func() {
 		if current != nil {
 			tables = append(tables, current)
 			current = nil
+			tableCols = 0
 		}
+	}
+
+	normaliseRow := func(row []string, cols int) []string {
+		switch {
+		case len(row) > cols:
+			return row[:cols]
+		case len(row) < cols:
+			padded := make([]string, cols)
+			copy(padded, row)
+			return padded
+		}
+		return row
 	}
 
 	for _, raw := range strings.Split(md, "\n") {
 		line := strings.TrimRight(raw, "\r")
 		trimmed := strings.TrimSpace(line)
 
-		// Track fenced code blocks so we don't parse tables inside.
-		// A fence opened with a given character run closes only on a matching
-		// character run of equal or greater length; mismatched markers (e.g.
-		// ~~~ inside ```) or shorter runs (e.g. ``` inside `````) are ignored.
-		if fenceChar == 0 {
-			if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
-				c := trimmed[0]
-				cnt := 0
-				for cnt < len(trimmed) && trimmed[cnt] == c {
-					cnt++
-				}
-				fenceChar, fenceMinLen = c, cnt
+		if c, n, ok := detectFenceMarker(trimmed); ok {
+			switch {
+			case fenceChar == 0:
+				// Entering a fence; remember the marker.
 				flushCurrent()
 				header = nil
-				continue
+				fenceChar = c
+				fenceLen = n
+			case c == fenceChar && n >= fenceLen:
+				// Closing the active fence with a matching marker of
+				// equal-or-longer length.
+				fenceChar = 0
+				fenceLen = 0
 			}
-		} else {
-			if len(trimmed) > 0 && trimmed[0] == fenceChar {
-				cnt := 0
-				for cnt < len(trimmed) && trimmed[cnt] == fenceChar {
-					cnt++
-				}
-				if cnt >= fenceMinLen {
-					fenceChar, fenceMinLen = 0, 0
-				}
-			}
+			// Any other fence marker inside an open fence is ignored.
+			continue
+		}
+		if fenceChar != 0 {
 			continue
 		}
 
@@ -93,16 +114,24 @@ func extractMarkdownTables(md string) [][][]string {
 		// Line is a pipe row. Route by parser state.
 		switch {
 		case header != nil:
-			// Awaiting separator. If this is one, the table is confirmed.
+			// Awaiting a separator with the same cell count as the header.
 			if isPipeSeparatorRow(trimmed) {
-				current = [][]string{header}
+				sep := splitPipeRow(trimmed)
+				if len(sep) == len(header) {
+					tableCols = len(header)
+					current = [][]string{header}
+					header = nil
+					continue
+				}
+				// Separator cell count disagrees with the header; not a
+				// valid GFM table. Drop the pending header entirely
+				// rather than treat the separator as a new candidate.
 				header = nil
 				continue
 			}
 			// Two consecutive data rows without a separator don't form a
-			// GFM table; drop the pending header candidate but treat the
-			// current line as a new candidate (it might still be a header
-			// for a table that follows).
+			// GFM table; drop the pending header but keep the current
+			// line as a fresh candidate for a table that may follow.
 			header = splitPipeRow(trimmed)
 		case current != nil:
 			// Inside a confirmed table.
@@ -110,7 +139,7 @@ func extractMarkdownTables(md string) [][][]string {
 				// Separator rows after the confirmed one are unusual; drop.
 				continue
 			}
-			current = append(current, splitPipeRow(trimmed))
+			current = append(current, normaliseRow(splitPipeRow(trimmed), tableCols))
 		default:
 			// Scanning prose and saw a pipe row: candidate header.
 			if isPipeSeparatorRow(trimmed) {
@@ -122,6 +151,33 @@ func extractMarkdownTables(md string) [][][]string {
 	}
 	flushCurrent()
 	return tables
+}
+
+// detectFenceMarker recognises a CommonMark-style code fence opening or
+// closing marker. Returns the fence character (backtick or tilde), the run
+// length, and true when the trimmed line is a valid fence marker line — that
+// is, at least three identical fence chars optionally followed by an info
+// string. Text after the opening run is treated as an info string and does
+// not affect fence closure.
+func detectFenceMarker(trimmed string) (byte, int, bool) {
+	if len(trimmed) < 3 {
+		return 0, 0, false
+	}
+	c := trimmed[0]
+	if c != '`' && c != '~' {
+		return 0, 0, false
+	}
+	n := 0
+	for n < len(trimmed) && trimmed[n] == c {
+		n++
+	}
+	if n < 3 {
+		return 0, 0, false
+	}
+	// Backtick fences disallow backticks in the info string per CommonMark;
+	// a tilde fence accepts any info string. For our purposes we only need
+	// to know the char + length to decide open/close.
+	return c, n, true
 }
 
 func isPipeTableRow(line string) bool {
@@ -174,9 +230,11 @@ func computeWidthRatios(rows [][]string) []int {
 	if cols < 2 {
 		return nil
 	}
-	// With more columns than widthRatioTotal, each column must receive at
-	// least ratio 1, making the sum exceed 100. Return nil so the caller
-	// skips patching rather than writing an invalid ratio slice.
+	// Every column must receive at least 1 in the final ratio (the API
+	// rejects 0), so we cannot honour both the "≥1 per column" floor and
+	// the "sum == widthRatioTotal" contract when the column count exceeds
+	// widthRatioTotal. Give up and let the server keep its equal-width
+	// default rather than emit an invalid width_ratios array.
 	if cols > widthRatioTotal {
 		return nil
 	}
@@ -226,10 +284,15 @@ func computeWidthRatios(rows [][]string) []int {
 				widest = i
 			}
 		}
-		ratios[widest] += diff
-		if ratios[widest] < 1 {
-			ratios[widest] = 1
+		// If piling the full error onto the widest column would push its
+		// ratio below 1, the table cannot be expressed as a valid
+		// width_ratios array that still sums to widthRatioTotal without
+		// silently violating the ≥1 floor on another column. Give up and
+		// return nil rather than write a bad array the API will reject.
+		if ratios[widest]+diff < 1 {
+			return nil
 		}
+		ratios[widest] += diff
 	}
 	return ratios
 }
@@ -238,6 +301,16 @@ func computeWidthRatios(rows [][]string) []int {
 // it is East Asian Wide/Full (CJK, full-width punctuation) and 1 otherwise.
 // Zero-width runes (control chars, format chars like ZWJ, non-spacing/enclosing
 // marks such as combining accents and emoji variation selectors) contribute 0.
+//
+// Known over-counting: Regional Indicator pairs (flags like 🇺🇸) and emoji
+// ZWJ sequences (👨‍👩‍👧‍👦) render as a single grapheme cluster of visual
+// width 2 but this function counts each base codepoint independently, so a
+// flag weighs 4 and a four-person family weighs 8. The weights are only used
+// as proportional inputs to column-width ratios, so the practical impact is
+// that cells dominated by flags or family emoji claim slightly more width
+// than the eye expects. Accepting this until a grapheme-cluster segmenter
+// (e.g. rivo/uniseg) becomes worth the dependency — see the visualWidth
+// test cases that pin the current behaviour.
 func visualWidth(s string) int {
 	w := 0
 	for _, r := range s {
@@ -294,6 +367,14 @@ func isWideRune(r rune) bool {
 // are patched; mismatches are skipped. Tables are matched to remote table
 // blocks by document-order index.
 func applyMarkdownTableColumnWidths(runtime *common.RuntimeContext, documentID, markdown string) {
+	applyTableColumnWidths(runtime.CallAPI, runtime.IO().ErrOut, documentID, markdown)
+}
+
+// applyTableColumnWidths is the testable core. Callers hand in an apiCaller
+// and an io.Writer so tests can exercise the orchestration (remote/local
+// count mismatch, per-table column-count skip, PATCH error non-fatal
+// handling) without touching the network.
+func applyTableColumnWidths(api apiCaller, errOut io.Writer, documentID, markdown string) {
 	if documentID == "" || strings.TrimSpace(markdown) == "" {
 		return
 	}
@@ -302,9 +383,9 @@ func applyMarkdownTableColumnWidths(runtime *common.RuntimeContext, documentID, 
 		return
 	}
 
-	remote, err := fetchDocumentTableBlocks(runtime, documentID)
+	remote, err := fetchTableBlocks(api, documentID)
 	if err != nil {
-		fmt.Fprintf(runtime.IO().ErrOut, "column-width adjustment skipped: %v\n", err)
+		fmt.Fprintf(errOut, "column-width adjustment skipped: %v\n", err)
 		return
 	}
 	// Strict precondition: index-based pairing is only safe when the local
@@ -316,7 +397,7 @@ func applyMarkdownTableColumnWidths(runtime *common.RuntimeContext, documentID, 
 	// ratios to tables that happen to match on column count.
 	if len(remote) != len(tables) {
 		fmt.Fprintf(
-			runtime.IO().ErrOut,
+			errOut,
 			"column-width adjustment skipped: remote has %d table block(s) but local markdown has %d; skipping to avoid misaligned ratios\n",
 			len(remote), len(tables),
 		)
@@ -330,7 +411,7 @@ func applyMarkdownTableColumnWidths(runtime *common.RuntimeContext, documentID, 
 		}
 		if remote[i].ColumnSize != len(ratios) {
 			fmt.Fprintf(
-				runtime.IO().ErrOut,
+				errOut,
 				"column-width skipped for table %d (block %s): local has %d columns, remote has %d\n",
 				i+1, remote[i].BlockID, len(ratios), remote[i].ColumnSize,
 			)
@@ -346,9 +427,9 @@ func applyMarkdownTableColumnWidths(runtime *common.RuntimeContext, documentID, 
 			validate.EncodePathSegment(documentID),
 			validate.EncodePathSegment(remote[i].BlockID),
 		)
-		if _, err := runtime.CallAPI("PATCH", url, nil, body); err != nil {
+		if _, err := api("PATCH", url, nil, body); err != nil {
 			fmt.Fprintf(
-				runtime.IO().ErrOut,
+				errOut,
 				"column-width PATCH failed for block %s: %v\n",
 				remote[i].BlockID, err,
 			)
@@ -357,21 +438,76 @@ func applyMarkdownTableColumnWidths(runtime *common.RuntimeContext, documentID, 
 		patched++
 	}
 	if patched > 0 {
-		fmt.Fprintf(runtime.IO().ErrOut, "column widths applied to %d/%d tables\n", patched, len(tables))
+		fmt.Fprintf(errOut, "column widths applied to %d/%d tables\n", patched, len(tables))
 	}
 }
 
-// docxTokenForUpdate returns the docx token for the supplied --doc input,
-// if it can be determined without a network call. Wiki inputs return false
-// because resolving them requires an extra API call; callers should skip
-// column-width application in that case rather than block the main flow.
-func docxTokenForUpdate(doc string) (string, bool) {
+// docxTokenForUpdate returns the docx token for the supplied --doc input.
+// Docx URLs / bare tokens short-circuit; wiki inputs are resolved to their
+// backing docx via /open-apis/wiki/v2/spaces/get_node so that column-width
+// application works uniformly regardless of how the user referenced the doc.
+func docxTokenForUpdate(runtime *common.RuntimeContext, doc string) (string, bool) {
+	return docxTokenForAutoWidths(runtime.CallAPI, doc)
+}
+
+// docxTokenForAutoWidths is the testable core: it normalises a user-supplied
+// doc token or URL to a docx token, optionally following a single wiki→docx
+// resolve call. Callers hand in an apiCaller so tests can stub the network.
+func docxTokenForAutoWidths(api apiCaller, doc string) (string, bool) {
 	ref, err := parseDocumentRef(doc)
 	if err != nil {
 		return "", false
 	}
-	if ref.Kind == "docx" {
+	switch ref.Kind {
+	case "docx":
 		return ref.Token, true
+	case "wiki":
+		return resolveWikiNodeToDocx(api, ref.Token)
+	}
+	return "", false
+}
+
+// resolveWikiNodeToDocx maps a wiki node token to its backing docx object
+// token using the public wiki API. Returns false for non-docx-backed nodes
+// (sheets, bitables, etc.) so the caller can skip cleanly.
+func resolveWikiNodeToDocx(api apiCaller, wikiToken string) (string, bool) {
+	resp, err := api(
+		"GET",
+		"/open-apis/wiki/v2/spaces/get_node",
+		map[string]interface{}{"token": wikiToken},
+		nil,
+	)
+	if err != nil || resp == nil {
+		return "", false
+	}
+	node, _ := resp["node"].(map[string]interface{})
+	if node == nil {
+		return "", false
+	}
+	if objType, _ := node["obj_type"].(string); objType != "docx" {
+		return "", false
+	}
+	token, _ := node["obj_token"].(string)
+	return token, token != ""
+}
+
+// resolveDocxTokenForCreateResult extracts the docx token from an MCP
+// create-doc result, preferring the doc_url (unambiguous about Kind) and
+// falling back to doc_id. Wiki URLs surfaced in the response are resolved to
+// docx via the public wiki API so the auto-widths path still runs.
+func resolveDocxTokenForCreateResult(api apiCaller, result map[string]interface{}) (string, bool) {
+	if docURL := strings.TrimSpace(common.GetString(result, "doc_url")); docURL != "" {
+		if ref, err := parseDocumentRef(docURL); err == nil {
+			switch ref.Kind {
+			case "docx":
+				return ref.Token, true
+			case "wiki":
+				return resolveWikiNodeToDocx(api, ref.Token)
+			}
+		}
+	}
+	if docID := strings.TrimSpace(common.GetString(result, "doc_id")); docID != "" {
+		return docID, true
 	}
 	return "", false
 }
@@ -382,10 +518,10 @@ type remoteTable struct {
 	ColumnSize int
 }
 
-// fetchDocumentTableBlocks returns all table blocks (block_type == 31) in the
-// given docx document, in document order. The function walks the paginated
-// /blocks endpoint.
-func fetchDocumentTableBlocks(runtime *common.RuntimeContext, documentID string) ([]remoteTable, error) {
+// fetchTableBlocks returns all table blocks (block_type == 31) in the given
+// docx document, in document order. The function walks the paginated /blocks
+// endpoint via the supplied apiCaller.
+func fetchTableBlocks(api apiCaller, documentID string) ([]remoteTable, error) {
 	var out []remoteTable
 	pageToken := ""
 	for {
@@ -393,7 +529,7 @@ func fetchDocumentTableBlocks(runtime *common.RuntimeContext, documentID string)
 		if pageToken != "" {
 			params["page_token"] = pageToken
 		}
-		resp, err := runtime.CallAPI(
+		resp, err := api(
 			"GET",
 			fmt.Sprintf("/open-apis/docx/v1/documents/%s/blocks", validate.EncodePathSegment(documentID)),
 			params,

--- a/shortcuts/doc/table_widths_test.go
+++ b/shortcuts/doc/table_widths_test.go
@@ -123,6 +123,24 @@ middle
 			t.Fatalf("expected 1 table with 2 rows, got %v", got)
 		}
 	})
+
+	t.Run("tilde fence inside backtick fence does not close it", func(t *testing.T) {
+		// A ~~~ line inside a ``` block must not toggle the fence off.
+		md := "```\n~~~\n| A | B |\n|---|---|\n| 1 | 2 |\n~~~\n```\n"
+		got := extractMarkdownTables(md)
+		if len(got) != 0 {
+			t.Fatalf("table inside backtick fence must be skipped, got %d table(s)", len(got))
+		}
+	})
+
+	t.Run("shorter fence run inside longer fence does not close it", func(t *testing.T) {
+		// A ``` run inside a ````` block must not close the outer fence.
+		md := "`````\n```\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n`````\n"
+		got := extractMarkdownTables(md)
+		if len(got) != 0 {
+			t.Fatalf("table inside longer fence must be skipped, got %d table(s)", len(got))
+		}
+	})
 }
 
 func TestComputeWidthRatios(t *testing.T) {
@@ -167,6 +185,18 @@ func TestComputeWidthRatios(t *testing.T) {
 		}
 		if got[1] <= got[0] || got[1] <= got[2] {
 			t.Fatalf("middle column should be widest, got %v", got)
+		}
+	})
+
+	t.Run("nil for more columns than widthRatioTotal", func(t *testing.T) {
+		// Each column needs at least ratio 1; with >100 columns the sum would
+		// exceed 100, so computeWidthRatios must return nil.
+		row := make([]string, widthRatioTotal+1)
+		for i := range row {
+			row[i] = "x"
+		}
+		if got := computeWidthRatios([][]string{row}); got != nil {
+			t.Fatalf("expected nil for %d columns, got len=%d: %v", widthRatioTotal+1, len(got), got)
 		}
 	})
 

--- a/shortcuts/doc/table_widths_test.go
+++ b/shortcuts/doc/table_widths_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractMarkdownTables(t *testing.T) {
+	t.Run("single pipe table", func(t *testing.T) {
+		md := `# Heading
+
+| A | B | C |
+|---|---|---|
+| 1 | 22 | 333 |
+| 4 | 55 | 666 |
+
+paragraph`
+		got := extractMarkdownTables(md)
+		want := [][][]string{
+			{
+				{"A", "B", "C"},
+				{"1", "22", "333"},
+				{"4", "55", "666"},
+			},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("tables mismatch\n got: %#v\nwant: %#v", got, want)
+		}
+	})
+
+	t.Run("two tables separated by prose", func(t *testing.T) {
+		md := `| x | y |
+|---|---|
+| 1 | 2 |
+
+middle
+
+| a | b | c |
+|---|---|---|
+| u | v | w |`
+		got := extractMarkdownTables(md)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 tables, got %d", len(got))
+		}
+		if len(got[0][0]) != 2 || len(got[1][0]) != 3 {
+			t.Fatalf("column counts wrong: %v %v", got[0][0], got[1][0])
+		}
+	})
+
+	t.Run("table inside fenced code is skipped", func(t *testing.T) {
+		md := "```md\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n"
+		got := extractMarkdownTables(md)
+		if len(got) != 0 {
+			t.Fatalf("expected 0 tables inside fence, got %d", len(got))
+		}
+	})
+
+	t.Run("escaped pipe inside cell is preserved", func(t *testing.T) {
+		md := `| A | B |
+|---|---|
+| foo \| bar | baz |`
+		got := extractMarkdownTables(md)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 table, got %d", len(got))
+		}
+		if got[0][1][0] != "foo | bar" {
+			t.Fatalf("escaped pipe not preserved: %q", got[0][1][0])
+		}
+	})
+
+	t.Run("no pipe table returns empty", func(t *testing.T) {
+		got := extractMarkdownTables("# title\n\nhello world\n")
+		if len(got) != 0 {
+			t.Fatalf("expected 0 tables, got %d", len(got))
+		}
+	})
+}
+
+func TestComputeWidthRatios(t *testing.T) {
+	t.Run("nil on empty input", func(t *testing.T) {
+		if got := computeWidthRatios(nil); got != nil {
+			t.Fatalf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("nil on single-column table", func(t *testing.T) {
+		if got := computeWidthRatios([][]string{{"only"}, {"cell"}}); got != nil {
+			t.Fatalf("expected nil for single column, got %v", got)
+		}
+	})
+
+	t.Run("equal widths sum to 100", func(t *testing.T) {
+		rows := [][]string{
+			{"aa", "bb", "cc"},
+			{"dd", "ee", "ff"},
+		}
+		got := computeWidthRatios(rows)
+		if len(got) != 3 {
+			t.Fatalf("expected 3 ratios, got %v", got)
+		}
+		sum := 0
+		for _, r := range got {
+			sum += r
+		}
+		if sum != 100 {
+			t.Fatalf("ratios must sum to 100, got %d from %v", sum, got)
+		}
+	})
+
+	t.Run("wider column gets larger ratio", func(t *testing.T) {
+		rows := [][]string{
+			{"A", "Much longer header here", "S"},
+			{"x", "a lot of content that spans width", "y"},
+		}
+		got := computeWidthRatios(rows)
+		if len(got) != 3 {
+			t.Fatalf("expected 3 ratios, got %v", got)
+		}
+		if got[1] <= got[0] || got[1] <= got[2] {
+			t.Fatalf("middle column should be widest, got %v", got)
+		}
+	})
+
+	t.Run("sum always equals 100 across varied shapes", func(t *testing.T) {
+		samples := [][][]string{
+			{{"a", "b"}},
+			{{"a", "b", "c", "d"}, {"1", "22", "333", "4444"}},
+			{{"CJK测试", "mix", "English"}, {"中文内容", "x", "longer english"}},
+			{{"", "", ""}},
+		}
+		for i, rows := range samples {
+			got := computeWidthRatios(rows)
+			if got == nil {
+				continue
+			}
+			sum := 0
+			for _, r := range got {
+				if r < 1 {
+					t.Errorf("sample %d: ratio < 1 in %v", i, got)
+				}
+				sum += r
+			}
+			if sum != 100 {
+				t.Errorf("sample %d: sum != 100 (got %d) from %v", i, sum, got)
+			}
+		}
+	})
+}
+
+func TestVisualWidth(t *testing.T) {
+	cases := []struct {
+		s    string
+		want int
+	}{
+		{"", 0},
+		{"abc", 3},
+		{"中文", 4},
+		{"中a文b", 6},
+		{"🚀", 2},
+		{"半角ﾊﾝｶｸ", 8}, // two CJK ideographs (2*2) + four halfwidth katakana (4*1)
+	}
+	for _, c := range cases {
+		if got := visualWidth(c.s); got != c.want {
+			t.Errorf("visualWidth(%q) = %d, want %d", c.s, got, c.want)
+		}
+	}
+}

--- a/shortcuts/doc/table_widths_test.go
+++ b/shortcuts/doc/table_widths_test.go
@@ -96,6 +96,33 @@ middle
 			t.Fatalf("expected 0 tables, got %d", len(got))
 		}
 	})
+
+	t.Run("pipe row without separator is not a table", func(t *testing.T) {
+		// A stray pipe line (prose, log excerpt) must not be mistaken for
+		// a 1-row table — the Lark renderer requires a GFM separator row.
+		md := "Here is a | looking | line |\n\nand some prose."
+		got := extractMarkdownTables(md)
+		if len(got) != 0 {
+			t.Fatalf("expected 0 tables without separator, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("two pipe rows without separator are not a table", func(t *testing.T) {
+		md := "| a | b |\n| 1 | 2 |\n"
+		got := extractMarkdownTables(md)
+		if len(got) != 0 {
+			t.Fatalf("expected 0 tables, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("false header followed by real table", func(t *testing.T) {
+		// Dangling pipe line, blank, then a real table — only the real one counts.
+		md := "| stray | line |\n\n| a | b |\n|---|---|\n| 1 | 2 |\n"
+		got := extractMarkdownTables(md)
+		if len(got) != 1 || len(got[0]) != 2 {
+			t.Fatalf("expected 1 table with 2 rows, got %v", got)
+		}
+	})
 }
 
 func TestComputeWidthRatios(t *testing.T) {
@@ -180,6 +207,10 @@ func TestVisualWidth(t *testing.T) {
 		{"中a文b", 6},
 		{"🚀", 2},
 		{"半角ﾊﾝｶｸ", 8}, // two CJK ideographs (2*2) + four halfwidth katakana (4*1)
+		{"☀️", 2},     // Misc Symbols (U+2600) + U+FE0F variation selector (zero-width)
+		{"✅", 2},      // Dingbats
+		{"🀄", 2},      // Mahjong tile (SMP 0x1F000-range)
+		{"🇺🇸", 4},     // Regional Indicator pair (flag) = 2 + 2
 	}
 	for _, c := range cases {
 		if got := visualWidth(c.s); got != c.want {

--- a/shortcuts/doc/table_widths_test.go
+++ b/shortcuts/doc/table_widths_test.go
@@ -50,6 +50,25 @@ middle
 		}
 	})
 
+	t.Run("blank line separates two tables", func(t *testing.T) {
+		// The common real-world case: two tables with only a blank line
+		// between them. Exercises the flush path on an empty non-pipe row
+		// so we don't accidentally accumulate both tables into one.
+		md := "| a | b |\n|---|---|\n| 1 | 2 |\n\n| c | d |\n|---|---|\n| 3 | 4 |\n"
+		got := extractMarkdownTables(md)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 tables separated by blank line, got %d", len(got))
+		}
+	})
+
+	t.Run("table immediately followed by a fenced block flushes", func(t *testing.T) {
+		md := "| a | b |\n|---|---|\n| 1 | 2 |\n```\ncode\n```\n"
+		got := extractMarkdownTables(md)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 table before fence, got %d", len(got))
+		}
+	})
+
 	t.Run("table inside fenced code is skipped", func(t *testing.T) {
 		md := "```md\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n"
 		got := extractMarkdownTables(md)

--- a/shortcuts/doc/table_widths_test.go
+++ b/shortcuts/doc/table_widths_test.go
@@ -4,7 +4,10 @@
 package doc
 
 import (
+	"bytes"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -124,21 +127,42 @@ middle
 		}
 	})
 
-	t.Run("tilde fence inside backtick fence does not close it", func(t *testing.T) {
-		// A ~~~ line inside a ``` block must not toggle the fence off.
-		md := "```\n~~~\n| A | B |\n|---|---|\n| 1 | 2 |\n~~~\n```\n"
+	t.Run("longer fence is not closed by a shorter inner fence", func(t *testing.T) {
+		// A 4-backtick fence should survive a literal ``` line inside it.
+		md := "````md\n```\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n````\n"
 		got := extractMarkdownTables(md)
 		if len(got) != 0 {
-			t.Fatalf("table inside backtick fence must be skipped, got %d table(s)", len(got))
+			t.Fatalf("expected 0 tables inside longer fence, got %d", len(got))
 		}
 	})
 
-	t.Run("shorter fence run inside longer fence does not close it", func(t *testing.T) {
-		// A ``` run inside a ````` block must not close the outer fence.
-		md := "`````\n```\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n`````\n"
+	t.Run("tilde fence inside backtick fence does not prematurely close", func(t *testing.T) {
+		md := "```md\n~~~\n| A | B |\n|---|---|\n| 1 | 2 |\n~~~\n```\n"
 		got := extractMarkdownTables(md)
 		if len(got) != 0 {
-			t.Fatalf("table inside longer fence must be skipped, got %d table(s)", len(got))
+			t.Fatalf("expected 0 tables with mismatched inner fence, got %d", len(got))
+		}
+	})
+
+	t.Run("separator with different cell count rejects the header", func(t *testing.T) {
+		// 2-column header, 3-column separator → not a valid GFM table.
+		md := "| a | b |\n|---|---|---|\n| 1 | 2 |\n"
+		got := extractMarkdownTables(md)
+		if len(got) != 0 {
+			t.Fatalf("expected 0 tables when separator width disagrees, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("body rows are normalised to the confirmed column count", func(t *testing.T) {
+		// Header/separator establish 2 columns; body row has 3 — should be
+		// truncated so computeWidthRatios sees the confirmed width.
+		md := "| a | b |\n|---|---|\n| 1 | 2 | 3 |\n"
+		got := extractMarkdownTables(md)
+		if len(got) != 1 || len(got[0]) != 2 {
+			t.Fatalf("expected 1 table with 2 rows, got %v", got)
+		}
+		if len(got[0][1]) != 2 {
+			t.Fatalf("expected body row normalised to 2 cells, got %v", got[0][1])
 		}
 	})
 }
@@ -188,24 +212,16 @@ func TestComputeWidthRatios(t *testing.T) {
 		}
 	})
 
-	t.Run("nil for more columns than widthRatioTotal", func(t *testing.T) {
-		// Each column needs at least ratio 1; with >100 columns the sum would
-		// exceed 100, so computeWidthRatios must return nil.
-		row := make([]string, widthRatioTotal+1)
-		for i := range row {
-			row[i] = "x"
-		}
-		if got := computeWidthRatios([][]string{row}); got != nil {
-			t.Fatalf("expected nil for %d columns, got len=%d: %v", widthRatioTotal+1, len(got), got)
-		}
-	})
-
 	t.Run("sum always equals 100 across varied shapes", func(t *testing.T) {
 		samples := [][][]string{
 			{{"a", "b"}},
 			{{"a", "b", "c", "d"}, {"1", "22", "333", "4444"}},
 			{{"CJK测试", "mix", "English"}, {"中文内容", "x", "longer english"}},
 			{{"", "", ""}},
+			// Pathological: many skinny columns forcing the <1 clamp to fire
+			// repeatedly so the apportionment remainder has to be absorbed by
+			// a single widest column.
+			{append([]string{"widecolumncontentwidecolumncontent"}, makeStrSlice(49, "a")...)},
 		}
 		for i, rows := range samples {
 			got := computeWidthRatios(rows)
@@ -224,6 +240,39 @@ func TestComputeWidthRatios(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("nil when column count exceeds widthRatioTotal", func(t *testing.T) {
+		row := makeStrSlice(widthRatioTotal+1, "x")
+		if got := computeWidthRatios([][]string{row}); got != nil {
+			t.Fatalf("expected nil for %d-column table, got %v", widthRatioTotal+1, got)
+		}
+	})
+
+	t.Run("exactly widthRatioTotal columns sum to 100", func(t *testing.T) {
+		row := makeStrSlice(widthRatioTotal, "x")
+		got := computeWidthRatios([][]string{row})
+		if len(got) != widthRatioTotal {
+			t.Fatalf("expected %d ratios, got %d", widthRatioTotal, len(got))
+		}
+		sum := 0
+		for _, r := range got {
+			if r < 1 {
+				t.Errorf("ratio < 1 in %v", got)
+			}
+			sum += r
+		}
+		if sum != 100 {
+			t.Fatalf("sum != 100 (got %d)", sum)
+		}
+	})
+}
+
+func makeStrSlice(n int, value string) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = value
+	}
+	return out
 }
 
 func TestVisualWidth(t *testing.T) {
@@ -247,4 +296,298 @@ func TestVisualWidth(t *testing.T) {
 			t.Errorf("visualWidth(%q) = %d, want %d", c.s, got, c.want)
 		}
 	}
+}
+
+// fakeAPI records each (method, url) it receives and replays scripted
+// responses so the orchestration can be exercised without touching the
+// network. Lookups fall through to a default error if the (method, url)
+// combination isn't scripted.
+type fakeAPI struct {
+	resps  map[string]fakeResp
+	calls  []string
+	blocks []map[string]interface{}
+}
+
+type fakeResp struct {
+	data map[string]interface{}
+	err  error
+}
+
+func (f *fakeAPI) call(method, url string, _ map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+	key := method + " " + url
+	f.calls = append(f.calls, key)
+	// Blocks endpoint returns the canned block list.
+	if method == "GET" && strings.HasPrefix(url, "/open-apis/docx/v1/documents/") && strings.HasSuffix(url, "/blocks") {
+		// fetchTableBlocks expects []interface{} from the real API.
+		items := make([]interface{}, len(f.blocks))
+		for i, b := range f.blocks {
+			items[i] = b
+		}
+		return map[string]interface{}{
+			"items":    items,
+			"has_more": false,
+		}, nil
+	}
+	if r, ok := f.resps[key]; ok {
+		return r.data, r.err
+	}
+	return nil, errors.New("unexpected call: " + key)
+}
+
+func makeTableBlock(blockID string, columnSize int) map[string]interface{} {
+	return map[string]interface{}{
+		"block_id":   blockID,
+		"block_type": float64(docxBlockTypeTable),
+		"table": map[string]interface{}{
+			"property": map[string]interface{}{
+				"column_size": float64(columnSize),
+			},
+		},
+	}
+}
+
+func TestApplyTableColumnWidths(t *testing.T) {
+	t.Run("skips when document_id or markdown empty", func(t *testing.T) {
+		f := &fakeAPI{}
+		var buf bytes.Buffer
+		applyTableColumnWidths(f.call, &buf, "", "# whatever")
+		applyTableColumnWidths(f.call, &buf, "doc", "   ")
+		if len(f.calls) != 0 {
+			t.Fatalf("no API calls expected, got %v", f.calls)
+		}
+	})
+
+	t.Run("no markdown tables → no API calls", func(t *testing.T) {
+		f := &fakeAPI{}
+		var buf bytes.Buffer
+		applyTableColumnWidths(f.call, &buf, "doc", "# heading\n\nparagraph\n")
+		if len(f.calls) != 0 {
+			t.Fatalf("expected 0 calls, got %v", f.calls)
+		}
+	})
+
+	t.Run("happy path PATCHes each table", func(t *testing.T) {
+		f := &fakeAPI{
+			blocks: []map[string]interface{}{
+				makeTableBlock("blkA", 3),
+				makeTableBlock("blkB", 2),
+			},
+			resps: map[string]fakeResp{
+				"PATCH /open-apis/docx/v1/documents/doc/blocks/blkA": {data: map[string]interface{}{}},
+				"PATCH /open-apis/docx/v1/documents/doc/blocks/blkB": {data: map[string]interface{}{}},
+			},
+		}
+		md := "| A | Bb | Ccc |\n|---|---|---|\n| 1 | 2 | 3 |\n\n| X | Yy |\n|---|---|\n| 4 | 5 |\n"
+		var buf bytes.Buffer
+		applyTableColumnWidths(f.call, &buf, "doc", md)
+		patchA := 0
+		patchB := 0
+		for _, c := range f.calls {
+			if c == "PATCH /open-apis/docx/v1/documents/doc/blocks/blkA" {
+				patchA++
+			}
+			if c == "PATCH /open-apis/docx/v1/documents/doc/blocks/blkB" {
+				patchB++
+			}
+		}
+		if patchA != 1 || patchB != 1 {
+			t.Fatalf("expected one PATCH per block, got A=%d B=%d (calls=%v)", patchA, patchB, f.calls)
+		}
+		if !strings.Contains(buf.String(), "column widths applied to 2/2 tables") {
+			t.Fatalf("expected summary line, got %q", buf.String())
+		}
+	})
+
+	t.Run("count mismatch aborts before any PATCH", func(t *testing.T) {
+		f := &fakeAPI{
+			blocks: []map[string]interface{}{
+				makeTableBlock("blkA", 2),
+				makeTableBlock("blkB", 2),
+			},
+		}
+		md := "| A | B |\n|---|---|\n| 1 | 2 |\n"
+		var buf bytes.Buffer
+		applyTableColumnWidths(f.call, &buf, "doc", md)
+		for _, c := range f.calls {
+			if strings.HasPrefix(c, "PATCH") {
+				t.Fatalf("no PATCH expected on count mismatch, got %v", f.calls)
+			}
+		}
+		if !strings.Contains(buf.String(), "column-width adjustment skipped") {
+			t.Fatalf("expected skip message, got %q", buf.String())
+		}
+	})
+
+	t.Run("per-table column-size mismatch is skipped with diagnostic", func(t *testing.T) {
+		f := &fakeAPI{
+			// Remote says 4 columns; local has 2.
+			blocks: []map[string]interface{}{makeTableBlock("blkA", 4)},
+		}
+		md := "| A | B |\n|---|---|\n| 1 | 2 |\n"
+		var buf bytes.Buffer
+		applyTableColumnWidths(f.call, &buf, "doc", md)
+		for _, c := range f.calls {
+			if strings.HasPrefix(c, "PATCH") {
+				t.Fatalf("no PATCH expected on per-table mismatch, got %v", f.calls)
+			}
+		}
+		if !strings.Contains(buf.String(), "column-width skipped for table 1") {
+			t.Fatalf("expected per-table skip message, got %q", buf.String())
+		}
+		if !strings.Contains(buf.String(), "blkA") {
+			t.Fatalf("expected block id in skip message, got %q", buf.String())
+		}
+	})
+
+	t.Run("per-block PATCH failure is non-fatal", func(t *testing.T) {
+		f := &fakeAPI{
+			blocks: []map[string]interface{}{
+				makeTableBlock("blkA", 2),
+				makeTableBlock("blkB", 2),
+			},
+			resps: map[string]fakeResp{
+				"PATCH /open-apis/docx/v1/documents/doc/blocks/blkA": {err: errors.New("boom")},
+				"PATCH /open-apis/docx/v1/documents/doc/blocks/blkB": {data: map[string]interface{}{}},
+			},
+		}
+		md := "| A | B |\n|---|---|\n| 1 | 2 |\n\n| X | Y |\n|---|---|\n| 3 | 4 |\n"
+		var buf bytes.Buffer
+		applyTableColumnWidths(f.call, &buf, "doc", md)
+		if !strings.Contains(buf.String(), "column-width PATCH failed for block blkA") {
+			t.Fatalf("expected per-block error log, got %q", buf.String())
+		}
+		if !strings.Contains(buf.String(), "column widths applied to 1/2 tables") {
+			t.Fatalf("expected summary with 1/2, got %q", buf.String())
+		}
+	})
+
+	t.Run("blocks-fetch error skips the whole pass", func(t *testing.T) {
+		// blocks map is nil; fakeAPI.call returns error for blocks path.
+		f := &fakeAPI{}
+		// Force an error from the blocks endpoint by removing default canned
+		// success: the fakeAPI special-cases that path, so override.
+		var buf bytes.Buffer
+		// Use a markdown with a table so we actually get to the fetch.
+		md := "| A | B |\n|---|---|\n| 1 | 2 |\n"
+		// Swap the special case by using an override call that errors.
+		callWithBlocksErr := func(method, url string, params map[string]interface{}, data interface{}) (map[string]interface{}, error) {
+			if method == "GET" && strings.HasSuffix(url, "/blocks") {
+				return nil, errors.New("fetch failed")
+			}
+			return f.call(method, url, params, data)
+		}
+		applyTableColumnWidths(callWithBlocksErr, &buf, "doc", md)
+		if !strings.Contains(buf.String(), "column-width adjustment skipped: ") {
+			t.Fatalf("expected skip message on fetch error, got %q", buf.String())
+		}
+	})
+}
+
+func TestDocxTokenForAutoWidths(t *testing.T) {
+	t.Run("bare docx token", func(t *testing.T) {
+		got, ok := docxTokenForAutoWidths(nil, "docxAbc123")
+		if !ok || got != "docxAbc123" {
+			t.Fatalf("expected bare token pass-through, got %q %v", got, ok)
+		}
+	})
+
+	t.Run("docx URL is parsed", func(t *testing.T) {
+		got, ok := docxTokenForAutoWidths(nil, "https://bytedance.feishu.cn/docx/abc123XYZ")
+		if !ok || got != "abc123XYZ" {
+			t.Fatalf("expected docx token, got %q %v", got, ok)
+		}
+	})
+
+	t.Run("wiki URL resolves to docx via api", func(t *testing.T) {
+		called := false
+		api := func(method, url string, params map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
+			called = true
+			if method != "GET" || url != "/open-apis/wiki/v2/spaces/get_node" {
+				t.Errorf("unexpected call %s %s", method, url)
+			}
+			if token, _ := params["token"].(string); token != "wikiNODE" {
+				t.Errorf("unexpected token param: %v", params)
+			}
+			return map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":  "docx",
+					"obj_token": "docxFromWiki",
+				},
+			}, nil
+		}
+		got, ok := docxTokenForAutoWidths(api, "https://bytedance.feishu.cn/wiki/wikiNODE")
+		if !ok || got != "docxFromWiki" {
+			t.Fatalf("expected resolved docx token, got %q %v", got, ok)
+		}
+		if !called {
+			t.Fatalf("expected wiki API call")
+		}
+	})
+
+	t.Run("wiki node backed by non-docx returns false", func(t *testing.T) {
+		api := func(string, string, map[string]interface{}, interface{}) (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":  "sheet",
+					"obj_token": "sheetTok",
+				},
+			}, nil
+		}
+		_, ok := docxTokenForAutoWidths(api, "https://bytedance.feishu.cn/wiki/wikiNODE")
+		if ok {
+			t.Fatalf("expected false for non-docx wiki node")
+		}
+	})
+
+	t.Run("wiki resolve error returns false", func(t *testing.T) {
+		api := func(string, string, map[string]interface{}, interface{}) (map[string]interface{}, error) {
+			return nil, errors.New("nope")
+		}
+		_, ok := docxTokenForAutoWidths(api, "https://bytedance.feishu.cn/wiki/wikiNODE")
+		if ok {
+			t.Fatalf("expected false on resolve error")
+		}
+	})
+}
+
+func TestResolveDocxTokenForCreateResult(t *testing.T) {
+	t.Run("prefers doc_url when docx", func(t *testing.T) {
+		got, ok := resolveDocxTokenForCreateResult(nil, map[string]interface{}{
+			"doc_url": "https://bytedance.feishu.cn/docx/abc123",
+			"doc_id":  "shouldIgnore",
+		})
+		if !ok || got != "abc123" {
+			t.Fatalf("expected abc123 from doc_url, got %q %v", got, ok)
+		}
+	})
+
+	t.Run("resolves wiki doc_url via api", func(t *testing.T) {
+		api := func(string, string, map[string]interface{}, interface{}) (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"node": map[string]interface{}{"obj_type": "docx", "obj_token": "docxResolved"},
+			}, nil
+		}
+		got, ok := resolveDocxTokenForCreateResult(api, map[string]interface{}{
+			"doc_url": "https://bytedance.feishu.cn/wiki/wikiTok",
+		})
+		if !ok || got != "docxResolved" {
+			t.Fatalf("expected resolved, got %q %v", got, ok)
+		}
+	})
+
+	t.Run("falls back to doc_id when no doc_url", func(t *testing.T) {
+		got, ok := resolveDocxTokenForCreateResult(nil, map[string]interface{}{
+			"doc_id": "fallbackTok",
+		})
+		if !ok || got != "fallbackTok" {
+			t.Fatalf("expected fallback, got %q %v", got, ok)
+		}
+	})
+
+	t.Run("returns false when nothing usable", func(t *testing.T) {
+		_, ok := resolveDocxTokenForCreateResult(nil, map[string]interface{}{})
+		if ok {
+			t.Fatalf("expected false on empty result")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

`docs +create` and `docs +update --mode overwrite` currently upload Markdown tables that render with equal column widths (e.g. 244/244/244 for a 3-column table) regardless of how uneven the cell content is. Users have to manually drag columns in the UI to get a readable layout.

This PR adds a local pipe-table parser and a content-aware width-ratio calculator. After the MCP create/update call succeeds, the CLI walks the document's table blocks in order, matches each against the corresponding Markdown table by column count, and PATCHes \`update_grid_column_width_ratio\` with ratios summing to 100.

## Changes

- New: \`shortcuts/doc/table_widths.go\`
  - \`extractMarkdownTables\` – GFM pipe-table parser (handles fenced code blocks, escaped \`\\|\`, multiple tables)
  - \`computeWidthRatios\` – column weights from max visual width per column, apportioned to 100 with rounding error absorbed by the widest column
  - \`visualWidth\` – CJK / emoji / full-width forms count 2, narrow forms 1, control chars 0
  - \`applyMarkdownTableColumnWidths\` – walks the doc's blocks, matches tables by index+column count, PATCHes each; non-fatal on per-table failure
  - \`fetchDocumentTableBlocks\` – paginated walk over \`/open-apis/docx/v1/documents/{id}/blocks\` filtering \`block_type == 31\`
- Wired into \`docs +create\` and \`docs +update --mode overwrite\` behind a new \`--auto-table-widths\` bool flag (default \`true\`, opt-out with \`=false\`)
- Tests in \`shortcuts/doc/table_widths_test.go\` cover parsing, ratio calc, visual-width edge cases; all pass

## Why only overwrite for \`+update\`

For \`append\` / \`insert_*\` / \`replace_range\`, only some table blocks in the document are newly created and identifying them from the MCP response is ambiguous (the response does not return the new block_ids). Rather than patch existing tables incorrectly, those modes ignore \`--auto-table-widths\` for now. Follow-up: a before/after table-count diff could cover \`append\`.

## Test Plan

- [x] \`go test ./shortcuts/doc/...\` passes (new tests cover table parsing, ratio calculation, visual-width edge cases)
- [x] \`go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main ./shortcuts/doc/...\`: 0 issues
- [x] \`go mod tidy\` produced no changes
- [x] Manual sanity: before this PR, \`lark-cli docs +create --markdown file.md\` with an uneven table yielded \`column_width:[244,244,244]\`; the new flow PATCHes \`width_ratios\` proportional to content width. (The current implementation writes \`update_grid_column_width_ratio\` via the docx open-apis; the block's \`column_width\` column values are adjusted on subsequent renders.)

## Related

- No existing issues found via \`gh issue list --repo larksuite/cli --search "column width OR table width"\`

## Notes

- Added flag is opt-out-able to keep the door open for anyone depending on equal widths.
- \`applyMarkdownTableColumnWidths\` treats fetch/PATCH failures as non-fatal (the main content is already created; column-width adjustment is a cosmetic follow-up). Errors are logged to \`stderr\` with the block_id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an --auto-table-widths flag (enabled by default) to document create and update commands; after creation/update, Markdown pipe-table column widths are auto-adjusted based on cell content to improve table formatting.
  * Auto-adjust runs for updates in overwrite mode when applicable; it is skipped with a logged message if the document/table cannot be resolved or counts/matching fail.

* **Tests**
  * Added unit tests for Markdown table parsing, visual-width estimation, and width-ratio calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->