### PR TITLE
fix: align drive add-comment text validation with OpenAPI limit

### DIFF
--- a/shortcuts/drive/drive_add_comment.go
+++ b/shortcuts/drive/drive_add_comment.go
@@ -16,7 +16,10 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
-const defaultLocateDocLimit = 10
+const (
+	defaultLocateDocLimit   = 10
+	maxCommentTextRuneCount = 10000
+)
 
 type commentDocRef struct {
 	Kind  string
@@ -551,6 +554,7 @@ func parseCommentReplyElements(raw string) ([]map[string]interface{}, error) {
 	}
 
 	replyElements := make([]map[string]interface{}, 0, len(inputs))
+	textRuneCount := 0
 	for i, input := range inputs {
 		index := i + 1
 		elementType := strings.TrimSpace(input.Type)
@@ -559,8 +563,12 @@ func parseCommentReplyElements(raw string) ([]map[string]interface{}, error) {
 			if strings.TrimSpace(input.Text) == "" {
 				return nil, output.ErrValidation("--content element #%d type=text requires non-empty text", index)
 			}
-			if utf8.RuneCountInString(input.Text) > 1000 {
-				return nil, output.ErrValidation("--content element #%d text exceeds 1000 characters", index)
+			// The OpenAPI enforces a 10000-rune limit on the rendered comment
+			// content. CLI can safely pre-check the caller-provided text runs,
+			// while mention/link expansion still remains server-side.
+			textRuneCount += utf8.RuneCountInString(input.Text)
+			if textRuneCount > maxCommentTextRuneCount {
+				return nil, output.ErrValidation("--content text across all text elements exceeds %d characters", maxCommentTextRuneCount)
 			}
 			replyElements = append(replyElements, map[string]interface{}{
 				"type": "text",

--- a/shortcuts/drive/drive_add_comment_test.go
+++ b/shortcuts/drive/drive_add_comment_test.go
@@ -223,8 +223,32 @@ func TestParseCommentReplyElements(t *testing.T) {
 	}
 }
 
+func TestParseCommentReplyElementsAllowsTextTotalAtOpenAPILimit(t *testing.T) {
+	t.Parallel()
+
+	first := strings.Repeat("a", 6000)
+	second := strings.Repeat("b", 4000)
+
+	got, err := parseCommentReplyElements(`[{"type":"text","text":"` + first + `"},{"type":"text","text":"` + second + `"}]`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 reply elements, got %d", len(got))
+	}
+	if got[0]["text"] != first {
+		t.Fatalf("unexpected first text reply element length: got %d, want %d", len(got[0]["text"].(string)), len(first))
+	}
+	if got[1]["text"] != second {
+		t.Fatalf("unexpected second text reply element length: got %d, want %d", len(got[1]["text"].(string)), len(second))
+	}
+}
+
 func TestParseCommentReplyElementsInvalid(t *testing.T) {
 	t.Parallel()
+
+	tooLongFirst := strings.Repeat("a", 6000)
+	tooLongSecond := strings.Repeat("b", 4001)
 
 	tests := []struct {
 		name    string
@@ -250,6 +274,11 @@ func TestParseCommentReplyElementsInvalid(t *testing.T) {
 			name:    "mention missing value",
 			input:   `[{"type":"mention_user","text":""}]`,
 			wantErr: "requires text or mention_user",
+		},
+		{
+			name:    "text total exceeds open api limit",
+			input:   `[{"type":"text","text":"` + tooLongFirst + `"},{"type":"text","text":"` + tooLongSecond + `"}]`,
+			wantErr: "text across all text elements exceeds 10000 characters",
 		},
 	}
 


### PR DESCRIPTION
 ## Summary
  This change aligns `drive +add-comment` validation with the underlying OpenAPI behavior. The CLI previously rejected any single `text` reply element longer than 1000 characters, which was stricter than the backend and blocked valid requests.

  ## Changes
  - Replace the per-element 1000-character `text` limit in `drive +add-comment` with a 10000-character aggregate limit across all caller-provided `text` elements.
  - Keep the validation conservative on the CLI side and leave mention/link expansion length checks to the backend.

  ## Test Plan
  - [x] Targeted unit tests pass: `go test ./shortcuts/drive -run 'TestParseCommentReplyElements'`
  - [x] Local build passes: `make build`
  - [ ] Full `make unit-test`
  - [ ] Manual local verification confirms the `lark xxx` command works as expected

  ## Related Issues
  - None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated comment text validation to enforce a combined 10,000 character limit across all text elements instead of individual limits, with clearer error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->