### PR TITLE
fix(base): add default-table follow-up hint to base-create

### DIFF
--- a/shortcuts/base/base_execute_test.go
+++ b/shortcuts/base/base_execute_test.go
@@ -96,6 +96,9 @@ func TestBaseWorkspaceExecuteCreate(t *testing.T) {
 	if data["created"] != true {
 		t.Fatalf("created = %#v, want true", data["created"])
 	}
+	if data["hint"] != baseCreateHint {
+		t.Fatalf("hint = %#v, want %q", data["hint"], baseCreateHint)
+	}
 	base, _ := data["base"].(map[string]interface{})
 	if got := common.GetString(base, "app_token"); got != "app_x" {
 		t.Fatalf("base.app_token = %q, want %q", got, "app_x")
@@ -198,6 +201,9 @@ func TestBaseWorkspaceExecuteCreateBotAutoGrantSkippedWithoutCurrentUser(t *test
 	}
 
 	data := decodeBaseEnvelope(t, stdout)
+	if data["hint"] != baseCreateHint {
+		t.Fatalf("hint = %#v, want %q", data["hint"], baseCreateHint)
+	}
 	grant, _ := data["permission_grant"].(map[string]interface{})
 	if grant["status"] != common.PermissionGrantSkipped {
 		t.Fatalf("permission_grant.status = %#v, want %q", grant["status"], common.PermissionGrantSkipped)

--- a/shortcuts/base/base_execute_test.go
+++ b/shortcuts/base/base_execute_test.go
@@ -67,11 +67,15 @@ func runShortcutWithAuthTypes(t *testing.T, shortcut common.Shortcut, authTypes 
 	parent.SilenceErrors = true
 	parent.SilenceUsage = true
 	stdout.Reset()
+	if stderr, ok := factory.IOStreams.ErrOut.(*bytes.Buffer); ok {
+		stderr.Reset()
+	}
 	return parent.ExecuteContext(context.Background())
 }
 
 func TestBaseWorkspaceExecuteCreate(t *testing.T) {
 	factory, stdout, reg := newExecuteFactory(t)
+	stderr, _ := factory.IOStreams.ErrOut.(*bytes.Buffer)
 	permStub := &httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/drive/v1/permissions/app_x/members?need_notification=false&type=bitable",
@@ -96,8 +100,8 @@ func TestBaseWorkspaceExecuteCreate(t *testing.T) {
 	if data["created"] != true {
 		t.Fatalf("created = %#v, want true", data["created"])
 	}
-	if data["hint"] != baseCreateHint {
-		t.Fatalf("hint = %#v, want %q", data["hint"], baseCreateHint)
+	if !strings.Contains(stderr.String(), baseCreateHint) {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), baseCreateHint)
 	}
 	base, _ := data["base"].(map[string]interface{})
 	if got := common.GetString(base, "app_token"); got != "app_x" {
@@ -187,6 +191,7 @@ func TestBaseWorkspaceExecuteGetAndCopy(t *testing.T) {
 
 func TestBaseWorkspaceExecuteCreateBotAutoGrantSkippedWithoutCurrentUser(t *testing.T) {
 	factory, stdout, reg := newExecuteFactoryWithUserOpenID(t, "")
+	stderr, _ := factory.IOStreams.ErrOut.(*bytes.Buffer)
 	reg.Register(&httpmock.Stub{
 		Method: "POST",
 		URL:    "/open-apis/base/v3/bases",
@@ -201,8 +206,8 @@ func TestBaseWorkspaceExecuteCreateBotAutoGrantSkippedWithoutCurrentUser(t *test
 	}
 
 	data := decodeBaseEnvelope(t, stdout)
-	if data["hint"] != baseCreateHint {
-		t.Fatalf("hint = %#v, want %q", data["hint"], baseCreateHint)
+	if !strings.Contains(stderr.String(), baseCreateHint) {
+		t.Fatalf("stderr = %q, want %q", stderr.String(), baseCreateHint)
 	}
 	grant, _ := data["permission_grant"].(map[string]interface{})
 	if grant["status"] != common.PermissionGrantSkipped {

--- a/shortcuts/base/base_ops.go
+++ b/shortcuts/base/base_ops.go
@@ -11,7 +11,7 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
-const baseCreateHint = "New bases include a default empty table with 5-10 blank records. After finishing table/field setup on this base, ask whether to delete that default table. If yes, run +table-list first, then delete the default table."
+const baseCreateHint = "Tip: New bases include a default empty table with 5-10 blank records. After finishing table/field setup on this base, ask whether to delete that default table. If yes, run +table-list first, then delete the default table."
 
 func dryRunBaseGet(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 	return common.NewDryRunAPI().

--- a/shortcuts/base/base_ops.go
+++ b/shortcuts/base/base_ops.go
@@ -10,6 +10,8 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
+const baseCreateHint = "New bases include a default empty table with 5-10 blank records. After finishing table/field setup on this base, ask whether to delete that default table. If yes, run +table-list first, then delete the default table."
+
 func dryRunBaseGet(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 	return common.NewDryRunAPI().
 		GET("/open-apis/base/v3/bases/:base_token").
@@ -62,7 +64,7 @@ func executeBaseCreate(runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
-	out := map[string]interface{}{"base": data, "created": true}
+	out := map[string]interface{}{"base": data, "created": true, "hint": baseCreateHint}
 	augmentBasePermissionGrant(runtime, out, data)
 	runtime.Out(out, nil)
 	return nil

--- a/shortcuts/base/base_ops.go
+++ b/shortcuts/base/base_ops.go
@@ -5,6 +5,7 @@ package base
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/shortcuts/common"
@@ -64,9 +65,10 @@ func executeBaseCreate(runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
-	out := map[string]interface{}{"base": data, "created": true, "hint": baseCreateHint}
+	out := map[string]interface{}{"base": data, "created": true}
 	augmentBasePermissionGrant(runtime, out, data)
 	runtime.Out(out, nil)
+	fmt.Fprintln(runtime.IO().ErrOut, baseCreateHint)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
Add a follow-up hint to `base +base-create` success output so agents know a new Base includes a default empty table and should ask whether to remove it after later table/field setup.

## Changes
- Add a fixed `data.hint` string to `base +base-create` success output
- Add unit test assertions for the new success payload field

## Test Plan
- [x] Unit tests pass
- [x] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A user-facing hint is now displayed after creating a new base, explaining the default empty table setup and next steps to populate it.
* **Bug Fixes**
  * The creation hint is reliably shown even when automatic permission grants are skipped or other post-create conditions apply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->