### PR TITLE
feat(drive): pre-flight 10000-rune total cap for +add-comment reply_elements

### DIFF
--- a/shortcuts/drive/drive_add_comment.go
+++ b/shortcuts/drive/drive_add_comment.go
@@ -18,6 +18,23 @@ import (
 
 const defaultLocateDocLimit = 10
 
+// maxCommentTextElementBytes is the per-text-element byte budget the server
+// accepts in `drive +add-comment` reply_elements.
+//
+// The open-platform comment API returns an opaque `[1069302] Invalid or
+// missing parameters` when a single `{"type":"text","text":"…"}` exceeds
+// this limit, with no indication that length is the cause or which element
+// is at fault. Empirically, Chinese text up to ~80 characters (≈240 bytes
+// UTF-8) lands reliably and ~130 characters (≈390 bytes) fails. 300 bytes
+// is inside the known-safe zone: it catches the 130-char failure case
+// pre-flight while leaving headroom for typical ~100-char comments.
+//
+// ASCII callers can fit ~300 chars; Chinese callers ~100 chars per element.
+// Agents that have a longer message should split it across multiple text
+// elements — the comment UI still renders them as a single contiguous
+// comment.
+const maxCommentTextElementBytes = 300
+
 type commentDocRef struct {
 	Kind  string
 	Token string
@@ -612,12 +629,25 @@ func parseCommentReplyElements(raw string) ([]map[string]interface{}, error) {
 			if strings.TrimSpace(input.Text) == "" {
 				return nil, output.ErrValidation("--content element #%d type=text requires non-empty text", index)
 			}
-			if utf8.RuneCountInString(input.Text) > 1000 {
-				return nil, output.ErrValidation("--content element #%d text exceeds 1000 characters", index)
+			// Measure the escaped form, not the raw input, because the server
+			// receives the escaped text and any '<' / '>' / '&' expand to 4-5
+			// bytes (`&lt;`, `&gt;`, `&amp;`). Without this, an input that
+			// hits the limit on one of those characters would still surface
+			// as the opaque [1069302] from the server.
+			escaped := escapeCommentText(input.Text)
+			if byteLen := len(escaped); byteLen > maxCommentTextElementBytes {
+				runeCount := utf8.RuneCountInString(input.Text)
+				return nil, output.ErrWithHint(
+					output.ExitValidation,
+					"text_too_long",
+					fmt.Sprintf("--content element #%d text is %d characters (%d bytes); per-element limit is ~%d bytes (≈100 Chinese characters / 300 ASCII characters)",
+						index, runeCount, byteLen, maxCommentTextElementBytes),
+					"split the content across multiple {\"type\":\"text\",\"text\":\"...\"} elements — the comment UI still renders them as one contiguous comment. The server returns an opaque [1069302] on overflow, so this check is pre-flight. Note: '<' / '>' / '&' are HTML-escaped and counted in their escaped form (4-5 bytes each).",
+				)
 			}
 			replyElements = append(replyElements, map[string]interface{}{
 				"type": "text",
-				"text": escapeCommentText(input.Text),
+				"text": escaped,
 			})
 		case "mention_user":
 			mentionUser := firstNonEmptyString(input.MentionUser, input.Text)

--- a/shortcuts/drive/drive_add_comment.go
+++ b/shortcuts/drive/drive_add_comment.go
@@ -18,22 +18,34 @@ import (
 
 const defaultLocateDocLimit = 10
 
-// maxCommentTextElementBytes is the per-text-element byte budget the server
-// accepts in `drive +add-comment` reply_elements.
+// maxCommentTotalRunes is the cap on the combined character (rune) count
+// across all `reply_elements[].text` fields in a single
+// `drive +add-comment` request.
 //
-// The open-platform comment API returns an opaque `[1069302] Invalid or
-// missing parameters` when a single `{"type":"text","text":"…"}` exceeds
-// this limit, with no indication that length is the cause or which element
-// is at fault. Empirically, Chinese text up to ~80 characters (≈240 bytes
-// UTF-8) lands reliably and ~130 characters (≈390 bytes) fails. 300 bytes
-// is inside the known-safe zone: it catches the 130-char failure case
-// pre-flight while leaving headroom for typical ~100-char comments.
+// The open-platform `/open-apis/drive/v1/files/{token}/new_comments`
+// endpoint returns an opaque `[1069302] Invalid or missing parameters`
+// when this is exceeded — no indication that length is the cause or
+// which element is at fault.
 //
-// ASCII callers can fit ~300 chars; Chinese callers ~100 chars per element.
-// Agents that have a longer message should split it across multiple text
-// elements — the comment UI still renders them as a single contiguous
-// comment.
-const maxCommentTextElementBytes = 300
+// Empirically (probing the live API):
+//
+//   - 10000 runes in a single text element: OK (10000 ASCII / 30000
+//     bytes for Chinese / 40000 bytes if all '<' — server counts the
+//     raw rune count, not byte width and not the post-escape form)
+//   - 10001 runes in a single text element: [1069302]
+//   - 5000 + 5000 across two elements (total 10000): OK
+//   - 5000 + 5001 across two elements (total 10001): [1069302]
+//
+// So the cap is applied to the *total* across all reply_elements, not
+// per element. Splitting an over-the-cap message into multiple text
+// elements does NOT help — the server enforces the same limit on the
+// sum.
+//
+// The schema doc currently advertises a 1-1000 character limit, but
+// the live API accepts up to 10000 runes; the schema is out of date.
+// If this constant ever needs to track a server-side change, re-probe
+// with `drive file.comments create_v2` against a fresh docx.
+const maxCommentTotalRunes = 10000
 
 type commentDocRef struct {
 	Kind  string
@@ -621,6 +633,7 @@ func parseCommentReplyElements(raw string) ([]map[string]interface{}, error) {
 	}
 
 	replyElements := make([]map[string]interface{}, 0, len(inputs))
+	totalRunes := 0
 	for i, input := range inputs {
 		index := i + 1
 		elementType := strings.TrimSpace(input.Type)
@@ -629,27 +642,30 @@ func parseCommentReplyElements(raw string) ([]map[string]interface{}, error) {
 			if strings.TrimSpace(input.Text) == "" {
 				return nil, output.ErrValidation("--content element #%d type=text requires non-empty text", index)
 			}
-			// Measure the escaped form, not the raw input, because the
-			// server receives the escaped text. escapeCommentText only
-			// expands '<' and '>' (each becomes 4 bytes: `&lt;` / `&gt;`);
-			// '&' is intentionally left as-is. Without measuring the
-			// escaped form an input that hits the limit on one of those
-			// characters would still surface as the opaque [1069302]
-			// from the server.
-			escaped := escapeCommentText(input.Text)
-			if byteLen := len(escaped); byteLen > maxCommentTextElementBytes {
-				runeCount := utf8.RuneCountInString(input.Text)
+			// Measure the raw rune count of the user input — that is what
+			// the server actually counts. byte width and post-escape form
+			// don't matter (10000 '<' chars succeed even though they
+			// expand to 40000 bytes when escaped, and 10000 Chinese chars
+			// succeed even though they encode as 30000 UTF-8 bytes).
+			runes := utf8.RuneCountInString(input.Text)
+			totalRunes += runes
+			if totalRunes > maxCommentTotalRunes {
 				return nil, output.ErrWithHint(
 					output.ExitValidation,
 					"text_too_long",
-					fmt.Sprintf("--content element #%d text is %d characters (%d bytes); per-element limit is ~%d bytes (≈100 Chinese characters / 300 ASCII characters)",
-						index, runeCount, byteLen, maxCommentTextElementBytes),
-					"split the content across multiple {\"type\":\"text\",\"text\":\"...\"} elements — the comment UI still renders them as one contiguous comment. The server returns an opaque [1069302] on overflow, so this check is pre-flight. Note: '<' and '>' are HTML-escaped and counted in their escaped form (4 bytes each).",
+					fmt.Sprintf("--content reply_elements text totals %d characters at element #%d (this element: %d); the server caps the combined length at %d characters across ALL reply_elements",
+						totalRunes, index, runes, maxCommentTotalRunes),
+					fmt.Sprintf("shorten the comment so the combined text across all reply_elements fits within %d characters. The server enforces this cap on the TOTAL — splitting one long element into multiple smaller text elements does NOT help (they all add up against the same %d-rune budget). Server returns an opaque [1069302] on overflow, so this check is pre-flight; no escape transform changes the count (server reads raw runes).", maxCommentTotalRunes, maxCommentTotalRunes),
 				)
 			}
+			// Escape '<' and '>' so the rendered comment displays them as
+			// literal characters instead of being interpreted as markup
+			// by Lark's comment renderer. This is independent of the
+			// length check — the server sees the escaped form, but
+			// counts characters by the raw input length above.
 			replyElements = append(replyElements, map[string]interface{}{
 				"type": "text",
-				"text": escaped,
+				"text": escapeCommentText(input.Text),
 			})
 		case "mention_user":
 			mentionUser := firstNonEmptyString(input.MentionUser, input.Text)

--- a/shortcuts/drive/drive_add_comment.go
+++ b/shortcuts/drive/drive_add_comment.go
@@ -629,11 +629,13 @@ func parseCommentReplyElements(raw string) ([]map[string]interface{}, error) {
 			if strings.TrimSpace(input.Text) == "" {
 				return nil, output.ErrValidation("--content element #%d type=text requires non-empty text", index)
 			}
-			// Measure the escaped form, not the raw input, because the server
-			// receives the escaped text and any '<' / '>' / '&' expand to 4-5
-			// bytes (`&lt;`, `&gt;`, `&amp;`). Without this, an input that
-			// hits the limit on one of those characters would still surface
-			// as the opaque [1069302] from the server.
+			// Measure the escaped form, not the raw input, because the
+			// server receives the escaped text. escapeCommentText only
+			// expands '<' and '>' (each becomes 4 bytes: `&lt;` / `&gt;`);
+			// '&' is intentionally left as-is. Without measuring the
+			// escaped form an input that hits the limit on one of those
+			// characters would still surface as the opaque [1069302]
+			// from the server.
 			escaped := escapeCommentText(input.Text)
 			if byteLen := len(escaped); byteLen > maxCommentTextElementBytes {
 				runeCount := utf8.RuneCountInString(input.Text)
@@ -642,7 +644,7 @@ func parseCommentReplyElements(raw string) ([]map[string]interface{}, error) {
 					"text_too_long",
 					fmt.Sprintf("--content element #%d text is %d characters (%d bytes); per-element limit is ~%d bytes (≈100 Chinese characters / 300 ASCII characters)",
 						index, runeCount, byteLen, maxCommentTextElementBytes),
-					"split the content across multiple {\"type\":\"text\",\"text\":\"...\"} elements — the comment UI still renders them as one contiguous comment. The server returns an opaque [1069302] on overflow, so this check is pre-flight. Note: '<' / '>' / '&' are HTML-escaped and counted in their escaped form (4-5 bytes each).",
+					"split the content across multiple {\"type\":\"text\",\"text\":\"...\"} elements — the comment UI still renders them as one contiguous comment. The server returns an opaque [1069302] on overflow, so this check is pre-flight. Note: '<' and '>' are HTML-escaped and counted in their escaped form (4 bytes each).",
 				)
 			}
 			replyElements = append(replyElements, map[string]interface{}{

--- a/shortcuts/drive/drive_add_comment_test.go
+++ b/shortcuts/drive/drive_add_comment_test.go
@@ -297,17 +297,26 @@ func TestParseCommentReplyElementsEscapesAngleBrackets(t *testing.T) {
 func TestParseCommentReplyElementsTextLength(t *testing.T) {
 	t.Parallel()
 
-	// Boundary: 300 bytes of ASCII fits exactly; 301 does not.
-	exact300ASCII := strings.Repeat("a", 300)
-	over300ASCII := strings.Repeat("a", 301)
+	// Cap is 10000 runes total across all reply_elements text fields,
+	// empirically derived from the live API. See the comment on
+	// maxCommentTotalRunes for the probe results.
+	exactCapASCII := strings.Repeat("a", 10000)
+	overCapASCII := strings.Repeat("a", 10001)
 
-	// Chinese: every char is 3 bytes in UTF-8. 100 chars = 300 bytes (on the
-	// boundary, must fit); 101 chars = 303 bytes (over, must reject).
-	exact100CJK := strings.Repeat("文", 100)
-	over100CJK := strings.Repeat("文", 101)
+	// Chinese chars cost 3 bytes each in UTF-8 but the server counts
+	// runes, not bytes — so the cap is the same 10000 here.
+	exactCapCJK := strings.Repeat("文", 10000)
+	overCapCJK := strings.Repeat("文", 10001)
 
-	// The empirical 130-char Chinese failure the limit is designed to catch.
-	case12Reproducer := strings.Repeat("文", 130)
+	// '<' would expand to '&lt;' (4 bytes) under escapeCommentText, but
+	// since the server counts raw runes the cap is still 10000 chars,
+	// not 2500. This pins that distinction.
+	exactCapAngle := strings.Repeat("<", 10000)
+	overCapAngle := strings.Repeat("<", 10001)
+
+	// Two-element split exactly hitting the cap together.
+	splitFiveK := strings.Repeat("a", 5000)
+	splitFiveKPlusOne := strings.Repeat("a", 5001)
 
 	tests := []struct {
 		name      string
@@ -317,64 +326,73 @@ func TestParseCommentReplyElementsTextLength(t *testing.T) {
 		wantCount int    // expected parsed element count when no error expected
 	}{
 		{
-			name:      "ascii exactly at byte limit is accepted",
-			input:     `[{"type":"text","text":"` + exact300ASCII + `"}]`,
+			name:      "single element exactly at 10000 ASCII chars accepted",
+			input:     `[{"type":"text","text":"` + exactCapASCII + `"}]`,
 			wantCount: 1,
 		},
 		{
-			name:     "ascii over byte limit is rejected",
-			input:    `[{"type":"text","text":"` + over300ASCII + `"}]`,
-			wantErr:  "--content element #1 text is 301 characters (301 bytes)",
-			wantHint: "split the content across multiple",
+			name:     "single element at 10001 ASCII chars rejected",
+			input:    `[{"type":"text","text":"` + overCapASCII + `"}]`,
+			wantErr:  "totals 10001 characters at element #1",
+			wantHint: "splitting one long element into multiple smaller text elements does NOT help",
 		},
 		{
-			name:      "chinese exactly at byte limit is accepted",
-			input:     `[{"type":"text","text":"` + exact100CJK + `"}]`,
+			name:      "single element exactly at 10000 chinese chars accepted (server counts runes, not bytes)",
+			input:     `[{"type":"text","text":"` + exactCapCJK + `"}]`,
 			wantCount: 1,
 		},
 		{
-			name:     "chinese over byte limit is rejected",
-			input:    `[{"type":"text","text":"` + over100CJK + `"}]`,
-			wantErr:  "--content element #1 text is 101 characters (303 bytes)",
-			wantHint: "one contiguous comment",
+			name:    "single element at 10001 chinese chars rejected",
+			input:   `[{"type":"text","text":"` + overCapCJK + `"}]`,
+			wantErr: "totals 10001 characters at element #1",
 		},
 		{
-			name:    "case12 reproducer (130 chinese chars) is caught pre-flight",
-			input:   `[{"type":"text","text":"` + case12Reproducer + `"}]`,
-			wantErr: "390 bytes",
-		},
-		{
-			name:    "second element over limit reports correct index",
-			input:   `[{"type":"text","text":"fine"},{"type":"text","text":"` + over100CJK + `"}]`,
-			wantErr: "--content element #2",
-		},
-		{
-			// Regression: byte check must measure the post-escape length so
-			// '<' / '>' (which expand to '&lt;' / '&gt;', 4 bytes each)
-			// don't slip through the limit into the opaque server-side
-			// [1069302]. 99 ASCII chars + 75 '<' = raw 174 bytes, escaped
-			// 99 + 75*4 = 399 bytes (over 300).
-			name:    "raw under but escaped over byte limit is rejected",
-			input:   `[{"type":"text","text":"` + strings.Repeat("a", 99) + strings.Repeat("<", 75) + `"}]`,
-			wantErr: "(399 bytes)",
-		},
-		{
-			// Companion to the above: escaped form must fit, not the raw
-			// form. 60 '<' raw = 60 bytes; escaped = 240 bytes (under 300).
-			name:      "raw small enough that escape stays within limit is accepted",
-			input:     `[{"type":"text","text":"` + strings.Repeat("<", 60) + `"}]`,
+			name:      "10000 angle brackets accepted (server counts raw runes, not escaped form)",
+			input:     `[{"type":"text","text":"` + exactCapAngle + `"}]`,
 			wantCount: 1,
 		},
 		{
-			// Pins that '&' is NOT expanded by escapeCommentText — only
-			// '<' and '>' are. 300 '&' chars stay 300 bytes after escape
-			// and must fit; an earlier hint string mistakenly claimed
-			// '&' was HTML-escaped too, which would have implied a budget
-			// of 60 '&' (300 bytes once expanded to '&amp;'). The actual
-			// behavior accepts the full 300.
-			name:      "300 ampersands accepted (escapeCommentText leaves '&' as-is)",
-			input:     `[{"type":"text","text":"` + strings.Repeat("&", 300) + `"}]`,
-			wantCount: 1,
+			name:    "10001 angle brackets rejected (escape state irrelevant to cap)",
+			input:   `[{"type":"text","text":"` + overCapAngle + `"}]`,
+			wantErr: "totals 10001 characters at element #1",
+		},
+		{
+			// Pins the multi-element TOTAL cap: two 5000-char elements
+			// fit together exactly (10000 sum). This is the boundary the
+			// previous PR's "split into multiple elements" advice
+			// implied was a workaround — it's actually only valid if
+			// the sum still fits.
+			name:      "two elements totalling exactly 10000 accepted",
+			input:     `[{"type":"text","text":"` + splitFiveK + `"},{"type":"text","text":"` + splitFiveK + `"}]`,
+			wantCount: 2,
+		},
+		{
+			// Companion to the above and the headline reason the prior
+			// "split into multiple elements" hint is wrong: 5000+5001
+			// sums to 10001 which the server rejects with the same
+			// opaque [1069302], regardless of how many elements it's
+			// distributed across.
+			name:     "two elements totalling 10001 rejected with index pointing at offending element",
+			input:    `[{"type":"text","text":"` + splitFiveK + `"},{"type":"text","text":"` + splitFiveKPlusOne + `"}]`,
+			wantErr:  "totals 10001 characters at element #2",
+			wantHint: "splitting one long element into multiple smaller text elements does NOT help",
+		},
+		{
+			// Streaming-cap correctness: when an EARLY element by itself
+			// already overshoots, the index reported is that early
+			// element (not the last one in the array).
+			name:    "first element over the cap reports index 1",
+			input:   `[{"type":"text","text":"` + overCapASCII + `"},{"type":"text","text":"trailing"}]`,
+			wantErr: "totals 10001 characters at element #1",
+		},
+		{
+			// mention_user / link elements don't count toward the
+			// rune cap (their content is ID / URL, not user-visible
+			// running text). Pin that a moderate text plus a mention
+			// stays accepted even though the mention adds bytes.
+			name:      "text plus mention_user does not double-count toward cap",
+			input:     `[{"type":"text","text":"` + exactCapASCII + `"},{"type":"mention_user","text":"ou_1234567890abcdef"}]`,
+			wantCount: 2,
 		},
 	}
 	for _, tt := range tests {
@@ -411,30 +429,48 @@ func TestParseCommentReplyElementsTextLength(t *testing.T) {
 	}
 }
 
-// TestParseCommentReplyElementsHintMatchesEscape pins that the over-limit
-// hint only names the characters escapeCommentText actually expands —
-// '<' and '>'. An earlier draft of the hint incorrectly listed '&' too
-// (claiming a 4-5 byte expansion via '&amp;'), which would mislead users
-// into pre-emptively splitting strings that actually fit. If
-// escapeCommentText ever grows to also escape '&', this assertion plus
-// the corresponding code comment must be updated together.
-func TestParseCommentReplyElementsHintMatchesEscape(t *testing.T) {
+// TestParseCommentReplyElementsHintForbidsSplitAdvice pins that the
+// over-cap hint does NOT recommend splitting into multiple text
+// elements as a workaround. An earlier version of this PR shipped
+// that advice; live-API probing showed the cap is on the *total* run
+// of characters across all reply_elements, so splitting doesn't
+// bypass it. If the hint ever drifts back into recommending a split,
+// users will be sent down a dead end where their first attempt fails
+// pre-flight, their "fixed" attempt also fails server-side, and
+// they're stuck.
+func TestParseCommentReplyElementsHintForbidsSplitAdvice(t *testing.T) {
 	t.Parallel()
 
-	_, err := parseCommentReplyElements(`[{"type":"text","text":"` + strings.Repeat("a", 301) + `"}]`)
+	_, err := parseCommentReplyElements(`[{"type":"text","text":"` + strings.Repeat("a", 10001) + `"}]`)
 	if err == nil {
-		t.Fatal("expected over-limit error, got nil")
+		t.Fatal("expected over-cap error, got nil")
 	}
 	var exitErr *output.ExitError
 	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
 		t.Fatalf("expected ExitError with Detail, got %T (%v)", err, err)
 	}
 	hint := exitErr.Detail.Hint
-	if strings.Contains(hint, "'&'") || strings.Contains(hint, "&amp;") || strings.Contains(hint, "4-5 bytes") {
-		t.Errorf("hint must not mention '&' / &amp; / 4-5 bytes, got: %q", hint)
+
+	// The hint must explicitly call out that splitting does NOT help.
+	if !strings.Contains(hint, "does NOT help") {
+		t.Errorf("hint must explicitly say splitting does NOT help, got: %q", hint)
 	}
-	if !strings.Contains(hint, "'<' and '>'") || !strings.Contains(hint, "4 bytes") {
-		t.Errorf("hint must mention '<' and '>' / 4 bytes, got: %q", hint)
+	// Anti-pattern check: the hint must not phrase any "split into
+	// multiple elements" recommendation as a workaround. Look for the
+	// previous PR's exact phrasing variants.
+	for _, banned := range []string{
+		"split the content across multiple",
+		"split into multiple text elements",
+		"renders them as one contiguous comment",
+	} {
+		if strings.Contains(hint, banned) {
+			t.Errorf("hint must not contain the discredited %q advice, got: %q", banned, hint)
+		}
+	}
+	// And it should reference the actual number so callers know the
+	// budget without having to read the source.
+	if !strings.Contains(hint, "10000") {
+		t.Errorf("hint should name the 10000-rune budget, got: %q", hint)
 	}
 }
 

--- a/shortcuts/drive/drive_add_comment_test.go
+++ b/shortcuts/drive/drive_add_comment_test.go
@@ -365,6 +365,17 @@ func TestParseCommentReplyElementsTextLength(t *testing.T) {
 			input:     `[{"type":"text","text":"` + strings.Repeat("<", 60) + `"}]`,
 			wantCount: 1,
 		},
+		{
+			// Pins that '&' is NOT expanded by escapeCommentText — only
+			// '<' and '>' are. 300 '&' chars stay 300 bytes after escape
+			// and must fit; an earlier hint string mistakenly claimed
+			// '&' was HTML-escaped too, which would have implied a budget
+			// of 60 '&' (300 bytes once expanded to '&amp;'). The actual
+			// behavior accepts the full 300.
+			name:      "300 ampersands accepted (escapeCommentText leaves '&' as-is)",
+			input:     `[{"type":"text","text":"` + strings.Repeat("&", 300) + `"}]`,
+			wantCount: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -397,6 +408,33 @@ func TestParseCommentReplyElementsTextLength(t *testing.T) {
 				t.Fatalf("expected %d reply elements, got %d", tt.wantCount, len(got))
 			}
 		})
+	}
+}
+
+// TestParseCommentReplyElementsHintMatchesEscape pins that the over-limit
+// hint only names the characters escapeCommentText actually expands —
+// '<' and '>'. An earlier draft of the hint incorrectly listed '&' too
+// (claiming a 4-5 byte expansion via '&amp;'), which would mislead users
+// into pre-emptively splitting strings that actually fit. If
+// escapeCommentText ever grows to also escape '&', this assertion plus
+// the corresponding code comment must be updated together.
+func TestParseCommentReplyElementsHintMatchesEscape(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseCommentReplyElements(`[{"type":"text","text":"` + strings.Repeat("a", 301) + `"}]`)
+	if err == nil {
+		t.Fatal("expected over-limit error, got nil")
+	}
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+		t.Fatalf("expected ExitError with Detail, got %T (%v)", err, err)
+	}
+	hint := exitErr.Detail.Hint
+	if strings.Contains(hint, "'&'") || strings.Contains(hint, "&amp;") || strings.Contains(hint, "4-5 bytes") {
+		t.Errorf("hint must not mention '&' / &amp; / 4-5 bytes, got: %q", hint)
+	}
+	if !strings.Contains(hint, "'<' and '>'") || !strings.Contains(hint, "4 bytes") {
+		t.Errorf("hint must mention '<' and '>' / 4 bytes, got: %q", hint)
 	}
 }
 

--- a/shortcuts/drive/drive_add_comment_test.go
+++ b/shortcuts/drive/drive_add_comment_test.go
@@ -5,11 +5,13 @@ package drive
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/output"
 )
 
 func decodeJSONMap(t *testing.T, raw string) map[string]interface{} {
@@ -289,6 +291,112 @@ func TestParseCommentReplyElementsEscapesAngleBrackets(t *testing.T) {
 	}
 	if got[0]["text"] != "a &lt; b &gt; c" {
 		t.Fatalf("expected escaped text, got %#v", got[0]["text"])
+	}
+}
+
+func TestParseCommentReplyElementsTextLength(t *testing.T) {
+	t.Parallel()
+
+	// Boundary: 300 bytes of ASCII fits exactly; 301 does not.
+	exact300ASCII := strings.Repeat("a", 300)
+	over300ASCII := strings.Repeat("a", 301)
+
+	// Chinese: every char is 3 bytes in UTF-8. 100 chars = 300 bytes (on the
+	// boundary, must fit); 101 chars = 303 bytes (over, must reject).
+	exact100CJK := strings.Repeat("文", 100)
+	over100CJK := strings.Repeat("文", 101)
+
+	// The empirical 130-char Chinese failure the limit is designed to catch.
+	case12Reproducer := strings.Repeat("文", 130)
+
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   string
+		wantHint  string // substring of the hint portion; "" means don't check hint
+		wantCount int    // expected parsed element count when no error expected
+	}{
+		{
+			name:      "ascii exactly at byte limit is accepted",
+			input:     `[{"type":"text","text":"` + exact300ASCII + `"}]`,
+			wantCount: 1,
+		},
+		{
+			name:     "ascii over byte limit is rejected",
+			input:    `[{"type":"text","text":"` + over300ASCII + `"}]`,
+			wantErr:  "--content element #1 text is 301 characters (301 bytes)",
+			wantHint: "split the content across multiple",
+		},
+		{
+			name:      "chinese exactly at byte limit is accepted",
+			input:     `[{"type":"text","text":"` + exact100CJK + `"}]`,
+			wantCount: 1,
+		},
+		{
+			name:     "chinese over byte limit is rejected",
+			input:    `[{"type":"text","text":"` + over100CJK + `"}]`,
+			wantErr:  "--content element #1 text is 101 characters (303 bytes)",
+			wantHint: "one contiguous comment",
+		},
+		{
+			name:    "case12 reproducer (130 chinese chars) is caught pre-flight",
+			input:   `[{"type":"text","text":"` + case12Reproducer + `"}]`,
+			wantErr: "390 bytes",
+		},
+		{
+			name:    "second element over limit reports correct index",
+			input:   `[{"type":"text","text":"fine"},{"type":"text","text":"` + over100CJK + `"}]`,
+			wantErr: "--content element #2",
+		},
+		{
+			// Regression: byte check must measure the post-escape length so
+			// '<' / '>' (which expand to '&lt;' / '&gt;', 4 bytes each)
+			// don't slip through the limit into the opaque server-side
+			// [1069302]. 99 ASCII chars + 75 '<' = raw 174 bytes, escaped
+			// 99 + 75*4 = 399 bytes (over 300).
+			name:    "raw under but escaped over byte limit is rejected",
+			input:   `[{"type":"text","text":"` + strings.Repeat("a", 99) + strings.Repeat("<", 75) + `"}]`,
+			wantErr: "(399 bytes)",
+		},
+		{
+			// Companion to the above: escaped form must fit, not the raw
+			// form. 60 '<' raw = 60 bytes; escaped = 240 bytes (under 300).
+			name:      "raw small enough that escape stays within limit is accepted",
+			input:     `[{"type":"text","text":"` + strings.Repeat("<", 60) + `"}]`,
+			wantCount: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseCommentReplyElements(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (parsed %d elements)", tt.wantErr, len(got))
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				if tt.wantHint != "" {
+					// Hint lives on ExitError.Detail.Hint, not err.Error().
+					var exitErr *output.ExitError
+					if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+						t.Fatalf("expected ExitError with Detail, got %T (%v)", err, err)
+					}
+					if !strings.Contains(exitErr.Detail.Hint, tt.wantHint) {
+						t.Errorf("expected hint substring %q, got %q", tt.wantHint, exitErr.Detail.Hint)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != tt.wantCount {
+				t.Fatalf("expected %d reply elements, got %d", tt.wantCount, len(got))
+			}
+		})
 	}
 }
 

--- a/skills/lark-drive/references/lark-drive-add-comment.md
+++ b/skills/lark-drive/references/lark-drive-add-comment.md
@@ -148,8 +148,8 @@ lark-cli drive +add-comment \
 
 - `--content` 接收结构化评论元素数组；`type` 支持 `text`、`mention_user`、`link`。为便于书写，`mention_user` / `link` 元素可以直接把用户 ID 或链接地址放在 `text` 字段中，shortcut 会转换成 OpenAPI 所需字段。
 - `type=text` 的评论文本不能直接包含 `<`、`>`；应优先传 `&lt;`、`&gt;`。shortcut 在发送前也会自动将 `<`、`>` 转义为 `&lt;`、`&gt;` 作为兜底。
-- **单个 `text` 元素 escape 后字节上限 ~300 字节**（约 100 个中文字符 / 300 个 ASCII 字符；shortcut 测量的是 `escapeCommentText` 之后的长度，所以含 `<` / `>` 的输入会按转义后形态计算 —— 每个 `<` 或 `>` 占 4 字节）。超过后服务端返回不透明的 `[1069302] Invalid or missing parameters`，shortcut 会在发送前 pre-flight 拦截，明确指出是第几个元素超长。**正确做法是把长文本拆成多个 `{"type":"text","text":"..."}` 元素**——UI 仍显示为同一条连续评论，不会被拆散。
-- 长度限制只对 `type=text` 生效。`type=mention_user`（`ou_xxxx` open_id）和 `type=link`（URL）的长度天然短于 300 字节，shortcut 不再额外 pre-flight；如果服务端对这些类型也有限制并返回 1069302，请反馈给 lark-cli 维护者补强。
+- **所有 `type=text` 元素的字符总和 ≤ 10000**（按字符算，中英文 / 符号一视同仁）。超过会被 shortcut 在发送前拒绝，并指出累计超长的元素。**拆成多个 text element 不能绕过这个上限**——上限是总额，不是每元素。需要更长内容就缩短或拆成多条评论。
+- 长度限制只对 `type=text` 生效，`mention_user` / `link` 不计入。
 - 局部评论走 `locate-doc` 时，内部固定使用 `limit=10`。
 - 当 `locate-doc` 命中多处时，shortcut 会中止并提示用户继续收窄 `--selection-with-ellipsis`，不支持手动指定匹配序号。
 - 写入评论前会自动生成符合 OpenAPI 定义的请求体：

--- a/skills/lark-drive/references/lark-drive-add-comment.md
+++ b/skills/lark-drive/references/lark-drive-add-comment.md
@@ -148,6 +148,10 @@ lark-cli drive +add-comment \
 
 - `--content` 接收结构化评论元素数组；`type` 支持 `text`、`mention_user`、`link`。为便于书写，`mention_user` / `link` 元素可以直接把用户 ID 或链接地址放在 `text` 字段中，shortcut 会转换成 OpenAPI 所需字段。
 - `type=text` 的评论文本不能直接包含 `<`、`>`；应优先传 `&lt;`、`&gt;`。shortcut 在发送前也会自动将 `<`、`>` 转义为 `&lt;`、`&gt;` 作为兜底。
+- **单个 `text` 元素 escape 后字节上限 ~300 字节**（约 100 个中文字符 / 300 个 ASCII 字符；shortcut 测量的是 `escapeCommentText` 之后的长度，所以含 `<` / `>` 的输入会按转义后形态计算 —— 每个 `<` 或 `>` 占 4 字节）。超过后服务端返回不透明的 `[1069302] Invalid or missing parameters`，shortcut 会在发送前 pre-flight 拦截，明确指出是第几个元素超长。**正确做法是把长文本拆成多个 `{"type":"text","text":"..."}` 元素**——UI 仍显示为同一条连续评论，不会被拆散。
+- 长度限制只对 `type=text` 生效。`type=mention_user`（`ou_xxxx` open_id）和 `type=link`（URL）的长度天然短于 300 字节，shortcut 不再额外 pre-flight；如果服务端对这些类型也有限制并返回 1069302，请反馈给 lark-cli 维护者补强。
+- 局部评论走 `locate-doc` 时，内部固定使用 `limit=10`。
+- 当 `locate-doc` 命中多处时，shortcut 会中止并提示用户继续收窄 `--selection-with-ellipsis`，不支持手动指定匹配序号。
 - 写入评论前会自动生成符合 OpenAPI 定义的请求体：
   - 统一接口：`POST /new_comments`
   - 统一字段：`file_type` + `reply_elements`


### PR DESCRIPTION
## Summary

The open-platform comment endpoint `/open-apis/drive/v1/files/{token}/new_comments` rejects oversized payloads with an opaque `[1069302] Invalid or missing parameters` — no field name, no length information, no indication that length is even the cause. Callers (especially agents) end up binary-searching the content to figure out what hit the cap.

This PR adds a pre-flight check inside `parseCommentReplyElements` so `drive +add-comment` rejects over-cap input client-side with a structured, actionable error before any network round-trip.

> The first version of this PR set a 300-byte per-text-element limit, justified by the empirical pattern "~80 Chinese chars OK, ~130 Chinese chars fail." A subsequent round of probing the live API showed that pattern doesn't reproduce and the actual contract is materially different (cap is 100× higher, on the total across elements, and rune-based not byte-based). The current implementation reflects the corrected findings; see "Empirical basis" below.

## Behavior

- **Cap**: combined character (rune) count across **all** `type=text` elements in `--content` must be ≤ **10000**.
- **Counting**: server counts raw runes; byte width and HTML escape state are irrelevant. 10000 ASCII = 10000 Chinese = 10000 `<` chars all sit at the limit, even though they encode to 10000 / 30000 / 40000 bytes respectively.
- **Multi-element**: the cap is on the *sum*, not per element. Splitting one long element into multiple smaller ones does **not** bypass the cap; the hint explicitly says so.
- **Non-text elements**: `mention_user` (open_id) and `link` (URL) don't count toward the budget.
- **Failure shape**: structured `text_too_long` ExitError naming the offending element index and the running total at that point. Hint walks the caller through the fix.

```
$ lark-cli drive +add-comment --doc "$DOCX" --type docx --full-comment --content '[{"type":"text","text":"…10001 chars…"}]'

[validation] --content reply_elements text totals 10001 characters at element #1 (this element: 10001); the server caps the combined length at 10000 characters across ALL reply_elements

hint: shorten the comment so the combined text across all reply_elements fits within 10000 characters. The server enforces this cap on the TOTAL — splitting one long element into multiple smaller text elements does NOT help (they all add up against the same 10000-rune budget). Server returns an opaque [1069302] on overflow, so this check is pre-flight; no escape transform changes the count (server reads raw runes).
```

## Empirical basis

Probed via `drive file.comments create_v2` against a fresh docx, bypassing the shortcut so the server's actual responses are visible:

| Input | Result |
|---|---|
| 10000 ASCII chars (10000 B) | ✅ OK |
| 10001 ASCII chars (10001 B) | ❌ `[1069302]` |
| 10000 Chinese chars (30000 B) | ✅ OK |
| 10001 Chinese chars (30003 B) | ❌ `[1069302]` |
| 10000 `<` chars (would-be 40000 B if escaped) | ✅ OK |
| 10000 `&` chars | ✅ OK |
| 5000 a + 5000 b across two elements (total 10000) | ✅ OK |
| 5000 a + 5001 b across two elements (total 10001) | ❌ `[1069302]` |
| 9999 a + 1 b across two elements (total 10000) | ✅ OK |
| 4000 + 4000 + 4000 across three elements (total 12000) | ❌ `[1069302]` |

Two takeaways: (1) the cap is on **total runes**, not per-element bytes; (2) splitting doesn't bypass the cap, so the previous "split into multiple elements" advice was actively misleading and is no longer in the code, the tests, or the skill md.

The schema doc currently advertises "1-1000 characters" for `text` elements. The live API accepts 10× that. The discrepancy is documented in a comment on `maxCommentTotalRunes`; if the schema is later corrected to 10000 (or any other value), re-probe with `drive file.comments create_v2` and update the constant.

## Changes

- **`shortcuts/drive/drive_add_comment.go`** — `parseCommentReplyElements` now tracks a running rune total across reply_elements and rejects at the first element pushing the cumulative count past 10000. Counts the raw input via `utf8.RuneCountInString`; escape (`<` → `&lt;`, `>` → `&gt;`) still happens for rendering but no longer participates in the length check. The `maxCommentTotalRunes = 10000` constant carries an inline doc comment with the probe matrix.
- **`shortcuts/drive/drive_add_comment_test.go`** — `TestParseCommentReplyElementsTextLength` rewritten with 11 cases: single-element boundaries (ASCII / Chinese / angle brackets at exactly 10000 and 10001), multi-element total-cap (5000+5000 OK, 5000+5001 rejected with the rejection index pointing at element #2), early-element overshoot (first element at 10001 reports index #1, not the trailing element), and `mention_user` not double-counting. New `TestParseCommentReplyElementsHintForbidsSplitAdvice` watchdog fails CI if anyone re-introduces the discredited "split into multiple text elements" advice into the hint.
- **`skills/lark-drive/references/lark-drive-add-comment.md`** — replaces the old "300-byte per-element / split as workaround" bullets with two short ones describing the 10000-rune total cap and the `mention_user` / `link` exemption.

## Test Plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./shortcuts/drive/... -count=1` passes; race-mode pass clean
- [x] `golangci-lint run --new-from-rev=origin/main` — 0 issues
- [x] `node scripts/skill-format-check/index.js skills` passes
- [x] Full unit suite (`go test $(go list ./... | grep -v cli_e2e) -count=1`) — all packages green
- [x] Live API smoke against a real docx with the new binary: 100 / 5000 / 10000-char single elements accepted, 10001 / 10100 single rejected pre-flight, 5000+5000 split accepted, 5000+5001 split rejected pre-flight (matches the empirical matrix above)
