### PR TITLE
feat(doc): add --show-diff flag to docs +update for post-update verification

### DIFF
--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -43,6 +43,7 @@ var DocsUpdate = common.Shortcut{
 		{Name: "selection-with-ellipsis", Desc: "content locator (e.g. 'start...end')"},
 		{Name: "selection-by-title", Desc: "title locator (e.g. '## Section')"},
 		{Name: "new-title", Desc: "also update document title"},
+		{Name: "show-diff", Type: "bool", Desc: "fetch the document before and after the update and print a unified diff of the affected region to stderr (skipped for append / overwrite; adds two fetch-doc calls)"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		mode := runtime.Str("mode")
@@ -120,12 +121,56 @@ var DocsUpdate = common.Shortcut{
 			args["new_title"] = v
 		}
 
+		// Optional diff capture: fetch the document before the update so we
+		// can render a unified diff after the update settles. Kept off the
+		// default path because it doubles read-side MCP calls for every
+		// update. append/overwrite don't get a diff — append has no "before"
+		// context worth showing, and overwrite marks every line as changed,
+		// defeating the purpose.
+		showDiff := runtime.Bool("show-diff") &&
+			mode != "append" && mode != "overwrite"
+		var beforeMarkdown string
+		var beforeErr error
+		if showDiff {
+			beforeMarkdown, beforeErr = fetchMarkdownForDiff(runtime, runtime.Str("doc"))
+			if beforeErr != nil {
+				fmt.Fprintf(runtime.IO().ErrOut,
+					"warning: --show-diff pre-fetch failed (%v); update will proceed without a diff\n",
+					beforeErr)
+			}
+		}
+
 		result, err := common.CallMCPTool(runtime, "update-doc", args)
 		if err != nil {
 			return err
 		}
 
 		normalizeDocsUpdateResult(result, runtime.Str("markdown"))
+
+		// Post-fetch and emit the diff. Any failure here is advisory only —
+		// the update already succeeded, so degrade gracefully instead of
+		// making the caller re-run.
+		if showDiff && beforeErr == nil {
+			afterMarkdown, afterErr := fetchMarkdownForDiff(runtime, runtime.Str("doc"))
+			switch {
+			case afterErr != nil:
+				fmt.Fprintf(runtime.IO().ErrOut,
+					"warning: --show-diff post-fetch failed (%v); update succeeded but no diff available\n",
+					afterErr)
+			default:
+				diff := computeMarkdownDiff(
+					fixExportedMarkdown(beforeMarkdown),
+					fixExportedMarkdown(afterMarkdown),
+				)
+				if diff == "" {
+					fmt.Fprintln(runtime.IO().ErrOut,
+						"note: --show-diff found no textual change after the update (server may have normalized the markdown)")
+				} else {
+					fmt.Fprintf(runtime.IO().ErrOut, "--- before\n+++ after\n%s", diff)
+				}
+			}
+		}
+
 		runtime.Out(result, nil)
 		return nil
 	},

--- a/shortcuts/doc/docs_update_diff.go
+++ b/shortcuts/doc/docs_update_diff.go
@@ -30,8 +30,8 @@ func computeMarkdownDiff(before, after string) string {
 	if before == after {
 		return ""
 	}
-	beforeLines := strings.Split(before, "\n")
-	afterLines := strings.Split(after, "\n")
+	beforeLines := splitDiffLines(before)
+	afterLines := splitDiffLines(after)
 
 	// Longest common prefix.
 	prefix := 0
@@ -90,10 +90,27 @@ func computeMarkdownDiff(before, after string) string {
 	return sb.String()
 }
 
+// splitDiffLines behaves like strings.Split(s, "\n") except that the empty
+// string is mapped to a zero-length slice rather than a slice containing one
+// empty element. Without this shim an empty-vs-content diff would emit a
+// spurious blank-line deletion/addition because Split("", "\n") yields [""].
+func splitDiffLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}
+
 // fetchMarkdownForDiff calls the fetch-doc MCP tool and extracts the
 // markdown payload. Errors are returned verbatim so the caller can decide
 // whether to block the update on a failing snapshot (currently: no — the
 // update still proceeds and the diff section is skipped).
+//
+// A paginated response (has_more=true) is reported as an error instead of
+// silently returning the first page: diffing a partial snapshot produces
+// misleading output (edits outside the fetched range look like "no textual
+// change"), and the right fix — paginating all the way — is a bigger
+// investment than the --show-diff surface currently warrants.
 func fetchMarkdownForDiff(runtime *common.RuntimeContext, docID string) (string, error) {
 	result, err := common.CallMCPTool(runtime, "fetch-doc", map[string]interface{}{
 		"doc_id":           docID,
@@ -101,6 +118,9 @@ func fetchMarkdownForDiff(runtime *common.RuntimeContext, docID string) (string,
 	})
 	if err != nil {
 		return "", err
+	}
+	if hasMore, ok := result["has_more"].(bool); ok && hasMore {
+		return "", fmt.Errorf("fetch-doc returned a paginated snapshot (has_more=true); --show-diff cannot diff partial documents")
 	}
 	md, _ := result["markdown"].(string)
 	return md, nil

--- a/shortcuts/doc/docs_update_diff.go
+++ b/shortcuts/doc/docs_update_diff.go
@@ -51,11 +51,6 @@ func computeMarkdownDiff(before, after string) string {
 	beforeEnd := len(beforeLines) - suffix
 	afterEnd := len(afterLines) - suffix
 
-	// Nothing changed (defensive; before == after already returned above).
-	if prefix == beforeEnd && prefix == afterEnd {
-		return ""
-	}
-
 	ctxStart := prefix - diffContextLines
 	if ctxStart < 0 {
 		ctxStart = 0

--- a/shortcuts/doc/docs_update_diff.go
+++ b/shortcuts/doc/docs_update_diff.go
@@ -65,10 +65,24 @@ func computeMarkdownDiff(before, after string) string {
 	}
 
 	var sb strings.Builder
-	// Hunk header uses 1-based line numbers matching unified-diff convention.
+	// Hunk header uses 1-based line numbers matching unified-diff
+	// convention, except that a zero-length range uses start=0 (git diff /
+	// diff -u do the same). Without this, a pure insertion into an empty
+	// "before" snapshot prints `@@ -1,0 +1,N @@` which is technically
+	// malformed.
+	beforeCount := ctxEndBefore - ctxStart
+	afterCount := ctxEndAfter - ctxStart
+	beforeStart := ctxStart + 1
+	if beforeCount == 0 {
+		beforeStart = 0
+	}
+	afterStart := ctxStart + 1
+	if afterCount == 0 {
+		afterStart = 0
+	}
 	fmt.Fprintf(&sb, "@@ -%d,%d +%d,%d @@\n",
-		ctxStart+1, ctxEndBefore-ctxStart,
-		ctxStart+1, ctxEndAfter-ctxStart,
+		beforeStart, beforeCount,
+		afterStart, afterCount,
 	)
 	for i := ctxStart; i < prefix; i++ {
 		fmt.Fprintf(&sb, " %s\n", beforeLines[i])
@@ -85,15 +99,25 @@ func computeMarkdownDiff(before, after string) string {
 	return sb.String()
 }
 
-// splitDiffLines behaves like strings.Split(s, "\n") except that the empty
-// string is mapped to a zero-length slice rather than a slice containing one
-// empty element. Without this shim an empty-vs-content diff would emit a
-// spurious blank-line deletion/addition because Split("", "\n") yields [""].
+// splitDiffLines returns the logical content lines of s for diff purposes.
+// It differs from strings.Split in two ways:
+//
+//  1. The empty input maps to a zero-length slice instead of [""], so an
+//     empty-vs-content diff doesn't emit a spurious blank-line add/remove.
+//  2. A single trailing "\n" is treated as a line terminator, not an extra
+//     blank line — so "a\nb\n" splits to ["a", "b"] rather than ["a", "b", ""].
+//     Without this, snapshots from fetch-doc (which always end with a
+//     newline) would report a phantom blank context line and inflate hunk
+//     counts.
 func splitDiffLines(s string) []string {
 	if s == "" {
 		return nil
 	}
-	return strings.Split(s, "\n")
+	lines := strings.Split(s, "\n")
+	if len(lines) > 1 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	return lines
 }
 
 // fetchMarkdownForDiff calls the fetch-doc MCP tool and extracts the

--- a/shortcuts/doc/docs_update_diff.go
+++ b/shortcuts/doc/docs_update_diff.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// diffContextLines is the number of unchanged lines printed on either side of
+// each diff hunk. Matches the `git diff -U2` convention, which is enough to
+// orient a reader in most docx blocks without drowning stderr in boilerplate.
+const diffContextLines = 2
+
+// computeMarkdownDiff returns a git-style unified diff between before and
+// after, focused on the single changed region between the longest common
+// prefix and the longest common suffix. Returns an empty string when before
+// and after are identical.
+//
+// The algorithm is intentionally simple — not Myers, not minimal — because
+// `docs +update` replace/insert/delete modes touch a localized block range,
+// so the "middle" that survives prefix/suffix trimming is already the
+// user-visible change. A full LCS diff would buy better output for paired
+// additions+deletions but at several hundred lines of implementation we
+// don't need right now.
+func computeMarkdownDiff(before, after string) string {
+	if before == after {
+		return ""
+	}
+	beforeLines := strings.Split(before, "\n")
+	afterLines := strings.Split(after, "\n")
+
+	// Longest common prefix.
+	prefix := 0
+	for prefix < len(beforeLines) && prefix < len(afterLines) &&
+		beforeLines[prefix] == afterLines[prefix] {
+		prefix++
+	}
+
+	// Longest common suffix, not overlapping the prefix on either side.
+	suffix := 0
+	for suffix < len(beforeLines)-prefix &&
+		suffix < len(afterLines)-prefix &&
+		beforeLines[len(beforeLines)-1-suffix] == afterLines[len(afterLines)-1-suffix] {
+		suffix++
+	}
+
+	beforeEnd := len(beforeLines) - suffix
+	afterEnd := len(afterLines) - suffix
+
+	// Nothing changed (defensive; before == after already returned above).
+	if prefix == beforeEnd && prefix == afterEnd {
+		return ""
+	}
+
+	ctxStart := prefix - diffContextLines
+	if ctxStart < 0 {
+		ctxStart = 0
+	}
+	ctxEndBefore := beforeEnd + diffContextLines
+	if ctxEndBefore > len(beforeLines) {
+		ctxEndBefore = len(beforeLines)
+	}
+	ctxEndAfter := afterEnd + diffContextLines
+	if ctxEndAfter > len(afterLines) {
+		ctxEndAfter = len(afterLines)
+	}
+
+	var sb strings.Builder
+	// Hunk header uses 1-based line numbers matching unified-diff convention.
+	fmt.Fprintf(&sb, "@@ -%d,%d +%d,%d @@\n",
+		ctxStart+1, ctxEndBefore-ctxStart,
+		ctxStart+1, ctxEndAfter-ctxStart,
+	)
+	for i := ctxStart; i < prefix; i++ {
+		fmt.Fprintf(&sb, " %s\n", beforeLines[i])
+	}
+	for i := prefix; i < beforeEnd; i++ {
+		fmt.Fprintf(&sb, "-%s\n", beforeLines[i])
+	}
+	for i := prefix; i < afterEnd; i++ {
+		fmt.Fprintf(&sb, "+%s\n", afterLines[i])
+	}
+	for i := beforeEnd; i < ctxEndBefore; i++ {
+		fmt.Fprintf(&sb, " %s\n", beforeLines[i])
+	}
+	return sb.String()
+}
+
+// fetchMarkdownForDiff calls the fetch-doc MCP tool and extracts the
+// markdown payload. Errors are returned verbatim so the caller can decide
+// whether to block the update on a failing snapshot (currently: no — the
+// update still proceeds and the diff section is skipped).
+func fetchMarkdownForDiff(runtime *common.RuntimeContext, docID string) (string, error) {
+	result, err := common.CallMCPTool(runtime, "fetch-doc", map[string]interface{}{
+		"doc_id":           docID,
+		"skip_task_detail": true,
+	})
+	if err != nil {
+		return "", err
+	}
+	md, _ := result["markdown"].(string)
+	return md, nil
+}

--- a/shortcuts/doc/docs_update_diff_test.go
+++ b/shortcuts/doc/docs_update_diff_test.go
@@ -17,6 +17,7 @@ func TestComputeMarkdownDiff(t *testing.T) {
 		after           string
 		wantEmpty       bool
 		wantContainsAll []string
+		wantLacks       []string
 	}{
 		{
 			name:      "identical inputs yield empty diff",
@@ -82,6 +83,22 @@ func TestComputeMarkdownDiff(t *testing.T) {
 			after:     "",
 			wantEmpty: true,
 		},
+		{
+			// Regression: strings.Split("", "\n") returns [""], which would
+			// have produced a spurious "-\n" blank-line deletion on empty→content.
+			name:            "empty before to non-empty after has only additions",
+			before:          "",
+			after:           "new content",
+			wantContainsAll: []string{"+new content"},
+			wantLacks:       []string{"-\n"},
+		},
+		{
+			name:            "non-empty before to empty after has only deletions",
+			before:          "old content",
+			after:           "",
+			wantContainsAll: []string{"-old content"},
+			wantLacks:       []string{"+\n"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -100,6 +117,11 @@ func TestComputeMarkdownDiff(t *testing.T) {
 			for _, needle := range tt.wantContainsAll {
 				if !strings.Contains(got, needle) {
 					t.Errorf("diff missing expected substring %q; full diff:\n%s", needle, got)
+				}
+			}
+			for _, forbidden := range tt.wantLacks {
+				if strings.Contains(got, forbidden) {
+					t.Errorf("diff unexpectedly contains %q; full diff:\n%s", forbidden, got)
 				}
 			}
 		})

--- a/shortcuts/doc/docs_update_diff_test.go
+++ b/shortcuts/doc/docs_update_diff_test.go
@@ -128,6 +128,64 @@ func TestComputeMarkdownDiff(t *testing.T) {
 	}
 }
 
+func TestComputeMarkdownDiffHunkHeaderZeroLengthRange(t *testing.T) {
+	t.Parallel()
+
+	// Empty before: unified-diff convention is start=0 for a zero-length
+	// range, not start=1.
+	got := computeMarkdownDiff("", "hello\nworld")
+	if !strings.Contains(got, "@@ -0,0 ") {
+		t.Errorf("expected zero-length before range as '-0,0', got:\n%s", got)
+	}
+
+	// Empty after: symmetric case.
+	got = computeMarkdownDiff("hello\nworld", "")
+	if !strings.Contains(got, " +0,0 @@") {
+		t.Errorf("expected zero-length after range as '+0,0', got:\n%s", got)
+	}
+}
+
+func TestSplitDiffLinesStripsTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string][]string{
+		"":           nil,
+		"a":          {"a"},
+		"a\n":        {"a"},
+		"a\nb":       {"a", "b"},
+		"a\nb\n":     {"a", "b"},
+		"a\n\nb\n":   {"a", "", "b"},
+		"\n":         {""}, // a single blank line should still be preserved
+		"only-blank": {"only-blank"},
+	}
+	for input, want := range cases {
+		got := splitDiffLines(input)
+		if len(got) != len(want) {
+			t.Errorf("splitDiffLines(%q) = %q, want %q", input, got, want)
+			continue
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("splitDiffLines(%q)[%d] = %q, want %q", input, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestComputeMarkdownDiffTrailingNewlineParity confirms a single-line
+// replacement against snapshots ending in '\n' (what fetch-doc returns)
+// produces the same diff as snapshots without the trailing newline.
+// Previously the trailing "" generated a phantom blank context line.
+func TestComputeMarkdownDiffTrailingNewlineParity(t *testing.T) {
+	t.Parallel()
+
+	withNL := computeMarkdownDiff("a\nold\nb\n", "a\nnew\nb\n")
+	withoutNL := computeMarkdownDiff("a\nold\nb", "a\nnew\nb")
+	if withNL != withoutNL {
+		t.Fatalf("diff should not depend on trailing newline\nwith:\n%s\n\nwithout:\n%s", withNL, withoutNL)
+	}
+}
+
 func TestComputeMarkdownDiffHunkHeaderLineNumbers(t *testing.T) {
 	t.Parallel()
 

--- a/shortcuts/doc/docs_update_diff_test.go
+++ b/shortcuts/doc/docs_update_diff_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputeMarkdownDiff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		before          string
+		after           string
+		wantEmpty       bool
+		wantContainsAll []string
+	}{
+		{
+			name:      "identical inputs yield empty diff",
+			before:    "line1\nline2\nline3",
+			after:     "line1\nline2\nline3",
+			wantEmpty: true,
+		},
+		{
+			name:   "single-line replacement in the middle",
+			before: "header\n\noriginal paragraph\n\nfooter",
+			after:  "header\n\nreplacement paragraph\n\nfooter",
+			wantContainsAll: []string{
+				"-original paragraph",
+				"+replacement paragraph",
+				"@@ ",
+				" header",
+				" footer",
+			},
+		},
+		{
+			name:   "pure insertion keeps removed section empty",
+			before: "start\nend",
+			after:  "start\nnew middle line\nend",
+			wantContainsAll: []string{
+				"+new middle line",
+				" start",
+				" end",
+			},
+		},
+		{
+			name:   "pure deletion keeps added section empty",
+			before: "start\nstale middle\nend",
+			after:  "start\nend",
+			wantContainsAll: []string{
+				"-stale middle",
+				" start",
+				" end",
+			},
+		},
+		{
+			name:   "prepend at the start has no leading context",
+			before: "first\nsecond",
+			after:  "brand new header\nfirst\nsecond",
+			wantContainsAll: []string{
+				"+brand new header",
+				" first",
+				" second",
+			},
+		},
+		{
+			name:   "append at the end has no trailing context",
+			before: "first\nsecond",
+			after:  "first\nsecond\ntrailer",
+			wantContainsAll: []string{
+				"+trailer",
+				" first",
+				" second",
+			},
+		},
+		{
+			name:      "empty-to-empty yields empty diff",
+			before:    "",
+			after:     "",
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := computeMarkdownDiff(tt.before, tt.after)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Fatalf("expected empty diff, got: %q", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("expected non-empty diff, got empty")
+			}
+			for _, needle := range tt.wantContainsAll {
+				if !strings.Contains(got, needle) {
+					t.Errorf("diff missing expected substring %q; full diff:\n%s", needle, got)
+				}
+			}
+		})
+	}
+}
+
+func TestComputeMarkdownDiffHunkHeaderLineNumbers(t *testing.T) {
+	t.Parallel()
+
+	before := "l1\nl2\nl3\nl4\nl5\nl6"
+	after := "l1\nl2\nl3\nCHANGED\nl5\nl6"
+
+	got := computeMarkdownDiff(before, after)
+
+	// Context is capped at 2 lines on each side, so the hunk should start
+	// at line 2 (= line 4 - 2 context) and span 5 lines before / 5 after.
+	wantHeader := "@@ -2,5 +2,5 @@"
+	if !strings.Contains(got, wantHeader) {
+		t.Fatalf("expected hunk header %q; got diff:\n%s", wantHeader, got)
+	}
+}

--- a/shortcuts/doc/docs_update_test.go
+++ b/shortcuts/doc/docs_update_test.go
@@ -440,14 +440,14 @@ func TestDocsUpdateShowDiffSkipsForAppendMode(t *testing.T) {
 	}
 }
 
-// TestDocsUpdateShowDiffPreFetchFailureDegradesGracefully omits the
-// pre-fetch stub, so fetchMarkdownForDiff returns a "no stub" error. The
-// update must still proceed and the warning must surface on stderr.
+// TestDocsUpdateShowDiffPreFetchFailureDegradesGracefully drives the
+// pre-fetch into the paginated-snapshot advisory path by registering a
+// stub that returns has_more=true (the guard added in Case 9). The update
+// itself must still succeed and the warning must land on stderr.
 func TestDocsUpdateShowDiffPreFetchFailureDegradesGracefully(t *testing.T) {
 	f, stdout, stderr, reg := cmdutil.TestFactory(t, showDiffTestConfig())
-	// Two stubs: the failing pre-fetch chooses the first matching /mcp stub
-	// anyway, so we need a stub for it (returning has_more=true triggers the
-	// advisory error path) plus the real update call.
+	// Two stubs: the pre-fetch returns has_more=true so fetchMarkdownForDiff
+	// rejects the partial snapshot, then the real update-doc call runs.
 	registerMCPStub(reg, map[string]interface{}{"markdown": "x", "has_more": true})
 	registerMCPStub(reg, map[string]interface{}{"success": true})
 

--- a/shortcuts/doc/docs_update_test.go
+++ b/shortcuts/doc/docs_update_test.go
@@ -3,13 +3,18 @@
 package doc
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -331,5 +336,163 @@ func TestDocsUpdateValidate(t *testing.T) {
 				t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
 			}
 		})
+	}
+}
+
+// showDiffTestConfig is kept minimal — just enough for TestFactory to mount
+// the update shortcut against the httpmock registry.
+func showDiffTestConfig() *core.CliConfig {
+	return &core.CliConfig{AppID: "show-diff-test", AppSecret: "test-secret", Brand: core.BrandFeishu}
+}
+
+func runDocsUpdateShortcut(t *testing.T, f *cmdutil.Factory, stdout *bytes.Buffer, args []string) error {
+	t.Helper()
+	parent := &cobra.Command{Use: "docs"}
+	DocsUpdate.Mount(parent, f)
+	parent.SetArgs(args)
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	if stdout != nil {
+		stdout.Reset()
+	}
+	return parent.Execute()
+}
+
+// registerMCPStub adds an /mcp stub returning the canned tools/call payload
+// once. httpmock matches each stub exactly one time, so a --show-diff run
+// (pre-fetch → update → post-fetch) needs three stubs.
+func registerMCPStub(reg *httpmock.Registry, payload map[string]interface{}) {
+	raw, _ := json.Marshal(payload)
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/mcp",
+		Body: map[string]interface{}{
+			"result": map[string]interface{}{
+				"content": []map[string]interface{}{
+					{"type": "text", "text": string(raw)},
+				},
+			},
+		},
+	})
+}
+
+// TestDocsUpdateShowDiffEmitsUnifiedDiff wires up three MCP stubs to drive
+// the full show-diff path: pre-fetch returns the original markdown, the
+// update-doc call reports success, and post-fetch returns the modified
+// markdown. The test asserts that the unified diff of the changed region
+// lands on stderr while the JSON response stays on stdout.
+func TestDocsUpdateShowDiffEmitsUnifiedDiff(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, showDiffTestConfig())
+	registerMCPStub(reg, map[string]interface{}{"markdown": "line one\noriginal middle\nline three\n"})
+	registerMCPStub(reg, map[string]interface{}{"success": true})
+	registerMCPStub(reg, map[string]interface{}{"markdown": "line one\nreplacement middle\nline three\n"})
+
+	err := runDocsUpdateShortcut(t, f, stdout, []string{
+		"+update",
+		"--doc", "DOC123",
+		"--mode", "replace_range",
+		"--selection-with-ellipsis", "original middle",
+		"--markdown", "replacement middle",
+		"--show-diff",
+		"--as", "bot",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	errOut := stderr.String()
+	if !strings.Contains(errOut, "--- before") || !strings.Contains(errOut, "+++ after") {
+		t.Errorf("expected unified-diff header on stderr, got:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "-original middle") {
+		t.Errorf("expected deletion line on stderr, got:\n%s", errOut)
+	}
+	if !strings.Contains(errOut, "+replacement middle") {
+		t.Errorf("expected addition line on stderr, got:\n%s", errOut)
+	}
+	// The update response JSON must still land on stdout cleanly.
+	if !strings.Contains(stdout.String(), "success") {
+		t.Errorf("expected update success JSON on stdout, got:\n%s", stdout.String())
+	}
+}
+
+// TestDocsUpdateShowDiffSkipsForAppendMode ensures append (and overwrite)
+// never trigger pre/post fetches — the only /mcp stub registered handles
+// the update-doc call itself; any extra fetch would trip 'no stub' in
+// httpmock and fail the test.
+func TestDocsUpdateShowDiffSkipsForAppendMode(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, showDiffTestConfig())
+	registerMCPStub(reg, map[string]interface{}{"success": true})
+
+	err := runDocsUpdateShortcut(t, f, stdout, []string{
+		"+update",
+		"--doc", "DOC123",
+		"--mode", "append",
+		"--markdown", "appended paragraph",
+		"--show-diff",
+		"--as", "bot",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "success") {
+		t.Errorf("expected update success on stdout, got:\n%s", stdout.String())
+	}
+}
+
+// TestDocsUpdateShowDiffPreFetchFailureDegradesGracefully omits the
+// pre-fetch stub, so fetchMarkdownForDiff returns a "no stub" error. The
+// update must still proceed and the warning must surface on stderr.
+func TestDocsUpdateShowDiffPreFetchFailureDegradesGracefully(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, showDiffTestConfig())
+	// Two stubs: the failing pre-fetch chooses the first matching /mcp stub
+	// anyway, so we need a stub for it (returning has_more=true triggers the
+	// advisory error path) plus the real update call.
+	registerMCPStub(reg, map[string]interface{}{"markdown": "x", "has_more": true})
+	registerMCPStub(reg, map[string]interface{}{"success": true})
+
+	err := runDocsUpdateShortcut(t, f, stdout, []string{
+		"+update",
+		"--doc", "DOC123",
+		"--mode", "replace_range",
+		"--selection-with-ellipsis", "any",
+		"--markdown", "replacement",
+		"--show-diff",
+		"--as", "bot",
+	})
+	if err != nil {
+		t.Fatalf("update should still succeed despite pre-fetch advisory failure, got: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "--show-diff pre-fetch failed") {
+		t.Errorf("expected pre-fetch failure warning on stderr, got:\n%s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "success") {
+		t.Errorf("expected update success on stdout, got:\n%s", stdout.String())
+	}
+}
+
+// TestDocsUpdateShowDiffIdenticalSnapshotsNote: pre and post fetch return
+// the same markdown, so the diff is empty. The shortcut should emit the
+// "no textual change" note instead of a diff block.
+func TestDocsUpdateShowDiffIdenticalSnapshotsNote(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, showDiffTestConfig())
+	registerMCPStub(reg, map[string]interface{}{"markdown": "unchanged\n"})
+	registerMCPStub(reg, map[string]interface{}{"success": true})
+	registerMCPStub(reg, map[string]interface{}{"markdown": "unchanged\n"})
+
+	err := runDocsUpdateShortcut(t, f, stdout, []string{
+		"+update",
+		"--doc", "DOC123",
+		"--mode", "replace_range",
+		"--selection-with-ellipsis", "unchanged",
+		"--markdown", "unchanged",
+		"--show-diff",
+		"--as", "bot",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "no textual change") {
+		t.Errorf("expected no-change note on stderr, got:\n%s", stderr.String())
 	}
 }


### PR DESCRIPTION
## Summary

Addresses Case 9 in the lark-cli pitfall list: `docs +update` currently returns `{success: true}` on every successful MCP call, so there's no way for the caller to verify the update actually landed where expected. Agents see "success", the doc looks unchanged, and nothing in the response tells them which block was really touched.

Add an opt-in `--show-diff` flag that captures a before/after snapshot via `fetch-doc` and prints a git-style unified diff of the changed region to stderr.

## Changes

- **`shortcuts/doc/docs_update.go`**: new `--show-diff` bool flag; wire pre-fetch + post-fetch around the existing `update-doc` call, degrade gracefully on snapshot failure, skip for `append` / `overwrite` modes.
- **`shortcuts/doc/docs_update_diff.go`** (new): `computeMarkdownDiff(before, after)` — prefix/suffix-trim unified diff with 2 lines of context; `fetchMarkdownForDiff` helper wrapping the MCP call.
- **`shortcuts/doc/docs_update_diff_test.go`** (new): 7-case table-driven test + hunk-header line-number assertion.

## Scope notes

- Off by default. Each use adds two `fetch-doc` calls, so this is an opt-in verification tool, not a default.
- `append` / `overwrite` are excluded — the former has nothing to compare against, the latter trivially marks every line as changed.
- Snapshot failures are advisory: the update still proceeds and emits a warning to stderr. The MCP result (JSON stdout) is never replaced.
- Both snapshots pass through `fixExportedMarkdown` so the diff isn't polluted by already-fixed `fetch-doc` artifacts.
- The diff algorithm is intentionally simple (prefix/suffix trim, not Myers LCS). Replace/insert/delete touch a localized range, so the surviving middle is already the user-visible change.

## Test Plan

- [x] `go test ./shortcuts/doc/...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [ ] Manual smoke: run a `docs +update --mode=replace_range --show-diff` against a test doc and confirm the diff hunk renders as expected

## Example output

```
$ lark-cli docs +update --doc <URL> --mode=replace_range --selection-with-ellipsis "old..." --markdown "new content" --show-diff
--- before
+++ after
@@ -14,5 +14,5 @@
 ## Overview
 
-old block contents that the user wanted to replace
+new content
 
 ## Next section
{"success": true, ...}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --show-diff option to preview a unified, contextual diff of markdown when performing doc updates (skipped for append/overwrite modes).
  * Diff preview is shown alongside the update output (preview separate from the update result).

* **Bug Fixes**
  * Pre- or post-update fetch failures now warn without aborting a successful update.
  * Paginated/partial fetches report a clear error; identical or normalized content reports a "no diff" note.
  * Diff avoids spurious empty-line +/- artifacts.

* **Tests**
  * New unit and end-to-end tests cover diff generation and show-diff behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->