### PR TITLE
 feat: support wiki node targets in drive +upload

### DIFF
--- a/shortcuts/drive/drive_io_test.go
+++ b/shortcuts/drive/drive_io_test.go
@@ -5,6 +5,10 @@ package drive
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"strings"
@@ -147,6 +151,83 @@ func TestDriveUploadLargeFileUsesMultipart(t *testing.T) {
 	}
 }
 
+func TestDriveUploadLargeFileToWikiUsesMultipart(t *testing.T) {
+	uploadTestConfig := &core.CliConfig{
+		AppID: "drive-upload-large-wiki-test", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	}
+	f, stdout, _, reg := cmdutil.TestFactory(t, uploadTestConfig)
+
+	prepareStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/files/upload_prepare",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"upload_id":  "test-upload-id",
+				"block_size": float64(common.MaxDriveMediaUploadSinglePartSize),
+				"block_num":  float64(2),
+			},
+		},
+	}
+	reg.Register(prepareStub)
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/files/upload_part",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok"},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/files/upload_part",
+		Body:   map[string]interface{}{"code": 0, "msg": "ok"},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/files/upload_finish",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"file_token": "file_multipart_wiki_token",
+			},
+		},
+	})
+
+	tmpDir := t.TempDir()
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Chdir() error: %v", err)
+	}
+	defer os.Chdir(origDir)
+
+	fh, err := os.Create("large.bin")
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+	if err := fh.Truncate(common.MaxDriveMediaUploadSinglePartSize + 1); err != nil {
+		t.Fatalf("Truncate() error: %v", err)
+	}
+	if err := fh.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+
+	err = mountAndRunDrive(t, DriveUpload, []string{
+		"+upload",
+		"--file", "large.bin",
+		"--wiki-token", "wikcn_multipart_upload_test",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("expected multipart wiki upload to succeed, got error: %v", err)
+	}
+
+	body := decodeCapturedJSONBody(t, prepareStub)
+	if got := body["parent_type"]; got != driveUploadParentTypeWiki {
+		t.Fatalf("parent_type = %#v, want %q", got, driveUploadParentTypeWiki)
+	}
+	if got := body["parent_node"]; got != "wikcn_multipart_upload_test" {
+		t.Fatalf("parent_node = %#v, want %q", got, "wikcn_multipart_upload_test")
+	}
+}
+
 func TestDriveUploadSmallFile(t *testing.T) {
 	uploadTestConfig := &core.CliConfig{
 		AppID: "drive-upload-small-test", AppSecret: "test-secret", Brand: core.BrandFeishu,
@@ -183,6 +264,56 @@ func TestDriveUploadSmallFile(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "file_small_token") {
 		t.Fatalf("stdout missing file_token: %s", stdout.String())
+	}
+}
+
+func TestDriveUploadSmallFileToWiki(t *testing.T) {
+	uploadTestConfig := &core.CliConfig{
+		AppID: "drive-upload-small-wiki-test", AppSecret: "test-secret", Brand: core.BrandFeishu,
+	}
+	f, stdout, _, reg := cmdutil.TestFactory(t, uploadTestConfig)
+
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/files/upload_all",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"file_token": "file_small_wiki_token",
+			},
+		},
+	}
+	reg.Register(stub)
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+
+	if err := os.WriteFile("small.bin", make([]byte, 1024), 0644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	err := mountAndRunDrive(t, DriveUpload, []string{
+		"+upload",
+		"--file", "small.bin",
+		"--wiki-token", "wikcn_target_upload_test",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("expected wiki upload to succeed, got error: %v", err)
+	}
+
+	body := decodeDriveMultipartBody(t, stub)
+	if got := body.Fields["parent_type"]; got != driveUploadParentTypeWiki {
+		t.Fatalf("parent_type = %q, want %q", got, driveUploadParentTypeWiki)
+	}
+	if got := body.Fields["parent_node"]; got != "wikcn_target_upload_test" {
+		t.Fatalf("parent_node = %q, want %q", got, "wikcn_target_upload_test")
+	}
+	if got := body.Fields["file_name"]; got != "small.bin" {
+		t.Fatalf("file_name = %q, want %q", got, "small.bin")
+	}
+	if got := body.Fields["size"]; got != "1024" {
+		t.Fatalf("size = %q, want %q", got, "1024")
 	}
 }
 
@@ -553,6 +684,254 @@ func TestDriveUploadWithCustomName(t *testing.T) {
 	}
 }
 
+func TestDriveUploadDryRunUsesWikiTarget(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "drive +upload"}
+	cmd.Flags().String("file", "", "")
+	cmd.Flags().String("folder-token", "", "")
+	cmd.Flags().String("wiki-token", "", "")
+	cmd.Flags().String("name", "", "")
+	if err := cmd.Flags().Set("file", "./report.pdf"); err != nil {
+		t.Fatalf("set --file: %v", err)
+	}
+	if err := cmd.Flags().Set("wiki-token", "wikcn_dryrun_upload_target"); err != nil {
+		t.Fatalf("set --wiki-token: %v", err)
+	}
+
+	runtime := common.TestNewRuntimeContextWithCtx(context.Background(), cmd, nil)
+	dry := DriveUpload.DryRun(context.Background(), runtime)
+	if dry == nil {
+		t.Fatal("DryRun returned nil")
+	}
+
+	data, err := json.Marshal(dry)
+	if err != nil {
+		t.Fatalf("marshal dry run: %v", err)
+	}
+
+	var got struct {
+		API []struct {
+			Body map[string]interface{} `json:"body"`
+		} `json:"api"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal dry run json: %v", err)
+	}
+	if len(got.API) != 1 {
+		t.Fatalf("expected 1 API call, got %d", len(got.API))
+	}
+	if got.API[0].Body["parent_type"] != driveUploadParentTypeWiki {
+		t.Fatalf("parent_type = %#v, want %q", got.API[0].Body["parent_type"], driveUploadParentTypeWiki)
+	}
+	if got.API[0].Body["parent_node"] != "wikcn_dryrun_upload_target" {
+		t.Fatalf("parent_node = %#v, want %q", got.API[0].Body["parent_node"], "wikcn_dryrun_upload_target")
+	}
+}
+
+func TestNewDriveUploadSpecPreservesPathAndName(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "drive +upload"}
+	cmd.Flags().String("file", "", "")
+	cmd.Flags().String("folder-token", "", "")
+	cmd.Flags().String("wiki-token", "", "")
+	cmd.Flags().String("name", "", "")
+	if err := cmd.Flags().Set("file", " report final.pdf "); err != nil {
+		t.Fatalf("set --file: %v", err)
+	}
+	if err := cmd.Flags().Set("folder-token", " fld_upload_target "); err != nil {
+		t.Fatalf("set --folder-token: %v", err)
+	}
+	if err := cmd.Flags().Set("wiki-token", " wikcn_upload_target "); err != nil {
+		t.Fatalf("set --wiki-token: %v", err)
+	}
+	if err := cmd.Flags().Set("name", " final upload.pdf "); err != nil {
+		t.Fatalf("set --name: %v", err)
+	}
+
+	runtime := common.TestNewRuntimeContextWithCtx(context.Background(), cmd, nil)
+	got := newDriveUploadSpec(runtime)
+	if got.FilePath != " report final.pdf " {
+		t.Fatalf("FilePath = %q, want original value", got.FilePath)
+	}
+	if got.Name != " final upload.pdf " {
+		t.Fatalf("Name = %q, want original value", got.Name)
+	}
+	if got.FolderToken != "fld_upload_target" {
+		t.Fatalf("FolderToken = %q, want trimmed token", got.FolderToken)
+	}
+	if got.WikiToken != "wikcn_upload_target" {
+		t.Fatalf("WikiToken = %q, want trimmed token", got.WikiToken)
+	}
+}
+
+func TestDriveUploadTargetLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		target driveUploadTarget
+		want   string
+	}{
+		{
+			name: "wiki node",
+			target: driveUploadTarget{
+				ParentType: driveUploadParentTypeWiki,
+				ParentNode: "wikcn_upload_target",
+			},
+			want: "wiki node " + common.MaskToken("wikcn_upload_target"),
+		},
+		{
+			name: "root folder",
+			target: driveUploadTarget{
+				ParentType: driveUploadParentTypeExplorer,
+			},
+			want: "Drive root folder",
+		},
+		{
+			name: "folder",
+			target: driveUploadTarget{
+				ParentType: driveUploadParentTypeExplorer,
+				ParentNode: "fld_upload_target",
+			},
+			want: "folder " + common.MaskToken("fld_upload_target"),
+		},
+		{
+			name: "unknown target",
+			target: driveUploadTarget{
+				ParentType: "unknown",
+				ParentNode: "node_upload_target",
+			},
+			want: "target " + common.MaskToken("node_upload_target"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.target.Label(); got != tt.want {
+				t.Fatalf("Label() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDriveUploadValidateRejectsConflictingTargets(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "drive +upload"}
+	cmd.Flags().String("file", "", "")
+	cmd.Flags().String("folder-token", "", "")
+	cmd.Flags().String("wiki-token", "", "")
+	cmd.Flags().String("name", "", "")
+	if err := cmd.Flags().Set("folder-token", "fld_upload_conflict"); err != nil {
+		t.Fatalf("set --folder-token: %v", err)
+	}
+	if err := cmd.Flags().Set("wiki-token", "wikcn_upload_conflict"); err != nil {
+		t.Fatalf("set --wiki-token: %v", err)
+	}
+
+	runtime := common.TestNewRuntimeContextWithCtx(context.Background(), cmd, nil)
+	err := DriveUpload.Validate(context.Background(), runtime)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("Validate() error = %v, want mutually exclusive error", err)
+	}
+}
+
+func TestDriveUploadValidateRejectsExplicitEmptyWikiToken(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "drive +upload"}
+	cmd.Flags().String("file", "", "")
+	cmd.Flags().String("folder-token", "", "")
+	cmd.Flags().String("wiki-token", "", "")
+	cmd.Flags().String("name", "", "")
+	if err := cmd.Flags().Set("file", "report.pdf"); err != nil {
+		t.Fatalf("set --file: %v", err)
+	}
+	if err := cmd.Flags().Set("wiki-token", "   "); err != nil {
+		t.Fatalf("set --wiki-token: %v", err)
+	}
+
+	runtime := common.TestNewRuntimeContextWithCtx(context.Background(), cmd, nil)
+	err := DriveUpload.Validate(context.Background(), runtime)
+	if err == nil || !strings.Contains(err.Error(), "--wiki-token cannot be empty") {
+		t.Fatalf("Validate() error = %v, want empty wiki-token error", err)
+	}
+}
+
+func TestDriveUploadValidateRejectsExplicitEmptyFolderToken(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "drive +upload"}
+	cmd.Flags().String("file", "", "")
+	cmd.Flags().String("folder-token", "", "")
+	cmd.Flags().String("wiki-token", "", "")
+	cmd.Flags().String("name", "", "")
+	if err := cmd.Flags().Set("file", "report.pdf"); err != nil {
+		t.Fatalf("set --file: %v", err)
+	}
+	if err := cmd.Flags().Set("folder-token", "   "); err != nil {
+		t.Fatalf("set --folder-token: %v", err)
+	}
+
+	runtime := common.TestNewRuntimeContextWithCtx(context.Background(), cmd, nil)
+	err := DriveUpload.Validate(context.Background(), runtime)
+	if err == nil || !strings.Contains(err.Error(), "--folder-token cannot be empty") {
+		t.Fatalf("Validate() error = %v, want empty folder-token error", err)
+	}
+}
+
+func TestDriveUploadValidateRejectsInvalidTargetTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		flag    string
+		value   string
+		wantErr string
+	}{
+		{
+			name:    "folder token",
+			flag:    "folder-token",
+			value:   "fld_bad?query=true",
+			wantErr: "--folder-token contains invalid characters",
+		},
+		{
+			name:    "wiki token",
+			flag:    "wiki-token",
+			value:   "wikcn_bad#fragment",
+			wantErr: "--wiki-token contains invalid characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := &cobra.Command{Use: "drive +upload"}
+			cmd.Flags().String("file", "", "")
+			cmd.Flags().String("folder-token", "", "")
+			cmd.Flags().String("wiki-token", "", "")
+			cmd.Flags().String("name", "", "")
+			if err := cmd.Flags().Set("file", "report.pdf"); err != nil {
+				t.Fatalf("set --file: %v", err)
+			}
+			if err := cmd.Flags().Set(tt.flag, tt.value); err != nil {
+				t.Fatalf("set --%s: %v", tt.flag, err)
+			}
+
+			runtime := common.TestNewRuntimeContextWithCtx(context.Background(), cmd, nil)
+			err := DriveUpload.Validate(context.Background(), runtime)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestDriveDownloadRejectsOverwriteWithoutFlag(t *testing.T) {
 	f, _, _, _ := cmdutil.TestFactory(t, driveTestConfig())
 
@@ -615,4 +994,39 @@ func TestDriveDownloadAllowsOverwriteFlag(t *testing.T) {
 	if !strings.Contains(stdout.String(), "existing.bin") {
 		t.Fatalf("stdout missing saved path: %s", stdout.String())
 	}
+}
+
+type capturedDriveMultipart struct {
+	Fields map[string]string
+	Files  map[string][]byte
+}
+
+func decodeDriveMultipartBody(t *testing.T, stub *httpmock.Stub) capturedDriveMultipart {
+	t.Helper()
+
+	contentType := stub.CapturedHeaders.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		t.Fatalf("parse content-type %q: %v", contentType, err)
+	}
+	if mediaType != "multipart/form-data" {
+		t.Fatalf("content type = %q, want multipart/form-data", mediaType)
+	}
+
+	reader := multipart.NewReader(bytes.NewReader(stub.CapturedBody), params["boundary"])
+	body := capturedDriveMultipart{Fields: map[string]string{}, Files: map[string][]byte{}}
+	for {
+		part, err := reader.NextPart()
+		if err != nil {
+			break
+		}
+		buf := new(bytes.Buffer)
+		_, _ = buf.ReadFrom(part)
+		if part.FileName() != "" {
+			body.Files[part.FormName()] = buf.Bytes()
+			continue
+		}
+		body.Fields[part.FormName()] = buf.String()
+	}
+	return body
 }

--- a/shortcuts/drive/drive_upload.go
+++ b/shortcuts/drive/drive_upload.go
@@ -11,12 +11,74 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"strings"
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 
 	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
+
+const (
+	driveUploadParentTypeExplorer = "explorer"
+	driveUploadParentTypeWiki     = "wiki"
+)
+
+type driveUploadSpec struct {
+	FilePath    string
+	FolderToken string
+	WikiToken   string
+	Name        string
+}
+
+type driveUploadTarget struct {
+	ParentType string
+	ParentNode string
+}
+
+func newDriveUploadSpec(runtime *common.RuntimeContext) driveUploadSpec {
+	return driveUploadSpec{
+		FilePath:    runtime.Str("file"),
+		FolderToken: strings.TrimSpace(runtime.Str("folder-token")),
+		WikiToken:   strings.TrimSpace(runtime.Str("wiki-token")),
+		Name:        runtime.Str("name"),
+	}
+}
+
+func (s driveUploadSpec) FileName() string {
+	if s.Name != "" {
+		return s.Name
+	}
+	return filepath.Base(s.FilePath)
+}
+
+func (s driveUploadSpec) Target() driveUploadTarget {
+	if s.WikiToken != "" {
+		return driveUploadTarget{
+			ParentType: driveUploadParentTypeWiki,
+			ParentNode: s.WikiToken,
+		}
+	}
+	return driveUploadTarget{
+		ParentType: driveUploadParentTypeExplorer,
+		ParentNode: s.FolderToken,
+	}
+}
+
+func (t driveUploadTarget) Label() string {
+	switch t.ParentType {
+	case driveUploadParentTypeWiki:
+		return "wiki node " + common.MaskToken(t.ParentNode)
+	case driveUploadParentTypeExplorer:
+		if t.ParentNode == "" {
+			return "Drive root folder"
+		}
+		return "folder " + common.MaskToken(t.ParentNode)
+	default:
+		return "target " + common.MaskToken(t.ParentNode)
+	}
+}
 
 var DriveUpload = common.Shortcut{
 	Service:     "drive",
@@ -27,25 +89,28 @@ var DriveUpload = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "file", Desc: "local file path (files > 20MB use multipart upload automatically)", Required: true},
-		{Name: "folder-token", Desc: "target folder token (default: root)"},
+		{Name: "folder-token", Desc: "target folder token (default: root folder; mutually exclusive with --wiki-token)"},
+		{Name: "wiki-token", Desc: "target wiki node token (uploads under that wiki node; mutually exclusive with --folder-token)"},
 		{Name: "name", Desc: "uploaded file name (default: local file name)"},
 	},
+	Tips: []string{
+		"Omit both --folder-token and --wiki-token to upload into the caller's Drive root folder.",
+		"Use --wiki-token <wiki_node_token> to upload under a wiki node; the shortcut maps this to parent_type=wiki automatically.",
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		return validateDriveUploadSpec(runtime, newDriveUploadSpec(runtime))
+	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
-		filePath := runtime.Str("file")
-		folderToken := runtime.Str("folder-token")
-		name := runtime.Str("name")
-		fileName := name
-		if fileName == "" {
-			fileName = filepath.Base(filePath)
-		}
+		spec := newDriveUploadSpec(runtime)
+		target := spec.Target()
 		d := common.NewDryRunAPI().
 			Desc("multipart/form-data upload (files > 20MB use chunked 3-step upload)").
 			POST("/open-apis/drive/v1/files/upload_all").
 			Body(map[string]interface{}{
-				"file_name":   fileName,
-				"parent_type": "explorer",
-				"parent_node": folderToken,
-				"file":        "@" + filePath,
+				"file_name":   spec.FileName(),
+				"parent_type": target.ParentType,
+				"parent_node": target.ParentNode,
+				"file":        "@" + spec.FilePath,
 			})
 		if runtime.IsBot() {
 			d.Desc("After file upload succeeds in bot mode, the CLI will also try to grant the current CLI user full_access (可管理权限) on the new file.")
@@ -53,29 +118,24 @@ var DriveUpload = common.Shortcut{
 		return d
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		filePath := runtime.Str("file")
-		folderToken := runtime.Str("folder-token")
-		name := runtime.Str("name")
+		spec := newDriveUploadSpec(runtime)
+		fileName := spec.FileName()
+		target := spec.Target()
 
-		fileName := name
-		if fileName == "" {
-			fileName = filepath.Base(filePath)
-		}
-
-		info, err := runtime.FileIO().Stat(filePath)
+		info, err := runtime.FileIO().Stat(spec.FilePath)
 		if err != nil {
 			return common.WrapInputStatError(err)
 		}
 		fileSize := info.Size()
 
-		fmt.Fprintf(runtime.IO().ErrOut, "Uploading: %s (%s)\n", fileName, common.FormatSize(fileSize))
+		fmt.Fprintf(runtime.IO().ErrOut, "Uploading: %s (%s) -> %s\n", fileName, common.FormatSize(fileSize), target.Label())
 
 		var fileToken string
 		if fileSize > common.MaxDriveMediaUploadSinglePartSize {
 			fmt.Fprintf(runtime.IO().ErrOut, "File exceeds 20MB, using multipart upload\n")
-			fileToken, err = uploadFileMultipart(ctx, runtime, filePath, fileName, folderToken, fileSize)
+			fileToken, err = uploadFileMultipart(ctx, runtime, spec.FilePath, fileName, target, fileSize)
 		} else {
-			fileToken, err = uploadFileToDrive(ctx, runtime, filePath, fileName, folderToken, fileSize)
+			fileToken, err = uploadFileToDrive(ctx, runtime, spec.FilePath, fileName, target, fileSize)
 		}
 		if err != nil {
 			return err
@@ -95,7 +155,44 @@ var DriveUpload = common.Shortcut{
 	},
 }
 
-func uploadFileToDrive(ctx context.Context, runtime *common.RuntimeContext, filePath, fileName, folderToken string, fileSize int64) (string, error) {
+func validateDriveUploadSpec(runtime *common.RuntimeContext, spec driveUploadSpec) error {
+	if driveUploadFlagExplicitlyEmpty(runtime, "folder-token") {
+		return common.FlagErrorf("--folder-token cannot be empty; omit --folder-token to upload into Drive root folder or pass a folder token")
+	}
+	if driveUploadFlagExplicitlyEmpty(runtime, "wiki-token") {
+		return common.FlagErrorf("--wiki-token cannot be empty; omit --wiki-token to upload into Drive root folder or pass a wiki node token")
+	}
+
+	targets := 0
+	if spec.FolderToken != "" {
+		targets++
+	}
+	if spec.WikiToken != "" {
+		targets++
+	}
+	if targets > 1 {
+		return common.FlagErrorf("--folder-token and --wiki-token are mutually exclusive")
+	}
+	if spec.FolderToken != "" {
+		if err := validate.ResourceName(spec.FolderToken, "--folder-token"); err != nil {
+			return output.ErrValidation("%s", err)
+		}
+	}
+	if spec.WikiToken != "" {
+		if err := validate.ResourceName(spec.WikiToken, "--wiki-token"); err != nil {
+			return output.ErrValidation("%s", err)
+		}
+	}
+	return nil
+}
+
+func driveUploadFlagExplicitlyEmpty(runtime *common.RuntimeContext, flagName string) bool {
+	return runtime.Cmd != nil &&
+		runtime.Cmd.Flags().Changed(flagName) &&
+		strings.TrimSpace(runtime.Str(flagName)) == ""
+}
+
+func uploadFileToDrive(ctx context.Context, runtime *common.RuntimeContext, filePath, fileName string, target driveUploadTarget, fileSize int64) (string, error) {
 	f, err := runtime.FileIO().Open(filePath)
 	if err != nil {
 		return "", common.WrapInputStatError(err)
@@ -105,8 +202,8 @@ func uploadFileToDrive(ctx context.Context, runtime *common.RuntimeContext, file
 	// Build SDK Formdata
 	fd := larkcore.NewFormdata()
 	fd.AddField("file_name", fileName)
-	fd.AddField("parent_type", "explorer")
-	fd.AddField("parent_node", folderToken)
+	fd.AddField("parent_type", target.ParentType)
+	fd.AddField("parent_node", target.ParentNode)
 	fd.AddField("size", fmt.Sprintf("%d", fileSize))
 	fd.AddFile("file", f)
 
@@ -145,12 +242,12 @@ func uploadFileToDrive(ctx context.Context, runtime *common.RuntimeContext, file
 // 1. upload_prepare — get upload_id, block_size, block_num
 // 2. upload_part   — upload each block sequentially
 // 3. upload_finish — finalize and get file_token
-func uploadFileMultipart(_ context.Context, runtime *common.RuntimeContext, filePath, fileName, folderToken string, fileSize int64) (string, error) {
+func uploadFileMultipart(_ context.Context, runtime *common.RuntimeContext, filePath, fileName string, target driveUploadTarget, fileSize int64) (string, error) {
 	// Step 1: Prepare
 	prepareBody := map[string]interface{}{
 		"file_name":   fileName,
-		"parent_type": "explorer",
-		"parent_node": folderToken,
+		"parent_type": target.ParentType,
+		"parent_node": target.ParentNode,
 		"size":        fileSize,
 	}
 	prepareResult, err := runtime.CallAPI("POST", "/open-apis/drive/v1/files/upload_prepare", nil, prepareBody)

--- a/skills/lark-drive/SKILL.md
+++ b/skills/lark-drive/SKILL.md
@@ -20,6 +20,7 @@ metadata:
 - 用户要把本地 `.md` / `.docx` / `.doc` / `.txt` / `.html` 导入成在线文档，使用 `lark-cli drive +import --type docx`。
 - 用户要把本地 `.xlsx` / `.xls` / `.csv` 导入成电子表格，使用 `lark-cli drive +import --type sheet`。
 - 用户要在云空间里新建文件夹，优先使用 `lark-cli drive +create-folder`。
+- 用户要把本地文件上传到知识库 / 文档库里的某个 wiki 节点下时，仍然使用 `lark-cli drive +upload --wiki-token <wiki_token>`；不要误切到 `wiki` 域命令。
 - `lark-base` 只负责导入完成后的 Base 内部操作（表、字段、记录、视图），不要在“本地文件 -> Base”这一步提前切到 `lark-base`。
 
 ## 修改标题

--- a/skills/lark-drive/references/lark-drive-upload.md
+++ b/skills/lark-drive/references/lark-drive-upload.md
@@ -3,23 +3,22 @@
 
 > **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
 
-上传本地文件到飞书云空间。
+上传本地文件到飞书云空间。目标位置可以是 Drive 文件夹，也可以是 wiki 节点。
 
 ## 命令
 
 ```bash
-# 推荐：使用 shortcut 一步上传
+# 上传到 Drive 文件夹
 lark-cli drive +upload --file ./report.pdf --folder-token fldbc_xxx
+
+# 上传到 wiki 节点
+lark-cli drive +upload --file ./report.pdf --wiki-token wikcn_xxx
+
+# 不指定目标时，上传到调用者的 Drive 根目录
+lark-cli drive +upload --file ./report.pdf
 
 # 自定义上传后的文件名
 lark-cli drive +upload --file ./report.pdf --name "季度总结.pdf"
-
-# 生成可用临时下载链接的上传方式（素材上传，适用于后续用 curl 下载）
-# 注意：需要可写 docx 文档 ID（用于挂载素材 block），且文件最大 20MB
-lark-cli drive +upload --as-media --doc docx_xxx --file ./report.pdf
-
-# 取出 tmp_download_url 后可直接 curl 下载
-curl -L -o report.pdf "<TMP_DOWNLOAD_URL>"
 
 # 原生命令（高级/分片上传）：预上传 + 完成上传
 lark-cli drive files upload_prepare --data '{
@@ -49,13 +48,31 @@ lark-cli schema drive.files.upload_prepare
 >
 > **不要擅自执行 owner 转移。** 如果用户需要把 owner 转给自己，必须单独确认。
 
+## 目标位置选择（关键）
+
+- 上传到 Drive 文件夹：传 `--folder-token <folder_token>`，shortcut 会发送 `parent_type=explorer`
+- 上传到 wiki 节点：传 `--wiki-token <wiki_token>`，shortcut 会发送 `parent_type=wiki`
+- 上传到 Drive 根目录：`--folder-token` 和 `--wiki-token` 都不传
+- 不要传空目标值：`--folder-token ""` / `--wiki-token ""` 会被视为参数错误；如需上传到 Drive 根目录，应直接省略这两个参数
+- `--folder-token` 和 `--wiki-token` 互斥，不要同时传
+- `--wiki-token` 传的是 **wiki node token**，不是 `space_id`
+
+Shortcut 参数：
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--file` | 是 | 本地文件路径 |
+| `--folder-token` | 否 | 目标文件夹 token；与 `--wiki-token` 互斥；省略时默认为 Drive 根目录；显式传空字符串会报错 |
+| `--wiki-token` | 否 | 目标 wiki 节点 token；与 `--folder-token` 互斥；会映射为 `parent_type=wiki`、`parent_node=<wiki_token>`；显式传空字符串会报错 |
+| `--name` | 否 | 上传后的文件名；默认使用本地文件名 |
+
 参数（预上传 `--data` JSON body）：
 
 | 字段 | 必填 | 说明 |
 |------|------|------|
 | `file_name` | 是 | 文件名 |
-| `parent_type` | 是 | 父节点类型，如 `"explorer"` |
-| `parent_node` | 是 | 父节点 token（文件夹 token） |
+| `parent_type` | 是 | 父节点类型；上传到文件夹 / 根目录时用 `"explorer"`，上传到 wiki 节点时用 `"wiki"` |
+| `parent_node` | 是 | 父节点 token；`explorer` 时传文件夹 token（根目录可为空字符串），`wiki` 时传 wiki node token |
 | `size` | 是 | 文件大小（字节） |
 
 > [!CAUTION]

--- a/tests/cli_e2e/drive/coverage.md
+++ b/tests/cli_e2e/drive/coverage.md
@@ -1,15 +1,16 @@
 # Drive CLI E2E Coverage
 
 ## Metrics
-- Denominator: 29 leaf commands
-- Covered: 2
-- Coverage: 6.9%
+- Denominator: 28 leaf commands
+- Covered: 1
+- Coverage: 3.6%
 
 ## Summary
 - TestDrive_FilesCreateFolderWorkflow: proves `drive files create_folder` in `create_folder as bot`; helper asserts the returned folder token and registers best-effort cleanup via `drive files delete`.
 - TestDrive_ApplyPermissionDryRun / TestDrive_ApplyPermissionDryRunRejectsFullAccess: dry-run coverage for `drive +apply-permission`; asserts URL→type inference for docx/sheet/slides, explicit `--type` overriding URL inference when both a recognized URL and `--type` are supplied, bare-token + explicit `--type` path, request method/URL/type-query/perm/remark body shape, optional `remark` omission when unset, and client-side rejection of `--perm full_access`. Runs without hitting the live API.
 - Cleanup note: `drive files delete` is only exercised in cleanup and is intentionally left uncovered.
-- Blocked area: upload, export, comment, subscription, and reply flows still need deterministic remote fixtures and filesystem setup. Permission flows are partially covered via the dry-run test for `+apply-permission`; the full permission.members.* API surface remains uncovered.
+- Blocked area: live upload, export, comment, permission, subscription, and reply flows still need deterministic remote fixtures and filesystem setup.
+- Dry-run note: `drive_upload_dryrun_test.go::TestDriveUploadDryRun_WikiTarget` covers the wiki-target request shape for `drive +upload`, but there is still no live upload workflow coverage.
 
 ## Command Table
 
@@ -24,7 +25,7 @@
 | ✕ | drive +import | shortcut |  | none | no import workflow yet |
 | ✕ | drive +move | shortcut |  | none | no move workflow yet |
 | ✕ | drive +task_result | shortcut |  | none | no async task-result workflow yet |
-| ✕ | drive +upload | shortcut |  | none | no upload workflow yet |
+| ✕ | drive +upload | shortcut | drive_upload_dryrun_test.go::TestDriveUploadDryRun_WikiTarget (dry-run only) | `--wiki-token`; `parent_type=wiki`; `parent_node` | no live upload workflow yet |
 | ✕ | drive file.comment.replys create | api |  | none | no reply workflow yet |
 | ✕ | drive file.comment.replys delete | api |  | none | no reply workflow yet |
 | ✕ | drive file.comment.replys list | api |  | none | no reply workflow yet |

--- a/tests/cli_e2e/drive/drive_upload_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_upload_dryrun_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDriveUploadDryRun_WikiTarget(t *testing.T) {
+	setDriveDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+upload",
+			"--file", "./report.pdf",
+			"--wiki-token", "wikcnDryRunUploadTarget",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	output := strings.TrimSpace(result.Stdout)
+	assert.Contains(t, output, "/open-apis/drive/v1/files/upload_all")
+	assert.Contains(t, output, "parent_type")
+	assert.Contains(t, output, "parent_node")
+	assert.Contains(t, output, "wikcnDryRunUploadTarget")
+	assert.Contains(t, output, `"parent_type": "wiki"`)
+}
+
+func TestDriveUploadDryRunRejectsEmptyWikiToken(t *testing.T) {
+	setDriveDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+upload",
+			"--file", "./report.pdf",
+			"--wiki-token", "",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	assert.Contains(t, result.Stderr, "--wiki-token cannot be empty")
+}
+
+func setDriveDryRunConfigEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "drive_dryrun_test")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "drive_dryrun_secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+}


### PR DESCRIPTION
 ## Summary

  Add wiki-target upload support to drive +upload by introducing --wiki-token and mapping uploads to parent_type=wiki / parent_node=<wiki_token>. This keeps existing folder/root behavior unchanged while making wiki uploads available through the same shortcut.

  ## Changes

  - Add --wiki-token to drive +upload, make it mutually exclusive with --folder-token, and route both single-part and multipart upload flows through a shared target resolver.
  - Update the lark-drive upload guidance to document folder/root/wiki targets and the parent_type=wiki behavior.
  - Add unit coverage for wiki upload request shapes and a dry-run E2E test for drive +upload --wiki-token.

  ## Test Plan

  - [x] Unit tests pass
  - [ ] Manual local verification confirms the lark xxx command works as expected
  - go test ./shortcuts/drive
  - go test ./tests/cli_e2e/drive -run 'TestDriveUploadDryRun_WikiTarget'
  - gofmt -l shortcuts/drive/drive_upload.go shortcuts/drive/drive_io_test.go tests/cli_e2e/drive/drive_upload_dryrun_test.go

  ## Related Issues

  - None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --wiki-token to target uploads to wiki nodes; omitting tokens uploads to Drive root.

* **Improvements**
  * Enforces mutual exclusivity of --folder-token/--wiki-token, rejects empty/whitespace tokens, and trims folder/wiki tokens.
  * Dry-run shows resolved destination fields (parent_type/parent_node) and progress displays the resolved destination label.

* **Tests**
  * Added dry-run and e2e tests, plus multipart decoding helpers to validate wiki-target behavior.

* **Documentation**
  * Updated upload docs and examples to cover folder vs. wiki targeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->