### PR TITLE
fix(whiteboard): register +media-upload shortcut and add whiteboard parent type

### DIFF
--- a/shortcuts/doc/doc_media_test.go
+++ b/shortcuts/doc/doc_media_test.go
@@ -118,7 +118,7 @@ func TestDocMediaUploadDryRunUsesMultipartForLargeFile(t *testing.T) {
 		t.Fatalf("set --parent-node: %v", err)
 	}
 
-	dry := decodeDocDryRun(t, MediaUpload.DryRun(context.Background(), common.TestNewRuntimeContext(cmd, nil)))
+	dry := decodeDocDryRun(t, DocMediaUpload.DryRun(context.Background(), common.TestNewRuntimeContext(cmd, nil)))
 	if dry.Description != "chunked media upload (files > 20MB)" {
 		t.Fatalf("dry-run description = %q", dry.Description)
 	}

--- a/shortcuts/doc/doc_media_upload.go
+++ b/shortcuts/doc/doc_media_upload.go
@@ -13,7 +13,7 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
-var MediaUpload = common.Shortcut{
+var DocMediaUpload = common.Shortcut{
 	Service:     "docs",
 	Command:     "+media-upload",
 	Description: "Upload media file (image/attachment) to a document block",
@@ -22,8 +22,8 @@ var MediaUpload = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "file", Desc: "local file path (files > 20MB use multipart upload automatically)", Required: true},
-		{Name: "parent-type", Desc: "parent type: docx_image | docx_file", Required: true},
-		{Name: "parent-node", Desc: "parent node ID (block_id)", Required: true},
+		{Name: "parent-type", Desc: "parent type: docx_image | docx_file | whiteboard", Required: true},
+		{Name: "parent-node", Desc: "parent node ID (block_id for docx, board_token for whiteboard)", Required: true},
 		{Name: "doc-id", Desc: "document ID (for drive_route_token)"},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {

--- a/shortcuts/doc/shortcuts.go
+++ b/shortcuts/doc/shortcuts.go
@@ -13,6 +13,7 @@ func Shortcuts() []common.Shortcut {
 		DocsFetch,
 		DocsUpdate,
 		DocMediaInsert,
+		DocMediaUpload,
 		DocMediaPreview,
 		DocMediaDownload,
 	}


### PR DESCRIPTION
…arent type

- Register DocMediaUpload in doc/shortcuts.go (was defined but never registered, so lark-cli docs +media-upload was unavailable)
- Rename MediaUpload to DocMediaUpload for consistency with DocMediaInsert/DocMediaPreview/DocMediaDownload
- Add whiteboard to --parent-type flag description
- Update --parent-node description to mention board_token for whiteboard

Drive +upload (parent_type=explorer) produces file tokens that the whiteboard API does not recognize (500 error). The correct approach is docs +media-upload with parent_type=whiteboard.

## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document media uploads now support whiteboard as an additional parent type alongside existing docx image and docx file targets.

* **Documentation**
  * Clarified flag descriptions to explain which identifier to provide for each parent type (e.g., block ID for docx parents, board token for whiteboard).
  * Improved overall parent-type and parent-node guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->