### PR TITLE
fix(doc): capture line-wrapped base64 in clipboard data URI regex

### DIFF
--- a/shortcuts/doc/clipboard.go
+++ b/shortcuts/doc/clipboard.go
@@ -48,8 +48,13 @@ func readClipboardImageBytes() ([]byte, error) {
 
 // reBase64DataURI matches a data URI image embedded in clipboard text content,
 // e.g. data:image/jpeg;base64,/9j/4AAQ...
-// The character class covers both standard (+/) and URL-safe (-_) base64 alphabets.
-var reBase64DataURI = regexp.MustCompile(`data:(image/[^;]+);base64,([A-Za-z0-9+/\-_]+=*)`)
+// The character class covers both standard (+/) and URL-safe (-_) base64
+// alphabets, plus ASCII whitespace: HTML and RTF clipboard payloads commonly
+// fold long base64 at 76 chars (standard MIME folding), so whitespace must be
+// captured as part of the payload for the downstream strings.Fields strip to
+// actually have something to normalise. Terminators like ", <, ), ; remain
+// outside the class so the match still ends at the URI boundary.
+var reBase64DataURI = regexp.MustCompile(`data:(image/[^;]+);base64,([A-Za-z0-9+/\-_\s]+=*)`)
 
 // readClipboardDarwin reads the clipboard image on macOS and returns image bytes.
 //

--- a/shortcuts/doc/clipboard_test.go
+++ b/shortcuts/doc/clipboard_test.go
@@ -4,9 +4,11 @@
 package doc
 
 import (
+	"bytes"
 	"encoding/base64"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -195,6 +197,60 @@ func TestReBase64DataURI_URLSafeMatch(t *testing.T) {
 func TestReBase64DataURI_NoMatch(t *testing.T) {
 	if reBase64DataURI.Match([]byte("no image here")) {
 		t.Error("expected no match for plain text")
+	}
+}
+
+// TestReBase64DataURI_LineWrapped exercises the common real-world case where
+// HTML or RTF clipboards fold a base64 payload at 76 chars (standard MIME
+// line wrapping). The regex must capture whitespace inside the payload so
+// strings.Fields can strip it before base64 decoding; otherwise the match is
+// truncated at the first newline and the decoded prefix happens to pass
+// hasKnownImageMagic (since PNG magic is just 8 bytes), silently uploading a
+// corrupt payload.
+func TestReBase64DataURI_LineWrapped(t *testing.T) {
+	// Build a deterministic payload larger than one wrap line so we force a
+	// fold. The exact bytes don't matter; the full round-trip does.
+	payload := make([]byte, 180)
+	for i := range payload {
+		payload[i] = byte(i * 7)
+	}
+	b64 := base64.StdEncoding.EncodeToString(payload)
+
+	// Insert realistic folding: a mix of \n, \r\n, and \t within a single
+	// payload, to catch regressions regardless of the clipboard source
+	// (HTML tends to use \n; RTF \par wraps use \r\n; some editors indent).
+	if len(b64) < 120 {
+		t.Fatalf("test payload too small for folding: len=%d", len(b64))
+	}
+	wrapped := b64[:40] + "\n   " + b64[40:80] + "\r\n\t" + b64[80:]
+	html := `<img src="data:image/png;base64,` + wrapped + `">`
+
+	m := reBase64DataURI.FindSubmatch([]byte(html))
+	if m == nil {
+		t.Fatal("expected regex to match line-wrapped base64 payload")
+	}
+	if string(m[1]) != "image/png" {
+		t.Errorf("mime type = %q, want %q", m[1], "image/png")
+	}
+
+	// The whole point of extending the character class: the downstream
+	// Fields strip must see the folding and normalise it away.
+	normalized := strings.Join(strings.Fields(string(m[2])), "")
+	if normalized != b64 {
+		t.Fatalf("normalized payload mismatch\n got: %q\nwant: %q", normalized, b64)
+	}
+	got, err := base64.StdEncoding.DecodeString(normalized)
+	if err != nil {
+		t.Fatalf("decode after normalisation failed: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Error("decoded bytes differ from original payload — truncation regression")
+	}
+
+	// The match must still stop at the URI boundary; extending the class
+	// with \s should not let the capture run off the end of the attribute.
+	if strings.Contains(string(m[0]), `">`) {
+		t.Errorf("regex captured past the URI terminator: %q", m[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

Targeted fix for PR #508 addressing the review thread at [#discussion_r3116012669](https://github.com/larksuite/cli/pull/508#discussion_r3116012669): the `strings.Fields` normalisation added in `adac5bf` is a no-op, and line-wrapped base64 payloads are silently uploaded as corrupt 8-byte "PNGs".

## Root cause

`reBase64DataURI` has character class `[A-Za-z0-9+/\-_]+=*`, which excludes whitespace. For a 76-char-folded HTML payload — standard MIME base64 folding, very common in real clipboards (Chrome, Safari, Feishu copy-image-as-HTML) — the regex stops at the first `\n`, so `m[2]` is already truncated by the time the `strings.Fields` strip runs. `Fields` then normalises a string that by construction has no whitespace, which does nothing.

Concretely, a payload like:

```
data:image/png;base64,iVBORw0KGgo
AAANSUhEUgAAAAE...
```

matches only `iVBORw0KGgo` (11 chars), decodes to exactly the 8-byte PNG signature `89 50 4E 47 0D 0A 1A 0A`, passes `hasKnownImageMagic`, and ends up being uploaded as a truncated 8-byte "PNG" block. The user sees a broken image.

## Fix

Extend the character class to include `\s`, so the existing `strings.Fields` strip on line 144 of `clipboard.go` actually has whitespace to normalise. Terminators (`"`, `<`, `)`, `;`) stay outside the class, so the match still ends at the URI boundary.

## Test plan

- [x] `go test ./shortcuts/doc/... -count=1` passes (new `TestReBase64DataURI_LineWrapped` added)
- [x] `go vet ./shortcuts/doc/...` clean
- [x] `gofmt -l` clean
- [x] The new test feeds a ≥180-byte payload folded with a mix of `\n`, `\r\n`, and `\t` through the regex, asserts full round-trip byte-equality after `strings.Fields` normalisation, and confirms the regex does not run past the `">` attribute terminator (catches an over-permissive regression in the other direction).
- [x] Existing tests — `TestReBase64DataURI_Match`, `TestReBase64DataURI_URLSafeMatch`, `TestReBase64DataURI_NoMatch`, `TestExtractBase64ImageFromClipboard_WithFakeOsascript` — still pass.

## Notes

- Targets `feat/media-insert-clipboard` so this lands as part of PR #508 before it merges to `main`.
- The TIFF / PR-body inconsistency flagged in [#discussion_r3116013106](https://github.com/larksuite/cli/pull/508#discussion_r3116013106) is **not** addressed here — that one's a design call for @herbertliu (restore the TIFF middle layer vs. update the PR description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)