### PR TITLE
feat: add SHA-256 checksum verification to install.js

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,13 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Download checksums from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version.replace(/-.*$/, '')")
+          gh release download "v${VERSION}" --pattern checksums.txt --dir .
+
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION=$(node -p "require('./package.json').version.replace(/-.*$/, '')")
-          gh release download "v${VERSION}" --pattern checksums.txt --dir .
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          gh release download "${TAG}" --pattern checksums.txt --dir .
+          test -s checksums.txt || { echo "checksums.txt missing or empty for ${TAG}"; exit 1; }
 
       - name: Publish to npm
         env:

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "scripts/install.js",
     "scripts/install-wizard.js",
     "scripts/run.js",
+    "checksums.txt",
     "CHANGELOG.md"
   ],
   "dependencies": {

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -5,10 +5,16 @@ const fs = require("fs");
 const path = require("path");
 const { execFileSync } = require("child_process");
 const os = require("os");
+const crypto = require("crypto");
 
 const VERSION = require("../package.json").version.replace(/-.*$/, "");
 const REPO = "larksuite/cli";
 const NAME = "lark-cli";
+const ALLOWED_HOSTS = [
+  "github.com",
+  "objects.githubusercontent.com",
+  "registry.npmmirror.com",
+];
 
 const PLATFORM_MAP = {
   darwin: "darwin",
@@ -24,13 +30,6 @@ const ARCH_MAP = {
 const platform = PLATFORM_MAP[process.platform];
 const arch = ARCH_MAP[process.arch];
 
-if (!platform || !arch) {
-  console.error(
-    `Unsupported platform: ${process.platform}-${process.arch}`
-  );
-  process.exit(1);
-}
-
 const isWindows = process.platform === "win32";
 const ext = isWindows ? ".zip" : ".tar.gz";
 const archiveName = `${NAME}-${VERSION}-${platform}-${arch}${ext}`;
@@ -39,8 +38,6 @@ const MIRROR_URL = `https://registry.npmmirror.com/-/binary/lark-cli/v${VERSION}
 
 const binDir = path.join(__dirname, "..", "bin");
 const dest = path.join(binDir, NAME + (isWindows ? ".exe" : ""));
-
-fs.mkdirSync(binDir, { recursive: true });
 
 function download(url, destPath) {
   const args = [
@@ -56,6 +53,8 @@ function download(url, destPath) {
 }
 
 function install() {
+  fs.mkdirSync(binDir, { recursive: true });
+
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lark-cli-"));
   const archivePath = path.join(tmpDir, archiveName);
 
@@ -88,24 +87,44 @@ function install() {
   }
 }
 
-// When triggered as a postinstall hook under npx, skip the binary download.
-// The "install" wizard doesn't need it, and run.js calls install.js directly
-// (with LARK_CLI_RUN=1) for other commands that do need the binary.
-const isNpxPostinstall =
-  process.env.npm_command === "exec" && !process.env.LARK_CLI_RUN;
-
-if (isNpxPostinstall) {
-  process.exit(0);
+// Stub exports — implementations added in subsequent tasks
+function getExpectedChecksum(archiveName, checksumsDir) {
+  return null;
 }
 
-try {
-  install();
-} catch (err) {
-  console.error(`Failed to install ${NAME}:`, err.message);
-  console.error(
-    `\nIf you are behind a firewall or in a restricted network, try setting a proxy:\n` +
-    `  export https_proxy=http://your-proxy:port\n` +
-    `  npm install -g @larksuite/cli`
-  );
-  process.exit(1);
+function verifyChecksum(archivePath, expectedHash) {
+  // no-op stub
 }
+
+if (require.main === module) {
+  if (!platform || !arch) {
+    console.error(
+      `Unsupported platform: ${process.platform}-${process.arch}`
+    );
+    process.exit(1);
+  }
+
+  // When triggered as a postinstall hook under npx, skip the binary download.
+  // The "install" wizard doesn't need it, and run.js calls install.js directly
+  // (with LARK_CLI_RUN=1) for other commands that do need the binary.
+  const isNpxPostinstall =
+    process.env.npm_command === "exec" && !process.env.LARK_CLI_RUN;
+
+  if (isNpxPostinstall) {
+    process.exit(0);
+  }
+
+  try {
+    install();
+  } catch (err) {
+    console.error(`Failed to install ${NAME}:`, err.message);
+    console.error(
+      `\nIf you are behind a firewall or in a restricted network, try setting a proxy:\n` +
+      `  export https_proxy=http://your-proxy:port\n` +
+      `  npm install -g @larksuite/cli`
+    );
+    process.exit(1);
+  }
+}
+
+module.exports = { getExpectedChecksum, verifyChecksum };

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -10,6 +10,10 @@ const crypto = require("crypto");
 const VERSION = require("../package.json").version.replace(/-.*$/, "");
 const REPO = "larksuite/cli";
 const NAME = "lark-cli";
+// Allowlist gates the *initial* request URL only. curl --location follows
+// redirects (capped by --max-redirs 3) without re-checking the target host.
+// This is acceptable because checksum verification is the primary integrity
+// control; the allowlist is defense-in-depth to reject obviously wrong URLs.
 const ALLOWED_HOSTS = [
   "github.com",
   "objects.githubusercontent.com",
@@ -127,8 +131,20 @@ function getExpectedChecksum(archiveName, checksumsDir) {
 function verifyChecksum(archivePath, expectedHash) {
   if (expectedHash === null) return;
 
-  const content = fs.readFileSync(archivePath);
-  const actual = crypto.createHash("sha256").update(content).digest("hex");
+  // Stream the file to avoid loading the entire archive into memory.
+  // Archives can be 10-100MB; streaming keeps RSS constant.
+  const hash = crypto.createHash("sha256");
+  const fd = fs.openSync(archivePath, "r");
+  try {
+    const buf = Buffer.alloc(64 * 1024);
+    let bytesRead;
+    while ((bytesRead = fs.readSync(fd, buf, 0, buf.length, null)) > 0) {
+      hash.update(buf.subarray(0, bytesRead));
+    }
+  } finally {
+    fs.closeSync(fd);
+  }
+  const actual = hash.digest("hex");
 
   if (actual.toLowerCase() !== expectedHash.toLowerCase()) {
     throw new Error(
@@ -168,4 +184,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { getExpectedChecksum, verifyChecksum };
+module.exports = { getExpectedChecksum, verifyChecksum, assertAllowedHost };

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -39,10 +39,19 @@ const MIRROR_URL = `https://registry.npmmirror.com/-/binary/lark-cli/v${VERSION}
 const binDir = path.join(__dirname, "..", "bin");
 const dest = path.join(binDir, NAME + (isWindows ? ".exe" : ""));
 
+function assertAllowedHost(url) {
+  const { hostname } = new URL(url);
+  if (!ALLOWED_HOSTS.includes(hostname)) {
+    throw new Error(`Download host not allowed: ${hostname}`);
+  }
+}
+
 function download(url, destPath) {
+  assertAllowedHost(url);
   const args = [
     "--fail", "--location", "--silent", "--show-error",
     "--connect-timeout", "10", "--max-time", "120",
+    "--max-redirs", "3",
     "--output", destPath,
   ];
   // --ssl-revoke-best-effort: on Windows (Schannel), avoid CRYPT_E_REVOCATION_OFFLINE
@@ -64,6 +73,9 @@ function install() {
     } catch (err) {
       download(MIRROR_URL, archivePath);
     }
+
+    const expectedHash = getExpectedChecksum(archiveName);
+    verifyChecksum(archivePath, expectedHash);
 
     if (isWindows) {
       execFileSync("powershell", [

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -113,7 +113,16 @@ function getExpectedChecksum(archiveName, checksumsDir) {
 }
 
 function verifyChecksum(archivePath, expectedHash) {
-  // no-op stub
+  if (expectedHash === null) return;
+
+  const content = fs.readFileSync(archivePath);
+  const actual = crypto.createHash("sha256").update(content).digest("hex");
+
+  if (actual.toLowerCase() !== expectedHash.toLowerCase()) {
+    throw new Error(
+      `[SECURITY] Checksum mismatch for ${path.basename(archivePath)}: expected ${expectedHash} but got ${actual}`
+    );
+  }
 }
 
 if (require.main === module) {

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -87,9 +87,29 @@ function install() {
   }
 }
 
-// Stub exports — implementations added in subsequent tasks
 function getExpectedChecksum(archiveName, checksumsDir) {
-  return null;
+  const dir = checksumsDir || path.join(__dirname, "..");
+  const checksumsPath = path.join(dir, "checksums.txt");
+
+  if (!fs.existsSync(checksumsPath)) {
+    console.error(
+      "[WARN] checksums.txt not found, skipping checksum verification"
+    );
+    return null;
+  }
+
+  const content = fs.readFileSync(checksumsPath, "utf8");
+  for (const line of content.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const idx = trimmed.indexOf("  ");
+    if (idx === -1) continue;
+    const hash = trimmed.slice(0, idx);
+    const name = trimmed.slice(idx + 2);
+    if (name === archiveName) return hash;
+  }
+
+  throw new Error(`Checksum entry not found for ${archiveName}`);
 }
 
 function verifyChecksum(archivePath, expectedHash) {

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -9,7 +9,7 @@ const os = require("os");
 
 const crypto = require("crypto");
 
-const { getExpectedChecksum, verifyChecksum } = require("./install.js");
+const { getExpectedChecksum, verifyChecksum, assertAllowedHost } = require("./install.js");
 
 describe("getExpectedChecksum", () => {
   function makeTmpChecksums(content) {
@@ -58,6 +58,32 @@ describe("getExpectedChecksum", () => {
     const result = getExpectedChecksum("anything.tar.gz", dir);
     assert.equal(result, null);
   });
+
+  it("skips malformed lines and still finds valid entry", () => {
+    const dir = makeTmpChecksums(
+      "garbage line without separator\n" +
+      "\n" +
+      "abc123  lark-cli-1.0.0-darwin-arm64.tar.gz\n" +
+      "also garbage\n"
+    );
+    const hash = getExpectedChecksum(
+      "lark-cli-1.0.0-darwin-arm64.tar.gz",
+      dir
+    );
+    assert.equal(hash, "abc123");
+  });
+
+  it("skips tab-separated lines (only double-space is valid)", () => {
+    const dir = makeTmpChecksums(
+      "wrong\tlark-cli-1.0.0-darwin-arm64.tar.gz\n" +
+      "correct  lark-cli-1.0.0-darwin-arm64.tar.gz\n"
+    );
+    const hash = getExpectedChecksum(
+      "lark-cli-1.0.0-darwin-arm64.tar.gz",
+      dir
+    );
+    assert.equal(hash, "correct");
+  });
 });
 
 describe("verifyChecksum", () => {
@@ -97,6 +123,44 @@ describe("verifyChecksum", () => {
         assert.match(err.message, /Checksum mismatch/);
         return true;
       }
+    );
+  });
+});
+
+describe("assertAllowedHost", () => {
+  it("accepts github.com", () => {
+    assertAllowedHost("https://github.com/larksuite/cli/releases/download/v1.0.0/archive.tar.gz");
+  });
+
+  it("accepts objects.githubusercontent.com", () => {
+    assertAllowedHost("https://objects.githubusercontent.com/some/path");
+  });
+
+  it("accepts registry.npmmirror.com", () => {
+    assertAllowedHost("https://registry.npmmirror.com/-/binary/lark-cli/v1.0.0/archive.tar.gz");
+  });
+
+  it("rejects unknown host", () => {
+    assert.throws(
+      () => assertAllowedHost("https://evil.example.com/payload"),
+      { message: /Download host not allowed: evil\.example\.com/ }
+    );
+  });
+
+  it("normalizes hostname to lowercase", () => {
+    // URL constructor lowercases hostnames per spec
+    assertAllowedHost("https://GitHub.COM/larksuite/cli/releases/download/v1.0.0/a.tar.gz");
+  });
+
+  it("ignores port when matching hostname", () => {
+    // URL.hostname does not include port
+    assertAllowedHost("https://github.com:443/larksuite/cli/releases/download/v1.0.0/a.tar.gz");
+  });
+
+  it("throws on invalid URL", () => {
+    assert.throws(
+      () => assertAllowedHost("not-a-url"),
+      TypeError
     );
   });
 });

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const { getExpectedChecksum, verifyChecksum } = require("./install.js");
+
+describe("getExpectedChecksum", () => {
+  function makeTmpChecksums(content) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "checksum-test-"));
+    fs.writeFileSync(path.join(dir, "checksums.txt"), content, "utf8");
+    return dir;
+  }
+
+  it("returns correct hash from standard-format checksums.txt", () => {
+    const dir = makeTmpChecksums(
+      "abc123def456  lark-cli-1.0.0-darwin-arm64.tar.gz\n"
+    );
+    const hash = getExpectedChecksum(
+      "lark-cli-1.0.0-darwin-arm64.tar.gz",
+      dir
+    );
+    assert.equal(hash, "abc123def456");
+  });
+
+  it("returns correct entry when multiple entries exist", () => {
+    const dir = makeTmpChecksums(
+      "aaaa  lark-cli-1.0.0-linux-amd64.tar.gz\n" +
+      "bbbb  lark-cli-1.0.0-darwin-arm64.tar.gz\n" +
+      "cccc  lark-cli-1.0.0-windows-amd64.zip\n"
+    );
+    const hash = getExpectedChecksum(
+      "lark-cli-1.0.0-darwin-arm64.tar.gz",
+      dir
+    );
+    assert.equal(hash, "bbbb");
+  });
+
+  it("throws Error when archiveName is not found", () => {
+    const dir = makeTmpChecksums(
+      "aaaa  lark-cli-1.0.0-linux-amd64.tar.gz\n"
+    );
+    assert.throws(
+      () => getExpectedChecksum("nonexistent.tar.gz", dir),
+      { message: /Checksum entry not found for nonexistent\.tar\.gz/ }
+    );
+  });
+
+  it("returns null when checksums.txt does not exist", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "checksum-test-"));
+    // No checksums.txt in dir
+    const result = getExpectedChecksum("anything.tar.gz", dir);
+    assert.equal(result, null);
+  });
+});

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -7,6 +7,8 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 
+const crypto = require("crypto");
+
 const { getExpectedChecksum, verifyChecksum } = require("./install.js");
 
 describe("getExpectedChecksum", () => {
@@ -55,5 +57,46 @@ describe("getExpectedChecksum", () => {
     // No checksums.txt in dir
     const result = getExpectedChecksum("anything.tar.gz", dir);
     assert.equal(result, null);
+  });
+});
+
+describe("verifyChecksum", () => {
+  function makeTmpFile(content) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "checksum-test-"));
+    const filePath = path.join(dir, "archive.tar.gz");
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  }
+
+  function sha256(content) {
+    return crypto.createHash("sha256").update(content).digest("hex");
+  }
+
+  it("returns normally when hash matches", () => {
+    const content = "binary content here";
+    const filePath = makeTmpFile(content);
+    const hash = sha256(content);
+    // Should not throw
+    verifyChecksum(filePath, hash);
+  });
+
+  it("matches case-insensitively", () => {
+    const content = "case test";
+    const filePath = makeTmpFile(content);
+    const hash = sha256(content).toUpperCase();
+    // Should not throw
+    verifyChecksum(filePath, hash);
+  });
+
+  it("throws [SECURITY]-prefixed Error on mismatch", () => {
+    const filePath = makeTmpFile("real content");
+    assert.throws(
+      () => verifyChecksum(filePath, "0000000000000000000000000000000000000000000000000000000000000000"),
+      (err) => {
+        assert.match(err.message, /^\[SECURITY\]/);
+        assert.match(err.message, /Checksum mismatch/);
+        return true;
+      }
+    );
   });
 });


### PR DESCRIPTION
## Summary

Downloaded binary archives in `scripts/install.js` were not verified against any checksum, leaving the install path vulnerable to CDN tampering, MITM, or corruption. This PR bundles GoReleaser's `checksums.txt` in the npm package and verifies the SHA-256 of every downloaded archive before extraction.

## Changes

- Restructure `scripts/install.js` to be side-effect-free on `require()` via `require.main === module` guard
- Add `getExpectedChecksum(archiveName, checksumsDir?)` to parse GoReleaser checksums.txt format
- Add `verifyChecksum(archivePath, expectedHash)` using streaming 64KB-chunk hash to avoid loading entire archive into memory; `[SECURITY]`-prefixed error on mismatch
- Add `assertAllowedHost(url)` host allowlist (github.com, objects.githubusercontent.com, registry.npmmirror.com) and `--max-redirs 3` to curl args in `download()`
- Integrate checksum verification into `install()` flow (after download, before extraction)
- Add `checksums.txt` to `package.json` `files` array
- Harden `.github/workflows/release.yml` publish-npm job: use `GITHUB_REF_NAME` instead of parsing `package.json`, add explicit `test -s checksums.txt` guard
- Create `scripts/install.test.js` with 16 unit tests covering all exported functions

## Design Decisions

- **Fail-open on missing checksums.txt** — intentional per spec §4.2. The missing-file scenario in production is CI pipeline failure, and the release workflow's `test -s checksums.txt` guard provides a compensating fail-closed control there. Switching client-side to fail-closed can follow once the pipeline is proven stable.
- **Host allowlist only gates the initial URL** — curl's redirect target is not re-validated, but checksum verification makes this acceptable defense-in-depth rather than a primary control.
- **Streaming hash** — archives are typically 10-30MB but can grow; streaming with 64KB chunks keeps memory usage constant regardless of archive size.

## Test Plan

- [x] `make unit-test` passed
- [x] `make validate` passed (build, vet, unit test, integration test)
- [ ] skipped: local-eval E2E (pure JavaScript change, no Go CLI commands affected)
- [ ] skipped: local-eval skillave (no shortcut/skill changes)
- [x] acceptance-reviewer passed (5/5 cases)
- [x] manual verification: `node --test scripts/install.test.js` (16/16 pass), `node -e "require('./scripts/install.js')"` (side-effect-free)

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cryptographic verification of downloaded packages to ensure integrity and authenticity.
  * Enhanced download security with strict hostname validation and limited redirects.

* **Tests**
  * Introduced comprehensive test coverage for package verification and security validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->