### PR TITLE
feat(doc): add --preview flag to docs +update for pre-write self-check

### DIFF
--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -43,6 +43,7 @@ var DocsUpdate = common.Shortcut{
 		{Name: "selection-with-ellipsis", Desc: "content locator (e.g. 'start...end')"},
 		{Name: "selection-by-title", Desc: "title locator (e.g. '## Section')"},
 		{Name: "new-title", Desc: "also update document title"},
+		{Name: "preview", Type: "bool", Desc: "skip the write; fetch the document, locate the selection, and emit a preview of where the update would land and what payload would be sent. Useful for Agent self-check before committing to a write."},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		mode := runtime.Str("mode")
@@ -95,6 +96,26 @@ var DocsUpdate = common.Shortcut{
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		mode := runtime.Str("mode")
 		markdown := runtime.Str("markdown")
+
+		// Preview short-circuits the write path entirely: fetch the document,
+		// locate the selection, and emit a structured preview. Useful for
+		// Agents to self-check before committing to a mutation.
+		if runtime.Bool("preview") {
+			before, err := fetchMarkdownForPreview(runtime, runtime.Str("doc"))
+			if err != nil {
+				return err
+			}
+			preview := buildPreviewResult(
+				mode,
+				runtime.Str("doc"),
+				markdown,
+				runtime.Str("selection-with-ellipsis"),
+				runtime.Str("selection-by-title"),
+				fixExportedMarkdown(before),
+			)
+			runtime.Out(preview, nil)
+			return nil
+		}
 
 		// Static semantic checks run before the MCP call so users see
 		// warnings even if the subsequent request fails. They never block

--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -111,6 +111,7 @@ var DocsUpdate = common.Shortcut{
 				markdown,
 				runtime.Str("selection-with-ellipsis"),
 				runtime.Str("selection-by-title"),
+				runtime.Str("new-title"),
 				fixExportedMarkdown(before),
 			)
 			runtime.Out(preview, nil)

--- a/shortcuts/doc/docs_update_preview.go
+++ b/shortcuts/doc/docs_update_preview.go
@@ -90,6 +90,7 @@ type previewResult struct {
 	Matches         []previewMatch `json:"matches,omitempty"`
 	PayloadMarkdown string         `json:"payload_markdown,omitempty"`
 	PayloadLines    int            `json:"payload_lines,omitempty"`
+	NewTitle        string         `json:"new_title,omitempty"`
 	Note            string         `json:"note,omitempty"`
 }
 
@@ -117,19 +118,28 @@ func findSelectionWithEllipsis(markdown, selection string) []previewMatch {
 	}
 	var matches []previewMatch
 	for i, line := range lines {
-		if !strings.Contains(line, start) {
+		startIdx := strings.Index(line, start)
+		if startIdx < 0 {
 			continue
 		}
 		// Find the first subsequent line (or same line) containing end.
+		// On the same line, end must appear strictly after start to avoid
+		// a false "A...B" match when the document actually reads "B ... A".
 		for j := i; j < len(lines); j++ {
-			if strings.Contains(lines[j], end) {
-				matches = append(matches, previewMatch{
-					StartLine: i + 1,
-					EndLine:   j + 1,
-					Snippet:   strings.Join(lines[i:j+1], "\n"),
-				})
-				break
+			if j == i {
+				after := line[startIdx+len(start):]
+				if !strings.Contains(after, end) {
+					continue
+				}
+			} else if !strings.Contains(lines[j], end) {
+				continue
 			}
+			matches = append(matches, previewMatch{
+				StartLine: i + 1,
+				EndLine:   j + 1,
+				Snippet:   strings.Join(lines[i:j+1], "\n"),
+			})
+			break
 		}
 	}
 	return matches
@@ -162,8 +172,16 @@ func findSelectionByTitle(markdown, title string) []previewMatch {
 	}
 	targetText := strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(title), "#"))
 	lines := strings.Split(markdown, "\n")
+	// Pre-compute fence state for each line so the outer and inner scans
+	// both see a consistent "in-fence" signal. Heading-looking lines inside
+	// ```…``` or ~~~…~~~ are code content, not real headings, and must not
+	// start a match or terminate a matched section.
+	inFence := fenceStateByLine(lines)
 	var matches []previewMatch
 	for i, line := range lines {
+		if inFence[i] {
+			continue
+		}
 		level := previewAtxHeadingLevel(line)
 		if level != targetLevel {
 			continue
@@ -172,9 +190,12 @@ func findSelectionByTitle(markdown, title string) []previewMatch {
 		if headingText != targetText {
 			continue
 		}
-		// Find section end: next heading of equal or shallower level.
+		// Find section end: next non-fenced heading of equal or shallower level.
 		end := len(lines)
 		for j := i + 1; j < len(lines); j++ {
+			if inFence[j] {
+				continue
+			}
 			if lvl := previewAtxHeadingLevel(lines[j]); lvl != 0 && lvl <= targetLevel {
 				end = j
 				break
@@ -189,14 +210,34 @@ func findSelectionByTitle(markdown, title string) []previewMatch {
 	return matches
 }
 
+// fenceStateByLine returns a bool slice where result[i] reports whether
+// lines[i] sits inside a fenced code block (between a ```/~~~ opener and
+// its matching closer). The opener/closer lines themselves are reported as
+// inside-fence so heading matching skips them too.
+func fenceStateByLine(lines []string) []bool {
+	state := make([]bool, len(lines))
+	inFence := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			state[i] = true
+			inFence = !inFence
+			continue
+		}
+		state[i] = inFence
+	}
+	return state
+}
+
 // buildPreviewResult constructs the preview output object for a given
 // update invocation. It never calls MCP — it operates on the already-
 // fetched markdown snapshot. The caller decides when to skip the actual
 // write (currently: always, when --preview is set).
-func buildPreviewResult(mode, docID, markdown, selectionWithEllipsis, selectionByTitle, beforeMarkdown string) *previewResult {
+func buildPreviewResult(mode, docID, markdown, selectionWithEllipsis, selectionByTitle, newTitle, beforeMarkdown string) *previewResult {
 	res := &previewResult{
-		Mode:  mode,
-		DocID: docID,
+		Mode:     mode,
+		DocID:    docID,
+		NewTitle: newTitle,
 	}
 	res.PayloadMarkdown = markdown
 	if markdown != "" {
@@ -222,7 +263,9 @@ func buildPreviewResult(mode, docID, markdown, selectionWithEllipsis, selectionB
 	switch {
 	case res.MatchCount == 0:
 		res.Note = "selection did not match any line in the fetched markdown snapshot; the real update may still succeed if the server resolves selection differently, but you probably want to narrow the selection first"
-	case res.MatchCount > 1 && mode != "replace_all":
+	case res.MatchCount > 1 && mode == "replace_all":
+		res.Note = fmt.Sprintf("selection matches %d locations; replace_all would apply to all matches", res.MatchCount)
+	case res.MatchCount > 1:
 		res.Note = fmt.Sprintf("selection matches %d locations; only replace_all is defined to apply to all matches — other modes act on the first match and the result may be non-deterministic across retries", res.MatchCount)
 	case res.MatchCount == 1:
 		res.Note = "selection matches exactly one location"

--- a/shortcuts/doc/docs_update_preview.go
+++ b/shortcuts/doc/docs_update_preview.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// previewAtxHeadingLevel returns the ATX heading level (1..6) of an ATX
+// heading line such as "## Section", or 0 otherwise. Kept local to the
+// preview module so Case 11 doesn't depend on the Case 2 branch (PR #619);
+// the two implementations will converge once both land on main.
+func previewAtxHeadingLevel(line string) int {
+	// CommonMark §4.2: 0..3 leading spaces OK, 4+ spaces or any leading
+	// tab force indented-code semantics.
+	for i := 0; i < 4 && i < len(line); i++ {
+		if line[i] == '\t' {
+			return 0
+		}
+		if line[i] != ' ' {
+			line = line[i:]
+			goto scan
+		}
+	}
+	if len(line) >= 4 {
+		return 0
+	}
+	line = ""
+scan:
+	level := 0
+	for level < len(line) && line[level] == '#' {
+		level++
+	}
+	if level == 0 || level > 6 {
+		return 0
+	}
+	if level == len(line) {
+		return level
+	}
+	switch line[level] {
+	case ' ', '\t':
+		return level
+	}
+	return 0
+}
+
+// fetchMarkdownForPreview calls the fetch-doc MCP tool and returns the
+// markdown payload. Errors bubble up verbatim so the caller (preview mode)
+// can surface them directly — a failed pre-fetch is fatal to preview
+// because the whole point is to reason about the document's current state.
+func fetchMarkdownForPreview(runtime *common.RuntimeContext, docID string) (string, error) {
+	result, err := common.CallMCPTool(runtime, "fetch-doc", map[string]interface{}{
+		"doc_id":           docID,
+		"skip_task_detail": true,
+	})
+	if err != nil {
+		return "", err
+	}
+	md, _ := result["markdown"].(string)
+	return md, nil
+}
+
+// previewMatch captures where a selection expression matches in a document's
+// markdown snapshot. Line numbers are 1-based inclusive, matching what the
+// user sees in any markdown editor.
+type previewMatch struct {
+	StartLine int
+	EndLine   int
+	Snippet   string
+}
+
+// previewResult is the JSON shape returned by `docs +update --preview`.
+// It captures everything the CLI can say about an update *without* calling
+// the write-path: where the selection matches, how many matches were found,
+// and the raw markdown payload that would be sent. The caller can then
+// sanity-check the selection is unique and the payload looks right before
+// re-running without --preview.
+//
+// Explicitly not included: the "rendered after" view. The CLI does not know
+// how the server will convert markdown into Lark blocks, so simulating it
+// here would mislead rather than help. The payload is reported verbatim.
+type previewResult struct {
+	Mode            string         `json:"mode"`
+	DocID           string         `json:"doc_id"`
+	MatchCount      int            `json:"match_count"`
+	Matches         []previewMatch `json:"matches,omitempty"`
+	PayloadMarkdown string         `json:"payload_markdown,omitempty"`
+	PayloadLines    int            `json:"payload_lines,omitempty"`
+	Note            string         `json:"note,omitempty"`
+}
+
+// findSelectionWithEllipsis locates the first block of markdown that starts
+// with any line containing the ellipsis prefix and ends at any line
+// containing the suffix. A plain-text selection (no "...") matches the
+// smallest line range containing the exact substring.
+//
+// The matching is intentionally simpler than the server's real selection
+// resolution (it operates on the raw fetched markdown rather than the block
+// tree), so a preview match is advisory. A returned empty slice means "not
+// found in the local markdown"; the server may still find it (e.g. in a
+// block that fetch-doc renders differently), which is why preview never
+// blocks the subsequent real update.
+func findSelectionWithEllipsis(markdown, selection string) []previewMatch {
+	lines := strings.Split(markdown, "\n")
+	if !strings.Contains(selection, "...") {
+		return findSingleLineMatches(lines, selection)
+	}
+	parts := strings.SplitN(selection, "...", 2)
+	start := strings.TrimSpace(parts[0])
+	end := strings.TrimSpace(parts[1])
+	if start == "" || end == "" {
+		return nil
+	}
+	var matches []previewMatch
+	for i, line := range lines {
+		if !strings.Contains(line, start) {
+			continue
+		}
+		// Find the first subsequent line (or same line) containing end.
+		for j := i; j < len(lines); j++ {
+			if strings.Contains(lines[j], end) {
+				matches = append(matches, previewMatch{
+					StartLine: i + 1,
+					EndLine:   j + 1,
+					Snippet:   strings.Join(lines[i:j+1], "\n"),
+				})
+				break
+			}
+		}
+	}
+	return matches
+}
+
+// findSingleLineMatches returns every line whose content contains needle.
+// Used for ellipsis-free selections; each match is a single-line range.
+func findSingleLineMatches(lines []string, needle string) []previewMatch {
+	var matches []previewMatch
+	for i, line := range lines {
+		if strings.Contains(line, needle) {
+			matches = append(matches, previewMatch{
+				StartLine: i + 1,
+				EndLine:   i + 1,
+				Snippet:   line,
+			})
+		}
+	}
+	return matches
+}
+
+// findSelectionByTitle locates a heading block in markdown by its ATX
+// heading syntax (e.g. "## Overview"). The match range is the heading line
+// itself plus the run of content lines before the next heading of equal or
+// shallower level — i.e. the section the heading owns.
+func findSelectionByTitle(markdown, title string) []previewMatch {
+	targetLevel := previewAtxHeadingLevel(strings.TrimSpace(title))
+	if targetLevel == 0 {
+		return nil
+	}
+	targetText := strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(title), "#"))
+	lines := strings.Split(markdown, "\n")
+	var matches []previewMatch
+	for i, line := range lines {
+		level := previewAtxHeadingLevel(line)
+		if level != targetLevel {
+			continue
+		}
+		headingText := strings.TrimSpace(strings.TrimLeft(strings.TrimSpace(line), "#"))
+		if headingText != targetText {
+			continue
+		}
+		// Find section end: next heading of equal or shallower level.
+		end := len(lines)
+		for j := i + 1; j < len(lines); j++ {
+			if lvl := previewAtxHeadingLevel(lines[j]); lvl != 0 && lvl <= targetLevel {
+				end = j
+				break
+			}
+		}
+		matches = append(matches, previewMatch{
+			StartLine: i + 1,
+			EndLine:   end,
+			Snippet:   strings.Join(lines[i:end], "\n"),
+		})
+	}
+	return matches
+}
+
+// buildPreviewResult constructs the preview output object for a given
+// update invocation. It never calls MCP — it operates on the already-
+// fetched markdown snapshot. The caller decides when to skip the actual
+// write (currently: always, when --preview is set).
+func buildPreviewResult(mode, docID, markdown, selectionWithEllipsis, selectionByTitle, beforeMarkdown string) *previewResult {
+	res := &previewResult{
+		Mode:  mode,
+		DocID: docID,
+	}
+	res.PayloadMarkdown = markdown
+	if markdown != "" {
+		res.PayloadLines = len(strings.Split(markdown, "\n"))
+	}
+
+	switch mode {
+	case "append":
+		res.Note = fmt.Sprintf("would append %d lines to end of document (preview does not read the trailing block)", res.PayloadLines)
+		return res
+	case "overwrite":
+		res.Note = fmt.Sprintf("would replace the entire document with %d lines (all existing blocks are discarded)", res.PayloadLines)
+		return res
+	}
+
+	switch {
+	case selectionWithEllipsis != "":
+		res.Matches = findSelectionWithEllipsis(beforeMarkdown, selectionWithEllipsis)
+	case selectionByTitle != "":
+		res.Matches = findSelectionByTitle(beforeMarkdown, selectionByTitle)
+	}
+	res.MatchCount = len(res.Matches)
+	switch {
+	case res.MatchCount == 0:
+		res.Note = "selection did not match any line in the fetched markdown snapshot; the real update may still succeed if the server resolves selection differently, but you probably want to narrow the selection first"
+	case res.MatchCount > 1 && mode != "replace_all":
+		res.Note = fmt.Sprintf("selection matches %d locations; only replace_all is defined to apply to all matches — other modes act on the first match and the result may be non-deterministic across retries", res.MatchCount)
+	case res.MatchCount == 1:
+		res.Note = "selection matches exactly one location"
+	}
+	return res
+}

--- a/shortcuts/doc/docs_update_preview_test.go
+++ b/shortcuts/doc/docs_update_preview_test.go
@@ -175,7 +175,7 @@ func TestBuildPreviewResult(t *testing.T) {
 
 	t.Run("append uses note with line count", func(t *testing.T) {
 		t.Parallel()
-		res := buildPreviewResult("append", "DOC", "new paragraph\nsecond line", "", "", before)
+		res := buildPreviewResult("append", "DOC", "new paragraph\nsecond line", "", "", "", before)
 		if res.PayloadLines != 2 {
 			t.Errorf("want 2 payload lines, got %d", res.PayloadLines)
 		}
@@ -186,7 +186,7 @@ func TestBuildPreviewResult(t *testing.T) {
 
 	t.Run("overwrite warns about discard", func(t *testing.T) {
 		t.Parallel()
-		res := buildPreviewResult("overwrite", "DOC", "new doc content", "", "", before)
+		res := buildPreviewResult("overwrite", "DOC", "new doc content", "", "", "", before)
 		if !strings.Contains(res.Note, "discarded") {
 			t.Errorf("note should mention discard, got %q", res.Note)
 		}
@@ -194,7 +194,7 @@ func TestBuildPreviewResult(t *testing.T) {
 
 	t.Run("replace_range with unique selection records single match", func(t *testing.T) {
 		t.Parallel()
-		res := buildPreviewResult("replace_range", "DOC", "new intro", "old intro", "", before)
+		res := buildPreviewResult("replace_range", "DOC", "new intro", "old intro", "", "", before)
 		if res.MatchCount != 1 {
 			t.Fatalf("want 1 match, got %d; note=%s", res.MatchCount, res.Note)
 		}
@@ -205,7 +205,7 @@ func TestBuildPreviewResult(t *testing.T) {
 
 	t.Run("replace_range with no match surfaces warning", func(t *testing.T) {
 		t.Parallel()
-		res := buildPreviewResult("replace_range", "DOC", "new", "nonexistent", "", before)
+		res := buildPreviewResult("replace_range", "DOC", "new", "nonexistent", "", "", before)
 		if res.MatchCount != 0 {
 			t.Errorf("want 0 matches, got %d", res.MatchCount)
 		}
@@ -216,9 +216,80 @@ func TestBuildPreviewResult(t *testing.T) {
 
 	t.Run("selection-by-title finds section", func(t *testing.T) {
 		t.Parallel()
-		res := buildPreviewResult("replace_range", "DOC", "new section body", "", "## Overview", before)
+		res := buildPreviewResult("replace_range", "DOC", "new section body", "", "## Overview", "", before)
 		if res.MatchCount != 1 {
 			t.Fatalf("want 1 match, got %d; note=%s", res.MatchCount, res.Note)
 		}
 	})
+
+	t.Run("replace_all with multi-match emits tailored note", func(t *testing.T) {
+		t.Parallel()
+		md := "foo bar\nbar foo\nfoo again"
+		res := buildPreviewResult("replace_all", "DOC", "qux", "foo", "", "", md)
+		if res.MatchCount != 3 {
+			t.Fatalf("want 3 matches, got %d", res.MatchCount)
+		}
+		if !strings.Contains(res.Note, "replace_all would apply to all") {
+			t.Errorf("note should call out replace_all semantics, got %q", res.Note)
+		}
+	})
+
+	t.Run("new_title is propagated to preview", func(t *testing.T) {
+		t.Parallel()
+		res := buildPreviewResult("append", "DOC", "body", "", "", "Renamed Doc", before)
+		if res.NewTitle != "Renamed Doc" {
+			t.Errorf("want NewTitle=Renamed Doc, got %q", res.NewTitle)
+		}
+	})
+}
+
+func TestFindSelectionWithEllipsisSameLineOrdering(t *testing.T) {
+	t.Parallel()
+
+	// "B...A" should not match a line where A appears before B.
+	md := "the quick brown fox"
+	matches := findSelectionWithEllipsis(md, "fox...quick")
+	if len(matches) != 0 {
+		t.Errorf("expected no match for reversed same-line ellipsis, got %d", len(matches))
+	}
+
+	// Same line, correct order, still works.
+	matches = findSelectionWithEllipsis(md, "quick...fox")
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match for same-line quick...fox, got %d", len(matches))
+	}
+	if matches[0].StartLine != 1 || matches[0].EndLine != 1 {
+		t.Errorf("want 1..1, got %d..%d", matches[0].StartLine, matches[0].EndLine)
+	}
+}
+
+func TestFindSelectionByTitleIgnoresFencedHeadings(t *testing.T) {
+	t.Parallel()
+
+	md := strings.Join([]string{
+		"# Real H1",
+		"",
+		"```markdown",
+		"## Fake Heading",
+		"```",
+		"",
+		"## Real H2",
+		"body",
+	}, "\n")
+
+	// Fenced "## Fake Heading" must not match.
+	matches := findSelectionByTitle(md, "## Fake Heading")
+	if len(matches) != 0 {
+		t.Errorf("fenced heading should not match, got %d match(es)", len(matches))
+	}
+
+	// And the fenced line must not be treated as a section terminator for
+	// outer headings either — searching for H1 should capture everything.
+	matches = findSelectionByTitle(md, "# Real H1")
+	if len(matches) != 1 {
+		t.Fatalf("want 1 match for H1, got %d", len(matches))
+	}
+	if !strings.Contains(matches[0].Snippet, "body") {
+		t.Errorf("H1 section should reach through fenced code to final body, got snippet:\n%s", matches[0].Snippet)
+	}
 }

--- a/shortcuts/doc/docs_update_preview_test.go
+++ b/shortcuts/doc/docs_update_preview_test.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPreviewAtxHeadingLevel(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]int{
+		"# H1":          1,
+		"## H2":         2,
+		"###### H6":     6,
+		"####### x":     0,
+		"##":            2,
+		"##\tTitle":     2,
+		"##no-space":    0,
+		"":              0,
+		"  ## indented": 2,
+		"   ## edge":    2,
+		"    ## code":   0,
+		"\t## code":     0,
+		"plain prose":   0,
+	}
+	for input, want := range cases {
+		if got := previewAtxHeadingLevel(input); got != want {
+			t.Errorf("previewAtxHeadingLevel(%q) = %d, want %d", input, got, want)
+		}
+	}
+}
+
+func TestFindSelectionWithEllipsis(t *testing.T) {
+	t.Parallel()
+
+	md := strings.Join([]string{
+		"# Doc title",
+		"",
+		"intro paragraph",
+		"",
+		"## Section One",
+		"",
+		"content of section one spanning",
+		"multiple lines and ending here.",
+		"",
+		"## Section Two",
+		"",
+		"other content.",
+	}, "\n")
+
+	t.Run("plain substring single-line", func(t *testing.T) {
+		t.Parallel()
+		matches := findSelectionWithEllipsis(md, "intro paragraph")
+		if len(matches) != 1 {
+			t.Fatalf("want 1 match, got %d", len(matches))
+		}
+		if matches[0].StartLine != 3 || matches[0].EndLine != 3 {
+			t.Errorf("want lines 3..3, got %d..%d", matches[0].StartLine, matches[0].EndLine)
+		}
+	})
+
+	t.Run("ellipsis spans multiple lines", func(t *testing.T) {
+		t.Parallel()
+		matches := findSelectionWithEllipsis(md, "content of section one...ending here")
+		if len(matches) != 1 {
+			t.Fatalf("want 1 match, got %d", len(matches))
+		}
+		if matches[0].StartLine != 7 || matches[0].EndLine != 8 {
+			t.Errorf("want lines 7..8, got %d..%d", matches[0].StartLine, matches[0].EndLine)
+		}
+		if !strings.Contains(matches[0].Snippet, "content of section one") {
+			t.Errorf("snippet missing start text: %q", matches[0].Snippet)
+		}
+	})
+
+	t.Run("selection that does not match returns no matches", func(t *testing.T) {
+		t.Parallel()
+		matches := findSelectionWithEllipsis(md, "nonexistent string")
+		if len(matches) != 0 {
+			t.Errorf("want 0 matches, got %d", len(matches))
+		}
+	})
+
+	t.Run("ellipsis with empty side returns no matches", func(t *testing.T) {
+		t.Parallel()
+		if m := findSelectionWithEllipsis(md, "...end"); len(m) != 0 {
+			t.Errorf("empty prefix should not match")
+		}
+		if m := findSelectionWithEllipsis(md, "start..."); len(m) != 0 {
+			t.Errorf("empty suffix should not match")
+		}
+	})
+}
+
+func TestFindSelectionByTitle(t *testing.T) {
+	t.Parallel()
+
+	md := strings.Join([]string{
+		"# Top",
+		"",
+		"intro",
+		"",
+		"## Section One",
+		"",
+		"section one body",
+		"",
+		"### Subsection",
+		"",
+		"subsection body",
+		"",
+		"## Section Two",
+		"",
+		"section two body",
+	}, "\n")
+
+	t.Run("matches h2 and captures full section", func(t *testing.T) {
+		t.Parallel()
+		matches := findSelectionByTitle(md, "## Section One")
+		if len(matches) != 1 {
+			t.Fatalf("want 1 match, got %d", len(matches))
+		}
+		if matches[0].StartLine != 5 || matches[0].EndLine != 12 {
+			t.Errorf("want lines 5..12, got %d..%d", matches[0].StartLine, matches[0].EndLine)
+		}
+		if !strings.Contains(matches[0].Snippet, "section one body") {
+			t.Errorf("snippet should include section body")
+		}
+		if !strings.Contains(matches[0].Snippet, "### Subsection") {
+			t.Errorf("snippet should include deeper subsection")
+		}
+	})
+
+	t.Run("heading level mismatch yields no match", func(t *testing.T) {
+		t.Parallel()
+		matches := findSelectionByTitle(md, "# Section One")
+		if len(matches) != 0 {
+			t.Errorf("want 0 matches for level-1 targeting level-2 heading, got %d", len(matches))
+		}
+	})
+
+	t.Run("nonexistent heading yields no match", func(t *testing.T) {
+		t.Parallel()
+		if m := findSelectionByTitle(md, "## Section Three"); len(m) != 0 {
+			t.Errorf("want 0 matches, got %d", len(m))
+		}
+	})
+
+	t.Run("deeper heading captures only until next shallower", func(t *testing.T) {
+		t.Parallel()
+		matches := findSelectionByTitle(md, "### Subsection")
+		if len(matches) != 1 {
+			t.Fatalf("want 1 match, got %d", len(matches))
+		}
+		if matches[0].StartLine != 9 || matches[0].EndLine != 12 {
+			t.Errorf("want lines 9..12, got %d..%d", matches[0].StartLine, matches[0].EndLine)
+		}
+	})
+}
+
+func TestBuildPreviewResult(t *testing.T) {
+	t.Parallel()
+
+	before := strings.Join([]string{
+		"# Doc",
+		"",
+		"## Overview",
+		"old intro",
+		"",
+		"## Next",
+		"other content",
+	}, "\n")
+
+	t.Run("append uses note with line count", func(t *testing.T) {
+		t.Parallel()
+		res := buildPreviewResult("append", "DOC", "new paragraph\nsecond line", "", "", before)
+		if res.PayloadLines != 2 {
+			t.Errorf("want 2 payload lines, got %d", res.PayloadLines)
+		}
+		if !strings.Contains(res.Note, "append") {
+			t.Errorf("note should mention append, got %q", res.Note)
+		}
+	})
+
+	t.Run("overwrite warns about discard", func(t *testing.T) {
+		t.Parallel()
+		res := buildPreviewResult("overwrite", "DOC", "new doc content", "", "", before)
+		if !strings.Contains(res.Note, "discarded") {
+			t.Errorf("note should mention discard, got %q", res.Note)
+		}
+	})
+
+	t.Run("replace_range with unique selection records single match", func(t *testing.T) {
+		t.Parallel()
+		res := buildPreviewResult("replace_range", "DOC", "new intro", "old intro", "", before)
+		if res.MatchCount != 1 {
+			t.Fatalf("want 1 match, got %d; note=%s", res.MatchCount, res.Note)
+		}
+		if !strings.Contains(res.Note, "exactly one") {
+			t.Errorf("single-match note unexpected: %q", res.Note)
+		}
+	})
+
+	t.Run("replace_range with no match surfaces warning", func(t *testing.T) {
+		t.Parallel()
+		res := buildPreviewResult("replace_range", "DOC", "new", "nonexistent", "", before)
+		if res.MatchCount != 0 {
+			t.Errorf("want 0 matches, got %d", res.MatchCount)
+		}
+		if !strings.Contains(res.Note, "did not match") {
+			t.Errorf("expected not-matched note, got %q", res.Note)
+		}
+	})
+
+	t.Run("selection-by-title finds section", func(t *testing.T) {
+		t.Parallel()
+		res := buildPreviewResult("replace_range", "DOC", "new section body", "", "## Overview", before)
+		if res.MatchCount != 1 {
+			t.Fatalf("want 1 match, got %d; note=%s", res.MatchCount, res.Note)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Addresses Case 11 in the lark-cli pitfall list: the existing \`--dry-run\` on \`docs +update\` only prints the request body, so Agents can verify the RPC shape but have no idea whether their selection actually resolves in the target doc. The result is blind writes followed by fetch-doc forensics.

Add \`--preview\` as a content-aware alternative: pre-fetch the document, locate the selection in its markdown, emit a structured result describing match positions, the raw payload, and human-readable notes for common traps.

## Changes

- **\`shortcuts/doc/docs_update_preview.go\`** (new): \`previewAtxHeadingLevel\` (CommonMark-conformant), \`findSelectionWithEllipsis\` / \`findSelectionByTitle\` / \`findSingleLineMatches\` helpers, \`buildPreviewResult\`, \`fetchMarkdownForPreview\`.
- **\`shortcuts/doc/docs_update.go\`**: new \`--preview\` bool flag; Execute short-circuits to the preview path when set.
- **\`shortcuts/doc/docs_update_preview_test.go\`** (new): 12-case ATX helper + 4-subtest ellipsis matcher + 4-subtest title matcher + 5-subtest preview-result builder.

## Shape

\`\`\`bash
lark-cli docs +update --doc <URL> --mode replace_range \\
  --selection-with-ellipsis "old intro...ending here" \\
  --markdown "new intro" --preview
\`\`\`

\`\`\`json
{
  \"mode\": \"replace_range\",
  \"doc_id\": \"<URL>\",
  \"match_count\": 1,
  \"matches\": [
    {\"StartLine\": 7, \"EndLine\": 8, \"Snippet\": \"old intro\nending here\"}
  ],
  \"payload_markdown\": \"new intro\",
  \"payload_lines\": 1,
  \"note\": \"selection matches exactly one location\"
}
\`\`\`

## Scope notes

- Local-only matcher: preview operates on the raw fetched markdown, not on the server's block tree. A miss is advisory — the server may still resolve the selection differently. This is documented on every matcher and on the flag's description. Preview is for Agent self-check, not for blocking the write path.
- \`append\` / \`overwrite\`: selection lookup is skipped; the note instead describes what the mode would do (append N lines / discard entire doc).
- \`previewAtxHeadingLevel\` is a CommonMark-conformant ATX parser local to this file, distinct from the one in PR #619 (Case 2). The two will converge once both land on main.
- The rendered-after view is deliberately not attempted — CLI doesn't know how the server will convert markdown into Lark blocks, so simulating it would mislead.

## Test Plan

- [x] \`go test ./shortcuts/doc/...\` passes
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l\` clean
- [ ] Manual smoke: run \`--preview\` against a live doc with a replace_range + unique selection and confirm the match + note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--preview` flag to `docs +update` so users can see a structured preview of proposed changes (matched locations, computed line counts, and outgoing payload) without modifying the document. Preview supports append/overwrite semantics and clear human-readable notes for 0/1/multiple matches.

* **Tests**
  * Added end-to-end tests covering heading detection, selection matching, multi-match behavior, append/overwrite handling, and preview result generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->