### PR TITLE
fix: add record-share-link-create in SKILL.md

### DIFF
--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-base
 version: 1.2.0
-description: "当需要用 lark-cli 操作飞书多维表格（Base）时调用：适用于建表、字段管理、记录读写、视图配置、历史查询，以及角色/表单/仪表盘管理/工作流；也适用于把旧的 +table / +field / +record 写法改成当前命令写法。涉及字段设计、公式字段、查找引用、跨表计算、行级派生指标、数据分析需求时也必须使用本 skill。"
+description: "当需要用 lark-cli 操作飞书多维表格（Base）时调用：适用于建表、字段管理、记录读写、记录分享链接、视图配置、历史查询，以及角色/表单/仪表盘管理/工作流；也适用于把旧的 +table / +field / +record 写法改成当前命令写法。涉及字段设计、公式字段、查找引用、跨表计算、行级派生指标、数据分析需求时也必须使用本 skill。"
 metadata:
   requires:
     bins: ["lark-cli"]
@@ -107,6 +107,7 @@ metadata:
 | `+record-upload-attachment` | 给已有记录上传附件 | [`lark-base-record-upload-attachment.md`](references/lark-base-record-upload-attachment.md) | 附件上传专用链路，不要用 `+record-upsert` / `+record-batch-*` 伪造附件值 |
 | `lark-cli docs +media-download` | 下载 Base 附件文件到本地 | [`../lark-doc/references/lark-doc-media-download.md`](../lark-doc/references/lark-doc-media-download.md) | Base 附件的 `file_token` 从 `+record-get` 返回的附件字段数组里取；**不要用 `lark-cli drive +download`**（对 Base 附件返回 403） |
 | `+record-delete / +record-history-list` | 删除记录，或查询某条记录的变更历史 | [`lark-base-record-delete.md`](references/lark-base-record-delete.md)、[`lark-base-record-history-list.md`](references/lark-base-record-history-list.md) | 删除时用户已明确目标可直接执行并带 `--yes`；历史查询按 `table-id + record-id`，不支持整表扫描；`+record-history-list` 只能串行执行 |
+| `+record-share-link-create` | 为一条或多条记录生成分享链接 | [`lark-base-record-share-link-create.md`](references/lark-base-record-share-link-create.md) | 单次最多 100 条；重复 record_id 会自动去重；适合分享单条记录或批量分享场景 |
 
 #### 2.3.4 View 子模块
 


### PR DESCRIPTION
Change-Id: Ie8dc96521ee692804b734b030f7c143171193eb9

## Summary                                                                                                                                                                
                                                                                                                                                                            
Add +record-share-link-create shortcut entry to lark-base SKILL.md so that AI agents can discover and use the record sharing capability.                                  
                                                                                                                                                                          
## Changes                                                                                                                                                                
                                                                                                                                                                          
• Added "记录分享" (record sharing) to the skill description                                                                                                              
• Added +record-share-link-create row in the Record sub-module table with usage notes                                                                                     
                                                                                                                                                                          
## Test Plan                                                                                                                                                              
                                                                                                                                                                          
[✓] Manually verified SKILL.md formatting and table alignment                                                                                                             
[✓] Dry-run E2E for +record-share-link-create (docs-only change, no behavior impact)                                                                                      
                                                                                                                                                                          
## Related Issues                                                                                                                                                         
                                                                                                                                                                          
• None    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated Lark Base skill description to reference "记录分享链接" in capability list.
  * Added a new record-sharing command to create share links, supporting single or batch share operations with per-call limits and automatic deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->