### PR TITLE
feat(event): add event subscription & consume system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,3 @@ cmd/api/download.bin
 app.log
 /sidecar-server-demo
 /server-demo
-span.log
-
-# Dev/test sandbox accidentally created when HOME is overridden
-.home/

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ cmd/api/download.bin
 app.log
 /sidecar-server-demo
 /server-demo
+span.log
+
+# Dev/test sandbox accidentally created when HOME is overridden
+.home/

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -12,10 +12,12 @@ import (
 	"github.com/larksuite/cli/cmd/completion"
 	cmdconfig "github.com/larksuite/cli/cmd/config"
 	"github.com/larksuite/cli/cmd/doctor"
+	cmdevent "github.com/larksuite/cli/cmd/event"
 	"github.com/larksuite/cli/cmd/profile"
 	"github.com/larksuite/cli/cmd/schema"
 	"github.com/larksuite/cli/cmd/service"
 	cmdupdate "github.com/larksuite/cli/cmd/update"
+	_ "github.com/larksuite/cli/events"
 	"github.com/larksuite/cli/internal/build"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/keychain"
@@ -117,6 +119,7 @@ func buildInternal(ctx context.Context, inv cmdutil.InvocationContext, opts ...B
 	rootCmd.AddCommand(schema.NewCmdSchema(f, nil))
 	rootCmd.AddCommand(completion.NewCmdCompletion(f))
 	rootCmd.AddCommand(cmdupdate.NewCmdUpdate(f))
+	rootCmd.AddCommand(cmdevent.NewCmdEvents(f))
 	service.RegisterServiceCommandsWithContext(ctx, rootCmd, f)
 	shortcuts.RegisterShortcutsWithContext(ctx, rootCmd, f)
 

--- a/cmd/event/appmeta_err.go
+++ b/cmd/event/appmeta_err.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// authURLPattern matches the "grant-scope" URL the Feishu open platform
+// embeds in 99991672-family permission errors. Host allowlist keeps us from
+// matching unrelated open.feishu.cn documentation links that happen to
+// carry a ?q= query.
+var authURLPattern = regexp.MustCompile(`https?://open\.(?:feishu\.cn|feishu\.net|larksuite\.com|larkoffice\.com)/app/[^/\s"']+/auth\?q=[^\s"'<>]+`)
+
+// describeAppMetaErr reduces an appmeta.FetchCurrentPublished error to a one-
+// line stderr-friendly summary. The app_versions OAPI dumps a multi-hundred-
+// character JSON body (full msg + troubleshooter + log_id + permission_
+// violations) when the bot lacks application-info scopes — useless for
+// humans and noisy for AI agents parsing stderr.
+//
+// Strategy:
+//   - If the error contains a /auth?q=... grant URL (the 99991672 shape),
+//     emit a short "needs scope X; grant at URL" line.
+//   - Otherwise truncate to keep stderr single-screen.
+func describeAppMetaErr(err error) string {
+	msg := err.Error()
+	if url := authURLPattern.FindString(msg); url != "" {
+		return fmt.Sprintf("bot is missing scopes needed for app-version metadata; grant at: %s", url)
+	}
+	const maxErrLen = 200
+	if len(msg) > maxErrLen {
+		return msg[:maxErrLen] + "…"
+	}
+	return msg
+}

--- a/cmd/event/appmeta_err_test.go
+++ b/cmd/event/appmeta_err_test.go
@@ -12,7 +12,7 @@ import (
 // realisticPermError mirrors the error shape seen when the app lacks the
 // application:application.app_version:readonly scope — HTTP 400 + OAPI
 // business code 99991672 + a grant URL buried in the msg field.
-const realisticPermError = `API GET /open-apis/application/v6/applications/cli_a96bbe46d5a15bc3/app_versions?lang=zh_cn&page_size=2 returned 400: {"code":99991672,"msg":"Access denied. One of the following scopes is required: [application:application:self_manage, application:application.app_version:readonly].应用尚未开通所需的应用身份权限：[application:application:self_manage, application:application.app_version:readonly]，点击链接申请并开通任一权限即可：https://open.feishu.cn/app/cli_a96bbe46d5a15bc3/auth?q=application:application:self_manage,application:application.app_version:readonly&op_from=openapi&token_type=tenant","error":{"message":"Refer to the documentation...","log_id":"20260421101203E2A5F141245B6F43B3A6"}}`
+const realisticPermError = `API GET /open-apis/application/v6/applications/cli_XXXXXXXXXXXXXXXX/app_versions?lang=zh_cn&page_size=2 returned 400: {"code":99991672,"msg":"Access denied. One of the following scopes is required: [application:application:self_manage, application:application.app_version:readonly].应用尚未开通所需的应用身份权限：[application:application:self_manage, application:application.app_version:readonly]，点击链接申请并开通任一权限即可：https://open.feishu.cn/app/cli_XXXXXXXXXXXXXXXX/auth?q=application:application:self_manage,application:application.app_version:readonly&op_from=openapi&token_type=tenant","error":{"message":"Refer to the documentation...","log_id":"20260421101203E2A5F141245B6F43B3A6"}}`
 
 func TestDescribeAppMetaErr_PermissionDeniedShort(t *testing.T) {
 	got := describeAppMetaErr(errors.New(realisticPermError))
@@ -27,7 +27,7 @@ func TestDescribeAppMetaErr_PermissionDeniedShort(t *testing.T) {
 	}
 	// Must preserve the actionable grant URL — that's the whole point of the
 	// long OAPI message, everything else is noise.
-	wantURL := "https://open.feishu.cn/app/cli_a96bbe46d5a15bc3/auth?q=application:application:self_manage,application:application.app_version:readonly&op_from=openapi&token_type=tenant"
+	wantURL := "https://open.feishu.cn/app/cli_XXXXXXXXXXXXXXXX/auth?q=application:application:self_manage,application:application.app_version:readonly&op_from=openapi&token_type=tenant"
 	if !strings.Contains(got, wantURL) {
 		t.Errorf("summary missing grant URL\ngot:  %q\nwant: %q", got, wantURL)
 	}

--- a/cmd/event/appmeta_err_test.go
+++ b/cmd/event/appmeta_err_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// realisticPermError mirrors the error shape seen when the app lacks the
+// application:application.app_version:readonly scope — HTTP 400 + OAPI
+// business code 99991672 + a grant URL buried in the msg field.
+const realisticPermError = `API GET /open-apis/application/v6/applications/cli_a96bbe46d5a15bc3/app_versions?lang=zh_cn&page_size=2 returned 400: {"code":99991672,"msg":"Access denied. One of the following scopes is required: [application:application:self_manage, application:application.app_version:readonly].应用尚未开通所需的应用身份权限：[application:application:self_manage, application:application.app_version:readonly]，点击链接申请并开通任一权限即可：https://open.feishu.cn/app/cli_a96bbe46d5a15bc3/auth?q=application:application:self_manage,application:application.app_version:readonly&op_from=openapi&token_type=tenant","error":{"message":"Refer to the documentation...","log_id":"20260421101203E2A5F141245B6F43B3A6"}}`
+
+func TestDescribeAppMetaErr_PermissionDeniedShort(t *testing.T) {
+	got := describeAppMetaErr(errors.New(realisticPermError))
+	// Must be short enough to read at a glance.
+	if len(got) > 400 {
+		t.Errorf("summary too long (%d chars): %q", len(got), got)
+	}
+	// Must name *why* we skipped (so reader knows this is optional preflight,
+	// not a hard failure).
+	if !strings.Contains(got, "scope") {
+		t.Errorf("summary should mention scope requirement, got: %q", got)
+	}
+	// Must preserve the actionable grant URL — that's the whole point of the
+	// long OAPI message, everything else is noise.
+	wantURL := "https://open.feishu.cn/app/cli_a96bbe46d5a15bc3/auth?q=application:application:self_manage,application:application.app_version:readonly&op_from=openapi&token_type=tenant"
+	if !strings.Contains(got, wantURL) {
+		t.Errorf("summary missing grant URL\ngot:  %q\nwant: %q", got, wantURL)
+	}
+	// Must NOT echo the full JSON envelope (log_id, troubleshooter, etc).
+	for _, noise := range []string{"log_id", `"error":`, "Refer to the documentation"} {
+		if strings.Contains(got, noise) {
+			t.Errorf("summary leaked noise %q: %q", noise, got)
+		}
+	}
+}
+
+func TestDescribeAppMetaErr_UnknownErrorTruncated(t *testing.T) {
+	long := strings.Repeat("x", 500)
+	got := describeAppMetaErr(errors.New(long))
+	if len(got) > 220 { // 200 + ellipsis + small slack
+		t.Errorf("unknown error not truncated, len=%d", len(got))
+	}
+}
+
+func TestDescribeAppMetaErr_ShortErrorPassesThrough(t *testing.T) {
+	got := describeAppMetaErr(errors.New("network unreachable"))
+	if got != "network unreachable" {
+		t.Errorf("short err should pass through unchanged, got: %q", got)
+	}
+}
+
+func TestDescribeAppMetaErr_LarkOfficeDomain(t *testing.T) {
+	// The lark brand uses open.larksuite.com; make sure we match that too so
+	// international users get the same short summary.
+	msg := `... grant link: https://open.larksuite.com/app/cli_xyz/auth?q=application:application:self_manage&op_from=openapi&token_type=tenant ...`
+	got := describeAppMetaErr(errors.New(msg))
+	if !strings.Contains(got, "open.larksuite.com") {
+		t.Errorf("want larksuite URL extracted, got: %q", got)
+	}
+}

--- a/cmd/event/bus.go
+++ b/cmd/event/bus.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/event/bus"
+	"github.com/larksuite/cli/internal/event/transport"
+)
+
+// NewCmdBus creates the hidden `event _bus` daemon subcommand. Forked
+// by the consume client; not meant to be called directly. The fork
+// command line is built in internal/event/consume/startup.go — keep the
+// two in sync when changing the command path.
+func NewCmdBus(f *cmdutil.Factory) *cobra.Command {
+	var domain string
+
+	cmd := &cobra.Command{
+		Use:    "_bus",
+		Short:  "Internal event bus daemon (do not call directly)",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+
+			eventsDir := filepath.Join(core.GetConfigDir(), "events", cfg.AppID)
+
+			logger, err := bus.SetupBusLogger(eventsDir)
+			if err != nil {
+				return err
+			}
+
+			tr := transport.New()
+			b := bus.NewBus(cfg.AppID, cfg.AppSecret, domain, tr, logger)
+
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+			defer signal.Stop(sigCh)
+			go func() {
+				select {
+				case <-sigCh:
+					cancel()
+				case <-ctx.Done():
+				}
+			}()
+
+			return b.Run(ctx)
+		},
+	}
+
+	cmd.Flags().StringVar(&domain, "domain", "", "API domain")
+	_ = cmd.Flags().MarkHidden("domain")
+
+	return cmd
+}

--- a/cmd/event/bus.go
+++ b/cmd/event/bus.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/event"
 	"github.com/larksuite/cli/internal/event/bus"
 	"github.com/larksuite/cli/internal/event/transport"
 )
@@ -35,7 +36,11 @@ func NewCmdBus(f *cmdutil.Factory) *cobra.Command {
 				return err
 			}
 
-			eventsDir := filepath.Join(core.GetConfigDir(), "events", cfg.AppID)
+			// Sanitize AppID before joining into the filesystem path —
+			// a corrupted/hostile AppID could otherwise escape events/
+			// via ".." or separators and place bus.log anywhere under
+			// the config dir. See event.SanitizeAppID.
+			eventsDir := filepath.Join(core.GetConfigDir(), "events", event.SanitizeAppID(cfg.AppID))
 
 			logger, err := bus.SetupBusLogger(eventsDir)
 			if err != nil {

--- a/cmd/event/console_url.go
+++ b/cmd/event/console_url.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/larksuite/cli/internal/core"
+)
+
+// consoleScopeGrantURL builds the Feishu/Lark developer-console deep link
+// that opens the "apply & grant scopes" dialog for an app. It mirrors the
+// URL the OAPI embeds in 99991672-family errors so a CLI-side hint reads
+// the same as a server-side one to the user.
+//
+// Shape (verified against a real 99991672 response):
+//
+//	https://open.feishu.cn/app/:app_id/auth?q=<scope1>,<scope2>&op_from=openapi&token_type=tenant
+//
+// Scopes are comma-joined without URL-encoding — Feishu's console serves
+// this shape and encoded commas/colons render as the noisy "%2C" / "%3A"
+// without any behavior benefit.
+func consoleScopeGrantURL(brand core.LarkBrand, appID string, scopes []string) string {
+	host := core.ResolveEndpoints(brand).Open
+	return fmt.Sprintf("%s/app/%s/auth?q=%s&op_from=openapi&token_type=tenant",
+		host, appID, strings.Join(scopes, ","))
+}
+
+// consoleEventSubscriptionURL points at the app's event subscription page
+// in the developer console. Unlike the scope grant URL this one doesn't
+// encode the missing items — there is no "apply for event" dialog, the
+// developer has to tick the checkboxes on the page. Path verified against
+// the live console (2026-04-21).
+func consoleEventSubscriptionURL(brand core.LarkBrand, appID string) string {
+	host := core.ResolveEndpoints(brand).Open
+	return fmt.Sprintf("%s/app/%s/event", host, appID)
+}

--- a/cmd/event/console_url_test.go
+++ b/cmd/event/console_url_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/internal/core"
+)
+
+func TestConsoleScopeGrantURL_Feishu(t *testing.T) {
+	got := consoleScopeGrantURL(core.BrandFeishu, "cli_a96bbe46d5a15bc3", []string{
+		"im:message:readonly",
+		"im:message.group_at_msg",
+	})
+	want := "https://open.feishu.cn/app/cli_a96bbe46d5a15bc3/auth?q=im:message:readonly,im:message.group_at_msg&op_from=openapi&token_type=tenant"
+	if got != want {
+		t.Errorf("url\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestConsoleScopeGrantURL_LarkBrand(t *testing.T) {
+	got := consoleScopeGrantURL(core.BrandLark, "cli_x", []string{"im:message"})
+	want := "https://open.larksuite.com/app/cli_x/auth?q=im:message&op_from=openapi&token_type=tenant"
+	if got != want {
+		t.Errorf("url\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestConsoleScopeGrantURL_EmptyBrandDefaultsFeishu(t *testing.T) {
+	got := consoleScopeGrantURL("", "cli_x", []string{"im:message"})
+	if got != "https://open.feishu.cn/app/cli_x/auth?q=im:message&op_from=openapi&token_type=tenant" {
+		t.Errorf("unexpected url: %s", got)
+	}
+}

--- a/cmd/event/console_url_test.go
+++ b/cmd/event/console_url_test.go
@@ -10,11 +10,11 @@ import (
 )
 
 func TestConsoleScopeGrantURL_Feishu(t *testing.T) {
-	got := consoleScopeGrantURL(core.BrandFeishu, "cli_a96bbe46d5a15bc3", []string{
+	got := consoleScopeGrantURL(core.BrandFeishu, "cli_XXXXXXXXXXXXXXXX", []string{
 		"im:message:readonly",
 		"im:message.group_at_msg",
 	})
-	want := "https://open.feishu.cn/app/cli_a96bbe46d5a15bc3/auth?q=im:message:readonly,im:message.group_at_msg&op_from=openapi&token_type=tenant"
+	want := "https://open.feishu.cn/app/cli_XXXXXXXXXXXXXXXX/auth?q=im:message:readonly,im:message.group_at_msg&op_from=openapi&token_type=tenant"
 	if got != want {
 		t.Errorf("url\n got: %s\nwant: %s", got, want)
 	}

--- a/cmd/event/consume.go
+++ b/cmd/event/consume.go
@@ -192,16 +192,16 @@ func runConsume(cmd *cobra.Command, f *cmdutil.Factory, eventKey string, o consu
 		}
 	}()
 
+	errOut := f.IOStreams.ErrOut
+	if o.quiet {
+		errOut = io.Discard
+	}
+
 	// Non-TTY: a closed stdin is a valid shutdown signal for subprocess
 	// callers. In TTY the stdin is the terminal, so we must not treat
 	// Ctrl-D as shutdown.
 	if !f.IOStreams.IsTerminal {
-		watchStdinEOF(os.Stdin, cancel)
-	}
-
-	errOut := f.IOStreams.ErrOut
-	if o.quiet {
-		errOut = io.Discard
+		watchStdinEOF(os.Stdin, cancel, errOut)
 	}
 
 	if err := consume.Run(ctx, transport.New(), cfg.AppID, cfg.ProfileName, domain, consume.Options{
@@ -424,12 +424,26 @@ func parseParams(raw []string) (map[string]string, error) {
 }
 
 // watchStdinEOF launches a goroutine that drains r until EOF or any error,
-// then invokes cancel. Used to wire stdin-close → exit in non-TTY mode so
-// AI subprocess callers can signal shutdown by closing the stdin pipe.
+// writes a diagnostic line to errOut, then invokes cancel. Used to wire
+// stdin-close → exit in non-TTY mode so AI subprocess callers can signal
+// shutdown by closing the stdin pipe.
+//
+// The diagnostic is important: classic daemonisation (`< /dev/null`, `nohup`,
+// systemd's default `StandardInput=null`) delivers EOF on the first read,
+// which makes consume exit immediately — users who expected a long-running
+// daemon see "doesn't start" with no obvious cause. The stderr line names
+// the cause and points at the workarounds. Pass io.Discard for errOut to
+// suppress the line (e.g. under --quiet).
+//
 // Never called in TTY mode (would turn accidental Ctrl-D into shutdown).
-func watchStdinEOF(r io.Reader, cancel context.CancelFunc) {
+func watchStdinEOF(r io.Reader, cancel context.CancelFunc, errOut io.Writer) {
 	go func() {
 		_, _ = io.Copy(io.Discard, r)
+		fmt.Fprintln(errOut, "[event] stdin closed — shutting down. "+
+			"consume treats stdin EOF as exit signal (wired for AI subprocess callers). "+
+			"To keep running: pass --max-events/--timeout for bounded run, "+
+			"or keep stdin open (e.g. `< /dev/tty` interactive, `< <(tail -f /dev/null)` script), "+
+			"or stop via SIGTERM instead of closing stdin.")
 		cancel()
 	}()
 }

--- a/cmd/event/consume.go
+++ b/cmd/event/consume.go
@@ -1,0 +1,435 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/appmeta"
+	"github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/credential"
+	eventlib "github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/consume"
+	"github.com/larksuite/cli/internal/event/transport"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/validate"
+)
+
+// consumeCmdOpts bundles the flag-backed inputs for `event consume`.
+// Kept as a struct so runConsume's signature stays short and new flags
+// don't balloon its parameter list.
+type consumeCmdOpts struct {
+	params    []string
+	jqExpr    string
+	quiet     bool
+	outputDir string
+
+	maxEvents int
+	timeout   time.Duration
+}
+
+func NewCmdConsume(f *cmdutil.Factory) *cobra.Command {
+	var o consumeCmdOpts
+
+	cmd := &cobra.Command{
+		Use:   "consume <EventKey>",
+		Short: "Start consuming events for an EventKey",
+		Long: `Start consuming real-time events for the given EventKey.
+
+The consume command connects to the event bus daemon (starting it if needed),
+subscribes to the specified EventKey, and streams processed events to stdout.
+
+Output is one JSON object per line (NDJSON). Pipe through 'jq .' if you need
+pretty-printed formatting.
+
+Use 'event list' to see all available EventKeys.
+Use 'event schema <EventKey>' for parameter details.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConsume(cmd, f, args[0], o)
+		},
+	}
+
+	cmd.Flags().StringArrayVarP(&o.params, "param", "p", nil, "Key=value parameter (repeatable)")
+	cmd.Flags().StringVar(&o.jqExpr, "jq", "", "JQ expression to filter output")
+	cmd.Flags().BoolVar(&o.quiet, "quiet", false, "Suppress informational messages on stderr")
+	cmd.Flags().StringVar(&o.outputDir, "output-dir", "", "Write each event as a file in this directory")
+	cmd.Flags().IntVar(&o.maxEvents, "max-events", 0, "Exit after N successful emits (0 = unlimited). Multi-worker EventKeys may emit up to workers-1 past N before all workers stop.")
+	cmd.Flags().DurationVar(&o.timeout, "timeout", 0, "Exit after DURATION (e.g. 30s, 2m). 0 = no timeout. Timeout is a normal exit (code 0; stderr 'reason: timeout').")
+	cmd.Flags().String("as", "auto", "identity type: user | bot | auto (must match EventKey's declared AuthTypes)")
+	_ = cmd.RegisterFlagCompletionFunc("as", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"user", "bot", "auto"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	return cmd
+}
+
+func runConsume(cmd *cobra.Command, f *cmdutil.Factory, eventKey string, o consumeCmdOpts) error {
+	cfg, err := f.Config()
+	if err != nil {
+		return err
+	}
+
+	paramMap, err := parseParams(o.params)
+	if err != nil {
+		return err
+	}
+
+	keyDef, ok := eventlib.Lookup(eventKey)
+	if !ok {
+		return unknownEventKeyErr(eventKey)
+	}
+
+	identity, err := resolveIdentity(cmd, f, keyDef)
+	if err != nil {
+		return err
+	}
+
+	if o.jqExpr != "" {
+		if err := output.ValidateJqExpression(o.jqExpr); err != nil {
+			return err
+		}
+	}
+
+	outputDir := o.outputDir
+	if outputDir != "" {
+		safePath, err := sanitizeOutputDir(outputDir)
+		if err != nil {
+			return err
+		}
+		outputDir = safePath
+	}
+
+	domain := core.ResolveEndpoints(cfg.Brand).Open
+
+	// Verify a tenant access token can be obtained up front. The forked bus
+	// daemon will resolve its own TAT from profile+keychain; we throw this
+	// one away. Failing here surfaces auth errors before we fork and crash.
+	if _, err := resolveTenantToken(cmd.Context(), f, cfg.AppID); err != nil {
+		return err
+	}
+
+	apiClient, err := f.NewAPIClient()
+	if err != nil {
+		// Pass the inner error through verbatim: f.NewAPIClient can return
+		// *core.ConfigError (Code=2 + actionable Hint "run lark-cli config
+		// init…") or auth-related errors — wrapping would force ExitInternal
+		// and strip the hint, turning "not configured" into "internal error".
+		return err
+	}
+	runtime := &consumeRuntime{client: apiClient, accessIdentity: identity}
+	// botRuntime pins identity=AsBot regardless of --as so preflight probes
+	// (app_versions, event/v1/connection) always use TAT. /app_versions
+	// rejects UAT with 99991668, and /connection is an app-level query.
+	botRuntime := &consumeRuntime{client: apiClient, accessIdentity: core.AsBot}
+
+	// Weak-dependency fetch of the app's current published version. Failures
+	// (210508 insufficient permission, network errors, never-published apps)
+	// leave appVer == nil and we downgrade preflight checks to a no-op with a
+	// stderr breadcrumb. Blocking startup here would be worse than letting a
+	// misconfigured subscription surface later — the OAPI access requirement
+	// is a soft one.
+	preflightErrOut := f.IOStreams.ErrOut
+	if o.quiet {
+		preflightErrOut = io.Discard
+	}
+	appVer, appVerErr := appmeta.FetchCurrentPublished(cmd.Context(), botRuntime, cfg.AppID)
+	switch {
+	case appVerErr != nil:
+		fmt.Fprintf(preflightErrOut, "[event] skipped console precheck: %s\n", describeAppMetaErr(appVerErr))
+	case appVer == nil:
+		fmt.Fprintln(preflightErrOut, "[event] skipped console precheck: app has no published version")
+	}
+
+	pf := &preflightCtx{
+		factory:  f,
+		appID:    cfg.AppID,
+		brand:    cfg.Brand,
+		eventKey: eventKey,
+		identity: identity,
+		keyDef:   keyDef,
+		appVer:   appVer,
+	}
+	if err := preflightEventTypes(pf); err != nil {
+		return err
+	}
+	if err := preflightScopes(cmd.Context(), pf); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	// Release the signal subscription when runConsume returns — without
+	// this, repeated invocations in the same process would leak the
+	// notify channel and the goroutine parked on <-sigCh.
+	defer signal.Stop(sigCh)
+	go func() {
+		select {
+		case <-sigCh:
+			if !o.quiet && f.IOStreams.IsTerminal {
+				fmt.Fprintln(f.IOStreams.ErrOut, "\nShutting down...")
+			}
+			cancel()
+		case <-ctx.Done():
+			// ctx cancelled by another path (timeout, stdin EOF, max-events);
+			// exit the goroutine so signal.Stop can clean up.
+		}
+	}()
+
+	// Non-TTY: a closed stdin is a valid shutdown signal for subprocess
+	// callers. In TTY the stdin is the terminal, so we must not treat
+	// Ctrl-D as shutdown.
+	if !f.IOStreams.IsTerminal {
+		watchStdinEOF(os.Stdin, cancel)
+	}
+
+	errOut := f.IOStreams.ErrOut
+	if o.quiet {
+		errOut = io.Discard
+	}
+
+	if err := consume.Run(ctx, transport.New(), cfg.AppID, cfg.ProfileName, domain, consume.Options{
+		EventKey:        eventKey,
+		Params:          paramMap,
+		JQExpr:          o.jqExpr,
+		Quiet:           o.quiet,
+		OutputDir:       outputDir,
+		Runtime:         runtime,
+		Out:             f.IOStreams.Out,
+		ErrOut:          errOut,
+		RemoteAPIClient: botRuntime,
+		MaxEvents:       o.maxEvents,
+		Timeout:         o.timeout,
+		IsTTY:           f.IOStreams.IsTerminal,
+	}); err != nil {
+		return err
+	}
+	// consume.Run returning nil means one of the three normal exits: --max-events
+	// reached, --timeout elapsed, or user signal (SIGTERM / stdin close / ctrl+C).
+	// All three are "success" in the Unix sense — the caller asked for one of
+	// these stopping conditions and got it. stderr carries reason=limit|timeout|
+	// signal for callers that need to distinguish. Exit code 0.
+	return nil
+}
+
+// resolveIdentity picks the identity for this session via the shared
+// ResolveAs flow (explicit --as > config DefaultAs > auto-detect) and
+// then enforces the EventKey's AuthTypes as a strict whitelist. If the
+// resolved identity isn't in AuthTypes, CheckIdentity returns an error
+// that steers the user toward passing --as explicitly. AuthTypes is
+// not a default — it only constrains what's allowed.
+func resolveIdentity(cmd *cobra.Command, f *cmdutil.Factory, keyDef *eventlib.KeyDefinition) (core.Identity, error) {
+	flagAs := core.Identity(cmd.Flag("as").Value.String())
+	identity := f.ResolveAs(cmd.Context(), cmd, flagAs)
+	if len(keyDef.AuthTypes) > 0 {
+		if err := f.CheckIdentity(identity, keyDef.AuthTypes); err != nil {
+			return "", err
+		}
+	}
+	return identity, nil
+}
+
+// preflightCtx bundles the shared state every preflight check reads.
+// Grouping avoids the 8-parameter signatures that made the call sites
+// unreadable.
+type preflightCtx struct {
+	factory  *cmdutil.Factory
+	appID    string
+	brand    core.LarkBrand
+	eventKey string
+	identity core.Identity
+	keyDef   *eventlib.KeyDefinition
+	appVer   *appmeta.AppVersion
+}
+
+// preflightScopes compares the required scopes for an EventKey against the
+// scopes actually available to the session and surfaces an actionable hint
+// when any are missing. Scope source depends on identity:
+//
+//   - user → stored.Scope from the UAT keychain record (the ground truth
+//     for "what the user actually consented to"). Skip check when stored
+//     record is missing.
+//   - bot  → the tenant scopes from the app's current published version
+//     (appVer.TenantScopes). Skip check when appVer is nil (the
+//     app_versions OAPI failed or the app has never been published) —
+//     weak dependency: we don't want a flaky preflight to block consume.
+func preflightScopes(ctx context.Context, pf *preflightCtx) error {
+	if len(pf.keyDef.Scopes) == 0 || pf.identity == "" {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var storedScopes string
+	switch {
+	case pf.identity.IsBot():
+		if pf.appVer == nil {
+			return nil
+		}
+		storedScopes = strings.Join(pf.appVer.TenantScopes, " ")
+	case pf.identity == core.AsUser:
+		result, err := pf.factory.Credential.ResolveToken(ctx, credential.NewTokenSpec(pf.identity, pf.appID))
+		if err != nil || result == nil || result.Scopes == "" {
+			return nil
+		}
+		storedScopes = result.Scopes
+	default:
+		return nil
+	}
+
+	missing := auth.MissingScopes(storedScopes, pf.keyDef.Scopes)
+	if len(missing) == 0 {
+		return nil
+	}
+	return output.ErrWithHint(
+		output.ExitAuth, "auth",
+		fmt.Sprintf("missing required scopes for EventKey %s (as %s): %s",
+			pf.eventKey, pf.identity, strings.Join(missing, ", ")),
+		scopeRemediationHint(pf.identity, missing, pf.appID, pf.brand),
+	)
+}
+
+// scopeRemediationHint returns the identity-appropriate fix suggestion for a
+// set of missing scopes. user gets the auth-login flow (scopes attach to the
+// token); bot gets pointed at the developer console (scopes attach to the
+// app and require a new published version to take effect). Both paths
+// include a deep-link URL so a human or AI reader can act without guessing
+// at the command or console navigation.
+func scopeRemediationHint(identity core.Identity, missing []string, appID string, brand core.LarkBrand) string {
+	if identity.IsBot() {
+		return fmt.Sprintf(
+			"grant these scopes and publish a new app version at: %s",
+			consoleScopeGrantURL(brand, appID, missing),
+		)
+	}
+	return fmt.Sprintf(
+		"run `lark-cli auth login --scope \"%s\"` in the background. It blocks and outputs a verification URL — retrieve the URL and open it in a browser to complete login.",
+		strings.Join(missing, " "),
+	)
+}
+
+// preflightEventTypes verifies that every event_type the EventKey depends on
+// is actually subscribed in the app's current published version. A mismatch
+// means the developer declared the EventKey in code but forgot to subscribe
+// (or publish) the upstream event type — the consume would succeed locally
+// but never receive anything. This is a configuration error, not auth, so
+// ExitValidation is the right exit code.
+//
+// keyDef.RequiredConsoleEvents drives what's checked — keys that leave it
+// empty opt out of the check entirely. The default-to-EventType shortcut
+// is intentionally NOT used: declaring the dependency explicitly is a form
+// of documentation (especially for processed keys that fan in multiple
+// upstreams), and a silent default hides mistakes at registration time.
+//
+// appVer == nil is a weak-dependency skip: when the app_versions OAPI fails
+// (permission denied, network error, or the app was never published) we
+// degrade gracefully rather than block startup.
+func preflightEventTypes(pf *preflightCtx) error {
+	if pf.appVer == nil || len(pf.keyDef.RequiredConsoleEvents) == 0 {
+		return nil
+	}
+	subscribed := make(map[string]bool, len(pf.appVer.EventTypes))
+	for _, t := range pf.appVer.EventTypes {
+		subscribed[t] = true
+	}
+	var missing []string
+	for _, t := range pf.keyDef.RequiredConsoleEvents {
+		if !subscribed[t] {
+			missing = append(missing, t)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return output.ErrWithHint(
+		output.ExitValidation, "validation",
+		fmt.Sprintf("EventKey %s requires event types not subscribed in console: %s",
+			pf.keyDef.Key, strings.Join(missing, ", ")),
+		fmt.Sprintf("subscribe these events and publish a new app version at: %s",
+			consoleEventSubscriptionURL(pf.brand, pf.appID)),
+	)
+}
+
+// sanitizeOutputDir rejects absolute/parent-escaping paths (mirrors the
+// check `mail +watch` does) and explicitly rejects ~ since SafeOutputPath
+// treats "~/x" as a literal dir named "~".
+func sanitizeOutputDir(dir string) (string, error) {
+	if strings.HasPrefix(dir, "~") {
+		return "", output.ErrValidation("%s; use a relative path like ./output instead", errOutputDirTilde)
+	}
+	safe, err := validate.SafeOutputPath(dir)
+	if err != nil {
+		return "", output.ErrValidation("%s %q: %s", errOutputDirUnsafe, dir, err)
+	}
+	return safe, nil
+}
+
+// resolveTenantToken fetches the app's tenant access token. Used by the
+// remote-connection preflight; separately, the bus daemon needs one too.
+func resolveTenantToken(ctx context.Context, f *cmdutil.Factory, appID string) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	result, err := f.Credential.ResolveToken(ctx, credential.NewTokenSpec(core.AsBot, appID))
+	if err != nil {
+		return "", output.ErrAuth("resolve tenant access token: %s", err)
+	}
+	if result == nil || result.Token == "" {
+		return "", output.ErrWithHint(
+			output.ExitAuth, "auth",
+			fmt.Sprintf("no tenant access token available for app %s", appID),
+			"Check that app_secret is configured (lark-cli config show) and try 'lark-cli auth login'.",
+		)
+	}
+	return result.Token, nil
+}
+
+// Sentinel errors for tests so assertions pin on error identity, not
+// phrasing. The human-readable message still includes the offending
+// value for the user; errors.Is works via ExitError.Unwrap().
+var (
+	errInvalidParamFormat = errors.New("invalid --param format")
+	errOutputDirTilde     = errors.New("--output-dir does not support ~ expansion")
+	errOutputDirUnsafe    = errors.New("unsafe --output-dir")
+)
+
+// parseParams turns ["key=value", ...] into map[string]string.
+func parseParams(raw []string) (map[string]string, error) {
+	m := make(map[string]string)
+	for _, kv := range raw {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k == "" {
+			return nil, output.ErrValidation("%s %q: expected key=value", errInvalidParamFormat, kv)
+		}
+		m[k] = v
+	}
+	return m, nil
+}
+
+// watchStdinEOF launches a goroutine that drains r until EOF or any error,
+// then invokes cancel. Used to wire stdin-close → exit in non-TTY mode so
+// AI subprocess callers can signal shutdown by closing the stdin pipe.
+// Never called in TTY mode (would turn accidental Ctrl-D into shutdown).
+func watchStdinEOF(r io.Reader, cancel context.CancelFunc) {
+	go func() {
+		_, _ = io.Copy(io.Discard, r)
+		cancel()
+	}()
+}

--- a/cmd/event/consume_stdin_test.go
+++ b/cmd/event/consume_stdin_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWatchStdinEOF_CancelsOnEOF — feeding an already-closed reader
+// causes the watcher to cancel the context quickly (< 1s).
+func TestWatchStdinEOF_CancelsOnEOF(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watchStdinEOF(strings.NewReader(""), cancel)
+
+	select {
+	case <-ctx.Done():
+		// Expected — cancel fired on EOF.
+	case <-time.After(1 * time.Second):
+		t.Fatal("watchStdinEOF did not cancel within 1s of EOF")
+	}
+}
+
+// TestWatchStdinEOF_StaysAliveWhileReaderBlocks — if the reader never
+// delivers EOF, the watcher must not fire the cancel.
+func TestWatchStdinEOF_StaysAliveWhileReaderBlocks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// io.Pipe gives us a reader that will block forever (no writer).
+	pr, _ := io.Pipe()
+	defer pr.Close()
+
+	watchStdinEOF(pr, cancel)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("watchStdinEOF cancelled without EOF")
+	case <-time.After(200 * time.Millisecond):
+		// Expected — still alive.
+	}
+}

--- a/cmd/event/consume_stdin_test.go
+++ b/cmd/event/consume_stdin_test.go
@@ -4,6 +4,7 @@
 package event
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"strings"
@@ -17,7 +18,7 @@ func TestWatchStdinEOF_CancelsOnEOF(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	watchStdinEOF(strings.NewReader(""), cancel)
+	watchStdinEOF(strings.NewReader(""), cancel, io.Discard)
 
 	select {
 	case <-ctx.Done():
@@ -37,12 +38,37 @@ func TestWatchStdinEOF_StaysAliveWhileReaderBlocks(t *testing.T) {
 	pr, _ := io.Pipe()
 	defer pr.Close()
 
-	watchStdinEOF(pr, cancel)
+	watchStdinEOF(pr, cancel, io.Discard)
 
 	select {
 	case <-ctx.Done():
 		t.Fatal("watchStdinEOF cancelled without EOF")
 	case <-time.After(200 * time.Millisecond):
 		// Expected — still alive.
+	}
+}
+
+// TestWatchStdinEOF_DiagnosticMessage — on EOF the watcher writes a
+// self-explanatory diagnostic to errOut that names the cause and points
+// at the workarounds. This is the single biggest footgun for daemon-
+// style callers (`< /dev/null`, `nohup`, systemd), so the message must
+// stay descriptive enough to unstick a new user in seconds.
+func TestWatchStdinEOF_DiagnosticMessage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var buf bytes.Buffer
+	watchStdinEOF(strings.NewReader(""), cancel, &buf)
+
+	select {
+	case <-ctx.Done():
+		got := buf.String()
+		for _, want := range []string{"stdin closed", "--max-events", "--timeout", "SIGTERM"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("diagnostic missing %q; got:\n%s", want, got)
+			}
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("watchStdinEOF did not cancel within 1s of EOF")
 	}
 }

--- a/cmd/event/consume_test.go
+++ b/cmd/event/consume_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseParams(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         []string
+		want       map[string]string
+		wantSentry error  // sentinel to pin on (preferred over wantErr substring)
+		wantEcho   string // optional: substring that MUST appear (usually the bad kv)
+	}{
+		{
+			name: "empty input",
+			in:   nil,
+			want: map[string]string{},
+		},
+		{
+			name: "single key=value",
+			in:   []string{"mailbox=user@example.com"},
+			want: map[string]string{"mailbox": "user@example.com"},
+		},
+		{
+			name: "multiple pairs",
+			in:   []string{"a=1", "b=2", "c=3"},
+			want: map[string]string{"a": "1", "b": "2", "c": "3"},
+		},
+		{
+			name: "value containing = is kept intact",
+			in:   []string{"filter=foo=bar"},
+			want: map[string]string{"filter": "foo=bar"},
+		},
+		{
+			name: "empty value allowed",
+			in:   []string{"key="},
+			want: map[string]string{"key": ""},
+		},
+		{
+			name: "duplicate key — last wins",
+			in:   []string{"k=1", "k=2"},
+			want: map[string]string{"k": "2"},
+		},
+		{
+			name:       "missing = separator",
+			in:         []string{"mailbox"},
+			wantSentry: errInvalidParamFormat,
+			wantEcho:   `"mailbox"`,
+		},
+		{
+			name:       "leading = (empty key)",
+			in:         []string{"=value"},
+			wantSentry: errInvalidParamFormat,
+			wantEcho:   `"=value"`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseParams(tc.in)
+			if tc.wantSentry != nil {
+				if err == nil {
+					t.Fatalf("want error wrapping %v, got nil", tc.wantSentry)
+				}
+				if !errors.Is(err, tc.wantSentry) {
+					t.Fatalf("want errors.Is(err, %v), got %q", tc.wantSentry, err.Error())
+				}
+				if tc.wantEcho != "" && !strings.Contains(err.Error(), tc.wantEcho) {
+					t.Errorf("err %q should echo %q so user sees the bad input", err.Error(), tc.wantEcho)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d; got=%v", len(got), len(tc.want), got)
+			}
+			for k, v := range tc.want {
+				if got[k] != v {
+					t.Errorf("key %q: got %q, want %q", k, got[k], v)
+				}
+			}
+		})
+	}
+}
+
+func TestSanitizeOutputDir(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		wantSentry error
+	}{
+		{
+			name: "relative path accepted",
+			in:   "./output",
+		},
+		{
+			name: "nested relative path accepted",
+			in:   "events/today",
+		},
+		{
+			name:       "tilde rejected explicitly",
+			in:         "~/events",
+			wantSentry: errOutputDirTilde,
+		},
+		{
+			name:       "parent escape rejected",
+			in:         "../outside",
+			wantSentry: errOutputDirUnsafe,
+		},
+		{
+			name:       "absolute path rejected",
+			in:         "/tmp/events",
+			wantSentry: errOutputDirUnsafe,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sanitizeOutputDir(tc.in)
+			if tc.wantSentry != nil {
+				if err == nil {
+					t.Fatalf("want error wrapping %v, got nil (path=%q)", tc.wantSentry, got)
+				}
+				if !errors.Is(err, tc.wantSentry) {
+					t.Fatalf("want errors.Is(err, %v), got %q", tc.wantSentry, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == "" {
+				t.Errorf("expected non-empty safe path, got %q", got)
+			}
+		})
+	}
+}

--- a/cmd/event/event.go
+++ b/cmd/event/event.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+)
+
+// NewCmdEvents creates the parent "event" command group.
+func NewCmdEvents(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "event",
+		Short: "Consume and manage real-time events",
+		Long:  `Unified event consumption system. Use 'event consume <EventKey>' to start consuming events.`,
+		// Without SilenceUsage, RunE errors print the full flag help banner.
+		SilenceUsage: true,
+	}
+
+	cmd.AddCommand(NewCmdConsume(f))
+	cmd.AddCommand(NewCmdList(f))
+	cmd.AddCommand(NewCmdSchema(f))
+	cmd.AddCommand(NewCmdStatus(f))
+	cmd.AddCommand(NewCmdStop(f))
+	cmd.AddCommand(NewCmdBus(f))
+
+	return cmd
+}

--- a/cmd/event/list.go
+++ b/cmd/event/list.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	eventlib "github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/output"
+)
+
+// NewCmdList creates the "event list" subcommand that shows all registered EventKeys.
+func NewCmdList(f *cmdutil.Factory) *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all available EventKeys",
+		Long:  "Show all registered EventKeys grouped by domain (first segment of the key). Use --json for machine-readable output.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runList(f, asJSON)
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit the full EventKey list as JSON (for AI / scripts)")
+	return cmd
+}
+
+func runList(f *cmdutil.Factory, asJSON bool) error {
+	all := eventlib.ListAll()
+
+	if asJSON {
+		return writeListJSON(f, all)
+	}
+
+	if len(all) == 0 {
+		fmt.Fprintln(f.IOStreams.Out, "No EventKeys registered.")
+		return nil
+	}
+
+	// Group by domain (first segment before '.').
+	type group struct {
+		domain string
+		keys   []*eventlib.KeyDefinition
+	}
+	order := []string{}
+	groups := map[string]*group{}
+
+	for _, def := range all {
+		domain := def.Key
+		if idx := strings.Index(def.Key, "."); idx > 0 {
+			domain = def.Key[:idx]
+		}
+		g, ok := groups[domain]
+		if !ok {
+			g = &group{domain: domain}
+			groups[domain] = g
+			order = append(order, domain)
+		}
+		g.keys = append(g.keys, def)
+	}
+
+	// Build rows per domain, plus a flat slice for global width computation.
+	// We need global widths (not per-section) so the "── domain ──" dividers
+	// don't break alignment across groups.
+	headers := []string{"KEY", "AUTH", "PARAMS", "DESCRIPTION"}
+	rowsByDomain := make(map[string][][]string, len(order))
+	var allRows [][]string
+	for _, domain := range order {
+		for _, def := range groups[domain].keys {
+			auth := "-"
+			if len(def.AuthTypes) > 0 {
+				auth = strings.Join(def.AuthTypes, "|")
+			}
+			desc := def.Description
+			if desc == "" {
+				desc = "-"
+			}
+			row := []string{
+				def.Key,
+				auth,
+				fmt.Sprintf("%d", len(def.Params)),
+				desc,
+			}
+			rowsByDomain[domain] = append(rowsByDomain[domain], row)
+			allRows = append(allRows, row)
+		}
+	}
+
+	out := f.IOStreams.Out
+	const colGap = "  "
+	widths := tableWidths(headers, allRows)
+	printTableRow(out, widths, headers, colGap)
+	for _, domain := range order {
+		fmt.Fprintf(out, "\n── %s ──\n", domain)
+		for _, row := range rowsByDomain[domain] {
+			printTableRow(out, widths, row, colGap)
+		}
+	}
+	fmt.Fprintln(out, "\nUse 'event schema <key>' for details.")
+	return nil
+}
+
+// writeListJSON emits the list as a JSON array. KeyDefinition has
+// the right json tags; we only need to splice in the per-key resolved
+// schema so the caller doesn't have to look it up separately per key.
+func writeListJSON(f *cmdutil.Factory, all []*eventlib.KeyDefinition) error {
+	type row struct {
+		*eventlib.KeyDefinition
+		// JSON wire name kept as `resolved_output_schema` for backward
+		// compatibility with existing AI / script consumers.
+		ResolvedSchema json.RawMessage `json:"resolved_output_schema,omitempty"`
+	}
+	rows := make([]row, len(all))
+	for i, def := range all {
+		resolved, _, err := resolveSchemaJSON(def)
+		if err != nil {
+			return err
+		}
+		rows[i] = row{KeyDefinition: def, ResolvedSchema: resolved}
+	}
+	output.PrintJson(f.IOStreams.Out, rows)
+	return nil
+}

--- a/cmd/event/list_test.go
+++ b/cmd/event/list_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+
+	_ "github.com/larksuite/cli/events"
+)
+
+func TestRunList_TextOutput(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test"})
+
+	if err := runList(f, false); err != nil {
+		t.Fatalf("runList: %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"KEY", "AUTH", "PARAMS", "DESCRIPTION",
+		"im.message.receive_v1",
+		"im.message.message_read_v1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("list output missing %q; full output:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunList_JSONOutput(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test"})
+
+	if err := runList(f, true); err != nil {
+		t.Fatalf("runList json: %v", err)
+	}
+
+	var rows []map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &rows); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(rows) == 0 {
+		t.Fatal("expected at least one EventKey in JSON output")
+	}
+
+	// Every row should carry at minimum key / event_type / kind.
+	for _, row := range rows {
+		for _, field := range []string{"key", "event_type", "schema"} {
+			if row[field] == nil {
+				t.Errorf("row missing %q: %+v", field, row)
+			}
+		}
+	}
+}

--- a/cmd/event/preflight_test.go
+++ b/cmd/event/preflight_test.go
@@ -89,7 +89,7 @@ func TestPreflightEventTypes_MissingBlocks(t *testing.T) {
 	appVer := &appmeta.AppVersion{EventTypes: []string{
 		"mail.user_mailbox.event.message_received_v1",
 	}}
-	err := preflightEventTypes(newPreflightCtx("cli_a96bbe46d5a15bc3", "feishu", "", def, appVer))
+	err := preflightEventTypes(newPreflightCtx("cli_XXXXXXXXXXXXXXXX", "feishu", "", def, appVer))
 	if err == nil {
 		t.Fatal("expected error for missing subscription")
 	}
@@ -106,7 +106,7 @@ func TestPreflightEventTypes_MissingBlocks(t *testing.T) {
 	if exit.Detail == nil {
 		t.Fatal("expected Detail with hint")
 	}
-	wantURL := "https://open.feishu.cn/app/cli_a96bbe46d5a15bc3/event"
+	wantURL := "https://open.feishu.cn/app/cli_XXXXXXXXXXXXXXXX/event"
 	if !strings.Contains(exit.Detail.Hint, wantURL) {
 		t.Errorf("hint missing subscription URL %q\ngot: %s", wantURL, exit.Detail.Hint)
 	}

--- a/cmd/event/preflight_test.go
+++ b/cmd/event/preflight_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/appmeta"
+	"github.com/larksuite/cli/internal/core"
+	eventlib "github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/output"
+)
+
+// newPreflightCtx is a tiny test helper so the preflight tests don't each
+// have to hand-assemble a preflightCtx with the same scaffold.
+func newPreflightCtx(appID string, brand core.LarkBrand, identity core.Identity, keyDef *eventlib.KeyDefinition, appVer *appmeta.AppVersion) *preflightCtx {
+	key := ""
+	if keyDef != nil {
+		key = keyDef.Key
+	}
+	return &preflightCtx{
+		appID:    appID,
+		brand:    brand,
+		eventKey: key,
+		identity: identity,
+		keyDef:   keyDef,
+		appVer:   appVer,
+	}
+}
+
+func TestPreflightEventTypes_NilAppVer_SkipsCheck(t *testing.T) {
+	def := &eventlib.KeyDefinition{
+		Key:                   "im.message.text",
+		EventType:             "im.message.receive_v1",
+		RequiredConsoleEvents: []string{"im.message.receive_v1"},
+	}
+	if err := preflightEventTypes(newPreflightCtx("cli_x", "feishu", "", def, nil)); err != nil {
+		t.Fatalf("nil appVer must be a weak-dependency skip, got err: %v", err)
+	}
+}
+
+func TestPreflightEventTypes_EmptyRequired_SkipsEvenIfEventTypeSet(t *testing.T) {
+	// Declaring RequiredConsoleEvents is the explicit opt-in for this check;
+	// a key that leaves it empty is assumed to not care (e.g. still being
+	// wired, or intentionally relies on default subscriptions). We do NOT
+	// silently fall back to keyDef.EventType — that would hide registration
+	// mistakes where a key meant to be guarded was left undeclared.
+	def := &eventlib.KeyDefinition{
+		Key:       "im.message.message_read_v1",
+		EventType: "im.message.message_read_v1",
+	}
+	appVer := &appmeta.AppVersion{EventTypes: []string{"im.message.receive_v1"}}
+	if err := preflightEventTypes(newPreflightCtx("cli_x", "feishu", "", def, appVer)); err != nil {
+		t.Fatalf("empty RequiredConsoleEvents must skip, got: %v", err)
+	}
+}
+
+func TestPreflightEventTypes_AllSubscribed_Passes(t *testing.T) {
+	def := &eventlib.KeyDefinition{
+		Key:       "im.reaction",
+		EventType: "im.message.reaction.created_v1", // single source of truth
+		RequiredConsoleEvents: []string{
+			"im.message.reaction.created_v1",
+			"im.message.reaction.deleted_v1",
+		},
+	}
+	appVer := &appmeta.AppVersion{EventTypes: []string{
+		"im.message.reaction.created_v1",
+		"im.message.reaction.deleted_v1",
+		"im.message.receive_v1", // extras are fine
+	}}
+	if err := preflightEventTypes(newPreflightCtx("cli_x", "feishu", "", def, appVer)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreflightEventTypes_MissingBlocks(t *testing.T) {
+	def := &eventlib.KeyDefinition{
+		Key:       "mail.receive",
+		EventType: "mail.user_mailbox.event.message_received_v1",
+		RequiredConsoleEvents: []string{
+			"mail.user_mailbox.event.message_received_v1",
+			"mail.user_mailbox.event.message_read_v1",
+		},
+	}
+	appVer := &appmeta.AppVersion{EventTypes: []string{
+		"mail.user_mailbox.event.message_received_v1",
+	}}
+	err := preflightEventTypes(newPreflightCtx("cli_a96bbe46d5a15bc3", "feishu", "", def, appVer))
+	if err == nil {
+		t.Fatal("expected error for missing subscription")
+	}
+	if !strings.Contains(err.Error(), "mail.user_mailbox.event.message_read_v1") {
+		t.Errorf("error should name the missing event type, got: %v", err)
+	}
+	var exit *output.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("expected output.ExitError, got %T: %v", err, err)
+	}
+	if exit.Code != output.ExitValidation {
+		t.Errorf("ExitCode = %d, want ExitValidation (%d)", exit.Code, output.ExitValidation)
+	}
+	if exit.Detail == nil {
+		t.Fatal("expected Detail with hint")
+	}
+	wantURL := "https://open.feishu.cn/app/cli_a96bbe46d5a15bc3/event"
+	if !strings.Contains(exit.Detail.Hint, wantURL) {
+		t.Errorf("hint missing subscription URL %q\ngot: %s", wantURL, exit.Detail.Hint)
+	}
+}
+
+// The user-scope branch of preflightScopes already has coverage via the
+// existing production path (it goes through factory.Credential). We cover
+// the bot branch here because it's the new behavior and is pure-input
+// (identity + keyDef + appVer), no factory dependency.
+
+func TestPreflightScopes_Bot_NoAppVer_SkipsCheck(t *testing.T) {
+	def := &eventlib.KeyDefinition{
+		Key:    "im.message.text",
+		Scopes: []string{"im:message", "im:message.group_at_msg"},
+	}
+	// Bot identity with nil appVer simulates "OAPI failed" → weak dep skip.
+	err := preflightScopes(nil, newPreflightCtx("cli_x", "feishu", core.AsBot, def, nil))
+	if err != nil {
+		t.Fatalf("bot + nil appVer should skip, got: %v", err)
+	}
+}
+
+func TestPreflightScopes_Bot_AllGranted_Passes(t *testing.T) {
+	def := &eventlib.KeyDefinition{
+		Key:    "im.message.text",
+		Scopes: []string{"im:message", "im:message.group_at_msg"},
+	}
+	appVer := &appmeta.AppVersion{TenantScopes: []string{
+		"im:message",
+		"im:message.group_at_msg",
+		"contact:user:readonly", // extras are fine
+	}}
+	err := preflightScopes(nil, newPreflightCtx("cli_x", "feishu", core.AsBot, def, appVer))
+	if err != nil {
+		t.Fatalf("all scopes granted, unexpected error: %v", err)
+	}
+}
+
+func TestPreflightScopes_Bot_MissingBlocks(t *testing.T) {
+	def := &eventlib.KeyDefinition{
+		Key:    "im.message.text",
+		Scopes: []string{"im:message", "im:message.group_at_msg"},
+	}
+	appVer := &appmeta.AppVersion{TenantScopes: []string{"im:message"}}
+	err := preflightScopes(nil, newPreflightCtx("cli_x", "feishu", core.AsBot, def, appVer))
+	if err == nil {
+		t.Fatal("expected error for missing scope")
+	}
+	if !strings.Contains(err.Error(), "im:message.group_at_msg") {
+		t.Errorf("error should name missing scope, got: %v", err)
+	}
+	var exit *output.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("expected output.ExitError, got %T: %v", err, err)
+	}
+	if exit.Code != output.ExitAuth {
+		t.Errorf("ExitCode = %d, want ExitAuth (%d)", exit.Code, output.ExitAuth)
+	}
+	// The hint is carried in Detail.Hint, not Error(): bot scope remediation
+	// must include a clickable console grant URL so humans and AI agents can
+	// act without guessing at console navigation. URL must carry (a) the
+	// appID, (b) the missing scope, and (c) the tenant token_type flag so
+	// Feishu console opens the correct grant dialog.
+	if exit.Detail == nil {
+		t.Fatal("expected Detail with hint, got nil Detail")
+	}
+	hint := exit.Detail.Hint
+	wantSubstrings := []string{
+		"https://open.feishu.cn/app/cli_x/auth?q=",
+		"im:message.group_at_msg",
+		"token_type=tenant",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(hint, want) {
+			t.Errorf("hint missing %q\ngot: %s", want, hint)
+		}
+	}
+}
+
+func TestPreflightScopes_NoRequiredScopes_SkipsCheck(t *testing.T) {
+	def := &eventlib.KeyDefinition{Key: "x"}
+	if err := preflightScopes(nil, newPreflightCtx("cli_x", "feishu", core.AsBot, def, nil)); err != nil {
+		t.Fatalf("no required scopes means nothing to verify, got: %v", err)
+	}
+}

--- a/cmd/event/runtime.go
+++ b/cmd/event/runtime.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/core"
+)
+
+// consumeRuntime implements event.APIClient by routing every call through
+// the project's client.APIClient with the identity resolved at session
+// start. Keeps business-side CallAPI on the same HTTP stack (UA, retry,
+// tracing, auth) as regular shortcut commands.
+type consumeRuntime struct {
+	client         *client.APIClient
+	accessIdentity core.Identity
+}
+
+func (r *consumeRuntime) CallAPI(ctx context.Context, method, path string, body interface{}) (json.RawMessage, error) {
+	resp, err := r.client.DoAPI(ctx, client.RawApiRequest{
+		Method: method,
+		URL:    path,
+		Data:   body,
+		As:     r.accessIdentity,
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Non-JSON HTTP errors (gateway text/plain 404 etc.) skip OAPI envelope parsing.
+	ct := resp.Header.Get("Content-Type")
+	if resp.StatusCode >= 400 && !client.IsJSONContentType(ct) && ct != "" {
+		const maxBodyEcho = 256
+		body := string(resp.RawBody)
+		if len(body) > maxBodyEcho {
+			body = body[:maxBodyEcho] + "…(truncated)"
+		}
+		return nil, fmt.Errorf("api %s %s returned %d: %s", method, path, resp.StatusCode, body)
+	}
+	// ParseJSONResponse + CheckLarkResponse give us the same structured
+	// *output.ExitError path as regular shortcut commands: Lark business
+	// code, ClassifyLarkError-driven exit code, hint, and permission
+	// remediation URL enrichment — all for free.
+	result, err := client.ParseJSONResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr := client.CheckLarkResponse(result); apiErr != nil {
+		return json.RawMessage(resp.RawBody), apiErr
+	}
+	return json.RawMessage(resp.RawBody), nil
+}

--- a/cmd/event/schema.go
+++ b/cmd/event/schema.go
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	eventlib "github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/schemas"
+	"github.com/larksuite/cli/internal/output"
+)
+
+// resolveSchemaJSON returns the final JSON Schema a consumer would see
+// for this EventKey: reflected / parsed base, envelope-wrapped for Native,
+// plus FieldOverrides overlay applied. Returns (schema, orphans, err):
+// `orphans` is the list of FieldOverrides pointers that did not resolve
+// in the rendered schema (used by CI lint; callers that don't care can
+// ignore).
+func resolveSchemaJSON(def *eventlib.KeyDefinition) (json.RawMessage, []string, error) {
+	spec, isNative := pickSpec(def.Schema)
+	if spec == nil {
+		return nil, nil, nil
+	}
+
+	base, err := renderSpec(spec)
+	if err != nil {
+		return nil, nil, err
+	}
+	if base == nil {
+		return nil, nil, nil
+	}
+
+	if isNative {
+		base = schemas.WrapV2Envelope(base)
+	}
+
+	if len(def.Schema.FieldOverrides) > 0 {
+		var parsed map[string]interface{}
+		if err := json.Unmarshal(base, &parsed); err != nil {
+			return nil, nil, err
+		}
+		orphans := schemas.ApplyFieldOverrides(parsed, def.Schema.FieldOverrides)
+		out, err := json.Marshal(parsed)
+		if err != nil {
+			return nil, nil, err
+		}
+		return out, orphans, nil
+	}
+
+	return base, nil, nil
+}
+
+// pickSpec returns the non-nil spec and whether it is the Native slot
+// (framework must wrap V2 envelope around it).
+func pickSpec(s eventlib.SchemaDef) (*eventlib.SchemaSpec, bool) {
+	if s.Native != nil {
+		return s.Native, true
+	}
+	if s.Custom != nil {
+		return s.Custom, false
+	}
+	return nil, false
+}
+
+// renderSpec produces a JSON Schema for a single spec. Type is reflected;
+// Raw is returned as a copy so callers can mutate safely.
+func renderSpec(s *eventlib.SchemaSpec) (json.RawMessage, error) {
+	if s.Type != nil {
+		return schemas.FromType(s.Type), nil
+	}
+	if len(s.Raw) > 0 {
+		buf := make(json.RawMessage, len(s.Raw))
+		copy(buf, s.Raw)
+		return buf, nil
+	}
+	return nil, fmt.Errorf("schemaSpec has neither Type nor Raw")
+}
+
+// NewCmdSchema creates the "event schema" subcommand that shows details for an EventKey.
+func NewCmdSchema(f *cmdutil.Factory) *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "schema <EventKey>",
+		Short: "Show details for an EventKey",
+		Long:  "Display detailed information about an EventKey including type, events, parameters, and response schema. Use --json for machine-readable output.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSchema(f, args[0], asJSON)
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit the EventKey definition + resolved schema as JSON (for AI / scripts)")
+	return cmd
+}
+
+func runSchema(f *cmdutil.Factory, key string, asJSON bool) error {
+	def, ok := eventlib.Lookup(key)
+	if !ok {
+		return unknownEventKeyErr(key)
+	}
+
+	if asJSON {
+		return writeSchemaJSON(f, def)
+	}
+
+	out := f.IOStreams.Out
+
+	fmt.Fprintf(out, "Key:         %s\n", def.Key)
+	if def.Description != "" {
+		fmt.Fprintf(out, "Description: %s\n", def.Description)
+	}
+	fmt.Fprintf(out, "Event:       %s\n", def.EventType)
+
+	if def.PreConsume != nil {
+		fmt.Fprintf(out, "Pre-consume: yes\n")
+	}
+
+	if len(def.Scopes) > 0 {
+		fmt.Fprintf(out, "\nRequired Scopes:\n")
+		for _, s := range def.Scopes {
+			fmt.Fprintf(out, "  - %s\n", s)
+		}
+	}
+
+	if len(def.RequiredConsoleEvents) > 0 {
+		fmt.Fprintf(out, "\nRequired Console Events (must be enabled in developer console):\n")
+		for _, e := range def.RequiredConsoleEvents {
+			fmt.Fprintf(out, "  - %s\n", e)
+		}
+	}
+
+	if len(def.Params) > 0 {
+		fmt.Fprintf(out, "\nParameters:\n")
+		w := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+		fmt.Fprintf(w, "  NAME\tTYPE\tREQUIRED\tDEFAULT\tDESCRIPTION\n")
+		for _, p := range def.Params {
+			required := "no"
+			if p.Required {
+				required = "yes"
+			}
+			defaultVal := p.Default
+			if defaultVal == "" {
+				defaultVal = "-"
+			}
+			desc := p.Description
+			if desc == "" {
+				desc = "-"
+			}
+			fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\n", p.Name, p.Type, required, defaultVal, desc)
+		}
+		w.Flush()
+
+		// Render Values inline below the param table for Enum / Multi params
+		// so AI consumers can see which values are allowed and what each
+		// means without having to parse --json.
+		for _, p := range def.Params {
+			if len(p.Values) == 0 {
+				continue
+			}
+			fmt.Fprintf(out, "\n  %s values:\n", p.Name)
+			vw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+			for _, v := range p.Values {
+				fmt.Fprintf(vw, "    %s\t%s\n", v.Value, v.Desc)
+			}
+			vw.Flush()
+		}
+	}
+
+	resolved, _, err := resolveSchemaJSON(def)
+	if err != nil {
+		return fmt.Errorf("resolve schema: %w", err)
+	}
+	if resolved != nil {
+		fmt.Fprintf(out, "\nOutput Schema:\n")
+		printIndentedJSON(out, resolved)
+	} else {
+		fmt.Fprintf(out, "\nOutput Schema: (schema not declared)\n")
+		if def.Schema.Native != nil {
+			fmt.Fprintf(out, "  Consumers receive the V2 envelope: {schema, header, event}.\n")
+			fmt.Fprintf(out, "  Inspect real payloads via `lark-cli event consume %s`.\n", def.Key)
+		}
+	}
+
+	return nil
+}
+
+// printIndentedJSON pretty-prints raw JSON to out with a 2-space leading
+// indent so it lines up under the "Output Schema:" label.
+func printIndentedJSON(out io.Writer, raw json.RawMessage) {
+	var parsed json.RawMessage
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		fmt.Fprintln(out, "  <invalid JSON>")
+		return
+	}
+	formatted, err := json.MarshalIndent(parsed, "  ", "  ")
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(out, "  %s\n", string(formatted))
+}
+
+// writeSchemaJSON emits the EventKey definition plus the resolved schema
+// (whether native-wrapped-in-V2-envelope or Process-declared) as a single
+// JSON object so callers can ingest schema + metadata in one pass.
+func writeSchemaJSON(f *cmdutil.Factory, def *eventlib.KeyDefinition) error {
+	type payload struct {
+		*eventlib.KeyDefinition
+		// JSON wire name kept as `resolved_output_schema` for backward
+		// compatibility with existing AI / script consumers; Go field was
+		// shortened to `ResolvedSchema` after the OutputSchema/OutputType
+		// fields were removed from KeyDefinition.
+		ResolvedSchema json.RawMessage `json:"resolved_output_schema,omitempty"`
+	}
+	resolved, _, err := resolveSchemaJSON(def)
+	if err != nil {
+		return err
+	}
+	output.PrintJson(f.IOStreams.Out, payload{
+		KeyDefinition:  def,
+		ResolvedSchema: resolved,
+	})
+	return nil
+}

--- a/cmd/event/schema_test.go
+++ b/cmd/event/schema_test.go
@@ -1,0 +1,132 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	eventlib "github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/schemas"
+
+	_ "github.com/larksuite/cli/events"
+)
+
+func TestRunSchema_ProcessedKey_Text(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test"})
+
+	if err := runSchema(f, "im.message.receive_v1", false); err != nil {
+		t.Fatalf("runSchema: %v", err)
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"Key:", "im.message.receive_v1",
+		"Event:", "im.message.receive_v1",
+		"Output Schema:",
+		`"message_id"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("schema output missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunSchema_NativeKey_WrapsEnvelope(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test"})
+
+	if err := runSchema(f, "im.message.message_read_v1", false); err != nil {
+		t.Fatalf("runSchema: %v", err)
+	}
+
+	out := stdout.String()
+	// Native keys should show the V2 envelope wrapper (schema/header/event keys).
+	for _, want := range []string{
+		"Output Schema:",
+		`"schema"`,
+		`"header"`,
+		`"event"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("native schema output missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunSchema_UnknownKey_SuggestsAlternatives(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test"})
+
+	err := runSchema(f, "im.message.recieve_v1", false) // typo: recieve
+	if err == nil {
+		t.Fatal("expected error for unknown key")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unknown EventKey") {
+		t.Errorf("error should mention unknown EventKey: %q", msg)
+	}
+	if !strings.Contains(msg, "im.message.receive_v1") {
+		t.Errorf("error should suggest the real key name (typo correction): %q", msg)
+	}
+}
+
+func TestRunSchema_JSONOutput(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test"})
+
+	if err := runSchema(f, "im.message.receive_v1", true); err != nil {
+		t.Fatalf("runSchema json: %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, stdout.String())
+	}
+	for _, field := range []string{"key", "event_type", "schema", "resolved_output_schema"} {
+		if _, ok := payload[field]; !ok {
+			t.Errorf("JSON output missing field %q: %+v", field, payload)
+		}
+	}
+	if payload["key"] != "im.message.receive_v1" {
+		t.Errorf("key = %v, want im.message.receive_v1", payload["key"])
+	}
+}
+
+func TestResolveSchemaJSON_CustomWithOverlay(t *testing.T) {
+	const syntheticKey = "t.custom.overlay"
+	t.Cleanup(func() { eventlib.UnregisterKeyForTest(syntheticKey) })
+
+	type out struct {
+		SenderID string `json:"sender_id"`
+	}
+	eventlib.RegisterKey(eventlib.KeyDefinition{
+		Key:       syntheticKey,
+		EventType: syntheticKey,
+		Schema: eventlib.SchemaDef{
+			Custom: &eventlib.SchemaSpec{Type: reflect.TypeOf(out{})},
+			FieldOverrides: map[string]schemas.FieldMeta{
+				"/sender_id": {Kind: "open_id"},
+			},
+		},
+		Process: func(context.Context, eventlib.APIClient, *eventlib.RawEvent, map[string]string) (json.RawMessage, error) {
+			return nil, nil
+		},
+	})
+	def, _ := eventlib.Lookup(syntheticKey)
+	resolved, orphans, err := resolveSchemaJSON(def)
+	if err != nil || len(orphans) != 0 {
+		t.Fatalf("resolve: err=%v orphans=%v", err, orphans)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(resolved, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	got := parsed["properties"].(map[string]interface{})["sender_id"].(map[string]interface{})["format"]
+	if got != "open_id" {
+		t.Errorf("overlay format = %v, want open_id", got)
+	}
+}

--- a/cmd/event/status.go
+++ b/cmd/event/status.go
@@ -1,0 +1,359 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/event/busctl"
+	"github.com/larksuite/cli/internal/event/busdiscover"
+	"github.com/larksuite/cli/internal/event/protocol"
+	"github.com/larksuite/cli/internal/event/transport"
+	"github.com/larksuite/cli/internal/output"
+)
+
+// NewCmdStatus creates the "event status" subcommand. Default lists all
+// discoverable Bus daemons on this machine; --current narrows to the
+// current profile's AppID only.
+func NewCmdStatus(f *cmdutil.Factory) *cobra.Command {
+	var (
+		asJSON       bool
+		current      bool
+		failOnOrphan bool
+	)
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show event bus daemon status for all discovered apps",
+		Long:  "Connect to each bus daemon under the config-dir/events/ tree and show PID, uptime, and active consumers. Use --current for only the current profile's app. Use --json for machine-readable output. Use --fail-on-orphan to exit 2 when any orphan bus is detected (for health checks).",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStatus(f, current, asJSON, failOnOrphan)
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Emit status as JSON (for AI / scripts)")
+	cmd.Flags().BoolVar(&current, "current", false, "Only show status for the current profile's app")
+	cmd.Flags().BoolVar(&failOnOrphan, "fail-on-orphan", false, "Exit 2 when any orphan bus is detected (default: always exit 0)")
+	return cmd
+}
+
+// busState is the three-way discriminator for an AppID's bus.
+type busState int
+
+const (
+	stateNotRunning busState = iota
+	stateRunning
+	stateOrphan
+)
+
+func (s busState) String() string {
+	switch s {
+	case stateRunning:
+		return "running"
+	case stateOrphan:
+		return "orphan"
+	default:
+		return "not_running"
+	}
+}
+
+// appStatus bundles one AppID's derived status for rendering.
+// State drives which fields are meaningful:
+//
+//	stateRunning    → PID, UptimeSec, Active, Consumers (socket-sourced)
+//	stateOrphan     → PID, UptimeSec (process-scan-sourced)
+//	stateNotRunning → none
+type appStatus struct {
+	AppID     string
+	State     busState
+	PID       int
+	UptimeSec int
+	Active    int
+	Consumers []protocol.ConsumerInfo
+}
+
+// busQuerier abstracts the socket-based status query so tests can inject.
+type busQuerier interface {
+	QueryBusStatus(appID string) (*protocol.StatusResponse, error)
+}
+
+// singleAppScanner wraps a Scanner and filters its results down to a
+// single AppID — used by `--current` to prevent unrelated orphan
+// processes from appearing in a profile-scoped status query.
+type singleAppScanner struct {
+	appID string
+	inner busdiscover.Scanner
+}
+
+func (s singleAppScanner) ScanBusProcesses() ([]busdiscover.Process, error) {
+	if s.inner == nil {
+		return nil, nil
+	}
+	all, err := s.inner.ScanBusProcesses()
+	if err != nil {
+		return nil, err
+	}
+	out := all[:0]
+	for _, p := range all {
+		if p.AppID == s.appID {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// transportQuerier is the production busQuerier — dials the IPC socket.
+type transportQuerier struct {
+	tr transport.IPC
+}
+
+func (q *transportQuerier) QueryBusStatus(appID string) (*protocol.StatusResponse, error) {
+	return busctl.QueryStatus(q.tr, appID)
+}
+
+func runStatus(f *cmdutil.Factory, current, asJSON, failOnOrphan bool) error {
+	cfg, err := f.Config()
+	if err != nil {
+		return err
+	}
+
+	// Seed: socket-discovered appIDs, plus optionally the current profile's AppID.
+	seeds := map[string]struct{}{}
+	if current {
+		seeds[cfg.AppID] = struct{}{}
+	} else {
+		for _, id := range discoverAppIDs() {
+			seeds[id] = struct{}{}
+		}
+		// Always include the current profile so users aren't told "no bus"
+		// when they've never run one — they see their current app as not_running.
+		seeds[cfg.AppID] = struct{}{}
+	}
+	seedList := make([]string, 0, len(seeds))
+	for id := range seeds {
+		seedList = append(seedList, id)
+	}
+
+	tr := transport.New()
+	// With --current, deriveStatuses must not fold in scanner-discovered
+	// AppIDs — users asked for their current profile, not "this profile
+	// plus any orphan bus processes on the host". Passing sc=nil makes
+	// orphan-detection for OTHER apps a no-op while still letting us
+	// classify the current profile as orphan if its socket is missing
+	// but its process is alive.
+	var scanner busdiscover.Scanner
+	if current {
+		scanner = singleAppScanner{appID: cfg.AppID, inner: busdiscover.Default()}
+	} else {
+		scanner = busdiscover.Default()
+	}
+	statuses := deriveStatuses(
+		seedList,
+		scanner,
+		&transportQuerier{tr: tr},
+		time.Now(),
+	)
+
+	if asJSON {
+		if err := writeStatusJSON(f.IOStreams.Out, statuses); err != nil {
+			return err
+		}
+	} else {
+		writeStatusText(f.IOStreams.Out, statuses)
+	}
+	return exitForOrphan(statuses, failOnOrphan)
+}
+
+// deriveStatuses computes per-AppID state from socket + process-scan inputs.
+//
+// Algorithm:
+//  1. Start with the seed AppIDs (socket-discovered + current profile).
+//  2. Scan live bus processes; union their AppIDs into the seed set.
+//     (This is how orphan AppIDs get picked up: no socket, but a live process.)
+//  3. For each AppID:
+//     - Query bus socket. Success ⇒ stateRunning.
+//     - Failure: check if we have a live process for this AppID ⇒ stateOrphan.
+//     - No process either ⇒ stateNotRunning.
+//
+// Scanner errors are non-fatal — orphan detection is a nice-to-have; we
+// mustn't break `event status` if `ps` is missing (container, minimal image).
+func deriveStatuses(seedAppIDs []string, sc busdiscover.Scanner, q busQuerier, now time.Time) []appStatus {
+	procByAppID := map[string]busdiscover.Process{}
+	if sc != nil {
+		if procs, err := sc.ScanBusProcesses(); err == nil {
+			for _, p := range procs {
+				procByAppID[p.AppID] = p
+			}
+		}
+	}
+
+	// Union seeds with scanner-discovered AppIDs.
+	ids := map[string]struct{}{}
+	for _, id := range seedAppIDs {
+		ids[id] = struct{}{}
+	}
+	for id := range procByAppID {
+		ids[id] = struct{}{}
+	}
+	sorted := make([]string, 0, len(ids))
+	for id := range ids {
+		sorted = append(sorted, id)
+	}
+	sort.Strings(sorted)
+
+	// Query bus sockets in parallel so one wedged peer can't drag out the
+	// whole command — per-op deadlines on the wire cap each query around
+	// 15s, but serial iteration compounds that for every configured app.
+	type probe struct {
+		resp *protocol.StatusResponse
+		err  error
+	}
+	probes := make([]probe, len(sorted))
+	var wg sync.WaitGroup
+	for i, appID := range sorted {
+		wg.Add(1)
+		go func(i int, appID string) {
+			defer wg.Done()
+			probes[i].resp, probes[i].err = q.QueryBusStatus(appID)
+		}(i, appID)
+	}
+	wg.Wait()
+
+	result := make([]appStatus, 0, len(sorted))
+	for i, appID := range sorted {
+		s := appStatus{AppID: appID, State: stateNotRunning}
+		if probes[i].err == nil {
+			resp := probes[i].resp
+			s.State = stateRunning
+			s.PID = resp.PID
+			s.UptimeSec = resp.UptimeSec
+			s.Active = resp.ActiveConns
+			s.Consumers = resp.Consumers
+		} else if p, ok := procByAppID[appID]; ok {
+			s.State = stateOrphan
+			s.PID = p.PID
+			s.UptimeSec = int(now.Sub(p.StartTime).Seconds())
+		}
+		result = append(result, s)
+	}
+	return result
+}
+
+// humanizeDuration formats d as a coarse "N unit ago" string, choosing the
+// largest unit where the count is >= 1. Used for orphan "started Xh ago"
+// text where exact precision matters less than quick legibility.
+func humanizeDuration(d time.Duration) string {
+	s := int(d.Seconds())
+	if s < 60 {
+		return fmt.Sprintf("%ds ago", s)
+	}
+	m := s / 60
+	if m < 60 {
+		return fmt.Sprintf("%dm ago", m)
+	}
+	h := m / 60
+	if h < 24 {
+		return fmt.Sprintf("%dh ago", h)
+	}
+	return fmt.Sprintf("%dd ago", h/24)
+}
+
+func writeStatusText(out io.Writer, statuses []appStatus) {
+	for i, s := range statuses {
+		if i > 0 {
+			fmt.Fprintln(out)
+		}
+		fmt.Fprintf(out, "── %s ──\n", s.AppID)
+		switch s.State {
+		case stateNotRunning:
+			fmt.Fprintln(out, "  Bus: not running")
+		case stateRunning:
+			fmt.Fprintf(out, "  Bus:              running (PID %d, uptime %s)\n",
+				s.PID, (time.Duration(s.UptimeSec) * time.Second).String())
+			fmt.Fprintf(out, "  Active consumers: %d\n", s.Active)
+			if len(s.Consumers) > 0 {
+				headers := []string{"CONSUMER", "EVENT KEY", "RECEIVED", "DROPPED"}
+				rows := make([][]string, 0, len(s.Consumers))
+				for _, c := range s.Consumers {
+					rows = append(rows, []string{
+						fmt.Sprintf("pid=%d", c.PID),
+						c.EventKey,
+						fmt.Sprintf("%d", c.Received),
+						fmt.Sprintf("%d", c.Dropped),
+					})
+				}
+				widths := tableWidths(headers, rows)
+				const colGap = "  "
+				fmt.Fprintln(out)
+				fmt.Fprint(out, "  ")
+				printTableRow(out, widths, headers, colGap)
+				for _, row := range rows {
+					fmt.Fprint(out, "  ")
+					printTableRow(out, widths, row, colGap)
+				}
+			}
+		case stateOrphan:
+			fmt.Fprintf(out, "  Bus:     orphan (PID %d, started %s)\n",
+				s.PID, humanizeDuration(time.Duration(s.UptimeSec)*time.Second))
+			fmt.Fprintln(out, "  Issue:   socket file missing — consumers cannot connect")
+			fmt.Fprintf(out, "  Action:  kill %d\n", s.PID)
+		}
+	}
+}
+
+func writeStatusJSON(w io.Writer, statuses []appStatus) error {
+	type jsonStatus struct {
+		AppID           string                  `json:"app_id"`
+		Status          string                  `json:"status"`
+		Running         bool                    `json:"running"` // backward compat
+		PID             int                     `json:"pid,omitempty"`
+		UptimeSec       int                     `json:"uptime_sec,omitempty"`
+		Active          int                     `json:"active_consumers,omitempty"`
+		Consumers       []protocol.ConsumerInfo `json:"consumers,omitempty"`
+		Issue           string                  `json:"issue,omitempty"`
+		SuggestedAction string                  `json:"suggested_action,omitempty"`
+	}
+	payload := make([]jsonStatus, 0, len(statuses))
+	for _, s := range statuses {
+		js := jsonStatus{
+			AppID:     s.AppID,
+			Status:    s.State.String(),
+			Running:   s.State == stateRunning,
+			PID:       s.PID,
+			UptimeSec: s.UptimeSec,
+			Active:    s.Active,
+			Consumers: s.Consumers,
+		}
+		if s.State == stateOrphan {
+			js.Issue = "socket file missing"
+			js.SuggestedAction = fmt.Sprintf("kill %d", s.PID)
+		}
+		payload = append(payload, js)
+	}
+	output.PrintJson(w, map[string]interface{}{"apps": payload})
+	return nil
+}
+
+// exitForOrphan returns an ExitValidation error when failOnOrphan is true
+// and at least one status is in stateOrphan. Default (failOnOrphan=false)
+// always returns nil — `event status` is primarily an observation
+// command, and silently converting the exit code would break existing
+// scripts that treat exit 0 as "command ran fine". Scripts that want
+// health-check semantics opt in explicitly.
+func exitForOrphan(statuses []appStatus, failOnOrphan bool) error {
+	if !failOnOrphan {
+		return nil
+	}
+	for _, s := range statuses {
+		if s.State == stateOrphan {
+			return output.ErrBare(output.ExitValidation)
+		}
+	}
+	return nil
+}

--- a/cmd/event/status_fail_on_orphan_test.go
+++ b/cmd/event/status_fail_on_orphan_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/larksuite/cli/internal/output"
+)
+
+func TestExitForOrphan_Orphan(t *testing.T) {
+	statuses := []appStatus{
+		{AppID: "cli_a", State: stateRunning},
+		{AppID: "cli_b", State: stateOrphan, PID: 70926},
+	}
+	err := exitForOrphan(statuses, true)
+	if err == nil {
+		t.Fatal("expected error when failOnOrphan=true and orphan present")
+	}
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *output.ExitError, got %T", err)
+	}
+	if exitErr.Code != output.ExitValidation {
+		t.Errorf("Code = %d, want %d", exitErr.Code, output.ExitValidation)
+	}
+}
+
+func TestExitForOrphan_NoOrphan(t *testing.T) {
+	statuses := []appStatus{
+		{AppID: "cli_a", State: stateRunning},
+		{AppID: "cli_b", State: stateNotRunning},
+	}
+	if err := exitForOrphan(statuses, true); err != nil {
+		t.Errorf("expected nil error when no orphan; got %v", err)
+	}
+}
+
+func TestExitForOrphan_FlagDisabled(t *testing.T) {
+	statuses := []appStatus{
+		{AppID: "cli_b", State: stateOrphan, PID: 70926},
+	}
+	if err := exitForOrphan(statuses, false); err != nil {
+		t.Errorf("flag off should never return error; got %v", err)
+	}
+}

--- a/cmd/event/status_orphan_test.go
+++ b/cmd/event/status_orphan_test.go
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event/busdiscover"
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// fakeScanner implements busdiscover.Scanner for tests.
+type fakeScanner struct {
+	procs []busdiscover.Process
+	err   error
+}
+
+func (f *fakeScanner) ScanBusProcesses() ([]busdiscover.Process, error) {
+	return f.procs, f.err
+}
+
+// fakeBusQuerier implements the bus status query — returns StatusResponse
+// for appIDs in respByAppID, error otherwise (simulating socket absent).
+type fakeBusQuerier struct {
+	respByAppID map[string]*protocol.StatusResponse
+}
+
+func (f *fakeBusQuerier) QueryBusStatus(appID string) (*protocol.StatusResponse, error) {
+	if r, ok := f.respByAppID[appID]; ok {
+		return r, nil
+	}
+	return nil, errors.New("dial failed")
+}
+
+func TestDeriveStatuses_RunningBus(t *testing.T) {
+	q := &fakeBusQuerier{
+		respByAppID: map[string]*protocol.StatusResponse{
+			"cli_a": protocol.NewStatusResponse(12345, 150, 1, nil),
+		},
+	}
+	sc := &fakeScanner{procs: nil}
+
+	statuses := deriveStatuses([]string{"cli_a"}, sc, q, time.Now())
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status, got %d", len(statuses))
+	}
+	s := statuses[0]
+	if s.State != stateRunning {
+		t.Errorf("State = %v, want stateRunning", s.State)
+	}
+	if s.PID != 12345 {
+		t.Errorf("PID = %d, want 12345", s.PID)
+	}
+	if s.UptimeSec != 150 {
+		t.Errorf("UptimeSec = %d, want 150", s.UptimeSec)
+	}
+}
+
+func TestDeriveStatuses_OrphanBus(t *testing.T) {
+	// Socket dial fails but the scanner finds a live bus process.
+	q := &fakeBusQuerier{respByAppID: map[string]*protocol.StatusResponse{}}
+	sc := &fakeScanner{procs: []busdiscover.Process{
+		{PID: 70926, AppID: "cli_a", StartTime: time.Now().Add(-19 * time.Hour)},
+	}}
+
+	now := time.Now()
+	statuses := deriveStatuses([]string{"cli_a"}, sc, q, now)
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status, got %d", len(statuses))
+	}
+	s := statuses[0]
+	if s.State != stateOrphan {
+		t.Errorf("State = %v, want stateOrphan", s.State)
+	}
+	if s.PID != 70926 {
+		t.Errorf("PID = %d, want 70926", s.PID)
+	}
+	// Uptime should be ~19h (within 1 minute tolerance for test timing).
+	wantUptime := int((19 * time.Hour).Seconds())
+	if s.UptimeSec < wantUptime-60 || s.UptimeSec > wantUptime+60 {
+		t.Errorf("UptimeSec = %d, want ~%d", s.UptimeSec, wantUptime)
+	}
+}
+
+func TestDeriveStatuses_NotRunning(t *testing.T) {
+	q := &fakeBusQuerier{respByAppID: map[string]*protocol.StatusResponse{}}
+	sc := &fakeScanner{procs: nil}
+
+	statuses := deriveStatuses([]string{"cli_a"}, sc, q, time.Now())
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status, got %d", len(statuses))
+	}
+	s := statuses[0]
+	if s.State != stateNotRunning {
+		t.Errorf("State = %v, want stateNotRunning", s.State)
+	}
+}
+
+func TestDeriveStatuses_DiscoversOrphanAppIDsFromProcessScan(t *testing.T) {
+	// Caller passes only cli_known; the scanner finds cli_orphan too.
+	// Both should appear in the result.
+	q := &fakeBusQuerier{respByAppID: map[string]*protocol.StatusResponse{}}
+	sc := &fakeScanner{procs: []busdiscover.Process{
+		{PID: 70926, AppID: "cli_orphan", StartTime: time.Now().Add(-1 * time.Hour)},
+	}}
+
+	statuses := deriveStatuses([]string{"cli_known"}, sc, q, time.Now())
+	if len(statuses) != 2 {
+		t.Fatalf("expected 2 statuses, got %d: %+v", len(statuses), statuses)
+	}
+	// Both statuses present regardless of order.
+	byID := map[string]appStatus{}
+	for _, s := range statuses {
+		byID[s.AppID] = s
+	}
+	if byID["cli_known"].State != stateNotRunning {
+		t.Errorf("cli_known state = %v, want stateNotRunning", byID["cli_known"].State)
+	}
+	if byID["cli_orphan"].State != stateOrphan {
+		t.Errorf("cli_orphan state = %v, want stateOrphan", byID["cli_orphan"].State)
+	}
+}
+
+func TestDeriveStatuses_ScannerErrorIsNotFatal(t *testing.T) {
+	// If scanner fails (e.g. ps not available), we still want running/not_running
+	// states to work — orphans just can't be detected.
+	q := &fakeBusQuerier{
+		respByAppID: map[string]*protocol.StatusResponse{
+			"cli_a": protocol.NewStatusResponse(12345, 150, 1, nil),
+		},
+	}
+	sc := &fakeScanner{err: errors.New("ps failed")}
+
+	statuses := deriveStatuses([]string{"cli_a"}, sc, q, time.Now())
+	if len(statuses) != 1 {
+		t.Fatalf("expected 1 status, got %d", len(statuses))
+	}
+	if statuses[0].State != stateRunning {
+		t.Errorf("State = %v, want stateRunning (scanner error must not break running detection)", statuses[0].State)
+	}
+}
+
+func TestWriteStatusText_OrphanBlock(t *testing.T) {
+	var buf bytes.Buffer
+	statuses := []appStatus{{
+		AppID:     "cli_a96a42f48438dbd2",
+		State:     stateOrphan,
+		PID:       70926,
+		UptimeSec: 68400, // 19 hours
+	}}
+	writeStatusText(&buf, statuses)
+	out := buf.String()
+
+	for _, want := range []string{
+		"── cli_a96a42f48438dbd2 ──",
+		"Bus:     orphan (PID 70926, started 19h ago)",
+		"Issue:   socket file missing — consumers cannot connect",
+		"Action:  kill 70926",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+	// Explicitly assert no "running" line leaked into an orphan block.
+	if strings.Contains(out, "running (PID") {
+		t.Errorf("orphan block must not contain 'running' text; got:\n%s", out)
+	}
+}
+
+func TestWriteStatusJSON_OrphanFields(t *testing.T) {
+	var buf bytes.Buffer
+	statuses := []appStatus{{
+		AppID:     "cli_a96a42f48438dbd2",
+		State:     stateOrphan,
+		PID:       70926,
+		UptimeSec: 68400,
+	}}
+	if err := writeStatusJSON(&buf, statuses); err != nil {
+		t.Fatalf("writeStatusJSON: %v", err)
+	}
+	var payload struct {
+		Apps []map[string]interface{} `json:"apps"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(payload.Apps) != 1 {
+		t.Fatalf("apps len = %d, want 1", len(payload.Apps))
+	}
+	a := payload.Apps[0]
+	if a["status"] != "orphan" {
+		t.Errorf("status = %v, want \"orphan\"", a["status"])
+	}
+	if a["running"] != false {
+		t.Errorf("running = %v, want false", a["running"])
+	}
+	if a["issue"] != "socket file missing" {
+		t.Errorf("issue = %v, want \"socket file missing\"", a["issue"])
+	}
+	if a["suggested_action"] != "kill 70926" {
+		t.Errorf("suggested_action = %v, want \"kill 70926\"", a["suggested_action"])
+	}
+	// pid should be numeric 70926 (float64 from JSON decode).
+	if pid, ok := a["pid"].(float64); !ok || int(pid) != 70926 {
+		t.Errorf("pid = %v, want 70926", a["pid"])
+	}
+}
+
+func TestWriteStatusJSON_RunningOmitsOrphanFields(t *testing.T) {
+	var buf bytes.Buffer
+	statuses := []appStatus{{
+		AppID:     "cli_running",
+		State:     stateRunning,
+		PID:       11111,
+		UptimeSec: 60,
+		Active:    0,
+	}}
+	if err := writeStatusJSON(&buf, statuses); err != nil {
+		t.Fatalf("writeStatusJSON: %v", err)
+	}
+	out := buf.String()
+	// Orphan-specific fields should not leak onto running rows.
+	if strings.Contains(out, `"issue"`) {
+		t.Errorf("running status must not include 'issue' field; got:\n%s", out)
+	}
+	if strings.Contains(out, `"suggested_action"`) {
+		t.Errorf("running status must not include 'suggested_action' field; got:\n%s", out)
+	}
+}
+
+func TestHumanizeDuration(t *testing.T) {
+	for _, tt := range []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "30s ago"},
+		{90 * time.Second, "1m ago"},
+		{45 * time.Minute, "45m ago"},
+		{90 * time.Minute, "1h ago"},
+		{5 * time.Hour, "5h ago"},
+		{30 * time.Hour, "1d ago"},
+		{80 * time.Hour, "3d ago"},
+	} {
+		got := humanizeDuration(tt.d)
+		if got != tt.want {
+			t.Errorf("humanizeDuration(%v) = %q, want %q", tt.d, got, tt.want)
+		}
+	}
+}

--- a/cmd/event/status_orphan_test.go
+++ b/cmd/event/status_orphan_test.go
@@ -149,7 +149,7 @@ func TestDeriveStatuses_ScannerErrorIsNotFatal(t *testing.T) {
 func TestWriteStatusText_OrphanBlock(t *testing.T) {
 	var buf bytes.Buffer
 	statuses := []appStatus{{
-		AppID:     "cli_a96a42f48438dbd2",
+		AppID:     "cli_XXXXXXXXXXXXXXXX",
 		State:     stateOrphan,
 		PID:       70926,
 		UptimeSec: 68400, // 19 hours
@@ -158,7 +158,7 @@ func TestWriteStatusText_OrphanBlock(t *testing.T) {
 	out := buf.String()
 
 	for _, want := range []string{
-		"── cli_a96a42f48438dbd2 ──",
+		"── cli_XXXXXXXXXXXXXXXX ──",
 		"Bus:     orphan (PID 70926, started 19h ago)",
 		"Issue:   socket file missing — consumers cannot connect",
 		"Action:  kill 70926",
@@ -176,7 +176,7 @@ func TestWriteStatusText_OrphanBlock(t *testing.T) {
 func TestWriteStatusJSON_OrphanFields(t *testing.T) {
 	var buf bytes.Buffer
 	statuses := []appStatus{{
-		AppID:     "cli_a96a42f48438dbd2",
+		AppID:     "cli_XXXXXXXXXXXXXXXX",
 		State:     stateOrphan,
 		PID:       70926,
 		UptimeSec: 68400,

--- a/cmd/event/stop.go
+++ b/cmd/event/stop.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/event/busctl"
+	"github.com/larksuite/cli/internal/event/transport"
+	"github.com/larksuite/cli/internal/output"
+)
+
+// stopStatus is the outcome tag for one appID's stop attempt. The wire
+// format (JSON) is the string form, so values MUST stay stable.
+type stopStatus string
+
+const (
+	stopStopped stopStatus = "stopped"
+	stopNoBus   stopStatus = "no_bus"
+	stopRefused stopStatus = "refused"
+	stopErrored stopStatus = "error"
+)
+
+// stopResult is the outcome for one appID — serialized as JSON and used
+// by the text formatter.
+type stopResult struct {
+	AppID  string     `json:"app_id"`
+	Status stopStatus `json:"status"`
+	PID    int        `json:"pid,omitempty"`
+	Reason string     `json:"reason,omitempty"`
+}
+
+// stopCmdOpts bundles the flag-backed inputs for `event stop`.
+type stopCmdOpts struct {
+	appID  string
+	all    bool
+	force  bool
+	asJSON bool
+}
+
+// NewCmdStop creates the "event stop" subcommand that stops the bus daemon.
+func NewCmdStop(f *cmdutil.Factory) *cobra.Command {
+	var o stopCmdOpts
+
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop the event bus daemon",
+		Long: `Stop the event bus daemon. Target is one of:
+  • the current profile's AppID (default)
+  • an explicit AppID via --app-id
+  • every running bus on this machine via --all
+
+Exit code: 2 if any target was refused or errored, 0 otherwise.
+
+--force widens two gates:
+  1. Allows stopping a bus that still has active consumers.
+  2. On shutdown-timeout (bus didn't exit within 5s), SIGKILLs the
+     process and cleans up the stale socket instead of returning an
+     error.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runStop(f, o)
+		},
+	}
+
+	cmd.Flags().StringVar(&o.appID, "app-id", "", "App ID of the bus to stop (default: current profile)")
+	cmd.Flags().BoolVar(&o.all, "all", false, "Stop all running bus daemons")
+	cmd.Flags().BoolVar(&o.force, "force", false, "Stop even with active consumers; on shutdown-timeout also SIGKILL the bus")
+	cmd.Flags().BoolVar(&o.asJSON, "json", false, "Emit results as JSON (for AI / scripts)")
+
+	return cmd
+}
+
+func runStop(f *cmdutil.Factory, o stopCmdOpts) error {
+	tr := transport.New()
+
+	targets := []string{}
+	if o.all {
+		targets = discoverAppIDs()
+	} else {
+		targetAppID := o.appID
+		if targetAppID == "" {
+			cfg, err := f.Config()
+			if err != nil {
+				return err
+			}
+			targetAppID = cfg.AppID
+		}
+		targets = []string{targetAppID}
+	}
+
+	if len(targets) == 0 {
+		if o.asJSON {
+			return writeStopJSON(f.IOStreams.Out, nil)
+		}
+		fmt.Fprintln(f.IOStreams.Out, "No event bus instances found.")
+		return nil
+	}
+
+	results := make([]stopResult, 0, len(targets))
+	for _, id := range targets {
+		results = append(results, stopBusOne(tr, id, o.force))
+	}
+
+	if o.asJSON {
+		return writeStopJSON(f.IOStreams.Out, results)
+	}
+	writeStopText(f.IOStreams.Out, f.IOStreams.ErrOut, results)
+
+	// Any refused or errored result triggers a non-zero exit so scripts
+	// that don't parse --json still get a signal.
+	for _, r := range results {
+		if r.Status == stopRefused || r.Status == stopErrored {
+			return output.ErrBare(output.ExitValidation)
+		}
+	}
+	return nil
+}
+
+// stopBusOne attempts to stop the bus for appID. Never returns an error;
+// failures live in result.Status / result.Reason.
+//
+// After sending Shutdown the function polls tr.Dial until the listener is
+// gone (proving the Bus process actually exited) or the budget elapses.
+// Declaring success on Encode alone is a lie: the bytes only reached the
+// kernel buffer, and the bus may still be alive — users then see "Bus
+// stopped" while `ps` still shows the process.
+func stopBusOne(tr transport.IPC, appID string, force bool) stopResult {
+	resp, err := busctl.QueryStatus(tr, appID)
+	if err != nil {
+		return stopResult{AppID: appID, Status: stopNoBus}
+	}
+
+	if resp.ActiveConns > 0 && !force {
+		pids := make([]int, len(resp.Consumers))
+		for i, c := range resp.Consumers {
+			pids[i] = c.PID
+		}
+		return stopResult{
+			AppID:  appID,
+			Status: stopRefused,
+			PID:    resp.PID,
+			Reason: fmt.Sprintf("%d active consumer(s) (pids: %v); use --force to override", resp.ActiveConns, pids),
+		}
+	}
+
+	if err := busctl.SendShutdown(tr, appID); err != nil {
+		return stopResult{AppID: appID, Status: stopErrored, PID: resp.PID, Reason: err.Error()}
+	}
+
+	// Poll until Bus exits (Dial fails) or budget elapses.
+	const pollInterval = 100 * time.Millisecond
+	deadline := time.Now().Add(shutdownBudget)
+	for time.Now().Before(deadline) {
+		time.Sleep(pollInterval)
+		probe, dialErr := tr.Dial(tr.Address(appID))
+		if dialErr != nil {
+			return stopResult{AppID: appID, Status: stopStopped, PID: resp.PID}
+		}
+		probe.Close()
+	}
+
+	// Bus did not exit in time.
+	if !force {
+		return stopResult{
+			AppID:  appID,
+			Status: stopErrored,
+			PID:    resp.PID,
+			Reason: fmt.Sprintf("Bus did not exit within %v (pid=%d still listening); use --force to kill", shutdownBudget, resp.PID),
+		}
+	}
+
+	// --force: SIGKILL and clean up the stale socket so the next `event start`
+	// doesn't trip on a leftover listener address.
+	if err := killProcess(resp.PID); err != nil {
+		if errors.Is(err, os.ErrProcessDone) {
+			// Bus exited in the narrow window between timeout and kill. Treat as
+			// success — the user's intent was "make bus go away", and it's gone.
+			tr.Cleanup(tr.Address(appID))
+			return stopResult{
+				AppID:  appID,
+				Status: stopStopped,
+				PID:    resp.PID,
+				Reason: "bus exited during kill attempt",
+			}
+		}
+		return stopResult{
+			AppID:  appID,
+			Status: stopErrored,
+			PID:    resp.PID,
+			Reason: fmt.Sprintf("failed to kill bus process: %v", err),
+		}
+	}
+	tr.Cleanup(tr.Address(appID))
+	return stopResult{
+		AppID:  appID,
+		Status: stopStopped,
+		PID:    resp.PID,
+		Reason: "killed (ungraceful) after shutdown timeout",
+	}
+}
+
+// killProcess terminates a bus process by PID. It's a package-level var so
+// tests can swap it out without spawning real sub-processes (which would
+// require permission-sensitive PIDs and slow the suite down).
+var killProcess = func(pid int) error {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return p.Kill()
+}
+
+// shutdownBudget bounds how long stopBusOne waits for the bus to actually
+// exit after a Shutdown message. A var rather than const so integration
+// tests can shrink it — production uses 5s (see test helper withShortBudget).
+var shutdownBudget = 5 * time.Second
+
+func writeStopJSON(w io.Writer, results []stopResult) error {
+	if results == nil {
+		results = []stopResult{}
+	}
+	output.PrintJson(w, map[string]interface{}{"results": results})
+	return nil
+}
+
+func writeStopText(out, errOut io.Writer, results []stopResult) {
+	for _, r := range results {
+		switch r.Status {
+		case stopStopped:
+			fmt.Fprintf(out, "Bus stopped for %s (pid=%d)\n", r.AppID, r.PID)
+		case stopNoBus:
+			fmt.Fprintf(out, "No bus running for %s\n", r.AppID)
+		case stopRefused:
+			fmt.Fprintf(errOut, "Refused stopping %s: %s\n", r.AppID, r.Reason)
+		case stopErrored:
+			fmt.Fprintf(errOut, "Error stopping %s: %s\n", r.AppID, r.Reason)
+		}
+	}
+}
+
+// discoverAppIDs returns appIDs with a live-looking bus.sock under the
+// events dir. Skips directories without a socket file: stopped buses
+// leave bus.log / bus.fork.lock behind but the sock is gone, so we
+// treat those as "not running". Unix-only: Windows named pipes aren't
+// on disk; Windows callers use --app-id.
+func discoverAppIDs() []string {
+	eventsDir := filepath.Join(core.GetConfigDir(), "events")
+	entries, err := os.ReadDir(eventsDir)
+	if err != nil {
+		return nil
+	}
+	var ids []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		sockPath := filepath.Join(eventsDir, e.Name(), "bus.sock")
+		if _, statErr := os.Stat(sockPath); statErr != nil {
+			continue
+		}
+		ids = append(ids, e.Name())
+	}
+	return ids
+}

--- a/cmd/event/stop_integration_test.go
+++ b/cmd/event/stop_integration_test.go
@@ -1,0 +1,374 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// mockTransport routes every Address(appID) to a fixed TCP address so we can
+// drive stopBusOne against a synthetic in-process "Bus". Listen is unused here
+// (the fake Bus binds its own listener manually), but the method is required
+// by the transport.IPC interface.
+type mockTransport struct {
+	mu      sync.Mutex
+	addr    string // "127.0.0.1:<port>"
+	cleaned bool
+}
+
+func (t *mockTransport) Listen(addr string) (net.Listener, error) {
+	return net.Listen("tcp", addr)
+}
+
+func (t *mockTransport) Dial(addr string) (net.Conn, error) {
+	// 500ms timeout so a dead address fails promptly during the poll loop.
+	return net.DialTimeout("tcp", addr, 500*time.Millisecond)
+}
+
+func (t *mockTransport) Address(appID string) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.addr
+}
+
+func (t *mockTransport) Cleanup(addr string) {
+	t.mu.Lock()
+	t.cleaned = true
+	t.mu.Unlock()
+}
+
+func (t *mockTransport) didCleanup() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.cleaned
+}
+
+// fakeBus is an in-process stand-in for the real Bus process. It accepts TCP
+// connections, answers StatusQuery with a canned StatusResponse, and (on
+// receiving Shutdown) either closes its listener after exitDelay or simply
+// keeps accepting new connections forever (unresponsive mode).
+type fakeBus struct {
+	listener     net.Listener
+	pid          int
+	exitDelay    time.Duration // 0 means never exit (unresponsive)
+	unresponsive bool
+
+	shutdownCount int32
+	wg            sync.WaitGroup
+
+	stopOnce sync.Once
+	done     chan struct{}
+}
+
+// newFakeBus starts listening on a random localhost TCP port.
+func newFakeBus(t *testing.T, pid int, exitDelay time.Duration, unresponsive bool) *fakeBus {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	b := &fakeBus{
+		listener:     ln,
+		pid:          pid,
+		exitDelay:    exitDelay,
+		unresponsive: unresponsive,
+		done:         make(chan struct{}),
+	}
+	b.wg.Add(1)
+	go b.serve()
+	return b
+}
+
+func (b *fakeBus) addr() string { return b.listener.Addr().String() }
+
+func (b *fakeBus) serve() {
+	defer b.wg.Done()
+	for {
+		conn, err := b.listener.Accept()
+		if err != nil {
+			return // listener closed
+		}
+		b.wg.Add(1)
+		go b.handle(conn)
+	}
+}
+
+func (b *fakeBus) handle(conn net.Conn) {
+	defer b.wg.Done()
+	defer conn.Close()
+
+	r := bufio.NewReader(conn)
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		return
+	}
+	msg, err := protocol.Decode(line)
+	if err != nil {
+		return
+	}
+
+	switch msg.(type) {
+	case *protocol.StatusQuery:
+		_ = protocol.Encode(conn, &protocol.StatusResponse{
+			Type:        protocol.MsgTypeStatusResponse,
+			PID:         b.pid,
+			UptimeSec:   1,
+			ActiveConns: 0,
+			Consumers:   nil,
+		})
+	case *protocol.Shutdown:
+		atomic.AddInt32(&b.shutdownCount, 1)
+		if b.unresponsive {
+			return // keep listener open; test must observe timeout
+		}
+		if b.exitDelay > 0 {
+			go func() {
+				time.Sleep(b.exitDelay)
+				b.stop()
+			}()
+		} else {
+			// exit immediately
+			go b.stop()
+		}
+	}
+}
+
+func (b *fakeBus) stop() {
+	b.stopOnce.Do(func() {
+		_ = b.listener.Close()
+		close(b.done)
+	})
+}
+
+func (b *fakeBus) wait(t *testing.T, budget time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		b.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(budget):
+		t.Fatalf("fakeBus did not shut down within %v", budget)
+	}
+}
+
+// TestStopReturnsStoppedOnlyAfterBusExits asserts stopBusOne waits for the
+// listener to actually disappear rather than declaring success on Encode.
+func TestStopReturnsStoppedOnlyAfterBusExits(t *testing.T) {
+	const pid = 44441
+	const exitDelay = 500 * time.Millisecond
+
+	bus := newFakeBus(t, pid, exitDelay, false)
+	defer bus.stop()
+	tr := &mockTransport{addr: bus.addr()}
+
+	start := time.Now()
+	res := stopBusOne(tr, "test-app", false)
+	elapsed := time.Since(start)
+
+	if res.Status != "stopped" {
+		t.Fatalf("status = %q (reason=%q); want stopped", res.Status, res.Reason)
+	}
+	if res.PID != pid {
+		t.Fatalf("pid = %d; want %d", res.PID, pid)
+	}
+	// Must wait long enough for the Bus to actually exit. Allow slight
+	// scheduler slack, but be strict enough to catch "returns on Encode".
+	if elapsed < 400*time.Millisecond {
+		t.Fatalf("stopBusOne returned in %v; expected >= %v (waited for bus to exit)", elapsed, exitDelay)
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("stopBusOne took %v; expected well under 3s", elapsed)
+	}
+
+	bus.wait(t, 2*time.Second)
+	if got := atomic.LoadInt32(&bus.shutdownCount); got != 1 {
+		t.Errorf("fakeBus received %d Shutdown messages; want 1", got)
+	}
+}
+
+// TestStopTimesOutOnUnresponsiveBusWithoutForce asserts that when the Bus
+// keeps listening past the 5s budget, stopBusOne returns "error" with an
+// actionable reason and does NOT kill the process.
+func TestStopTimesOutOnUnresponsiveBusWithoutForce(t *testing.T) {
+	const pid = 44442
+
+	// Track killProcess calls to prove --force is not implied.
+	origKill := killProcess
+	t.Cleanup(func() { killProcess = origKill })
+	var killCalls []int
+	var killMu sync.Mutex
+	killProcess = func(p int) error {
+		killMu.Lock()
+		killCalls = append(killCalls, p)
+		killMu.Unlock()
+		return nil
+	}
+
+	bus := newFakeBus(t, pid, 0, true)
+	defer bus.stop()
+	tr := &mockTransport{addr: bus.addr()}
+
+	// Shrink the shutdown budget so this test doesn't wait 5s of wallclock.
+	origBudget := shutdownBudget
+	t.Cleanup(func() { shutdownBudget = origBudget })
+	shutdownBudget = 500 * time.Millisecond
+
+	start := time.Now()
+	res := stopBusOne(tr, "test-app", false)
+	elapsed := time.Since(start)
+
+	if res.Status != "error" {
+		t.Fatalf("status = %q (reason=%q); want error", res.Status, res.Reason)
+	}
+	if res.PID != pid {
+		t.Errorf("pid = %d; want %d", res.PID, pid)
+	}
+	// Bound is the shrunken budget + per-iteration poll slack.
+	if elapsed < shutdownBudget || elapsed > shutdownBudget+2*time.Second {
+		t.Fatalf("elapsed = %v; want >= %v and < %v", elapsed, shutdownBudget, shutdownBudget+2*time.Second)
+	}
+	if !strings.Contains(res.Reason, "did not exit within") {
+		t.Errorf("reason %q should mention 'did not exit within'", res.Reason)
+	}
+	killMu.Lock()
+	defer killMu.Unlock()
+	if len(killCalls) != 0 {
+		t.Errorf("killProcess called %v; want 0 calls without --force", killCalls)
+	}
+	if tr.didCleanup() {
+		t.Errorf("Cleanup should not be called when --force is false")
+	}
+}
+
+// TestStopForceKillsUnresponsiveBus asserts that with --force, after the
+// shutdown budget expires, killProcess is invoked with the Bus PID and the
+// socket is cleaned up. Result is "stopped" with a reason flagging ungraceful.
+func TestStopForceKillsUnresponsiveBus(t *testing.T) {
+	const pid = 44443
+
+	origKill := killProcess
+	t.Cleanup(func() { killProcess = origKill })
+	var killCalls []int
+	var killMu sync.Mutex
+	killProcess = func(p int) error {
+		killMu.Lock()
+		killCalls = append(killCalls, p)
+		killMu.Unlock()
+		return nil
+	}
+
+	bus := newFakeBus(t, pid, 0, true)
+	defer bus.stop()
+	tr := &mockTransport{addr: bus.addr()}
+
+	origBudget := shutdownBudget
+	t.Cleanup(func() { shutdownBudget = origBudget })
+	shutdownBudget = 500 * time.Millisecond
+
+	start := time.Now()
+	res := stopBusOne(tr, "test-app", true)
+	elapsed := time.Since(start)
+
+	if res.Status != "stopped" {
+		t.Fatalf("status = %q (reason=%q); want stopped", res.Status, res.Reason)
+	}
+	if res.PID != pid {
+		t.Errorf("pid = %d; want %d", res.PID, pid)
+	}
+	if elapsed < shutdownBudget || elapsed > shutdownBudget+2*time.Second {
+		t.Fatalf("elapsed = %v; want >= %v and < %v", elapsed, shutdownBudget, shutdownBudget+2*time.Second)
+	}
+	if !strings.Contains(res.Reason, "killed") {
+		t.Errorf("reason %q should mention 'killed'", res.Reason)
+	}
+
+	killMu.Lock()
+	defer killMu.Unlock()
+	if len(killCalls) != 1 || killCalls[0] != pid {
+		t.Errorf("killProcess calls = %v; want [%d]", killCalls, pid)
+	}
+	if !tr.didCleanup() {
+		t.Errorf("Cleanup was not invoked after force-kill")
+	}
+}
+
+// TestStopReturnsStoppedFastWhenBusExitsImmediately verifies that when Bus
+// exits as soon as it receives Shutdown, stopBusOne returns quickly — within
+// one poll interval (~200ms) — not after the full 5s budget.
+func TestStopReturnsStoppedFastWhenBusExitsImmediately(t *testing.T) {
+	const pid = 12345
+
+	bus := newFakeBus(t, pid, 0, false) // exitDelay=0, unresponsive=false
+	defer bus.stop()
+	tr := &mockTransport{addr: bus.addr()}
+
+	start := time.Now()
+	res := stopBusOne(tr, "test-app", false)
+	elapsed := time.Since(start)
+
+	if res.Status != "stopped" {
+		t.Fatalf("expected stopped, got %q (reason: %s)", res.Status, res.Reason)
+	}
+	if res.PID != pid {
+		t.Errorf("expected PID=%d, got %d", pid, res.PID)
+	}
+	// Should return on the first failed probe (100ms interval + small scheduling
+	// slack). Budget is 5s; we expect well under 500ms.
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("expected fast return (<500ms), got %v — possibly waiting the full budget", elapsed)
+	}
+}
+
+// TestStopForceHandlesProcessAlreadyDeadRace verifies that when killProcess
+// returns os.ErrProcessDone (Bus exited during the kill attempt window), we
+// treat it as success rather than reporting a misleading error.
+func TestStopForceHandlesProcessAlreadyDeadRace(t *testing.T) {
+	const pid = 99999
+
+	// Inject killProcess that simulates the Bus having died between
+	// our timeout check and the kill call.
+	origKill := killProcess
+	t.Cleanup(func() { killProcess = origKill })
+	var killCalls []int
+	var killMu sync.Mutex
+	killProcess = func(p int) error {
+		killMu.Lock()
+		killCalls = append(killCalls, p)
+		killMu.Unlock()
+		return os.ErrProcessDone
+	}
+
+	bus := newFakeBus(t, pid, 0, true) // unresponsive
+	defer bus.stop()
+	tr := &mockTransport{addr: bus.addr()}
+
+	res := stopBusOne(tr, "test-app", true)
+
+	if res.Status != "stopped" {
+		t.Errorf("expected stopped (race treated as success), got %q (reason: %s)", res.Status, res.Reason)
+	}
+	killMu.Lock()
+	if len(killCalls) != 1 || killCalls[0] != pid {
+		t.Errorf("expected killProcess called once with pid=%d, got %v", pid, killCalls)
+	}
+	killMu.Unlock()
+	if !tr.didCleanup() {
+		t.Error("expected Cleanup to be called even when kill reported already-dead")
+	}
+	if !strings.Contains(res.Reason, "exited during kill attempt") {
+		t.Errorf("expected reason about race, got %q", res.Reason)
+	}
+}

--- a/cmd/event/suggestions.go
+++ b/cmd/event/suggestions.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	eventlib "github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/output"
+)
+
+const maxSuggestions = 3
+
+// suggestEventKeys returns up to maxSuggestions registered EventKeys that
+// resemble input, ranked closest-first. Empty slice means no guess.
+//
+// Substring match wins over edit distance: "im.message" should surface
+// every im.message.* key even when some unrelated key is a closer typo.
+// Levenshtein handles the remaining case — real character typos like
+// "recieve" → "receive".
+func suggestEventKeys(input string) []string {
+	type match struct {
+		key  string
+		dist int
+	}
+	var hits []match
+	threshold := max(2, len(input)/5)
+
+	for _, def := range eventlib.ListAll() {
+		if strings.Contains(def.Key, input) {
+			hits = append(hits, match{def.Key, 0})
+			continue
+		}
+		if d := levenshtein(input, def.Key); d <= threshold {
+			hits = append(hits, match{def.Key, d})
+		}
+	}
+	sort.Slice(hits, func(i, j int) bool { return hits[i].dist < hits[j].dist })
+
+	n := min(maxSuggestions, len(hits))
+	out := make([]string, n)
+	for i := range out {
+		out[i] = hits[i].key
+	}
+	return out
+}
+
+// formatSuggestions renders keys as a human-readable tail, e.g.
+// `"im.message.receive_v1"` or `one of: "a", "b", "c"`.
+func formatSuggestions(keys []string) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	quoted := make([]string, len(keys))
+	for i, k := range keys {
+		quoted[i] = fmt.Sprintf("%q", k)
+	}
+	if len(quoted) == 1 {
+		return quoted[0]
+	}
+	return "one of: " + strings.Join(quoted, ", ")
+}
+
+// unknownEventKeyErr is the standard "unknown EventKey" error with a
+// suggestion tail when available. Shared by `consume` and `schema`.
+func unknownEventKeyErr(key string) error {
+	msg := fmt.Sprintf("unknown EventKey: %s", key)
+	if guesses := suggestEventKeys(key); len(guesses) > 0 {
+		msg += " — did you mean " + formatSuggestions(guesses) + "?"
+	}
+	return output.ErrWithHint(
+		output.ExitValidation, "validation",
+		msg,
+		"Run 'lark-cli event list' to see available keys.",
+	)
+}
+
+// levenshtein computes classic edit distance. Inputs are short (EventKey
+// strings <60 chars) against a small registry (tens of entries), so the
+// straightforward two-row DP is plenty.
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	ra, rb := []rune(a), []rune(b)
+	if len(ra) == 0 {
+		return len(rb)
+	}
+	if len(rb) == 0 {
+		return len(ra)
+	}
+	prev := make([]int, len(rb)+1)
+	curr := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		curr[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[j] = min(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(rb)]
+}

--- a/cmd/event/suggestions_test.go
+++ b/cmd/event/suggestions_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"strings"
+	"testing"
+
+	_ "github.com/larksuite/cli/events"
+)
+
+func TestLevenshtein(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"a", "", 1},
+		{"", "abc", 3},
+		{"kitten", "kitten", 0},
+		{"kitten", "sitten", 1},
+		{"kitten", "sitting", 3},
+		{"飞书", "飞书", 0},
+		{"飞书", "飞s", 1},
+	}
+	for _, tc := range cases {
+		if got := levenshtein(tc.a, tc.b); got != tc.want {
+			t.Errorf("levenshtein(%q,%q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// TestSuggestEventKeys uses the real registry populated by events
+// blank-import. Assertions are loose (prefix / size) so new EventKey
+// registrations don't break the test.
+func TestSuggestEventKeys(t *testing.T) {
+	cases := []struct {
+		name              string
+		input             string
+		wantEmpty         bool
+		wantAllHavePrefix string // every suggestion must start with this
+		wantContains      string // this exact key must be present
+	}{
+		{
+			name:         "typo via Levenshtein (recieve → receive)",
+			input:        "im.message.recieve_v1",
+			wantContains: "im.message.receive_v1",
+		},
+		{
+			name:              "substring match returns im.message.* keys",
+			input:             "im.message",
+			wantAllHavePrefix: "im.message.",
+		},
+		{
+			name:      "completely unrelated input returns empty",
+			input:     "xyzzy_no_such_event_key_at_all",
+			wantEmpty: true,
+		},
+		{
+			name:         "exact key is a substring of itself",
+			input:        "im.message.receive_v1",
+			wantContains: "im.message.receive_v1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := suggestEventKeys(tc.input)
+			if tc.wantEmpty {
+				if len(got) != 0 {
+					t.Errorf("expected empty slice, got %v", got)
+				}
+				return
+			}
+			if len(got) == 0 {
+				t.Fatalf("expected non-empty suggestions, got nothing")
+			}
+			if len(got) > maxSuggestions {
+				t.Errorf("got %d suggestions, want at most %d: %v", len(got), maxSuggestions, got)
+			}
+			if tc.wantAllHavePrefix != "" {
+				for _, k := range got {
+					if !strings.HasPrefix(k, tc.wantAllHavePrefix) {
+						t.Errorf("suggestion %q lacks prefix %q (full slice: %v)", k, tc.wantAllHavePrefix, got)
+					}
+				}
+			}
+			if tc.wantContains != "" {
+				found := false
+				for _, k := range got {
+					if k == tc.wantContains {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("want %q in suggestions, got %v", tc.wantContains, got)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatSuggestions(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{name: "empty → empty string", in: nil, want: ""},
+		{name: "single key → just quoted", in: []string{"a"}, want: `"a"`},
+		{name: "two keys → one of", in: []string{"a", "b"}, want: `one of: "a", "b"`},
+		{name: "three keys → one of", in: []string{"a", "b", "c"}, want: `one of: "a", "b", "c"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatSuggestions(tc.in); got != tc.want {
+				t.Errorf("formatSuggestions(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUnknownEventKeyErr_IncludesSuggestion(t *testing.T) {
+	err := unknownEventKeyErr("im.message.recieve_v1") // typo
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"unknown EventKey: im.message.recieve_v1",
+		"did you mean",
+		"im.message.receive_v1",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q missing %q", msg, want)
+		}
+	}
+}
+
+func TestUnknownEventKeyErr_NoSuggestion(t *testing.T) {
+	err := unknownEventKeyErr("xyzzy_no_such_event_key_at_all")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unknown EventKey") {
+		t.Errorf("error should mention unknown EventKey: %q", msg)
+	}
+	if strings.Contains(msg, "did you mean") {
+		t.Errorf("error should NOT suggest anything for nonsense input: %q", msg)
+	}
+}

--- a/cmd/event/table.go
+++ b/cmd/event/table.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"fmt"
+	"io"
+)
+
+// tableWidths returns the max cell width for each column, considering
+// both the header labels and every row. Rows may be shorter or longer
+// than headers; extra columns are ignored, missing ones keep the header
+// width. The returned slice has len(headers) entries.
+func tableWidths(headers []string, rows [][]string) []int {
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	for _, row := range rows {
+		for i, cell := range row {
+			if i >= len(widths) {
+				break
+			}
+			if l := len(cell); l > widths[i] {
+				widths[i] = l
+			}
+		}
+	}
+	return widths
+}
+
+// printTableRow renders one row of cells padded to widths and separated
+// by gap. The final cell is not padded, so no trailing whitespace leaks
+// into the output.
+func printTableRow(out io.Writer, widths []int, cells []string, gap string) {
+	for i, cell := range cells {
+		if i == len(cells)-1 {
+			fmt.Fprintln(out, cell)
+			return
+		}
+		fmt.Fprintf(out, "%-*s%s", widths[i], cell, gap)
+	}
+}

--- a/events/im/message_receive.go
+++ b/events/im/message_receive.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/larksuite/cli/internal/event"
+	convertlib "github.com/larksuite/cli/shortcuts/im/convert_lib"
+)
+
+// ImMessageReceiveOutput is the flattened shape emitted for im.message.receive_v1.
+// The `desc` tags drive the reflection-based schema shown by `event schema`.
+//
+// Content semantics (see processImMessageReceive):
+//   - text / post / image / file / audio: human-readable text from convertlib
+//     with @mentions resolved to display names.
+//   - interactive (card): raw `content` JSON string — card payloads carry
+//     structured actions that a flat rendering would lose.
+type ImMessageReceiveOutput struct {
+	Type        string `json:"type"                   desc:"事件类型，恒定为 im.message.receive_v1"`
+	EventID     string `json:"event_id,omitempty"     desc:"飞书事件唯一 ID，可用于去重"`
+	Timestamp   string `json:"timestamp,omitempty"    desc:"事件投递时间（毫秒时间戳字符串），优先取自 header.create_time"                  kind:"timestamp_ms"`
+	ID          string `json:"id,omitempty"           desc:"消息 ID（等同于 message_id，历史别名，保留兼容）"                                kind:"message_id"`
+	MessageID   string `json:"message_id,omitempty"   desc:"消息 ID，以 om_ 开头"                                                          kind:"message_id"`
+	CreateTime  string `json:"create_time,omitempty"  desc:"消息发送时间（毫秒时间戳字符串）"                                                  kind:"timestamp_ms"`
+	ChatID      string `json:"chat_id,omitempty"      desc:"群组/会话 ID，以 oc_ 开头"                                                      kind:"chat_id"`
+	ChatType    string `json:"chat_type,omitempty"    desc:"会话类型"                                                                     enum:"p2p,group"`
+	MessageType string `json:"message_type,omitempty" desc:"消息类型；interactive 保留原始 JSON，其余已渲染为可读文本"                         enum:"text,post,image,file,audio,media,sticker,interactive,share_chat,share_user,system"`
+	SenderID    string `json:"sender_id,omitempty"    desc:"发送者 open_id，以 ou_ 开头"                                                    kind:"open_id"`
+	Content     string `json:"content,omitempty"      desc:"消息内容；interactive（卡片）保持原始 JSON 字符串，调用方需 fromjson 自行解析"`
+}
+
+func processImMessageReceive(_ context.Context, _ event.APIClient, raw *event.RawEvent, _ map[string]string) (json.RawMessage, error) {
+	var envelope struct {
+		Header struct {
+			EventID    string `json:"event_id"`
+			EventType  string `json:"event_type"`
+			CreateTime string `json:"create_time"`
+		} `json:"header"`
+		Event struct {
+			Message struct {
+				MessageID   string        `json:"message_id"`
+				ChatID      string        `json:"chat_id"`
+				ChatType    string        `json:"chat_type"`
+				MessageType string        `json:"message_type"`
+				Content     string        `json:"content"`
+				CreateTime  string        `json:"create_time"`
+				Mentions    []interface{} `json:"mentions"`
+			} `json:"message"`
+			Sender struct {
+				SenderID struct {
+					OpenID string `json:"open_id"`
+				} `json:"sender_id"`
+			} `json:"sender"`
+		} `json:"event"`
+	}
+	if err := json.Unmarshal(raw.Payload, &envelope); err != nil {
+		// Garbage in → original bytes back out so consumers still see the event.
+		return raw.Payload, nil
+	}
+
+	msg := envelope.Event.Message
+	content := msg.Content
+	if msg.MessageType != "interactive" {
+		content = convertlib.ConvertBodyContent(msg.MessageType, &convertlib.ConvertContext{
+			RawContent: msg.Content,
+			MentionMap: convertlib.BuildMentionKeyMap(msg.Mentions),
+		})
+	}
+
+	timestamp := envelope.Header.CreateTime
+	if timestamp == "" {
+		timestamp = msg.CreateTime
+	}
+
+	out := &ImMessageReceiveOutput{
+		Type:        envelope.Header.EventType,
+		EventID:     envelope.Header.EventID,
+		Timestamp:   timestamp,
+		ID:          msg.MessageID,
+		MessageID:   msg.MessageID,
+		CreateTime:  msg.CreateTime,
+		ChatID:      msg.ChatID,
+		ChatType:    msg.ChatType,
+		MessageType: msg.MessageType,
+		SenderID:    envelope.Event.Sender.SenderID.OpenID,
+		Content:     content,
+	}
+	return json.Marshal(out)
+}

--- a/events/im/message_receive_test.go
+++ b/events/im/message_receive_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event"
+)
+
+// TestMain registers this subpackage's keys before tests run. In production
+// the aggregator in package events does this; in isolated `go test ./events/im/...`
+// runs the aggregator is not linked, so tests register locally.
+func TestMain(m *testing.M) {
+	for _, k := range Keys() {
+		event.RegisterKey(k)
+	}
+	os.Exit(m.Run())
+}
+
+func TestIMKeys_ProcessedReceiveRegistered(t *testing.T) {
+	def, ok := event.Lookup("im.message.receive_v1")
+	if !ok {
+		t.Fatal("im.message.receive_v1 should be registered via Keys()")
+	}
+	if def.Schema.Custom == nil {
+		t.Error("Processed key must set Schema.Custom")
+	}
+	if def.Schema.Native != nil {
+		t.Error("Processed key must not set Schema.Native")
+	}
+	if def.Process == nil {
+		t.Error("Process must not be nil for Processed key")
+	}
+}
+
+func TestIMKeys_NativeEventsRegistered(t *testing.T) {
+	want := []string{
+		"im.message.message_read_v1",
+		"im.message.reaction.created_v1",
+		"im.message.reaction.deleted_v1",
+		"im.chat.member.bot.added_v1",
+		"im.chat.member.bot.deleted_v1",
+		"im.chat.member.user.added_v1",
+		"im.chat.member.user.withdrawn_v1",
+		"im.chat.member.user.deleted_v1",
+		"im.chat.updated_v1",
+		"im.chat.disbanded_v1",
+	}
+	for _, k := range want {
+		def, ok := event.Lookup(k)
+		if !ok {
+			t.Errorf("%s should be registered via Keys()", k)
+			continue
+		}
+		if def.Schema.Native == nil {
+			t.Errorf("%s: Schema.Native must be set for native key", k)
+		}
+		if def.Schema.Custom != nil {
+			t.Errorf("%s: Native key must not set Schema.Custom", k)
+		}
+		if def.Process != nil {
+			t.Errorf("%s: Native key must not set Process", k)
+		}
+		if def.Schema.Native != nil && def.Schema.Native.Type == nil {
+			t.Errorf("%s: Schema.Native.Type must reference an SDK type", k)
+		}
+	}
+}
+
+func TestProcessImMessageReceive_Text(t *testing.T) {
+	payload := `{
+		"schema": "2.0",
+		"header": {
+			"event_id": "ev_test_text",
+			"event_type": "im.message.receive_v1",
+			"create_time": "1776409469273",
+			"app_id": "cli_test"
+		},
+		"event": {
+			"sender": {
+				"sender_id": {"open_id": "ou_sender"}
+			},
+			"message": {
+				"message_id":   "om_text_001",
+				"chat_id":      "oc_chat",
+				"chat_type":    "p2p",
+				"message_type": "text",
+				"create_time":  "1776409468987",
+				"content":      "{\"text\":\"hello there\"}"
+			}
+		}
+	}`
+	out := runReceive(t, payload)
+
+	if out.Type != "im.message.receive_v1" {
+		t.Errorf("Type = %q", out.Type)
+	}
+	if out.MessageID != "om_text_001" || out.ID != "om_text_001" {
+		t.Errorf("MessageID/ID = %q/%q", out.MessageID, out.ID)
+	}
+	if out.ChatType != "p2p" || out.ChatID != "oc_chat" {
+		t.Errorf("chat_id/chat_type = %q/%q", out.ChatID, out.ChatType)
+	}
+	if out.SenderID != "ou_sender" {
+		t.Errorf("SenderID = %q", out.SenderID)
+	}
+	if out.Content != "hello there" {
+		t.Errorf("Content = %q, want \"hello there\"", out.Content)
+	}
+	if out.Timestamp != "1776409469273" {
+		t.Errorf("Timestamp = %q", out.Timestamp)
+	}
+}
+
+func TestProcessImMessageReceive_Interactive(t *testing.T) {
+	payload := `{
+		"schema": "2.0",
+		"header": {
+			"event_id": "ev_test_card",
+			"event_type": "im.message.receive_v1",
+			"create_time": "1776409469274",
+			"app_id": "cli_test"
+		},
+		"event": {
+			"sender": {
+				"sender_id": {"open_id": "ou_sender"}
+			},
+			"message": {
+				"message_id":   "om_card_001",
+				"chat_id":      "oc_chat",
+				"chat_type":    "group",
+				"message_type": "interactive",
+				"create_time":  "1776409468987",
+				"content":      "{\"header\":{\"title\":{\"tag\":\"plain_text\",\"content\":\"A card\"}}}"
+			}
+		}
+	}`
+	out := runReceive(t, payload)
+
+	if out.Type != "im.message.receive_v1" {
+		t.Errorf("Type = %q (interactive should NOT fall back to envelope form)", out.Type)
+	}
+	if out.MessageType != "interactive" {
+		t.Errorf("MessageType = %q", out.MessageType)
+	}
+	if out.ChatType != "group" {
+		t.Errorf("ChatType = %q", out.ChatType)
+	}
+}
+
+func TestProcessImMessageReceive_MalformedPayload(t *testing.T) {
+	raw := &event.RawEvent{
+		EventID:   "ev_bad",
+		EventType: "im.message.receive_v1",
+		Payload:   json.RawMessage(`not json`),
+		Timestamp: time.Now(),
+	}
+	got, err := processImMessageReceive(context.Background(), nil, raw, nil)
+	if err != nil {
+		t.Fatalf("Process should swallow parse errors, got %v", err)
+	}
+	if string(got) != "not json" {
+		t.Errorf("malformed fallback output = %q, want original bytes", string(got))
+	}
+}
+
+func runReceive(t *testing.T, payload string) ImMessageReceiveOutput {
+	t.Helper()
+	raw := &event.RawEvent{
+		EventID:   "ev_test",
+		EventType: "im.message.receive_v1",
+		Payload:   json.RawMessage(payload),
+		Timestamp: time.Now(),
+	}
+	got, err := processImMessageReceive(context.Background(), nil, raw, nil)
+	if err != nil {
+		t.Fatalf("Process error: %v", err)
+	}
+	var out ImMessageReceiveOutput
+	if err := json.Unmarshal(got, &out); err != nil {
+		t.Fatalf("Process output is not valid ImMessageReceiveOutput JSON: %v\nraw=%s", err, string(got))
+	}
+	return out
+}

--- a/events/im/message_receive_test.go
+++ b/events/im/message_receive_test.go
@@ -37,6 +37,13 @@ func TestIMKeys_ProcessedReceiveRegistered(t *testing.T) {
 	if def.Process == nil {
 		t.Error("Process must not be nil for Processed key")
 	}
+	// Guard against re-regressing: preflightScopes skips validation when
+	// Scopes is empty. im.message.receive_v1 must declare its required
+	// scopes so a bot missing im:message gets a preflight error instead of
+	// a silent "no events" at runtime.
+	if len(def.Scopes) == 0 {
+		t.Error("Scopes must not be empty — preflightScopes would bypass validation")
+	}
 }
 
 func TestIMKeys_NativeEventsRegistered(t *testing.T) {

--- a/events/im/native.go
+++ b/events/im/native.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"reflect"
+
+	"github.com/larksuite/cli/internal/event/schemas"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+// nativeIMKey curates metadata for a Native IM event. bodyType points at
+// the SDK struct (framework reflects it into a JSON Schema on demand),
+// fieldOverrides adds field-level semantic annotations the SDK struct
+// can't express (open_id / chat_id / timestamp_ms 等 Feishu-specific
+// kinds). Paths are JSON Pointer, anchored at the full resolved schema
+// (i.e. start with /event/... since Native is wrapped in V2 envelope).
+type nativeIMKey struct {
+	key            string
+	title          string
+	description    string
+	scopes         []string
+	bodyType       reflect.Type
+	fieldOverrides map[string]schemas.FieldMeta
+}
+
+// userIDOv returns `{open_id, union_id, user_id}` overrides for an SDK
+// UserID object at the given schema path prefix.
+func userIDOv(prefix string) map[string]schemas.FieldMeta {
+	return map[string]schemas.FieldMeta{
+		prefix + "/open_id":  {Kind: "open_id"},
+		prefix + "/union_id": {Kind: "union_id"},
+		prefix + "/user_id":  {Kind: "user_id"},
+	}
+}
+
+// mergeOv merges multiple FieldMeta maps left-to-right (later wins on
+// conflicting keys). Nil / empty maps are silently ignored.
+func mergeOv(ms ...map[string]schemas.FieldMeta) map[string]schemas.FieldMeta {
+	out := map[string]schemas.FieldMeta{}
+	for _, m := range ms {
+		for k, v := range m {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+var nativeIMKeys = []nativeIMKey{
+	{
+		key:         "im.message.message_read_v1",
+		title:       "Message read",
+		description: "用户阅读机器人发送的单聊消息后触发",
+		scopes:      []string{"im:message:readonly", "im:message"},
+		bodyType:    reflect.TypeOf(larkim.P2MessageReadV1Data{}),
+		fieldOverrides: mergeOv(
+			userIDOv("/event/reader/reader_id"),
+			map[string]schemas.FieldMeta{
+				"/event/reader/read_time":  {Kind: "timestamp_ms"},
+				"/event/message_id_list/*": {Kind: "message_id"},
+			},
+		),
+	},
+	{
+		key:         "im.message.reaction.created_v1",
+		title:       "Reaction added",
+		description: "消息被添加表情回复时触发",
+		scopes:      []string{"im:message:readonly", "im:message.reactions:read"},
+		bodyType:    reflect.TypeOf(larkim.P2MessageReactionCreatedV1Data{}),
+		fieldOverrides: mergeOv(
+			userIDOv("/event/user_id"),
+			map[string]schemas.FieldMeta{
+				"/event/message_id":  {Kind: "message_id"},
+				"/event/action_time": {Kind: "timestamp_ms"},
+			},
+		),
+	},
+	{
+		key:         "im.message.reaction.deleted_v1",
+		title:       "Reaction removed",
+		description: "消息被删除表情回复时触发",
+		scopes:      []string{"im:message:readonly", "im:message.reactions:read"},
+		bodyType:    reflect.TypeOf(larkim.P2MessageReactionDeletedV1Data{}),
+		fieldOverrides: mergeOv(
+			userIDOv("/event/user_id"),
+			map[string]schemas.FieldMeta{
+				"/event/message_id":  {Kind: "message_id"},
+				"/event/action_time": {Kind: "timestamp_ms"},
+			},
+		),
+	},
+	{
+		key:         "im.chat.member.bot.added_v1",
+		title:       "Bot added to chat",
+		description: "机器人被用户添加至群聊时触发",
+		scopes:      []string{"im:chat.members:bot_access"},
+		bodyType:    reflect.TypeOf(larkim.P2ChatMemberBotAddedV1Data{}),
+		fieldOverrides: mergeOv(
+			userIDOv("/event/operator_id"),
+			map[string]schemas.FieldMeta{
+				"/event/chat_id": {Kind: "chat_id"},
+			},
+		),
+	},
+	{
+		key:         "im.chat.member.bot.deleted_v1",
+		title:       "Bot removed from chat",
+		description: "机器人被移出群聊后触发",
+		scopes:      []string{"im:chat.members:bot_access"},
+		bodyType:    reflect.TypeOf(larkim.P2ChatMemberBotDeletedV1Data{}),
+		fieldOverrides: mergeOv(
+			userIDOv("/event/operator_id"),
+			map[string]schemas.FieldMeta{
+				"/event/chat_id": {Kind: "chat_id"},
+			},
+		),
+	},
+	{
+		key:         "im.chat.member.user.added_v1",
+		title:       "User added to chat",
+		description: "新用户进群（含话题群）时触发",
+		scopes:      []string{"im:chat.members:read"},
+		bodyType:    reflect.TypeOf(larkim.P2ChatMemberUserAddedV1Data{}),
+		fieldOverrides: mergeOv(
+			userIDOv("/event/operator_id"),
+			userIDOv("/event/users/*/user_id"),
+			map[string]schemas.FieldMeta{
+				"/event/chat_id": {Kind: "chat_id"},
+			},
+		),
+	},
+	{
+		key:         "im.chat.member.user.withdrawn_v1",
+		title:       "User invite withdrawn",
+		description: "撤销拉用户进群后触发",
+		scopes:      []string{"im:chat.members:read"},
+		bodyType:    reflect.TypeOf(larkim.P2ChatMemberUserWithdrawnV1Data{}),
+		fieldOverrides: mergeOv(
+			userIDOv("/event/operator_id"),
+			userIDOv("/event/users/*/user_id"),
+			map[string]schemas.FieldMeta{
+				"/event/chat_id": {Kind: "chat_id"},
+			},
+		),
+	},
+	{
+		key:         "im.chat.member.user.deleted_v1",
+		title:       "User left chat",
+		description: "用户主动退群或被移出群聊时触发",
+		scopes:      []string{"im:chat.members:read"},
+		bodyType:    reflect.TypeOf(larkim.P2ChatMemberUserDeletedV1Data{}),
+		fieldOverrides: mergeOv(
+			userIDOv("/event/operator_id"),
+			userIDOv("/event/users/*/user_id"),
+			map[string]schemas.FieldMeta{
+				"/event/chat_id": {Kind: "chat_id"},
+			},
+		),
+	},
+	{
+		key:         "im.chat.updated_v1",
+		title:       "Chat updated",
+		description: "群配置（群主、头像、名称、权限等）被修改后触发",
+		scopes:      []string{"im:chat:read"},
+		bodyType:    reflect.TypeOf(larkim.P2ChatUpdatedV1Data{}),
+		fieldOverrides: mergeOv(
+			userIDOv("/event/operator_id"),
+			userIDOv("/event/before_change/owner_id"),
+			userIDOv("/event/after_change/owner_id"),
+			userIDOv("/event/moderator_list/added_member_list/*/user_id"),
+			userIDOv("/event/moderator_list/removed_member_list/*/user_id"),
+			map[string]schemas.FieldMeta{
+				"/event/chat_id": {Kind: "chat_id"},
+			},
+		),
+	},
+	{
+		key:         "im.chat.disbanded_v1",
+		title:       "Chat disbanded",
+		description: "群被解散后触发",
+		scopes:      []string{"im:chat:read"},
+		bodyType:    reflect.TypeOf(larkim.P2ChatDisbandedV1Data{}),
+		fieldOverrides: mergeOv(
+			userIDOv("/event/operator_id"),
+			map[string]schemas.FieldMeta{
+				"/event/chat_id": {Kind: "chat_id"},
+			},
+		),
+	},
+}

--- a/events/im/register.go
+++ b/events/im/register.go
@@ -26,7 +26,13 @@ func Keys() []event.KeyDefinition {
 			Schema: event.SchemaDef{
 				Custom: &event.SchemaSpec{Type: reflect.TypeOf(ImMessageReceiveOutput{})},
 			},
-			Process:               processImMessageReceive,
+			Process: processImMessageReceive,
+			// Narrowest grant that lets a bot read incoming p2p messages;
+			// broader scopes (im:message, im:message:readonly) cover this
+			// too but shouldn't be required up-front. MissingScopes uses
+			// AND semantics so we keep this list single-element rather
+			// than listing every acceptable substitute.
+			Scopes:                []string{"im:message.p2p_msg:readonly"},
 			AuthTypes:             []string{"bot"},
 			RequiredConsoleEvents: []string{"im.message.receive_v1"},
 		},

--- a/events/im/register.go
+++ b/events/im/register.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package im registers IM-domain EventKeys.
+//
+// im.message.receive_v1 is a processed key: the envelope is flattened and
+// @mentions are resolved via convertlib. All other IM event types are
+// native (envelope passthrough), with the SDK struct reflected for schemas.
+package im
+
+import (
+	"reflect"
+
+	"github.com/larksuite/cli/internal/event"
+)
+
+// Keys returns all IM-domain EventKey definitions. The aggregator in
+// package events feeds these into event.RegisterKey at startup.
+func Keys() []event.KeyDefinition {
+	out := []event.KeyDefinition{
+		{
+			Key:         "im.message.receive_v1",
+			DisplayName: "Receive message",
+			Description: "接收 IM 消息（text/post/image/file/audio/media/sticker/interactive/share_chat/share_user/system 所有类型）",
+			EventType:   "im.message.receive_v1",
+			Schema: event.SchemaDef{
+				Custom: &event.SchemaSpec{Type: reflect.TypeOf(ImMessageReceiveOutput{})},
+			},
+			Process:               processImMessageReceive,
+			AuthTypes:             []string{"bot"},
+			RequiredConsoleEvents: []string{"im.message.receive_v1"},
+		},
+	}
+
+	for _, rk := range nativeIMKeys {
+		out = append(out, event.KeyDefinition{
+			Key:         rk.key,
+			DisplayName: rk.title,
+			Description: rk.description,
+			EventType:   rk.key,
+			Schema: event.SchemaDef{
+				Native:         &event.SchemaSpec{Type: rk.bodyType},
+				FieldOverrides: rk.fieldOverrides,
+			},
+			Scopes:                rk.scopes,
+			AuthTypes:             []string{"bot"},
+			RequiredConsoleEvents: []string{rk.key},
+		})
+	}
+
+	return out
+}

--- a/events/im/register.go
+++ b/events/im/register.go
@@ -21,7 +21,7 @@ func Keys() []event.KeyDefinition {
 		{
 			Key:         "im.message.receive_v1",
 			DisplayName: "Receive message",
-			Description: "接收 IM 消息（text/post/image/file/audio/media/sticker/interactive/share_chat/share_user/system 所有类型）",
+			Description: "接收 IM 消息",
 			EventType:   "im.message.receive_v1",
 			Schema: event.SchemaDef{
 				Custom: &event.SchemaSpec{Type: reflect.TypeOf(ImMessageReceiveOutput{})},

--- a/events/lint_test.go
+++ b/events/lint_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package events
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/schemas"
+)
+
+// TestAllKeys_FieldOverridePointersResolve guarantees every FieldOverrides
+// path on every registered EventKey resolves to at least one node in the
+// rendered schema. Orphan paths typically mean a typo or an SDK field
+// rename — failing the build on orphans prevents silent schema drift.
+//
+// The package-level init() in register.go has already registered all
+// domain keys by the time tests run, so we just iterate event.ListAll().
+func TestAllKeys_FieldOverridePointersResolve(t *testing.T) {
+	for _, def := range event.ListAll() {
+		if len(def.Schema.FieldOverrides) == 0 {
+			continue
+		}
+		raw := renderDefSchemaForLint(t, def)
+		if raw == nil {
+			t.Errorf("%s: FieldOverrides set but Schema has no Native/Custom spec", def.Key)
+			continue
+		}
+		var parsed map[string]interface{}
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			t.Errorf("%s: parse schema: %v", def.Key, err)
+			continue
+		}
+		orphans := schemas.ApplyFieldOverrides(parsed, def.Schema.FieldOverrides)
+		if len(orphans) > 0 {
+			t.Errorf("%s: orphan FieldOverrides paths (typo or SDK drift): %v", def.Key, orphans)
+		}
+	}
+}
+
+// renderDefSchemaForLint mirrors cmd/events/schema.go's resolve pipeline
+// enough to produce the schema overrides are applied against. Kept inline
+// here so the lint test has no dependency on cmd/events (which would
+// create a package cycle).
+func renderDefSchemaForLint(t *testing.T, def *event.KeyDefinition) json.RawMessage {
+	t.Helper()
+	spec, isNative := pickSpec(def.Schema)
+	if spec == nil {
+		return nil
+	}
+	raw := renderSpec(t, spec)
+	if raw == nil {
+		return nil
+	}
+	if isNative {
+		raw = schemas.WrapV2Envelope(raw)
+	}
+	return raw
+}
+
+func pickSpec(s event.SchemaDef) (*event.SchemaSpec, bool) {
+	if s.Native != nil {
+		return s.Native, true
+	}
+	if s.Custom != nil {
+		return s.Custom, false
+	}
+	return nil, false
+}
+
+// renderSpec never gets the "neither set" branch in production (validateSpec
+// panics at RegisterKey time). Silent nil here is fine for the lint path.
+func renderSpec(t *testing.T, s *event.SchemaSpec) json.RawMessage {
+	t.Helper()
+	if s.Type != nil {
+		return schemas.FromType(s.Type)
+	}
+	if len(s.Raw) > 0 {
+		return append(json.RawMessage{}, s.Raw...)
+	}
+	return nil
+}
+
+// TestOrphanDetectionMechanism proves the pipeline itself catches orphan
+// paths — without this, TestAllKeys_FieldOverridePointersResolve would
+// pass vacuously whenever no registered key uses FieldOverrides (which is
+// the current state; both IM and mail rely on struct tags). The synthetic
+// key below has one valid path and one deliberately-broken path; the
+// valid one must resolve and the broken one must be reported.
+func TestOrphanDetectionMechanism(t *testing.T) {
+	type synthetic struct {
+		ValidField string `json:"valid_field"`
+	}
+	spec := &event.SchemaSpec{Type: reflect.TypeOf(synthetic{})}
+	raw := renderSpec(t, spec)
+	if raw == nil {
+		t.Fatal("renderSpec returned nil for synthetic type")
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	overrides := map[string]schemas.FieldMeta{
+		"/valid_field":   {Kind: "open_id"},
+		"/broken_typo":   {Kind: "chat_id"},
+		"/valid_field/x": {Kind: "email"}, // dives past a scalar
+	}
+	orphans := schemas.ApplyFieldOverrides(parsed, overrides)
+	wantOrphans := map[string]bool{"/broken_typo": true, "/valid_field/x": true}
+	if len(orphans) != len(wantOrphans) {
+		t.Fatalf("orphans = %v, want exactly %v", orphans, wantOrphans)
+	}
+	for _, o := range orphans {
+		if !wantOrphans[o] {
+			t.Errorf("unexpected orphan %q", o)
+		}
+	}
+	// Confirm the valid path got applied.
+	vf := parsed["properties"].(map[string]interface{})["valid_field"].(map[string]interface{})
+	if vf["format"] != "open_id" {
+		t.Errorf("valid path not applied: %v", vf)
+	}
+}

--- a/events/register.go
+++ b/events/register.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package events wires every domain's EventKey definitions into the
+// global event.Registry. Each domain subpackage exposes a Keys() function
+// returning its []event.KeyDefinition; this package's init() pulls
+// them all in and calls event.RegisterKey on each. Blank-importing this
+// package ensures the registry is populated before commands run.
+package events
+
+import (
+	"github.com/larksuite/cli/events/im"
+	"github.com/larksuite/cli/internal/event"
+)
+
+// Mail is intentionally omitted: only IM is wired up this phase. The
+// events/mail package still exists and is self-testable, but its keys
+// are not registered into the production binary.
+func init() {
+	all := [][]event.KeyDefinition{
+		im.Keys(),
+	}
+	for _, keys := range all {
+		for _, k := range keys {
+			event.RegisterKey(k)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/larksuite/cli
 go 1.23.0
 
 require (
+	github.com/Microsoft/go-winio v0.6.2
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/gofrs/flock v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
+github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/appmeta/app_version.go
+++ b/internal/appmeta/app_version.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package appmeta exposes read-only views of a Feishu app's self-declared
+// metadata (published version, subscribed event types, requested scopes).
+// It's intentionally a thin wrapper over the Open API so callers can make
+// preflight decisions without each one re-parsing the same response shape.
+package appmeta
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/larksuite/cli/internal/event"
+)
+
+// APIClient is the minimal surface appmeta needs from the CLI's HTTP stack.
+// Aliased to event.APIClient so all three narrow interfaces (event,
+// appmeta, consume) are one and the same type — a concrete adapter
+// implements the shape once and satisfies all call sites. Callers
+// typically pass a bot/TAT-pinned adapter because /app_versions rejects
+// UAT with 99991668.
+type APIClient = event.APIClient
+
+// AppVersion is the projected subset of one /app_versions item that preflight
+// checks care about. Fields we don't consume (audit metadata, visibility,
+// avatars) are dropped to keep the struct small and the contract obvious.
+type AppVersion struct {
+	VersionID    string
+	Version      string
+	EventTypes   []string // subscribed event types, e.g. "im.message.receive_v1"
+	TenantScopes []string // scopes whose token_types contains "tenant"
+}
+
+// appVersionStatusPublished is the integer value the OAPI emits for a version
+// that has passed audit (and, paired with a non-empty publish_time, is live).
+// Documented values: 0=unknown, 1=audit-passed, 2=audit-rejected, 3=under-
+// audit, 4=not-submitted.
+const appVersionStatusPublished = 1
+
+// FetchCurrentPublished returns the most recently published version of appID,
+// or (nil, nil) when the app has never been published. It propagates API
+// errors verbatim so callers can decide whether to treat them as hard
+// failures or weak-dependency skips.
+//
+// Why page_size=2 is enough: Feishu disallows creating a new version while
+// any in-progress version (status ∈ {2, 3, 4}) exists, so at any moment the
+// items array sorted by create_time desc is [<maybe one in-progress>,
+// <latest published>, ...]. The first item with status==1 and non-empty
+// publish_time in the first two items is therefore always the live one.
+func FetchCurrentPublished(ctx context.Context, client APIClient, appID string) (*AppVersion, error) {
+	path := fmt.Sprintf(
+		"/open-apis/application/v6/applications/%s/app_versions?lang=zh_cn&page_size=2",
+		appID,
+	)
+	raw, err := client.CallAPI(ctx, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var envelope struct {
+		Data struct {
+			Items []struct {
+				VersionID   string          `json:"version_id"`
+				Version     string          `json:"version"`
+				Status      int             `json:"status"`
+				PublishTime json.RawMessage `json:"publish_time"`
+				EventInfos  []struct {
+					EventType string `json:"event_type"`
+				} `json:"event_infos"`
+				Scopes []struct {
+					Scope      string   `json:"scope"`
+					TokenTypes []string `json:"token_types"`
+				} `json:"scopes"`
+			} `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("decode app_versions response: %w", err)
+	}
+
+	for _, it := range envelope.Data.Items {
+		if it.Status != appVersionStatusPublished || !publishTimeSet(it.PublishTime) {
+			continue
+		}
+		v := &AppVersion{
+			VersionID: it.VersionID,
+			Version:   it.Version,
+		}
+		for _, e := range it.EventInfos {
+			if e.EventType != "" {
+				v.EventTypes = append(v.EventTypes, e.EventType)
+			}
+		}
+		for _, s := range it.Scopes {
+			if s.Scope != "" && containsString(s.TokenTypes, "tenant") {
+				v.TenantScopes = append(v.TenantScopes, s.Scope)
+			}
+		}
+		return v, nil
+	}
+	return nil, nil
+}
+
+// publishTimeSet accepts the two shapes the OAPI has been observed to emit
+// for an unpublished item: JSON null and the empty string. Any other value
+// is taken as a real publish_time (we don't parse the number — just its
+// presence).
+func publishTimeSet(raw json.RawMessage) bool {
+	s := string(raw)
+	return s != "" && s != "null" && s != `""`
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/appmeta/app_version_test.go
+++ b/internal/appmeta/app_version_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package appmeta
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/event/testutil"
+)
+
+const respFourVersions = `{
+  "code": 0,
+  "data": {
+    "has_more": false,
+    "items": [
+      {"version_id": "oav_draft", "version": "1.0.3", "status": 4, "publish_time": null,
+       "event_infos": [{"event_type": "im.message.receive_v1"}, {"event_type": "mail.user_mailbox.event.message_received_v1"}],
+       "scopes": [{"scope": "draft:only", "token_types": ["tenant"]}]
+      },
+      {"version_id": "oav_latest", "version": "1.0.2", "status": 1, "publish_time": "1776684746",
+       "event_infos": [
+         {"event_type": "im.message.receive_v1"},
+         {"event_type": "im.message.message_read_v1"}
+       ],
+       "scopes": [
+         {"scope": "im:message", "token_types": ["tenant", "user"]},
+         {"scope": "im:message.group_at_msg", "token_types": ["tenant"]},
+         {"scope": "contact:user:readonly", "token_types": ["user"]}
+       ]
+      }
+    ]
+  }
+}`
+
+func TestFetchCurrentPublished_SelectsLatestPublished(t *testing.T) {
+	c := &testutil.StubAPIClient{Body: respFourVersions}
+
+	v, err := FetchCurrentPublished(context.Background(), c, "cli_test")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v == nil {
+		t.Fatal("expected a version, got nil")
+	}
+	if v.VersionID != "oav_latest" {
+		t.Errorf("VersionID = %q, want oav_latest (draft must be skipped)", v.VersionID)
+	}
+	if v.Version != "1.0.2" {
+		t.Errorf("Version = %q, want 1.0.2", v.Version)
+	}
+
+	wantEvents := map[string]bool{"im.message.receive_v1": true, "im.message.message_read_v1": true}
+	if len(v.EventTypes) != len(wantEvents) {
+		t.Fatalf("EventTypes = %v, want %v", v.EventTypes, wantEvents)
+	}
+	for _, e := range v.EventTypes {
+		if !wantEvents[e] {
+			t.Errorf("unexpected event type %q in %v", e, v.EventTypes)
+		}
+	}
+
+	// Only scopes where token_types contains "tenant" belong to TenantScopes.
+	wantTenant := map[string]bool{"im:message": true, "im:message.group_at_msg": true}
+	if len(v.TenantScopes) != len(wantTenant) {
+		t.Fatalf("TenantScopes = %v, want %v (contact:user:readonly is user-only)", v.TenantScopes, wantTenant)
+	}
+	for _, s := range v.TenantScopes {
+		if !wantTenant[s] {
+			t.Errorf("unexpected tenant scope %q in %v", s, v.TenantScopes)
+		}
+	}
+}
+
+func TestFetchCurrentPublished_PathContainsQuery(t *testing.T) {
+	c := &testutil.StubAPIClient{Body: respFourVersions}
+	_, _ = FetchCurrentPublished(context.Background(), c, "cli_x")
+	// The fetcher must encode lang and page_size in the path so callers don't
+	// need to know about Params vs body semantics of the underlying client.
+	for _, want := range []string{
+		"/open-apis/application/v6/applications/cli_x/app_versions",
+		"lang=zh_cn",
+		"page_size=2",
+	} {
+		if !strings.Contains(c.GotPath, want) {
+			t.Errorf("path %q missing %q", c.GotPath, want)
+		}
+	}
+}
+
+func TestFetchCurrentPublished_NoPublishedYet(t *testing.T) {
+	c := &testutil.StubAPIClient{Body: `{"code":0,"data":{"items":[
+    {"version_id":"oav_draft","status":4,"publish_time":null,"event_infos":[],"scopes":[]}
+  ]}}`}
+	v, err := FetchCurrentPublished(context.Background(), c, "cli_x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != nil {
+		t.Errorf("want nil (app never published), got %+v", v)
+	}
+}
+
+func TestFetchCurrentPublished_EmptyItems(t *testing.T) {
+	c := &testutil.StubAPIClient{Body: `{"code":0,"data":{"items":[]}}`}
+	v, err := FetchCurrentPublished(context.Background(), c, "cli_x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != nil {
+		t.Errorf("want nil for empty items, got %+v", v)
+	}
+}
+
+func TestFetchCurrentPublished_APIErrorPropagated(t *testing.T) {
+	want := errors.New("insufficient permission level")
+	c := &testutil.StubAPIClient{Err: want}
+	v, err := FetchCurrentPublished(context.Background(), c, "cli_x")
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want wrapping %v", err, want)
+	}
+	if v != nil {
+		t.Errorf("want nil version on error, got %+v", v)
+	}
+}
+
+func TestFetchCurrentPublished_PublishTimeEmptyStringTreatedAsUnpublished(t *testing.T) {
+	// Defensive: if the OAPI ever emits "" instead of null for publish_time on
+	// an unpublished record, we must still skip it.
+	c := &testutil.StubAPIClient{Body: `{"code":0,"data":{"items":[
+    {"version_id":"oav_x","status":1,"publish_time":"","event_infos":[],"scopes":[]}
+  ]}}`}
+	v, err := FetchCurrentPublished(context.Background(), c, "cli_x")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != nil {
+		t.Errorf("want nil (empty publish_time), got %+v", v)
+	}
+}

--- a/internal/event/appid.go
+++ b/internal/event/appid.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import "strings"
+
+// SanitizeAppID guards filesystem path construction from a malformed
+// AppID. Config corruption, manual edit, or a hostile caller could push
+// "..", path separators, or NUL into the AppID string — using the raw
+// value in filepath.Join would then escape the events/ subtree and let
+// the caller place files anywhere under the config dir or its parents.
+//
+// Replace dangerous sequences with "_". "Wedged bus with an unreadable
+// AppID directory" is acceptable; "bus.sock / bus.log landing under
+// $HOME/.ssh/" is not. Applied everywhere AppID contributes to a path:
+//
+//   - internal/event/transport/transport_unix.go   (bus.sock)
+//   - internal/event/transport/transport_windows.go (named pipe name)
+//   - cmd/event/bus.go                              (bus.log directory)
+//
+// Empty or dot-only inputs collapse to "_" so filepath.Join never
+// produces the config-dir root itself as the events/{appid} segment.
+func SanitizeAppID(appID string) string {
+	if appID == "" {
+		return "_"
+	}
+	repl := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		"\x00", "_",
+		"..", "_",
+	)
+	out := repl.Replace(appID)
+	if out == "" || out == "." {
+		return "_"
+	}
+	return out
+}

--- a/internal/event/appid_test.go
+++ b/internal/event/appid_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSanitizeAppID_RejectsPathTraversal — regression guard for the
+// "AppID path traversal" finding (CodeRabbit Bug 8). The sanitizer must
+// neutralise any input that, when joined into a filepath, would escape
+// the events/ subtree.
+func TestSanitizeAppID_RejectsPathTraversal(t *testing.T) {
+	cases := []struct {
+		name        string
+		input       string
+		wantClean   string // exact expected sanitized output
+		forbidChars string // characters that MUST NOT appear in output
+	}{
+		{"happy path", "cli_a96a42f48438dbd2", "cli_a96a42f48438dbd2", "/\\\x00"},
+		{"empty", "", "_", ""},
+		{"dot", ".", "_", ""},
+		{"double-dot only", "..", "_", ".."},
+		{"leading traversal", "../etc/passwd", "__etc_passwd", "/"},
+		{"traversal inside", "cli_../../etc", "cli_____etc", "/"},
+		{"backslash traversal", "..\\windows\\system32", "__windows_system32", "\\"},
+		{"nul injection", "cli_\x00backdoor", "cli__backdoor", "\x00"},
+		{"pure slashes", "///", "___", "/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SanitizeAppID(tc.input)
+			if got != tc.wantClean {
+				t.Errorf("SanitizeAppID(%q) = %q, want %q", tc.input, got, tc.wantClean)
+			}
+			for _, c := range tc.forbidChars {
+				if strings.ContainsRune(got, c) {
+					t.Errorf("SanitizeAppID(%q) = %q contains forbidden rune %q", tc.input, got, c)
+				}
+			}
+			// Structural guarantee: when joined as a path segment, the
+			// result must not introduce a "..", absolute-path escape,
+			// or NUL byte.
+			joined := filepath.Join("/root/events", got, "bus.log")
+			if strings.Contains(joined, "..") {
+				t.Errorf("joined path %q contains .. after sanitization", joined)
+			}
+			if !strings.HasPrefix(joined, "/root/events/") {
+				t.Errorf("joined path %q escaped /root/events/ parent", joined)
+			}
+		})
+	}
+}

--- a/internal/event/appid_test.go
+++ b/internal/event/appid_test.go
@@ -20,7 +20,7 @@ func TestSanitizeAppID_RejectsPathTraversal(t *testing.T) {
 		wantClean   string // exact expected sanitized output
 		forbidChars string // characters that MUST NOT appear in output
 	}{
-		{"happy path", "cli_a96a42f48438dbd2", "cli_a96a42f48438dbd2", "/\\\x00"},
+		{"happy path", "cli_XXXXXXXXXXXXXXXX", "cli_XXXXXXXXXXXXXXXX", "/\\\x00"},
 		{"empty", "", "_", ""},
 		{"dot", ".", "_", ""},
 		{"double-dot only", "..", "_", ".."},
@@ -43,8 +43,10 @@ func TestSanitizeAppID_RejectsPathTraversal(t *testing.T) {
 			}
 			// Structural guarantee: when joined as a path segment, the
 			// result must not introduce a "..", absolute-path escape,
-			// or NUL byte.
-			joined := filepath.Join("/root/events", got, "bus.log")
+			// or NUL byte. Normalize separators via filepath.ToSlash so
+			// the same assertions work on Windows (where filepath.Join
+			// emits backslashes).
+			joined := filepath.ToSlash(filepath.Join("/root/events", got, "bus.log"))
 			if strings.Contains(joined, "..") {
 				t.Errorf("joined path %q contains .. after sanitization", joined)
 			}

--- a/internal/event/bus/bus.go
+++ b/internal/event/bus/bus.go
@@ -337,7 +337,22 @@ func (b *Bus) handleHello(conn net.Conn, reader *bufio.Reader, hello *protocol.H
 	b.mu.Unlock()
 
 	ack := protocol.NewHelloAck("v1", firstForKey)
-	_ = protocol.EncodeWithDeadline(conn, ack, protocol.WriteTimeout)
+	// Route through bc.writeFrame so all writes to this connection go
+	// through the same mutex (see writeMu docs). On failure we must
+	// undo the hub + bus-level registration — otherwise the consumer
+	// lives on in b.conns / hub.subscribers without ever receiving an
+	// ack, skewing first/last bookkeeping and keeping the bus non-idle.
+	// bc.Close() triggers the onClose callback which handles both,
+	// including the firstForKey==true case (keyCounts incremented to 1
+	// by RegisterAndIsFirst is decremented back to 0 by
+	// UnregisterAndIsLast; no PreConsume was triggered because the
+	// client never received the ack).
+	if err := bc.writeFrame(ack); err != nil {
+		b.logger.Printf("WARN: hello_ack write to pid=%d key=%q failed: %v (rejecting connection)",
+			hello.PID, hello.EventKey, err)
+		bc.Close()
+		return
+	}
 
 	// Quote untrusted fields — EventKey / EventTypes come straight off
 	// the wire from an unprivileged local process, and a value with

--- a/internal/event/bus/bus.go
+++ b/internal/event/bus/bus.go
@@ -1,0 +1,371 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package bus implements the event-bus daemon: it listens on an IPC
+// socket, accepts consumer connections, starts event sources, and fans
+// out events to matching subscribers via the Hub. The daemon is a
+// single-user, per-AppID process; lifecycle is driven by consumer
+// presence (idle timeout) and explicit shutdown commands.
+package bus
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/protocol"
+	"github.com/larksuite/cli/internal/event/source"
+	"github.com/larksuite/cli/internal/event/transport"
+)
+
+const (
+	idleTimeout = 30 * time.Second
+)
+
+// Bus is the central event bus daemon. It listens on an IPC socket,
+// accepts consume client connections, starts event sources, and fans
+// out events to matching subscribers via the Hub.
+type Bus struct {
+	appID     string
+	appSecret string
+	domain    string
+	transport transport.IPC
+	hub       *Hub
+	dedup     *event.DedupFilter
+	listener  net.Listener
+	logger    *log.Logger
+	startTime time.Time
+
+	mu         sync.Mutex
+	conns      map[*Conn]struct{}
+	idleTimer  *time.Timer
+	shutdownCh chan struct{}
+}
+
+// NewBus creates a new Bus daemon instance.
+func NewBus(appID, appSecret, domain string, tr transport.IPC, logger *log.Logger) *Bus {
+	return &Bus{
+		appID:     appID,
+		appSecret: appSecret,
+		domain:    domain,
+		transport: tr,
+		hub:       NewHub(),
+		dedup:     event.NewDedupFilter(),
+		logger:    logger,
+		startTime: time.Now(),
+		conns:     make(map[*Conn]struct{}),
+		// Buffered so handleShutdown and source-exit paths never drop the signal when
+		// Run hasn't entered its select yet, or has already left it for another reason.
+		// Run will observe the latched value whenever it next enters select.
+		shutdownCh: make(chan struct{}, 1),
+	}
+}
+
+// Run binds the IPC socket, starts event sources, and enters the accept
+// loop. Blocks until ctx is cancelled, the idle timer fires (no active
+// connections for idleTimeout), or a shutdown command is received.
+func (b *Bus) Run(ctx context.Context) error {
+	addr := b.transport.Address(b.appID)
+
+	ln, err := b.transport.Listen(addr)
+	if err != nil {
+		// Probe: is this a live bus (bow out) or a stale socket (clean up)?
+		// Dial uses the transport's baseline timeout (5s via DialTimeout
+		// on Unix — see transport_unix.go dialTimeout; 5s via winio on
+		// Windows) so a wedged peer can't hang startup here. There is a
+		// tiny residual race where another bus cleans up and re-listens
+		// between our probe and our Listen retry below — acceptable in
+		// practice since listen-contending buses are a rare user error
+		// (not an attacker), and both end up owning different socket
+		// incarnations at worst (the loser just exits on its own Listen
+		// failure on the next attempt).
+		if probe, dialErr := b.transport.Dial(addr); dialErr == nil {
+			probe.Close()
+			b.logger.Printf("Another bus is already running for %s, exiting", b.appID)
+			return nil
+		}
+		b.transport.Cleanup(addr)
+		ln, err = b.transport.Listen(addr)
+		if err != nil {
+			return fmt.Errorf("bus listen: %w", err)
+		}
+	}
+	b.listener = ln
+	b.logger.Printf("Bus started for app=%s pid=%d addr=%s", b.appID, os.Getpid(), addr)
+
+	b.idleTimer = time.NewTimer(idleTimeout)
+
+	sourceCtx, sourceCancel := context.WithCancel(ctx)
+	defer sourceCancel()
+	b.startSources(sourceCtx)
+
+	acceptDone := make(chan struct{})
+	go func() {
+		defer close(acceptDone)
+		b.acceptLoop(ctx)
+	}()
+
+	// A bare `<-b.idleTimer.C` can observe a stale fire latched just before
+	// a new Hello registered — Stop() doesn't drain .C, and the tick can
+	// linger in the channel across the concurrent Stop+Reset in handleHello
+	// / OnClose. Re-check the live conn count under lock before treating
+	// the tick as "idle"; if a race happened, re-arm the timer and keep running.
+	for {
+		select {
+		case <-ctx.Done():
+			b.logger.Printf("Bus shutting down (context cancelled)")
+		case <-b.idleTimer.C:
+			b.mu.Lock()
+			active := len(b.conns)
+			if active > 0 {
+				b.idleTimer.Reset(idleTimeout)
+				b.mu.Unlock()
+				continue
+			}
+			b.mu.Unlock()
+			b.logger.Printf("Bus shutting down (idle %v, no active connections)", idleTimeout)
+		case <-b.shutdownCh:
+			b.logger.Printf("Bus shutting down (shutdown command received)")
+		}
+		break
+	}
+
+	b.listener.Close()
+	// Don't delete the socket: Run() already handles stale sockets (probe
+	// → cleanup → re-listen), and unconditional deletion races a new bus
+	// that may have already recreated the socket at the same path.
+	shutdownConns(b)
+	<-acceptDone
+	b.logger.Printf("Bus exited cleanly")
+	return nil
+}
+
+// shutdownConns closes every connection managed by b. It snapshots b.conns
+// under lock then releases before calling Close() — without this, c.Close()
+// synchronously invokes onClose which re-acquires b.mu, causing a deterministic
+// deadlock. Do not refactor this back into a persistent hold on b.mu.
+func shutdownConns(b *Bus) {
+	b.mu.Lock()
+	conns := make([]*Conn, 0, len(b.conns))
+	for c := range b.conns {
+		conns = append(conns, c)
+	}
+	b.mu.Unlock()
+	for _, c := range conns {
+		c.Close()
+	}
+}
+
+// startSources launches every registered source (or a default
+// FeishuSource when none are registered). If any source exits before
+// shutdown, the whole bus shuts down — a source-less bus is a zombie
+// (consumers stay connected but never receive events, idle timer never
+// fires).
+func (b *Bus) startSources(ctx context.Context) {
+	sources := source.All()
+	if len(sources) == 0 {
+		sources = []source.Source{&source.FeishuSource{
+			AppID:     b.appID,
+			AppSecret: b.appSecret,
+			Domain:    b.domain,
+			Logger:    b.logger,
+		}}
+	}
+	eventTypes := subscribedEventTypes()
+	b.hub.SetLogger(b.logger)
+	for _, src := range sources {
+		go func(s source.Source) {
+			b.logger.Printf("Starting source: %s", s.Name())
+			err := s.Start(ctx, eventTypes, func(raw *event.RawEvent) {
+				b.logger.Printf("Event received: type=%s id=%s", raw.EventType, raw.EventID)
+				if b.dedup.IsDuplicate(raw.EventID) {
+					b.logger.Printf("Event deduplicated: id=%s", raw.EventID)
+					return
+				}
+				b.hub.Publish(raw)
+			}, func(state, detail string) {
+				b.hub.BroadcastSourceStatus(s.Name(), state, detail)
+			})
+			if ctx.Err() != nil {
+				return
+			}
+			if err != nil {
+				b.logger.Printf("Source %s exited with error: %v — shutting down bus", s.Name(), err)
+			} else {
+				b.logger.Printf("Source %s exited without error before shutdown — shutting down bus", s.Name())
+			}
+			select {
+			case b.shutdownCh <- struct{}{}:
+			default:
+			}
+		}(src)
+	}
+}
+
+// subscribedEventTypes returns the deduplicated union of EventTypes from
+// every registered EventKey. Sources that talk to a server-side
+// dispatcher use this list to avoid subscribing to events no one wants.
+func subscribedEventTypes() []string {
+	seen := make(map[string]struct{})
+	var types []string
+	for _, def := range event.ListAll() {
+		if _, ok := seen[def.EventType]; ok {
+			continue
+		}
+		seen[def.EventType] = struct{}{}
+		types = append(types, def.EventType)
+	}
+	return types
+}
+
+// acceptLoop accepts incoming IPC connections until the listener is closed.
+func (b *Bus) acceptLoop(ctx context.Context) {
+	for {
+		conn, err := b.listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			// listener.Close() also causes Accept to return an error.
+			// Check if we should exit by testing the listener.
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			b.logger.Printf("Accept error: %v", err)
+			return
+		}
+		go b.handleConn(conn)
+	}
+}
+
+// handleConn reads the first protocol message and dispatches by type.
+// The bufio.Reader is handed to Conn so bytes buffered past the first
+// frame aren't lost to a second Scanner reading the same socket.
+func (b *Bus) handleConn(conn net.Conn) {
+	br := bufio.NewReader(conn)
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	line, err := protocol.ReadFrame(br)
+	if err != nil {
+		conn.Close()
+		return
+	}
+	conn.SetReadDeadline(time.Time{})
+
+	msg, err := protocol.Decode(bytes.TrimRight(line, "\n"))
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	switch m := msg.(type) {
+	case *protocol.Hello:
+		b.handleHello(conn, br, m)
+	case *protocol.StatusQuery:
+		b.handleStatusQuery(conn)
+	case *protocol.Shutdown:
+		b.handleShutdown(conn)
+	default:
+		conn.Close()
+	}
+}
+
+// handleHello registers a consume connection with the hub. reader
+// carries any bytes handleConn already pulled off conn.
+func (b *Bus) handleHello(conn net.Conn, reader *bufio.Reader, hello *protocol.Hello) {
+	bc := NewConn(conn, reader, hello.EventKey, hello.EventTypes, hello.PID)
+	bc.SetLogger(b.logger)
+
+	// Register + isFirst decision under one lock so concurrent Hellos
+	// can't both trigger PreConsume. Waits if another conn is currently
+	// holding a cleanup lock for the same EventKey, closing the
+	// PreShutdownCheck × Hello TOCTOU race.
+	firstForKey := b.hub.RegisterAndIsFirst(bc)
+
+	bc.SetCheckLastForKey(func(eventKey string) bool {
+		// Atomically reserve cleanup rights. If someone else is already
+		// cleaning up, or another subscriber exists, this returns false so
+		// consume doesn't run cleanup (and won't tear down upstream
+		// subscription while a peer is still using it). On true return,
+		// the lock is released in OnClose.
+		return b.hub.AcquireCleanupLock(eventKey)
+	})
+	bc.SetOnClose(func(c *Conn) {
+		b.hub.UnregisterAndIsLast(c)
+		// Release cleanup lock if this connection had acquired one. Release
+		// is idempotent — safe even when AcquireCleanupLock was never
+		// called or returned false. Must fire on every disconnect path
+		// (PreShutdownCheck, socket EOF, forced shutdown) so waiters in
+		// RegisterAndIsFirst don't block forever.
+		b.hub.ReleaseCleanupLock(c.EventKey())
+		b.mu.Lock()
+		delete(b.conns, c)
+		remaining := len(b.conns)
+		b.mu.Unlock()
+		b.logger.Printf("Consumer disconnected: pid=%d key=%s (remaining=%d)", c.PID(), c.EventKey(), remaining)
+		if remaining == 0 {
+			// Stop+drain before Reset — Go docs require this to avoid
+			// resetting a timer with a stale fire already sitting in .C.
+			if !b.idleTimer.Stop() {
+				select {
+				case <-b.idleTimer.C:
+				default:
+				}
+			}
+			b.idleTimer.Reset(idleTimeout)
+		}
+	})
+
+	b.mu.Lock()
+	b.conns[bc] = struct{}{}
+	// Stop+drain the idle timer while holding mu so a fire can't slip
+	// past a fresh registration — Run re-checks count under the same lock.
+	if !b.idleTimer.Stop() {
+		select {
+		case <-b.idleTimer.C:
+		default:
+		}
+	}
+	b.mu.Unlock()
+
+	ack := protocol.NewHelloAck("v1", firstForKey)
+	_ = protocol.EncodeWithDeadline(conn, ack, protocol.WriteTimeout)
+
+	// Quote untrusted fields — EventKey / EventTypes come straight off
+	// the wire from an unprivileged local process, and a value with
+	// embedded newlines would forge bus.log entries.
+	b.logger.Printf("Consumer connected: pid=%d key=%q event_types=%q first=%v",
+		hello.PID, hello.EventKey, hello.EventTypes, firstForKey)
+
+	bc.Start()
+}
+
+// handleStatusQuery responds with Bus status information and closes the connection.
+func (b *Bus) handleStatusQuery(conn net.Conn) {
+	defer conn.Close()
+	resp := protocol.NewStatusResponse(
+		os.Getpid(),
+		int(time.Since(b.startTime).Seconds()),
+		b.hub.ConnCount(),
+		b.hub.Consumers(),
+	)
+	_ = protocol.EncodeWithDeadline(conn, resp, protocol.WriteTimeout)
+}
+
+// handleShutdown signals Run() to exit gracefully.
+func (b *Bus) handleShutdown(conn net.Conn) {
+	defer conn.Close()
+	b.logger.Printf("Received shutdown command")
+	select {
+	case b.shutdownCh <- struct{}{}:
+	default:
+	}
+}

--- a/internal/event/bus/bus_shutdown_test.go
+++ b/internal/event/bus/bus_shutdown_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package bus
+
+import (
+	"io"
+	"log"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestRunShutdownWithMultipleConns reproduces the Run() × onClose re-entrant
+// deadlock. With the buggy code that holds b.mu across c.Close(), the FIRST
+// conn's onClose callback re-acquires b.mu and deadlocks forever.
+//
+// The test installs onClose callbacks that mirror handleHello's real callback:
+// they acquire b.mu.Lock() and delete(b.conns, c). Under the fix, shutdownConns
+// releases b.mu before calling Close(), so each onClose can re-acquire it.
+func TestRunShutdownWithMultipleConns(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	hub := NewHub()
+	b := &Bus{
+		hub:    hub,
+		logger: logger,
+		conns:  make(map[*Conn]struct{}),
+	}
+
+	const N = 3
+	pipes := make([]net.Conn, 0, N*2)
+	t.Cleanup(func() {
+		for _, p := range pipes {
+			p.Close()
+		}
+	})
+
+	for i := 0; i < N; i++ {
+		server, client := net.Pipe()
+		pipes = append(pipes, server, client)
+
+		bc := NewConn(server, nil, "im.msg", []string{"im.message.receive_v1"}, 1000+i)
+		bc.SetLogger(logger)
+		hub.RegisterAndIsFirst(bc)
+
+		// Mirror handleHello's onClose: takes b.mu, mutates b.conns, releases.
+		// If shutdownConns holds b.mu during c.Close(), this will deadlock.
+		bc.SetOnClose(func(c *Conn) {
+			b.hub.UnregisterAndIsLast(c)
+			b.mu.Lock()
+			delete(b.conns, c)
+			b.mu.Unlock()
+		})
+
+		b.mu.Lock()
+		b.conns[bc] = struct{}{}
+		b.mu.Unlock()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		shutdownConns(b)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Completed without deadlock.
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdownConns deadlocked: did not complete within 2s")
+	}
+
+	if got := hub.ConnCount(); got != 0 {
+		t.Errorf("expected 0 subscribers in hub after shutdown, got %d", got)
+	}
+	b.mu.Lock()
+	remaining := len(b.conns)
+	b.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("expected 0 conns in Bus after shutdown, got %d", remaining)
+	}
+}
+
+// TestShutdownSignalNotDroppedBeforeRunSelects verifies that sending on
+// shutdownCh before Run enters its select still delivers. The bug was that an
+// unbuffered channel drops the signal (via select/default) if nobody is ready
+// to receive; the fix is a buffered (cap=1) channel so the signal is latched.
+func TestShutdownSignalNotDroppedBeforeRunSelects(t *testing.T) {
+	b := NewBus("test-app", "test-secret", "", nil, log.New(io.Discard, "", 0))
+
+	// Fire the same pattern used by handleShutdown — the producer is NOT
+	// blocked on a receiver, so it must rely on the buffer to latch.
+	select {
+	case b.shutdownCh <- struct{}{}:
+	default:
+		t.Fatal("handleShutdown's send took default branch — signal would be lost")
+	}
+
+	// A later receiver must see the signal.
+	select {
+	case <-b.shutdownCh:
+		// Passed
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("shutdown signal was not latched")
+	}
+}

--- a/internal/event/bus/conn.go
+++ b/internal/event/bus/conn.go
@@ -22,10 +22,17 @@ const (
 
 // Conn represents a single consume client connection in the Bus.
 type Conn struct {
-	conn            net.Conn
-	reader          *bufio.Reader
-	sendCh          chan interface{}
-	sendMu          sync.Mutex // serialises PushDropOldest to keep drop+push atomic
+	conn    net.Conn
+	reader  *bufio.Reader
+	sendCh  chan interface{}
+	sendMu sync.Mutex // serialises PushDropOldest to keep drop+push atomic
+	// writeMu serialises all net.Conn writes. protocol.Encode plus
+	// SetWriteDeadline is a 2-call sequence shared between SenderLoop
+	// (event frames), handleControlMessage (PreShutdownAck), and the
+	// HelloAck write in bus.handleHello — all of which can race if the
+	// mutex is bypassed. Without it the shared write deadline corrupts
+	// and large frames interleave bytes on the wire.
+	writeMu         sync.Mutex
 	eventKey        string
 	eventTypes      []string
 	pid             int
@@ -108,6 +115,19 @@ func (c *Conn) Start() {
 	go c.ReaderLoop()
 }
 
+// writeFrame is the single write path to c.conn. Serialised via writeMu
+// so SenderLoop (event frames), handleControlMessage (PreShutdownAck),
+// and bus.handleHello (HelloAck) never interleave bytes or race the
+// shared SetWriteDeadline call.
+func (c *Conn) writeFrame(msg interface{}) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if err := c.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		return err
+	}
+	return protocol.Encode(c.conn, msg)
+}
+
 // SenderLoop writes messages from sendCh to the connection.
 // It exits when the closed channel is signaled, not when sendCh is closed,
 // so that Hub.Publish can safely send to sendCh without risk of panic.
@@ -117,8 +137,7 @@ func (c *Conn) SenderLoop() {
 		case <-c.closed:
 			return
 		case msg := <-c.sendCh:
-			c.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
-			if err := protocol.Encode(c.conn, msg); err != nil {
+			if err := c.writeFrame(msg); err != nil {
 				if c.logger != nil {
 					c.logger.Printf("WARN: write to pid=%d failed: %v", c.pid, err)
 				}
@@ -165,8 +184,9 @@ func (c *Conn) handleControlMessage(msg interface{}) {
 			lastForKey = c.checkLastForKey(m.EventKey)
 		}
 		ack := protocol.NewPreShutdownAck(lastForKey)
-		c.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
-		protocol.Encode(c.conn, ack)
+		if err := c.writeFrame(ack); err != nil && c.logger != nil {
+			c.logger.Printf("WARN: pre_shutdown_ack to pid=%d failed: %v", c.pid, err)
+		}
 	}
 }
 
@@ -181,6 +201,25 @@ func (c *Conn) shutdown() {
 			c.onClose(c)
 		}
 	})
+}
+
+// TrySend enqueues msg onto sendCh without evicting, under sendMu so it
+// respects PushDropOldest's atomicity contract. Returns true iff the
+// channel had room. Used by Hub.BroadcastSourceStatus for best-effort
+// fan-out of source-level status messages — a source-status that can't
+// fit the queue is dropped silently (the event itself isn't event data
+// worth applying back-pressure for) but the send still synchronises
+// with concurrent PushDropOldest so a broadcaster cannot steal a slot
+// in the window between another goroutine's drop and retry push.
+func (c *Conn) TrySend(msg interface{}) bool {
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	select {
+	case c.sendCh <- msg:
+		return true
+	default:
+		return false
+	}
 }
 
 // PushDropOldest enqueues msg onto sendCh. If sendCh is full, it drops

--- a/internal/event/bus/conn.go
+++ b/internal/event/bus/conn.go
@@ -22,9 +22,9 @@ const (
 
 // Conn represents a single consume client connection in the Bus.
 type Conn struct {
-	conn    net.Conn
-	reader  *bufio.Reader
-	sendCh  chan interface{}
+	conn   net.Conn
+	reader *bufio.Reader
+	sendCh chan interface{}
 	sendMu sync.Mutex // serialises PushDropOldest to keep drop+push atomic
 	// writeMu serialises all net.Conn writes. protocol.Encode plus
 	// SetWriteDeadline is a 2-call sequence shared between SenderLoop

--- a/internal/event/bus/conn.go
+++ b/internal/event/bus/conn.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package bus
+
+import (
+	"bufio"
+	"bytes"
+	"log"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+const (
+	sendChCap    = 100
+	writeTimeout = 5 * time.Second
+)
+
+// Conn represents a single consume client connection in the Bus.
+type Conn struct {
+	conn            net.Conn
+	reader          *bufio.Reader
+	sendCh          chan interface{}
+	sendMu          sync.Mutex // serialises PushDropOldest to keep drop+push atomic
+	eventKey        string
+	eventTypes      []string
+	pid             int
+	onClose         func(*Conn)
+	checkLastForKey func(eventKey string) bool
+	logger          *log.Logger
+	closed          chan struct{}
+	closeOnce       sync.Once
+	received        atomic.Int64  // events Hub has fanned out to us (post-filter)
+	seqCounter      atomic.Uint64 // per-conn monotonic seq assigned by Hub.Publish
+	dropped         atomic.Int64  // events evicted via drop-oldest backpressure
+}
+
+// NewConn creates a Conn. reader may be a *bufio.Reader already
+// attached to conn (handed over from Bus.handleConn so any buffered
+// bytes aren't lost during handoff). Passing nil is acceptable — the
+// conn-bound test helpers do this — and we construct a fresh Reader.
+func NewConn(conn net.Conn, reader *bufio.Reader, eventKey string, eventTypes []string, pid int) *Conn {
+	if reader == nil {
+		reader = bufio.NewReader(conn)
+	}
+	return &Conn{
+		conn:       conn,
+		reader:     reader,
+		sendCh:     make(chan interface{}, sendChCap),
+		eventKey:   eventKey,
+		eventTypes: eventTypes,
+		pid:        pid,
+		closed:     make(chan struct{}),
+	}
+}
+
+// SetOnClose installs a callback invoked once when the connection
+// shuts down (socket EOF, peer Bye, or explicit Close).
+func (c *Conn) SetOnClose(fn func(*Conn)) { c.onClose = fn }
+
+// SetCheckLastForKey installs the callback used to answer a
+// PreShutdownCheck from the consumer. Returning true means "you are the
+// last subscriber for this EventKey, run cleanup."
+func (c *Conn) SetCheckLastForKey(fn func(string) bool) { c.checkLastForKey = fn }
+
+// SetLogger attaches a logger for write-failure / control-message
+// diagnostics. nil is tolerated (logging becomes a no-op).
+func (c *Conn) SetLogger(l *log.Logger) { c.logger = l }
+
+// EventKey returns the EventKey this connection subscribed to during Hello.
+func (c *Conn) EventKey() string { return c.eventKey }
+
+// EventTypes returns the upstream event types this connection wants to receive.
+func (c *Conn) EventTypes() []string { return c.eventTypes }
+
+// SendCh returns the buffered outbound channel the Hub pushes events into.
+func (c *Conn) SendCh() chan interface{} { return c.sendCh }
+
+// PID returns the consumer-reported PID (for observability only; not trusted).
+func (c *Conn) PID() int { return c.pid }
+
+// IncrementReceived bumps the per-conn events-fanned-out counter.
+func (c *Conn) IncrementReceived() { c.received.Add(1) }
+
+// Received returns the current events-fanned-out counter value.
+func (c *Conn) Received() int64 { return c.received.Load() }
+
+// NextSeq returns a monotonically increasing seq number for this connection.
+// Used by Hub.Publish to assign sequence numbers to events destined for this
+// consumer, so the consumer can detect gaps caused by backpressure drops.
+// First call returns 1 (atomic.Uint64 starts at 0, Add returns the new value).
+func (c *Conn) NextSeq() uint64 { return c.seqCounter.Add(1) }
+
+// DroppedCount returns the number of events dropped due to backpressure on
+// this connection.
+func (c *Conn) DroppedCount() int64 { return c.dropped.Load() }
+
+// IncrementDropped records that one event was dropped due to backpressure.
+func (c *Conn) IncrementDropped() { c.dropped.Add(1) }
+
+// Start launches the sender and reader goroutines. Must be called exactly once.
+func (c *Conn) Start() {
+	go c.SenderLoop()
+	go c.ReaderLoop()
+}
+
+// SenderLoop writes messages from sendCh to the connection.
+// It exits when the closed channel is signaled, not when sendCh is closed,
+// so that Hub.Publish can safely send to sendCh without risk of panic.
+func (c *Conn) SenderLoop() {
+	for {
+		select {
+		case <-c.closed:
+			return
+		case msg := <-c.sendCh:
+			c.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+			if err := protocol.Encode(c.conn, msg); err != nil {
+				if c.logger != nil {
+					c.logger.Printf("WARN: write to pid=%d failed: %v", c.pid, err)
+				}
+				c.shutdown()
+				return
+			}
+		}
+	}
+}
+
+// ReaderLoop monitors the connection for EOF/close and processes any
+// control messages (Bye, PreShutdownCheck) the consume client sends.
+// Uses the bufio.Reader handed in from handleConn so buffered bytes
+// carried over from the Hello read aren't dropped.
+func (c *Conn) ReaderLoop() {
+	for {
+		line, err := protocol.ReadFrame(c.reader)
+		if err != nil {
+			break
+		}
+		line = bytes.TrimRight(line, "\n")
+		if len(line) == 0 {
+			continue
+		}
+		msg, err := protocol.Decode(line)
+		if err != nil {
+			continue
+		}
+		c.handleControlMessage(msg)
+	}
+	c.shutdown()
+}
+
+func (c *Conn) handleControlMessage(msg interface{}) {
+	switch m := msg.(type) {
+	case *protocol.Bye:
+		c.shutdown()
+	case *protocol.PreShutdownCheck:
+		// Query the Hub (via callback) and reply with whether this is the
+		// last consumer for the given EventKey. The consume client uses this
+		// to decide whether to run cleanup (e.g. unsubscribe mailbox).
+		lastForKey := true
+		if c.checkLastForKey != nil {
+			lastForKey = c.checkLastForKey(m.EventKey)
+		}
+		ack := protocol.NewPreShutdownAck(lastForKey)
+		c.conn.SetWriteDeadline(time.Now().Add(writeTimeout))
+		protocol.Encode(c.conn, ack)
+	}
+}
+
+func (c *Conn) shutdown() {
+	c.closeOnce.Do(func() {
+		close(c.closed)
+		c.conn.Close()
+		// NOTE: sendCh is intentionally NOT closed here. SenderLoop exits via
+		// the closed channel. Closing sendCh would race with Hub.Publish which
+		// may still hold a reference to this conn's SendCh() after RUnlock.
+		if c.onClose != nil {
+			c.onClose(c)
+		}
+	})
+}
+
+// PushDropOldest enqueues msg onto sendCh. If sendCh is full, it drops
+// exactly one oldest event and retries the push atomically under sendMu —
+// preventing concurrent Publish callers from racing each other into a state
+// where the channel refills between drop and push.
+//
+// Returns (enqueued, dropped) where enqueued=true means msg is now in the
+// channel, and dropped=true means an older event was evicted to make room.
+//
+// If the push would require evicting but the channel drained on its own
+// between operations (SenderLoop raced us), the eviction is skipped and the
+// push still succeeds — in that case returns (true, false).
+func (c *Conn) PushDropOldest(msg interface{}) (enqueued, dropped bool) {
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
+	// Fast path: channel has room.
+	select {
+	case c.sendCh <- msg:
+		return true, false
+	default:
+	}
+	// Slow path: drop one oldest if we can, then push.
+	select {
+	case <-c.sendCh:
+		dropped = true
+	default:
+		// SenderLoop drained it between our check and here — harmless.
+	}
+	select {
+	case c.sendCh <- msg:
+		return true, dropped
+	default:
+		// Should essentially never happen under sendMu: we either dropped
+		// one (making room) or the channel was empty. But if something
+		// external drained and refilled at exactly the wrong instant,
+		// fail gracefully rather than block.
+		return false, dropped
+	}
+}
+
+// Close shuts the connection down idempotently (safe to call multiple times).
+func (c *Conn) Close() {
+	c.shutdown()
+}

--- a/internal/event/bus/conn_test.go
+++ b/internal/event/bus/conn_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
 package bus
 
 import (

--- a/internal/event/bus/conn_test.go
+++ b/internal/event/bus/conn_test.go
@@ -3,7 +3,10 @@ package bus
 import (
 	"bufio"
 	"bytes"
+	"io"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,6 +36,122 @@ func TestConn_SenderWritesEvents(t *testing.T) {
 		t.Errorf("unexpected line: %s", line)
 	}
 }
+
+// serializingDetector wraps a net.Conn and records whether any two
+// Write calls were ever in-flight simultaneously. Used to verify that
+// Conn's write paths (SenderLoop event encode + handleControlMessage
+// ack encode) don't race each other on the same underlying connection.
+type serializingDetector struct {
+	net.Conn
+	inFlight atomic.Int32
+	violated atomic.Bool
+}
+
+func (s *serializingDetector) Write(b []byte) (int, error) {
+	if s.inFlight.Add(1) > 1 {
+		s.violated.Store(true)
+	}
+	// Brief yield inside the critical section so concurrent attempts have
+	// a real chance to overlap; without it Go's goroutine scheduling may
+	// serialise writes coincidentally even when the code is racy.
+	time.Sleep(500 * time.Microsecond)
+	defer s.inFlight.Add(-1)
+	return s.Conn.Write(b)
+}
+
+// TestConn_ConcurrentWritesSerialised — regression test for the
+// "SenderLoop + handleControlMessage race on net.Conn" finding.
+// protocol.Encode plus SetWriteDeadline is a 2-call sequence; without
+// an internal mutex, two goroutines writing frames simultaneously can
+// corrupt framing or race the shared deadline.
+func TestConn_ConcurrentWritesSerialised(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	det := &serializingDetector{Conn: server}
+	bc := NewConn(det, nil, "im.msg", []string{"im.msg"}, 12345)
+
+	// Drain whatever the pipe receives so Writes on the server side
+	// unblock; content doesn't matter for this test, we only care that
+	// the server-side Write path never sees concurrent calls.
+	go func() { _, _ = io.Copy(io.Discard, client) }()
+
+	go bc.SenderLoop()
+
+	var wg sync.WaitGroup
+	const workers = 8
+	const perWorker = 20
+	deadline := time.Now().Add(2 * time.Second)
+
+	// Path 1: events via SendCh → SenderLoop → writeFrame.
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perWorker && time.Now().Before(deadline); j++ {
+				bc.SendCh() <- &protocol.Event{Type: protocol.MsgTypeEvent, EventType: "im.msg"}
+			}
+		}()
+	}
+
+	// Path 2: ack writes via handleControlMessage on a separate goroutine,
+	// simulating the ReaderLoop calling it on a PreShutdownCheck arrival.
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perWorker && time.Now().Before(deadline); j++ {
+				bc.handleControlMessage(&protocol.PreShutdownCheck{EventKey: "im.msg"})
+			}
+		}()
+	}
+
+	wg.Wait()
+	bc.Close()
+
+	if det.violated.Load() {
+		t.Error("concurrent Write on net.Conn detected: SenderLoop and handleControlMessage " +
+			"overlapped without serialisation (framing / deadline race)")
+	}
+}
+
+// TestConn_TrySend_NonEvicting verifies TrySend succeeds while the
+// channel has room and returns false when full — it must never drop
+// existing messages to make room (broadcast paths use this for
+// best-effort source-status fan-out).
+func TestConn_TrySend_NonEvicting(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+	bc := NewConn(server, nil, "im.msg", []string{"im.msg"}, 12345)
+
+	// Fill the channel to capacity without starting SenderLoop so nothing
+	// drains.
+	for i := 0; i < sendChCap; i++ {
+		if !bc.TrySend(i) {
+			t.Fatalf("TrySend returned false at iteration %d; expected all sendChCap (%d) to fit", i, sendChCap)
+		}
+	}
+	// One more: channel is full; must fail (not evict).
+	if bc.TrySend("overflow") {
+		t.Fatal("TrySend on full channel returned true: TrySend must be non-evicting")
+	}
+	// Drain one and verify the order preserved — if TrySend had
+	// evicted, the first item would be missing and we'd see 1 not 0.
+	first := <-bc.SendCh()
+	if first != 0 {
+		t.Errorf("first drained item = %v, want 0 (head of queue preserved)", first)
+	}
+}
+
+// Note: the sendMu-sharing invariant for TrySend (Bug 3 regression) is
+// proven by TestPublishRaceBookkeepingAccurate in hub_publish_race_test.go
+// — that test's `returnedFalse > 0` assertion fires directly when a
+// TrySend bypasses sendMu and steals the slot between another
+// goroutine's drop and its retry push. Verified by manually reverting
+// raceSubscriber.TrySend's lock: the assertion caught it in 3
+// iterations. We therefore do not duplicate that coverage here.
 
 func TestConn_ReaderDetectsEOF(t *testing.T) {
 	server, client := net.Pipe()

--- a/internal/event/bus/conn_test.go
+++ b/internal/event/bus/conn_test.go
@@ -1,0 +1,57 @@
+package bus
+
+import (
+	"bufio"
+	"bytes"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+func TestConn_SenderWritesEvents(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	bc := NewConn(server, nil, "im.msg", []string{"im.message.receive_v1"}, 12345)
+	go bc.SenderLoop()
+
+	bc.SendCh() <- &protocol.Event{
+		Type:      protocol.MsgTypeEvent,
+		EventType: "im.message.receive_v1",
+	}
+
+	scanner := bufio.NewScanner(client)
+	client.SetReadDeadline(time.Now().Add(time.Second))
+	if !scanner.Scan() {
+		t.Fatalf("expected to read a line: %v", scanner.Err())
+	}
+	line := scanner.Bytes()
+	if !bytes.Contains(line, []byte(`"event"`)) {
+		t.Errorf("unexpected line: %s", line)
+	}
+}
+
+func TestConn_ReaderDetectsEOF(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+
+	bc := NewConn(server, nil, "im.msg", []string{"im.msg"}, 12345)
+
+	done := make(chan struct{})
+	go func() {
+		bc.ReaderLoop()
+		close(done)
+	}()
+
+	client.Close()
+
+	select {
+	case <-done:
+		// ReaderLoop exited
+	case <-time.After(time.Second):
+		t.Fatal("ReaderLoop did not exit on EOF")
+	}
+}

--- a/internal/event/bus/handle_hello_test.go
+++ b/internal/event/bus/handle_hello_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package bus
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// TestHandleHello_HelloAckWriteFailureUnregisters — regression for the
+// Bug 6 finding (CodeRabbit PR #615). If writing HelloAck fails (peer
+// closed mid-handshake, write timeout), handleHello previously
+// swallowed the error and proceeded to bc.Start(), leaving the
+// connection registered with the hub while SenderLoop/ReaderLoop raced
+// on a broken conn. First/last bookkeeping could end up skewed and
+// cleanup lock decisions incorrect.
+//
+// Expected: on HelloAck write error, handleHello must (1) NOT start the
+// conn's goroutines, and (2) undo all hub/bus-level registration so
+// counters return to pre-Hello state.
+func TestHandleHello_HelloAckWriteFailureUnregisters(t *testing.T) {
+	logger := log.New(io.Discard, "", 0)
+	hub := NewHub()
+	b := &Bus{
+		hub:        hub,
+		logger:     logger,
+		conns:      make(map[*Conn]struct{}),
+		idleTimer:  time.NewTimer(30 * time.Second), // arbitrary, timer API only
+		shutdownCh: make(chan struct{}, 1),
+	}
+
+	// net.Pipe: synchronous / unbuffered. Close the client side
+	// immediately so any write on the server side fails with
+	// io.ErrClosedPipe.
+	server, client := net.Pipe()
+	client.Close()
+	defer server.Close()
+
+	hello := &protocol.Hello{
+		PID:        9999,
+		EventKey:   "im.msg",
+		EventTypes: []string{"im.message.receive_v1"},
+	}
+
+	// handleHello creates a Conn with NewConn(server, reader, ...), so
+	// we provide a reader. The hello has already been decoded by the
+	// caller; we just need a reader for the subsequent ReaderLoop (which
+	// should NOT start on the failure path).
+	br := bufio.NewReader(server)
+
+	done := make(chan struct{})
+	go func() {
+		b.handleHello(server, br, hello)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("handleHello did not return within 3s: stuck on write or not handling the error path")
+	}
+
+	// Hub must be empty — no lingering subscriber.
+	if got := hub.ConnCount(); got != 0 {
+		t.Errorf("hub.ConnCount after failed HelloAck = %d, want 0 (connection must be unregistered)", got)
+	}
+	if got := hub.EventKeyCount("im.msg"); got != 0 {
+		t.Errorf("hub.EventKeyCount(im.msg) after failed HelloAck = %d, want 0", got)
+	}
+	// Bus-level conn map also empty.
+	b.mu.Lock()
+	remaining := len(b.conns)
+	b.mu.Unlock()
+	if remaining != 0 {
+		t.Errorf("b.conns after failed HelloAck = %d entries, want 0", remaining)
+	}
+}

--- a/internal/event/bus/hub.go
+++ b/internal/event/bus/hub.go
@@ -101,17 +101,23 @@ func (h *Hub) UnregisterAndIsLast(s Subscriber) bool {
 }
 
 // AcquireCleanupLock is the race-free replacement for "check last then
-// cleanup". Returns true iff this subscriber is still the only one
-// registered for eventKey AND no other cleanup is already in progress. On
-// true return, caller MUST eventually call ReleaseCleanupLock to unblock
-// any waiting RegisterAndIsFirst. Both checks (count <= 1 and
-// already-locked) run under the same write lock so they are atomic —
-// preventing a late-arriving Hello from slipping in between the check and
-// the reservation.
+// cleanup". Returns true iff exactly one subscriber is registered for
+// eventKey (i.e. the caller is the sole remaining holder) AND no other
+// cleanup is already in progress. On true return, caller MUST eventually
+// call ReleaseCleanupLock to unblock any waiting RegisterAndIsFirst. Both
+// checks (count == 1 and already-locked) run under the same write lock so
+// they are atomic — preventing a late-arriving Hello from slipping in
+// between the check and the reservation.
+//
+// A count of 0 (no live subscriber for this key — e.g. a bogus or
+// duplicate PreShutdownCheck from an already-unregistered peer) is
+// explicitly rejected: granting a cleanup lock there would install a
+// reservation for a key nobody owns, blocking future RegisterAndIsFirst
+// on that key until somebody happens to Release it.
 func (h *Hub) AcquireCleanupLock(eventKey string) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	if h.keyCounts[eventKey] > 1 {
+	if h.keyCounts[eventKey] != 1 {
 		return false
 	}
 	if _, alreadyLocked := h.cleanupInProgress[eventKey]; alreadyLocked {

--- a/internal/event/bus/hub.go
+++ b/internal/event/bus/hub.go
@@ -28,6 +28,11 @@ type Subscriber interface {
 	// other into a state where the channel refills between the drop and the
 	// retry push.
 	PushDropOldest(msg interface{}) (enqueued, dropped bool)
+	// TrySend enqueues msg non-evictively, sharing the same mutex as
+	// PushDropOldest so a best-effort sender (e.g. source-status
+	// broadcast) cannot slip into the drop-then-retry window of a
+	// concurrent PushDropOldest. Returns true iff the channel had room.
+	TrySend(msg interface{}) bool
 	// DroppedCount returns the total number of events evicted via the
 	// drop-oldest path on this subscriber's send channel, surfaced to the
 	// status command via ConsumerInfo.Dropped.
@@ -75,13 +80,19 @@ func (h *Hub) SetLogger(l *log.Logger) { h.logger.Store(l) }
 // UnregisterAndIsLast removes s and returns whether s was the last
 // subscriber for s.EventKey() at the moment of removal. Pairs with
 // RegisterAndIsFirst for atomic lifecycle decisions.
+//
+// If s was never registered (or has already been unregistered), this
+// returns false and leaves keyCounts unchanged — a stale/duplicate
+// unregister must not corrupt first/last bookkeeping for an active
+// subscriber of the same EventKey nor fire a spurious cleanup.
 func (h *Hub) UnregisterAndIsLast(s Subscriber) bool {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	delete(h.subscribers, s)
-	if h.keyCounts[s.EventKey()] > 0 {
-		h.keyCounts[s.EventKey()]--
+	if _, registered := h.subscribers[s]; !registered {
+		return false
 	}
+	delete(h.subscribers, s)
+	h.keyCounts[s.EventKey()]--
 	isLast := h.keyCounts[s.EventKey()] == 0
 	if isLast {
 		delete(h.keyCounts, s.EventKey())
@@ -216,16 +227,16 @@ func (h *Hub) EventKeyCount(eventKey string) int {
 
 // BroadcastSourceStatus fans out a source-level status change to every
 // subscriber. Best-effort: channel full → drop silently (status isn't
-// worth applying back-pressure for).
+// worth applying back-pressure for). Routes through Subscriber.TrySend
+// so the send shares PushDropOldest's sendMu — without this a status
+// broadcast could slip into the tiny window between another
+// goroutine's drop and its retry push and break the atomicity contract.
 func (h *Hub) BroadcastSourceStatus(source, state, detail string) {
 	msg := protocol.NewSourceStatus(source, state, detail)
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	for s := range h.subscribers {
-		select {
-		case s.SendCh() <- msg:
-		default:
-		}
+		s.TrySend(msg)
 	}
 }
 

--- a/internal/event/bus/hub.go
+++ b/internal/event/bus/hub.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package bus
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+
+	"github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// Subscriber is the interface a connection must satisfy for Hub registration.
+type Subscriber interface {
+	EventKey() string
+	EventTypes() []string
+	SendCh() chan interface{}
+	PID() int
+	IncrementReceived()
+	Received() int64
+	// PushDropOldest enqueues msg with drop-oldest backpressure atomically.
+	// Returns enqueued=true iff msg is now in the channel, and dropped=true
+	// iff an older event was evicted to make room. Implementations must
+	// serialise drop+push so concurrent Publish callers cannot race each
+	// other into a state where the channel refills between the drop and the
+	// retry push.
+	PushDropOldest(msg interface{}) (enqueued, dropped bool)
+	// DroppedCount returns the total number of events evicted via the
+	// drop-oldest path on this subscriber's send channel, surfaced to the
+	// status command via ConsumerInfo.Dropped.
+	DroppedCount() int64
+	// IncrementDropped records that one event was evicted via the drop-oldest
+	// path. Hub.Publish calls this when PushDropOldest reports dropped=true.
+	IncrementDropped()
+	// NextSeq returns a monotonically increasing sequence number for events
+	// destined for this subscriber. Hub.Publish stamps the returned value on
+	// protocol.Event.Seq so the consumer side can detect gaps from drops.
+	// Implementations that do not care about sequence numbers (e.g. tests)
+	// may return 0.
+	NextSeq() uint64
+}
+
+// Hub manages event fan-out to registered subscribers.
+type Hub struct {
+	mu          sync.RWMutex
+	subscribers map[Subscriber]struct{}
+	keyCounts   map[string]int
+	// cleanupInProgress maps an EventKey to a "release" channel that is
+	// closed when cleanup finishes. Presence of a key means a cleanup lock
+	// is currently held; RegisterAndIsFirst waits on the channel to avoid
+	// the PreShutdownCheck × Hello TOCTOU race.
+	cleanupInProgress map[string]chan struct{}
+	// logger is read from Publish (per-event hot path) and written by
+	// SetLogger. atomic.Pointer avoids a race even though in today's
+	// wiring SetLogger fires before any source goroutine starts — the
+	// guarantee becomes an invariant of the type, not of the caller.
+	logger atomic.Pointer[log.Logger]
+}
+
+// NewHub returns a freshly initialised Hub with no subscribers.
+func NewHub() *Hub {
+	return &Hub{
+		subscribers:       make(map[Subscriber]struct{}),
+		keyCounts:         make(map[string]int),
+		cleanupInProgress: make(map[string]chan struct{}),
+	}
+}
+
+// SetLogger attaches a logger for backpressure diagnostics. nil is tolerated.
+func (h *Hub) SetLogger(l *log.Logger) { h.logger.Store(l) }
+
+// UnregisterAndIsLast removes s and returns whether s was the last
+// subscriber for s.EventKey() at the moment of removal. Pairs with
+// RegisterAndIsFirst for atomic lifecycle decisions.
+func (h *Hub) UnregisterAndIsLast(s Subscriber) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.subscribers, s)
+	if h.keyCounts[s.EventKey()] > 0 {
+		h.keyCounts[s.EventKey()]--
+	}
+	isLast := h.keyCounts[s.EventKey()] == 0
+	if isLast {
+		delete(h.keyCounts, s.EventKey())
+	}
+	return isLast
+}
+
+// AcquireCleanupLock is the race-free replacement for "check last then
+// cleanup". Returns true iff this subscriber is still the only one
+// registered for eventKey AND no other cleanup is already in progress. On
+// true return, caller MUST eventually call ReleaseCleanupLock to unblock
+// any waiting RegisterAndIsFirst. Both checks (count <= 1 and
+// already-locked) run under the same write lock so they are atomic —
+// preventing a late-arriving Hello from slipping in between the check and
+// the reservation.
+func (h *Hub) AcquireCleanupLock(eventKey string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.keyCounts[eventKey] > 1 {
+		return false
+	}
+	if _, alreadyLocked := h.cleanupInProgress[eventKey]; alreadyLocked {
+		return false
+	}
+	h.cleanupInProgress[eventKey] = make(chan struct{})
+	return true
+}
+
+// ReleaseCleanupLock signals that cleanup for eventKey has finished. Any
+// RegisterAndIsFirst calls waiting on this key will proceed. Safe to call
+// even if no lock is held (no-op in that case), so OnClose can call it
+// unconditionally on every disconnect path.
+func (h *Hub) ReleaseCleanupLock(eventKey string) {
+	h.mu.Lock()
+	ch := h.cleanupInProgress[eventKey]
+	delete(h.cleanupInProgress, eventKey)
+	h.mu.Unlock()
+	if ch != nil {
+		close(ch)
+	}
+}
+
+// RegisterAndIsFirst adds s to the hub and reports whether it's the first
+// subscriber for its EventKey. If a cleanup is in progress for
+// s.EventKey() (another conn holds the cleanup lock), this waits until
+// cleanup releases before registering — closing the PreShutdownCheck ×
+// Hello TOCTOU race. The wait releases h.mu before blocking on the
+// channel, so concurrent operations on other keys aren't stalled.
+func (h *Hub) RegisterAndIsFirst(s Subscriber) bool {
+	for {
+		h.mu.Lock()
+		ch, locked := h.cleanupInProgress[s.EventKey()]
+		if locked {
+			h.mu.Unlock()
+			<-ch // wait for release, then re-check (defensive against races)
+			continue
+		}
+		isFirst := h.keyCounts[s.EventKey()] == 0
+		h.subscribers[s] = struct{}{}
+		h.keyCounts[s.EventKey()]++
+		h.mu.Unlock()
+		return isFirst
+	}
+}
+
+// Publish fans out a RawEvent to all matching subscribers (non-blocking).
+//
+// A fresh *protocol.Event is allocated per subscriber so each consumer sees
+// its own monotonically-increasing Seq (assigned via Conn.NextSeq) — sharing
+// a single msg struct across subscribers would alias Seq and defeat the
+// gap-detection at the consume side. The extra allocation per fan-out is
+// cheap compared to the socket write that follows.
+func (h *Hub) Publish(raw *event.RawEvent) {
+	h.mu.RLock()
+	matches := make([]Subscriber, 0, len(h.subscribers))
+	for s := range h.subscribers {
+		for _, et := range s.EventTypes() {
+			if et == raw.EventType {
+				matches = append(matches, s)
+				break
+			}
+		}
+	}
+	h.mu.RUnlock()
+
+	// Resolve source time once per Publish (not per subscriber) — same value
+	// across the fan-out. Prefer the upstream header create_time
+	// (raw.SourceTime) over the local arrival timestamp so consumers see
+	// original publisher intent; fall back to Timestamp when SourceTime
+	// wasn't populated (e.g. test-only sources, pre-4.4 RawEvent producers).
+	sourceTime := raw.SourceTime
+	if sourceTime == "" && !raw.Timestamp.IsZero() {
+		sourceTime = fmt.Sprintf("%d", raw.Timestamp.UnixMilli())
+	}
+
+	for _, s := range matches {
+		msg := protocol.NewEvent(
+			raw.EventType,
+			raw.EventID,
+			sourceTime,
+			s.NextSeq(),
+			raw.Payload,
+		)
+
+		enqueued, dropped := s.PushDropOldest(msg)
+		if dropped {
+			s.IncrementDropped()
+			if lg := h.logger.Load(); lg != nil {
+				lg.Printf("WARN: backpressure on conn pid=%d event_key=%s dropped_total=%d",
+					s.PID(), s.EventKey(), s.DroppedCount())
+			}
+		}
+		if enqueued {
+			s.IncrementReceived()
+		}
+	}
+}
+
+// ConnCount returns the current number of registered subscribers.
+func (h *Hub) ConnCount() int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return len(h.subscribers)
+}
+
+// EventKeyCount returns the number of subscribers registered for eventKey.
+func (h *Hub) EventKeyCount(eventKey string) int {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.keyCounts[eventKey]
+}
+
+// BroadcastSourceStatus fans out a source-level status change to every
+// subscriber. Best-effort: channel full → drop silently (status isn't
+// worth applying back-pressure for).
+func (h *Hub) BroadcastSourceStatus(source, state, detail string) {
+	msg := protocol.NewSourceStatus(source, state, detail)
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for s := range h.subscribers {
+		select {
+		case s.SendCh() <- msg:
+		default:
+		}
+	}
+}
+
+// Consumers returns info about all connected consumers.
+func (h *Hub) Consumers() []protocol.ConsumerInfo {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	result := make([]protocol.ConsumerInfo, 0, len(h.subscribers))
+	for s := range h.subscribers {
+		result = append(result, protocol.ConsumerInfo{
+			PID:      s.PID(),
+			EventKey: s.EventKey(),
+			Received: s.Received(),
+			Dropped:  s.DroppedCount(),
+		})
+	}
+	return result
+}

--- a/internal/event/bus/hub_observability_test.go
+++ b/internal/event/bus/hub_observability_test.go
@@ -1,0 +1,150 @@
+package bus
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// TestHubDroppedCountIncrements verifies Publish increments a per-conn
+// Dropped counter when the drop-oldest path fires.
+func TestHubDroppedCountIncrements(t *testing.T) {
+	h := NewHub()
+	// Use a real Conn for its IncrementDropped path.
+	server, client := testNetPipe(t)
+	defer server.Close()
+	defer client.Close()
+	c := NewConn(server, nil, "k", []string{"t"}, 1)
+	c.sendCh = make(chan interface{}, 1) // tiny buffer to force drops
+	h.RegisterAndIsFirst(c)
+
+	// First publish fills the channel.
+	h.Publish(&event.RawEvent{EventType: "t"})
+	// Second publish triggers drop-oldest.
+	h.Publish(&event.RawEvent{EventType: "t"})
+	// Third publish also triggers drop-oldest.
+	h.Publish(&event.RawEvent{EventType: "t"})
+
+	if got := c.DroppedCount(); got != 2 {
+		t.Errorf("expected 2 drops, got %d", got)
+	}
+}
+
+// TestPublishAssignsIncrementalSeq verifies each event sent to a consumer
+// has a monotonically increasing Seq starting from 1.
+func TestPublishAssignsIncrementalSeq(t *testing.T) {
+	h := NewHub()
+	server, client := testNetPipe(t)
+	defer server.Close()
+	defer client.Close()
+	c := NewConn(server, nil, "k", []string{"t"}, 1)
+	c.sendCh = make(chan interface{}, 10)
+	h.RegisterAndIsFirst(c)
+
+	for i := 0; i < 5; i++ {
+		h.Publish(&event.RawEvent{EventType: "t"})
+	}
+
+	for i := uint64(1); i <= 5; i++ {
+		msg := <-c.SendCh()
+		ev, ok := msg.(*protocol.Event)
+		if !ok {
+			t.Fatalf("iter %d: expected *protocol.Event, got %T", i, msg)
+		}
+		if ev.Seq != i {
+			t.Errorf("iter %d: expected seq %d, got %d", i, i, ev.Seq)
+		}
+	}
+}
+
+// TestPublishPopulatesEventIDAndSourceTime verifies the protocol.Event
+// carries EventID and SourceTime derived from the RawEvent.
+func TestPublishPopulatesEventIDAndSourceTime(t *testing.T) {
+	h := NewHub()
+	server, client := testNetPipe(t)
+	defer server.Close()
+	defer client.Close()
+	c := NewConn(server, nil, "k", []string{"t"}, 1)
+	c.sendCh = make(chan interface{}, 1)
+	h.RegisterAndIsFirst(c)
+
+	const eid = "test-event-id-123"
+	h.Publish(&event.RawEvent{
+		EventID:   eid,
+		EventType: "t",
+		Timestamp: time.UnixMilli(1234567890123),
+	})
+
+	msg := <-c.SendCh()
+	ev := msg.(*protocol.Event)
+	if ev.EventID != eid {
+		t.Errorf("expected EventID %q, got %q", eid, ev.EventID)
+	}
+	if ev.SourceTime != "1234567890123" {
+		t.Errorf("expected SourceTime \"1234567890123\", got %q", ev.SourceTime)
+	}
+}
+
+// TestPublishSourceTimeTakesPrecedence verifies that when RawEvent carries
+// an explicit SourceTime (from the upstream header.create_time), it wins
+// over Timestamp — Timestamp is a local observability field; SourceTime
+// is the upstream publisher's intent and should flow through unchanged.
+func TestPublishSourceTimeTakesPrecedence(t *testing.T) {
+	h := NewHub()
+	server, client := testNetPipe(t)
+	defer server.Close()
+	defer client.Close()
+	c := NewConn(server, nil, "k", []string{"t"}, 1)
+	c.sendCh = make(chan interface{}, 1)
+	h.RegisterAndIsFirst(c)
+
+	const upstreamTs = "1700000000000"
+	h.Publish(&event.RawEvent{
+		EventID:    "evt-1",
+		EventType:  "t",
+		SourceTime: upstreamTs,
+		// Local arrival time — different from upstream publish time.
+		Timestamp: time.UnixMilli(1999999999999),
+	})
+
+	msg := <-c.SendCh()
+	ev := msg.(*protocol.Event)
+	if ev.SourceTime != upstreamTs {
+		t.Errorf("SourceTime: got %q, want %q (explicit SourceTime must beat derived Timestamp)", ev.SourceTime, upstreamTs)
+	}
+}
+
+// TestPublishSourceTimeFallback verifies that when SourceTime is empty
+// (e.g. a test source that didn't populate it), Publish falls back to
+// formatting Timestamp as UnixMilli so protocol.Event.SourceTime is still
+// populated for downstream consumers that rely on it.
+func TestPublishSourceTimeFallback(t *testing.T) {
+	h := NewHub()
+	server, client := testNetPipe(t)
+	defer server.Close()
+	defer client.Close()
+	c := NewConn(server, nil, "k", []string{"t"}, 1)
+	c.sendCh = make(chan interface{}, 1)
+	h.RegisterAndIsFirst(c)
+
+	h.Publish(&event.RawEvent{
+		EventID:   "evt-2",
+		EventType: "t",
+		Timestamp: time.UnixMilli(42),
+	})
+
+	msg := <-c.SendCh()
+	ev := msg.(*protocol.Event)
+	if ev.SourceTime != "42" {
+		t.Errorf("SourceTime fallback: got %q, want %q", ev.SourceTime, "42")
+	}
+}
+
+// testNetPipe is a test helper that returns an net.Pipe pair.
+func testNetPipe(t *testing.T) (net.Conn, net.Conn) {
+	t.Helper()
+	return net.Pipe()
+}

--- a/internal/event/bus/hub_observability_test.go
+++ b/internal/event/bus/hub_observability_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
 package bus
 
 import (

--- a/internal/event/bus/hub_publish_race_test.go
+++ b/internal/event/bus/hub_publish_race_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
 package bus
 
 import (

--- a/internal/event/bus/hub_publish_race_test.go
+++ b/internal/event/bus/hub_publish_race_test.go
@@ -1,0 +1,232 @@
+package bus
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event"
+)
+
+// TestPublishRaceBookkeepingAccurate verifies that under concurrent Publish
+// calls with a tiny send channel, the Received counter never drifts above
+// the number of events actually enqueued. The pre-fix code handled full
+// channels via two independent select statements:
+//
+//	select { case <-sendCh: default: }         // A2: drop oldest
+//	select { case sendCh <- msg: default: }    // A3: push new
+//	s.IncrementReceived()                      // unconditional
+//
+// Between A2 and A3 another Publish goroutine can refill the slot, causing
+// A3 to hit default and silently drop the message — but Received is still
+// incremented. With the fix, PushDropOldest holds a per-subscriber mutex
+// across drop+push and Received is only incremented when enqueued == true.
+//
+// Strategy: use a test subscriber that counts actual enqueues in its
+// PushDropOldest implementation. With the fix wired through Hub.Publish,
+// IncrementReceived is gated by enqueued, so Received == actual_enqueues
+// exactly. If Hub.Publish reverts to the old pattern (ignoring the return
+// values and always calling IncrementReceived), the test observes
+// Received > actual_enqueues under contention.
+func TestPublishRaceBookkeepingAccurate(t *testing.T) {
+	h := NewHub()
+	sub := newRaceSubscriber("race.key", []string{"race.type"}, 2)
+	h.RegisterAndIsFirst(sub)
+
+	const publishers = 50
+	const perPublisher = 500
+	const N = publishers * perPublisher
+
+	var wg sync.WaitGroup
+	for i := 0; i < publishers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perPublisher; j++ {
+				h.Publish(&event.RawEvent{
+					EventType: "race.type",
+					Payload:   json.RawMessage(`{}`),
+				})
+			}
+		}()
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("publishers did not complete in 10s")
+	}
+
+	received := sub.Received()
+	enqueued := atomic.LoadInt64(&sub.actualEnqueued)
+	returnedFalse := atomic.LoadInt64(&sub.returnedFalse)
+
+	// Layer-B invariant (Hub.Publish gates IncrementReceived on enqueued):
+	//   Received == actual_enqueues
+	// Hub.Publish must increment Received iff PushDropOldest returned
+	// enqueued=true. A subscriber whose PushDropOldest tracks true enqueues
+	// internally must have Received exactly equal to that count.
+	//
+	// Under the buggy two-select pattern in Hub.Publish (no PushDropOldest
+	// gate), Received is incremented unconditionally, so under contention
+	// Received > actual_enqueues whenever any A3 push fell through to default.
+	if received != enqueued {
+		t.Errorf("counter drift: Received=%d actual_enqueued=%d (diff=%d) "+
+			"-- Hub.Publish is incrementing Received for pushes that did not enqueue",
+			received, enqueued, received-enqueued)
+	}
+
+	// Also sanity-check Received never exceeds total Publish count.
+	if received > int64(N) {
+		t.Errorf("Received=%d > N=%d -- Received exceeds total Publish calls", received, N)
+	}
+
+	// Layer-A sensitivity (PushDropOldest holds sendMu across drop+push):
+	// under the fix, PushDropOldest should never return enqueued=false in
+	// this test — no SenderLoop is draining the channel, so either the fast
+	// path succeeds (room available), the slow path drops one and refills
+	// (we made room under the lock), or the slow-path fast-path succeeds
+	// (empty-on-entry, other goroutines blocked on sendMu). The final
+	// default branch of PushDropOldest is effectively unreachable under
+	// sendMu with no external drainer.
+	//
+	// If sendMu is removed, the classic A2/A3 race becomes visible: between
+	// one goroutine's drop (select <-sendCh) and its push (select sendCh <- msg),
+	// another goroutine races in and refills, so the first's push hits the
+	// default branch and returns (false, dropped). returnedFalse > 0 is a
+	// direct witness that sendMu protection is missing or broken.
+	if returnedFalse > 0 {
+		t.Errorf("PushDropOldest returned enqueued=false %d times — sendMu missing or broken; A2/A3 race not fixed",
+			returnedFalse)
+	}
+
+	// Conservation of Publish calls: every Publish reaches PushDropOldest
+	// exactly once (filter match is 1:1 here), so each call must resolve
+	// either to an actual enqueue or to a returned-false. Any drift here
+	// signals lost accounting somewhere in the path.
+	totalPublishes := int64(N)
+	if enqueued+returnedFalse != totalPublishes {
+		t.Errorf("publish accounting drift: enqueued=%d + returnedFalse=%d != total=%d",
+			enqueued, returnedFalse, totalPublishes)
+	}
+}
+
+// TestPublishDoesNotIncrementWhenPushDropOldestFails is a direct, non-racy
+// check that Hub.Publish gates IncrementReceived on the enqueued flag. It
+// uses a stub subscriber that always returns enqueued=false. If Hub.Publish
+// ever drops the `if enqueued` guard (layer-B bug), Received will go up
+// even though no events actually landed. This catches the subtle variant
+// that the stress test above may miss because production PushDropOldest's
+// sendMu makes enqueued=false essentially unreachable in practice.
+func TestPublishDoesNotIncrementWhenPushDropOldestFails(t *testing.T) {
+	h := NewHub()
+	sub := &alwaysFailSubscriber{
+		eventKey:   "fail.key",
+		eventTypes: []string{"fail.type"},
+		sendCh:     make(chan interface{}, 1),
+	}
+	h.RegisterAndIsFirst(sub)
+
+	for i := 0; i < 100; i++ {
+		h.Publish(&event.RawEvent{
+			EventType: "fail.type",
+			Payload:   json.RawMessage(`{}`),
+		})
+	}
+
+	if got := sub.Received(); got != 0 {
+		t.Errorf("Received=%d after 100 Publishes that all failed to enqueue; "+
+			"Hub.Publish is ignoring the enqueued flag (layer-B bug)", got)
+	}
+}
+
+// alwaysFailSubscriber implements Subscriber and always reports PushDropOldest
+// as failing. Used to verify Hub.Publish honours the enqueued return value.
+type alwaysFailSubscriber struct {
+	eventKey   string
+	eventTypes []string
+	sendCh     chan interface{}
+	received   atomic.Int64
+	dropped    atomic.Int64
+}
+
+func (s *alwaysFailSubscriber) EventKey() string         { return s.eventKey }
+func (s *alwaysFailSubscriber) EventTypes() []string     { return s.eventTypes }
+func (s *alwaysFailSubscriber) SendCh() chan interface{} { return s.sendCh }
+func (s *alwaysFailSubscriber) PID() int                 { return 0 }
+func (s *alwaysFailSubscriber) IncrementReceived()       { s.received.Add(1) }
+func (s *alwaysFailSubscriber) Received() int64          { return s.received.Load() }
+func (s *alwaysFailSubscriber) DroppedCount() int64      { return s.dropped.Load() }
+func (s *alwaysFailSubscriber) IncrementDropped()        { s.dropped.Add(1) }
+func (s *alwaysFailSubscriber) NextSeq() uint64          { return 0 }
+func (s *alwaysFailSubscriber) PushDropOldest(msg interface{}) (enqueued, dropped bool) {
+	return false, false
+}
+
+// raceSubscriber implements Subscriber and tracks actual enqueues (vs.
+// IncrementReceived calls) to let tests detect counter drift. The sendCh
+// is deliberately tiny and never drained so PushDropOldest must hit the
+// drop-and-retry path on every Publish after the first few.
+type raceSubscriber struct {
+	eventKey       string
+	eventTypes     []string
+	sendCh         chan interface{}
+	pid            int
+	received       atomic.Int64
+	actualEnqueued int64        // incremented only when PushDropOldest actually enqueues
+	returnedFalse  int64        // incremented each time PushDropOldest returns enqueued=false
+	dropped        atomic.Int64 // incremented each time PushDropOldest evicts an older msg
+	sendMu         sync.Mutex
+}
+
+func newRaceSubscriber(key string, types []string, capacity int) *raceSubscriber {
+	return &raceSubscriber{
+		eventKey:   key,
+		eventTypes: types,
+		sendCh:     make(chan interface{}, capacity),
+		pid:        1,
+	}
+}
+
+func (s *raceSubscriber) EventKey() string         { return s.eventKey }
+func (s *raceSubscriber) EventTypes() []string     { return s.eventTypes }
+func (s *raceSubscriber) SendCh() chan interface{} { return s.sendCh }
+func (s *raceSubscriber) PID() int                 { return s.pid }
+func (s *raceSubscriber) IncrementReceived()       { s.received.Add(1) }
+func (s *raceSubscriber) Received() int64          { return s.received.Load() }
+func (s *raceSubscriber) DroppedCount() int64      { return s.dropped.Load() }
+func (s *raceSubscriber) IncrementDropped()        { s.dropped.Add(1) }
+func (s *raceSubscriber) NextSeq() uint64          { return 0 }
+
+// PushDropOldest mirrors the production Conn.PushDropOldest semantics and
+// additionally tracks actual enqueues so the test can compare them to
+// Received. Dropped accounting is driven by Hub.Publish via IncrementDropped
+// (matching production), so this method does not touch s.dropped directly —
+// it just signals dropped=true in the return value.
+func (s *raceSubscriber) PushDropOldest(msg interface{}) (enqueued, dropped bool) {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	select {
+	case s.sendCh <- msg:
+		atomic.AddInt64(&s.actualEnqueued, 1)
+		return true, false
+	default:
+	}
+	select {
+	case <-s.sendCh:
+		dropped = true
+	default:
+	}
+	select {
+	case s.sendCh <- msg:
+		atomic.AddInt64(&s.actualEnqueued, 1)
+		return true, dropped
+	default:
+		atomic.AddInt64(&s.returnedFalse, 1)
+		return false, dropped
+	}
+}

--- a/internal/event/bus/hub_publish_race_test.go
+++ b/internal/event/bus/hub_publish_race_test.go
@@ -52,6 +52,23 @@ func TestPublishRaceBookkeepingAccurate(t *testing.T) {
 			}
 		}()
 	}
+	// Concurrent TrySend contenders — the key witness for Bug 3 (source-
+	// status broadcast bypassing sendMu). TrySend must share the same
+	// sendMu as PushDropOldest; if it races in between another
+	// goroutine's drop and its retry-push, the retry-push hits default
+	// and returnedFalse bumps (caught by the existing assertion below).
+	// With sendMu correctly held, TrySend serialises with Publish's
+	// PushDropOldest and returnedFalse stays 0.
+	const trySenders = 20
+	for i := 0; i < trySenders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perPublisher; j++ {
+				sub.TrySend("source-status")
+			}
+		}()
+	}
 
 	done := make(chan struct{})
 	go func() { wg.Wait(); close(done) }()
@@ -163,6 +180,14 @@ func (s *alwaysFailSubscriber) Received() int64          { return s.received.Loa
 func (s *alwaysFailSubscriber) DroppedCount() int64      { return s.dropped.Load() }
 func (s *alwaysFailSubscriber) IncrementDropped()        { s.dropped.Add(1) }
 func (s *alwaysFailSubscriber) NextSeq() uint64          { return 0 }
+func (s *alwaysFailSubscriber) TrySend(msg interface{}) bool {
+	select {
+	case s.sendCh <- msg:
+		return true
+	default:
+		return false
+	}
+}
 func (s *alwaysFailSubscriber) PushDropOldest(msg interface{}) (enqueued, dropped bool) {
 	return false, false
 }
@@ -201,6 +226,20 @@ func (s *raceSubscriber) Received() int64          { return s.received.Load() }
 func (s *raceSubscriber) DroppedCount() int64      { return s.dropped.Load() }
 func (s *raceSubscriber) IncrementDropped()        { s.dropped.Add(1) }
 func (s *raceSubscriber) NextSeq() uint64          { return 0 }
+
+// TrySend satisfies the Subscriber interface. Non-evicting; shares
+// s.sendMu with PushDropOldest so the test can assert serialised
+// behaviour under concurrent broadcast+publish.
+func (s *raceSubscriber) TrySend(msg interface{}) bool {
+	s.sendMu.Lock()
+	defer s.sendMu.Unlock()
+	select {
+	case s.sendCh <- msg:
+		return true
+	default:
+		return false
+	}
+}
 
 // PushDropOldest mirrors the production Conn.PushDropOldest semantics and
 // additionally tracks actual enqueues so the test can compare them to

--- a/internal/event/bus/hub_test.go
+++ b/internal/event/bus/hub_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
 package bus
 
 import (

--- a/internal/event/bus/hub_test.go
+++ b/internal/event/bus/hub_test.go
@@ -1,0 +1,257 @@
+package bus
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+func TestHub_Subscribe(t *testing.T) {
+	h := NewHub()
+	c := newTestConn("mail.user_mailbox.event.message_received_v1", []string{"mail.event.v1"})
+	h.RegisterAndIsFirst(c)
+
+	if h.ConnCount() != 1 {
+		t.Errorf("expected 1 conn, got %d", h.ConnCount())
+	}
+}
+
+func TestHub_Publish_RoutesToSubscriber(t *testing.T) {
+	h := NewHub()
+	c := newTestConn("im.msg", []string{"im.message.receive_v1"})
+	h.RegisterAndIsFirst(c)
+
+	raw := &event.RawEvent{
+		EventID:   "evt-1",
+		EventType: "im.message.receive_v1",
+		Payload:   json.RawMessage(`{}`),
+	}
+	h.Publish(raw)
+
+	select {
+	case msg := <-c.sendCh:
+		evt, ok := msg.(*protocol.Event)
+		if !ok {
+			t.Fatalf("expected *Event, got %T", msg)
+		}
+		if evt.EventType != "im.message.receive_v1" {
+			t.Errorf("got event_type %q", evt.EventType)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timeout waiting for event")
+	}
+}
+
+func TestHub_Publish_SkipsUnmatchedSubscriber(t *testing.T) {
+	h := NewHub()
+	c := newTestConn("mail.new", []string{"mail.event.v1"})
+	h.RegisterAndIsFirst(c)
+
+	raw := &event.RawEvent{
+		EventID:   "evt-1",
+		EventType: "im.message.receive_v1",
+		Payload:   json.RawMessage(`{}`),
+	}
+	h.Publish(raw)
+
+	select {
+	case <-c.sendCh:
+		t.Fatal("should not receive unmatched event")
+	case <-time.After(50 * time.Millisecond):
+		// OK
+	}
+}
+
+func TestHub_Publish_NonBlocking(t *testing.T) {
+	h := NewHub()
+	c := newTestConn("im", []string{"im.message.receive_v1"})
+	c.sendCh = make(chan interface{}, 1) // tiny buffer
+	h.RegisterAndIsFirst(c)
+
+	c.sendCh <- &protocol.Event{} // fill it
+
+	done := make(chan struct{})
+	go func() {
+		raw := &event.RawEvent{
+			EventType: "im.message.receive_v1",
+			Payload:   json.RawMessage(`{}`),
+		}
+		h.Publish(raw)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Publish returned without blocking
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Publish blocked on full channel")
+	}
+}
+
+func TestHub_Unregister(t *testing.T) {
+	h := NewHub()
+	c := newTestConn("im", []string{"im.msg"})
+	h.RegisterAndIsFirst(c)
+	h.UnregisterAndIsLast(c)
+
+	if h.ConnCount() != 0 {
+		t.Errorf("expected 0 conns, got %d", h.ConnCount())
+	}
+}
+
+func TestHub_EventKeyCount(t *testing.T) {
+	h := NewHub()
+	c1 := newTestConn("mail.user_mailbox.event.message_received_v1", []string{"mail.v1"})
+	c2 := newTestConn("mail.user_mailbox.event.message_received_v1", []string{"mail.v1"})
+	h.RegisterAndIsFirst(c1)
+	h.RegisterAndIsFirst(c2)
+
+	if h.EventKeyCount("mail.user_mailbox.event.message_received_v1") != 2 {
+		t.Errorf("expected 2, got %d", h.EventKeyCount("mail.user_mailbox.event.message_received_v1"))
+	}
+
+	h.UnregisterAndIsLast(c1)
+	if h.EventKeyCount("mail.user_mailbox.event.message_received_v1") != 1 {
+		t.Errorf("expected 1 after unregister, got %d", h.EventKeyCount("mail.user_mailbox.event.message_received_v1"))
+	}
+}
+
+// TestHub_RegisterAndIsFirst_Concurrent proves the atomic variant does not
+// allow two concurrent Hellos to both observe isFirst=true. Before the
+// atomic API, handleHello did `EventKeyCount == 0` read, then `Register`
+// write — this test reliably caught the race window when run with `-race`
+// and the old two-step code.
+func TestHub_RegisterAndIsFirst_Concurrent(t *testing.T) {
+	h := NewHub()
+	const N = 200
+	eventKey := "mail.user_mailbox.event.message_received_v1"
+
+	var firstCount int32
+	var wg sync.WaitGroup
+	wg.Add(N)
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			c := newTestConn(eventKey, []string{"mail.v1"})
+			if h.RegisterAndIsFirst(c) {
+				atomic.AddInt32(&firstCount, 1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&firstCount); got != 1 {
+		t.Errorf("RegisterAndIsFirst returned true %d times across %d concurrent registrants; want exactly 1", got, N)
+	}
+	if got := h.EventKeyCount(eventKey); got != N {
+		t.Errorf("EventKeyCount = %d, want %d", got, N)
+	}
+}
+
+// TestHub_UnregisterAndIsLast_Concurrent proves symmetric behavior for
+// the leave path: only one concurrent Unregister sees isLast=true.
+func TestHub_UnregisterAndIsLast_Concurrent(t *testing.T) {
+	h := NewHub()
+	const N = 200
+	eventKey := "im.message.receive_v1"
+
+	conns := make([]*testConn, N)
+	for i := 0; i < N; i++ {
+		conns[i] = newTestConn(eventKey, []string{"im.v1"})
+		h.RegisterAndIsFirst(conns[i])
+	}
+
+	var lastCount int32
+	var wg sync.WaitGroup
+	wg.Add(N)
+	start := make(chan struct{})
+	for i := 0; i < N; i++ {
+		c := conns[i]
+		go func() {
+			defer wg.Done()
+			<-start
+			if h.UnregisterAndIsLast(c) {
+				atomic.AddInt32(&lastCount, 1)
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&lastCount); got != 1 {
+		t.Errorf("UnregisterAndIsLast returned true %d times; want exactly 1", got)
+	}
+	if got := h.EventKeyCount(eventKey); got != 0 {
+		t.Errorf("EventKeyCount after all unregister = %d, want 0", got)
+	}
+}
+
+// --- Test helpers ---
+
+type testConn struct {
+	eventKey   string
+	eventTypes []string
+	sendCh     chan interface{}
+	pid        int
+	received   atomic.Int64
+}
+
+func newTestConn(eventKey string, eventTypes []string) *testConn {
+	return &testConn{
+		eventKey:   eventKey,
+		eventTypes: eventTypes,
+		sendCh:     make(chan interface{}, 100),
+		pid:        1,
+	}
+}
+
+func (c *testConn) EventKey() string         { return c.eventKey }
+func (c *testConn) EventTypes() []string     { return c.eventTypes }
+func (c *testConn) SendCh() chan interface{} { return c.sendCh }
+func (c *testConn) PID() int                 { return c.pid }
+func (c *testConn) IncrementReceived()       { c.received.Add(1) }
+func (c *testConn) Received() int64          { return c.received.Load() }
+
+// DroppedCount satisfies the Subscriber interface. testConn does not
+// track drops in its PushDropOldest implementation, so this is always 0.
+func (c *testConn) DroppedCount() int64 { return 0 }
+
+// IncrementDropped satisfies the Subscriber interface. testConn does not
+// track drops, so this is a no-op — tests that care about drop counters
+// should use a real *Conn via NewConn.
+func (c *testConn) IncrementDropped() {}
+
+// NextSeq satisfies the Subscriber interface. testConn does not track
+// sequence numbers; tests that assert on Seq use a real *Conn.
+func (c *testConn) NextSeq() uint64 { return 0 }
+
+// PushDropOldest mirrors the production Conn.PushDropOldest behaviour
+// (drop oldest on full, push new) but omits the sendMu because tests here
+// do not exercise concurrent Publish stress. Callers that need the atomic
+// drop+push guarantee should use a production *Conn.
+func (c *testConn) PushDropOldest(msg interface{}) (enqueued, dropped bool) {
+	select {
+	case c.sendCh <- msg:
+		return true, false
+	default:
+	}
+	select {
+	case <-c.sendCh:
+		dropped = true
+	default:
+	}
+	select {
+	case c.sendCh <- msg:
+		return true, dropped
+	default:
+		return false, dropped
+	}
+}

--- a/internal/event/bus/hub_test.go
+++ b/internal/event/bus/hub_test.go
@@ -104,6 +104,48 @@ func TestHub_Unregister(t *testing.T) {
 	}
 }
 
+// TestHub_UnregisterAndIsLast_NeverRegistered — regression for the
+// "decrements unregistered subscribers" finding. Calling
+// UnregisterAndIsLast on a Subscriber that was never registered must
+// return false (it was never the last of anything) and MUST NOT
+// corrupt keyCounts for that EventKey.
+func TestHub_UnregisterAndIsLast_NeverRegistered(t *testing.T) {
+	h := NewHub()
+	real := newTestConn("im", []string{"im.msg"})
+	h.RegisterAndIsFirst(real)
+	ghost := newTestConn("im", []string{"im.msg"}) // same EventKey, never registered
+
+	if h.UnregisterAndIsLast(ghost) {
+		t.Error("ghost unregister returned true: must be false when subscriber never registered")
+	}
+	if got := h.EventKeyCount("im"); got != 1 {
+		t.Errorf("keyCount for 'im' = %d after ghost unregister; want 1 (real still registered)", got)
+	}
+	// Now unregistering the real subscriber should still correctly
+	// report last=true. If the ghost path decremented the counter, this
+	// would have been clobbered.
+	if !h.UnregisterAndIsLast(real) {
+		t.Error("real unregister returned false; expected true (sole subscriber)")
+	}
+}
+
+// TestHub_UnregisterAndIsLast_DoubleUnregister — second call on the
+// same already-unregistered subscriber must return false. Prior code
+// returned true because keyCounts[key]==0 fell through the isLast check
+// on the stale second call, potentially firing cleanup twice.
+func TestHub_UnregisterAndIsLast_DoubleUnregister(t *testing.T) {
+	h := NewHub()
+	c := newTestConn("im", []string{"im.msg"})
+	h.RegisterAndIsFirst(c)
+
+	if !h.UnregisterAndIsLast(c) {
+		t.Fatal("first unregister returned false; expected true (sole subscriber)")
+	}
+	if h.UnregisterAndIsLast(c) {
+		t.Error("second unregister returned true: duplicate unregister must report false")
+	}
+}
+
 func TestHub_EventKeyCount(t *testing.T) {
 	h := NewHub()
 	c1 := newTestConn("mail.user_mailbox.event.message_received_v1", []string{"mail.v1"})
@@ -253,5 +295,17 @@ func (c *testConn) PushDropOldest(msg interface{}) (enqueued, dropped bool) {
 		return true, dropped
 	default:
 		return false, dropped
+	}
+}
+
+// TrySend satisfies the Subscriber interface. Non-evicting best-effort
+// send; tests that care about the sendMu serialisation guarantee should
+// use a production *Conn.
+func (c *testConn) TrySend(msg interface{}) bool {
+	select {
+	case c.sendCh <- msg:
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/event/bus/hub_toctou_test.go
+++ b/internal/event/bus/hub_toctou_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
 package bus
 
 import (
@@ -98,4 +101,30 @@ func TestReleaseCleanupLockIsIdempotent(t *testing.T) {
 	h := NewHub()
 	h.ReleaseCleanupLock("never.locked.key") // should not panic
 	h.ReleaseCleanupLock("never.locked.key") // still should not panic
+}
+
+// TestAcquireCleanupLockRejectsIfZeroSubscribers guards the count==0 hole:
+// a bogus or duplicate PreShutdownCheck for a key with no live subscriber
+// must NOT be granted a cleanup lock. Granting it would install a
+// reservation for a key nobody owns, distorting last-subscriber
+// bookkeeping and blocking any future RegisterAndIsFirst for that key
+// until something happened to release it.
+func TestAcquireCleanupLockRejectsIfZeroSubscribers(t *testing.T) {
+	h := NewHub()
+
+	// Never-registered key: count is 0, must reject.
+	if h.AcquireCleanupLock("never.registered.key") {
+		t.Error("AcquireCleanupLock should reject for a never-registered key (count==0)")
+	}
+
+	// Register then unregister: count returns to 0 (and the key entry
+	// gets deleted by UnregisterAndIsLast). A late PreShutdownCheck from
+	// an already-gone peer must still not slip through.
+	sub := newTestConn("transient.key", []string{"t"})
+	sub.pid = 1
+	h.RegisterAndIsFirst(sub)
+	h.UnregisterAndIsLast(sub)
+	if h.AcquireCleanupLock("transient.key") {
+		t.Error("AcquireCleanupLock should reject after all subscribers have unregistered (count==0)")
+	}
 }

--- a/internal/event/bus/hub_toctou_test.go
+++ b/internal/event/bus/hub_toctou_test.go
@@ -1,0 +1,101 @@
+package bus
+
+import (
+	"testing"
+	"time"
+)
+
+// TestConcurrentPreShutdownAndHelloRaceFree verifies that once a subscriber
+// has acquired the cleanup lock for its key, a concurrent Hello registration
+// for the same key blocks until cleanup releases. This prevents the bug
+// where consume B subscribes during consume A's cleanup window and ends up
+// silently black-holed when A's cleanup tears down the upstream subscription.
+func TestConcurrentPreShutdownAndHelloRaceFree(t *testing.T) {
+	h := NewHub()
+	subA := newTestConn("mail.key", []string{"mail.receive"})
+	subA.pid = 1001
+	h.RegisterAndIsFirst(subA)
+
+	// A acquires cleanup lock (simulating PreShutdownCheck -> ack true).
+	if !h.AcquireCleanupLock("mail.key") {
+		t.Fatal("A should acquire cleanup lock — it's the only subscriber")
+	}
+
+	// While A's cleanup is "in progress", B tries to register for same key.
+	subB := newTestConn("mail.key", []string{"mail.receive"})
+	subB.pid = 1002
+
+	registered := make(chan bool, 1)
+	go func() {
+		isFirst := h.RegisterAndIsFirst(subB)
+		registered <- isFirst
+	}()
+
+	// Register MUST NOT return while cleanup lock is held.
+	select {
+	case <-registered:
+		t.Fatal("B registered DURING A's cleanup — TOCTOU race not fixed")
+	case <-time.After(200 * time.Millisecond):
+		// Good — B is blocked.
+	}
+
+	// Release cleanup lock. B should proceed.
+	h.ReleaseCleanupLock("mail.key")
+
+	select {
+	case isFirst := <-registered:
+		// After A's unregister happens in real flow, B would be first. In this
+		// synthetic test we didn't unregister A, so B sees isFirst=false. Just
+		// assert that B registered — isFirst semantics are covered elsewhere.
+		_ = isFirst
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("B never registered after cleanup released")
+	}
+}
+
+// TestAcquireCleanupLockRejectsIfMultipleSubscribers verifies that
+// AcquireCleanupLock returns false when more than one subscriber is
+// registered for the key — in that case there's no "last subscriber" to
+// reserve cleanup for.
+func TestAcquireCleanupLockRejectsIfMultipleSubscribers(t *testing.T) {
+	h := NewHub()
+	subA := newTestConn("shared.key", []string{"t"})
+	subA.pid = 1
+	subB := newTestConn("shared.key", []string{"t"})
+	subB.pid = 2
+	h.RegisterAndIsFirst(subA)
+	h.RegisterAndIsFirst(subB)
+
+	if h.AcquireCleanupLock("shared.key") {
+		t.Fatal("AcquireCleanupLock should reject when >1 subscribers exist")
+	}
+}
+
+// TestAcquireCleanupLockRejectsIfAlreadyLocked ensures the lock is
+// exclusive — only one subscriber can hold the cleanup reservation at a time.
+func TestAcquireCleanupLockRejectsIfAlreadyLocked(t *testing.T) {
+	h := NewHub()
+	sub := newTestConn("exclusive.key", []string{"t"})
+	sub.pid = 1
+	h.RegisterAndIsFirst(sub)
+
+	if !h.AcquireCleanupLock("exclusive.key") {
+		t.Fatal("first acquire should succeed")
+	}
+	if h.AcquireCleanupLock("exclusive.key") {
+		t.Fatal("second acquire should fail — already locked")
+	}
+
+	h.ReleaseCleanupLock("exclusive.key")
+	if !h.AcquireCleanupLock("exclusive.key") {
+		t.Fatal("re-acquire after release should succeed")
+	}
+}
+
+// TestReleaseCleanupLockIsIdempotent ensures calling Release without a prior
+// Acquire is a no-op (doesn't panic).
+func TestReleaseCleanupLockIsIdempotent(t *testing.T) {
+	h := NewHub()
+	h.ReleaseCleanupLock("never.locked.key") // should not panic
+	h.ReleaseCleanupLock("never.locked.key") // still should not panic
+}

--- a/internal/event/bus/log.go
+++ b/internal/event/bus/log.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package bus
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+const (
+	maxLogSize    = 5 * 1024 * 1024 // 5 MB
+	logFileName   = "bus.log"
+	logBackupName = "bus.log.1"
+)
+
+// SetupBusLogger creates a log.Logger that writes to eventsDir/bus.log
+// with simple rotation: when the log exceeds maxLogSize, the current
+// log is renamed to bus.log.1 and a fresh file is opened.
+//
+// LIMITATION: the size check runs exactly once, at bus start. A long-
+// running bus (multi-day) will never rotate mid-run — bus.log grows
+// unbounded until the next restart. This is adequate for dev/test and
+// short (<1 day) production runs, which is the current target. For
+// production daemons that stay up indefinitely, replace with a full
+// rotation library (e.g. gopkg.in/natefinch/lumberjack.v2) or add a
+// background ticker that periodically calls a MaybeRotate() helper.
+// The lifecycle of the underlying *os.File is tied to the returned
+// logger, so any rotation strategy also needs coordination with bus
+// shutdown to close the file cleanly.
+func SetupBusLogger(eventsDir string) (*log.Logger, error) {
+	if err := vfs.MkdirAll(eventsDir, 0700); err != nil {
+		return nil, err
+	}
+
+	logPath := filepath.Join(eventsDir, logFileName)
+	backupPath := filepath.Join(eventsDir, logBackupName)
+
+	// Rotate if current log exceeds max size.
+	if info, err := vfs.Stat(logPath); err == nil && info.Size() > maxLogSize {
+		_ = vfs.Remove(backupPath)
+		_ = vfs.Rename(logPath, backupPath)
+	}
+
+	f, err := vfs.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	return log.New(f, "", log.LstdFlags), nil
+}

--- a/internal/event/busctl/busctl.go
+++ b/internal/event/busctl/busctl.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package busctl is the wire-level control client for the event bus
+// daemon: sends StatusQuery / Shutdown over IPC and returns the parsed
+// response. Keeping this in internal/event/ lets cmd/event/ talk only
+// to one abstraction layer instead of directly importing transport +
+// protocol for control-plane operations.
+package busctl
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+	"github.com/larksuite/cli/internal/event/transport"
+)
+
+// readTimeout bounds the status-response read. Matches protocol.WriteTimeout
+// so a wedged bus can't hang the caller longer on one side than the other.
+const readTimeout = 5 * time.Second
+
+// QueryStatus dials the bus for appID, sends a StatusQuery, and reads
+// back the StatusResponse. Uses bufio-framed reads so a multi-segment
+// response (common once consumer count grows) reassembles correctly.
+func QueryStatus(tr transport.IPC, appID string) (*protocol.StatusResponse, error) {
+	conn, err := tr.Dial(tr.Address(appID))
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	if err := protocol.EncodeWithDeadline(conn, protocol.NewStatusQuery(), protocol.WriteTimeout); err != nil {
+		return nil, err
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(readTimeout)); err != nil {
+		return nil, err
+	}
+	line, err := protocol.ReadFrame(bufio.NewReader(conn))
+	if err != nil {
+		return nil, err
+	}
+
+	msg, err := protocol.Decode(bytes.TrimRight(line, "\n"))
+	if err != nil {
+		return nil, err
+	}
+	resp, ok := msg.(*protocol.StatusResponse)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response type from bus: %T", msg)
+	}
+	return resp, nil
+}
+
+// SendShutdown dials the bus for appID and sends a Shutdown command.
+// Does not wait for the bus process to exit — the caller is responsible
+// for polling Dial to confirm shutdown actually happened.
+func SendShutdown(tr transport.IPC, appID string) error {
+	conn, err := tr.Dial(tr.Address(appID))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return protocol.EncodeWithDeadline(conn, protocol.NewShutdown(), protocol.WriteTimeout)
+}

--- a/internal/event/busdiscover/busdiscover.go
+++ b/internal/event/busdiscover/busdiscover.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package busdiscover scans the OS process table for live `lark-cli event _bus`
+// processes. It exists so `event status` can detect orphan bus processes —
+// processes still alive but whose IPC socket has gone missing, rendering them
+// invisible to the socket-based status path.
+//
+// Truth model: we treat the process table as primary truth. A bus process is
+// detected iff (a) its command line contains "lark-cli" AND "event _bus", and
+// (b) its --profile flag value can be parsed as an AppID. This two-gate filter
+// also naturally excludes pid-reused processes: after a bus dies, if the OS
+// reassigns its pid to an unrelated process, that process's cmdline won't match
+// the gate and will be silently filtered out.
+package busdiscover
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Process describes one live bus process discovered on this machine.
+type Process struct {
+	PID       int
+	AppID     string    // parsed from --profile flag
+	StartTime time.Time // process creation time
+}
+
+// Scanner discovers live bus processes. Implementations are platform-specific.
+type Scanner interface {
+	ScanBusProcesses() ([]Process, error)
+}
+
+// Default returns a production scanner for the current platform.
+func Default() Scanner {
+	return newPlatformScanner()
+}
+
+// appIDPattern captures the AppID value following a --profile flag.
+// AppIDs are canonically of the form cli_<alnum_underscore> — we require that
+// prefix to avoid accidentally matching unrelated flag values.
+var appIDPattern = regexp.MustCompile(`--profile\s+(cli_[a-zA-Z0-9_]+)`)
+
+// parseAppIDFromCmdline returns the AppID from a bus command line, or "" if
+// the command line does not belong to a lark-cli event _bus process.
+//
+// Gate 1: cmdline must contain both "lark-cli" and "event _bus" substrings.
+// Gate 2: --profile flag must be present with a value matching cli_* pattern.
+func parseAppIDFromCmdline(cmdline string) string {
+	if !strings.Contains(cmdline, "lark-cli") {
+		return ""
+	}
+	if !strings.Contains(cmdline, "event _bus") {
+		return ""
+	}
+	m := appIDPattern.FindStringSubmatch(cmdline)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}

--- a/internal/event/busdiscover/busdiscover_test.go
+++ b/internal/event/busdiscover/busdiscover_test.go
@@ -13,13 +13,13 @@ func TestParseAppIDFromCmdline(t *testing.T) {
 	}{
 		{
 			name:    "unix full path bus",
-			cmdline: "/Users/bytedance/go/src/github/cli/lark-cli event _bus --profile cli_a96a42f48438dbd2 --domain https://open.feishu.cn",
-			want:    "cli_a96a42f48438dbd2",
+			cmdline: "/Users/bytedance/go/src/github/cli/lark-cli event _bus --profile cli_XXXXXXXXXXXXXXXX --domain https://open.feishu.cn",
+			want:    "cli_XXXXXXXXXXXXXXXX",
 		},
 		{
 			name:    "windows quoted exe bus",
-			cmdline: `"C:\Program Files\lark-cli\lark-cli.exe" event _bus --profile cli_b1c2d3e4f5g6h7i8 --domain https://open.larksuite.com`,
-			want:    "cli_b1c2d3e4f5g6h7i8",
+			cmdline: `"C:\Program Files\lark-cli\lark-cli.exe" event _bus --profile cli_XXXXXXXXXXXXXXXX --domain https://open.larksuite.com`,
+			want:    "cli_XXXXXXXXXXXXXXXX",
 		},
 		{
 			name:    "no profile flag",

--- a/internal/event/busdiscover/busdiscover_test.go
+++ b/internal/event/busdiscover/busdiscover_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package busdiscover
+
+import "testing"
+
+func TestParseAppIDFromCmdline(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		cmdline string
+		want    string
+	}{
+		{
+			name:    "unix full path bus",
+			cmdline: "/Users/bytedance/go/src/github/cli/lark-cli event _bus --profile cli_a96a42f48438dbd2 --domain https://open.feishu.cn",
+			want:    "cli_a96a42f48438dbd2",
+		},
+		{
+			name:    "windows quoted exe bus",
+			cmdline: `"C:\Program Files\lark-cli\lark-cli.exe" event _bus --profile cli_b1c2d3e4f5g6h7i8 --domain https://open.larksuite.com`,
+			want:    "cli_b1c2d3e4f5g6h7i8",
+		},
+		{
+			name:    "no profile flag",
+			cmdline: "/usr/local/bin/lark-cli event _bus --domain https://open.feishu.cn",
+			want:    "",
+		},
+		{
+			name:    "not a bus process",
+			cmdline: "/usr/local/bin/lark-cli event consume im.message.receive_v1",
+			want:    "",
+		},
+		{
+			name:    "completely unrelated",
+			cmdline: "/Applications/Visual Studio Code.app/Contents/MacOS/Electron --type=renderer",
+			want:    "",
+		},
+		{
+			name:    "lark-cli but not event",
+			cmdline: "/usr/local/bin/lark-cli auth login",
+			want:    "",
+		},
+		{
+			name:    "profile arg with trailing space and more flags",
+			cmdline: "lark-cli event _bus --profile cli_xyz123 --verbose",
+			want:    "cli_xyz123",
+		},
+		{
+			name:    "empty cmdline",
+			cmdline: "",
+			want:    "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAppIDFromCmdline(tt.cmdline)
+			if got != tt.want {
+				t.Errorf("parseAppIDFromCmdline(%q) = %q, want %q", tt.cmdline, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/event/busdiscover/busdiscover_unix.go
+++ b/internal/event/busdiscover/busdiscover_unix.go
@@ -9,6 +9,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -22,7 +23,16 @@ const lstartLayout = "Mon Jan _2 15:04:05 2006"
 func newPlatformScanner() Scanner {
 	return &unixScanner{
 		runPS: func() ([]byte, error) {
-			return exec.Command("ps", "-eo", "pid,lstart,command").Output()
+			cmd := exec.Command("ps", "-eo", "pid,lstart,command")
+			// Force C locale so `ps -o lstart` emits English weekday /
+			// month names ("Mon Apr 19 …") matching lstartLayout. Without
+			// this, on hosts with LC_TIME=zh_CN / de_DE / fr_FR the output
+			// is localized ("一 4月 19 …") and parseOneUnixPSLine silently
+			// drops every row — orphan bus detection fails entirely.
+			// Inherit the rest of the environment so ps can still find
+			// system paths etc.
+			cmd.Env = append(os.Environ(), "LC_ALL=C", "LANG=C")
+			return cmd.Output()
 		},
 	}
 }

--- a/internal/event/busdiscover/busdiscover_unix.go
+++ b/internal/event/busdiscover/busdiscover_unix.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package busdiscover
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// lstartLayout is the fixed format that `ps -o lstart` emits on macOS/Linux.
+// It is a 24-character field, e.g. "Sun Apr 19 03:03:40 2026".
+const lstartLayout = "Mon Jan _2 15:04:05 2006"
+
+func newPlatformScanner() Scanner {
+	return &unixScanner{
+		runPS: func() ([]byte, error) {
+			return exec.Command("ps", "-eo", "pid,lstart,command").Output()
+		},
+	}
+}
+
+// unixScanner shells out to `ps` and parses the output.
+// runPS is a field so tests can inject canned output without spawning ps.
+type unixScanner struct {
+	runPS func() ([]byte, error)
+}
+
+func (s *unixScanner) ScanBusProcesses() ([]Process, error) {
+	out, err := s.runPS()
+	if err != nil {
+		return nil, fmt.Errorf("busdiscover: run ps: %w", err)
+	}
+	return parseUnixPS(out), nil
+}
+
+// parseUnixPS parses the output of `ps -eo pid,lstart,command`.
+//
+// Expected columns (width-based, lstart is always 24 chars):
+//
+//	PID<spaces>LSTART<space>COMMAND
+//
+// The first line is a header and is skipped. Lines that don't parse cleanly
+// (wrong column count, unparseable lstart, non-bus cmdline) are silently
+// dropped — we're scanning the whole system, most lines are not buses.
+func parseUnixPS(out []byte) []Process {
+	var result []Process
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	// Allow long lines; commands can exceed the default 64KB token.
+	sc.Buffer(make([]byte, 0, 128*1024), 1024*1024)
+
+	first := true
+	for sc.Scan() {
+		line := sc.Text()
+		if first {
+			first = false
+			continue // header
+		}
+		p, ok := parseOneUnixPSLine(line)
+		if !ok {
+			continue
+		}
+		result = append(result, p)
+	}
+	return result
+}
+
+// parseOneUnixPSLine parses a single ps data line. Returns (_, false) on any
+// format error or if the cmdline is not a bus process.
+func parseOneUnixPSLine(line string) (Process, bool) {
+	// Skip leading whitespace before PID.
+	line = strings.TrimLeft(line, " ")
+	if line == "" {
+		return Process{}, false
+	}
+
+	// Extract PID (first whitespace-delimited token).
+	sp := strings.IndexByte(line, ' ')
+	if sp < 0 {
+		return Process{}, false
+	}
+	pid, err := strconv.Atoi(line[:sp])
+	if err != nil {
+		return Process{}, false
+	}
+	rest := strings.TrimLeft(line[sp:], " ")
+
+	// LSTART is exactly 24 chars in format "Mon Jan _2 15:04:05 2006".
+	if len(rest) < 24 {
+		return Process{}, false
+	}
+	lstart := rest[:24]
+	startTime, err := time.ParseInLocation(lstartLayout, lstart, time.Local)
+	if err != nil {
+		return Process{}, false
+	}
+	// Remainder is the command line.
+	cmdline := strings.TrimLeft(rest[24:], " ")
+
+	appID := parseAppIDFromCmdline(cmdline)
+	if appID == "" {
+		return Process{}, false
+	}
+	return Process{PID: pid, AppID: appID, StartTime: startTime}, true
+}

--- a/internal/event/busdiscover/busdiscover_windows.go
+++ b/internal/event/busdiscover/busdiscover_windows.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package busdiscover
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// psCommand is the PowerShell one-liner that emits JSON for bus candidate
+// processes. We filter by Name='lark-cli.exe' in WQL to avoid enumerating
+// the entire process table. .ToString('o') produces ISO 8601 with fractional
+// seconds and timezone — stable across locales.
+//
+// PowerShell 5.1 compatibility: we deliberately do NOT use `-AsArray`, which
+// was introduced in PowerShell 6.0 (Core). Without it, ConvertTo-Json emits
+// a JSON array for 2+ results and a bare object for a single result; 0
+// results produces empty output. parseWindowsPS handles all three shapes.
+//
+// WQL filter limitation: this matches only the standard `lark-cli.exe`
+// binary name (as distributed by npm and GitHub releases). Renamed binaries
+// will not be detected — unlike the Unix scanner, which matches any cmdline
+// containing "lark-cli". Documented asymmetry; acceptable trade-off for the
+// performance win of avoiding a full process-table enumeration.
+const psCommand = `Get-CimInstance Win32_Process -Filter "Name='lark-cli.exe'" | ` +
+	`ForEach-Object { [pscustomobject]@{ Pid = $_.ProcessId; ` +
+	`CreationDate = $_.CreationDate.ToString('o'); ` +
+	`CommandLine = $_.CommandLine } } | ConvertTo-Json`
+
+func newPlatformScanner() Scanner {
+	return &windowsScanner{
+		runPS: func() ([]byte, error) {
+			cmd := exec.Command("powershell.exe", "-NoProfile", "-Command", psCommand)
+			return cmd.Output()
+		},
+	}
+}
+
+// windowsScanner shells out to PowerShell's Get-CimInstance Win32_Process.
+// runPS is a field for test injection.
+type windowsScanner struct {
+	runPS func() ([]byte, error)
+}
+
+// psRecord matches the JSON shape emitted by our PowerShell command.
+type psRecord struct {
+	Pid          int    `json:"Pid"`
+	CreationDate string `json:"CreationDate"`
+	CommandLine  string `json:"CommandLine"`
+}
+
+func (s *windowsScanner) ScanBusProcesses() ([]Process, error) {
+	out, err := s.runPS()
+	if err != nil {
+		// When PowerShell exits non-zero, the real diagnostic (parameter
+		// errors, missing CIM class, unavailable WinRM) lives in Stderr.
+		// Surface it — `exit status 1` alone is never actionable.
+		if ee, ok := err.(*exec.ExitError); ok && len(bytes.TrimSpace(ee.Stderr)) > 0 {
+			return nil, fmt.Errorf("busdiscover: run powershell: %w: %s", err, bytes.TrimSpace(ee.Stderr))
+		}
+		return nil, fmt.Errorf("busdiscover: run powershell: %w", err)
+	}
+	return parseWindowsPS(out)
+}
+
+// parseWindowsPS decodes PowerShell JSON output and filters to bus processes.
+// ConvertTo-Json (without -AsArray, which is PS 6.0+) emits:
+//   - empty output for 0 results
+//   - a bare `{...}` object for 1 result
+//   - a `[...]` array for 2+ results
+//
+// We handle all three shapes. An unexpected first byte surfaces as an error
+// so we can debug environments where PowerShell behaves differently.
+func parseWindowsPS(out []byte) ([]Process, error) {
+	trimmed := bytes.TrimSpace(out)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	var records []psRecord
+	switch trimmed[0] {
+	case '[':
+		if err := json.Unmarshal(trimmed, &records); err != nil {
+			return nil, fmt.Errorf("busdiscover: decode ps json array: %w", err)
+		}
+	case '{':
+		var single psRecord
+		if err := json.Unmarshal(trimmed, &single); err != nil {
+			return nil, fmt.Errorf("busdiscover: decode ps json object: %w", err)
+		}
+		records = []psRecord{single}
+	default:
+		return nil, fmt.Errorf("busdiscover: unexpected ps output: %q", trimmed[:min(len(trimmed), 64)])
+	}
+
+	var result []Process
+	for _, r := range records {
+		appID := parseAppIDFromCmdline(r.CommandLine)
+		if appID == "" {
+			continue
+		}
+		t, err := time.Parse(time.RFC3339Nano, r.CreationDate)
+		if err != nil {
+			// Skip entries with unparseable timestamps rather than failing
+			// the whole scan — one bad row shouldn't hide other buses.
+			continue
+		}
+		result = append(result, Process{
+			PID:       r.Pid,
+			AppID:     appID,
+			StartTime: t,
+		})
+	}
+	return result, nil
+}

--- a/internal/event/busdiscover/locale_unix_test.go
+++ b/internal/event/busdiscover/locale_unix_test.go
@@ -31,10 +31,12 @@ func TestPSLocaleForcedC(t *testing.T) {
 	// to C) and the test passes vacuously even pre-fix. macOS bundles
 	// ICU locales universally; Linux CI runners typically have only C
 	// + en_US. Skip explicitly rather than silently pass.
-	if out, err := exec.Command("locale", "-a").Output(); err == nil {
-		if !strings.Contains(string(out), "zh_CN") {
-			t.Skip("no non-C locale (zh_CN) installed; can't prove LC_ALL override")
-		}
+	out, err := exec.Command("locale", "-a").Output()
+	if err != nil {
+		t.Skipf("locale command unavailable: %v", err)
+	}
+	if !strings.Contains(string(out), "zh_CN") {
+		t.Skip("no non-C locale (zh_CN) installed; can't prove LC_ALL override")
 	}
 
 	// Force a non-English LC_TIME on the test process. If the production
@@ -47,7 +49,7 @@ func TestPSLocaleForcedC(t *testing.T) {
 	t.Setenv("LANG", "zh_CN.UTF-8")
 
 	s := newPlatformScanner().(*unixScanner)
-	out, err := s.runPS()
+	out, err = s.runPS()
 	if err != nil {
 		t.Skipf("runPS failed (likely no ps on this host): %v", err)
 	}

--- a/internal/event/busdiscover/locale_unix_test.go
+++ b/internal/event/busdiscover/locale_unix_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package busdiscover
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestPSLocaleForcedC — regression for the Bug 7 finding (CodeRabbit PR
+// #615). `ps -o lstart` emits weekday/month names per the caller's
+// LC_TIME; on zh_CN / de_DE / fr_FR the output does NOT match the
+// English "Mon Jan _2 15:04:05 2006" layout and silently drops every
+// row in parseOneUnixPSLine, so orphan bus detection fails entirely
+// on localized hosts.
+//
+// The fix forces C locale when invoking ps. This test proves it by:
+// setting our own process LC_TIME to a locale that would produce
+// non-English output if inherited, then calling the production runPS
+// and asserting the output is English-formatted.
+//
+// Skipped if the `ps` command isn't available or the machine lacks
+// a usable LC_TIME locale to test against.
+func TestPSLocaleForcedC(t *testing.T) {
+	// This test depends on a non-C locale being installed on the host —
+	// otherwise setting LC_ALL=zh_CN.UTF-8 has no effect (ps falls back
+	// to C) and the test passes vacuously even pre-fix. macOS bundles
+	// ICU locales universally; Linux CI runners typically have only C
+	// + en_US. Skip explicitly rather than silently pass.
+	if out, err := exec.Command("locale", "-a").Output(); err == nil {
+		if !strings.Contains(string(out), "zh_CN") {
+			t.Skip("no non-C locale (zh_CN) installed; can't prove LC_ALL override")
+		}
+	}
+
+	// Force a non-English LC_TIME on the test process. If the production
+	// scanner inherits the environment without overriding LC_ALL, the
+	// child `ps` will emit localized weekday/month (e.g. "周日 4月").
+	// With the fix, LC_ALL=C on cmd.Env overrides this and the output
+	// stays English.
+	t.Setenv("LC_ALL", "zh_CN.UTF-8")
+	t.Setenv("LC_TIME", "zh_CN.UTF-8")
+	t.Setenv("LANG", "zh_CN.UTF-8")
+
+	s := newPlatformScanner().(*unixScanner)
+	out, err := s.runPS()
+	if err != nil {
+		t.Skipf("runPS failed (likely no ps on this host): %v", err)
+	}
+	text := string(out)
+
+	// Look for at least one English weekday abbreviation in the output.
+	// Any real ps output on a multi-process system will have many lines
+	// with Mon/Tue/Wed/Thu/Fri/Sat/Sun.
+	englishWeekdays := []string{"Mon ", "Tue ", "Wed ", "Thu ", "Fri ", "Sat ", "Sun "}
+	foundEnglish := false
+	for _, d := range englishWeekdays {
+		if strings.Contains(text, d) {
+			foundEnglish = true
+			break
+		}
+	}
+	if !foundEnglish {
+		t.Errorf("ps output contains no English weekday abbreviations; sample:\n%s\n"+
+			"This suggests LC_ALL=C is NOT being set on the ps invocation — "+
+			"orphan bus detection will fail on localized (zh_CN / de_DE / fr_FR) hosts.", firstNLines(text, 5))
+	}
+}
+
+func firstNLines(s string, n int) string {
+	lines := strings.SplitN(s, "\n", n+1)
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/event/busdiscover/unix_test.go
+++ b/internal/event/busdiscover/unix_test.go
@@ -15,7 +15,7 @@ func TestUnixScanner_ParsesBusProcesses(t *testing.T) {
 	// Header line + three processes: one bus, one vim, one lark-cli consume
 	// (not a bus). Only the bus should be returned.
 	canned := []byte(`  PID                  LSTART COMMAND
-70926 Sun Apr 19 03:03:40 2026 /Users/bytedance/go/src/github/cli/lark-cli event _bus --profile cli_a96a42f48438dbd2 --domain https://open.feishu.cn
+70926 Sun Apr 19 03:03:40 2026 /Users/bytedance/go/src/github/cli/lark-cli event _bus --profile cli_XXXXXXXXXXXXXXXX --domain https://open.feishu.cn
 12345 Mon Apr 20 10:00:00 2026 /usr/bin/vim /tmp/foo.txt
 54321 Mon Apr 20 11:00:00 2026 /usr/local/bin/lark-cli event consume im.message.receive_v1
 `)
@@ -31,8 +31,8 @@ func TestUnixScanner_ParsesBusProcesses(t *testing.T) {
 	if procs[0].PID != 70926 {
 		t.Errorf("PID = %d, want 70926", procs[0].PID)
 	}
-	if procs[0].AppID != "cli_a96a42f48438dbd2" {
-		t.Errorf("AppID = %q, want cli_a96a42f48438dbd2", procs[0].AppID)
+	if procs[0].AppID != "cli_XXXXXXXXXXXXXXXX" {
+		t.Errorf("AppID = %q, want cli_XXXXXXXXXXXXXXXX", procs[0].AppID)
 	}
 	wantTime := time.Date(2026, 4, 19, 3, 3, 40, 0, time.Local)
 	if !procs[0].StartTime.Equal(wantTime) {
@@ -68,7 +68,7 @@ func TestUnixScanner_PSFailurePropagates(t *testing.T) {
 func TestUnixScanner_SkipsMalformedLines(t *testing.T) {
 	// Line too short to contain an lstart field should be silently skipped.
 	canned := []byte(`  PID                  LSTART COMMAND
-70926 Sun Apr 19 03:03:40 2026 /usr/local/bin/lark-cli event _bus --profile cli_a96a42f48438dbd2
+70926 Sun Apr 19 03:03:40 2026 /usr/local/bin/lark-cli event _bus --profile cli_XXXXXXXXXXXXXXXX
 short_line
 99999 bogus_date_format /usr/local/bin/lark-cli event _bus --profile cli_xyz
 `)

--- a/internal/event/busdiscover/unix_test.go
+++ b/internal/event/busdiscover/unix_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package busdiscover
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestUnixScanner_ParsesBusProcesses(t *testing.T) {
+	// Header line + three processes: one bus, one vim, one lark-cli consume
+	// (not a bus). Only the bus should be returned.
+	canned := []byte(`  PID                  LSTART COMMAND
+70926 Sun Apr 19 03:03:40 2026 /Users/bytedance/go/src/github/cli/lark-cli event _bus --profile cli_a96a42f48438dbd2 --domain https://open.feishu.cn
+12345 Mon Apr 20 10:00:00 2026 /usr/bin/vim /tmp/foo.txt
+54321 Mon Apr 20 11:00:00 2026 /usr/local/bin/lark-cli event consume im.message.receive_v1
+`)
+	s := &unixScanner{runPS: func() ([]byte, error) { return canned, nil }}
+
+	procs, err := s.ScanBusProcesses()
+	if err != nil {
+		t.Fatalf("ScanBusProcesses: %v", err)
+	}
+	if len(procs) != 1 {
+		t.Fatalf("got %d processes, want 1: %+v", len(procs), procs)
+	}
+	if procs[0].PID != 70926 {
+		t.Errorf("PID = %d, want 70926", procs[0].PID)
+	}
+	if procs[0].AppID != "cli_a96a42f48438dbd2" {
+		t.Errorf("AppID = %q, want cli_a96a42f48438dbd2", procs[0].AppID)
+	}
+	wantTime := time.Date(2026, 4, 19, 3, 3, 40, 0, time.Local)
+	if !procs[0].StartTime.Equal(wantTime) {
+		t.Errorf("StartTime = %v, want %v", procs[0].StartTime, wantTime)
+	}
+}
+
+func TestUnixScanner_HandlesEmptyPS(t *testing.T) {
+	canned := []byte(`  PID                  LSTART COMMAND
+`)
+	s := &unixScanner{runPS: func() ([]byte, error) { return canned, nil }}
+
+	procs, err := s.ScanBusProcesses()
+	if err != nil {
+		t.Fatalf("ScanBusProcesses: %v", err)
+	}
+	if len(procs) != 0 {
+		t.Errorf("expected 0 processes, got %d", len(procs))
+	}
+}
+
+func TestUnixScanner_PSFailurePropagates(t *testing.T) {
+	s := &unixScanner{runPS: func() ([]byte, error) {
+		return nil, errors.New("ps not found")
+	}}
+
+	_, err := s.ScanBusProcesses()
+	if err == nil {
+		t.Fatal("expected error from runPS failure")
+	}
+}
+
+func TestUnixScanner_SkipsMalformedLines(t *testing.T) {
+	// Line too short to contain an lstart field should be silently skipped.
+	canned := []byte(`  PID                  LSTART COMMAND
+70926 Sun Apr 19 03:03:40 2026 /usr/local/bin/lark-cli event _bus --profile cli_a96a42f48438dbd2
+short_line
+99999 bogus_date_format /usr/local/bin/lark-cli event _bus --profile cli_xyz
+`)
+	s := &unixScanner{runPS: func() ([]byte, error) { return canned, nil }}
+
+	procs, err := s.ScanBusProcesses()
+	if err != nil {
+		t.Fatalf("ScanBusProcesses: %v", err)
+	}
+	// The malformed lines should be dropped; the valid one kept.
+	if len(procs) != 1 {
+		t.Fatalf("got %d processes, want 1 (malformed lines must be skipped): %+v", len(procs), procs)
+	}
+	if procs[0].PID != 70926 {
+		t.Errorf("PID = %d, want 70926", procs[0].PID)
+	}
+}

--- a/internal/event/busdiscover/windows_test.go
+++ b/internal/event/busdiscover/windows_test.go
@@ -19,7 +19,7 @@ func TestWindowsScanner_ParsesBusProcesses(t *testing.T) {
   {
     "Pid": 4711,
     "CreationDate": "2026-04-19T03:03:40.1234567+08:00",
-    "CommandLine": "\"C:\\Program Files\\lark-cli\\lark-cli.exe\" event _bus --profile cli_b1c2d3e4f5g6h7i8 --domain https://open.larksuite.com"
+    "CommandLine": "\"C:\\Program Files\\lark-cli\\lark-cli.exe\" event _bus --profile cli_XXXXXXXXXXXXXXXX --domain https://open.larksuite.com"
   },
   {
     "Pid": 4712,
@@ -39,8 +39,8 @@ func TestWindowsScanner_ParsesBusProcesses(t *testing.T) {
 	if procs[0].PID != 4711 {
 		t.Errorf("PID = %d, want 4711", procs[0].PID)
 	}
-	if procs[0].AppID != "cli_b1c2d3e4f5g6h7i8" {
-		t.Errorf("AppID = %q, want cli_b1c2d3e4f5g6h7i8", procs[0].AppID)
+	if procs[0].AppID != "cli_XXXXXXXXXXXXXXXX" {
+		t.Errorf("AppID = %q, want cli_XXXXXXXXXXXXXXXX", procs[0].AppID)
 	}
 	// Compare in UTC to side-step local-timezone flakiness on CI runners.
 	wantUTC := time.Date(2026, 4, 18, 19, 3, 40, 123456700, time.UTC)

--- a/internal/event/busdiscover/windows_test.go
+++ b/internal/event/busdiscover/windows_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package busdiscover
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestWindowsScanner_ParsesBusProcesses(t *testing.T) {
+	// Canned output for the 2+ results case where ConvertTo-Json emits a JSON
+	// array of objects, each with Pid, CreationDate (ISO 8601 after .ToString('o')),
+	// CommandLine.
+	canned := []byte(`[
+  {
+    "Pid": 4711,
+    "CreationDate": "2026-04-19T03:03:40.1234567+08:00",
+    "CommandLine": "\"C:\\Program Files\\lark-cli\\lark-cli.exe\" event _bus --profile cli_b1c2d3e4f5g6h7i8 --domain https://open.larksuite.com"
+  },
+  {
+    "Pid": 4712,
+    "CreationDate": "2026-04-19T10:00:00.0000000+08:00",
+    "CommandLine": "\"C:\\Windows\\System32\\notepad.exe\""
+  }
+]`)
+	s := &windowsScanner{runPS: func() ([]byte, error) { return canned, nil }}
+
+	procs, err := s.ScanBusProcesses()
+	if err != nil {
+		t.Fatalf("ScanBusProcesses: %v", err)
+	}
+	if len(procs) != 1 {
+		t.Fatalf("got %d processes, want 1: %+v", len(procs), procs)
+	}
+	if procs[0].PID != 4711 {
+		t.Errorf("PID = %d, want 4711", procs[0].PID)
+	}
+	if procs[0].AppID != "cli_b1c2d3e4f5g6h7i8" {
+		t.Errorf("AppID = %q, want cli_b1c2d3e4f5g6h7i8", procs[0].AppID)
+	}
+	// Compare in UTC to side-step local-timezone flakiness on CI runners.
+	wantUTC := time.Date(2026, 4, 18, 19, 3, 40, 123456700, time.UTC)
+	if !procs[0].StartTime.UTC().Equal(wantUTC) {
+		t.Errorf("StartTime UTC = %v, want %v", procs[0].StartTime.UTC(), wantUTC)
+	}
+}
+
+func TestWindowsScanner_EmptyArray(t *testing.T) {
+	s := &windowsScanner{runPS: func() ([]byte, error) { return []byte(`[]`), nil }}
+	procs, err := s.ScanBusProcesses()
+	if err != nil {
+		t.Fatalf("ScanBusProcesses: %v", err)
+	}
+	if len(procs) != 0 {
+		t.Errorf("expected 0 processes, got %d", len(procs))
+	}
+}
+
+func TestWindowsScanner_PSFailurePropagates(t *testing.T) {
+	s := &windowsScanner{runPS: func() ([]byte, error) {
+		return nil, errors.New("powershell not found")
+	}}
+	_, err := s.ScanBusProcesses()
+	if err == nil {
+		t.Fatal("expected error from runPS failure")
+	}
+}
+
+func TestWindowsScanner_SingleObjectFallback(t *testing.T) {
+	// PowerShell's ConvertTo-Json without -AsArray collapses a single-item array
+	// into a bare object. Scanner must handle both.
+	canned := []byte(`{
+  "Pid": 4711,
+  "CreationDate": "2026-04-19T03:03:40.0000000+00:00",
+  "CommandLine": "lark-cli.exe event _bus --profile cli_xyz"
+}`)
+	s := &windowsScanner{runPS: func() ([]byte, error) { return canned, nil }}
+	procs, err := s.ScanBusProcesses()
+	if err != nil {
+		t.Fatalf("ScanBusProcesses: %v", err)
+	}
+	if len(procs) != 1 {
+		t.Fatalf("got %d processes, want 1", len(procs))
+	}
+	if procs[0].AppID != "cli_xyz" {
+		t.Errorf("AppID = %q, want cli_xyz", procs[0].AppID)
+	}
+}
+
+func TestWindowsScanner_UnexpectedOutput(t *testing.T) {
+	s := &windowsScanner{runPS: func() ([]byte, error) {
+		return []byte(`not json at all`), nil
+	}}
+	_, err := s.ScanBusProcesses()
+	if err == nil {
+		t.Fatal("expected error for non-JSON output")
+	}
+}

--- a/internal/event/consume/bounded_test.go
+++ b/internal/event/consume/bounded_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestBoundedLoop_MaxEvents — when MaxEvents is set, the loop cancels the
+// context after that many successful emits, regardless of how many more
+// events are queued.
+func TestBoundedLoop_MaxEvents(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var emitted atomic.Int64
+	opts := Options{MaxEvents: 3, ErrOut: io.Discard}
+
+	// Simulate 5 successful emits.
+	for i := 0; i < 5; i++ {
+		emitted.Add(1)
+		stopNow := checkMaxEvents(opts, &emitted)
+		if (i + 1) >= 3 {
+			if !stopNow {
+				t.Fatalf("checkMaxEvents should return true at emit %d (max=3)", i+1)
+			}
+		} else {
+			if stopNow {
+				t.Fatalf("checkMaxEvents should not return true at emit %d (max=3)", i+1)
+			}
+		}
+	}
+	_ = ctx
+}
+
+// TestBoundedLoop_NoLimitWhenZero — MaxEvents=0 means unlimited.
+func TestBoundedLoop_NoLimitWhenZero(t *testing.T) {
+	var emitted atomic.Int64
+	opts := Options{MaxEvents: 0, ErrOut: io.Discard}
+	for i := 0; i < 100; i++ {
+		emitted.Add(1)
+		if checkMaxEvents(opts, &emitted) {
+			t.Fatalf("checkMaxEvents should never return true when MaxEvents=0; returned true at emit %d", i+1)
+		}
+	}
+}
+
+// TestExitReason_Limit — emitted >= MaxEvents → reason="limit".
+func TestExitReason_Limit(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // mimic loop cancelling itself after hitting limit
+
+	opts := Options{MaxEvents: 5, Timeout: 0}
+	reason := exitReason(ctx, 5, opts)
+	if reason != "limit" {
+		t.Errorf("reason = %q, want \"limit\"", reason)
+	}
+}
+
+// TestExitReason_Timeout — ctx.Err() == DeadlineExceeded → reason="timeout".
+func TestExitReason_Timeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	time.Sleep(5 * time.Millisecond)
+
+	opts := Options{MaxEvents: 5, Timeout: 1 * time.Millisecond}
+	reason := exitReason(ctx, 0, opts)
+	if reason != "timeout" {
+		t.Errorf("reason = %q, want \"timeout\"", reason)
+	}
+}
+
+// TestExitReason_Signal — ctx cancelled, no timeout deadline → reason="signal".
+func TestExitReason_Signal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	opts := Options{MaxEvents: 0, Timeout: 0}
+	reason := exitReason(ctx, 0, opts)
+	if reason != "signal" {
+		t.Errorf("reason = %q, want \"signal\"", reason)
+	}
+}

--- a/internal/event/consume/consume.go
+++ b/internal/event/consume/consume.go
@@ -1,0 +1,280 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package consume drives the consume-side half of the events pipeline:
+// ensure the Bus daemon is running, establish the hello handshake, run
+// any PreConsume setup, and loop over events coming off the Bus socket.
+//
+// The loop/handshake/jq logic lives in sibling files (loop.go,
+// handshake.go, jq.go) so the entry point here stays readable.
+package consume
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/transport"
+)
+
+// Options configures the consume loop.
+type Options struct {
+	EventKey  string
+	Params    map[string]string
+	JQExpr    string
+	Quiet     bool
+	OutputDir string
+	Runtime   event.APIClient
+	// Out is the stdout destination for event data. nil falls back to
+	// os.Stdout — production callers should inject cmdutil.IOStreams.Out
+	// so tests can capture output and redirect/color hooks work.
+	Out    io.Writer
+	ErrOut io.Writer
+	// RemoteAPIClient is a bot-identity API client used for preflight HTTP
+	// probes (e.g. GET /open-apis/event/v1/connection). Nil disables the
+	// remote-connection check, which is the right behavior when no tenant
+	// token is available.
+	RemoteAPIClient APIClient
+
+	// MaxEvents bounds emission: after N successful emits the loop exits
+	// with reason="limit" and exit code 0. 0 = unlimited.
+	MaxEvents int
+	// Timeout bounds wall-clock: after Timeout elapsed the loop exits with
+	// reason="timeout" and exit code 0 (normal termination, same as --max-events
+	// being reached — caller asked for a deadline and got it). 0 = no timeout.
+	Timeout time.Duration
+	// IsTTY lets the loop pick a TTY-appropriate "to stop" text.
+	// False by default — safe for CI/subprocess use.
+	IsTTY bool
+}
+
+// Run is the consume client entry point: ensure the bus is up, hello,
+// run PreConsume for the first subscriber, enter the consume loop, and
+// call cleanup on exit if we were the last subscriber.
+func Run(ctx context.Context, tr transport.IPC, appID, profileName, domain string, opts Options) error {
+	errOut := opts.ErrOut
+	if errOut == nil {
+		// Defensive fallback; cmd layer always wires IOStreams.ErrOut.
+		errOut = os.Stderr //nolint:forbidigo // library-caller fallback
+	}
+
+	keyDef, ok := event.Lookup(opts.EventKey)
+	if !ok {
+		return fmt.Errorf("unknown EventKey: %s\nRun 'lark-cli event list' to see available keys", opts.EventKey)
+	}
+
+	if err := validateParams(keyDef, opts.Params); err != nil {
+		return err
+	}
+
+	// Pre-flight: validate jq expression now so bad expressions don't cause
+	// us to spin up the bus daemon + handshake + run PreConsume side effects
+	// (e.g. server-side subscription creation) before failing.
+	if opts.JQExpr != "" {
+		if _, err := CompileJQ(opts.JQExpr); err != nil {
+			return err
+		}
+	}
+
+	// Apply --timeout by wrapping the caller's context. Cancel fires on:
+	//   • caller cancel (signal / stdin close)
+	//   • timeout deadline
+	//   • --max-events reached (loop calls inner cancel)
+	// The exit summary distinguishes the three via exitReason().
+	if opts.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, opts.Timeout)
+		defer cancel()
+	}
+
+	if !opts.Quiet {
+		if profileName != "" {
+			fmt.Fprintf(errOut, "[event] consuming as %s (%s)\n", profileName, appID)
+		} else {
+			fmt.Fprintf(errOut, "[event] consuming as %s\n", appID)
+		}
+	}
+
+	conn, err := EnsureBus(ctx, tr, appID, profileName, domain, opts.RemoteAPIClient, errOut)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ack, br, err := doHello(conn, opts.EventKey, []string{keyDef.EventType})
+	if err != nil {
+		return fmt.Errorf("handshake failed: %w", err)
+	}
+
+	var cleanup func()
+	if ack.FirstForKey && keyDef.PreConsume != nil {
+		if !opts.Quiet {
+			fmt.Fprintf(errOut, "[event] running pre-consume setup...\n")
+		}
+		cleanup, err = keyDef.PreConsume(ctx, opts.Runtime, opts.Params)
+		if err != nil {
+			return fmt.Errorf("pre-consume failed: %w", err)
+		}
+	}
+
+	lastForKey := false
+	var emitted atomic.Int64
+	startTime := time.Now()
+
+	// On normal shutdown consumeLoop asks the bus whether we're the last
+	// subscriber and only then runs cleanup. On panic we can't round-trip
+	// with the bus, so cleanup runs unconditionally — unsubscribing a
+	// still-live co-consumer is recoverable, leaking server state isn't.
+	defer func() {
+		r := recover()
+		if cleanup != nil {
+			switch {
+			case r != nil:
+				fmt.Fprintf(errOut, "WARN: panic recovered; running cleanup unconditionally (may affect other consumers of %s)\n", opts.EventKey)
+				cleanup()
+			case lastForKey:
+				if !opts.Quiet {
+					fmt.Fprintf(errOut, "[event] running cleanup...\n")
+				}
+				cleanup()
+				if !opts.Quiet {
+					fmt.Fprintf(errOut, "[event] cleanup done.\n")
+				}
+			}
+		}
+		if !opts.Quiet && r == nil {
+			reason := exitReason(ctx, emitted.Load(), opts)
+			fmt.Fprintf(errOut, "[event] exited — received %d event(s) in %s (reason: %s)\n",
+				emitted.Load(), truncateDuration(time.Since(startTime)), reason)
+		}
+		if r != nil {
+			panic(r)
+		}
+	}()
+
+	if !opts.Quiet {
+		fmt.Fprintln(errOut, listeningText(opts))
+		if !opts.IsTTY {
+			fmt.Fprintln(errOut, stopHintText())
+		}
+	}
+
+	writeReadyMarker(errOut, opts)
+
+	return consumeLoop(ctx, conn, br, keyDef, opts, &lastForKey, &emitted)
+}
+
+// truncateDuration drops sub-second precision so "received N events in
+// 1m23s" reads naturally (nanosecond noise isn't useful for humans).
+func truncateDuration(d time.Duration) time.Duration {
+	return d.Truncate(time.Second)
+}
+
+// validateParams fills in declared defaults for unspecified params, then
+// checks that all required params are present and no unknown params are given.
+func validateParams(def *event.KeyDefinition, params map[string]string) error {
+	for _, p := range def.Params {
+		if _, ok := params[p.Name]; !ok && p.Default != "" {
+			params[p.Name] = p.Default
+		}
+	}
+	for _, p := range def.Params {
+		if p.Required {
+			if _, ok := params[p.Name]; !ok {
+				return fmt.Errorf("required param %q missing. Run 'lark-cli event schema %s' for details", p.Name, def.Key)
+			}
+		}
+	}
+	known := make(map[string]bool)
+	for _, p := range def.Params {
+		known[p.Name] = true
+	}
+	for k := range params {
+		if !known[k] {
+			return fmt.Errorf("unknown param %q for EventKey %s. Run 'lark-cli event schema %s' for details", k, def.Key, def.Key)
+		}
+	}
+	return nil
+}
+
+// checkMaxEvents reports whether the current emit count reached MaxEvents.
+// Returns false when MaxEvents is 0 (unlimited).
+func checkMaxEvents(opts Options, emitted *atomic.Int64) bool {
+	if opts.MaxEvents <= 0 {
+		return false
+	}
+	return emitted.Load() >= int64(opts.MaxEvents)
+}
+
+// listeningText produces the "listening for events" stderr line. It is
+// TTY-aware: interactive users still see "ctrl+c to stop"; subprocess
+// callers see a machine-meaningful description of how the run will end.
+// When bounded (MaxEvents > 0 or Timeout > 0), it advertises those
+// bounds so AI agents reading stderr can calibrate their wait window.
+func listeningText(opts Options) string {
+	base := fmt.Sprintf("[event] listening for events (key=%s)", opts.EventKey)
+	if opts.IsTTY {
+		return base + ", ctrl+c to stop"
+	}
+	// Non-TTY: describe exit condition.
+	switch {
+	case opts.MaxEvents > 0 && opts.Timeout > 0:
+		return fmt.Sprintf("%s; will exit after %d event(s) or %s timeout", base, opts.MaxEvents, opts.Timeout)
+	case opts.MaxEvents > 0:
+		return fmt.Sprintf("%s; will exit after %d event(s)", base, opts.MaxEvents)
+	case opts.Timeout > 0:
+		return fmt.Sprintf("%s; will exit after %s timeout", base, opts.Timeout)
+	default:
+		return base + "; send SIGTERM or close stdin to stop"
+	}
+}
+
+// exitReason categorises why the consume loop returned. Priority:
+//  1. emitted >= MaxEvents → "limit"
+//  2. ctx.Err() is context.DeadlineExceeded → "timeout"
+//  3. otherwise → "signal"
+//
+// The count check MUST come first: when --max-events triggers, the worker
+// calls cancel() on an inner ctx (consumeLoop's own derived ctx), not on
+// the outer ctx passed to Run(). If --timeout also happens to be set, the
+// outer ctx may report DeadlineExceeded concurrently. Count-first ensures
+// the reported reason reflects the observable fact (we hit N emits)
+// rather than the ctx state race. Do not reorder these branches.
+//
+// Called from the defer in Run() to populate the exit summary.
+func exitReason(ctx context.Context, emitted int64, opts Options) string {
+	if opts.MaxEvents > 0 && emitted >= int64(opts.MaxEvents) {
+		return "limit"
+	}
+	if ctx.Err() == context.DeadlineExceeded {
+		return "timeout"
+	}
+	return "signal"
+}
+
+// stopHintText is a non-TTY-only guard rail for AI subprocess callers.
+// It steers them toward SIGTERM/stdin-close and explicitly names `kill -9`
+// as the thing to avoid, because that's where cleanup (e.g. mailbox
+// unsubscribe in PreConsume) gets skipped and server-side subscriptions
+// can leak until TTL expires. TTY users see "ctrl+c to stop" which is
+// already graceful, so we don't emit this line there.
+func stopHintText() string {
+	return "[event] to stop gracefully: send SIGTERM (kill <pid>) or close stdin. " +
+		"Avoid kill -9 — it skips cleanup and may leak server-side subscriptions."
+}
+
+// writeReadyMarker emits a stable, parseable "ready" line to w. This is
+// the contract signal for AI agents: after this line, the bus + SDK
+// subscription is live and events that arrive will be delivered. The
+// line is fixed-format "[event] ready event_key=<key>\n" — do NOT add
+// fields here without updating the AI-facing contract.
+func writeReadyMarker(w io.Writer, opts Options) {
+	if opts.Quiet {
+		return
+	}
+	fmt.Fprintf(w, "[event] ready event_key=%s\n", opts.EventKey)
+}

--- a/internal/event/consume/handshake.go
+++ b/internal/event/consume/handshake.go
@@ -9,9 +9,18 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 
 	"github.com/larksuite/cli/internal/event/protocol"
 )
+
+// helloAckTimeout bounds the wait for HelloAck after sending Hello. A
+// bus that accepted the connection but wedged before replying would
+// otherwise hang the consumer indefinitely. Symmetric with the 5-second
+// read deadline the bus applies to its own Hello read (bus.go
+// handleConn). Cleared (SetReadDeadline zero) once the ack arrives so
+// the subsequent event-loop reads are unbounded.
+const helloAckTimeout = 5 * time.Second
 
 // doHello sends a Hello and waits for HelloAck. Returns a bufio.Reader
 // holding any bytes already pulled off conn (events buffered with the
@@ -23,11 +32,21 @@ func doHello(conn net.Conn, eventKey string, eventTypes []string) (*protocol.Hel
 		return nil, nil, err
 	}
 
+	if err := conn.SetReadDeadline(time.Now().Add(helloAckTimeout)); err != nil {
+		return nil, nil, fmt.Errorf("set hello_ack deadline: %w", err)
+	}
 	br := bufio.NewReader(conn)
 	line, err := protocol.ReadFrame(br)
 	if err != nil {
 		return nil, nil, fmt.Errorf("no hello_ack received: %w", err)
 	}
+	// Clear the deadline: subsequent event-loop reads are unbounded.
+	// Best-effort (matches bus.go's handleConn symmetry): a failure here
+	// means the connection already broke after ack was received, and
+	// the loop will surface the real error immediately on its first
+	// read. Aborting handshake with a misleading "clear deadline" error
+	// would mask that.
+	_ = conn.SetReadDeadline(time.Time{})
 	msg, err := protocol.Decode(bytes.TrimRight(line, "\n"))
 	if err != nil {
 		return nil, nil, err

--- a/internal/event/consume/handshake.go
+++ b/internal/event/consume/handshake.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// doHello sends a Hello and waits for HelloAck. Returns a bufio.Reader
+// holding any bytes already pulled off conn (events buffered with the
+// ack in the same TCP segment) so the caller's consume loop can keep
+// reading without a fresh scanner dropping them.
+func doHello(conn net.Conn, eventKey string, eventTypes []string) (*protocol.HelloAck, *bufio.Reader, error) {
+	hello := protocol.NewHello(os.Getpid(), eventKey, eventTypes, "v1")
+	if err := protocol.EncodeWithDeadline(conn, hello, protocol.WriteTimeout); err != nil {
+		return nil, nil, err
+	}
+
+	br := bufio.NewReader(conn)
+	line, err := protocol.ReadFrame(br)
+	if err != nil {
+		return nil, nil, fmt.Errorf("no hello_ack received: %w", err)
+	}
+	msg, err := protocol.Decode(bytes.TrimRight(line, "\n"))
+	if err != nil {
+		return nil, nil, err
+	}
+	ack, ok := msg.(*protocol.HelloAck)
+	if !ok {
+		return nil, nil, fmt.Errorf("expected hello_ack, got %T", msg)
+	}
+	return ack, br, nil
+}

--- a/internal/event/consume/handshake_test.go
+++ b/internal/event/consume/handshake_test.go
@@ -52,7 +52,7 @@ func TestDoHello_ReadDeadline(t *testing.T) {
 		// Accept any error — the concrete type may be a net.OpError
 		// wrapping "i/o timeout" — we assert only on wall-clock elapsed.
 		// The deadline is expected to be in the low single-digit seconds;
-		// we bound at helloAckTimeout + 1s of slack.
+		// we bound at helloAckTimeout + 2s of slack.
 		if elapsed > helloAckTimeout+2*time.Second {
 			t.Errorf("doHello returned %v after %v; deadline should fire within ~%v", err, elapsed, helloAckTimeout)
 		}

--- a/internal/event/consume/handshake_test.go
+++ b/internal/event/consume/handshake_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// TestDoHello_ReadDeadline — regression for the Bug 4 finding
+// (CodeRabbit PR #615): consumer-side doHello had no read deadline on
+// the HelloAck frame. If the bus accepts the connection but never
+// replies (wedged, crashed, or network-stalled), the consumer hangs
+// indefinitely, breaking bounded-startup contracts.
+//
+// Strategy: use net.Pipe for a lossless server side that reads Hello
+// but deliberately sends nothing back. Without a read deadline the
+// call hangs forever; with the fix it returns an error within
+// helloAckTimeout.
+func TestDoHello_ReadDeadline(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	// Server goroutine: read whatever Hello bytes arrive and discard;
+	// never respond. Must drain the bytes so the client's Write does
+	// not block forever on net.Pipe's synchronous semantics.
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			if _, err := server.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := doHello(client, "im.msg", []string{"im.msg"})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		elapsed := time.Since(start)
+		if err == nil {
+			t.Fatal("doHello returned nil error when server never replied; must fail with deadline-driven error")
+		}
+		// Accept any error — the concrete type may be a net.OpError
+		// wrapping "i/o timeout" — we assert only on wall-clock elapsed.
+		// The deadline is expected to be in the low single-digit seconds;
+		// we bound at helloAckTimeout + 1s of slack.
+		if elapsed > helloAckTimeout+2*time.Second {
+			t.Errorf("doHello returned %v after %v; deadline should fire within ~%v", err, elapsed, helloAckTimeout)
+		}
+	case <-time.After(helloAckTimeout + 3*time.Second):
+		t.Fatal("doHello hung past deadline + 3s slack: read deadline is missing or not being honoured")
+	}
+}

--- a/internal/event/consume/jq.go
+++ b/internal/event/consume/jq.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/itchyny/gojq"
+)
+
+// CompileJQ parses and compiles a jq expression once. The returned
+// *gojq.Code is reused across every event on the hot path — compiling per
+// event is a noticeable CPU tax on high-frequency streams.
+//
+// Exported so CLI entry points can pre-flight validate the expression
+// BEFORE spinning up the bus daemon + handshake + running any PreConsume
+// side effects (e.g. server-side subscription creation). A bad jq should
+// fail immediately rather than after expensive setup.
+func CompileJQ(expr string) (*gojq.Code, error) {
+	query, err := gojq.Parse(expr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid jq expression: %w", err)
+	}
+	code, err := gojq.Compile(query)
+	if err != nil {
+		return nil, fmt.Errorf("jq compile error: %w", err)
+	}
+	return code, nil
+}
+
+// applyJQ runs a pre-compiled jq program against a JSON event and returns
+// the result. Returns (nil, nil) when the expression produces no output
+// (e.g. select(.foo) filters the event out) so the caller can skip the
+// event without treating it as an error.
+func applyJQ(code *gojq.Code, data json.RawMessage) (json.RawMessage, error) {
+	var input interface{}
+	if err := json.Unmarshal(data, &input); err != nil {
+		return nil, fmt.Errorf("jq: unmarshal input: %w", err)
+	}
+
+	iter := code.Run(input)
+	v, ok := iter.Next()
+	if !ok {
+		return nil, nil
+	}
+	if err, isErr := v.(error); isErr {
+		return nil, fmt.Errorf("jq: %w", err)
+	}
+
+	result, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("jq: marshal result: %w", err)
+	}
+	return json.RawMessage(result), nil
+}

--- a/internal/event/consume/listening_text_test.go
+++ b/internal/event/consume/listening_text_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+func TestListeningText_TTY(t *testing.T) {
+	got := listeningText(Options{EventKey: "im.message.receive_v1", IsTTY: true})
+	want := "[event] listening for events (key=im.message.receive_v1), ctrl+c to stop"
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestListeningText_NonTTY_Default(t *testing.T) {
+	got := listeningText(Options{EventKey: "im.message.receive_v1", IsTTY: false})
+	want := "[event] listening for events (key=im.message.receive_v1); send SIGTERM or close stdin to stop"
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestListeningText_NonTTY_MaxEvents(t *testing.T) {
+	got := listeningText(Options{EventKey: "im.message.receive_v1", IsTTY: false, MaxEvents: 1})
+	want := "[event] listening for events (key=im.message.receive_v1); will exit after 1 event(s)"
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestListeningText_NonTTY_Timeout(t *testing.T) {
+	got := listeningText(Options{EventKey: "im.message.receive_v1", IsTTY: false, Timeout: 30 * time.Second})
+	want := "[event] listening for events (key=im.message.receive_v1); will exit after 30s timeout"
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestListeningText_NonTTY_MaxEventsAndTimeout(t *testing.T) {
+	got := listeningText(Options{EventKey: "im.message.receive_v1", IsTTY: false, MaxEvents: 1, Timeout: 30 * time.Second})
+	want := "[event] listening for events (key=im.message.receive_v1); will exit after 1 event(s) or 30s timeout"
+	if got != want {
+		t.Errorf("got  %q\nwant %q", got, want)
+	}
+}
+
+func TestStopHintText_Content(t *testing.T) {
+	// The string itself is part of the AI-facing contract: it must name
+	// `kill -9` explicitly so AI agents parsing stderr are steered away
+	// from SIGKILL. If you rename the signal or drop the word "cleanup",
+	// update skills/lark-event/SKILL.md's matching warning too.
+	got := stopHintText()
+	mustContain := []string{"SIGTERM", "kill -9", "cleanup"}
+	for _, s := range mustContain {
+		if !bytes.Contains([]byte(got), []byte(s)) {
+			t.Errorf("stopHintText missing %q; got %q", s, got)
+		}
+	}
+}
+
+func TestReadyMarker_EmittedAfterListening(t *testing.T) {
+	var buf bytes.Buffer
+	writeReadyMarker(&buf, Options{EventKey: "im.message.receive_v1"})
+
+	got := buf.String()
+	want := "[event] ready event_key=im.message.receive_v1\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadyMarker_SuppressedWhenQuiet(t *testing.T) {
+	var buf bytes.Buffer
+	writeReadyMarker(&buf, Options{EventKey: "im.message.receive_v1", Quiet: true})
+
+	if buf.Len() != 0 {
+		t.Errorf("Quiet=true must suppress ready marker; got %q", buf.String())
+	}
+}

--- a/internal/event/consume/loop.go
+++ b/internal/event/consume/loop.go
@@ -1,0 +1,317 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/itchyny/gojq"
+	"github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// consumeLoop reads events from the bus socket and dispatches to workers.
+// *lastForKey is set before conn closes so Run knows whether to run cleanup.
+//
+// An inner cancel lets a terminal sink error (stdout EPIPE) trigger the
+// same shutdown path as Ctrl+C. Non-terminal sink errors (disk full on
+// --output-dir) are logged and the loop keeps running — one bad event
+// shouldn't tear down a long-running pipeline.
+func consumeLoop(ctx context.Context, conn net.Conn, br *bufio.Reader, keyDef *event.KeyDefinition, opts Options, lastForKey *bool, emitted *atomic.Int64) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sink, err := newSink(opts)
+	if err != nil {
+		return err
+	}
+
+	// Compile jq once at startup; applyJQ reuses the *gojq.Code per event
+	// so a bad expression fails immediately instead of burning on every
+	// event. Must happen before any worker goroutine starts to avoid a
+	// data race on jqCode. Run() also pre-flights the expression before
+	// EnsureBus/PreConsume, but we re-compile here so callers that invoke
+	// consumeLoop directly (tests, library use) don't rely on Run's guard.
+	var jqCode *gojq.Code
+	if opts.JQExpr != "" {
+		jqCode, err = CompileJQ(opts.JQExpr)
+		if err != nil {
+			return err
+		}
+	}
+
+	bufSize := keyDef.BufferSize
+	if bufSize <= 0 {
+		bufSize = event.DefaultBufferSize
+	}
+	socketCh := make(chan *protocol.Event, bufSize)
+
+	// stopReader lets shutdown preempt the reader goroutine so we can
+	// reuse conn for the PreShutdownCheck round-trip — otherwise a second
+	// scanner would race for the ack bytes.
+	stopReader := make(chan struct{})
+	readerDone := make(chan struct{})
+
+	// Socket reader goroutine.
+	//
+	// bufio.Reader.ReadBytes('\n') (not Scanner) so short read deadlines
+	// that fire mid-frame don't drop buffered bytes — on timeout we poll
+	// stopReader and keep reading into the same buffer. The caller hands
+	// in the reader carrying any bytes buffered past hello_ack.
+	go func() {
+		defer close(readerDone)
+		defer close(socketCh)
+		var buf []byte
+		// lastSeq tracks the last seq we saw from the bus for this
+		// connection. The bus assigns monotonically increasing per-conn
+		// seqs in Hub.Publish (see bus/hub.go), so any gap here means
+		// events were dropped by the bus's drop-oldest backpressure
+		// path (sendCh overflow). This is consume-session-local state —
+		// not a struct/package field — since each connection starts
+		// fresh at seq=1 on the bus side.
+		var lastSeq uint64
+		for {
+			select {
+			case <-stopReader:
+				return
+			default:
+			}
+			conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+			chunk, err := br.ReadBytes('\n')
+			if len(chunk) > 0 {
+				// Size cap on the partial-frame accumulator. Without this
+				// check a bus that dribbles a multi-MB line at 200ms
+				// boundaries would grow `buf` unbounded (the 200ms
+				// deadline + continue path never breaks out). Reject the
+				// frame and reset — protocol.MaxFrameBytes mirrors the
+				// server-side cap so legitimate messages always fit.
+				if len(buf)+len(chunk) > protocol.MaxFrameBytes {
+					if !opts.Quiet {
+						fmt.Fprintf(opts.ErrOut,
+							"WARN: dropping oversized frame (>%d bytes) from bus\n", protocol.MaxFrameBytes)
+					}
+					buf = nil
+					continue
+				}
+				buf = append(buf, chunk...)
+			}
+			if err != nil {
+				var ne net.Error
+				if errors.As(err, &ne) && ne.Timeout() {
+					// Deadline hit mid-frame; buf retains partial bytes.
+					// Loop back to poll stopReader and keep reading.
+					continue
+				}
+				// EOF or other terminal error → reader is done.
+				return
+			}
+			// A complete line (ending with '\n') arrived.
+			line := buf
+			// Trim trailing newline for the decoder.
+			if n := len(line); n > 0 && line[n-1] == '\n' {
+				line = line[:n-1]
+			}
+			buf = nil
+
+			msg, decErr := protocol.Decode(line)
+			if decErr != nil {
+				continue
+			}
+			switch m := msg.(type) {
+			case *protocol.Event:
+				// Seq gap detection: the bus assigns monotonic per-conn seqs,
+				// so lastSeq+1 is the expected next value. A skip means the
+				// bus dropped events to cope with channel overflow before
+				// they ever reached us — a WARN here is the consumer-visible
+				// witness for that silent loss.
+				if lastSeq > 0 && m.Seq > 0 && m.Seq > lastSeq+1 {
+					gap := m.Seq - lastSeq - 1
+					if !opts.Quiet {
+						fmt.Fprintf(opts.ErrOut,
+							"WARN: event seq gap %d->%d, missed %d events (dropped by bus backpressure)\n",
+							lastSeq, m.Seq, gap)
+					}
+				}
+				// Only advance forward. Concurrent Publishers can race on
+				// sendMu so a later Seq may arrive before an earlier one;
+				// clobbering lastSeq with the out-of-order lower value
+				// would synthesise a false "gap" warning on the next event.
+				if m.Seq > lastSeq {
+					lastSeq = m.Seq
+				}
+				select {
+				case socketCh <- m:
+				default:
+					// Back-pressure: drop the oldest event to make room (non-blocking).
+					select {
+					case <-socketCh:
+					default:
+					}
+					select {
+					case socketCh <- m:
+					default:
+					}
+					if !opts.Quiet {
+						fmt.Fprintf(opts.ErrOut, "WARN: consume backpressure, dropped oldest event\n")
+					}
+				}
+			case *protocol.SourceStatus:
+				if !opts.Quiet {
+					if m.Detail != "" {
+						fmt.Fprintf(opts.ErrOut, "[source] %s: %s (%s)\n", m.Source, m.State, m.Detail)
+					} else {
+						fmt.Fprintf(opts.ErrOut, "[source] %s: %s\n", m.Source, m.State)
+					}
+				}
+			default:
+				// Unknown message types are ignored to stay forward-compatible.
+			}
+		}
+	}()
+
+	workers := keyDef.Workers
+	if workers <= 0 {
+		workers = 1
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for evt := range socketCh {
+				wrote, err := processAndOutput(ctx, keyDef, evt, opts, sink, jqCode)
+				if wrote {
+					emitted.Add(1)
+					// MaxEvents bound: cancel inner ctx so the select in the outer
+					// switch observes ctx.Done() and goes through the normal shutdown
+					// path (cleanup check, wg.Wait) rather than ripping connections.
+					if checkMaxEvents(opts, emitted) {
+						cancel()
+						return
+					}
+				}
+				if err != nil {
+					if isTerminalSinkError(err) {
+						// Downstream pipe closed (e.g. `| head -n 1` exited).
+						// Trigger graceful shutdown so cleanup still runs.
+						if !opts.Quiet {
+							fmt.Fprintf(opts.ErrOut, "consume: output pipe closed (%v), shutting down\n", err)
+						}
+						cancel()
+						return
+					}
+					// Non-terminal (e.g. disk full on --output-dir): log and continue.
+					if !opts.Quiet {
+						fmt.Fprintf(opts.ErrOut, "WARN: sink write failed, skipping event: %v\n", err)
+					}
+				}
+			}
+		}()
+	}
+
+	// Signal when ALL workers have drained.
+	allDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(allDone)
+	}()
+
+	select {
+	case <-ctx.Done():
+		// Drain the reader and clear its deadline so the PreShutdownCheck
+		// round-trip has exclusive use of conn.
+		close(stopReader)
+		<-readerDone
+		conn.SetReadDeadline(time.Time{})
+		*lastForKey = checkLastForKey(conn, opts.EventKey)
+		conn.Close()
+	case <-allDone:
+		// Socket closed by bus side — we can't query, assume last.
+		*lastForKey = true
+	}
+
+	// Wait for all workers to finish.
+	// conn.Close() causes scanner EOF → close(socketCh) → workers exit range loop.
+	wg.Wait()
+
+	return nil
+}
+
+// processAndOutput runs Process, applies JQ, and writes the result.
+// Returns (wrote, err): wrote=true only when sink.Write was called and
+// succeeded; err is non-nil only for sink.Write failures. Process/JQ
+// errors are logged and the event is dropped (wrote=false, err=nil).
+// The caller decides whether a sink error is terminal (EPIPE) via
+// isTerminalSinkError.
+func processAndOutput(ctx context.Context, keyDef *event.KeyDefinition, evt *protocol.Event, opts Options, sink Sink, jqCode *gojq.Code) (bool, error) {
+	var result json.RawMessage
+
+	if keyDef.Process != nil {
+		raw := &event.RawEvent{
+			EventType: evt.EventType,
+			Payload:   evt.Payload,
+		}
+		var err error
+		result, err = keyDef.Process(ctx, opts.Runtime, raw, opts.Params)
+		if err != nil {
+			if !opts.Quiet {
+				fmt.Fprintf(opts.ErrOut, "WARN: Process error: %v\n", err)
+			}
+			return false, nil
+		}
+		if result == nil {
+			return false, nil
+		}
+	} else {
+		result = evt.Payload
+	}
+
+	if jqCode != nil {
+		filtered, err := applyJQ(jqCode, result)
+		if err != nil {
+			if !opts.Quiet {
+				fmt.Fprintf(opts.ErrOut, "WARN: JQ error: %v\n", err)
+			}
+			return false, nil
+		}
+		if filtered == nil {
+			return false, nil
+		}
+		result = filtered
+	}
+
+	if err := sink.Write(result); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// isTerminalSinkError returns true when a sink.Write failure means the
+// output channel is permanently broken and the consume should stop.
+// EPIPE (broken pipe) and ErrClosed cover the "downstream consumer of
+// stdout exited" case. Transient filesystem errors return false so the
+// loop keeps running.
+func isTerminalSinkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	if errors.Is(err, fs.ErrClosed) {
+		return true
+	}
+	return false
+}

--- a/internal/event/consume/loop_jq_test.go
+++ b/internal/event/consume/loop_jq_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestCompileJQReportsErrorEarly verifies that invalid jq expressions fail
+// at CompileJQ time, not when the first event arrives. Before the fix,
+// a bad expression would fail repeatedly on every event via applyJQ.
+func TestCompileJQReportsErrorEarly(t *testing.T) {
+	_, err := CompileJQ("invalid{{{")
+	if err == nil {
+		t.Fatal("expected compile error for invalid jq expression")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "compile") && !strings.Contains(msg, "parse") && !strings.Contains(msg, "invalid") {
+		t.Errorf("error should mention compile/parse/invalid, got: %v", err)
+	}
+}
+
+// TestCompileJQReturnsUsableCode verifies a valid expression compiles to
+// a gojq.Code that applyJQ can invoke.
+func TestCompileJQReturnsUsableCode(t *testing.T) {
+	code, err := CompileJQ(".foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if code == nil {
+		t.Fatal("expected non-nil code")
+	}
+
+	input := json.RawMessage(`{"foo":"bar"}`)
+	result, err := applyJQ(code, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(result) != `"bar"` {
+		t.Errorf("expected \"bar\", got %s", string(result))
+	}
+}
+
+// TestApplyJQReusesCompiledCode confirms that applyJQ can be called many
+// times without reallocating compilation state. This is the core perf goal:
+// pre-fix, this test loop would have called gojq.Parse + Compile 10000 times.
+func TestApplyJQReusesCompiledCode(t *testing.T) {
+	code, err := CompileJQ(".foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := json.RawMessage(`{"foo":"bar"}`)
+	for i := 0; i < 10000; i++ {
+		result, err := applyJQ(code, data)
+		if err != nil {
+			t.Fatalf("iteration %d: %v", i, err)
+		}
+		if string(result) != `"bar"` {
+			t.Fatalf("iteration %d: unexpected result %s", i, string(result))
+		}
+	}
+}
+
+// TestApplyJQFilterReturnsNilOnNoOutput verifies that expressions producing
+// no output (e.g., select that filters out) return (nil, nil), not error.
+// The existing applyJQ had this semantic; the refactor must preserve it.
+func TestApplyJQFilterReturnsNilOnNoOutput(t *testing.T) {
+	code, err := CompileJQ(`select(.type == "match")`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// This input doesn't match the filter, so select produces no output.
+	result, err := applyJQ(code, json.RawMessage(`{"type":"nomatch"}`))
+	if err != nil {
+		t.Fatalf("should not error on filter-out: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result for filtered-out event, got %s", string(result))
+	}
+}
+
+// TestApplyJQConcurrentSafe verifies that a single compiled *gojq.Code
+// can be safely shared across many goroutines concurrently — the whole
+// point of pre-compile is that workers share one Code instance without
+// mutex overhead. A regression (e.g., gojq Code becoming internally
+// stateful) would manifest as a -race failure or a wrong result.
+func TestApplyJQConcurrentSafe(t *testing.T) {
+	code, err := CompileJQ(".value")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const goroutines = 32
+	const iterationsPerGoroutine = 1000
+
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(gid int) {
+			defer wg.Done()
+			for i := 0; i < iterationsPerGoroutine; i++ {
+				// Different input per goroutine to catch any shared-buffer mistakes.
+				input := json.RawMessage(fmt.Sprintf(`{"value":"goroutine-%d-iter-%d"}`, gid, i))
+				result, err := applyJQ(code, input)
+				if err != nil {
+					errs <- fmt.Errorf("goroutine %d iter %d: %w", gid, i, err)
+					return
+				}
+				expected := fmt.Sprintf(`"goroutine-%d-iter-%d"`, gid, i)
+				if string(result) != expected {
+					errs <- fmt.Errorf("goroutine %d iter %d: expected %s, got %s", gid, i, expected, string(result))
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}

--- a/internal/event/consume/loop_seq_test.go
+++ b/internal/event/consume/loop_seq_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// seqGapDetector mirrors the inline gap-detection logic from consumeLoop's
+// reader goroutine so tests can exercise it in isolation. If this logic
+// changes in loop.go, update here too.
+type seqGapDetector struct {
+	lastSeq uint64
+	errOut  io.Writer
+	quiet   bool
+}
+
+func (d *seqGapDetector) observe(m *protocol.Event) {
+	if d.lastSeq > 0 && m.Seq > 0 && m.Seq > d.lastSeq+1 {
+		gap := m.Seq - d.lastSeq - 1
+		if !d.quiet {
+			fmt.Fprintf(d.errOut, "WARN: event seq gap %d->%d, missed %d events (dropped by bus backpressure)\n",
+				d.lastSeq, m.Seq, gap)
+		}
+	}
+	// CRITICAL: only advance forward to tolerate out-of-order arrivals from
+	// concurrent Publishers winning sendMu races.
+	if m.Seq > d.lastSeq {
+		d.lastSeq = m.Seq
+	}
+}
+
+func TestSeqGapDetectorNoWarningOnFirstEvent(t *testing.T) {
+	var buf bytes.Buffer
+	d := &seqGapDetector{errOut: &buf}
+	d.observe(&protocol.Event{Seq: 5})
+	if strings.Contains(buf.String(), "gap") {
+		t.Errorf("unexpected gap warning on first event: %s", buf.String())
+	}
+}
+
+func TestSeqGapDetectorNoWarningOnContiguous(t *testing.T) {
+	var buf bytes.Buffer
+	d := &seqGapDetector{errOut: &buf}
+	for i := uint64(1); i <= 10; i++ {
+		d.observe(&protocol.Event{Seq: i})
+	}
+	if buf.Len() > 0 {
+		t.Errorf("unexpected output on contiguous seqs: %s", buf.String())
+	}
+}
+
+func TestSeqGapDetectorWarnsOnActualGap(t *testing.T) {
+	var buf bytes.Buffer
+	d := &seqGapDetector{errOut: &buf}
+	d.observe(&protocol.Event{Seq: 1})
+	d.observe(&protocol.Event{Seq: 5}) // skipped 2, 3, 4
+	out := buf.String()
+	if !strings.Contains(out, "gap 1->5") {
+		t.Errorf("expected 'gap 1->5' in output, got: %s", out)
+	}
+	if !strings.Contains(out, "missed 3 events") {
+		t.Errorf("expected 'missed 3 events' in output, got: %s", out)
+	}
+}
+
+// TestSeqGapDetectorHandlesOutOfOrderWithoutFalsePositive is the regression
+// test for the bug where lastSeq went backwards. Under concurrent Publishers,
+// msg Seq=6 may arrive before msg Seq=5 (B wins sendMu). The detector must
+// NOT emit a false gap warning when Seq=7 arrives after that sequence.
+func TestSeqGapDetectorHandlesOutOfOrderWithoutFalsePositive(t *testing.T) {
+	var buf bytes.Buffer
+	d := &seqGapDetector{errOut: &buf}
+	d.observe(&protocol.Event{Seq: 6}) // arrives first
+	d.observe(&protocol.Event{Seq: 5}) // arrives out-of-order
+	d.observe(&protocol.Event{Seq: 7}) // next real event
+	if buf.Len() > 0 {
+		t.Errorf("unexpected warning for out-of-order (no actual gap): %s", buf.String())
+	}
+}
+
+func TestSeqGapDetectorQuietMode(t *testing.T) {
+	var buf bytes.Buffer
+	d := &seqGapDetector{errOut: &buf, quiet: true}
+	d.observe(&protocol.Event{Seq: 1})
+	d.observe(&protocol.Event{Seq: 10}) // big gap
+	if buf.Len() > 0 {
+		t.Errorf("quiet mode should suppress warnings, got: %s", buf.String())
+	}
+}
+
+func TestSeqGapDetectorZeroSeqIgnored(t *testing.T) {
+	// Legacy events without Seq (old Bus version) have Seq=0. The detector
+	// should neither warn nor advance lastSeq on these.
+	var buf bytes.Buffer
+	d := &seqGapDetector{errOut: &buf}
+	d.observe(&protocol.Event{Seq: 5})
+	d.observe(&protocol.Event{Seq: 0}) // legacy
+	d.observe(&protocol.Event{Seq: 6}) // expected next
+	if buf.Len() > 0 {
+		t.Errorf("unexpected warning across legacy zero-seq event: %s", buf.String())
+	}
+	if d.lastSeq != 6 {
+		t.Errorf("expected lastSeq=6 after legacy skip, got %d", d.lastSeq)
+	}
+}

--- a/internal/event/consume/remote_preflight.go
+++ b/internal/event/consume/remote_preflight.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/larksuite/cli/internal/event"
+)
+
+// APIClient aliases event.APIClient so the same concrete adapter the
+// cmd layer constructs satisfies every consume-time HTTP call site.
+type APIClient = event.APIClient
+
+// CheckRemoteConnections calls GET /open-apis/event/v1/connection to learn
+// how many WebSocket connections are currently active for this app globally.
+// Returns the online instance count, or an error if the API call fails.
+//
+// Field verified via `lark-cli api GET /open-apis/event/v1/connection`:
+//
+//	{"code":0,"msg":"","data":{"online_instance_cnt":N}}
+//
+// Mismatching the tag name would silently decode to 0 and defeat the check.
+func CheckRemoteConnections(ctx context.Context, client APIClient) (int, error) {
+	raw, err := client.CallAPI(ctx, "GET", "/open-apis/event/v1/connection", nil)
+	if err != nil {
+		return 0, fmt.Errorf("connection check: %w", err)
+	}
+	var result struct {
+		Data struct {
+			OnlineInstanceCnt int `json:"online_instance_cnt"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return 0, fmt.Errorf("connection check: decode: %w (body=%s)", err, truncateForError(raw))
+	}
+	return result.Data.OnlineInstanceCnt, nil
+}
+
+// truncateForError bounds body length and strips control chars so a
+// malformed OAPI response (or one reflecting auth headers) doesn't flood
+// stderr and doesn't forge log lines via embedded newlines.
+func truncateForError(b []byte) string {
+	const max = 256
+	s := string(b)
+	if len(s) > max {
+		s = s[:max] + "…(truncated)"
+	}
+	// Collapse control chars to spaces for log hygiene.
+	out := make([]byte, 0, len(s))
+	for _, r := range s {
+		if r == '\n' || r == '\r' || r == '\t' {
+			out = append(out, ' ')
+			continue
+		}
+		out = append(out, string(r)...)
+	}
+	return string(out)
+}

--- a/internal/event/consume/remote_preflight_test.go
+++ b/internal/event/consume/remote_preflight_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/larksuite/cli/internal/event/testutil"
+)
+
+func TestCheckRemoteConnections_Success(t *testing.T) {
+	c := &testutil.StubAPIClient{Body: `{"code":0,"msg":"success","data":{"online_instance_cnt":1}}`}
+	count, err := CheckRemoteConnections(context.Background(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+	if c.GotMethod != "GET" || c.GotPath != "/open-apis/event/v1/connection" {
+		t.Errorf("wrong request: %s %s", c.GotMethod, c.GotPath)
+	}
+}
+
+func TestCheckRemoteConnections_ZeroConnections(t *testing.T) {
+	c := &testutil.StubAPIClient{Body: `{"code":0,"data":{"online_instance_cnt":0}}`}
+	count, err := CheckRemoteConnections(context.Background(), c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0", count)
+	}
+}
+
+func TestCheckRemoteConnections_APIErrorPropagated(t *testing.T) {
+	// Errors from the underlying client layer (CheckLarkResponse) come
+	// through as structured *output.ExitError — the preflight only needs
+	// to surface them, not decode code/msg itself.
+	want := errors.New("API GET /open-apis/event/v1/connection: [99991663] token is invalid")
+	c := &testutil.StubAPIClient{Err: want}
+	_, err := CheckRemoteConnections(context.Background(), c)
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want wrapping %v", err, want)
+	}
+}
+
+func TestCheckRemoteConnections_MalformedJSON(t *testing.T) {
+	c := &testutil.StubAPIClient{Body: `not json at all`}
+	_, err := CheckRemoteConnections(context.Background(), c)
+	if err == nil {
+		t.Fatal("expected decode error")
+	}
+}

--- a/internal/event/consume/shutdown.go
+++ b/internal/event/consume/shutdown.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"bufio"
+	"net"
+	"time"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// preShutdownAckTimeout bounds how long checkLastForKey will wait on
+// the bus's ack. A bus that is wedged or already dead must not strand
+// the consumer in this call — user Ctrl-C has already fired and we are
+// past the ctx-Done selection point here.
+const preShutdownAckTimeout = 2 * time.Second
+
+// checkLastForKey asks the bus to atomically reserve a cleanup lock for
+// this consumer's EventKey. Returns true iff the caller acquired the
+// reservation (so the caller MUST run cleanup — disconnect will release
+// the lock on the bus side), or false if another subscriber holds the key
+// and cleanup should NOT run. On any error (including timeout) the caller
+// defaults to true: running cleanup for a still-busy key is safer than
+// leaking server-side state; the other consumer can re-subscribe by
+// re-running consume.
+//
+// The "reserve first, then ack" design closes a TOCTOU race: without the
+// reservation, a new subscriber could register for the same key between
+// our observation of "alone" and the actual cleanup call — silently
+// black-holing them.
+func checkLastForKey(conn net.Conn, eventKey string) bool {
+	msg := protocol.NewPreShutdownCheck(eventKey)
+	if err := protocol.EncodeWithDeadline(conn, msg, protocol.WriteTimeout); err != nil {
+		return true
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(preShutdownAckTimeout)); err != nil {
+		return true
+	}
+	scanner := bufio.NewScanner(conn)
+	if scanner.Scan() {
+		resp, err := protocol.Decode(scanner.Bytes())
+		if err == nil {
+			if ack, ok := resp.(*protocol.PreShutdownAck); ok {
+				return ack.LastForKey
+			}
+		}
+	}
+	return true
+}

--- a/internal/event/consume/shutdown.go
+++ b/internal/event/consume/shutdown.go
@@ -5,6 +5,7 @@ package consume
 
 import (
 	"bufio"
+	"bytes"
 	"net"
 	"time"
 
@@ -30,6 +31,20 @@ const preShutdownAckTimeout = 2 * time.Second
 // reservation, a new subscriber could register for the same key between
 // our observation of "alone" and the actual cleanup call — silently
 // black-holing them.
+//
+// The read loop discards non-ack frames. Event and source-status frames
+// may already be in flight from the bus side when we send our
+// PreShutdownCheck; reading just the first frame could see an event and
+// fall through, masking the real ack (or conversely, falsely reporting
+// LastForKey=true on a non-ack frame we couldn't decode). Loop until an
+// ack arrives, we see decoded-but-unrelated frames, or the deadline
+// fires.
+//
+// Note: we create a fresh bufio.Reader on the raw conn here. The main
+// consume loop's bufio.Reader (from doHello) may hold buffered bytes at
+// shutdown, but those bytes predate our PreShutdownCheck and therefore
+// cannot contain the ack we're waiting for — so any bytes it abandons
+// are event/source-status frames we don't care about at shutdown time.
 func checkLastForKey(conn net.Conn, eventKey string) bool {
 	msg := protocol.NewPreShutdownCheck(eventKey)
 	if err := protocol.EncodeWithDeadline(conn, msg, protocol.WriteTimeout); err != nil {
@@ -39,14 +54,24 @@ func checkLastForKey(conn net.Conn, eventKey string) bool {
 	if err := conn.SetReadDeadline(time.Now().Add(preShutdownAckTimeout)); err != nil {
 		return true
 	}
-	scanner := bufio.NewScanner(conn)
-	if scanner.Scan() {
-		resp, err := protocol.Decode(scanner.Bytes())
-		if err == nil {
-			if ack, ok := resp.(*protocol.PreShutdownAck); ok {
-				return ack.LastForKey
-			}
+	br := bufio.NewReader(conn)
+	for {
+		line, err := protocol.ReadFrame(br)
+		if err != nil {
+			// Deadline, EOF, or protocol error: default to cleanup (safer
+			// than leaving server-side state stranded).
+			return true
 		}
+		resp, err := protocol.Decode(bytes.TrimRight(line, "\n"))
+		if err != nil {
+			// Malformed frame on a presumed-healthy connection. Skip and
+			// keep reading — the ack may follow.
+			continue
+		}
+		if ack, ok := resp.(*protocol.PreShutdownAck); ok {
+			return ack.LastForKey
+		}
+		// Any other decoded frame type (Event, SourceStatus, …) was
+		// queued before or alongside our ack. Discard and continue.
 	}
-	return true
 }

--- a/internal/event/consume/shutdown_test.go
+++ b/internal/event/consume/shutdown_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// TestCheckLastForKey_IgnoresNonAckFrames — regression for Bug 5
+// (CodeRabbit PR #615). `checkLastForKey` previously scanned exactly
+// one frame after sending PreShutdownCheck. If an event frame or
+// source-status frame was already queued on the bus side (buffered
+// with or before the ack in the same TCP window), the scanner read
+// that first, the type-assert to *PreShutdownAck failed, and the
+// function fell through to its default `return true`. That either
+// fires an extra cleanup (spurious unsubscribe) or hides the actual
+// LastForKey=false answer the bus reserved.
+//
+// Fix expectation: loop over frames until we see PreShutdownAck or the
+// deadline fires, discarding any other frame type.
+func TestCheckLastForKey_IgnoresNonAckFrames(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	// Server goroutine: read one PreShutdownCheck from the client, then
+	// deliberately reply with an Event frame (non-ack) first, followed by
+	// PreShutdownAck{LastForKey: false}. If the fix is correct,
+	// checkLastForKey sees the Event, discards it, reads the next frame,
+	// sees the ack, and returns false.
+	errs := make(chan error, 2)
+	go func() {
+		// Drain the PreShutdownCheck the client sends.
+		buf := make([]byte, 4096)
+		if _, err := server.Read(buf); err != nil && err != io.EOF {
+			errs <- err
+			return
+		}
+		// Now write an Event frame first (should be discarded by the client).
+		evt := protocol.NewEvent("im.msg", "evt_1", "", 1, json.RawMessage(`{}`))
+		if err := protocol.Encode(server, evt); err != nil {
+			errs <- err
+			return
+		}
+		// Then the real ack.
+		ack := protocol.NewPreShutdownAck(false)
+		if err := protocol.Encode(server, ack); err != nil {
+			errs <- err
+			return
+		}
+	}()
+
+	got := checkLastForKey(client, "im.msg")
+	if got != false {
+		t.Errorf("checkLastForKey = %v, want false (bus replied with LastForKey=false; "+
+			"an Event frame before the ack must not be mistaken for the ack)", got)
+	}
+
+	select {
+	case err := <-errs:
+		t.Fatalf("server goroutine error: %v", err)
+	default:
+	}
+}
+
+// TestCheckLastForKey_ReturnsAckValue — sanity test that the straightforward
+// "one frame = ack" path still works.
+func TestCheckLastForKey_ReturnsAckValue(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	go func() {
+		buf := make([]byte, 4096)
+		_, _ = server.Read(buf)
+		ack := protocol.NewPreShutdownAck(true)
+		_ = protocol.Encode(server, ack)
+	}()
+
+	got := checkLastForKey(client, "im.msg")
+	if got != true {
+		t.Errorf("checkLastForKey = %v, want true", got)
+	}
+}
+
+// TestCheckLastForKey_DefaultsToTrueOnTimeout — when the bus never
+// replies, we default to `true` (safer to run cleanup than to leave
+// server-side state stranded). Bounded by preShutdownAckTimeout.
+func TestCheckLastForKey_DefaultsToTrueOnTimeout(t *testing.T) {
+	server, client := net.Pipe()
+	defer server.Close()
+	defer client.Close()
+
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			if _, err := server.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	start := time.Now()
+	got := checkLastForKey(client, "im.msg")
+	elapsed := time.Since(start)
+
+	if got != true {
+		t.Errorf("checkLastForKey = %v, want true (default on timeout)", got)
+	}
+	if elapsed > preShutdownAckTimeout+2*time.Second {
+		t.Errorf("elapsed = %v, expected ~%v (timeout-bounded)", elapsed, preShutdownAckTimeout)
+	}
+}

--- a/internal/event/consume/sink.go
+++ b/internal/event/consume/sink.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+// Sink is an output destination for processed events.
+type Sink interface {
+	Write(data json.RawMessage) error
+}
+
+// newSink picks a sink based on opts. DirSink's target directory is
+// created once here so per-event writes skip the MkdirAll syscall.
+func newSink(opts Options) (Sink, error) {
+	if opts.OutputDir != "" {
+		if err := vfs.MkdirAll(opts.OutputDir, 0755); err != nil {
+			return nil, fmt.Errorf("create output dir: %w", err)
+		}
+		// Include PID so concurrent processes writing to the same directory
+		// can't collide on filename even if their nanosecond clocks and
+		// sequence resets happen to align (see DirSink.Write).
+		return &DirSink{Dir: opts.OutputDir, pid: os.Getpid()}, nil
+	}
+	out := opts.Out
+	if out == nil {
+		// Defensive fallback for library callers that forget to wire
+		// Options.Out; cmd/event/consume.go always injects IOStreams.Out.
+		out = os.Stdout //nolint:forbidigo // library-caller fallback; cmd path always sets Options.Out
+	}
+	return &WriterSink{W: out, ErrOut: opts.ErrOut}, nil
+}
+
+// WriterSink writes one JSON event per line (or pretty-printed) to W.
+// Concurrent writes are serialised so workers don't interleave bytes.
+//
+// When Pretty is true and a payload is not valid JSON (should be rare —
+// the bus only forwards upstream payloads, which are JSON by protocol,
+// but --jq output can technically be anything), the sink falls back to
+// raw passthrough. If ErrOut is non-nil we emit a one-shot warning on
+// the first such fallback so callers know the pretty formatting didn't
+// apply and can investigate; subsequent fallbacks are silent to avoid
+// log spam on pathological streams.
+type WriterSink struct {
+	W            io.Writer
+	Pretty       bool
+	ErrOut       io.Writer
+	prettyWarned atomic.Bool
+	mu           sync.Mutex
+}
+
+func (s *WriterSink) Write(data json.RawMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.Pretty {
+		var v interface{}
+		if err := json.Unmarshal(data, &v); err == nil {
+			pretty, _ := json.MarshalIndent(v, "", "  ")
+			_, err := fmt.Fprintln(s.W, string(pretty))
+			return err
+		}
+		// Non-JSON payload. Fall through to raw passthrough, but log once.
+		if s.ErrOut != nil && s.prettyWarned.CompareAndSwap(false, true) {
+			fmt.Fprintln(s.ErrOut, "WARN: --pretty: payload is not valid JSON; falling back to raw output (this and future malformed events)")
+		}
+	}
+	_, err := fmt.Fprintln(s.W, string(data))
+	return err
+}
+
+// DirSink writes each event as its own JSON file under Dir. Filenames
+// combine a nanosecond timestamp, the writing process PID, and an atomic
+// sequence so concurrent writers — whether goroutines in the same
+// process or separate processes sharing a DirSink output — never
+// collide on filename.
+type DirSink struct {
+	Dir string
+	pid int
+	seq atomic.Int64
+}
+
+func (s *DirSink) Write(data json.RawMessage) error {
+	name := fmt.Sprintf("%d_%d_%d.json", time.Now().UnixNano(), s.pid, s.seq.Add(1))
+	// Mode 0600: event payloads often carry message contents, user IDs,
+	// and other PII — world-readable on a multi-user host leaks data.
+	return vfs.WriteFile(filepath.Join(s.Dir, name), data, 0600)
+}

--- a/internal/event/consume/sink_test.go
+++ b/internal/event/consume/sink_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestWriterSink_PrettyFallbackWarnsOnce verifies that WriterSink logs a
+// single WARN to ErrOut when asked to pretty-print a non-JSON payload
+// and suppresses duplicates on subsequent malformed writes. Callers rely
+// on this to notice that --pretty silently degraded, while avoiding log
+// spam on pathological streams.
+func TestWriterSink_PrettyFallbackWarnsOnce(t *testing.T) {
+	var out, errOut bytes.Buffer
+	s := &WriterSink{W: &out, Pretty: true, ErrOut: &errOut}
+
+	// Two malformed payloads back-to-back.
+	if err := s.Write(json.RawMessage("not json {{{")); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := s.Write(json.RawMessage("still not json")); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	warnings := strings.Count(errOut.String(), "WARN:")
+	if warnings != 1 {
+		t.Errorf("expected exactly 1 WARN line (once-semantics), got %d: %q", warnings, errOut.String())
+	}
+	if !strings.Contains(errOut.String(), "pretty") {
+		t.Errorf("warning should mention pretty: %q", errOut.String())
+	}
+
+	// Raw passthrough should have been written both times.
+	if strings.Count(out.String(), "not json") != 2 {
+		t.Errorf("expected 2 raw passthrough lines in W, got: %q", out.String())
+	}
+}
+
+// TestWriterSink_PrettyHappyPath verifies that valid JSON is formatted
+// with 2-space indent and no warning fires.
+func TestWriterSink_PrettyHappyPath(t *testing.T) {
+	var out, errOut bytes.Buffer
+	s := &WriterSink{W: &out, Pretty: true, ErrOut: &errOut}
+
+	if err := s.Write(json.RawMessage(`{"k":"v"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if errOut.Len() != 0 {
+		t.Errorf("expected no warning on valid JSON, got: %q", errOut.String())
+	}
+	if !strings.Contains(out.String(), "\n  \"k\"") {
+		t.Errorf("expected indented output, got: %q", out.String())
+	}
+}
+
+// TestWriterSink_PrettyNoErrOut verifies that omitting ErrOut suppresses
+// the warning (no panic, silent degradation) — legacy callers that don't
+// wire ErrOut still get the prior behaviour.
+func TestWriterSink_PrettyNoErrOut(t *testing.T) {
+	var out bytes.Buffer
+	s := &WriterSink{W: &out, Pretty: true} // ErrOut left nil
+
+	if err := s.Write(json.RawMessage("not json")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Reached here without panic, raw output emitted — good enough.
+	if !strings.Contains(out.String(), "not json") {
+		t.Errorf("expected raw passthrough, got: %q", out.String())
+	}
+}
+
+// TestDirSink_FilenameIncludesPID verifies filenames embed os.Getpid() so
+// two processes writing to the same output dir can't collide even if
+// their nanosecond clocks and sequence values happen to align.
+func TestDirSink_FilenameIncludesPID(t *testing.T) {
+	dir := t.TempDir()
+	s := &DirSink{Dir: dir, pid: os.Getpid()}
+
+	if err := s.Write(json.RawMessage(`{"a":1}`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("expected 1 file, got %d: %v", len(entries), err)
+	}
+	name := entries[0].Name()
+	wantPID := fmt.Sprintf("_%d_", os.Getpid())
+	if !strings.Contains(name, wantPID) {
+		t.Errorf("filename %q should contain PID segment %q", name, wantPID)
+	}
+	if filepath.Ext(name) != ".json" {
+		t.Errorf("filename %q should have .json extension", name)
+	}
+}
+
+// TestDirSink_FilenameFormat verifies the full "<ns>_<pid>_<seq>.json"
+// shape — guards against a refactor silently dropping the seq or pid
+// segment and reintroducing the collision risk.
+func TestDirSink_FilenameFormat(t *testing.T) {
+	dir := t.TempDir()
+	s := &DirSink{Dir: dir, pid: 12345}
+
+	for i := 0; i < 3; i++ {
+		if err := s.Write(json.RawMessage(`{}`)); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 files, got %d", len(entries))
+	}
+	for _, e := range entries {
+		name := e.Name()
+		// Expect three numeric segments then .json: ns_pid_seq.json.
+		trimmed := strings.TrimSuffix(name, ".json")
+		parts := strings.Split(trimmed, "_")
+		if len(parts) != 3 {
+			t.Errorf("filename %q should split into 3 underscore parts, got %d", name, len(parts))
+			continue
+		}
+		if parts[1] != "12345" {
+			t.Errorf("filename %q should have PID=12345 as middle segment, got %q", name, parts[1])
+		}
+	}
+}

--- a/internal/event/consume/startup.go
+++ b/internal/event/consume/startup.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/event/protocol"
+	"github.com/larksuite/cli/internal/event/transport"
+	"github.com/larksuite/cli/internal/lockfile"
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+const (
+	dialRetryInterval = 50 * time.Millisecond
+	dialTimeout       = 3 * time.Second
+)
+
+// EnsureBus dials the bus daemon for appID, forking a new one if none is
+// running. profileName lets the forked bus pull credentials from the
+// keychain instead of taking them as process arguments. Passing
+// io.Discard as errOut (--quiet) silences the diagnostic chain.
+//
+// apiClient is a bot-identity client used for the remote-connection probe;
+// pass nil to skip the probe entirely (degrades to "assume no remote bus").
+// domain is still required because the forked bus daemon receives it via
+// --domain (the parent is the one that resolved which brand's endpoints to
+// use).
+//
+// Known limitation: if a local bus answers the dial we skip the remote
+// check — a bus on another machine for the same AppID will duplicate
+// events and we won't notice from here (see `event status`).
+func EnsureBus(ctx context.Context, tr transport.IPC, appID, profileName, domain string, apiClient APIClient, errOut io.Writer) (net.Conn, error) {
+	if errOut == nil {
+		// Defensive fallback; cmd layer always wires IOStreams.ErrOut.
+		errOut = os.Stderr //nolint:forbidigo // library-caller fallback
+	}
+	addr := tr.Address(appID)
+
+	if conn, err := probeAndDialBus(tr, addr); err == nil {
+		return conn, nil
+	}
+	fmt.Fprintf(errOut, "[event] local bus not found; checking remote connections...\n")
+
+	if apiClient != nil {
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		count, checkErr := CheckRemoteConnections(ctx, apiClient)
+		if checkErr != nil {
+			fmt.Fprintf(errOut, "[event] remote connection check failed: %v (proceeding to start local bus)\n", checkErr)
+		} else {
+			fmt.Fprintf(errOut, "[event] remote connection check: online_instance_cnt=%d\n", count)
+			if count > 0 {
+				return nil, fmt.Errorf("another event bus is already connected to this app "+
+					"(%d active connection(s) detected via API).\n"+
+					"Only one bus should run globally to avoid duplicate event delivery.\n"+
+					"Use 'lark-cli event status' to check, or 'lark-cli event stop' on the other machine first", count)
+			}
+		}
+	} else {
+		fmt.Fprintf(errOut, "[event] no API client supplied; skipping remote connection check\n")
+	}
+
+	// Lock contention (lockfile.ErrHeld) means another consume is already
+	// forking — let the dial retry catch its bus. Other fork errors
+	// (missing exe, no write perms) should surface now rather than
+	// waiting out the dial timeout.
+	pid, forkErr := forkBus(appID, profileName, domain)
+	if forkErr != nil && !errors.Is(forkErr, lockfile.ErrHeld) {
+		eventsRoot := filepath.Join(core.GetConfigDir(), "events")
+		return nil, fmt.Errorf("failed to start event bus daemon: %w\n"+
+			"Check: disk space, permissions on %s, and 'lark-cli doctor'", forkErr, eventsRoot)
+	}
+	// pid==0 when another consume already forked and we hit ErrHeld — that
+	// bus is not ours to announce, and the dial loop below will still catch it.
+	if pid > 0 {
+		announceForkedBus(errOut, pid)
+	}
+
+	deadline := time.Now().Add(dialTimeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(dialRetryInterval)
+		if conn, err := tr.Dial(addr); err == nil {
+			return conn, nil
+		}
+	}
+
+	// Per spec §6.4: three-line friendly diagnostic. Path expands at runtime
+	// from core.GetConfigDir() so LARKSUITE_CLI_CONFIG_DIR overrides are honoured.
+	logPath := filepath.Join(core.GetConfigDir(), "events", appID, "bus.log")
+	fmt.Fprintln(errOut, "[event] event bus exited unexpectedly.")
+	fmt.Fprintln(errOut, "[event] please check app credentials (lark-cli config show) and retry.")
+	fmt.Fprintf(errOut, "[event] logs: %s\n", logPath)
+	return nil, fmt.Errorf("failed to connect to event bus within %v (app=%s)", dialTimeout, appID)
+}
+
+// probeAndDialBus sends a StatusQuery to verify the bus is actually serving,
+// then returns a fresh connection for the caller's Hello handshake. This
+// distinguishes a healthy bus from a mid-shutdown or half-dead listener
+// (where Dial would succeed but doHello would EOF with a misleading error).
+//
+// If the probe times out or decodes a non-StatusResponse, returns an error
+// so the caller can fall through to fork a new bus.
+func probeAndDialBus(tr transport.IPC, addr string) (net.Conn, error) {
+	// Step 1: probe with StatusQuery.
+	probe, err := tr.Dial(addr)
+	if err != nil {
+		return nil, err
+	}
+	probe.SetDeadline(time.Now().Add(2 * time.Second))
+	if err := protocol.Encode(probe, protocol.NewStatusQuery()); err != nil {
+		probe.Close()
+		return nil, fmt.Errorf("bus probe: encode: %w", err)
+	}
+	br := bufio.NewReader(probe)
+	line, err := protocol.ReadFrame(br)
+	probe.Close()
+	if err != nil {
+		return nil, fmt.Errorf("bus probe: read status: %w", err)
+	}
+	msg, err := protocol.Decode(bytes.TrimRight(line, "\n"))
+	if err != nil {
+		return nil, fmt.Errorf("bus probe: decode status: %w", err)
+	}
+	if _, ok := msg.(*protocol.StatusResponse); !ok {
+		return nil, fmt.Errorf("bus probe: expected StatusResponse, got %T", msg)
+	}
+
+	// Step 2: Bus is healthy — Dial a fresh conn for the caller.
+	return tr.Dial(addr)
+}
+
+// forkBus spawns the bus daemon as a detached child. Detach mechanics
+// are platform-specific (see startup_unix.go / startup_windows.go); the
+// lock + argv + --profile-based credential lookup are shared.
+func forkBus(appID, profileName, domain string) (int, error) {
+	lockPath := filepath.Join(core.GetConfigDir(), "events", appID, "bus.fork.lock")
+	if err := vfs.MkdirAll(filepath.Dir(lockPath), 0700); err != nil {
+		return 0, err
+	}
+
+	lock := lockfile.New(lockPath)
+	if err := lock.TryLock(); err != nil {
+		return 0, err
+	}
+	defer lock.Unlock()
+
+	exe, err := os.Executable()
+	if err != nil {
+		return 0, err
+	}
+
+	args := buildForkArgs(profileName, domain)
+	cmd := exec.Command(exe, args...)
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	applyDetachAttrs(cmd)
+
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+	return cmd.Process.Pid, nil
+}
+
+// buildForkArgs builds the argv (minus argv[0]) used to re-invoke this
+// binary as a bus daemon. Extracted as a pure function so tests can
+// assert the shape without actually forking a child process.
+//
+// NOTE: The cmdline shape "event _bus --profile cli_..." is parsed by
+// internal/event/busdiscover to detect orphan bus processes. If you
+// change arg splitting or flag names here, update the two-gate filter
+// in busdiscover.parseAppIDFromCmdline in lockstep, or orphans for the
+// changed shape will become invisible to `event status`.
+func buildForkArgs(profileName, domain string) []string {
+	args := []string{"event", "_bus", "--profile", profileName}
+	if domain != "" {
+		args = append(args, "--domain", domain)
+	}
+	return args
+}
+
+// announceForkedBus writes an AI-visible line to w confirming a bus daemon
+// was forked. The "auto-exits 30s" hint corresponds to bus.idleTimeout;
+// if that constant ever changes, update this text too.
+func announceForkedBus(w io.Writer, pid int) {
+	fmt.Fprintf(w, "[event] started bus daemon pid=%d (auto-exits 30s after last consumer)\n", pid)
+}

--- a/internal/event/consume/startup.go
+++ b/internal/event/consume/startup.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/event"
 	"github.com/larksuite/cli/internal/event/protocol"
 	"github.com/larksuite/cli/internal/event/transport"
 	"github.com/larksuite/cli/internal/lockfile"
@@ -99,7 +100,7 @@ func EnsureBus(ctx context.Context, tr transport.IPC, appID, profileName, domain
 
 	// Per spec §6.4: three-line friendly diagnostic. Path expands at runtime
 	// from core.GetConfigDir() so LARKSUITE_CLI_CONFIG_DIR overrides are honoured.
-	logPath := filepath.Join(core.GetConfigDir(), "events", appID, "bus.log")
+	logPath := filepath.Join(core.GetConfigDir(), "events", event.SanitizeAppID(appID), "bus.log")
 	fmt.Fprintln(errOut, "[event] event bus exited unexpectedly.")
 	fmt.Fprintln(errOut, "[event] please check app credentials (lark-cli config show) and retry.")
 	fmt.Fprintf(errOut, "[event] logs: %s\n", logPath)
@@ -146,7 +147,7 @@ func probeAndDialBus(tr transport.IPC, addr string) (net.Conn, error) {
 // are platform-specific (see startup_unix.go / startup_windows.go); the
 // lock + argv + --profile-based credential lookup are shared.
 func forkBus(appID, profileName, domain string) (int, error) {
-	lockPath := filepath.Join(core.GetConfigDir(), "events", appID, "bus.fork.lock")
+	lockPath := filepath.Join(core.GetConfigDir(), "events", event.SanitizeAppID(appID), "bus.fork.lock")
 	if err := vfs.MkdirAll(filepath.Dir(lockPath), 0700); err != nil {
 		return 0, err
 	}

--- a/internal/event/consume/startup.go
+++ b/internal/event/consume/startup.go
@@ -90,9 +90,17 @@ func EnsureBus(ctx context.Context, tr transport.IPC, appID, profileName, domain
 		announceForkedBus(errOut, pid)
 	}
 
+	// Honour ctx cancellation on the dial retry loop so a SIGINT during
+	// fork+dial doesn't wait out the full dialTimeout. time.After is safe
+	// here — the loop runs ~dialTimeout/dialRetryInterval times worst case
+	// (3s/50ms = 60 iters), so per-iter timer allocation is negligible.
 	deadline := time.Now().Add(dialTimeout)
 	for time.Now().Before(deadline) {
-		time.Sleep(dialRetryInterval)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(dialRetryInterval):
+		}
 		if conn, err := tr.Dial(addr); err == nil {
 			return conn, nil
 		}

--- a/internal/event/consume/startup_announce_test.go
+++ b/internal/event/consume/startup_announce_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestAnnounceForkedBus(t *testing.T) {
+	var buf bytes.Buffer
+	announceForkedBus(&buf, 12345)
+
+	got := buf.String()
+	for _, want := range []string{
+		"[event] started bus daemon",
+		"pid=12345",
+		"auto-exits 30s after last consumer",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q; got:\n%s", want, got)
+		}
+	}
+}

--- a/internal/event/consume/startup_fork_test.go
+++ b/internal/event/consume/startup_fork_test.go
@@ -22,9 +22,9 @@ func TestBuildForkArgs(t *testing.T) {
 	}{
 		{
 			name:    "no domain (lark default)",
-			profile: "cli_a96bbe46d5a15bc3",
+			profile: "cli_XXXXXXXXXXXXXXXX",
 			domain:  "",
-			want:    []string{"event", "_bus", "--profile", "cli_a96bbe46d5a15bc3"},
+			want:    []string{"event", "_bus", "--profile", "cli_XXXXXXXXXXXXXXXX"},
 		},
 		{
 			name:    "custom domain appended",

--- a/internal/event/consume/startup_fork_test.go
+++ b/internal/event/consume/startup_fork_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"reflect"
+	"testing"
+)
+
+// The fork argv shape is a contract with internal/event/busdiscover —
+// that package parses running-process cmdlines to detect orphan buses
+// by looking for "event", "_bus", "--profile", <appID>. If this test
+// breaks, the orphan detector needs a matching update; do not silence
+// one without the other.
+func TestBuildForkArgs(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile string
+		domain  string
+		want    []string
+	}{
+		{
+			name:    "no domain (lark default)",
+			profile: "cli_a96bbe46d5a15bc3",
+			domain:  "",
+			want:    []string{"event", "_bus", "--profile", "cli_a96bbe46d5a15bc3"},
+		},
+		{
+			name:    "custom domain appended",
+			profile: "cli_x",
+			domain:  "https://open.feishu.cn",
+			want: []string{
+				"event", "_bus",
+				"--profile", "cli_x",
+				"--domain", "https://open.feishu.cn",
+			},
+		},
+		{
+			name:    "empty profile still keeps flag skeleton (defensive — prod never passes this)",
+			profile: "",
+			domain:  "",
+			want:    []string{"event", "_bus", "--profile", ""},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildForkArgs(tc.profile, tc.domain)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("buildForkArgs(%q, %q) = %v, want %v", tc.profile, tc.domain, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildForkArgs_SubcommandStable pins the two positional args
+// ("event", "_bus") because busdiscover's orphan-detection regex
+// keys off them. Separate test so a single failure message names the
+// exact contract violated.
+func TestBuildForkArgs_SubcommandStable(t *testing.T) {
+	got := buildForkArgs("cli_x", "")
+	if len(got) < 2 || got[0] != "event" || got[1] != "_bus" {
+		t.Fatalf("argv[0:2] = %v, want [event _bus] — busdiscover relies on this shape", got[:min(2, len(got))])
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/event/consume/startup_probe_test.go
+++ b/internal/event/consume/startup_probe_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package consume
+
+import (
+	"bufio"
+	"bytes"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// probeMockTransport is a minimal mock for probeAndDialBus tests. It
+// owns a listener plus a WaitGroup so `stop()` is a hard barrier: when
+// stop returns, no accept/read goroutine remains running. Earlier
+// versions leaked goroutines via accept loops that never woke up on
+// listener close and per-conn readers that held the conn past test end.
+type probeMockTransport struct {
+	mu       sync.Mutex
+	listener net.Listener
+	addr     string
+
+	wg    sync.WaitGroup // accept + per-conn reader goroutines
+	conns []net.Conn     // every accepted conn, closed in stop()
+}
+
+func newProbeMockTransport(t *testing.T) *probeMockTransport {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return &probeMockTransport{listener: ln, addr: ln.Addr().String()}
+}
+
+func (m *probeMockTransport) Listen(addr string) (net.Listener, error) {
+	return m.listener, nil
+}
+
+func (m *probeMockTransport) Dial(addr string) (net.Conn, error) {
+	return net.Dial("tcp", m.addr)
+}
+
+func (m *probeMockTransport) Address(appID string) string { return m.addr }
+func (m *probeMockTransport) Cleanup(addr string)         {}
+
+// trackConn records conn so stop() can close it, ensuring readers don't
+// block on a dangling peer past test cleanup.
+func (m *probeMockTransport) trackConn(c net.Conn) {
+	m.mu.Lock()
+	m.conns = append(m.conns, c)
+	m.mu.Unlock()
+}
+
+// stop closes the listener and every tracked conn, then waits for all
+// spawned goroutines (accept loop, per-conn readers) to exit.
+func (m *probeMockTransport) stop() {
+	m.mu.Lock()
+	_ = m.listener.Close()
+	conns := append([]net.Conn(nil), m.conns...)
+	m.conns = nil
+	m.mu.Unlock()
+	for _, c := range conns {
+		_ = c.Close()
+	}
+	m.wg.Wait()
+}
+
+// runHealthyBus spawns a goroutine that accepts one probe + one real
+// Hello conn. The real conn is tracked so stop() closes it; the
+// goroutine exits when the listener errors or the test ends.
+func runHealthyBus(t *testing.T, m *probeMockTransport) {
+	t.Helper()
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		// Accept probe
+		probeConn, err := m.listener.Accept()
+		if err != nil {
+			return
+		}
+		m.trackConn(probeConn)
+		br := bufio.NewReader(probeConn)
+		line, _ := br.ReadBytes('\n')
+		msg, _ := protocol.Decode(bytes.TrimRight(line, "\n"))
+		if _, ok := msg.(*protocol.StatusQuery); ok {
+			_ = protocol.Encode(probeConn, protocol.NewStatusResponse(12345, 10, 0, nil))
+		}
+		_ = probeConn.Close()
+
+		// Accept the "real" conn the caller Dials after probe succeeds.
+		realConn, err := m.listener.Accept()
+		if err != nil {
+			return
+		}
+		m.trackConn(realConn)
+		// Leave it open; caller will use this for Hello. stop() will close it.
+	}()
+}
+
+// runDeadBus accepts conns but never responds to StatusQuery — simulates
+// a mid-shutdown bus where the listener is still up but the handler
+// layer isn't responsive. Tracked conns ensure readers unblock on stop.
+func runDeadBus(t *testing.T, m *probeMockTransport) {
+	t.Helper()
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		for {
+			conn, err := m.listener.Accept()
+			if err != nil {
+				return
+			}
+			m.trackConn(conn)
+			m.wg.Add(1)
+			go func(c net.Conn) {
+				defer m.wg.Done()
+				buf := make([]byte, 4096)
+				for {
+					if _, err := c.Read(buf); err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+}
+
+func TestProbeAndDialBusHealthy(t *testing.T) {
+	m := newProbeMockTransport(t)
+	t.Cleanup(m.stop)
+	runHealthyBus(t, m)
+
+	conn, err := probeAndDialBus(m, m.addr)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if conn == nil {
+		t.Fatal("expected non-nil conn")
+	}
+	conn.Close()
+}
+
+func TestProbeAndDialBusUnresponsive(t *testing.T) {
+	m := newProbeMockTransport(t)
+	t.Cleanup(m.stop)
+	runDeadBus(t, m)
+
+	start := time.Now()
+	conn, err := probeAndDialBus(m, m.addr)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected error on unresponsive bus")
+	}
+	// Should fail within ~2s deadline plus a bit of scheduling slack.
+	if elapsed > 3*time.Second {
+		t.Errorf("expected ~2s timeout, got %v", elapsed)
+	}
+}

--- a/internal/event/consume/startup_unix.go
+++ b/internal/event/consume/startup_unix.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package consume
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// applyDetachAttrs sets Unix-specific SysProcAttr so the forked bus
+// daemon detaches from the controlling terminal. Without Setsid, the
+// bus would receive SIGHUP when the parent shell exits and die with it.
+func applyDetachAttrs(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/event/consume/startup_windows.go
+++ b/internal/event/consume/startup_windows.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package consume
+
+import (
+	"os/exec"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// applyDetachAttrs sets Windows-specific SysProcAttr so the forked bus
+// daemon runs as a detached background process:
+//
+//   - DETACHED_PROCESS: no console is attached; the child does not
+//     inherit the parent's console (equivalent in spirit to Unix Setsid's
+//     "escape the controlling terminal").
+//   - CREATE_NEW_PROCESS_GROUP: the child lives in its own process group,
+//     so a Ctrl+C in the parent shell does not propagate to the bus.
+//   - HideWindow: belt-and-suspenders against any GUI/console window
+//     flashing on start (DETACHED_PROCESS should already ensure no
+//     window, but some Go stdlib paths still probe this flag).
+//
+// Windows has no fork(2); exec.Start with these flags is the standard
+// "daemonize" idiom on this platform.
+func applyDetachAttrs(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,
+	}
+}

--- a/internal/event/dedup.go
+++ b/internal/event/dedup.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	defaultDedupTTL = 5 * time.Minute
+	defaultRingSize = 10000
+)
+
+// DedupFilter provides dual-layer deduplication: TTL map + ring buffer.
+type DedupFilter struct {
+	seen map[string]time.Time
+	ring []string
+	pos  int
+	ttl  time.Duration
+	mu   sync.Mutex
+}
+
+// NewDedupFilter creates a DedupFilter with default settings.
+func NewDedupFilter() *DedupFilter {
+	return NewDedupFilterWithSize(defaultRingSize, defaultDedupTTL)
+}
+
+// NewDedupFilterWithSize creates a DedupFilter with custom ring size and TTL.
+func NewDedupFilterWithSize(ringSize int, ttl time.Duration) *DedupFilter {
+	return &DedupFilter{
+		seen: make(map[string]time.Time),
+		ring: make([]string, ringSize),
+		ttl:  ttl,
+	}
+}
+
+// IsDuplicate returns true if eventID has been seen within TTL or is in the ring buffer.
+// The ring buffer serves as a fallback for events whose TTL map entries were evicted
+// (e.g., by the ring eviction mechanism). TTL expiry always takes precedence.
+func (d *DedupFilter) IsDuplicate(eventID string) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := time.Now()
+
+	// Check TTL map first — TTL expiry takes precedence over ring presence.
+	if ts, ok := d.seen[eventID]; ok {
+		if now.Sub(ts) < d.ttl {
+			return true
+		}
+		// TTL expired: treat as not seen, remove stale entry and re-record below.
+		delete(d.seen, eventID)
+	} else {
+		// Not in TTL map — check ring buffer as fallback.
+		// This covers events evicted from the map by ring overflow but still recent.
+		for _, id := range d.ring {
+			if id == eventID {
+				// Restore to TTL map and report as duplicate.
+				d.seen[eventID] = now
+				return true
+			}
+		}
+	}
+
+	// Not seen (or TTL expired) — record it.
+	d.seen[eventID] = now
+
+	// Evict oldest entry from ring if the slot is occupied.
+	if old := d.ring[d.pos]; old != "" {
+		delete(d.seen, old)
+	}
+	d.ring[d.pos] = eventID
+	d.pos = (d.pos + 1) % len(d.ring)
+
+	// Periodic cleanup of expired TTL entries (every 1000 inserts).
+	if d.pos%1000 == 0 {
+		d.cleanupExpired(now)
+	}
+
+	return false
+}
+
+func (d *DedupFilter) cleanupExpired(now time.Time) {
+	for id, ts := range d.seen {
+		if now.Sub(ts) >= d.ttl {
+			delete(d.seen, id)
+		}
+	}
+}

--- a/internal/event/dedup_test.go
+++ b/internal/event/dedup_test.go
@@ -1,0 +1,150 @@
+package event
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDedupFilter_FirstSeen(t *testing.T) {
+	d := NewDedupFilter()
+	if d.IsDuplicate("evt-1") {
+		t.Error("first occurrence should not be duplicate")
+	}
+}
+
+func TestDedupFilter_SecondSeen(t *testing.T) {
+	d := NewDedupFilter()
+	d.IsDuplicate("evt-1")
+	if !d.IsDuplicate("evt-1") {
+		t.Error("second occurrence within TTL should be duplicate")
+	}
+}
+
+func TestDedupFilter_TTLExpiry(t *testing.T) {
+	d := NewDedupFilterWithSize(defaultRingSize, 10*time.Millisecond)
+	d.IsDuplicate("evt-1")
+	time.Sleep(20 * time.Millisecond)
+	if d.IsDuplicate("evt-1") {
+		t.Error("should not be duplicate after TTL expires")
+	}
+}
+
+func TestDedupFilter_RingBuffer(t *testing.T) {
+	d := NewDedupFilterWithSize(5, 10*time.Millisecond) // small ring + short TTL for test
+	// Fill ring buffer
+	for i := 0; i < 5; i++ {
+		d.IsDuplicate("evt-" + string(rune('a'+i)))
+	}
+	// All 5 should be duplicates (still in TTL map + ring)
+	for i := 0; i < 5; i++ {
+		if !d.IsDuplicate("evt-" + string(rune('a'+i))) {
+			t.Errorf("evt-%c should still be duplicate", rune('a'+i))
+		}
+	}
+	// Wait for TTL to expire
+	time.Sleep(20 * time.Millisecond)
+	// Push 5 more, evicting the first 5 from ring
+	for i := 5; i < 10; i++ {
+		d.IsDuplicate("evt-" + string(rune('a'+i)))
+	}
+	// After eviction + TTL expiry, first 5 should no longer be duplicates
+	for i := 0; i < 5; i++ {
+		if d.IsDuplicate("evt-" + string(rune('a'+i))) {
+			t.Errorf("evt-%c should not be duplicate after ring eviction + TTL expiry", rune('a'+i))
+		}
+	}
+}
+
+func TestDedupFilter_ConcurrentSafe(t *testing.T) {
+	d := NewDedupFilter()
+	done := make(chan struct{})
+	for i := 0; i < 100; i++ {
+		go func(id string) {
+			d.IsDuplicate(id)
+			done <- struct{}{}
+		}("evt-" + string(rune(i)))
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+}
+
+// TestDedupFilter_ConcurrentFirstSeenExactlyOnce asserts the stronger
+// invariant the existing "ConcurrentSafe" test fails to check: under
+// N concurrent writers, exactly N IsDuplicate calls observe "first
+// seen" (returned false) across the set of unique IDs — not N-1 (a
+// lost update) and not N+1 (unlikely but would mean the map + ring
+// drift). Without this, a buggy IsDuplicate that silently dropped
+// writes would still pass ConcurrentSafe.
+func TestDedupFilter_ConcurrentFirstSeenExactlyOnce(t *testing.T) {
+	const n = 200
+	d := NewDedupFilter()
+
+	ids := make([]string, n)
+	for i := 0; i < n; i++ {
+		ids[i] = "evt-unique-" + string(rune('A'+i%26)) + string(rune('a'+(i/26)%26)) + string(rune('0'+i%10))
+	}
+
+	results := make(chan bool, n)
+	for i := 0; i < n; i++ {
+		go func(id string) {
+			results <- d.IsDuplicate(id) // false on first-seen
+		}(ids[i])
+	}
+
+	firstSeen := 0
+	for i := 0; i < n; i++ {
+		if !<-results {
+			firstSeen++
+		}
+	}
+	if firstSeen != n {
+		t.Errorf("first-seen count = %d, want %d (IsDuplicate lost a write under contention)", firstSeen, n)
+	}
+
+	// Follow-up: every ID must now read as duplicate, even after the
+	// concurrent burst. Catches a class of bug where the map write and
+	// ring update race and one side loses.
+	for _, id := range ids {
+		if !d.IsDuplicate(id) {
+			t.Errorf("ID %q not flagged as duplicate on second call (map/ring inconsistency)", id)
+			break
+		}
+	}
+}
+
+// TestDedupFilter_ConcurrentRingEviction exercises the ring's eviction
+// path under concurrent writers. With ringSize=16 and 100 unique IDs,
+// eviction runs continuously; the invariant is "once evicted and TTL
+// expired, ID is no longer considered duplicate" — no deadlock, no
+// panic, no wedged-state.
+func TestDedupFilter_ConcurrentRingEviction(t *testing.T) {
+	const ringSize = 16
+	const writers = 8
+	const perWriter = 40
+	d := NewDedupFilterWithSize(ringSize, 5*time.Millisecond)
+
+	var wg sync.WaitGroup
+	wg.Add(writers)
+	for w := 0; w < writers; w++ {
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				d.IsDuplicate("evt-w" + string(rune('0'+w)) + "-" + string(rune('0'+i%10)) + string(rune('a'+i/10)))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	// After TTL expires and more writes push them out of the ring,
+	// early IDs must be re-acceptable as first-seen.
+	time.Sleep(10 * time.Millisecond)
+	for i := 0; i < ringSize*4; i++ {
+		d.IsDuplicate("evt-fill-" + string(rune('0'+i%10)) + string(rune('a'+i/10)))
+	}
+	// This old ID should have been evicted from both map (TTL) and ring (capacity).
+	if d.IsDuplicate("evt-w0-0a") {
+		t.Error("evicted ID should not be reported as duplicate")
+	}
+}

--- a/internal/event/dedup_test.go
+++ b/internal/event/dedup_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
 package event
 
 import (

--- a/internal/event/integration_test.go
+++ b/internal/event/integration_test.go
@@ -1,0 +1,386 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !windows
+
+package event_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/bus"
+	"github.com/larksuite/cli/internal/event/protocol"
+	"github.com/larksuite/cli/internal/event/source"
+	"github.com/larksuite/cli/internal/event/testutil"
+	"github.com/larksuite/cli/internal/event/transport"
+)
+
+// integNativeSchema returns a minimal SchemaDef with a Native spec for
+// integration tests that just need a valid registration.
+type integTestOut struct{ A string }
+
+func integNativeSchema() event.SchemaDef {
+	return event.SchemaDef{Native: &event.SchemaSpec{Type: reflect.TypeOf(integTestOut{})}}
+}
+
+// waitForBusReady polls tr.Dial until it succeeds, timing out after 2s.
+// Replaces opaque `time.Sleep(300ms)` after `go b.Run(ctx)` — the sleep
+// was both flaky (CI slow path sometimes needed >300ms to bind) and
+// wasteful (the common path binds in <5ms). Returns when a Dial
+// succeeds; the test keeps the conn and continues.
+func waitForBusReady(t *testing.T, tr transport.IPC, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if conn, err := tr.Dial(addr); err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("bus at %s did not come up within 2s", addr)
+}
+
+// runBus spawns `b.Run(ctx)` in a goroutine and installs a t.Cleanup
+// that verifies the bus exited cleanly. Without this, `go b.Run(ctx)`
+// fire-and-forget tests silently pass when Run fails with e.g. a listen
+// error — the consumer dial times out instead and the test failure
+// message points at the symptom, not the cause.
+func runBus(t *testing.T, b *bus.Bus, ctx context.Context) {
+	t.Helper()
+	errCh := make(chan error, 1)
+	go func() { errCh <- b.Run(ctx) }()
+	t.Cleanup(func() {
+		select {
+		case err := <-errCh:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Errorf("bus.Run returned unexpected error: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Log("bus did not exit within 2s of test cleanup (non-fatal)")
+		}
+	})
+}
+
+// mockIntegSource is an event source that emits events on demand via emit().
+// emitFn is set by Start (goroutine) and read by emit (test goroutine), so
+// they're coordinated via a sync.Mutex to keep the race detector happy.
+type mockIntegSource struct {
+	mu     sync.Mutex
+	emitFn func(*event.RawEvent)
+}
+
+func (s *mockIntegSource) Name() string { return "mock-integration" }
+
+func (s *mockIntegSource) Start(ctx context.Context, _ []string, emit func(*event.RawEvent), _ source.StatusNotifier) error {
+	s.mu.Lock()
+	s.emitFn = emit
+	s.mu.Unlock()
+	<-ctx.Done()
+	return nil
+}
+
+func (s *mockIntegSource) emit(e *event.RawEvent) {
+	s.mu.Lock()
+	fn := s.emitFn
+	s.mu.Unlock()
+	if fn != nil {
+		fn(e)
+	}
+}
+
+func TestIntegration_BusToConsume(t *testing.T) {
+	// 1. Reset registries to get a clean state.
+	event.ResetRegistryForTest()
+	source.ResetForTest()
+
+	// 2. Register a test EventKey (native so no Process func needed).
+	event.RegisterKey(event.KeyDefinition{
+		Key:       "test.event.v1",
+		EventType: "test.event.v1",
+		Schema:    integNativeSchema(),
+	})
+
+	// 3. Register a mock source that can emit events on demand.
+	mockSrc := &mockIntegSource{}
+	source.Register(mockSrc)
+
+	// 4. Create Bus with a temp socket path.
+	dir := t.TempDir()
+	addr := filepath.Join(dir, "t.sock") // short name to avoid macOS 104-char limit
+
+	tr := transport.New()
+	logger := log.New(os.Stderr, "[test-bus] ", log.LstdFlags)
+
+	testTr := testutil.NewWrappedFake(tr, addr)
+	b := bus.NewBus("test-app", "test-secret", "", testTr, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	runBus(t, b, ctx)
+	waitForBusReady(t, testTr, addr)
+
+	// 6. Connect as a consumer (dial + Hello handshake).
+	conn, err := testTr.Dial(addr)
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	hello := &protocol.Hello{
+		Type:       protocol.MsgTypeHello,
+		PID:        os.Getpid(),
+		EventKey:   "test.event.v1",
+		EventTypes: []string{"test.event.v1"},
+		Version:    "v1",
+	}
+	if err := protocol.Encode(conn, hello); err != nil {
+		t.Fatalf("encode hello: %v", err)
+	}
+
+	// Read HelloAck from Bus.
+	scanner := bufio.NewScanner(conn)
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if !scanner.Scan() {
+		t.Fatal("no hello_ack received")
+	}
+	msg, err := protocol.Decode(scanner.Bytes())
+	if err != nil {
+		t.Fatalf("decode hello_ack: %v", err)
+	}
+	ack, ok := msg.(*protocol.HelloAck)
+	if !ok {
+		t.Fatalf("expected HelloAck, got %T", msg)
+	}
+	if !ack.FirstForKey {
+		t.Error("expected first_for_key to be true")
+	}
+
+	// 7. Trigger an event from the mock source.
+	mockSrc.emit(&event.RawEvent{
+		EventID:   "evt-integration-1",
+		EventType: "test.event.v1",
+		Payload:   json.RawMessage(`{"test": true}`),
+		Timestamp: time.Now(),
+	})
+
+	// 8. Verify the event is received on the consume side.
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if !scanner.Scan() {
+		t.Fatal("no event received")
+	}
+	evtMsg, err := protocol.Decode(scanner.Bytes())
+	if err != nil {
+		t.Fatalf("decode event: %v", err)
+	}
+	evt, ok := evtMsg.(*protocol.Event)
+	if !ok {
+		t.Fatalf("expected Event, got %T", evtMsg)
+	}
+	if evt.EventType != "test.event.v1" {
+		t.Errorf("expected event_type %q, got %q", "test.event.v1", evt.EventType)
+	}
+	var payloadMap map[string]interface{}
+	if err := json.Unmarshal(evt.Payload, &payloadMap); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if v, ok := payloadMap["test"]; !ok || v != true {
+		t.Errorf("unexpected payload: %s", string(evt.Payload))
+	}
+
+	// Close consumer connection before cancelling so Bus can clean up.
+	conn.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	// Shut down cleanly. runBus's t.Cleanup waits for Run to exit.
+	cancel()
+}
+
+func TestIntegration_MultipleConsumers(t *testing.T) {
+	// Verify that events are fanned out to multiple consumers subscribed to the same event type.
+	event.ResetRegistryForTest()
+	source.ResetForTest()
+
+	event.RegisterKey(event.KeyDefinition{
+		Key:       "multi.event.v1",
+		EventType: "multi.event.v1",
+		Schema:    integNativeSchema(),
+	})
+
+	mockSrc := &mockIntegSource{}
+	source.Register(mockSrc)
+
+	dir := t.TempDir()
+	addr := filepath.Join(dir, "m.sock")
+	tr := transport.New()
+	logger := log.New(os.Stderr, "[test-multi] ", log.LstdFlags)
+
+	testTr := testutil.NewWrappedFake(tr, addr)
+	b := bus.NewBus("test-multi", "test-secret", "", testTr, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	runBus(t, b, ctx)
+	waitForBusReady(t, testTr, addr)
+
+	// Connect two consumers.
+	connectConsumer := func(name string) (net.Conn, *bufio.Scanner) {
+		conn, err := testTr.Dial(addr)
+		if err != nil {
+			t.Fatalf("dial %s: %v", name, err)
+		}
+		hello := &protocol.Hello{
+			Type:       protocol.MsgTypeHello,
+			PID:        os.Getpid(),
+			EventKey:   "multi.event.v1",
+			EventTypes: []string{"multi.event.v1"},
+			Version:    "v1",
+		}
+		protocol.Encode(conn, hello)
+		sc := bufio.NewScanner(conn)
+		conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		if !sc.Scan() {
+			t.Fatalf("%s: no hello_ack", name)
+		}
+		msg, _ := protocol.Decode(sc.Bytes())
+		if _, ok := msg.(*protocol.HelloAck); !ok {
+			t.Fatalf("%s: expected HelloAck, got %T", name, msg)
+		}
+		return conn, sc
+	}
+
+	conn1, sc1 := connectConsumer("consumer-1")
+	defer conn1.Close()
+	conn2, sc2 := connectConsumer("consumer-2")
+	defer conn2.Close()
+
+	// Small delay to ensure both are registered with the Hub.
+	time.Sleep(100 * time.Millisecond)
+
+	// Emit an event.
+	mockSrc.emit(&event.RawEvent{
+		EventID:   "evt-multi-1",
+		EventType: "multi.event.v1",
+		Payload:   json.RawMessage(`{"fan":"out"}`),
+		Timestamp: time.Now(),
+	})
+
+	// Both consumers should receive it.
+	for _, tc := range []struct {
+		name string
+		conn net.Conn
+		sc   *bufio.Scanner
+	}{
+		{"consumer-1", conn1, sc1},
+		{"consumer-2", conn2, sc2},
+	} {
+		tc.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		if !tc.sc.Scan() {
+			t.Fatalf("%s: no event received", tc.name)
+		}
+		evtMsg, err := protocol.Decode(tc.sc.Bytes())
+		if err != nil {
+			t.Fatalf("%s: decode event: %v", tc.name, err)
+		}
+		evt, ok := evtMsg.(*protocol.Event)
+		if !ok {
+			t.Fatalf("%s: expected Event, got %T", tc.name, evtMsg)
+		}
+		if evt.EventType != "multi.event.v1" {
+			t.Errorf("%s: expected event_type %q, got %q", tc.name, "multi.event.v1", evt.EventType)
+		}
+	}
+
+	cancel()
+}
+
+func TestIntegration_DedupFilter(t *testing.T) {
+	// Verify that duplicate events (same EventID) are not delivered twice.
+	event.ResetRegistryForTest()
+	source.ResetForTest()
+
+	event.RegisterKey(event.KeyDefinition{
+		Key:       "dedup.event.v1",
+		EventType: "dedup.event.v1",
+		Schema:    integNativeSchema(),
+	})
+
+	mockSrc := &mockIntegSource{}
+	source.Register(mockSrc)
+
+	dir := t.TempDir()
+	addr := filepath.Join(dir, "d.sock")
+	tr := transport.New()
+	logger := log.New(os.Stderr, "[test-dedup] ", log.LstdFlags)
+
+	testTr := testutil.NewWrappedFake(tr, addr)
+	b := bus.NewBus("test-dedup", "test-secret", "", testTr, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	runBus(t, b, ctx)
+	waitForBusReady(t, testTr, addr)
+
+	conn, err := testTr.Dial(addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	hello := &protocol.Hello{
+		Type:       protocol.MsgTypeHello,
+		PID:        os.Getpid(),
+		EventKey:   "dedup.event.v1",
+		EventTypes: []string{"dedup.event.v1"},
+		Version:    "v1",
+	}
+	protocol.Encode(conn, hello)
+	sc := bufio.NewScanner(conn)
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if !sc.Scan() {
+		t.Fatal("no hello_ack")
+	}
+
+	// Emit the same event twice (same EventID).
+	for i := 0; i < 2; i++ {
+		mockSrc.emit(&event.RawEvent{
+			EventID:   "evt-dedup-same",
+			EventType: "dedup.event.v1",
+			Payload:   json.RawMessage(`{"dup": true}`),
+			Timestamp: time.Now(),
+		})
+	}
+
+	// Should receive exactly one event.
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if !sc.Scan() {
+		t.Fatal("expected at least one event")
+	}
+	evtMsg, _ := protocol.Decode(sc.Bytes())
+	if _, ok := evtMsg.(*protocol.Event); !ok {
+		t.Fatalf("expected Event, got %T", evtMsg)
+	}
+
+	// Second read should timeout (no duplicate delivered).
+	conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	if sc.Scan() {
+		t.Error("received duplicate event; dedup filter should have blocked it")
+	}
+
+	cancel()
+}

--- a/internal/event/protocol/codec.go
+++ b/internal/event/protocol/codec.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package protocol defines the newline-delimited JSON wire format the
+// bus and consume client use to exchange events and lifecycle messages
+// over an IPC socket.
+package protocol
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"time"
+)
+
+// MaxFrameBytes caps the size of a single wire frame on read. Reached
+// values come from legitimate consumer Hello / bus StatusResponse with
+// many consumers / large event payloads; 1 MB is comfortable upper
+// bound. Oversized frames (whether from a hostile local process or a
+// runaway upstream event) are rejected rather than allowed to grow the
+// reader's buffer unbounded and OOM the process.
+const MaxFrameBytes = 1 << 20
+
+// WriteTimeout is the deadline applied to every write of a control
+// message (Hello, HelloAck, StatusQuery/Response, Shutdown,
+// PreShutdownCheck/Ack). Prevents a wedged peer kernel buffer from
+// stalling a writer indefinitely.
+const WriteTimeout = 5 * time.Second
+
+// typeEnvelope is used to peek at the "type" field before full decode.
+type typeEnvelope struct {
+	Type string `json:"type"`
+}
+
+// Encode writes a message as a single JSON line followed by \n.
+func Encode(w io.Writer, msg interface{}) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("protocol encode: %w", err)
+	}
+	data = append(data, '\n')
+	_, err = w.Write(data)
+	return err
+}
+
+// EncodeWithDeadline wraps Encode with a WriteDeadline on conn so the
+// write can't block forever on a wedged peer.
+func EncodeWithDeadline(conn net.Conn, msg interface{}, timeout time.Duration) error {
+	if err := conn.SetWriteDeadline(time.Now().Add(timeout)); err != nil {
+		return err
+	}
+	return Encode(conn, msg)
+}
+
+// ReadFrame reads one newline-delimited message from br, rejecting
+// frames larger than MaxFrameBytes with a size-cap error. Replaces the
+// raw `br.ReadBytes('\n')` pattern which grows the internal buffer
+// unbounded — a DoS vector any local peer could trigger by writing
+// without a newline.
+func ReadFrame(br *bufio.Reader) ([]byte, error) {
+	var buf []byte
+	for {
+		chunk, err := br.ReadSlice('\n')
+		switch err {
+		case nil:
+			if len(buf) == 0 {
+				// Fast path: whole frame fit in br's internal buffer.
+				return chunk, nil
+			}
+			if len(buf)+len(chunk) > MaxFrameBytes {
+				return nil, fmt.Errorf("protocol: frame exceeds %d bytes", MaxFrameBytes)
+			}
+			return append(buf, chunk...), nil
+		case bufio.ErrBufferFull:
+			if len(buf)+len(chunk) > MaxFrameBytes {
+				return nil, fmt.Errorf("protocol: frame exceeds %d bytes", MaxFrameBytes)
+			}
+			buf = append(buf, chunk...)
+		default:
+			return nil, err
+		}
+	}
+}
+
+// Decode parses a single JSON line into the appropriate message type.
+func Decode(line []byte) (interface{}, error) {
+	var env typeEnvelope
+	if err := json.Unmarshal(line, &env); err != nil {
+		return nil, fmt.Errorf("protocol decode type: %w", err)
+	}
+
+	var msg interface{}
+	switch env.Type {
+	case MsgTypeHello:
+		msg = &Hello{}
+	case MsgTypeHelloAck:
+		msg = &HelloAck{}
+	case MsgTypeEvent:
+		msg = &Event{}
+	case MsgTypeBye:
+		msg = &Bye{}
+	case MsgTypePreShutdownCheck:
+		msg = &PreShutdownCheck{}
+	case MsgTypePreShutdownAck:
+		msg = &PreShutdownAck{}
+	case MsgTypeStatusQuery:
+		msg = &StatusQuery{}
+	case MsgTypeStatusResponse:
+		msg = &StatusResponse{}
+	case MsgTypeShutdown:
+		msg = &Shutdown{}
+	case MsgTypeSourceStatus:
+		msg = &SourceStatus{}
+	default:
+		return nil, fmt.Errorf("protocol: unknown message type %q", env.Type)
+	}
+
+	if err := json.Unmarshal(line, msg); err != nil {
+		return nil, fmt.Errorf("protocol decode %s: %w", env.Type, err)
+	}
+	return msg, nil
+}

--- a/internal/event/protocol/codec_test.go
+++ b/internal/event/protocol/codec_test.go
@@ -1,0 +1,76 @@
+package protocol
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestEncodeDecodeHello(t *testing.T) {
+	msg := &Hello{
+		Type:       MsgTypeHello,
+		PID:        12345,
+		EventKey:   "mail.user_mailbox.event.message_received_v1",
+		EventTypes: []string{"mail.user_mailbox.event.message_received_v1"},
+		Version:    "v1",
+	}
+
+	var buf bytes.Buffer
+	if err := Encode(&buf, msg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	decoded, err := Decode(buf.Bytes())
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	hello, ok := decoded.(*Hello)
+	if !ok {
+		t.Fatalf("expected *Hello, got %T", decoded)
+	}
+	if hello.PID != 12345 || hello.EventKey != "mail.user_mailbox.event.message_received_v1" {
+		t.Errorf("unexpected hello: %+v", hello)
+	}
+}
+
+func TestEncodeDecodeEvent(t *testing.T) {
+	payload := json.RawMessage(`{"foo":"bar"}`)
+	msg := &Event{
+		Type:      MsgTypeEvent,
+		EventType: "im.message.receive_v1",
+		Payload:   payload,
+	}
+
+	var buf bytes.Buffer
+	if err := Encode(&buf, msg); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	decoded, err := Decode(buf.Bytes())
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	evt, ok := decoded.(*Event)
+	if !ok {
+		t.Fatalf("expected *Event, got %T", decoded)
+	}
+	if evt.EventType != "im.message.receive_v1" {
+		t.Errorf("got event_type %q", evt.EventType)
+	}
+}
+
+func TestEncodeAddsNewline(t *testing.T) {
+	msg := &Bye{Type: MsgTypeBye}
+	var buf bytes.Buffer
+	Encode(&buf, msg)
+	if buf.Bytes()[buf.Len()-1] != '\n' {
+		t.Error("encoded message should end with newline")
+	}
+}
+
+func TestDecodeUnknownType(t *testing.T) {
+	_, err := Decode([]byte(`{"type":"unknown_xyz"}`))
+	if err == nil {
+		t.Error("expected error for unknown type")
+	}
+}

--- a/internal/event/protocol/codec_test.go
+++ b/internal/event/protocol/codec_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
 package protocol
 
 import (

--- a/internal/event/protocol/messages.go
+++ b/internal/event/protocol/messages.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package protocol
+
+import "encoding/json"
+
+// Message type constants.
+const (
+	MsgTypeHello            = "hello"
+	MsgTypeHelloAck         = "hello_ack"
+	MsgTypeEvent            = "event"
+	MsgTypeBye              = "bye"
+	MsgTypePreShutdownCheck = "pre_shutdown_check"
+	MsgTypePreShutdownAck   = "pre_shutdown_ack"
+	MsgTypeStatusQuery      = "status_query"
+	MsgTypeStatusResponse   = "status_response"
+	MsgTypeShutdown         = "shutdown"
+	MsgTypeSourceStatus     = "source_status"
+)
+
+// Source state constants (SourceStatus.State).
+const (
+	SourceStateConnecting   = "connecting"
+	SourceStateConnected    = "connected"
+	SourceStateDisconnected = "disconnected"
+	SourceStateReconnecting = "reconnecting"
+)
+
+// SourceStatus is sent Bus → consume to surface WebSocket / source-level
+// lifecycle events to the user. Best-effort: the hub drops the message
+// when a consumer's send channel is full.
+type SourceStatus struct {
+	Type   string `json:"type"`
+	Source string `json:"source"` // e.g. "feishu-websocket"
+	State  string `json:"state"`
+	Detail string `json:"detail,omitempty"` // free-form, e.g. "attempt 1", "connection reset by peer"
+}
+
+// Hello is sent by consume → Bus on connect.
+type Hello struct {
+	Type       string   `json:"type"`
+	PID        int      `json:"pid"`
+	EventKey   string   `json:"event_key"`
+	EventTypes []string `json:"event_types"`
+	Version    string   `json:"version"`
+}
+
+// HelloAck is sent by Bus → consume after Hello.
+type HelloAck struct {
+	Type        string `json:"type"`
+	BusVersion  string `json:"bus_version"`
+	FirstForKey bool   `json:"first_for_key"`
+}
+
+// Event is sent by Bus → consume for each routed event.
+//
+// EventID and SourceTime replicate the corresponding fields on the upstream
+// RawEvent so the consumer can attribute each message without having to
+// peek into the Feishu-specific envelope inside Payload. Both are omitted
+// from the wire when empty (omitempty) so old consumers reading new bytes
+// simply ignore them (Go's default JSON unmarshal behaviour).
+//
+// Seq is a per-connection monotonically increasing counter assigned by
+// Hub.Publish. A gap in the seq stream at the consumer side means the bus
+// dropped events via the drop-oldest backpressure path on sendCh; the
+// consumer logs a WARN with the gap size so silent data loss is detectable.
+type Event struct {
+	Type       string          `json:"type"`
+	EventType  string          `json:"event_type"`
+	EventID    string          `json:"event_id,omitempty"`
+	SourceTime string          `json:"source_time,omitempty"` // ms-precision unix timestamp, stringified
+	Seq        uint64          `json:"seq,omitempty"`
+	Payload    json.RawMessage `json:"payload"`
+}
+
+// Bye is sent by consume → Bus before graceful disconnect.
+type Bye struct {
+	Type string `json:"type"`
+}
+
+// PreShutdownCheck is sent by consume → Bus to atomically reserve a
+// cleanup lock for the consumer's EventKey. Bus replies with
+// PreShutdownAck{LastForKey}. A true ack means the caller has exclusive
+// cleanup rights until it disconnects (or the bus releases on its
+// behalf); false means another subscriber beat us and cleanup should not
+// run. See checkLastForKey in internal/event/consume/shutdown.go for the
+// caller semantics and internal/event/bus/hub.go AcquireCleanupLock for
+// the bus-side atomicity guarantee.
+type PreShutdownCheck struct {
+	Type     string `json:"type"`
+	EventKey string `json:"event_key"`
+}
+
+// PreShutdownAck is sent by Bus → consume in response to PreShutdownCheck.
+// LastForKey=true means "you acquired the cleanup reservation". Under the
+// current protocol this is equivalent to "you were the last subscriber at
+// the time of the ack AND no concurrent cleanup was in progress".
+type PreShutdownAck struct {
+	Type       string `json:"type"`
+	LastForKey bool   `json:"last_for_key"`
+}
+
+// StatusQuery is sent by "event stop/status" → Bus.
+type StatusQuery struct {
+	Type string `json:"type"`
+}
+
+// ConsumerInfo describes a single connected consumer.
+type ConsumerInfo struct {
+	PID      int    `json:"pid"`
+	EventKey string `json:"event_key"`
+	Received int64  `json:"received"` // events fanned out by Hub to this consumer
+	Dropped  int64  `json:"dropped"`  // events evicted by drop-oldest backpressure on this conn
+}
+
+// StatusResponse is sent by Bus → "event stop/status".
+type StatusResponse struct {
+	Type        string         `json:"type"`
+	PID         int            `json:"pid"`
+	UptimeSec   int            `json:"uptime_sec"`
+	ActiveConns int            `json:"active_conns"`
+	Consumers   []ConsumerInfo `json:"consumers"`
+}
+
+// Shutdown is sent by "event stop" → Bus to request graceful shutdown.
+type Shutdown struct {
+	Type string `json:"type"`
+}
+
+// ----- Constructors -----
+//
+// These helpers set Type automatically so callers can't silently produce
+// messages missing the discriminator (the wire format requires `type` —
+// Decode rejects messages without it). Prefer these over struct literals
+// in production code; tests may still use literals when they deliberately
+// exercise malformed frames.
+
+// NewHello creates a Hello message with Type pre-filled.
+func NewHello(pid int, eventKey string, eventTypes []string, version string) *Hello {
+	return &Hello{
+		Type:       MsgTypeHello,
+		PID:        pid,
+		EventKey:   eventKey,
+		EventTypes: eventTypes,
+		Version:    version,
+	}
+}
+
+// NewHelloAck creates a HelloAck with Type pre-filled.
+func NewHelloAck(busVersion string, firstForKey bool) *HelloAck {
+	return &HelloAck{
+		Type:        MsgTypeHelloAck,
+		BusVersion:  busVersion,
+		FirstForKey: firstForKey,
+	}
+}
+
+// NewEvent creates an Event with Type pre-filled.
+func NewEvent(eventType, eventID, sourceTime string, seq uint64, payload json.RawMessage) *Event {
+	return &Event{
+		Type:       MsgTypeEvent,
+		EventType:  eventType,
+		EventID:    eventID,
+		SourceTime: sourceTime,
+		Seq:        seq,
+		Payload:    payload,
+	}
+}
+
+// NewPreShutdownCheck creates a PreShutdownCheck with Type pre-filled.
+func NewPreShutdownCheck(eventKey string) *PreShutdownCheck {
+	return &PreShutdownCheck{Type: MsgTypePreShutdownCheck, EventKey: eventKey}
+}
+
+// NewPreShutdownAck creates a PreShutdownAck with Type pre-filled.
+func NewPreShutdownAck(lastForKey bool) *PreShutdownAck {
+	return &PreShutdownAck{Type: MsgTypePreShutdownAck, LastForKey: lastForKey}
+}
+
+// NewStatusQuery creates a StatusQuery message.
+func NewStatusQuery() *StatusQuery {
+	return &StatusQuery{Type: MsgTypeStatusQuery}
+}
+
+// NewStatusResponse creates a StatusResponse with Type pre-filled.
+func NewStatusResponse(pid int, uptimeSec int, activeConns int, consumers []ConsumerInfo) *StatusResponse {
+	return &StatusResponse{
+		Type:        MsgTypeStatusResponse,
+		PID:         pid,
+		UptimeSec:   uptimeSec,
+		ActiveConns: activeConns,
+		Consumers:   consumers,
+	}
+}
+
+// NewShutdown creates a Shutdown message.
+func NewShutdown() *Shutdown { return &Shutdown{Type: MsgTypeShutdown} }
+
+// NewSourceStatus creates a SourceStatus with Type pre-filled.
+func NewSourceStatus(source, state, detail string) *SourceStatus {
+	return &SourceStatus{
+		Type:   MsgTypeSourceStatus,
+		Source: source,
+		State:  state,
+		Detail: detail,
+	}
+}

--- a/internal/event/registry.go
+++ b/internal/event/registry.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+var (
+	keys = map[string]*KeyDefinition{}
+	mu   sync.RWMutex
+)
+
+// RegisterKey adds an KeyDefinition to the global registry.
+// Panics on duplicates, empty EventType, or Schema/Process contract
+// violations (see SchemaDef docs).
+func RegisterKey(def KeyDefinition) {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if _, exists := keys[def.Key]; exists {
+		panic(fmt.Sprintf("duplicate EventKey: %s", def.Key))
+	}
+	if def.EventType == "" {
+		panic(fmt.Sprintf("EventKey %s: EventType must not be empty", def.Key))
+	}
+
+	validateSchema(def)
+	validateParams(def)
+	validateAuth(def)
+
+	if def.BufferSize > MaxBufferSize {
+		def.BufferSize = MaxBufferSize
+	}
+	if def.BufferSize <= 0 {
+		def.BufferSize = DefaultBufferSize
+	}
+	if def.Workers <= 0 {
+		def.Workers = 1
+	}
+	keys[def.Key] = &def
+}
+
+// validateSchema enforces the Native / Custom / Process invariants documented
+// on SchemaDef. Exactly one of Native or Custom must be set; Native is
+// incompatible with Process (Process produces a complete shape — use Custom).
+func validateSchema(def KeyDefinition) {
+	nativeSet := def.Schema.Native != nil
+	customSet := def.Schema.Custom != nil
+	if nativeSet && customSet {
+		panic(fmt.Sprintf("EventKey %s: Schema.Native and Schema.Custom are mutually exclusive", def.Key))
+	}
+	if !nativeSet && !customSet {
+		panic(fmt.Sprintf("EventKey %s: Schema requires either Native or Custom", def.Key))
+	}
+	if nativeSet && def.Process != nil {
+		panic(fmt.Sprintf("EventKey %s: Schema.Native forbids Process (Process produces a complete shape — use Schema.Custom)", def.Key))
+	}
+	if spec := def.Schema.Native; spec != nil {
+		validateSpec(def.Key, "Schema.Native", spec)
+	}
+	if spec := def.Schema.Custom; spec != nil {
+		validateSpec(def.Key, "Schema.Custom", spec)
+	}
+}
+
+// validateSpec requires exactly one of Type or Raw on a SchemaSpec.
+func validateSpec(key, field string, s *SchemaSpec) {
+	typeSet := s.Type != nil
+	rawSet := len(s.Raw) > 0
+	if typeSet == rawSet { // both set OR both empty
+		panic(fmt.Sprintf("EventKey %s: %s requires exactly one of Type or Raw", key, field))
+	}
+}
+
+// validateParams checks that Enum/Multi params have non-empty Values and
+// every value has a non-empty Desc (AI consumers need Desc to decide).
+func validateParams(def KeyDefinition) {
+	for _, p := range def.Params {
+		switch p.Type {
+		case "", ParamString, ParamBool, ParamInt:
+			// no Values required
+		case ParamEnum, ParamMulti:
+			if len(p.Values) == 0 {
+				panic(fmt.Sprintf("EventKey %s: param %q type %q requires Values", def.Key, p.Name, p.Type))
+			}
+			for _, v := range p.Values {
+				if v.Desc == "" {
+					panic(fmt.Sprintf("EventKey %s: param %q value %q requires non-empty Desc", def.Key, p.Name, v.Value))
+				}
+			}
+		default:
+			panic(fmt.Sprintf("EventKey %s: param %q has unknown type %q", def.Key, p.Name, p.Type))
+		}
+	}
+}
+
+func validateAuth(def KeyDefinition) {
+	for _, t := range def.AuthTypes {
+		if t != "user" && t != "bot" {
+			panic(fmt.Sprintf("EventKey %s: AuthTypes elements must be \"user\" or \"bot\"; got %q", def.Key, t))
+		}
+	}
+}
+
+// Lookup returns the definition for a given EventKey.
+func Lookup(key string) (*KeyDefinition, bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	def, ok := keys[key]
+	return def, ok
+}
+
+// ListAll returns all registered KeyDefinitions sorted by Key.
+func ListAll() []*KeyDefinition {
+	mu.RLock()
+	defer mu.RUnlock()
+	result := make([]*KeyDefinition, 0, len(keys))
+	for _, def := range keys {
+		result = append(result, def)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Key < result[j].Key
+	})
+	return result
+}
+
+// resetRegistry clears the registry (for testing only).
+func resetRegistry() {
+	mu.Lock()
+	defer mu.Unlock()
+	keys = map[string]*KeyDefinition{}
+}
+
+// ResetRegistryForTest clears the registry. Only for testing.
+func ResetRegistryForTest() { resetRegistry() }
+
+// UnregisterKeyForTest removes a single EventKey from the registry without
+// affecting others. Use this (not ResetRegistryForTest) in tests that
+// register a synthetic key alongside production keys — otherwise -count=N
+// reruns will either panic on duplicate registration or wipe keys that
+// other tests depend on.
+func UnregisterKeyForTest(key string) {
+	mu.Lock()
+	defer mu.Unlock()
+	delete(keys, key)
+}

--- a/internal/event/registry_test.go
+++ b/internal/event/registry_test.go
@@ -1,0 +1,245 @@
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// mustPanic is a test helper: use with defer right before the call that
+// should panic. Verifies the panic message contains `substring`.
+func mustPanic(t *testing.T, substring string) {
+	t.Helper()
+	r := recover()
+	if r == nil {
+		t.Fatal("expected panic, got none")
+	}
+	msg, _ := r.(string)
+	if msg == "" {
+		if err, ok := r.(error); ok {
+			msg = err.Error()
+		} else {
+			msg = fmt.Sprintf("%v", r)
+		}
+	}
+	if !strings.Contains(msg, substring) {
+		t.Errorf("panic %q does not contain %q", msg, substring)
+	}
+}
+
+type emptyOut struct {
+	A string `json:"a"`
+}
+
+func nativeSchema() SchemaDef {
+	return SchemaDef{Native: &SchemaSpec{Type: reflect.TypeOf(emptyOut{})}}
+}
+
+func customSchema() SchemaDef {
+	return SchemaDef{Custom: &SchemaSpec{Type: reflect.TypeOf(emptyOut{})}}
+}
+
+func customProcess() func(context.Context, APIClient, *RawEvent, map[string]string) (json.RawMessage, error) {
+	return func(context.Context, APIClient, *RawEvent, map[string]string) (json.RawMessage, error) {
+		return nil, nil
+	}
+}
+
+func TestRegisterKey_NativeOnly(t *testing.T) {
+	resetRegistry()
+	RegisterKey(KeyDefinition{
+		Key:       "t.native",
+		EventType: "t.native",
+		Schema:    nativeSchema(),
+	})
+	def, ok := Lookup("t.native")
+	if !ok {
+		t.Fatal("Lookup failed")
+	}
+	if def.Schema.Native == nil {
+		t.Fatal("Native not stored")
+	}
+	if def.Process != nil {
+		t.Error("Process should be nil for Native")
+	}
+}
+
+func TestRegisterKey_CustomWithProcess(t *testing.T) {
+	resetRegistry()
+	RegisterKey(KeyDefinition{
+		Key:       "t.custom",
+		EventType: "t.custom",
+		Schema:    customSchema(),
+		Process:   customProcess(),
+	})
+	def, ok := Lookup("t.custom")
+	if !ok {
+		t.Fatal("Lookup failed")
+	}
+	if def.Schema.Custom == nil {
+		t.Fatal("Custom not stored")
+	}
+	if def.Process == nil {
+		t.Error("Process should be set")
+	}
+}
+
+func TestRegisterKey_DuplicatePanics(t *testing.T) {
+	resetRegistry()
+	RegisterKey(KeyDefinition{Key: "t.dup", EventType: "t.dup", Schema: nativeSchema()})
+	defer mustPanic(t, "duplicate EventKey")
+	RegisterKey(KeyDefinition{Key: "t.dup", EventType: "t.dup", Schema: nativeSchema()})
+}
+
+func TestRegisterKey_EmptyEventTypePanics(t *testing.T) {
+	resetRegistry()
+	defer mustPanic(t, "EventType must not be empty")
+	RegisterKey(KeyDefinition{Key: "t.no_type", Schema: nativeSchema()})
+}
+
+func TestRegisterKey_PanicsWhenBothSchemasSet(t *testing.T) {
+	resetRegistry()
+	defer mustPanic(t, "mutually exclusive")
+	RegisterKey(KeyDefinition{
+		Key:       "t.both",
+		EventType: "t.both",
+		Schema: SchemaDef{
+			Native: &SchemaSpec{Type: reflect.TypeOf(emptyOut{})},
+			Custom: &SchemaSpec{Type: reflect.TypeOf(emptyOut{})},
+		},
+	})
+}
+
+func TestRegisterKey_PanicsWhenNoSchemaSet(t *testing.T) {
+	resetRegistry()
+	defer mustPanic(t, "Schema requires either Native or Custom")
+	RegisterKey(KeyDefinition{Key: "t.empty", EventType: "t.empty"})
+}
+
+func TestRegisterKey_PanicsWhenNativeWithProcess(t *testing.T) {
+	resetRegistry()
+	defer mustPanic(t, "Schema.Native forbids Process")
+	RegisterKey(KeyDefinition{
+		Key:       "t.badcombo",
+		EventType: "t.badcombo",
+		Schema:    nativeSchema(),
+		Process:   customProcess(),
+	})
+}
+
+func TestRegisterKey_PanicsWhenSpecHasBothTypeAndRaw(t *testing.T) {
+	resetRegistry()
+	defer mustPanic(t, "requires exactly one of Type or Raw")
+	RegisterKey(KeyDefinition{
+		Key:       "t.bothsrc",
+		EventType: "t.bothsrc",
+		Schema: SchemaDef{
+			Custom: &SchemaSpec{Type: reflect.TypeOf(emptyOut{}), Raw: json.RawMessage(`{}`)},
+		},
+	})
+}
+
+func TestRegisterKey_PanicsWhenSpecHasNeitherTypeNorRaw(t *testing.T) {
+	resetRegistry()
+	defer mustPanic(t, "requires exactly one of Type or Raw")
+	RegisterKey(KeyDefinition{
+		Key:       "t.nosrc",
+		EventType: "t.nosrc",
+		Schema: SchemaDef{
+			Custom: &SchemaSpec{},
+		},
+	})
+}
+
+func TestRegisterKey_ParamMultiRequiresValues(t *testing.T) {
+	resetRegistry()
+	defer mustPanic(t, "requires Values")
+	RegisterKey(KeyDefinition{
+		Key:       "t.paramnovalues",
+		EventType: "t.paramnovalues",
+		Schema:    nativeSchema(),
+		Params:    []ParamDef{{Name: "fields", Type: ParamMulti}},
+	})
+}
+
+func TestRegisterKey_ParamEnumRequiresValues(t *testing.T) {
+	resetRegistry()
+	defer mustPanic(t, "requires Values")
+	RegisterKey(KeyDefinition{
+		Key:       "t.enumnovalues",
+		EventType: "t.enumnovalues",
+		Schema:    nativeSchema(),
+		Params:    []ParamDef{{Name: "mode", Type: ParamEnum}},
+	})
+}
+
+func TestRegisterKey_ParamValueRequiresDesc(t *testing.T) {
+	resetRegistry()
+	defer mustPanic(t, "requires non-empty Desc")
+	RegisterKey(KeyDefinition{
+		Key:       "t.paramdesc",
+		EventType: "t.paramdesc",
+		Schema:    nativeSchema(),
+		Params: []ParamDef{{
+			Name:   "f",
+			Type:   ParamEnum,
+			Values: []ParamValue{{Value: "x"}},
+		}},
+	})
+}
+
+func TestRegisterKey_UnknownParamType(t *testing.T) {
+	resetRegistry()
+	defer mustPanic(t, "unknown type")
+	RegisterKey(KeyDefinition{
+		Key:       "t.badtype",
+		EventType: "t.badtype",
+		Schema:    nativeSchema(),
+		Params:    []ParamDef{{Name: "x", Type: ParamType("wtf")}},
+	})
+}
+
+func TestRegisterKey_InvalidAuthTypesPanics(t *testing.T) {
+	resetRegistry()
+	defer mustPanic(t, "AuthTypes elements must be")
+	RegisterKey(KeyDefinition{
+		Key:       "t.badauth",
+		EventType: "t.badauth",
+		Schema:    nativeSchema(),
+		AuthTypes: []string{"invalid"},
+	})
+}
+
+func TestRegisterKey_ValidAuthTypes(t *testing.T) {
+	resetRegistry()
+	RegisterKey(KeyDefinition{Key: "u.e", EventType: "u.e", Schema: nativeSchema(), AuthTypes: []string{"user"}})
+	RegisterKey(KeyDefinition{Key: "b.e", EventType: "b.e", Schema: nativeSchema(), AuthTypes: []string{"bot"}})
+	RegisterKey(KeyDefinition{Key: "ub.e", EventType: "ub.e", Schema: nativeSchema(), AuthTypes: []string{"bot", "user"}})
+	RegisterKey(KeyDefinition{Key: "na.e", EventType: "na.e", Schema: nativeSchema()})
+}
+
+func TestListAll_SortedByKey(t *testing.T) {
+	resetRegistry()
+	RegisterKey(KeyDefinition{Key: "z.event", EventType: "z", Schema: nativeSchema()})
+	RegisterKey(KeyDefinition{Key: "a.event", EventType: "a", Schema: nativeSchema()})
+	RegisterKey(KeyDefinition{Key: "m.event", EventType: "m", Schema: nativeSchema()})
+	all := ListAll()
+	if len(all) != 3 || all[0].Key != "a.event" || all[1].Key != "m.event" || all[2].Key != "z.event" {
+		t.Errorf("keys not sorted: %v", []string{all[0].Key, all[1].Key, all[2].Key})
+	}
+}
+
+func TestBufferSize_Clamped(t *testing.T) {
+	resetRegistry()
+	RegisterKey(KeyDefinition{
+		Key: "big", EventType: "big", Schema: nativeSchema(),
+		BufferSize: 5000,
+	})
+	def, _ := Lookup("big")
+	if def.BufferSize != MaxBufferSize {
+		t.Errorf("BufferSize = %d, want %d", def.BufferSize, MaxBufferSize)
+	}
+}

--- a/internal/event/registry_test.go
+++ b/internal/event/registry_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
 package event
 
 import (

--- a/internal/event/schemas/envelope.go
+++ b/internal/event/schemas/envelope.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package schemas
+
+import "encoding/json"
+
+// v2Envelope is the JSON Schema for the Feishu V2 event envelope. Native
+// EventKeys deliver payloads in this shape; WrapV2Envelope splices a
+// specific body schema into the `event` property.
+//
+// This is a wire-format contract with the server, not a Go struct we
+// could reflect — if upstream introduces V3 or changes header fields,
+// this constant needs a bump. Source of truth:
+// https://open.feishu.cn/document/server-docs/event-subscription-guide/overview
+var v2Envelope = map[string]interface{}{
+	"type":        "object",
+	"description": "飞书事件",
+	"properties": map[string]interface{}{
+		"schema": map[string]interface{}{
+			"type":        "string",
+			"enum":        []string{"2.0"},
+			"description": "飞书事件协议版本",
+		},
+		"header": map[string]interface{}{
+			"type":        "object",
+			"description": "事件头，所有事件结构一致",
+			"properties": map[string]interface{}{
+				"event_id":    map[string]string{"type": "string", "description": "事件唯一 ID"},
+				"event_type":  map[string]string{"type": "string", "description": "事件类型，用于路由"},
+				"create_time": map[string]string{"type": "string", "description": "事件创建时间，毫秒时间戳字符串"},
+				"token":       map[string]string{"type": "string", "description": "回调校验 token"},
+				"tenant_key":  map[string]string{"type": "string", "description": "租户唯一标识"},
+				"app_id":      map[string]string{"type": "string", "description": "接收事件的应用 ID"},
+			},
+		},
+	},
+}
+
+// WrapV2Envelope returns a JSON Schema that describes the V2 envelope
+// with body spliced in as the `event` property. If body can't be parsed
+// it's returned unchanged.
+func WrapV2Envelope(body json.RawMessage) json.RawMessage {
+	var parsed interface{}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return body
+	}
+	envelope := map[string]interface{}{}
+	for k, v := range v2Envelope {
+		envelope[k] = v
+	}
+	// Rebuild properties so the caller's body goes into `event` without
+	// mutating the package-level template.
+	props := map[string]interface{}{}
+	for k, v := range v2Envelope["properties"].(map[string]interface{}) {
+		props[k] = v
+	}
+	props["event"] = parsed
+	envelope["properties"] = props
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		return body
+	}
+	return data
+}

--- a/internal/event/schemas/fromtype.go
+++ b/internal/event/schemas/fromtype.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package schemas derives JSON Schema fragments from Go types via reflection.
+//
+// The intended use case is translating typed event structs from the open
+// Feishu SDK (e.g. larkim.P2MessageReadV1Data) into a JSON Schema that
+// describes the shape of the `event` body an EventKey delivers. Domain
+// packages register event keys with an SDK type reference; framework code
+// calls FromType to produce the schema at lookup time.
+//
+// Only publicly exported fields with a `json` tag (or the field name) are
+// included. Unexported fields, embedded anonymous structs, and fields
+// tagged `json:"-"` are skipped.
+package schemas
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"sync"
+)
+
+// FromType returns a JSON Schema describing the shape of the given Go type.
+// The result is cached per reflect.Type.
+func FromType(t reflect.Type) json.RawMessage {
+	if t == nil {
+		return nil
+	}
+	if cached, ok := cacheLoad(t); ok {
+		return cached
+	}
+	// localCache is shared across reflection recursion so a shared subtype
+	// (e.g. UserID referenced from multiple event structs in the same root)
+	// is only walked once. Scoped per FromType call to avoid coupling the
+	// package-level cache (which stores marshaled JSON) to the intermediate
+	// *schemaNode tree.
+	localCache := map[reflect.Type]*schemaNode{}
+	node := reflectSchema(t, map[reflect.Type]bool{}, localCache)
+	out, err := json.Marshal(node)
+	if err != nil {
+		return nil
+	}
+	raw := json.RawMessage(out)
+	cacheStore(t, raw)
+	return raw
+}
+
+var (
+	cacheMu sync.RWMutex
+	cache   = map[reflect.Type]json.RawMessage{}
+)
+
+func cacheLoad(t reflect.Type) (json.RawMessage, bool) {
+	cacheMu.RLock()
+	defer cacheMu.RUnlock()
+	v, ok := cache[t]
+	return v, ok
+}
+
+func cacheStore(t reflect.Type, v json.RawMessage) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	cache[t] = v
+}
+
+// schemaNode is the internal building block we marshal to JSON. Keys use
+// JSON Schema naming so the marshaled output is directly usable.
+type schemaNode struct {
+	Type                 string                 `json:"type,omitempty"`
+	Description          string                 `json:"description,omitempty"`
+	Enum                 []string               `json:"enum,omitempty"`
+	Format               string                 `json:"format,omitempty"`
+	Properties           map[string]*schemaNode `json:"properties,omitempty"`
+	Items                *schemaNode            `json:"items,omitempty"`
+	AdditionalProperties *schemaNode            `json:"additionalProperties,omitempty"`
+}
+
+// reflectSchema walks t and produces a schemaNode. The visiting map breaks
+// cycles: if a type references itself (directly or transitively) we stop
+// at {type:object} without recursing further. cache memoises already-seen
+// types within a single FromType call so shared subtypes (same *schemaNode
+// referenced from multiple parents) are walked once.
+func reflectSchema(t reflect.Type, visiting map[reflect.Type]bool, cache map[reflect.Type]*schemaNode) *schemaNode {
+	// Unwrap pointers.
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if visiting[t] {
+		return &schemaNode{Type: "object"}
+	}
+	if cached, ok := cache[t]; ok {
+		return cached
+	}
+
+	var node *schemaNode
+	switch t.Kind() {
+	case reflect.String:
+		node = &schemaNode{Type: "string"}
+	case reflect.Bool:
+		node = &schemaNode{Type: "boolean"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		node = &schemaNode{Type: "integer"}
+	case reflect.Float32, reflect.Float64:
+		node = &schemaNode{Type: "number"}
+	case reflect.Slice, reflect.Array:
+		elem := t.Elem()
+		// []byte → string (common JSON convention)
+		if elem.Kind() == reflect.Uint8 {
+			node = &schemaNode{Type: "string"}
+		} else {
+			node = &schemaNode{
+				Type:  "array",
+				Items: reflectSchema(elem, visiting, cache),
+			}
+		}
+	case reflect.Map:
+		// JSON objects with dynamic keys: enumerate the value type via
+		// additionalProperties so consumers know what map[string]V becomes.
+		node = &schemaNode{
+			Type:                 "object",
+			AdditionalProperties: reflectSchema(t.Elem(), visiting, cache),
+		}
+	case reflect.Interface:
+		// Unconstrained — anything could be here. Leave type unset so the
+		// schema is permissive.
+		node = &schemaNode{}
+	case reflect.Struct:
+		node = reflectStruct(t, visiting, cache)
+	default:
+		node = &schemaNode{}
+	}
+
+	// Only cache structs and named types where reuse actually pays off; for
+	// anonymous leaf nodes (reflect returns the same reflect.Type for any
+	// string field, so caching helps) we still populate — it's cheap.
+	cache[t] = node
+	return node
+}
+
+func reflectStruct(t reflect.Type, visiting map[reflect.Type]bool, cache map[reflect.Type]*schemaNode) *schemaNode {
+	visiting[t] = true
+	defer delete(visiting, t)
+
+	node := &schemaNode{
+		Type:       "object",
+		Properties: map[string]*schemaNode{},
+	}
+
+	collectFields(t, node.Properties, visiting, cache)
+
+	if len(node.Properties) == 0 {
+		node.Properties = nil
+	}
+	return node
+}
+
+// collectFields walks struct fields, handling anonymous embedded fields by
+// recursing into their fields (so the embedded type's JSON fields appear
+// alongside the parent's).
+func collectFields(t reflect.Type, props map[string]*schemaNode, visiting map[reflect.Type]bool, cache map[reflect.Type]*schemaNode) {
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+
+		// Anonymous embed: recurse into its fields (after unwrapping pointer).
+		// This must come before the exported check because reflect reports
+		// an anonymous field of a lowercase type as unexported, yet its
+		// exported fields still promote through encoding/json.
+		if f.Anonymous {
+			embedded := f.Type
+			for embedded.Kind() == reflect.Ptr {
+				embedded = embedded.Elem()
+			}
+			if embedded.Kind() == reflect.Struct {
+				collectFields(embedded, props, visiting, cache)
+			}
+			continue
+		}
+
+		// Skip unexported fields.
+		if !f.IsExported() {
+			continue
+		}
+
+		name := parseJSONTag(f)
+		if name == "-" {
+			continue
+		}
+
+		child := reflectSchema(f.Type, visiting, cache)
+
+		// Field-level tags (desc, enum, kind) are annotations on a specific
+		// field, not on the underlying type. The cache shares *schemaNode
+		// across all fields of the same type, so we must clone before
+		// mutating to avoid leaking one field's annotation onto another.
+		//
+		// For array fields (child.Type == "array" && child.Items != nil),
+		// enum/kind describe the element type, not the array itself. We dive
+		// into items: clone the items node, annotate it, then rebuild the
+		// array node with the new items pointer. desc always stays on the
+		// outer field.
+		desc := f.Tag.Get("desc")
+		enumTag := f.Tag.Get("enum")
+		kindTag := f.Tag.Get("kind")
+
+		hasTagAnnotation := desc != "" || enumTag != "" || kindTag != ""
+		if hasTagAnnotation {
+			isArray := child != nil && child.Type == "array" && child.Items != nil
+
+			if isArray {
+				// Clone the items node and apply enum/kind to it.
+				itemsClone := *child.Items
+				if enumTag != "" {
+					itemsClone.Enum = splitCSV(enumTag)
+				}
+				if kindTag != "" {
+					itemsClone.Format = kindTag
+				}
+				// Rebuild the array node with cloned+annotated items.
+				// desc stays on the array node itself.
+				newArr := *child
+				newArr.Items = &itemsClone
+				if desc != "" {
+					newArr.Description = desc
+				}
+				child = &newArr
+			} else {
+				// Scalar (or map, etc.) — clone the field node and annotate.
+				cloned := *child
+				if desc != "" {
+					cloned.Description = desc
+				}
+				if enumTag != "" {
+					cloned.Enum = splitCSV(enumTag)
+				}
+				if kindTag != "" {
+					cloned.Format = kindTag
+				}
+				child = &cloned
+			}
+		}
+
+		props[name] = child
+	}
+}
+
+// splitCSV splits a comma-separated string into trimmed, non-empty parts.
+// Used for parsing `enum:"a,b,c"` struct tags.
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// parseJSONTag returns the wire name. `json:"-"` stays as "-" so callers
+// can detect and skip. Empty / missing tags fall back to Go field name.
+func parseJSONTag(f reflect.StructField) string {
+	tag := f.Tag.Get("json")
+	if tag == "" {
+		return f.Name
+	}
+	name := strings.SplitN(tag, ",", 2)[0]
+	if name == "" {
+		return f.Name
+	}
+	return name
+}

--- a/internal/event/schemas/fromtype_test.go
+++ b/internal/event/schemas/fromtype_test.go
@@ -1,0 +1,266 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package schemas
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+type inner struct {
+	OpenID  *string `json:"open_id,omitempty"`
+	UserID  *string `json:"user_id,omitempty"`
+	UnionID *string `json:"union_id,omitempty"`
+}
+
+type sample struct {
+	Name          string   `json:"name"`
+	Optional      *string  `json:"optional,omitempty"`
+	Tags          []string `json:"tags"`
+	Reader        *inner   `json:"reader,omitempty"`
+	Count         int      `json:"count"`
+	Flag          bool     `json:"flag"`
+	Skipped       string   `json:"-"`
+	unexportedStr string
+}
+
+func TestFromType_ScalarAndOptional(t *testing.T) {
+	raw := FromType(reflect.TypeOf(sample{}))
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed["type"] != "object" {
+		t.Errorf("type = %v, want object", parsed["type"])
+	}
+	props, _ := parsed["properties"].(map[string]interface{})
+	if props == nil {
+		t.Fatal("properties missing")
+	}
+	// scalar
+	if got := props["name"].(map[string]interface{})["type"]; got != "string" {
+		t.Errorf("name.type = %v, want string", got)
+	}
+	// pointer = optional, same JSON type
+	if got := props["optional"].(map[string]interface{})["type"]; got != "string" {
+		t.Errorf("optional.type = %v, want string", got)
+	}
+	// slice → array + items
+	tagsNode := props["tags"].(map[string]interface{})
+	if tagsNode["type"] != "array" {
+		t.Errorf("tags.type = %v, want array", tagsNode["type"])
+	}
+	if items, ok := tagsNode["items"].(map[string]interface{}); !ok || items["type"] != "string" {
+		t.Errorf("tags.items = %v, want string type", tagsNode["items"])
+	}
+	// nested struct
+	readerNode := props["reader"].(map[string]interface{})
+	if readerNode["type"] != "object" {
+		t.Errorf("reader.type = %v, want object", readerNode["type"])
+	}
+	// bool / int
+	if props["flag"].(map[string]interface{})["type"] != "boolean" {
+		t.Errorf("flag.type wrong")
+	}
+	if props["count"].(map[string]interface{})["type"] != "integer" {
+		t.Errorf("count.type wrong")
+	}
+	// json:"-" skipped
+	if _, ok := props["Skipped"]; ok {
+		t.Error("Skipped should not be in schema")
+	}
+	if _, ok := props["-"]; ok {
+		t.Error("- should not be in schema")
+	}
+	// unexported skipped
+	if _, ok := props["unexportedStr"]; ok {
+		t.Error("unexported field should not be in schema")
+	}
+}
+
+type descSharedInner struct {
+	V string `json:"v"`
+}
+
+type descSharedOuter struct {
+	Owner  descSharedInner `json:"owner"  desc:"the owner"`
+	Member descSharedInner `json:"member" desc:"the member"`
+}
+
+// TestFromType_SharedSubtypeDistinctDescriptions guards the shared-cache
+// correctness bug introduced by Task 4.3: two fields of the same struct
+// type should carry their own `desc` annotation, not a last-write-wins
+// value written onto a shared *schemaNode.
+func TestFromType_SharedSubtypeDistinctDescriptions(t *testing.T) {
+	raw := FromType(reflect.TypeOf(descSharedOuter{}))
+	var parsed struct {
+		Properties map[string]struct {
+			Description string `json:"description"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if got := parsed.Properties["owner"].Description; got != "the owner" {
+		t.Errorf("owner.description = %q, want %q", got, "the owner")
+	}
+	if got := parsed.Properties["member"].Description; got != "the member" {
+		t.Errorf("member.description = %q, want %q", got, "the member")
+	}
+}
+
+type mapSample struct {
+	Attrs map[string]int `json:"attrs"`
+}
+
+// TestFromType_MapAdditionalProperties verifies that a map field emits
+// additionalProperties describing the value type — consumers of the
+// schema can then tell that Attrs is map[string]int rather than an
+// uninstrumented object.
+func TestFromType_MapAdditionalProperties(t *testing.T) {
+	raw := FromType(reflect.TypeOf(mapSample{}))
+	var parsed struct {
+		Properties map[string]struct {
+			Type                 string `json:"type"`
+			AdditionalProperties struct {
+				Type string `json:"type"`
+			} `json:"additionalProperties"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	attrs := parsed.Properties["attrs"]
+	if attrs.Type != "object" {
+		t.Errorf("attrs.type = %q, want object", attrs.Type)
+	}
+	if attrs.AdditionalProperties.Type != "integer" {
+		t.Errorf("attrs.additionalProperties.type = %q, want integer", attrs.AdditionalProperties.Type)
+	}
+}
+
+type cyclic struct {
+	Name  string   `json:"name"`
+	Child *cyclic  `json:"child,omitempty"`
+	Kids  []cyclic `json:"kids,omitempty"`
+}
+
+func TestFromType_HandlesCycles(t *testing.T) {
+	raw := FromType(reflect.TypeOf(cyclic{}))
+	if len(raw) == 0 {
+		t.Fatal("expected schema for cyclic type")
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// Just make sure we didn't blow up / stack overflow.
+	if parsed["type"] != "object" {
+		t.Errorf("cyclic.type = %v", parsed["type"])
+	}
+}
+
+type embedBase struct {
+	EventID string `json:"event_id"`
+}
+
+type embedOuter struct {
+	*embedBase
+	Payload string `json:"payload"`
+}
+
+func TestFromType_FlattensEmbeds(t *testing.T) {
+	raw := FromType(reflect.TypeOf(embedOuter{}))
+	var parsed struct {
+		Properties map[string]interface{} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := parsed.Properties["event_id"]; !ok {
+		t.Error("embedded field event_id should appear at top level")
+	}
+	if _, ok := parsed.Properties["payload"]; !ok {
+		t.Error("payload should appear")
+	}
+}
+
+func TestFromType_NilSafe(t *testing.T) {
+	if got := FromType(nil); got != nil {
+		t.Errorf("FromType(nil) = %s, want nil", got)
+	}
+}
+
+type tagSample struct {
+	ChatType     string `json:"chat_type"     enum:"p2p,group"`
+	OpenID       string `json:"open_id"       kind:"open_id"`
+	InternalDate string `json:"internal_date" kind:"timestamp_ms"`
+	// Array: enum/kind should dive into items, not decorate the array itself.
+	Recipients []string `json:"recipients" kind:"email"`
+	States     []string `json:"states"     enum:"unread,read,flagged"`
+	// Untagged []string sharing the same element reflect.Type as Recipients/States —
+	// must NOT inherit items.Format / items.Enum from their tag annotations. Guards
+	// the outer-array-node cache clone (without `newArr := *child`, the cache entry
+	// for []string would keep whatever items pointer the last tagged field wrote).
+	Plain []string `json:"plain"`
+}
+
+func TestFromType_EnumAndKindTags(t *testing.T) {
+	raw := FromType(reflect.TypeOf(tagSample{}))
+	var parsed struct {
+		Properties map[string]struct {
+			Type   string   `json:"type"`
+			Enum   []string `json:"enum"`
+			Format string   `json:"format"`
+			Items  *struct {
+				Type   string   `json:"type"`
+				Enum   []string `json:"enum"`
+				Format string   `json:"format"`
+			} `json:"items"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	// Scalar: enum applies to the field itself.
+	if got := parsed.Properties["chat_type"].Enum; len(got) != 2 || got[0] != "p2p" || got[1] != "group" {
+		t.Errorf("chat_type enum = %v, want [p2p group]", got)
+	}
+
+	// Scalar: kind → format.
+	if got := parsed.Properties["open_id"].Format; got != "open_id" {
+		t.Errorf("open_id format = %q, want open_id", got)
+	}
+	if got := parsed.Properties["internal_date"].Format; got != "timestamp_ms" {
+		t.Errorf("internal_date format = %q, want timestamp_ms", got)
+	}
+
+	// Array of string: kind should land on items, NOT the array.
+	recipients := parsed.Properties["recipients"]
+	if recipients.Format != "" {
+		t.Errorf("recipients array.format = %q, want empty (format belongs on items)", recipients.Format)
+	}
+	if recipients.Items == nil || recipients.Items.Format != "email" {
+		t.Errorf("recipients.items.format = %q, want email", recipients.Items)
+	}
+
+	// Array of string: enum should land on items too.
+	states := parsed.Properties["states"]
+	if len(states.Enum) != 0 {
+		t.Errorf("states array.enum = %v, want empty", states.Enum)
+	}
+	if states.Items == nil || len(states.Items.Enum) != 3 {
+		t.Errorf("states.items.enum = %v, want 3 values", states.Items)
+	}
+
+	// Untagged []string: cache for []string must be clean — no format / enum
+	// carried over from Recipients / States. Proves the outer-array-node clone.
+	plain := parsed.Properties["plain"]
+	if plain.Items != nil && (plain.Items.Format != "" || len(plain.Items.Enum) != 0) {
+		t.Errorf("plain.items = {format:%q, enum:%v}, want clean (cache must not be polluted)",
+			plain.Items.Format, plain.Items.Enum)
+	}
+}

--- a/internal/event/schemas/overlay.go
+++ b/internal/event/schemas/overlay.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package schemas: overlay.go — apply FieldMeta decorations onto a parsed
+// JSON Schema in place.
+//
+// Business authors declare language-level semantics two ways:
+//  1. Struct tags (`desc:"..." enum:"..." kind:"..."`) — co-located with
+//     the field, baked into the reflected schema by fromtype.go.
+//  2. FieldOverrides map[pointer]FieldMeta on SchemaDef — an overlay
+//     keyed by JSON Pointer paths, applied post-reflection (and
+//     post-envelope for Native). Useful when:
+//     - you can't edit the struct (SDK types)
+//     - cross-nested-array paths are awkward to tag (/*/mime_type)
+//     - you want to override a tag globally at registration time
+//
+// Overlay wins over tag. Paths that don't resolve in the target schema
+// are returned as orphans; CI lint fails on orphans so typos / SDK drift
+// can't silently mask schema claims.
+package schemas
+
+import "sort"
+
+// FieldMeta is the semantic overlay for a single schema node. All fields
+// are optional; non-empty fields replace the corresponding schema
+// annotation.
+type FieldMeta struct {
+	Description string
+	Enum        []string
+	Kind        string // semantic marker (open_id / chat_id / email / timestamp_ms …); renders to JSON Schema "format" keyword
+}
+
+// ApplyFieldOverrides mutates `schema` in place, merging each entry of
+// `overrides` onto the node(s) that its JSON Pointer path resolves to.
+// Returns the list of pointer paths that resolved to nothing — callers
+// (typically CI lint in tests) use this list to fail on orphans.
+func ApplyFieldOverrides(schema map[string]interface{}, overrides map[string]FieldMeta) []string {
+	var orphans []string
+	for path, meta := range overrides {
+		nodes := ResolvePointer(schema, path)
+		if len(nodes) == 0 {
+			orphans = append(orphans, path)
+			continue
+		}
+		for _, node := range nodes {
+			if meta.Description != "" {
+				node["description"] = meta.Description
+			}
+			if len(meta.Enum) > 0 {
+				arr := make([]interface{}, len(meta.Enum))
+				for i, v := range meta.Enum {
+					arr[i] = v
+				}
+				node["enum"] = arr
+			}
+			if meta.Kind != "" {
+				node["format"] = meta.Kind
+			}
+		}
+	}
+	sort.Strings(orphans)
+	return orphans
+}

--- a/internal/event/schemas/overlay_test.go
+++ b/internal/event/schemas/overlay_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package schemas
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestApplyFieldOverrides_AddDescriptionEnumFormat(t *testing.T) {
+	schema := parseSchema(t, `{
+        "type":"object",
+        "properties":{
+            "message_type":{"type":"string"},
+            "sender_id":{"type":"string"}
+        }
+    }`)
+	overrides := map[string]FieldMeta{
+		"/message_type": {Enum: []string{"text", "post"}, Description: "消息类型"},
+		"/sender_id":    {Kind: "open_id"},
+	}
+	orphans := ApplyFieldOverrides(schema, overrides)
+	if len(orphans) != 0 {
+		t.Fatalf("unexpected orphans: %v", orphans)
+	}
+
+	msgType := schema["properties"].(map[string]interface{})["message_type"].(map[string]interface{})
+	if msgType["description"] != "消息类型" {
+		t.Errorf("description not applied: %v", msgType)
+	}
+	if enumRaw, ok := msgType["enum"].([]interface{}); !ok || len(enumRaw) != 2 {
+		t.Errorf("enum not applied: %v", msgType)
+	}
+
+	senderID := schema["properties"].(map[string]interface{})["sender_id"].(map[string]interface{})
+	if senderID["format"] != "open_id" {
+		t.Errorf("format not applied: %v", senderID)
+	}
+}
+
+func TestApplyFieldOverrides_OverridesStructTagValues(t *testing.T) {
+	schema := parseSchema(t, `{
+        "type":"object",
+        "properties":{
+            "chat_type":{"type":"string","description":"from tag","enum":["old_a","old_b"]}
+        }
+    }`)
+	overrides := map[string]FieldMeta{
+		"/chat_type": {Description: "from overlay", Enum: []string{"new_a"}},
+	}
+	ApplyFieldOverrides(schema, overrides)
+	ct := schema["properties"].(map[string]interface{})["chat_type"].(map[string]interface{})
+	if ct["description"] != "from overlay" {
+		t.Errorf("overlay description should override tag: %v", ct)
+	}
+	enumRaw := ct["enum"].([]interface{})
+	if len(enumRaw) != 1 || enumRaw[0] != "new_a" {
+		t.Errorf("overlay enum should override tag: %v", ct)
+	}
+}
+
+func TestApplyFieldOverrides_OrphanPathsReported(t *testing.T) {
+	schema := parseSchema(t, `{"type":"object","properties":{"a":{"type":"string"}}}`)
+	overrides := map[string]FieldMeta{
+		"/a":     {Kind: "open_id"},
+		"/x/y":   {Kind: "chat_id"},
+		"/a/bad": {Kind: "chat_id"},
+	}
+	orphans := ApplyFieldOverrides(schema, overrides)
+	want := []string{"/a/bad", "/x/y"}
+	if !reflect.DeepEqual(orphans, want) {
+		t.Errorf("orphans = %v, want %v", orphans, want)
+	}
+}
+
+func TestApplyFieldOverrides_ArrayItemsWildcard(t *testing.T) {
+	schema := parseSchema(t, `{
+        "type":"object",
+        "properties":{
+            "ids":{"type":"array","items":{"type":"string"}}
+        }
+    }`)
+	overrides := map[string]FieldMeta{
+		"/ids/*": {Kind: "message_id"},
+	}
+	if orphans := ApplyFieldOverrides(schema, overrides); len(orphans) != 0 {
+		t.Fatalf("unexpected orphans: %v", orphans)
+	}
+	items := schema["properties"].(map[string]interface{})["ids"].(map[string]interface{})["items"].(map[string]interface{})
+	if items["format"] != "message_id" {
+		t.Errorf("items.format not applied: %v", items)
+	}
+}
+
+// Smoke test the full pipeline: FromType → overlay on parsed result.
+type overlaySample struct {
+	Type      string `json:"type"`
+	MessageID string `json:"message_id"`
+}
+
+func TestApplyFieldOverrides_OnReflectedSchema(t *testing.T) {
+	raw := FromType(reflect.TypeOf(overlaySample{}))
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	ApplyFieldOverrides(m, map[string]FieldMeta{
+		"/message_id": {Kind: "message_id"},
+	})
+	props := m["properties"].(map[string]interface{})
+	mid := props["message_id"].(map[string]interface{})
+	if mid["format"] != "message_id" {
+		t.Errorf("format not applied to reflected schema: %v", mid)
+	}
+}

--- a/internal/event/schemas/pointer.go
+++ b/internal/event/schemas/pointer.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package schemas: pointer.go — resolve a JSON-Pointer-like path into a
+// parsed JSON Schema tree, returning the matching sub-nodes so overlay
+// can mutate them in place.
+//
+// Standard JSON Pointer (RFC 6901) navigates object properties; we extend
+// with `/*` meaning "every element of an array", which resolves via the
+// schema's `items` sub-tree. This matches business authors' mental model
+// of "apply semantic overlay to each element of this list".
+//
+// The resolver returns []map[string]interface{} because callers mutate
+// the node in place (adding description / enum / format). Paths with no
+// match return an empty slice; callers treat this as silent skip (the
+// CI lint pass is elsewhere and flags orphans).
+package schemas
+
+import "strings"
+
+// ResolvePointer walks `schema` along the given path and returns any
+// sub-nodes that match. Path syntax:
+//
+//   - "" or "/" → the root node itself
+//   - "/foo" → property "foo" of the root object
+//   - "/foo/bar" → nested property
+//   - "/foo/*" → the items schema of an array property "foo"
+//   - "/foo/*/bar" → property "bar" inside each element of array "foo"
+//
+// The function silently tolerates structural surprises (missing key,
+// wrong type, non-array with `/*`) by returning a shorter slice — it is
+// not validation.
+func ResolvePointer(schema map[string]interface{}, path string) []map[string]interface{} {
+	if path == "" || path == "/" {
+		return []map[string]interface{}{schema}
+	}
+	trimmed := strings.TrimPrefix(path, "/")
+	parts := strings.Split(trimmed, "/")
+
+	current := []map[string]interface{}{schema}
+	for _, part := range parts {
+		next := []map[string]interface{}{}
+		for _, node := range current {
+			if part == "*" {
+				// Array element via `items`.
+				items, ok := node["items"].(map[string]interface{})
+				if !ok {
+					continue
+				}
+				next = append(next, items)
+				continue
+			}
+			// Property of an object.
+			props, ok := node["properties"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			child, ok := props[part].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			next = append(next, child)
+		}
+		if len(next) == 0 {
+			return nil
+		}
+		current = next
+	}
+	return current
+}

--- a/internal/event/schemas/pointer_test.go
+++ b/internal/event/schemas/pointer_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package schemas
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func parseSchema(t *testing.T, s string) map[string]interface{} {
+	t.Helper()
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return m
+}
+
+func TestResolvePointer_SimpleField(t *testing.T) {
+	schema := parseSchema(t, `{
+        "type":"object",
+        "properties":{
+            "chat_id":{"type":"string"}
+        }
+    }`)
+	nodes := ResolvePointer(schema, "/chat_id")
+	if len(nodes) != 1 {
+		t.Fatalf("want 1 node, got %d", len(nodes))
+	}
+	if nodes[0]["type"] != "string" {
+		t.Errorf("got %v", nodes[0])
+	}
+}
+
+func TestResolvePointer_Nested(t *testing.T) {
+	schema := parseSchema(t, `{
+        "type":"object",
+        "properties":{
+            "message":{
+                "type":"object",
+                "properties":{
+                    "chat_type":{"type":"string"}
+                }
+            }
+        }
+    }`)
+	nodes := ResolvePointer(schema, "/message/chat_type")
+	if len(nodes) != 1 {
+		t.Fatalf("want 1 node, got %d", len(nodes))
+	}
+}
+
+func TestResolvePointer_ArrayElementWildcard(t *testing.T) {
+	schema := parseSchema(t, `{
+        "type":"object",
+        "properties":{
+            "message_id_list":{
+                "type":"array",
+                "items":{"type":"string"}
+            }
+        }
+    }`)
+	nodes := ResolvePointer(schema, "/message_id_list/*")
+	if len(nodes) != 1 {
+		t.Fatalf("want 1 node, got %d", len(nodes))
+	}
+	if nodes[0]["type"] != "string" {
+		t.Errorf("want string items, got %v", nodes[0])
+	}
+}
+
+func TestResolvePointer_ArrayElementField(t *testing.T) {
+	schema := parseSchema(t, `{
+        "type":"object",
+        "properties":{
+            "attachments":{
+                "type":"array",
+                "items":{
+                    "type":"object",
+                    "properties":{
+                        "mime_type":{"type":"string"}
+                    }
+                }
+            }
+        }
+    }`)
+	nodes := ResolvePointer(schema, "/attachments/*/mime_type")
+	if len(nodes) != 1 || nodes[0]["type"] != "string" {
+		t.Errorf("want mime_type node, got %v", nodes)
+	}
+}
+
+func TestResolvePointer_MissingReturnsEmpty(t *testing.T) {
+	schema := parseSchema(t, `{"type":"object","properties":{"a":{"type":"string"}}}`)
+	nodes := ResolvePointer(schema, "/b/c/d")
+	if len(nodes) != 0 {
+		t.Errorf("want empty for missing path, got %v", nodes)
+	}
+}
+
+func TestResolvePointer_RootReturnsSelf(t *testing.T) {
+	schema := parseSchema(t, `{"type":"object"}`)
+	nodes := ResolvePointer(schema, "")
+	if len(nodes) != 1 {
+		t.Fatalf("want 1 root node, got %d", len(nodes))
+	}
+	if nodes[0]["type"] != "object" {
+		t.Errorf("root resolution broken")
+	}
+}

--- a/internal/event/source/feishu.go
+++ b/internal/event/source/feishu.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	larkevent "github.com/larksuite/oapi-sdk-go/v3/event"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
+	larkws "github.com/larksuite/oapi-sdk-go/v3/ws"
+
+	"github.com/larksuite/cli/internal/event"
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// maxEventBodyBytes caps an individual inbound event payload. Feishu's
+// own upstream events are well under 100 KB in practice; 1 MB is a
+// defensive headroom. Oversized payloads are dropped with a log line
+// rather than fanned out — otherwise each subscriber's sendCh (cap 100)
+// could hold 100× the oversized payload in memory.
+const maxEventBodyBytes = 1 << 20
+
+// FeishuSource connects to the Feishu WebSocket gateway and emits events.
+type FeishuSource struct {
+	AppID     string
+	AppSecret string
+	Domain    string
+	Logger    *log.Logger
+}
+
+func (s *FeishuSource) Name() string { return "feishu-websocket" }
+
+func (s *FeishuSource) Start(ctx context.Context, eventTypes []string, emit func(*event.RawEvent), notify StatusNotifier) error {
+	d := dispatcher.NewEventDispatcher("", "")
+
+	rawHandler := s.buildRawHandler(emit)
+
+	for _, et := range eventTypes {
+		d.OnCustomizedEvent(et, rawHandler)
+	}
+
+	opts := []larkws.ClientOption{larkws.WithEventHandler(d)}
+	if s.Domain != "" {
+		opts = append(opts, larkws.WithDomain(s.Domain))
+	}
+	if s.Logger != nil || notify != nil {
+		opts = append(opts, larkws.WithLogLevel(larkcore.LogLevelInfo))
+		opts = append(opts, larkws.WithLogger(&sdkLogger{l: s.Logger, notify: notify}))
+	}
+
+	if notify != nil {
+		notify(protocol.SourceStateConnecting, "")
+	}
+	cli := larkws.NewClient(s.AppID, s.AppSecret, opts...)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- cli.Start(ctx) }()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errCh:
+		return err
+	}
+}
+
+// buildRawHandler returns the per-event callback passed to the SDK
+// dispatcher. Extracted from Start so unit tests can exercise the
+// three failure modes (nil body, malformed JSON, missing header
+// fields) without spinning up a WebSocket client. A nil Logger is
+// tolerated — callers constructed with minimal test setup won't panic.
+func (s *FeishuSource) buildRawHandler(emit func(*event.RawEvent)) func(context.Context, *larkevent.EventReq) error {
+	return func(_ context.Context, e *larkevent.EventReq) error {
+		if e.Body == nil {
+			return nil
+		}
+		if len(e.Body) > maxEventBodyBytes {
+			if s.Logger != nil {
+				s.Logger.Printf("[feishu] drop oversized event: %d bytes > cap %d", len(e.Body), maxEventBodyBytes)
+			}
+			return nil
+		}
+		var envelope struct {
+			Header struct {
+				EventID    string `json:"event_id"`
+				EventType  string `json:"event_type"`
+				CreateTime string `json:"create_time"`
+			} `json:"header"`
+		}
+		if err := json.Unmarshal(e.Body, &envelope); err != nil {
+			if s.Logger != nil {
+				preview := string(e.Body)
+				if len(preview) > 200 {
+					preview = preview[:200] + "...(truncated)"
+				}
+				s.Logger.Printf("[feishu] drop malformed event: unmarshal error: %v body=%s", err, preview)
+			}
+			return nil
+		}
+		if envelope.Header.EventID == "" || envelope.Header.EventType == "" {
+			if s.Logger != nil {
+				s.Logger.Printf("[feishu] drop event missing header fields: event_id=%q event_type=%q",
+					envelope.Header.EventID, envelope.Header.EventType)
+			}
+			return nil
+		}
+		emit(&event.RawEvent{
+			EventID:    envelope.Header.EventID,
+			EventType:  envelope.Header.EventType,
+			SourceTime: envelope.Header.CreateTime,
+			Payload:    json.RawMessage(e.Body),
+			Timestamp:  time.Now(),
+		})
+		return nil
+	}
+}
+
+// sdkLogger adapts *log.Logger to larkcore.Logger. Every SDK line goes
+// to bus.log; lines matching known lifecycle patterns also fire notify
+// so consumers see WebSocket connect/disconnect/reconnect in real time.
+type sdkLogger struct {
+	l      *log.Logger
+	notify StatusNotifier
+}
+
+func (a *sdkLogger) Debug(_ context.Context, _ ...interface{}) {}
+func (a *sdkLogger) Info(_ context.Context, args ...interface{}) {
+	msg := fmt.Sprint(args...)
+	if a.l != nil {
+		a.l.Output(2, "[SDK] "+msg)
+	}
+	a.tryNotify(msg, "")
+}
+func (a *sdkLogger) Warn(_ context.Context, args ...interface{}) {
+	msg := fmt.Sprint(args...)
+	if a.l != nil {
+		a.l.Output(2, "[SDK WARN] "+msg)
+	}
+	a.tryNotify(msg, "")
+}
+func (a *sdkLogger) Error(_ context.Context, args ...interface{}) {
+	msg := fmt.Sprint(args...)
+	if a.l != nil {
+		a.l.Output(2, "[SDK ERROR] "+msg)
+	}
+	// Errors usually manifest as disconnects; surface them with the error
+	// text as detail so users see why.
+	a.tryNotify(msg, msg)
+}
+
+// reconnectAttemptRe captures the attempt number from SDK's "trying to
+// reconnect: N" lines so we can surface it as detail.
+var reconnectAttemptRe = regexp.MustCompile(`reconnect:?\s*(\d+)`)
+
+// tryNotify classifies an SDK log line into a lifecycle state. A nil
+// notify or a line we don't recognise is a no-op — non-lifecycle noise
+// (e.g. heartbeat) stays in bus.log but doesn't reach the user.
+//
+// Matching is HasPrefix, not Contains: SDK log lines are of the form
+// "<verb> to <url>[conn_id=...]", so "connected to " and "disconnected
+// to " are mutually exclusive at the start of the string. A prior
+// Contains-based switch accidentally matched "connected to ws" inside
+// "disconnected to wss://...", misreporting every disconnect as a
+// reconnect. See TestTryNotify_Classify for the regression case.
+func (a *sdkLogger) tryNotify(msg, errDetail string) {
+	if a.notify == nil {
+		return
+	}
+	lower := strings.ToLower(msg)
+	switch {
+	case strings.HasPrefix(lower, sdkLogReconnecting):
+		detail := ""
+		if m := reconnectAttemptRe.FindStringSubmatch(lower); len(m) == 2 {
+			detail = "attempt " + m[1]
+		}
+		a.notify(protocol.SourceStateReconnecting, detail)
+	case strings.HasPrefix(lower, sdkLogDisconnected):
+		a.notify(protocol.SourceStateDisconnected, errDetail)
+	case strings.HasPrefix(lower, sdkLogConnected):
+		a.notify(protocol.SourceStateConnected, "")
+	}
+}
+
+var _ larkcore.Logger = (*sdkLogger)(nil)

--- a/internal/event/source/feishu_log_test.go
+++ b/internal/event/source/feishu_log_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package source
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	larkevent "github.com/larksuite/oapi-sdk-go/v3/event"
+
+	"github.com/larksuite/cli/internal/event"
+)
+
+// TestRawHandlerLogsMalformedJSON ensures invalid JSON is logged rather than
+// silently dropped.
+func TestRawHandlerLogsMalformedJSON(t *testing.T) {
+	var buf bytes.Buffer
+	s := &FeishuSource{Logger: log.New(&buf, "", 0)}
+	emitted := 0
+	handler := s.buildRawHandler(func(_ *event.RawEvent) { emitted++ })
+
+	req := &larkevent.EventReq{Body: []byte("not-json-{{{")}
+	if err := handler(context.Background(), req); err != nil {
+		t.Fatalf("handler returned err: %v", err)
+	}
+
+	if emitted != 0 {
+		t.Errorf("expected 0 emits, got %d", emitted)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "malformed") {
+		t.Errorf("expected log to mention 'malformed', got: %s", out)
+	}
+	if !strings.Contains(out, "not-json") {
+		t.Errorf("expected log to include body preview, got: %s", out)
+	}
+}
+
+// TestRawHandlerLogsMissingHeaderFields ensures valid JSON with empty
+// event_id or event_type is logged and dropped.
+func TestRawHandlerLogsMissingHeaderFields(t *testing.T) {
+	var buf bytes.Buffer
+	s := &FeishuSource{Logger: log.New(&buf, "", 0)}
+	emitted := 0
+	handler := s.buildRawHandler(func(_ *event.RawEvent) { emitted++ })
+
+	// Missing event_id
+	req := &larkevent.EventReq{Body: []byte(`{"header":{"event_type":"im.receive"}}`)}
+	handler(context.Background(), req)
+	// Missing event_type
+	req2 := &larkevent.EventReq{Body: []byte(`{"header":{"event_id":"abc"}}`)}
+	handler(context.Background(), req2)
+
+	if emitted != 0 {
+		t.Errorf("expected 0 emits (both missing fields), got %d", emitted)
+	}
+	out := buf.String()
+	if strings.Count(out, "missing header fields") != 2 {
+		t.Errorf("expected 2 'missing header fields' logs, got: %s", out)
+	}
+}
+
+// TestRawHandlerNilBodyNoLog verifies that a nil body (legit SDK quirk)
+// doesn't trigger any log noise — it's a silent skip, which is the correct
+// behavior per the comment in Start().
+func TestRawHandlerNilBodyNoLog(t *testing.T) {
+	var buf bytes.Buffer
+	s := &FeishuSource{Logger: log.New(&buf, "", 0)}
+	emitted := 0
+	handler := s.buildRawHandler(func(_ *event.RawEvent) { emitted++ })
+
+	req := &larkevent.EventReq{Body: nil}
+	handler(context.Background(), req)
+
+	if emitted != 0 {
+		t.Errorf("expected 0 emits, got %d", emitted)
+	}
+	if buf.Len() > 0 {
+		t.Errorf("expected no log output, got: %s", buf.String())
+	}
+}
+
+// TestRawHandlerValidEnvelopeEmits verifies the happy path still works —
+// well-formed envelope calls emit with the right fields, including
+// SourceTime carried over from the upstream header.create_time.
+func TestRawHandlerValidEnvelopeEmits(t *testing.T) {
+	s := &FeishuSource{}
+	var captured *event.RawEvent
+	handler := s.buildRawHandler(func(e *event.RawEvent) { captured = e })
+
+	body := []byte(`{"header":{"event_id":"evt-42","event_type":"im.message.receive_v1","create_time":"1700000000000"}}`)
+	handler(context.Background(), &larkevent.EventReq{Body: body})
+
+	if captured == nil {
+		t.Fatal("expected emit to fire")
+	}
+	if captured.EventID != "evt-42" {
+		t.Errorf("EventID: got %q, expected evt-42", captured.EventID)
+	}
+	if captured.EventType != "im.message.receive_v1" {
+		t.Errorf("EventType: got %q, expected im.message.receive_v1", captured.EventType)
+	}
+	if captured.SourceTime != "1700000000000" {
+		t.Errorf("SourceTime: got %q, expected 1700000000000 (from header.create_time)", captured.SourceTime)
+	}
+	if string(captured.Payload) != string(body) {
+		t.Errorf("Payload should be raw bytes")
+	}
+}
+
+// TestRawHandlerNilLoggerDoesNotPanic verifies graceful degradation when
+// FeishuSource was constructed without a logger (e.g. minimal test setup).
+func TestRawHandlerNilLoggerDoesNotPanic(t *testing.T) {
+	s := &FeishuSource{Logger: nil} // no logger
+	handler := s.buildRawHandler(func(_ *event.RawEvent) {})
+	handler(context.Background(), &larkevent.EventReq{Body: []byte("bad json")})
+	// Pass if we reach here without panicking.
+}

--- a/internal/event/source/feishu_test.go
+++ b/internal/event/source/feishu_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package source
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// TestTryNotify_Classify covers the four log shapes we care about plus
+// the regression case: SDK's "disconnected to <wss-url>" literally
+// contains the substring "connected to ws", so a Contains-based switch
+// misreported every disconnect as a reconnect. HasPrefix matching makes
+// "connected to " and "disconnected to " mutually exclusive.
+func TestTryNotify_Classify(t *testing.T) {
+	cases := []struct {
+		name       string
+		msg        string
+		errDetail  string
+		wantState  string
+		wantDetail string
+		wantCalled bool
+	}{
+		{
+			name:       "connected (SDK connect success)",
+			msg:        "connected to wss://example.com/gw [conn_id=abc]",
+			wantState:  protocol.SourceStateConnected,
+			wantCalled: true,
+		},
+		{
+			// REGRESSION: prior Contains-based switch matched "connected to ws"
+			// inside "disconnected to wss...", misclassifying every disconnect
+			// as a Connected notification. Must now land in Disconnected.
+			name:       "disconnected must not be misclassified as connected",
+			msg:        "disconnected to wss://example.com/gw [conn_id=abc]",
+			wantState:  protocol.SourceStateDisconnected,
+			wantCalled: true,
+		},
+		{
+			name:       "disconnected carries errDetail through",
+			msg:        "disconnected to wss://example.com/gw [conn_id=abc]",
+			errDetail:  "read tcp: broken pipe",
+			wantState:  protocol.SourceStateDisconnected,
+			wantDetail: "read tcp: broken pipe",
+			wantCalled: true,
+		},
+		{
+			name:       "reconnecting with attempt 1",
+			msg:        "trying to reconnect: 1 [conn_id=abc]",
+			wantState:  protocol.SourceStateReconnecting,
+			wantDetail: "attempt 1",
+			wantCalled: true,
+		},
+		{
+			name:       "reconnecting with attempt 12",
+			msg:        "trying to reconnect: 12",
+			wantState:  protocol.SourceStateReconnecting,
+			wantDetail: "attempt 12",
+			wantCalled: true,
+		},
+		{
+			name:       "case-insensitive connected",
+			msg:        "CONNECTED TO WSS://example.com",
+			wantState:  protocol.SourceStateConnected,
+			wantCalled: true,
+		},
+		{
+			// Generic SDK errors shouldn't mutate source state; they stay in
+			// bus.log but don't reach the user as a lifecycle event.
+			name:       "ignore generic connect-failed error",
+			msg:        "connect failed, err: dial tcp: i/o timeout",
+			errDetail:  "connect failed, err: dial tcp: i/o timeout",
+			wantCalled: false,
+		},
+		{
+			name:       "ignore read-loop failure",
+			msg:        "receive message failed, err: websocket: close 1006",
+			errDetail:  "receive message failed, err: websocket: close 1006",
+			wantCalled: false,
+		},
+		{
+			name:       "ignore heartbeat noise",
+			msg:        "receive pong",
+			wantCalled: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotState, gotDetail string
+			called := false
+			lg := &sdkLogger{notify: func(state, detail string) {
+				called = true
+				gotState = state
+				gotDetail = detail
+			}}
+			lg.tryNotify(tc.msg, tc.errDetail)
+
+			if called != tc.wantCalled {
+				t.Fatalf("called=%v, want %v (msg=%q)", called, tc.wantCalled, tc.msg)
+			}
+			if !called {
+				return
+			}
+			if gotState != tc.wantState {
+				t.Errorf("state = %q, want %q", gotState, tc.wantState)
+			}
+			if gotDetail != tc.wantDetail {
+				t.Errorf("detail = %q, want %q", gotDetail, tc.wantDetail)
+			}
+		})
+	}
+}
+
+// TestTryNotify_NilNotifySafe protects the early-return guard: a logger
+// without a notify callback (the l-only path used before bus wiring) must
+// not panic when classifying lines.
+func TestTryNotify_NilNotifySafe(t *testing.T) {
+	lg := &sdkLogger{notify: nil}
+	lg.tryNotify("disconnected to wss://example.com", "")
+	lg.tryNotify("connected to wss://example.com", "")
+	lg.tryNotify("trying to reconnect: 1", "")
+}

--- a/internal/event/source/sdk_log_patterns.go
+++ b/internal/event/source/sdk_log_patterns.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package source: SDK log pattern constants.
+//
+// These substrings are matched against larksuite/oapi-sdk-go/v3/ws log
+// output to derive connection-lifecycle notifications. The SDK does not
+// expose these states as a proper callback API (see upstream tracking in
+// feishu.go), so we scrape log lines.
+//
+// This is inherently fragile: if the SDK localizes its logs, renames a
+// pattern, or changes log levels, classification silently breaks. The
+// sidecar test (sdk_log_patterns_test.go) feeds real observed log
+// strings through the classifier so SDK drift is caught at CI time
+// rather than in production.
+//
+// Note on shape: matching in tryNotify is HasPrefix, not Contains. SDK
+// log lines are "<verb> to <url>[conn_id=...]", so "connected to " and
+// "disconnected to " are mutually exclusive at the start of the string.
+// A prior Contains-based switch accidentally matched "connected to ws"
+// inside "disconnected to wss://...", misreporting every disconnect as
+// a reconnect. Constants are stored with the trailing space preserved
+// so downstream HasPrefix matches remain unambiguous.
+//
+// LAST VERIFIED: larksuite/oapi-sdk-go/v3 v3.5.3 on 2026-04-19.
+// When bumping the SDK dependency, re-run the test; if it fails, update
+// BOTH the patterns here AND the corresponding sample strings in the test.
+
+package source
+
+// DO NOT trim the trailing space on sdkLogConnected or sdkLogDisconnected —
+// it is the HasPrefix disambiguator that prevents "disconnected to ..."
+// from matching sdkLogConnected. The sdk_log_patterns_test.go has a
+// HasSuffix pin that will fail if the space is ever removed.
+const (
+	// sdkLogReconnecting prefixes SDK lines like "trying to reconnect: 2".
+	sdkLogReconnecting = "trying to reconnect"
+
+	// sdkLogConnected prefixes SDK lines like "connected to wss://.../gw[conn_id=...]".
+	// Trailing space is intentional: it prevents accidental overlap with
+	// "disconnected to ..." under HasPrefix matching (see feishu.go).
+	sdkLogConnected = "connected to "
+
+	// sdkLogDisconnected prefixes SDK lines like "disconnected to wss://.../gw[conn_id=...]".
+	// Trailing space is intentional (see sdkLogConnected).
+	sdkLogDisconnected = "disconnected to "
+)

--- a/internal/event/source/sdk_log_patterns_test.go
+++ b/internal/event/source/sdk_log_patterns_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package source
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/larksuite/cli/internal/event/protocol"
+)
+
+// TestSDKLogPatternsMatchKnownSDKOutput verifies that the lifecycle-pattern
+// substrings still appear in real SDK log strings.
+//
+// Truth source for the format: larksuite/oapi-sdk-go/v3@v3.5.3 ws/client.go
+// fmtLog — it constructs lines via fmt.Sprint which does NOT insert a
+// separator between the message and the [conn_id=...] bracket. So the real
+// SDK output is "connected to wss://.../gw[conn_id=abc]" (no space before
+// the bracket), not "connected to wss://.../gw [conn_id=abc]". The samples
+// below must preserve that exact shape; softening them with a spurious
+// space would be fake provenance (see CLAUDE.md §4 — unit tests are not the
+// truth source, the SDK is).
+//
+// If the SDK changes its log format, this test will fail — prompting us to
+// update both the constants in sdk_log_patterns.go AND the samples here.
+// Do NOT silence the failure by softening the samples; the whole point is to
+// catch upstream drift at CI time, not in production.
+//
+// Note: tryNotify uses HasPrefix (not Contains) after we discovered that
+// "disconnected to wss..." literally contains "connected to ws" as a
+// substring. So samples here must begin with the expected prefix, matching
+// the real SDK line shape "<verb> to <url>[conn_id=...]".
+func TestSDKLogPatternsMatchKnownSDKOutput(t *testing.T) {
+	cases := []struct {
+		name          string
+		sdkLogSample  string
+		expectedState string
+	}{
+		// Sample strings matching oapi-sdk-go/v3 ws/client.go fmtLog output.
+		// fmtLog uses fmt.Sprint — no separator before the [conn_id=...]
+		// bracket.
+		// Shape: "trying to reconnect: N[conn_id=...]"
+		{
+			name:          "reconnect with attempt number",
+			sdkLogSample:  "trying to reconnect: 2[conn_id=abc123]",
+			expectedState: protocol.SourceStateReconnecting,
+		},
+		{
+			name:          "reconnect high attempt",
+			sdkLogSample:  "trying to reconnect: 12",
+			expectedState: protocol.SourceStateReconnecting,
+		},
+		// Shape: "connected to wss://<host>/<path>[conn_id=...]"
+		{
+			name:          "connected success with conn_id",
+			sdkLogSample:  "connected to wss://open.feishu.cn/gateway[conn_id=abc123]",
+			expectedState: protocol.SourceStateConnected,
+		},
+		{
+			name:          "connected to custom gateway",
+			sdkLogSample:  "connected to wss://internal.example.com/gw",
+			expectedState: protocol.SourceStateConnected,
+		},
+		// Shape: "disconnected to wss://<host>/<path>[conn_id=...]"
+		//
+		// CRITICAL regression sample: this line literally contains
+		// "connected to ws" as a substring. A Contains-based matcher would
+		// misclassify it as Connected. HasPrefix is what keeps it honest.
+		{
+			name:          "disconnected does not alias connected",
+			sdkLogSample:  "disconnected to wss://open.feishu.cn/gateway[conn_id=abc123]",
+			expectedState: protocol.SourceStateDisconnected,
+		},
+		// Case-insensitivity: Info/Warn callers may emit upper or mixed
+		// case in future SDK versions; tryNotify lowercases first.
+		{
+			name:          "connected uppercase",
+			sdkLogSample:  "CONNECTED TO WSS://OPEN.FEISHU.CN/GATEWAY",
+			expectedState: protocol.SourceStateConnected,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var gotState string
+			called := false
+			notify := func(state, detail string) {
+				mu.Lock()
+				gotState = state
+				called = true
+				mu.Unlock()
+			}
+			logger := &sdkLogger{notify: notify}
+			// Route through Info — the classifier should fire regardless
+			// of level. (Warn/Error exercise the same tryNotify path.)
+			logger.Info(context.Background(), tc.sdkLogSample)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if !called {
+				t.Fatalf("SDK log sample %q did not trigger notify — the SDK may have changed its log format; update sdk_log_patterns.go accordingly",
+					tc.sdkLogSample)
+			}
+			if gotState != tc.expectedState {
+				t.Errorf("SDK log sample %q classified as %q, want %q — the SDK may have changed its log format; update sdk_log_patterns.go accordingly",
+					tc.sdkLogSample, gotState, tc.expectedState)
+			}
+		})
+	}
+}
+
+// TestSDKLogPatternsConstantsContainExpectedSubstrings is a paranoid check
+// that someone hasn't modified the constants themselves to subtly break
+// matching. If this fails, the constants were changed incorrectly.
+func TestSDKLogPatternsConstantsContainExpectedSubstrings(t *testing.T) {
+	// These assertions pin the semantic intent of each constant.
+	if !strings.Contains(sdkLogReconnecting, "reconnect") {
+		t.Errorf("sdkLogReconnecting should contain 'reconnect', got %q", sdkLogReconnecting)
+	}
+	if !strings.Contains(sdkLogConnected, "connected") {
+		t.Errorf("sdkLogConnected should contain 'connected', got %q", sdkLogConnected)
+	}
+	if !strings.Contains(sdkLogDisconnected, "disconnected") {
+		t.Errorf("sdkLogDisconnected should contain 'disconnected', got %q", sdkLogDisconnected)
+	}
+	// Constants must be lowercase: tryNotify calls strings.ToLower before
+	// matching, so any uppercase content here would never match.
+	if sdkLogReconnecting != strings.ToLower(sdkLogReconnecting) {
+		t.Errorf("sdkLogReconnecting must be lowercase, got %q", sdkLogReconnecting)
+	}
+	if sdkLogConnected != strings.ToLower(sdkLogConnected) {
+		t.Errorf("sdkLogConnected must be lowercase, got %q", sdkLogConnected)
+	}
+	if sdkLogDisconnected != strings.ToLower(sdkLogDisconnected) {
+		t.Errorf("sdkLogDisconnected must be lowercase, got %q", sdkLogDisconnected)
+	}
+	// Ambiguity guard: sdkLogConnected must not be a prefix of
+	// sdkLogDisconnected (or vice versa). The trailing space on both is
+	// what enforces this; if someone drops the space, HasPrefix matching
+	// breaks and every disconnect becomes a connect.
+	if strings.HasPrefix(sdkLogDisconnected, sdkLogConnected) {
+		t.Errorf("sdkLogConnected %q is a prefix of sdkLogDisconnected %q — HasPrefix matching will misclassify every disconnect as a connect. Restore the trailing space on sdkLogConnected.",
+			sdkLogConnected, sdkLogDisconnected)
+	}
+	// Explicit trailing-space pins. The HasPrefix guard above catches the
+	// case where the space on sdkLogConnected is dropped (because then
+	// "connected to" becomes a prefix of "disconnected to "), but it does
+	// NOT catch the symmetric case where the space is dropped from
+	// sdkLogDisconnected — that would still produce an unambiguous constant
+	// pair yet silently break matching against noise lines like
+	// "disconnected: io timeout" which happen to start with "disconnected".
+	// Pin both explicitly so any trailing-space regression is loud.
+	if !strings.HasSuffix(sdkLogConnected, " ") {
+		t.Error("sdkLogConnected must keep its trailing space — it disambiguates from 'disconnected' under HasPrefix")
+	}
+	if !strings.HasSuffix(sdkLogDisconnected, " ") {
+		t.Error("sdkLogDisconnected must keep its trailing space — without it, 'disconnected to ws...' has no unique prefix vs noise lines starting with 'disconnected:'")
+	}
+}

--- a/internal/event/source/source.go
+++ b/internal/event/source/source.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package source is a pluggable event source abstraction. Sources produce
+// RawEvents into the bus; the bus fans them out to consume subscribers.
+//
+// Keeping this package separate from internal/event means business
+// registrations (events/im, events/mail, ...) can import event without
+// transitively pulling in SDK dependencies like larkws.
+package source
+
+import (
+	"context"
+	"sync"
+
+	"github.com/larksuite/cli/internal/event"
+)
+
+// StatusNotifier is how a source surfaces lifecycle state (connecting /
+// connected / disconnected / reconnecting) to the bus for broadcast.
+// state values are the SourceState* constants in the protocol package.
+// detail is free-form context (e.g. "attempt 1", error summary).
+// Sources that have no such lifecycle may never call this.
+type StatusNotifier func(state, detail string)
+
+// Source produces events. Implementations block in Start until ctx is
+// cancelled or an unrecoverable error occurs.
+//
+// IMPORTANT emit contract: the emit callback passed to Start MUST return
+// quickly (typically microseconds). Hub.Publish dispatches to subscribers
+// via drop-oldest non-blocking sends, so emit itself will not block on
+// slow consumers — but anything else the source does on the hot path
+// (between receiving a message from upstream and calling emit) sits on
+// the SDK's read loop. A stalled emit path means the SDK stops reading
+// from the upstream socket, the upstream gateway eventually times out
+// its write buffer, and the connection gets dropped with a reconnect
+// cycle as the only recovery. Do expensive work in a worker goroutine
+// that emit hands off to via a channel, never inline.
+type Source interface {
+	Name() string
+	// Start begins producing events. eventTypes is the set of upstream
+	// event type names the bus wants subscribed; sources that talk to a
+	// server-side dispatcher (e.g. FeishuSource) use this to opt into
+	// only the events downstream consumers care about. notify is the
+	// optional lifecycle callback (see StatusNotifier).
+	Start(ctx context.Context, eventTypes []string, emit func(*event.RawEvent), notify StatusNotifier) error
+}
+
+var (
+	registry   []Source
+	registryMu sync.Mutex
+)
+
+// Register adds a source. Called from init() of source implementations
+// or from tests that need to inject mocks.
+func Register(s Source) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = append(registry, s)
+}
+
+// All returns a snapshot of registered sources.
+func All() []Source {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	out := make([]Source, len(registry))
+	copy(out, registry)
+	return out
+}
+
+// ResetForTest clears the registry. Only for tests.
+func ResetForTest() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = nil
+}

--- a/internal/event/source/source_test.go
+++ b/internal/event/source/source_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package source
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/event"
+)
+
+type mockSource struct {
+	name   string
+	events []*event.RawEvent
+}
+
+func (s *mockSource) Name() string { return s.name }
+func (s *mockSource) Start(ctx context.Context, _ []string, emit func(*event.RawEvent), _ StatusNotifier) error {
+	for _, e := range s.events {
+		emit(e)
+	}
+	<-ctx.Done()
+	return nil
+}
+
+func TestRegister(t *testing.T) {
+	ResetForTest()
+
+	src := &mockSource{name: "test-source"}
+	Register(src)
+
+	sources := All()
+	if len(sources) != 1 || sources[0].Name() != "test-source" {
+		t.Errorf("unexpected sources: %v", sources)
+	}
+}
+
+func TestMockSource_EmitsEvents(t *testing.T) {
+	src := &mockSource{
+		name: "test",
+		events: []*event.RawEvent{
+			{EventID: "1", EventType: "im.message.receive_v1"},
+			{EventID: "2", EventType: "im.message.receive_v1"},
+		},
+	}
+
+	received := make(chan *event.RawEvent, 10)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	go src.Start(ctx, nil, func(e *event.RawEvent) {
+		received <- e
+	}, nil)
+
+	time.Sleep(50 * time.Millisecond)
+	if len(received) != 2 {
+		t.Errorf("expected 2 events, got %d", len(received))
+	}
+}

--- a/internal/event/testutil/testutil.go
+++ b/internal/event/testutil/testutil.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package testutil holds shared helpers used across the event subsystem's
+// test files. Types here are test-only but live outside _test.go so they
+// can be imported by tests in sibling packages.
+package testutil
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"sync"
+
+	"github.com/larksuite/cli/internal/event/transport"
+)
+
+// FakeTransport is a test-only transport.IPC. It supports two modes:
+//
+//   - TCP-standalone: `NewTCPFake(addr)` produces a transport that listens
+//     and dials on a localhost TCP address. Good for integration-style
+//     tests that need a real network endpoint but want to isolate from
+//     the real Unix socket path.
+//   - Wrapped-overlay: `NewWrappedFake(inner, addr)` delegates every call
+//     to an underlying real transport, rewriting `addr` to the injected
+//     value. Good for tests that want real Unix-socket behaviour but on a
+//     short per-test path (e.g. t.TempDir()).
+type FakeTransport struct {
+	addr     string
+	inner    transport.IPC // nil ⇒ TCP mode
+	mu       sync.Mutex
+	cleaned  bool
+	cleanups int
+}
+
+// NewTCPFake returns a FakeTransport that serves on the given TCP addr.
+func NewTCPFake(addr string) *FakeTransport {
+	return &FakeTransport{addr: addr}
+}
+
+// NewWrappedFake returns a FakeTransport that delegates to inner but always
+// overrides the address with addr. Caller owns inner's lifecycle.
+func NewWrappedFake(inner transport.IPC, addr string) *FakeTransport {
+	return &FakeTransport{addr: addr, inner: inner}
+}
+
+// Listen implements transport.IPC. The addr parameter is ignored — the
+// constructor-supplied address wins so tests don't have to thread it.
+func (t *FakeTransport) Listen(_ string) (net.Listener, error) {
+	if t.inner != nil {
+		return t.inner.Listen(t.addr)
+	}
+	return net.Listen("tcp", t.addr)
+}
+
+// Dial implements transport.IPC. See Listen comment for addr handling.
+func (t *FakeTransport) Dial(_ string) (net.Conn, error) {
+	if t.inner != nil {
+		return t.inner.Dial(t.addr)
+	}
+	return net.Dial("tcp", t.addr)
+}
+
+// Address implements transport.IPC. Returns the constructor address
+// regardless of the appID argument.
+func (t *FakeTransport) Address(_ string) string { return t.addr }
+
+// Cleanup implements transport.IPC. Records the call so tests can assert
+// that Cleanup did or did not fire, and delegates to inner when wrapped.
+func (t *FakeTransport) Cleanup(_ string) {
+	t.mu.Lock()
+	t.cleaned = true
+	t.cleanups++
+	t.mu.Unlock()
+	if t.inner != nil {
+		t.inner.Cleanup(t.addr)
+	}
+}
+
+// DidCleanup reports whether Cleanup has been called at least once.
+func (t *FakeTransport) DidCleanup() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.cleaned
+}
+
+// CleanupCount returns the number of times Cleanup has been invoked.
+func (t *FakeTransport) CleanupCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.cleanups
+}
+
+// StubAPIClient is a minimal event.APIClient / appmeta.APIClient /
+// consume.APIClient stub. It records the last call and returns a
+// pre-configured body or error.
+type StubAPIClient struct {
+	Body string // body to return on success; empty ⇒ "{}"
+	Err  error  // if non-nil, returned instead of Body
+
+	mu        sync.Mutex
+	GotMethod string
+	GotPath   string
+	GotBody   interface{}
+	Calls     int
+}
+
+// CallAPI records the call and returns the configured response.
+func (s *StubAPIClient) CallAPI(_ context.Context, method, path string, body interface{}) (json.RawMessage, error) {
+	s.mu.Lock()
+	s.GotMethod = method
+	s.GotPath = path
+	s.GotBody = body
+	s.Calls++
+	s.mu.Unlock()
+	if s.Err != nil {
+		return nil, s.Err
+	}
+	if s.Body == "" {
+		return json.RawMessage("{}"), nil
+	}
+	return json.RawMessage(s.Body), nil
+}
+
+// ErrStubUnconfigured is returned as a sentinel so tests can assert via
+// errors.Is when they expect a stub to have been skipped.
+var ErrStubUnconfigured = errors.New("testutil.StubAPIClient: no body or err configured")

--- a/internal/event/transport/transport.go
+++ b/internal/event/transport/transport.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package transport abstracts the platform-specific IPC mechanism the
+// bus and consume client use to talk to each other: Unix domain sockets
+// on POSIX, named pipes on Windows.
+package transport
+
+import "net"
+
+// IPC abstracts the platform-specific IPC mechanism (Unix socket on
+// POSIX, Named Pipe on Windows). Named `IPC` (not `Transport`) to avoid
+// the `transport.Transport` stutter at call sites.
+type IPC interface {
+	Listen(addr string) (net.Listener, error)
+	Dial(addr string) (net.Conn, error)
+	Address(appID string) string
+	Cleanup(addr string)
+}
+
+// New returns the platform-appropriate IPC implementation.
+// Implemented in transport_unix.go and transport_windows.go.

--- a/internal/event/transport/transport_test.go
+++ b/internal/event/transport/transport_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
 //go:build !windows
 
 package transport

--- a/internal/event/transport/transport_test.go
+++ b/internal/event/transport/transport_test.go
@@ -1,0 +1,134 @@
+//go:build !windows
+
+package transport
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestUnixTransport_Address(t *testing.T) {
+	tr := New()
+	addr := tr.Address("cli_test123")
+	if addr == "" {
+		t.Fatal("address should not be empty")
+	}
+	if !contains(addr, "cli_test123") {
+		t.Errorf("address %q should contain appID", addr)
+	}
+}
+
+func TestUnixTransport_ListenAndDial(t *testing.T) {
+	tr := New()
+	dir := t.TempDir()
+	addr := filepath.Join(dir, "t.sock") // short name: macOS limits unix socket paths to 103 bytes
+
+	ln, err := tr.Listen(addr)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			accepted <- conn
+		}
+	}()
+
+	conn, err := tr.Dial(addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	serverConn := <-accepted
+	defer serverConn.Close()
+
+	_, err = conn.Write([]byte("hello\n"))
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, 64)
+	n, err := serverConn.Read(buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(buf[:n]) != "hello\n" {
+		t.Errorf("got %q, want %q", string(buf[:n]), "hello\n")
+	}
+}
+
+func TestUnixTransport_ListenTwiceFails(t *testing.T) {
+	tr := New()
+	dir := t.TempDir()
+	addr := filepath.Join(dir, "s") // 1-char name: macOS limits unix socket paths to 103 bytes
+
+	ln1, err := tr.Listen(addr)
+	if err != nil {
+		t.Fatalf("first listen: %v", err)
+	}
+	defer ln1.Close()
+
+	_, err = tr.Listen(addr)
+	if err == nil {
+		t.Error("second listen on same addr should fail")
+	}
+}
+
+func TestUnixTransport_Cleanup(t *testing.T) {
+	tr := New()
+	dir := t.TempDir()
+	addr := filepath.Join(dir, "t.sock") // short name: macOS limits unix socket paths to 103 bytes
+
+	ln, _ := tr.Listen(addr)
+	ln.Close()
+	tr.Cleanup(addr)
+
+	if _, err := os.Stat(addr); !os.IsNotExist(err) {
+		t.Error("sock file should be removed after Cleanup")
+	}
+}
+
+// TestUnixDialTimeout verifies Dial fails-fast rather than blocking
+// indefinitely when nothing is listening. Uses a valid but abandoned
+// socket path (not a file, not a listener) so the OS treats it as
+// "connection refused" / ENOENT immediately.
+//
+// A non-existent path typically returns ENOENT synchronously without
+// exercising the 5s timeout; the real guarantee here is "Dial doesn't
+// hang forever" — the ceiling just has to sit safely above the 5s
+// timeout so a truly wedged peer also bounces out.
+func TestUnixDialTimeout(t *testing.T) {
+	tmpDir := t.TempDir()
+	sockPath := filepath.Join(tmpDir, "n.sock") // short name for macOS 103-byte limit
+
+	// Ensure the file doesn't exist.
+	os.Remove(sockPath)
+
+	tr := &unixTransport{}
+	start := time.Now()
+	conn, err := tr.Dial(sockPath)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		conn.Close()
+		t.Fatal("expected error dialing non-listening socket")
+	}
+	if elapsed > 6*time.Second {
+		t.Errorf("Dial took %v; should fail-fast or honor 5s timeout", elapsed)
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/event/transport/transport_unix.go
+++ b/internal/event/transport/transport_unix.go
@@ -1,0 +1,74 @@
+// internal/event/transport/transport_unix.go
+//go:build !windows
+
+package transport
+
+import (
+	"net"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+// dialTimeout bounds how long Dial will block waiting for the server
+// side to accept. Without this, an accept-queue-full or otherwise
+// wedged bus would hang the caller indefinitely. Matches the Windows
+// winio.DialPipe timeout for symmetric behaviour across platforms.
+const dialTimeout = 5 * time.Second
+
+type unixTransport struct{}
+
+// New returns a Unix socket transport.
+func New() IPC {
+	return &unixTransport{}
+}
+
+func (t *unixTransport) Listen(addr string) (net.Listener, error) {
+	if err := vfs.MkdirAll(filepath.Dir(addr), 0700); err != nil {
+		return nil, err
+	}
+	return net.Listen("unix", addr)
+}
+
+func (t *unixTransport) Dial(addr string) (net.Conn, error) {
+	return net.DialTimeout("unix", addr, dialTimeout)
+}
+
+// Address returns the bus socket path under the project's config dir.
+// Using core.GetConfigDir rather than os.UserHomeDir keeps the event
+// subsystem consistent with the rest of the CLI (credentials, config,
+// lockfile all go through the same helper) and honours the
+// LARKSUITE_CLI_CONFIG_DIR env override so container/tmpdir-based tests
+// get real isolation.
+func (t *unixTransport) Address(appID string) string {
+	return filepath.Join(core.GetConfigDir(), "events", sanitizeAppID(appID), "bus.sock")
+}
+
+// sanitizeAppID guards path construction against a malformed AppID
+// (config corruption, manual edit) that could escape the events dir
+// via "..", separators, or NUL. Strips them defensively — a corrupt
+// AppID becoming a wedged bus is acceptable; silently `listen`ing in
+// a parent directory is not.
+func sanitizeAppID(appID string) string {
+	if appID == "" {
+		return "_"
+	}
+	repl := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		"\x00", "_",
+		"..", "_",
+	)
+	out := repl.Replace(appID)
+	if out == "" || out == "." {
+		return "_"
+	}
+	return out
+}
+
+func (t *unixTransport) Cleanup(addr string) {
+	_ = vfs.Remove(addr)
+}

--- a/internal/event/transport/transport_unix.go
+++ b/internal/event/transport/transport_unix.go
@@ -6,10 +6,10 @@ package transport
 import (
 	"net"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/event"
 	"github.com/larksuite/cli/internal/vfs"
 )
 
@@ -44,29 +44,7 @@ func (t *unixTransport) Dial(addr string) (net.Conn, error) {
 // LARKSUITE_CLI_CONFIG_DIR env override so container/tmpdir-based tests
 // get real isolation.
 func (t *unixTransport) Address(appID string) string {
-	return filepath.Join(core.GetConfigDir(), "events", sanitizeAppID(appID), "bus.sock")
-}
-
-// sanitizeAppID guards path construction against a malformed AppID
-// (config corruption, manual edit) that could escape the events dir
-// via "..", separators, or NUL. Strips them defensively — a corrupt
-// AppID becoming a wedged bus is acceptable; silently `listen`ing in
-// a parent directory is not.
-func sanitizeAppID(appID string) string {
-	if appID == "" {
-		return "_"
-	}
-	repl := strings.NewReplacer(
-		"/", "_",
-		"\\", "_",
-		"\x00", "_",
-		"..", "_",
-	)
-	out := repl.Replace(appID)
-	if out == "" || out == "." {
-		return "_"
-	}
-	return out
+	return filepath.Join(core.GetConfigDir(), "events", event.SanitizeAppID(appID), "bus.sock")
 }
 
 func (t *unixTransport) Cleanup(addr string) {

--- a/internal/event/transport/transport_unix.go
+++ b/internal/event/transport/transport_unix.go
@@ -1,4 +1,6 @@
-// internal/event/transport/transport_unix.go
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
 //go:build !windows
 
 package transport

--- a/internal/event/transport/transport_windows.go
+++ b/internal/event/transport/transport_windows.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+// internal/event/transport/transport_windows.go
+//
+// Windows Named Pipe transport for the event bus IPC. Uses Microsoft's
+// go-winio (same library docker/containerd depend on) so the consumer
+// side looks identical to Unix sockets from the bus/consume layer —
+// they just work against `net.Conn` / `net.Listener`.
+//
+// Pipe name format: \\.\pipe\lark-cli-<appID>. The pipe is a kernel
+// object (not on the filesystem) so Cleanup is a no-op: Windows
+// releases the pipe automatically when the server process exits.
+
+package transport
+
+import (
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+// pipeBufferSize is the per-direction kernel buffer for each named pipe.
+// 64 KB is generous for our JSON event payloads (typical < 10 KB, bulk
+// events ~ 30-50 KB) — one event always fits without forcing a partial
+// write, and the writer rarely blocks waiting for the reader. Raising it
+// further wastes kernel memory per connection without reducing syscalls;
+// lowering it causes more context switches on burst traffic.
+const pipeBufferSize = 65536
+
+type windowsTransport struct{}
+
+// New returns a Named Pipe transport for Windows.
+func New() IPC {
+	return &windowsTransport{}
+}
+
+func (t *windowsTransport) Listen(addr string) (net.Listener, error) {
+	// PipeConfig values mirror the kernel defaults we care about:
+	//   - MessageMode=false → byte stream, matches our newline-delimited JSON protocol
+	//   - InputBufferSize / OutputBufferSize match a typical event payload plus slack
+	// SecurityDescriptor is left empty → defaults to the creating user,
+	// which is exactly what we want (per-user IPC, not system-wide).
+	return winio.ListenPipe(addr, &winio.PipeConfig{
+		InputBufferSize:  pipeBufferSize,
+		OutputBufferSize: pipeBufferSize,
+	})
+}
+
+func (t *windowsTransport) Dial(addr string) (net.Conn, error) {
+	// 5s dial timeout matches the forkBus retry budget on the consume side.
+	timeout := 5 * time.Second
+	return winio.DialPipe(addr, &timeout)
+}
+
+// Address returns the pipe path for a given appID. Named pipe names live
+// in a global kernel namespace, keyed by appID so multiple bus daemons
+// for different apps coexist without collision. Backslash and NUL are
+// stripped defensively — a corrupt AppID should not be able to reshape
+// the pipe path.
+func (t *windowsTransport) Address(appID string) string {
+	return `\\.\pipe\lark-cli-` + sanitizePipeAppID(appID)
+}
+
+func sanitizePipeAppID(appID string) string {
+	if appID == "" {
+		return "_"
+	}
+	out := make([]rune, 0, len(appID))
+	for _, r := range appID {
+		if r == '\\' || r == '/' || r == 0 {
+			out = append(out, '_')
+			continue
+		}
+		out = append(out, r)
+	}
+	return string(out)
+}
+
+// Cleanup is a no-op on Windows: named pipes are kernel objects that
+// get released automatically when the server-side handle closes. There
+// is no stale file to remove like on Unix.
+func (t *windowsTransport) Cleanup(addr string) {}

--- a/internal/event/transport/transport_windows.go
+++ b/internal/event/transport/transport_windows.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/Microsoft/go-winio"
+
+	"github.com/larksuite/cli/internal/event"
 )
 
 // pipeBufferSize is the per-direction kernel buffer for each named pipe.
@@ -58,26 +60,11 @@ func (t *windowsTransport) Dial(addr string) (net.Conn, error) {
 
 // Address returns the pipe path for a given appID. Named pipe names live
 // in a global kernel namespace, keyed by appID so multiple bus daemons
-// for different apps coexist without collision. Backslash and NUL are
-// stripped defensively — a corrupt AppID should not be able to reshape
-// the pipe path.
+// for different apps coexist without collision. SanitizeAppID strips
+// separators / NUL / ".." — a corrupt AppID should not be able to
+// reshape the pipe path.
 func (t *windowsTransport) Address(appID string) string {
-	return `\\.\pipe\lark-cli-` + sanitizePipeAppID(appID)
-}
-
-func sanitizePipeAppID(appID string) string {
-	if appID == "" {
-		return "_"
-	}
-	out := make([]rune, 0, len(appID))
-	for _, r := range appID {
-		if r == '\\' || r == '/' || r == 0 {
-			out = append(out, '_')
-			continue
-		}
-		out = append(out, r)
-	}
-	return string(out)
+	return `\\.\pipe\lark-cli-` + event.SanitizeAppID(appID)
 }
 
 // Cleanup is a no-op on Windows: named pipes are kernel objects that

--- a/internal/event/types.go
+++ b/internal/event/types.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package event is the hub of the Lark CLI event subsystem: it owns the
+// registry of EventKeys, the RawEvent type that sources emit, the
+// APIClient interface that EventKey PreConsume hooks call through, and
+// the dedup filter used by the bus to drop SDK replays.
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"time"
+
+	"github.com/larksuite/cli/internal/event/schemas"
+)
+
+const (
+	DefaultBufferSize = 100
+	MaxBufferSize     = 1000
+)
+
+// RawEvent is the unit of data flowing through the Bus.
+//
+// Timestamp records "when we (the source) saw it locally", useful for
+// bus-internal observability. SourceTime is the upstream publisher's
+// create_time (ms unix timestamp, stringified) propagated verbatim to the
+// consumer as protocol.Event.SourceTime — preferred over Timestamp when
+// set because it preserves upstream semantics even if the source reorders
+// or batches delivery locally.
+type RawEvent struct {
+	EventID    string          `json:"event_id"`
+	EventType  string          `json:"event_type"`
+	SourceTime string          `json:"source_time,omitempty"`
+	Payload    json.RawMessage `json:"payload"`
+	Timestamp  time.Time       `json:"timestamp"`
+}
+
+// APIClient provides API access to Process and PreConsume functions.
+// Intentionally narrow — avoids importing shortcuts/common.Runtime so the
+// event package stays self-contained. The concrete implementation (in
+// cmd/event/consume.go) wraps the project's unified client.APIClient so
+// calls go through the same SDK stack as every other command (UA,
+// retries, tracing, permission diagnostics).
+type APIClient interface {
+	// CallAPI invokes a Lark Open API and returns the raw JSON response
+	// body. The identity is whatever the consume command resolved from
+	// the EventKey's AuthTypes (--as flag, config default, etc.) —
+	// implementations do not expose it so business code can't pin a
+	// different identity and skip the pre-flight checks.
+	CallAPI(ctx context.Context, method, path string, body interface{}) (json.RawMessage, error)
+}
+
+// ParamType classifies param value semantics. Enum/Multi require Values.
+type ParamType string
+
+const (
+	ParamString ParamType = "string" // free text
+	ParamEnum   ParamType = "enum"   // single-pick from Values
+	ParamMulti  ParamType = "multi"  // multi-pick from Values (comma separated)
+	ParamBool   ParamType = "bool"
+	ParamInt    ParamType = "int"
+)
+
+// ParamValue is one allowed value of an Enum/Multi param. Desc is
+// mandatory so AI consumers can decide which value to pick.
+type ParamValue struct {
+	Value string `json:"value"`
+	Desc  string `json:"desc"`
+}
+
+// ParamDef describes a --param key=value parameter for a business EventKey.
+type ParamDef struct {
+	Name        string       `json:"name"`
+	Type        ParamType    `json:"type"`
+	Required    bool         `json:"required"`
+	Default     string       `json:"default,omitempty"`
+	Description string       `json:"description"`
+	Values      []ParamValue `json:"values,omitempty"`
+}
+
+// ProcessFunc is the type of the business logic function for an EventKey.
+type ProcessFunc = func(ctx context.Context, rt APIClient, raw *RawEvent, params map[string]string) (json.RawMessage, error)
+
+// SchemaDef describes how an EventKey's delivered payload is typed.
+// Exactly one of Native or Custom must be non-nil.
+type SchemaDef struct {
+	// Native: the SDK struct describing the `event` body. Framework
+	// auto-wraps it in the V2 envelope (schema/header/event). Use for
+	// the "zero-effort" path — business just points at the SDK type.
+	Native *SchemaSpec `json:"native,omitempty"`
+
+	// Custom: the complete schema consumers see. Framework does not
+	// modify it. Use for Processed keys (Process produces this shape)
+	// or Native keys where business wants to hand-author the envelope.
+	Custom *SchemaSpec `json:"custom,omitempty"`
+
+	// FieldOverrides is a pointer-keyed semantic overlay applied after
+	// reflection (and envelope wrap, for Native). Paths that do not
+	// resolve are reported by CI lint. See internal/event/schemas.
+	FieldOverrides map[string]schemas.FieldMeta `json:"field_overrides,omitempty"`
+}
+
+// SchemaSpec points at a schema source — exactly one of Type or Raw.
+type SchemaSpec struct {
+	Type reflect.Type    `json:"-"`
+	Raw  json.RawMessage `json:"raw,omitempty"`
+}
+
+// KeyDefinition is the registration unit for event keys.
+type KeyDefinition struct {
+	Key         string `json:"key"`
+	DisplayName string `json:"display_name,omitempty"`
+	Description string `json:"description,omitempty"`
+	EventType   string `json:"event_type"`
+
+	Params []ParamDef `json:"params,omitempty"`
+
+	// Schema describes the payload shape consumers receive.
+	Schema SchemaDef `json:"schema"`
+
+	// Process is the business logic function. Required when Schema.Custom
+	// carries Processed output; must be nil when Schema.Native is used.
+	Process func(ctx context.Context, rt APIClient, raw *RawEvent, params map[string]string) (json.RawMessage, error) `json:"-"`
+
+	// PreConsume runs before consumption starts. Returns a cleanup function.
+	PreConsume func(ctx context.Context, rt APIClient, params map[string]string) (cleanup func(), err error) `json:"-"`
+
+	// --- Auth & Permission metadata (AI-readable) ---
+
+	// Scopes lists the OAuth scopes required to consume this EventKey.
+	// Used for pre-flight scope checks and displayed in `event schema`.
+	Scopes []string `json:"scopes,omitempty"`
+
+	// AuthTypes lists identities this EventKey supports, matching the
+	// semantics already used by shortcut definitions. The first element is
+	// the default used when --as and DefaultAs don't specify; the full
+	// slice is the allowed set. An empty slice means "no identity required"
+	// (rare — only for keys that neither subscribe via OAPI nor invoke
+	// APIs in Process/PreConsume).
+	//
+	// Examples:
+	//   []string{"bot"}          — IM events (bot-scoped subscription)
+	//   []string{"user"}         — mail (subscribe API is UAT-only)
+	//   []string{"bot", "user"}  — both identities supported, bot default
+	AuthTypes []string `json:"auth_types,omitempty"`
+
+	// RequiredConsoleEvents lists event types that must be enabled in the
+	// Feishu developer console for this EventKey to receive events.
+	RequiredConsoleEvents []string `json:"required_console_events,omitempty"`
+
+	BufferSize int `json:"buffer_size,omitempty"`
+	Workers    int `json:"workers,omitempty"`
+}

--- a/internal/lockfile/lock_unix.go
+++ b/internal/lockfile/lock_unix.go
@@ -14,7 +14,7 @@ import (
 func tryLockFile(f *os.File) error {
 	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
 	if err != nil {
-		return fmt.Errorf("lock already held by another process (lock: %s): %w", f.Name(), err)
+		return fmt.Errorf("%w (lock: %s, syscall: %v)", ErrHeld, f.Name(), err)
 	}
 	return nil
 }

--- a/internal/lockfile/lock_windows.go
+++ b/internal/lockfile/lock_windows.go
@@ -36,7 +36,7 @@ func tryLockFile(f *os.File) error {
 		uintptr(unsafe.Pointer(&ol)),
 	)
 	if r1 == 0 {
-		return fmt.Errorf("lock already held by another process (lock: %s): %v", f.Name(), err)
+		return fmt.Errorf("%w (lock: %s, syscall: %v)", ErrHeld, f.Name(), err)
 	}
 	return nil
 }

--- a/internal/lockfile/lockfile.go
+++ b/internal/lockfile/lockfile.go
@@ -4,6 +4,7 @@
 package lockfile
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +17,14 @@ import (
 // safeIDChars strips everything except alphanumerics, underscores, hyphens, and dots
 // to prevent path traversal via crafted app IDs (e.g. "../../tmp/evil").
 var safeIDChars = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
+
+// ErrHeld is returned (wrapped) when TryLock cannot acquire the lock because
+// another owner holds it — either this same LockFile instance was already
+// locked, or another process holds the flock (Unix) / LockFileEx (Windows)
+// on the underlying file. Callers use errors.Is(err, ErrHeld) to distinguish
+// benign contention (retryable) from real failures (e.g. EACCES, missing
+// parent dir) which should surface.
+var ErrHeld = errors.New("lockfile: lock already held")
 
 // LockFile represents an exclusive file lock.
 type LockFile struct {
@@ -55,7 +64,7 @@ func ForSubscribe(appID string) (*LockFile, error) {
 // The lock is automatically released when the process exits.
 func (l *LockFile) TryLock() error {
 	if l.file != nil {
-		return fmt.Errorf("lock already held: %s", l.path)
+		return fmt.Errorf("%w: %s", ErrHeld, l.path)
 	}
 	f, err := vfs.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {

--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -4,6 +4,7 @@
 package lockfile
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -39,9 +40,13 @@ func TestTryLock_Conflict(t *testing.T) {
 	defer l1.Unlock()
 
 	l2 := New(path)
-	if err := l2.TryLock(); err == nil {
+	err := l2.TryLock()
+	if err == nil {
 		l2.Unlock()
 		t.Fatal("second TryLock should fail when lock is held by another instance")
+	}
+	if !errors.Is(err, ErrHeld) {
+		t.Errorf("expected error to wrap ErrHeld, got: %v", err)
 	}
 }
 
@@ -57,8 +62,8 @@ func TestTryLock_AlreadyHeld(t *testing.T) {
 	if err == nil {
 		t.Fatal("double TryLock on same instance should fail")
 	}
-	if !strings.Contains(err.Error(), "lock already held") {
-		t.Errorf("error should mention 'lock already held', got: %v", err)
+	if !errors.Is(err, ErrHeld) {
+		t.Errorf("expected error to wrap ErrHeld, got: %v", err)
 	}
 }
 
@@ -194,4 +199,22 @@ func TestForSubscribe_RejectsEmptyAppID(t *testing.T) {
 	if err == nil {
 		t.Fatal("ForSubscribe should reject empty app ID")
 	}
+}
+
+// TestErrHeld_RelockAfterUnlock verifies that once Unlock releases the lock,
+// a fresh TryLock succeeds — the ErrHeld sentinel is not "sticky" on the
+// LockFile object.
+func TestErrHeld_RelockAfterUnlock(t *testing.T) {
+	l := newTestLock(t)
+	if err := l.TryLock(); err != nil {
+		t.Fatalf("first TryLock failed: %v", err)
+	}
+	if err := l.Unlock(); err != nil {
+		t.Fatalf("Unlock failed: %v", err)
+	}
+	// Second lock on same object should succeed (not return ErrHeld).
+	if err := l.TryLock(); err != nil {
+		t.Errorf("TryLock after Unlock should succeed; got: %v", err)
+	}
+	l.Unlock()
 }

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -709,9 +709,10 @@ func (s Shortcut) mountDeclarative(ctx context.Context, parent *cobra.Command, f
 	botOnly := len(shortcut.AuthTypes) == 1 && shortcut.AuthTypes[0] == "bot"
 
 	cmd := &cobra.Command{
-		Use:   shortcut.Command,
-		Short: shortcut.Description,
-		Args:  rejectPositionalArgs(),
+		Use:    shortcut.Command,
+		Short:  shortcut.Description,
+		Hidden: shortcut.Hidden,
+		Args:   rejectPositionalArgs(),
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runShortcut(cmd, f, &shortcut, botOnly)
 		},

--- a/shortcuts/common/types.go
+++ b/shortcuts/common/types.go
@@ -42,6 +42,7 @@ type Shortcut struct {
 	Flags     []Flag   // flag definitions; --dry-run is auto-injected
 	HasFormat bool     // auto-inject --format flag (json|pretty|table|ndjson|csv)
 	Tips      []string // optional tips shown in --help output
+	Hidden    bool     // hide from --help / tab completion (still executable); use when deprecating a command in favor of a replacement
 
 	// Business logic hooks.
 	DryRun   func(ctx context.Context, runtime *RuntimeContext) *DryRunAPI // optional: framework prints & returns when --dry-run is set

--- a/shortcuts/event/subscribe.go
+++ b/shortcuts/event/subscribe.go
@@ -86,6 +86,11 @@ var EventSubscribe = common.Shortcut{
 	Risk:        "read",
 	Scopes:      []string{}, // no direct OAPI; scopes depend on subscribed event types
 	AuthTypes:   []string{"bot"},
+	// Hidden: superseded by `event consume`. Kept executable so existing
+	// scripts keep working, but removed from --help/tab-completion so new
+	// users land on the replacement. Delete once downstream callers have
+	// migrated.
+	Hidden: true,
 	Flags: []common.Flag{
 		// Output destination — where events go
 		{Name: "output-dir", Desc: "write each event as a JSON file in this directory (default: stdout)"},

--- a/skills/lark-event/SKILL.md
+++ b/skills/lark-event/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark-event
-version: 1.2.0
+version: 1.0.0
 description: "飞书事件实时订阅：通过 `lark-cli event consume <EventKey>` 消费 IM 消息等实时事件。支持 `--max-events` / `--timeout` bounded 执行，适合 AI agent 作为子进程启动。业务细节在 references 下按业务域拆分。"
 metadata:
   requires:
@@ -26,11 +26,13 @@ metadata:
 
 **子进程启动契约**：`event consume` 的 stderr 出现 `[event] ready event_key=<key>` 后，之后到达的事件保证送到 stdout。父进程 block 读 stderr 到这行再开始读 stdout，**不要 sleep 兜底**。
 
+**stdin EOF 视为退出信号**：`event consume` 把 stdin 关闭当退出信号（为 AI 子进程场景设计）。`< /dev/null` / `nohup` / systemd 默认 `StandardInput=null` 起会立刻优雅退出（stderr `reason: signal`）。要持续跑：保持 stdin 开（`< /dev/tty` 或 `< <(tail -f /dev/null)`），或用 `--max-events`/`--timeout`（bounded）
+
 **一个 consume 一个 EventKey**：命令只接 1 个位置参数，不支持 `key1,key2` 或通配符。监听 N 个 key 要开 N 个子进程。
 
 **抓样本看 payload 形态**：`event consume <key> --max-events 1 --timeout 30s` —— 收到 1 条或 30 秒后退出，常用于探测事件的 shape。
 
-**不要 `kill -9` consume 进程**：跳过 cleanup 会留下 orphan 本地 bus（用 `event status --fail-on-orphan` 检测、`event stop --all --force` 清理）；有 PreConsume 的 EventKey 还会在服务端残留订阅。
+**避免 `kill -9` consume 进程**：对**有 PreConsume 的 EventKey**（需在服务端建订阅的类型），`kill -9` 会跳过 OAPI unsubscribe，造成服务端订阅残留（症状：重启报订阅已存在、事件重复推送）。优先用 SIGTERM / 关 stdin 停。
 
 ## 业务索引
 

--- a/skills/lark-event/SKILL.md
+++ b/skills/lark-event/SKILL.md
@@ -1,21 +1,68 @@
 ---
 name: lark-event
-version: 1.0.0
-description: "飞书事件订阅：通过 WebSocket 长连接实时监听飞书事件（消息、通讯录变更、日历变更等），输出 NDJSON 到 stdout，支持 compact Agent 友好格式、正则路由、文件输出。当用户需要实时监听飞书事件、构建事件驱动管道时使用。"
+version: 1.2.0
+description: "飞书事件实时订阅：通过 `lark-cli event consume <EventKey>` 消费 IM 消息等实时事件。支持 `--max-events` / `--timeout` bounded 执行，适合 AI agent 作为子进程启动。业务细节在 references 下按业务域拆分。"
 metadata:
   requires:
     bins: ["lark-cli"]
   cliHelp: "lark-cli event --help"
 ---
 
-# event (v1)
+# Lark Events
 
-> **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md) 了解认证、权限处理和安全规则。
+> **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md) 了解认证、`--as user/bot` 切换、`Permission denied` 的处理和安全规则。
 
-## Shortcuts（推荐优先使用）
+## 核心命令
 
-Shortcut 是对常用操作的高级封装（`lark-cli event +<verb> [flags]`）。有 Shortcut 的操作优先使用。
+| 命令 | 用途 |
+|------|------|
+| `lark-cli event list [--json]` | 列出所有可订阅的 EventKey |
+| `lark-cli event schema <EventKey> [--json]` | 查看指定 EventKey 的参数、schema|
+| `lark-cli event consume <EventKey> [flags]` | 前台阻塞式消费事件（Ctrl+C / SIGTERM / 关 stdin 退出） |
+| `lark-cli event status [--fail-on-orphan] [--json]` | 查看本机 bus 守护进程状态 |
+| `lark-cli event stop [--all] [--force] [--json]` | 停止 bus 守护进程 |
 
-| Shortcut | 说明 |
-|----------|------|
-| [`+subscribe`](references/lark-event-subscribe.md) | Subscribe to Lark events via WebSocket long connection (read-only, NDJSON output); bot-only; supports compact agent-friendly format, regex routing, file output |
+**AI 调用路线**：`event list --json` → 选定 EventKey → `event schema <key> --json` 拿 schema → 写 `--jq` → `event consume`。具体 flag 查 `event consume --help`。
+
+**子进程启动契约**：`event consume` 的 stderr 出现 `[event] ready event_key=<key>` 后，之后到达的事件保证送到 stdout。父进程 block 读 stderr 到这行再开始读 stdout，**不要 sleep 兜底**。
+
+**一个 consume 一个 EventKey**：命令只接 1 个位置参数，不支持 `key1,key2` 或通配符。监听 N 个 key 要开 N 个子进程。
+
+**抓样本看 payload 形态**：`event consume <key> --max-events 1 --timeout 30s` —— 收到 1 条或 30 秒后退出，常用于探测事件的 shape。
+
+**不要 `kill -9` consume 进程**：跳过 cleanup 会留下 orphan 本地 bus（用 `event status --fail-on-orphan` 检测、`event stop --all --force` 清理）；有 PreConsume 的 EventKey 还会在服务端残留订阅。
+
+## 业务索引
+
+| 业务 | Reference | 覆盖 |
+|---|---|---|
+| IM | [`references/lark-event-im.md`](references/lark-event-im.md) | 11 个 IM key（消息、群、reaction） |
+
+## 输出形状来自 Output Schema
+
+`event schema <key>` 的 Output Schema 给出字段路径、类型、是否 optional：
+
+- 顶层有 `{schema, header, event}` → V2 信封结构，字段路径走 `.event.xxx`
+- 顶层直接是扁平字段 → 路径走 `.xxx`
+
+**schema 长什么样，JQ 就怎么写**。
+
+`Output Schema` 里字段除了 `type` / `description`，还可能带：
+- `enum: [...]` — 该字段只能取这几个值
+- `format: "open_id" / "chat_id" / "email" / "timestamp_ms" / ...` — 语义标记，可用于反查 API 或格式转换
+
+具体业务的 shape 差异和字段语义见对应 reference。
+
+## 常用 Flag（consume）
+
+| Flag | 说明 |
+|---|---|
+| `--param key=value` / `-p` | 业务参数（可重复；多值用逗号）；取值见 `event schema <key>` 和对应业务 reference |
+| `--jq <expr>` | JQ 过滤/变形每条事件；表达式输出空则跳过该条 |
+| `--max-events N` | 收到 N 条事件后退出。默认 0 = 无限 |
+| `--timeout D` | D（如 `30s`、`2m`）后退出。默认 0 = 不超时。和 `--max-events` 取先达到者 |
+| `--quiet` | 抑制 stderr 状态提示。**AI 不要用**——会压制 ready marker |
+| `--output-dir <dir>` | 事件按文件写入目录，不走 stdout |
+| `--as user/bot/auto` | 强制身份；默认用 EventKey 声明的 `AuthTypes[0]` |
+
+输出是 **NDJSON**（一行一个 JSON 对象）。pretty-print 用 `| jq .`。

--- a/skills/lark-event/references/lark-event-im.md
+++ b/skills/lark-event/references/lark-event-im.md
@@ -1,0 +1,59 @@
+# IM Events
+
+> **前置条件：** 先阅读 [`../SKILL.md`](../SKILL.md) 了解 `event consume` 的通用机制（命令、子进程启动契约、JQ 用法）。
+
+## Key 目录（11 个）
+
+| EventKey | 用途 |
+|---|---|
+| `im.message.receive_v1` | 接收 IM 消息（text / post / image / file / audio / media / sticker / interactive / share_chat / share_user / system 所有类型） |
+| `im.message.message_read_v1` | 用户已读机器人发送的**单聊**消息（群消息不触发） |
+| `im.message.reaction.created_v1` | 消息被添加表情回复 |
+| `im.message.reaction.deleted_v1` | 消息被删除表情回复 |
+| `im.chat.updated_v1` | 群配置（群主、头像、名称、权限等）被修改 |
+| `im.chat.disbanded_v1` | 群被解散 |
+| `im.chat.member.bot.added_v1` | 机器人被添加至群聊 |
+| `im.chat.member.bot.deleted_v1` | 机器人被移出群聊 |
+| `im.chat.member.user.added_v1` | 新用户进群（含话题群） |
+| `im.chat.member.user.deleted_v1` | 用户主动退群**或**被移出群聊 |
+| `im.chat.member.user.withdrawn_v1` | 撤销拉用户进群（邀请方撤回邀请，用户未真正加入） |
+
+
+## 注意点（`im.message.receive_v1`）
+
+**sender_id 只有 open_id**：事件 payload 里没有姓名字段；要拿发送者显示名得另调 contact API。
+
+**`.content` 对 `interactive`（卡片）消息是原始 JSON 字符串**，要先 fromjson：
+
+```bash
+# 错的：直接当对象取，会拿到 null 或 error
+lark-cli event consume im.message.receive_v1 --jq '.content.header.title.content'
+
+# 对的：fromjson 先解析成对象
+lark-cli event consume im.message.receive_v1 \
+  --jq 'select(.message_type=="interactive") | .content | fromjson | .header.title.content'
+```
+
+## 常用 JQ 范式
+
+### 1. 按会话类型过滤（私聊 vs 群聊）
+
+`chat_type` 枚举只有 `p2p` / `group` 两个值。
+
+```bash
+# 只看私聊
+lark-cli event consume im.message.receive_v1 \
+  --jq 'select(.chat_type=="p2p") | {from: .sender_id, msg: .content}'
+
+# 只看群聊
+lark-cli event consume im.message.receive_v1 \
+  --jq 'select(.chat_type=="group") | {chat: .chat_id, from: .sender_id, msg: .content}'
+```
+
+### 2. 按消息类型过滤
+
+```bash
+# 只看纯文本（排除卡片、图片等）
+lark-cli event consume im.message.receive_v1 \
+  --jq 'select(.message_type=="text") | .content'
+```

--- a/skills/lark-event/references/lark-event-im.md
+++ b/skills/lark-event/references/lark-event-im.md
@@ -18,6 +18,7 @@
 | `im.chat.member.user.deleted_v1` | 用户主动退群**或**被移出群聊 |
 | `im.chat.member.user.withdrawn_v1` | 撤销拉用户进群（邀请方撤回邀请，用户未真正加入） |
 
+> **Shape**：`im.message.receive_v1` 是唯一 flat（字段直接 `.xxx`），其余 10 个都是 V2 信封（字段在 `.event.xxx` 下）。
 
 ## 注意点（`im.message.receive_v1`）
 


### PR DESCRIPTION
## Summary

Adds a new `event` top-level command for real-time Lark event subscription & consume, built for AI-agent subprocess ergonomics. Production scope this phase: **IM domain only** (11 keys — message / reaction / chat member / chat lifecycle).

- **`event list` / `event schema` / `event consume` / `event status` / `event stop`** — full CLI surface around a local `_bus` daemon per AppID (Unix Socket on macOS/Linux, Named Pipe on Windows), with orphan-bus detection and cleanup.
- **Schema system**: `SchemaDef { Native | Custom } + FieldOverrides map[JSONPointer]FieldMeta` replaces the old `Kind/OutputSchema/OutputType`. Native schemas auto-wrap in the V2 envelope; Custom are business-authored and emitted verbatim. Struct tags `desc` / `enum` / `kind` drive reflected annotations; `kind` renders to the standard JSON Schema `format` keyword with a Feishu-specific value vocabulary (`open_id` / `chat_id` / `email` / `timestamp_ms` / …).
- **Subprocess contract for AI agents**:
  - `[event] ready event_key=<key>` stderr marker before any stdout emission (parent blocks on this instead of sleep).
  - stdin EOF is a graceful shutdown signal (paired with a descriptive diagnostic so `< /dev/null` / `nohup` / systemd callers aren't mystified).
  - `--max-events N` / `--timeout D` for bounded runs; ideal for 'fetch one sample' pattern.
  - No `--dry-run` — event subscription is a long-running lifecycle, not a single HTTP write, so `--max-events 1 --timeout 30s` is the preview path (mirrors Google Workspace CLI's choice on their events subscribe).
- **Reliability**: per-key buffer + workers, orphan-bus GC, dedup of SDK replays, SIGTERM/Ctrl-C trigger PreConsume cleanup (unsubscribe OAPI when applicable).

## Non-goals this phase

- Mail real-time subscription: out of scope for this PR. Continue using `lark-cli mail +watch` (unchanged). The framework's `PreConsume` / `FieldOverrides` / `ParamMulti` capabilities are complete and mail can return in a later PR without further framework changes.
- Runtime schema validation: schemas are descriptive (AI + JQ ergonomics), not contracts.

## Testing

- [x] `go test ./cmd/event/... ./events/... ./internal/event/...` all green locally
- [x] `events/lint_test.go` guards orphan `FieldOverrides` pointers with a synthetic canary key
- [x] Smoke: `event schema im.message.receive_v1 --json` shows enum on `message_type` / `chat_type` and `format` on every ID / timestamp field
- [x] Smoke: `event schema im.chat.disbanded_v1` shows V2 envelope wrap with FieldOverrides applied
- [x] Smoke: `event consume im.message.receive_v1 --max-events 1 --timeout 30s` exits cleanly after one event / timeout
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time event consumption: event consume with jq filtering, params, identity switching (--as), output options (--output-dir/NDJSON), --max-events and --timeout; prints a stable ready marker.
  * Event discovery: event list and event schema for browsing keys and payload shapes.
  * Bus management: event status, event stop, and a background event-bus daemon with auto-start and lifecycle controls.
  * Improved typo suggestions for unknown EventKey inputs.

* **Documentation**
  * Expanded IM event reference and updated consume guidance (stdin EOF semantics, ready-marker contract, usage patterns).

* **Style**
  * Legacy subscribe shortcut hidden from help (backwards-compatible).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->