### PR TITLE
feat(doc): warn when replace_range targets a heading but markdown lacks matching heading

### DIFF
--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -99,7 +99,7 @@ var DocsUpdate = common.Shortcut{
 		// Static semantic checks run before the MCP call so users see
 		// warnings even if the subsequent request fails. They never block
 		// execution — the update still proceeds.
-		for _, w := range docsUpdateWarnings(mode, markdown) {
+		for _, w := range docsUpdateWarnings(mode, markdown, runtime.Str("selection-by-title")) {
 			fmt.Fprintf(runtime.IO().ErrOut, "warning: %s\n", w)
 		}
 

--- a/shortcuts/doc/docs_update_check.go
+++ b/shortcuts/doc/docs_update_check.go
@@ -64,7 +64,11 @@ func checkDocsUpdateReplaceHeadingBlockType(mode, markdown, selectionByTitle str
 	if mode != "replace_range" {
 		return ""
 	}
-	targetLevel := atxHeadingLevel(selectionByTitle)
+	// --selection-by-title is a user-typed flag value, so strip surrounding
+	// whitespace before interpreting it as a heading line. The helper itself
+	// keeps CommonMark semantics (leading-space sensitivity) for markdown
+	// payload lines where whitespace is significant.
+	targetLevel := atxHeadingLevel(strings.TrimSpace(selectionByTitle))
 	if targetLevel == 0 {
 		return ""
 	}
@@ -80,25 +84,35 @@ func checkDocsUpdateReplaceHeadingBlockType(mode, markdown, selectionByTitle str
 }
 
 // atxHeadingLevel returns the ATX heading level (1..6) of an ATX heading
-// line such as "## Section", or 0 when the line is not an ATX heading. The
-// selection-by-title validator already requires a leading '#', so this is a
-// narrow helper; it also trims whitespace to tolerate stray indentation.
+// line such as "## Section", or 0 when the line is not an ATX heading.
+//
+// The matching rules follow CommonMark §4.2:
+//
+//   - 0..3 leading spaces are permitted; 4+ spaces (or any leading tab, which
+//     counts as 4 columns) turn the line into an indented code block.
+//   - The opening run of '#' is 1..6 characters.
+//   - The run must be followed by a space, a tab, or end of line. Empty
+//     headings (e.g. "##") are valid per spec.
 func atxHeadingLevel(line string) int {
-	trimmed := strings.TrimSpace(line)
+	body, ok := fenceIndentOK(line)
+	if !ok {
+		return 0
+	}
 	level := 0
-	for level < len(trimmed) && trimmed[level] == '#' {
+	for level < len(body) && body[level] == '#' {
 		level++
 	}
 	if level == 0 || level > 6 {
 		return 0
 	}
-	if level == len(trimmed) {
-		return 0
+	if level == len(body) {
+		return level
 	}
-	if trimmed[level] != ' ' {
-		return 0
+	switch body[level] {
+	case ' ', '\t':
+		return level
 	}
-	return level
+	return 0
 }
 
 // firstProseHeadingLevel returns the ATX heading level of the first non-blank

--- a/shortcuts/doc/docs_update_check.go
+++ b/shortcuts/doc/docs_update_check.go
@@ -34,7 +34,7 @@ import (
 //     _**text**_   *__text__*
 //     Lark stores only one of the two emphases (usually italic), silently
 //     dropping the other. The user wanted both; they will get one.
-func docsUpdateWarnings(mode, markdown string) []string {
+func docsUpdateWarnings(mode, markdown, selectionByTitle string) []string {
 	var warnings []string
 	if w := checkDocsUpdateReplaceMultilineMarkdown(mode, markdown); w != "" {
 		warnings = append(warnings, w)
@@ -42,7 +42,93 @@ func docsUpdateWarnings(mode, markdown string) []string {
 	if w := checkDocsUpdateBoldItalic(markdown); w != "" {
 		warnings = append(warnings, w)
 	}
+	if w := checkDocsUpdateReplaceHeadingBlockType(mode, markdown, selectionByTitle); w != "" {
+		warnings = append(warnings, w)
+	}
 	return warnings
+}
+
+// checkDocsUpdateReplaceHeadingBlockType flags replace_range invocations
+// whose --selection-by-title points at a heading block but whose --markdown
+// payload would not render as a heading of the same level. Lark's block
+// model stores {type, content} as independent attributes and replace_* only
+// rewrites content, so the target will keep its heading styling even though
+// the user's markdown expects a different shape. The canonical fix is
+// delete_range + insert_before, which is stated in the warning.
+//
+// The check intentionally fires only when --selection-by-title is present
+// (that's the one high-signal place where we know the target is a heading;
+// --selection-with-ellipsis and bare selection modes can target anything
+// and would produce too many false positives).
+func checkDocsUpdateReplaceHeadingBlockType(mode, markdown, selectionByTitle string) string {
+	if mode != "replace_range" {
+		return ""
+	}
+	targetLevel := atxHeadingLevel(selectionByTitle)
+	if targetLevel == 0 {
+		return ""
+	}
+	payloadLevel := firstProseHeadingLevel(markdown)
+	if payloadLevel == targetLevel {
+		return ""
+	}
+	return "--mode=replace_range does not change block type; the target heading selected by " +
+		"--selection-by-title will keep its heading level even though --markdown " +
+		"does not lead with a matching heading. " +
+		"To change block type (e.g. demote a heading to a paragraph), use --mode=delete_range " +
+		"followed by --mode=insert_before."
+}
+
+// atxHeadingLevel returns the ATX heading level (1..6) of an ATX heading
+// line such as "## Section", or 0 when the line is not an ATX heading. The
+// selection-by-title validator already requires a leading '#', so this is a
+// narrow helper; it also trims whitespace to tolerate stray indentation.
+func atxHeadingLevel(line string) int {
+	trimmed := strings.TrimSpace(line)
+	level := 0
+	for level < len(trimmed) && trimmed[level] == '#' {
+		level++
+	}
+	if level == 0 || level > 6 {
+		return 0
+	}
+	if level == len(trimmed) {
+		return 0
+	}
+	if trimmed[level] != ' ' {
+		return 0
+	}
+	return level
+}
+
+// firstProseHeadingLevel returns the ATX heading level of the first non-blank
+// prose line of markdown, skipping fenced code blocks. Returns 0 when the
+// first prose line is not an ATX heading (including setext headings, which
+// the author probably intended but which introduce enough ambiguity that we
+// treat them as "not a heading match" for this pre-flight check).
+func firstProseHeadingLevel(markdown string) int {
+	lines := strings.Split(markdown, "\n")
+	inFence := false
+	var fenceMarker string
+	for _, line := range lines {
+		if inFence {
+			if isCodeFenceClose(line, fenceMarker) {
+				inFence = false
+				fenceMarker = ""
+			}
+			continue
+		}
+		if marker := codeFenceOpenMarker(line); marker != "" {
+			inFence = true
+			fenceMarker = marker
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		return atxHeadingLevel(line)
+	}
+	return 0
 }
 
 // checkDocsUpdateReplaceMultilineMarkdown flags markdown that contains a

--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -443,7 +443,6 @@ func TestCheckDocsUpdateReplaceHeadingBlockType(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := checkDocsUpdateReplaceHeadingBlockType(tc.mode, tc.markdown, tc.selectionByTitle)
@@ -465,10 +464,14 @@ func TestAtxHeadingLevel(t *testing.T) {
 		"## H2":         2,
 		"###### H6":     6,
 		"####### x":     0, // 7 hashes is not a heading
-		"##":            0, // no content
+		"##":            2, // CommonMark: empty ATX heading is valid
+		"##\tH2":        2, // tab after hashes is valid
 		"##no-space":    0,
 		"":              0,
-		"  ## indented": 2,
+		"  ## indented": 2, // 2 leading spaces OK (≤3)
+		"   ## edge":    2, // exactly 3 leading spaces still OK
+		"    ## code":   0, // 4 spaces becomes indented code block
+		"\t## code":     0, // leading tab counts as 4 columns
 		"not a heading": 0,
 	}
 	for input, want := range cases {

--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -358,7 +358,7 @@ func TestDocsUpdateWarningsAggregates(t *testing.T) {
 	t.Parallel()
 
 	// Both flags trigger: replace_range with blank line AND triple-asterisk.
-	warnings := docsUpdateWarnings("replace_range", "***opening***\n\nsecond paragraph")
+	warnings := docsUpdateWarnings("replace_range", "***opening***\n\nsecond paragraph", "")
 	if len(warnings) != 2 {
 		t.Fatalf("expected 2 warnings, got %d: %v", len(warnings), warnings)
 	}
@@ -368,8 +368,112 @@ func TestDocsUpdateWarningsEmpty(t *testing.T) {
 	t.Parallel()
 
 	// Clean markdown in a non-replace mode produces zero warnings.
-	warnings := docsUpdateWarnings("insert_before", "plain paragraph text")
+	warnings := docsUpdateWarnings("insert_before", "plain paragraph text", "")
 	if len(warnings) != 0 {
 		t.Fatalf("expected no warnings, got: %v", warnings)
+	}
+}
+
+func TestCheckDocsUpdateReplaceHeadingBlockType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		mode             string
+		markdown         string
+		selectionByTitle string
+		wantWarning      bool
+	}{
+		{
+			name:             "plain replacement for H2 target warns",
+			mode:             "replace_range",
+			markdown:         "just a paragraph",
+			selectionByTitle: "## Overview",
+			wantWarning:      true,
+		},
+		{
+			name:             "mismatched heading level warns",
+			mode:             "replace_range",
+			markdown:         "### different level",
+			selectionByTitle: "## Overview",
+			wantWarning:      true,
+		},
+		{
+			name:             "matching heading level does not warn",
+			mode:             "replace_range",
+			markdown:         "## New title",
+			selectionByTitle: "## Overview",
+			wantWarning:      false,
+		},
+		{
+			name:             "non-replace_range mode does not warn",
+			mode:             "insert_before",
+			markdown:         "just a paragraph",
+			selectionByTitle: "## Overview",
+			wantWarning:      false,
+		},
+		{
+			name:             "selection without heading prefix does not warn",
+			mode:             "replace_range",
+			markdown:         "just a paragraph",
+			selectionByTitle: "",
+			wantWarning:      false,
+		},
+		{
+			name:             "leading fenced code block is skipped",
+			mode:             "replace_range",
+			markdown:         "```go\nfmt.Println(\"hi\")\n```\n## New title",
+			selectionByTitle: "## Overview",
+			wantWarning:      false,
+		},
+		{
+			name:             "leading blank lines are skipped",
+			mode:             "replace_range",
+			markdown:         "\n\n## New title",
+			selectionByTitle: "## Overview",
+			wantWarning:      false,
+		},
+		{
+			name:             "ATX hash without space is not a heading",
+			mode:             "replace_range",
+			markdown:         "##tag",
+			selectionByTitle: "## Overview",
+			wantWarning:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := checkDocsUpdateReplaceHeadingBlockType(tc.mode, tc.markdown, tc.selectionByTitle)
+			if tc.wantWarning && got == "" {
+				t.Fatalf("expected a warning, got none")
+			}
+			if !tc.wantWarning && got != "" {
+				t.Fatalf("expected no warning, got: %s", got)
+			}
+		})
+	}
+}
+
+func TestAtxHeadingLevel(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]int{
+		"# H1":          1,
+		"## H2":         2,
+		"###### H6":     6,
+		"####### x":     0, // 7 hashes is not a heading
+		"##":            0, // no content
+		"##no-space":    0,
+		"":              0,
+		"  ## indented": 2,
+		"not a heading": 0,
+	}
+	for input, want := range cases {
+		if got := atxHeadingLevel(input); got != want {
+			t.Fatalf("atxHeadingLevel(%q) = %d, want %d", input, got, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Addresses Case 2 in the lark-cli pitfall list: `replace_range` cannot change a block's type, so using it to "demote" a heading block to a paragraph silently fails — the API returns success but the heading styling persists.

This PR extends the existing `docsUpdateWarnings` infrastructure (from the PR #569 pre-write semantic check series) with a targeted, high-signal warning: when the invocation is `--mode=replace_range --selection-by-title "## X"` and `--markdown` does not lead with a matching heading level, the user almost certainly expects a block-type change that won't happen.

## Changes

- **`shortcuts/doc/docs_update_check.go`**:
  - New `checkDocsUpdateReplaceHeadingBlockType` — fires only on `replace_range` + heading-style `--selection-by-title` + non-matching first-prose-line heading level
  - New narrow helpers `atxHeadingLevel` (ATX-only, CommonMark-conformant) and `firstProseHeadingLevel` (reuses existing fence-tracking helpers)
  - Signature of `docsUpdateWarnings` extended with `selectionByTitle` argument
- **`shortcuts/doc/docs_update.go`**: pass `--selection-by-title` through to `docsUpdateWarnings`
- **`shortcuts/doc/docs_update_check_test.go`**: table-driven tests (8 cases on the check + 9 on the ATX helper); 100% coverage on the new function

## Scope notes

The warning is deliberately narrow:

- Fires only when `--selection-by-title` is used. Other selection modes (`--selection-with-ellipsis`, bare token) can target any block and would produce false positives.
- Fires only when the markdown's first non-blank, non-fenced prose line is not an ATX heading of the same level.
- Non-blocking — the update still proceeds, consistent with the existing warnings from #569.

## Test Plan

- [x] `go test ./shortcuts/doc/...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] New coverage on `checkDocsUpdateReplaceHeadingBlockType` is 100%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a validation warning when using replace mode with a title-based selection: alerts if the selected heading style/level conflicts with the replacement and recommends delete + insert instead.

* **Tests**
  * Expanded test coverage for heading detection and warning generation, including ATX heading edge cases and skipped fenced-code scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->