### PR TITLE
feat(lark-im): add chat.members.bots to skill

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -86,6 +86,7 @@ lark-cli im <resource> <method> [flags] # 调用 API
 
 ### chat.members
 
+  - `bots` — 获取群内机器人列表。 Identity: supports `user` and `bot`; the caller must be in the target chat and must belong to the same tenant for internal chats.
   - `create` — 将用户或机器人拉入群聊。Identity: supports `user` and `bot`; the caller must be in the target chat; for `bot` calls, added users must be within the app's availability; for internal chats the operator must belong to the same tenant; if only owners/admins can add members, the caller must be an owner/admin, or a chat-creator bot with `im:chat:operate_as_owner`.
   - `delete` — 将用户或机器人移出群聊。Identity: supports `user` and `bot`; only group owner, admin, or creator bot can remove others; max 50 users or 5 bots per request.
   - `get` — 获取群成员列表。Identity: supports `user` and `bot`; the caller must be in the target chat and must belong to the same tenant for internal chats.
@@ -123,6 +124,7 @@ lark-cli im <resource> <method> [flags] # 调用 API
 | `chats.link` | `im:chat:read` |
 | `chats.list` | `im:chat:read` |
 | `chats.update` | `im:chat:update` |
+| `chat.members.bots` | `im:chat.members:read` |
 | `chat.members.create` | `im:chat.members:write_only` |
 | `chat.members.delete` | `im:chat.members:write_only` |
 | `chat.members.get` | `im:chat.members:read` |


### PR DESCRIPTION
  - Add chat.members.bots entry under chat.members API resources
  - Add chat.members.bots -> im:chat.members:read scope mapping

Change-Id: I57039a9a8649d794bbda84a1e41fae9cc31d570a

## Summary                                                                                                                                                                                                          
                                                                                                                                                                                                                      
  The `chat.members.bots` API is already registered in lark-cli but was missing                                                                                                                                       
  from the `lark-im` skill docs, so agents could not discover it when asked to
  list bots in a chat. This PR adds the entry and its required scope mapping so                                                                                                                                       
  the skill stays in sync with the registered API surface.
                                                                                                                                                                                                                      
  ## Changes      

  - Add `chat.members.bots` entry under the `chat.members` API resources section in `skills/lark-im/SKILL.md`
  - Add `chat.members.bots` → `im:chat.members:read` row to the scope table
                                                                                                                                                                                                                      
  ## Test Plan
                                                                                                                                                                                                                      
  - [x] Docs-only change — no Go source touched, so `make unit-test`, `go vet`, `gofmt -l .`, `go mod tidy`, and golangci-lint are not affected by this diff                                                          
  - [x] Manual verification in BOE: `lark-cli im chat.members bots --params '{"chat_id":"oc_aa3a3f1a6150397580df93d0f59d92c0"}' --as user` returns the bot list
                                                                                                                                                                                                                      
  ## Related Issues
                                                                                                                                                                                                                      
  - None          

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for a new API method to retrieve the list of bots within a chat, including scope requirements and permission details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->