### PR TITLE
fix(doc): tighten remediation hint + add E2E dry-run suppression test

### DIFF
--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -147,7 +147,7 @@ func TestCheckDocsUpdateReplaceMultilineMarkdown(t *testing.T) {
 				t.Fatalf("checkDocsUpdateReplaceMultilineMarkdown(%q, %q) = %q, wantHint=%v",
 					tt.mode, tt.markdown, got, tt.wantHint)
 			}
-			if tt.wantHint && !strings.Contains(got, "delete_range") {
+			if tt.wantHint && (!strings.Contains(got, "delete_range") || !strings.Contains(got, "insert_before")) {
 				t.Errorf("hint should suggest delete_range/insert_before remediation, got: %s", got)
 			}
 		})

--- a/tests/cli_e2e/docs/docs_update_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_update_dryrun_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package docs
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDocs_UpdateDryRunSuppressesSemanticWarnings asserts the contract that
+// docsUpdateWarnings is NOT invoked on the --dry-run path. The unit tests in
+// shortcuts/doc/docs_update_check_test.go prove the helper emits warnings for
+// replace_range + blank-line and for combined-emphasis markers; this E2E
+// locks in that they never reach the user during dry-run planning, so a
+// future refactor that moves warning emission into a shared code path can't
+// silently regress.
+//
+// Input is intentionally crafted to trigger BOTH warnings the helper emits:
+//   - mode=replace_range + markdown containing "\n\n" (blank-line warning)
+//   - markdown containing `***combined***` (combined bold+italic warning)
+//
+// Neither string may appear in dry-run output.
+func TestDocs_UpdateDryRunSuppressesSemanticWarnings(t *testing.T) {
+	// Fake creds are enough — dry-run short-circuits before any real API call.
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	// "***combined***" is a triple-asterisk combined-emphasis shape; "\n\n"
+	// is a paragraph break. Both would normally produce warnings when
+	// Execute runs under --mode=replace_range; both must be absent here.
+	markdown := "***combined***\n\nsecond paragraph"
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+update",
+			"--doc", "doxcnDryRunE2E",
+			"--mode", "replace_range",
+			"--selection-with-ellipsis", "placeholder",
+			"--markdown", markdown,
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	// Neither warning prefix ("warning:") nor either specific warning body
+	// may appear in dry-run output (stdout OR stderr).
+	combined := result.Stdout + "\n" + result.Stderr
+	for _, needle := range []string{
+		"warning:",
+		"does not split a block into multiple paragraphs",
+		"combined bold+italic markers",
+	} {
+		if strings.Contains(combined, needle) {
+			t.Errorf("dry-run output must not surface pre-write warning %q\nstdout:\n%s\nstderr:\n%s",
+				needle, result.Stdout, result.Stderr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Second follow-up on #569, closing the two CodeRabbit review nits (both `Minor` severity). Targeting `feat/docs-update-semantic-check` so it lands together with #569 and the earlier #578 follow-up.

## Changes

### Comment 1 — tighten remediation-hint assertion (`docs_update_check_test.go:150`)

The previous assertion only checked for `delete_range` in the warning message; `insert_before` (the other half of the recommended remediation) could be dropped without failing any test.

```diff
-if tt.wantHint && !strings.Contains(got, "delete_range") {
+if tt.wantHint && (!strings.Contains(got, "delete_range") || !strings.Contains(got, "insert_before")) {
     t.Errorf("hint should suggest delete_range/insert_before remediation, got: %s", got)
 }
```

### Comment 2 — new E2E dry-run suppression test (`tests/cli_e2e/docs/docs_update_dryrun_test.go`)

The PR #569 description commits to "Not emitted in dry-run mode (kept quiet during planning)", but nothing at the E2E layer protected that contract. A later refactor that moved `docsUpdateWarnings` into a shared code path could silently regress it.

The new test invokes:
```
docs +update --dry-run --mode=replace_range \
  --selection-with-ellipsis placeholder \
  --markdown "***combined***\n\nsecond paragraph"
```

which is crafted to trip **both** pre-write warnings (blank-line + combined-emphasis). The assertion requires that neither the `warning:` prefix, the blank-line message, nor the combined-emphasis message appears on stdout or stderr.

### Regression-detection check (performed locally, not committed)

Before committing, I temporarily wired `docsUpdateWarnings` into `DryRun`, rebuilt the binary, and re-ran the E2E test. It failed as expected, citing the injected warnings in stderr. Reverted, rebuilt, re-ran — passes. The test has real teeth.

## Caveat worth flagging

`tests/cli_e2e/docs/docs_update_dryrun_test.go` needs `git add -f` to track, because the repo's `.gitignore` has a bare `docs/` rule on line 24 that accidentally matches `tests/cli_e2e/docs/` (same directory name). Existing files under that path are grandfathered in via `git add -f` at creation; new additions default to ignored. Not in scope for this PR — worth a separate cleanup of `.gitignore` to narrow to `/docs/` (repo root only).

## Test plan

- [x] `go test ./shortcuts/doc/...` — all unit tests pass (including the tightened assertion)
- [x] `go test ./tests/cli_e2e/docs/...` — new E2E passes
- [x] `go build -o lark-cli ./` — binary rebuild needed since E2E exec's `lark-cli`
- [x] `gofmt` + `go vet` clean
- [x] Manual sanity: injected warning emission into DryRun → E2E fails with clear stderr; reverted → passes
