### PR TITLE
feat(doc): add docs +batch-update for multi-operation sequential updates

### DIFF
--- a/shortcuts/doc/docs_batch_update.go
+++ b/shortcuts/doc/docs_batch_update.go
@@ -49,6 +49,23 @@ var validBatchOnError = map[string]bool{
 // left in a partial-apply state; pair with --on-error=stop + `docs +fetch`
 // to recover manually. This tradeoff is explicit in the shortcut's
 // description.
+//
+// Two design notes worth calling out for callers:
+//
+//  1. Validate runs once up front against the static op list, before any
+//     MCP write. It cannot foresee in-batch staleness — for example, if
+//     op[0] deletes a section that op[1]'s --selection-by-title resolves
+//     into, op[1] passes Validate but fails at execute time. This is by
+//     design (sequential semantics; each op sees the doc state produced
+//     by the previous op). If you need stricter atomicity, split the
+//     batch or fetch the doc between groups of related ops.
+//
+//  2. On --on-error=stop the shortcut emits TWO failure signals: the
+//     stdout JSON envelope (with stopped_early=true and the partial
+//     result list), AND a non-zero exit via the returned error. They are
+//     complementary: scripts that key on exit code see "the batch did
+//     not complete cleanly"; callers parsing JSON see "exactly which
+//     ops succeeded and how far we got". Don't treat them as redundant.
 var DocsBatchUpdate = common.Shortcut{
 	Service:     "docs",
 	Command:     "+batch-update",
@@ -138,7 +155,7 @@ var DocsBatchUpdate = common.Shortcut{
 				}
 				continue
 			}
-			normalizeDocsUpdateResult(out, op.Markdown)
+			normalizeWhiteboardResult(out, op.Markdown)
 			results = append(results, batchUpdateResult{
 				Index: i, Mode: op.Mode, Success: true, Result: out,
 			})
@@ -206,7 +223,7 @@ func parseBatchUpdateOps(raw string) ([]batchUpdateOp, error) {
 // own Validate phase, before any MCP work, so a single malformed op fails
 // the whole invocation up front instead of after N successful ops.
 func validateBatchUpdateOp(op batchUpdateOp) error {
-	if !validModes[op.Mode] {
+	if !validModesV1[op.Mode] {
 		return fmt.Errorf("invalid mode %q, valid: append | overwrite | replace_range | replace_all | insert_before | insert_after | delete_range", op.Mode)
 	}
 	if op.Mode != "delete_range" && op.Markdown == "" {
@@ -215,11 +232,11 @@ func validateBatchUpdateOp(op batchUpdateOp) error {
 	if op.SelectionWithEllipsis != "" && op.SelectionByTitle != "" {
 		return fmt.Errorf("selection_with_ellipsis and selection_by_title are mutually exclusive")
 	}
-	if needsSelection[op.Mode] && op.SelectionWithEllipsis == "" && op.SelectionByTitle == "" {
+	if needsSelectionV1[op.Mode] && op.SelectionWithEllipsis == "" && op.SelectionByTitle == "" {
 		return fmt.Errorf("mode=%s requires selection_with_ellipsis or selection_by_title", op.Mode)
 	}
 	if op.SelectionByTitle != "" {
-		if err := validateSelectionByTitle(op.SelectionByTitle); err != nil {
+		if err := validateSelectionByTitleV1(op.SelectionByTitle); err != nil {
 			return err
 		}
 	}

--- a/shortcuts/doc/docs_batch_update.go
+++ b/shortcuts/doc/docs_batch_update.go
@@ -128,6 +128,21 @@ var DocsBatchUpdate = common.Shortcut{
 		successCount := 0
 
 		for i, op := range ops {
+			// Honor cancellation between ops so a user interrupt or parent
+			// timeout doesn't have to wait for the rest of the batch. Emit
+			// the partial envelope first so callers see exactly how far we
+			// got, mirroring the --on-error=stop shape.
+			if err := ctx.Err(); err != nil {
+				runtime.Out(map[string]interface{}{
+					"doc":           runtime.Str("doc"),
+					"total":         len(ops),
+					"applied":       successCount,
+					"results":       results,
+					"stopped_early": true,
+				}, nil)
+				return err
+			}
+
 			// Re-run the same static warnings the single-op shortcut emits so
 			// batch users get the same advisory signal per-op.
 			for _, w := range docsUpdateWarnings(op.Mode, op.Markdown) {
@@ -200,7 +215,12 @@ func buildBatchUpdateArgs(docID string, op batchUpdateOp) map[string]interface{}
 // with a clearer error on the two mistakes users make most often: passing a
 // single object instead of an array, or passing an empty array.
 func parseBatchUpdateOps(raw string) ([]batchUpdateOp, error) {
-	trimmed := strings.TrimSpace(raw)
+	// Strip a leading UTF-8 BOM (U+FEFF) before the prefix check.
+	// strings.TrimSpace doesn't treat BOM as whitespace, so payloads written
+	// by editors / shells that prepend a BOM (PowerShell redirection, some
+	// Windows editors) would otherwise fail the "[" prefix probe with a
+	// confusing "must be a JSON array" error.
+	trimmed := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(raw), "\ufeff"))
 	if trimmed == "" {
 		return nil, common.FlagErrorf("--operations is required")
 	}

--- a/shortcuts/doc/docs_batch_update.go
+++ b/shortcuts/doc/docs_batch_update.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// batchUpdateOp is one entry in the --operations JSON array. The field set
+// mirrors the flags of `docs +update` so an operations file is effectively a
+// serialized batch of +update invocations against a single document.
+//
+// Omit-empty is deliberate: a caller may submit an append / overwrite op
+// without any selection, and the MCP call itself ignores unset fields.
+type batchUpdateOp struct {
+	Mode                  string `json:"mode"`
+	Markdown              string `json:"markdown,omitempty"`
+	SelectionWithEllipsis string `json:"selection_with_ellipsis,omitempty"`
+	SelectionByTitle      string `json:"selection_by_title,omitempty"`
+	NewTitle              string `json:"new_title,omitempty"`
+}
+
+// batchUpdateResult is the per-op entry in the shortcut's JSON response.
+// Success is explicit (not derived from the presence of Error) so callers
+// can script against a stable schema without having to infer state.
+type batchUpdateResult struct {
+	Index   int                    `json:"index"`
+	Mode    string                 `json:"mode"`
+	Success bool                   `json:"success"`
+	Error   string                 `json:"error,omitempty"`
+	Result  map[string]interface{} `json:"result,omitempty"`
+}
+
+var validBatchOnError = map[string]bool{
+	"stop":     true,
+	"continue": true,
+}
+
+// DocsBatchUpdate applies a sequence of update-doc operations to a single
+// document. It is an orchestration convenience — there is no server-side
+// transaction, so "batch" here means "one CLI call, shared validation,
+// unified reporting", not atomic. On a mid-batch failure the document is
+// left in a partial-apply state; pair with --on-error=stop + `docs +fetch`
+// to recover manually. This tradeoff is explicit in the shortcut's
+// description.
+var DocsBatchUpdate = common.Shortcut{
+	Service:     "docs",
+	Command:     "+batch-update",
+	Description: "Apply a sequence of update-doc operations to a single document. Sequential execution, not atomic — partial failure leaves the document in a partial-apply state. Pair with --on-error=stop + docs +fetch to recover.",
+	Risk:        "write",
+	Scopes:      []string{"docx:document:write_only", "docx:document:readonly"},
+	AuthTypes:   []string{"user", "bot"},
+	Flags: []common.Flag{
+		{Name: "doc", Desc: "document URL or token", Required: true},
+		{Name: "operations", Desc: "JSON array of operations (each entry: mode, markdown, selection_with_ellipsis, selection_by_title, new_title)", Required: true, Input: []string{common.File, common.Stdin}},
+		{Name: "on-error", Default: "stop", Desc: "behavior when a single operation fails: stop | continue"},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		onError := runtime.Str("on-error")
+		if !validBatchOnError[onError] {
+			return common.FlagErrorf("invalid --on-error %q, valid: stop | continue", onError)
+		}
+		ops, err := parseBatchUpdateOps(runtime.Str("operations"))
+		if err != nil {
+			return err
+		}
+		for i, op := range ops {
+			if err := validateBatchUpdateOp(op); err != nil {
+				return common.FlagErrorf("--operations[%d]: %s", i, err.Error())
+			}
+		}
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		ops, err := parseBatchUpdateOps(runtime.Str("operations"))
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
+		}
+		d := common.NewDryRunAPI().
+			Desc(fmt.Sprintf("%d-op sequential batch against doc %q; MCP tool: update-doc", len(ops), runtime.Str("doc"))).
+			Set("mcp_tool", "update-doc").
+			Set("op_count", len(ops))
+		mcpEndpoint := common.MCPEndpoint(runtime.Config.Brand)
+		for i, op := range ops {
+			args := buildBatchUpdateArgs(runtime.Str("doc"), op)
+			d.POST(mcpEndpoint).
+				Desc(fmt.Sprintf("[%d/%d] %s", i+1, len(ops), op.Mode)).
+				Body(map[string]interface{}{
+					"method": "tools/call",
+					"params": map[string]interface{}{
+						"name":      "update-doc",
+						"arguments": args,
+					},
+				})
+		}
+		return d
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		ops, err := parseBatchUpdateOps(runtime.Str("operations"))
+		if err != nil {
+			return err
+		}
+		stopOnError := runtime.Str("on-error") == "stop"
+		results := make([]batchUpdateResult, 0, len(ops))
+		successCount := 0
+
+		for i, op := range ops {
+			// Re-run the same static warnings the single-op shortcut emits so
+			// batch users get the same advisory signal per-op.
+			for _, w := range docsUpdateWarnings(op.Mode, op.Markdown) {
+				fmt.Fprintf(runtime.IO().ErrOut, "warning: --operations[%d]: %s\n", i, w)
+			}
+
+			args := buildBatchUpdateArgs(runtime.Str("doc"), op)
+			out, callErr := common.CallMCPTool(runtime, "update-doc", args)
+			if callErr != nil {
+				results = append(results, batchUpdateResult{
+					Index: i, Mode: op.Mode, Success: false, Error: callErr.Error(),
+				})
+				if stopOnError {
+					fmt.Fprintf(runtime.IO().ErrOut,
+						"error: --operations[%d] failed; stopping (--on-error=stop); %d/%d applied before the failure\n",
+						i, successCount, len(ops))
+					runtime.Out(map[string]interface{}{
+						"doc":           runtime.Str("doc"),
+						"total":         len(ops),
+						"applied":       successCount,
+						"results":       results,
+						"stopped_early": true,
+					}, nil)
+					return callErr
+				}
+				continue
+			}
+			normalizeDocsUpdateResult(out, op.Markdown)
+			results = append(results, batchUpdateResult{
+				Index: i, Mode: op.Mode, Success: true, Result: out,
+			})
+			successCount++
+		}
+
+		runtime.Out(map[string]interface{}{
+			"doc":           runtime.Str("doc"),
+			"total":         len(ops),
+			"applied":       successCount,
+			"results":       results,
+			"stopped_early": false,
+		}, nil)
+		return nil
+	},
+}
+
+// buildBatchUpdateArgs constructs the update-doc MCP arguments for one op,
+// omitting empty optional fields so the server sees the same shape as a
+// single-op `docs +update` call.
+func buildBatchUpdateArgs(docID string, op batchUpdateOp) map[string]interface{} {
+	args := map[string]interface{}{
+		"doc_id": docID,
+		"mode":   op.Mode,
+	}
+	if op.Markdown != "" {
+		args["markdown"] = op.Markdown
+	}
+	if op.SelectionWithEllipsis != "" {
+		args["selection_with_ellipsis"] = op.SelectionWithEllipsis
+	}
+	if op.SelectionByTitle != "" {
+		args["selection_by_title"] = op.SelectionByTitle
+	}
+	if op.NewTitle != "" {
+		args["new_title"] = op.NewTitle
+	}
+	return args
+}
+
+// parseBatchUpdateOps accepts a JSON array and returns the typed ops slice
+// with a clearer error on the two mistakes users make most often: passing a
+// single object instead of an array, or passing an empty array.
+func parseBatchUpdateOps(raw string) ([]batchUpdateOp, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, common.FlagErrorf("--operations is required")
+	}
+	if !strings.HasPrefix(trimmed, "[") {
+		return nil, common.FlagErrorf("--operations must be a JSON array of operation objects (received object or scalar)")
+	}
+	var ops []batchUpdateOp
+	if err := json.Unmarshal([]byte(trimmed), &ops); err != nil {
+		return nil, common.FlagErrorf("--operations is not valid JSON: %s", err.Error())
+	}
+	if len(ops) == 0 {
+		return nil, common.FlagErrorf("--operations must contain at least one operation")
+	}
+	return ops, nil
+}
+
+// validateBatchUpdateOp reuses the same rule set as `docs +update`. Keeping
+// it duplicated (rather than factoring the original Validate into a shared
+// helper) is a deliberate small trade: the batch shortcut calls this in its
+// own Validate phase, before any MCP work, so a single malformed op fails
+// the whole invocation up front instead of after N successful ops.
+func validateBatchUpdateOp(op batchUpdateOp) error {
+	if !validModes[op.Mode] {
+		return fmt.Errorf("invalid mode %q, valid: append | overwrite | replace_range | replace_all | insert_before | insert_after | delete_range", op.Mode)
+	}
+	if op.Mode != "delete_range" && op.Markdown == "" {
+		return fmt.Errorf("mode=%s requires markdown", op.Mode)
+	}
+	if op.SelectionWithEllipsis != "" && op.SelectionByTitle != "" {
+		return fmt.Errorf("selection_with_ellipsis and selection_by_title are mutually exclusive")
+	}
+	if needsSelection[op.Mode] && op.SelectionWithEllipsis == "" && op.SelectionByTitle == "" {
+		return fmt.Errorf("mode=%s requires selection_with_ellipsis or selection_by_title", op.Mode)
+	}
+	if op.SelectionByTitle != "" {
+		if err := validateSelectionByTitle(op.SelectionByTitle); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/shortcuts/doc/docs_batch_update_test.go
+++ b/shortcuts/doc/docs_batch_update_test.go
@@ -4,9 +4,54 @@
 package doc
 
 import (
+	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
 )
+
+func batchUpdateTestConfig() *core.CliConfig {
+	return &core.CliConfig{AppID: "batch-update-test", AppSecret: "test-secret", Brand: core.BrandFeishu}
+}
+
+func runBatchUpdateShortcut(t *testing.T, f *cmdutil.Factory, stdout *bytes.Buffer, args []string) error {
+	t.Helper()
+	parent := &cobra.Command{Use: "docs"}
+	DocsBatchUpdate.Mount(parent, f)
+	parent.SetArgs(args)
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	if stdout != nil {
+		stdout.Reset()
+	}
+	return parent.Execute()
+}
+
+// registerUpdateDocMCPStubs registers one /mcp stub per expected call.
+// httpmock matches each stub exactly once, so a batch with N ops needs N
+// stubs. Each call gets the same canned payload.
+func registerUpdateDocMCPStubs(reg *httpmock.Registry, count int, payload map[string]interface{}) {
+	raw, _ := json.Marshal(payload)
+	for i := 0; i < count; i++ {
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "/mcp",
+			Body: map[string]interface{}{
+				"result": map[string]interface{}{
+					"content": []map[string]interface{}{
+						{"type": "text", "text": string(raw)},
+					},
+				},
+			},
+		})
+	}
+}
 
 func TestParseBatchUpdateOps(t *testing.T) {
 	t.Parallel()
@@ -204,4 +249,269 @@ func TestBuildBatchUpdateArgs(t *testing.T) {
 			t.Errorf("expected markdown omitted for delete_range with empty markdown")
 		}
 	})
+}
+
+// TestDocsBatchUpdateDryRun exercises the DryRun branch end-to-end: the
+// output must describe the op count and list one POST step per operation,
+// covering both the multi-op orchestration and the dry-run argument
+// construction path that mirrors Execute.
+func TestDocsBatchUpdateDryRun(t *testing.T) {
+	t.Parallel()
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, batchUpdateTestConfig())
+
+	ops := `[
+		{"mode":"replace_range","markdown":"A","selection_with_ellipsis":"old...A"},
+		{"mode":"insert_before","markdown":"B","selection_by_title":"## Intro"},
+		{"mode":"delete_range","selection_with_ellipsis":"stale...end"}
+	]`
+	err := runBatchUpdateShortcut(t, f, stdout, []string{
+		"+batch-update",
+		"--doc", "DOC123",
+		"--operations", ops,
+		"--dry-run",
+		"--as", "bot",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "3-op sequential batch") {
+		t.Errorf("dry-run should describe 3-op batch, got: %s", out)
+	}
+	if !strings.Contains(out, `"op_count": 3`) && !strings.Contains(out, `"op_count":3`) {
+		t.Errorf("dry-run should set op_count=3, got: %s", out)
+	}
+	// Each op index appears as [i/N] inside a step desc.
+	for _, prefix := range []string{"[1/3] replace_range", "[2/3] insert_before", "[3/3] delete_range"} {
+		if !strings.Contains(out, prefix) {
+			t.Errorf("dry-run missing step %q; got: %s", prefix, out)
+		}
+	}
+}
+
+// TestDocsBatchUpdateValidateRejectsMalformedOp ensures a bad op inside
+// --operations short-circuits before any MCP call. Covers the per-op
+// Validate loop path that the parse/validate unit tests alone don't
+// exercise from the CLI entry point.
+func TestDocsBatchUpdateValidateRejectsMalformedOp(t *testing.T) {
+	t.Parallel()
+
+	f, _, _, _ := cmdutil.TestFactory(t, batchUpdateTestConfig())
+	err := runBatchUpdateShortcut(t, f, nil, []string{
+		"+batch-update",
+		"--doc", "DOC123",
+		"--operations", `[{"mode":"replace_range","markdown":"x"}]`, // missing selection
+		"--dry-run",
+		"--as", "bot",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error for missing selection, got nil")
+	}
+	if !strings.Contains(err.Error(), "requires selection_with_ellipsis or selection_by_title") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+func TestDocsBatchUpdateValidateRejectsInvalidOnError(t *testing.T) {
+	t.Parallel()
+
+	f, _, _, _ := cmdutil.TestFactory(t, batchUpdateTestConfig())
+	err := runBatchUpdateShortcut(t, f, nil, []string{
+		"+batch-update",
+		"--doc", "DOC123",
+		"--operations", `[{"mode":"append","markdown":"x"}]`,
+		"--on-error", "panic-on-everything",
+		"--dry-run",
+		"--as", "bot",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error for bad --on-error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid --on-error") {
+		t.Fatalf("unexpected error message: %v", err)
+	}
+}
+
+// TestDocsBatchUpdateExecuteAllSuccess mocks update-doc to succeed and
+// verifies the batch response shape: total, applied, stopped_early=false,
+// and per-op success entries.
+func TestDocsBatchUpdateExecuteAllSuccess(t *testing.T) {
+	t.Parallel()
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, batchUpdateTestConfig())
+	registerUpdateDocMCPStubs(reg, 2, map[string]interface{}{
+		"success": true,
+		"message": "ok",
+	})
+
+	ops := `[
+		{"mode":"append","markdown":"first"},
+		{"mode":"append","markdown":"second"}
+	]`
+	err := runBatchUpdateShortcut(t, f, stdout, []string{
+		"+batch-update",
+		"--doc", "DOC123",
+		"--operations", ops,
+		"--as", "bot",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var envelope struct {
+		Data struct {
+			Total        int  `json:"total"`
+			Applied      int  `json:"applied"`
+			StoppedEarly bool `json:"stopped_early"`
+			Results      []struct {
+				Index   int    `json:"index"`
+				Mode    string `json:"mode"`
+				Success bool   `json:"success"`
+				Error   string `json:"error"`
+			} `json:"results"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("failed to parse stdout JSON: %v\nstdout:\n%s", err, stdout.String())
+	}
+	if envelope.Data.Total != 2 || envelope.Data.Applied != 2 {
+		t.Fatalf("expected total=2 applied=2, got total=%d applied=%d", envelope.Data.Total, envelope.Data.Applied)
+	}
+	if envelope.Data.StoppedEarly {
+		t.Errorf("expected stopped_early=false for all-success run")
+	}
+	if len(envelope.Data.Results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(envelope.Data.Results))
+	}
+	for i, r := range envelope.Data.Results {
+		if r.Index != i || !r.Success || r.Error != "" {
+			t.Errorf("result[%d] = %+v; want success=true, error=\"\"", i, r)
+		}
+	}
+}
+
+// TestDocsBatchUpdateStopsOnFirstFailure registers only one successful MCP
+// stub for a 2-op batch, so the second call trips "no stub" in httpmock and
+// surfaces as an MCP error. With --on-error=stop (the default), the batch
+// must halt, report applied=1, and set stopped_early=true.
+func TestDocsBatchUpdateStopsOnFirstFailure(t *testing.T) {
+	// Explicitly no t.Parallel(): this test ends with an unmatched stub on
+	// the failure path, and the parent TestFactory registry.Verify() will
+	// flag unused stubs across siblings if the parallel schedule bleeds.
+	f, stdout, _, reg := cmdutil.TestFactory(t, batchUpdateTestConfig())
+	registerUpdateDocMCPStubs(reg, 1, map[string]interface{}{
+		"success": true,
+	})
+
+	ops := `[
+		{"mode":"append","markdown":"first"},
+		{"mode":"append","markdown":"second"}
+	]`
+	err := runBatchUpdateShortcut(t, f, stdout, []string{
+		"+batch-update",
+		"--doc", "DOC123",
+		"--operations", ops,
+		"--as", "bot",
+	})
+	if err == nil {
+		t.Fatalf("expected error from second op failing, got nil")
+	}
+
+	// Even on error the shortcut prints its partial result envelope first.
+	var envelope struct {
+		Data struct {
+			Total        int  `json:"total"`
+			Applied      int  `json:"applied"`
+			StoppedEarly bool `json:"stopped_early"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("failed to parse partial result: %v\nstdout:\n%s", err, stdout.String())
+	}
+	if envelope.Data.Total != 2 {
+		t.Errorf("expected total=2, got %d", envelope.Data.Total)
+	}
+	if envelope.Data.Applied != 1 {
+		t.Errorf("expected applied=1 before stop, got %d", envelope.Data.Applied)
+	}
+	if !envelope.Data.StoppedEarly {
+		t.Errorf("expected stopped_early=true, got false")
+	}
+}
+
+// TestDocsBatchUpdateContinuesOnError exercises --on-error=continue for a
+// 3-op batch where the middle op fails: a later op must still run, the
+// envelope's per-op results must mark the failed index with an error
+// string, and stopped_early must stay false. Regression for the original
+// review note that the suite covered stop-on-error but not the continue
+// mode.
+func TestDocsBatchUpdateContinuesOnError(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, batchUpdateTestConfig())
+	// httpmock matches stubs in registration order, one per call. Register:
+	//   stub[0] → op[0] success
+	//   stub[1] → op[1] returns HTTP 500 (so CallMCPTool surfaces an error)
+	//   stub[2] → op[2] success (proves the loop continued past op[1])
+	registerUpdateDocMCPStubs(reg, 1, map[string]interface{}{"success": true, "applied": "first"})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/mcp",
+		Status: 500,
+		Body:   map[string]interface{}{"error": map[string]interface{}{"message": "synthetic op[1] failure"}},
+	})
+	registerUpdateDocMCPStubs(reg, 1, map[string]interface{}{"success": true, "applied": "third"})
+
+	ops := `[
+		{"mode":"append","markdown":"first"},
+		{"mode":"append","markdown":"second"},
+		{"mode":"append","markdown":"third"}
+	]`
+	err := runBatchUpdateShortcut(t, f, stdout, []string{
+		"+batch-update",
+		"--doc", "DOC123",
+		"--operations", ops,
+		"--on-error", "continue",
+		"--as", "bot",
+	})
+	if err != nil {
+		t.Fatalf("--on-error=continue must not surface a top-level error, got: %v", err)
+	}
+
+	var envelope struct {
+		Data struct {
+			Total        int  `json:"total"`
+			Applied      int  `json:"applied"`
+			StoppedEarly bool `json:"stopped_early"`
+			Results      []struct {
+				Index   int    `json:"index"`
+				Mode    string `json:"mode"`
+				Success bool   `json:"success"`
+				Error   string `json:"error"`
+			} `json:"results"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("failed to parse stdout JSON: %v\nstdout:\n%s", err, stdout.String())
+	}
+	if envelope.Data.Total != 3 {
+		t.Errorf("expected total=3, got %d", envelope.Data.Total)
+	}
+	if envelope.Data.Applied != 2 {
+		t.Errorf("expected applied=2 (op[0] and op[2] succeed, op[1] fails), got %d", envelope.Data.Applied)
+	}
+	if envelope.Data.StoppedEarly {
+		t.Errorf("expected stopped_early=false for continue-on-error, got true")
+	}
+	if len(envelope.Data.Results) != 3 {
+		t.Fatalf("expected 3 per-op results, got %d", len(envelope.Data.Results))
+	}
+	if !envelope.Data.Results[0].Success || envelope.Data.Results[0].Error != "" {
+		t.Errorf("results[0] should be success with no error, got %+v", envelope.Data.Results[0])
+	}
+	if envelope.Data.Results[1].Success || envelope.Data.Results[1].Error == "" {
+		t.Errorf("results[1] should be failure with error, got %+v", envelope.Data.Results[1])
+	}
+	if !envelope.Data.Results[2].Success || envelope.Data.Results[2].Error != "" {
+		t.Errorf("results[2] should be success with no error (continue ran op[2] after op[1] failed), got %+v", envelope.Data.Results[2])
+	}
 }

--- a/shortcuts/doc/docs_batch_update_test.go
+++ b/shortcuts/doc/docs_batch_update_test.go
@@ -5,7 +5,9 @@ package doc
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -105,6 +107,16 @@ func TestParseBatchUpdateOps(t *testing.T) {
 				{"mode":"delete_range","selection_with_ellipsis":"z...z"}
 			]`,
 			wantLen: 3,
+		},
+		{
+			name:    "leading UTF-8 BOM accepted",
+			input:   "\ufeff" + `[{"mode":"append","markdown":"hello"}]`,
+			wantLen: 1,
+		},
+		{
+			name:    "BOM after surrounding whitespace accepted",
+			input:   " \t\ufeff\n" + `[{"mode":"append","markdown":"hello"}]`,
+			wantLen: 1,
 		},
 	}
 	for _, tt := range tests {
@@ -513,5 +525,52 @@ func TestDocsBatchUpdateContinuesOnError(t *testing.T) {
 	}
 	if !envelope.Data.Results[2].Success || envelope.Data.Results[2].Error != "" {
 		t.Errorf("results[2] should be success with no error (continue ran op[2] after op[1] failed), got %+v", envelope.Data.Results[2])
+	}
+}
+
+// TestDocsBatchUpdateRespectsContextCancellation verifies the Execute loop
+// honors a cancelled context: with a pre-cancelled context and zero MCP
+// stubs registered, the shortcut must surface context.Canceled and emit a
+// partial envelope (applied=0, stopped_early=true) without making any MCP
+// calls. Regression for the per-iteration ctx.Err() check.
+func TestDocsBatchUpdateRespectsContextCancellation(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, batchUpdateTestConfig())
+
+	parent := &cobra.Command{Use: "docs"}
+	DocsBatchUpdate.Mount(parent, f)
+	parent.SetArgs([]string{
+		"+batch-update",
+		"--doc", "DOC123",
+		"--operations", `[{"mode":"append","markdown":"a"},{"mode":"append","markdown":"b"}]`,
+		"--as", "bot",
+	})
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := parent.ExecuteContext(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+
+	var envelope struct {
+		Data struct {
+			Total        int  `json:"total"`
+			Applied      int  `json:"applied"`
+			StoppedEarly bool `json:"stopped_early"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("failed to parse partial envelope: %v\nstdout:\n%s", err, stdout.String())
+	}
+	if envelope.Data.Total != 2 {
+		t.Errorf("expected total=2, got %d", envelope.Data.Total)
+	}
+	if envelope.Data.Applied != 0 {
+		t.Errorf("expected applied=0 (cancelled before any MCP call), got %d", envelope.Data.Applied)
+	}
+	if !envelope.Data.StoppedEarly {
+		t.Errorf("expected stopped_early=true on cancellation, got false")
 	}
 }

--- a/shortcuts/doc/docs_batch_update_test.go
+++ b/shortcuts/doc/docs_batch_update_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseBatchUpdateOps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantLen int
+		wantErr string
+	}{
+		{
+			name:    "empty input rejected",
+			input:   "",
+			wantErr: "--operations is required",
+		},
+		{
+			name:    "whitespace-only rejected",
+			input:   "   \n\t",
+			wantErr: "--operations is required",
+		},
+		{
+			name:    "single object rejected with clear message",
+			input:   `{"mode":"append","markdown":"x"}`,
+			wantErr: "must be a JSON array",
+		},
+		{
+			name:    "scalar rejected",
+			input:   `"append"`,
+			wantErr: "must be a JSON array",
+		},
+		{
+			name:    "empty array rejected",
+			input:   `[]`,
+			wantErr: "at least one operation",
+		},
+		{
+			name:    "malformed JSON surfaced",
+			input:   `[{"mode":"append"`,
+			wantErr: "not valid JSON",
+		},
+		{
+			name:    "single-op array parses",
+			input:   `[{"mode":"append","markdown":"hello"}]`,
+			wantLen: 1,
+		},
+		{
+			name: "multi-op array parses",
+			input: `[
+				{"mode":"replace_range","markdown":"x","selection_with_ellipsis":"a...b"},
+				{"mode":"insert_before","markdown":"y","selection_by_title":"## H2"},
+				{"mode":"delete_range","selection_with_ellipsis":"z...z"}
+			]`,
+			wantLen: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ops, err := parseBatchUpdateOps(tt.input)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(ops) != tt.wantLen {
+				t.Fatalf("got %d ops, want %d", len(ops), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestValidateBatchUpdateOp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		op      batchUpdateOp
+		wantErr string
+	}{
+		{
+			name: "append with markdown is valid",
+			op:   batchUpdateOp{Mode: "append", Markdown: "hello"},
+		},
+		{
+			name: "replace_range with selection-with-ellipsis is valid",
+			op:   batchUpdateOp{Mode: "replace_range", Markdown: "new", SelectionWithEllipsis: "a...b"},
+		},
+		{
+			name: "replace_range with selection-by-title is valid",
+			op:   batchUpdateOp{Mode: "replace_range", Markdown: "new", SelectionByTitle: "## Section"},
+		},
+		{
+			name: "delete_range without markdown is valid",
+			op:   batchUpdateOp{Mode: "delete_range", SelectionWithEllipsis: "a...b"},
+		},
+		{
+			name:    "unknown mode rejected",
+			op:      batchUpdateOp{Mode: "bogus", Markdown: "x"},
+			wantErr: "invalid mode",
+		},
+		{
+			name:    "non-delete mode without markdown rejected",
+			op:      batchUpdateOp{Mode: "replace_range", SelectionWithEllipsis: "a...b"},
+			wantErr: "requires markdown",
+		},
+		{
+			name:    "both selections rejected",
+			op:      batchUpdateOp{Mode: "replace_range", Markdown: "x", SelectionWithEllipsis: "a", SelectionByTitle: "## b"},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name:    "selection-requiring mode without any selection rejected",
+			op:      batchUpdateOp{Mode: "replace_range", Markdown: "x"},
+			wantErr: "requires selection_with_ellipsis or selection_by_title",
+		},
+		{
+			name:    "selection-by-title without leading hash rejected",
+			op:      batchUpdateOp{Mode: "replace_range", Markdown: "x", SelectionByTitle: "Section"},
+			wantErr: "heading prefix",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateBatchUpdateOp(tt.op)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildBatchUpdateArgs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("omits empty optional fields", func(t *testing.T) {
+		t.Parallel()
+		args := buildBatchUpdateArgs("DOC123", batchUpdateOp{Mode: "append", Markdown: "hello"})
+		if _, ok := args["selection_with_ellipsis"]; ok {
+			t.Errorf("expected selection_with_ellipsis omitted when empty")
+		}
+		if _, ok := args["selection_by_title"]; ok {
+			t.Errorf("expected selection_by_title omitted when empty")
+		}
+		if _, ok := args["new_title"]; ok {
+			t.Errorf("expected new_title omitted when empty")
+		}
+		if args["doc_id"] != "DOC123" {
+			t.Errorf("expected doc_id DOC123, got %v", args["doc_id"])
+		}
+		if args["mode"] != "append" {
+			t.Errorf("expected mode append, got %v", args["mode"])
+		}
+	})
+
+	t.Run("carries all set fields", func(t *testing.T) {
+		t.Parallel()
+		args := buildBatchUpdateArgs("DOC123", batchUpdateOp{
+			Mode:                  "replace_range",
+			Markdown:              "new",
+			SelectionWithEllipsis: "a...b",
+			NewTitle:              "Renamed",
+		})
+		if args["selection_with_ellipsis"] != "a...b" {
+			t.Errorf("expected selection_with_ellipsis a...b")
+		}
+		if args["new_title"] != "Renamed" {
+			t.Errorf("expected new_title Renamed")
+		}
+	})
+
+	t.Run("delete_range without markdown omits the key", func(t *testing.T) {
+		t.Parallel()
+		args := buildBatchUpdateArgs("DOC123", batchUpdateOp{
+			Mode:                  "delete_range",
+			SelectionWithEllipsis: "a...b",
+		})
+		if _, ok := args["markdown"]; ok {
+			t.Errorf("expected markdown omitted for delete_range with empty markdown")
+		}
+	})
+}

--- a/shortcuts/doc/shortcuts.go
+++ b/shortcuts/doc/shortcuts.go
@@ -12,6 +12,7 @@ func Shortcuts() []common.Shortcut {
 		DocsCreate,
 		DocsFetch,
 		DocsUpdate,
+		DocsBatchUpdate,
 		DocMediaInsert,
 		DocMediaUpload,
 		DocMediaPreview,


### PR DESCRIPTION
## Summary

Addresses Case 10 in the lark-cli pitfall list: Agents applying several related edits to one document currently pay N MCP round-trips and get N separate \`{success:true}\` responses, with no unified error/recovery story. This PR adds a \`docs +batch-update\` shortcut that accepts a JSON array of operations and runs them sequentially against a single document.

## Changes

- **\`shortcuts/doc/docs_batch_update.go\`** (new): \`DocsBatchUpdate\` shortcut; \`batchUpdateOp\` / \`batchUpdateResult\` types; \`parseBatchUpdateOps\` / \`validateBatchUpdateOp\` / \`buildBatchUpdateArgs\` helpers.
- **\`shortcuts/doc/shortcuts.go\`**: register the new shortcut.
- **\`shortcuts/doc/docs_batch_update_test.go\`** (new): parse (8 cases) + validate (9 cases) + build-args (3 subtests) coverage.

## Explicit non-goal: atomicity

There is no server-side transaction for \`update-doc\`. A mid-batch failure leaves the document in a partial-apply state. The shortcut description states this up front. Callers choose how to handle it:

- \`--on-error=stop\` (default): halt at the first failure; the response still reports how many ops landed.
- \`--on-error=continue\`: best-effort; every op runs, each entry in \`results[]\` has its own \`success\`/\`error\`.

Pair with \`docs +fetch\` after a partial run to reconcile state manually.

## Shape

\`\`\`bash
lark-cli docs +batch-update --doc <URL> --operations '[
  {\"mode\":\"replace_range\",\"markdown\":\"New intro\",\"selection_by_title\":\"## Intro\"},
  {\"mode\":\"insert_before\",\"markdown\":\"> Note: revised\",\"selection_with_ellipsis\":\"## Intro\"},
  {\"mode\":\"delete_range\",\"selection_with_ellipsis\":\"stale section...end\"}
]'
\`\`\`

Response:

\`\`\`json
{
  \"doc\": \"<URL>\",
  \"total\": 3,
  \"applied\": 3,
  \"stopped_early\": false,
  \"results\": [
    {\"index\":0, \"mode\":\"replace_range\", \"success\":true, \"result\":{...}},
    ...
  ]
}
\`\`\`

## Validation semantics

Single-op validation runs against every op **before** any MCP call, so a malformed entry fails the whole invocation up front rather than after N successful ops. This matches what batch-users expect from \`kubectl apply\`-style tooling.

## Test Plan

- [x] \`go test ./shortcuts/doc/...\` passes
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l\` clean
- [x] Coverage: parse/validate/build 90-100%
- [ ] Manual smoke: run a 3-op batch against a test doc and verify \`results[]\` shape + partial-failure path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a batch document update command: accepts a JSON array of operations, supports dry-run (planned per-op sequence), executes ops sequentially, and returns aggregated metadata plus per-op results.

* **Bug Fixes / Behavior**
  * Improved validation (JSON shape, UTF‑8 BOM trimming, mutually exclusive selection rules, mode-specific requirements), advisory warnings per op, configurable stop-on-error vs continue behavior, and proper handling of cancellation with partial results.

* **Tests**
  * Extensive tests covering parsing, validation, dry-run output, execution scenarios (full success, stop-on-failure, continue-on-error) and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->