### PR TITLE
feat(doc): add --omit-title flag to docs +fetch for round-trip safety

### DIFF
--- a/shortcuts/doc/docs_fetch.go
+++ b/shortcuts/doc/docs_fetch.go
@@ -24,6 +24,7 @@ var DocsFetch = common.Shortcut{
 		{Name: "doc", Desc: "document URL or token", Required: true},
 		{Name: "offset", Desc: "pagination offset"},
 		{Name: "limit", Desc: "pagination limit"},
+		{Name: "omit-title", Type: "bool", Desc: "in --format=pretty output, skip the leading '# <title>' line. Lark stores document title as an independent field, so including it when piping fetch output into `docs +update --mode=overwrite` accumulates duplicate H1 blocks on every round-trip."},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		args := map[string]interface{}{
@@ -69,17 +70,33 @@ var DocsFetch = common.Shortcut{
 			result["markdown"] = fixExportedMarkdown(md)
 		}
 
+		omitTitle := runtime.Bool("omit-title")
 		runtime.OutFormat(result, nil, func(w io.Writer) {
-			if title, ok := result["title"].(string); ok && title != "" {
-				fmt.Fprintf(w, "# %s\n\n", title)
-			}
-			if md, ok := result["markdown"].(string); ok {
-				fmt.Fprintln(w, md)
-			}
-			if hasMore, ok := result["has_more"].(bool); ok && hasMore {
-				fmt.Fprintln(w, "\n--- more content available, use --offset and --limit to paginate ---")
-			}
+			renderFetchPretty(w, result, omitTitle)
 		})
 		return nil
 	},
+}
+
+// renderFetchPretty writes the human-readable (pretty) form of a fetch-doc
+// result to w. Split out from Execute so tests can verify the --omit-title
+// behavior directly without spinning up a runtime/MCP mock.
+//
+// When omitTitle is false (default), the leading "# <title>\n\n" is
+// preserved for reader orientation. When true, the title line is skipped so
+// the output is safe to pipe into `docs +update --mode=overwrite` without
+// accumulating duplicate H1 blocks on every round-trip (see Case 13 in the
+// pitfall list).
+func renderFetchPretty(w io.Writer, result map[string]interface{}, omitTitle bool) {
+	if !omitTitle {
+		if title, ok := result["title"].(string); ok && title != "" {
+			fmt.Fprintf(w, "# %s\n\n", title)
+		}
+	}
+	if md, ok := result["markdown"].(string); ok {
+		fmt.Fprintln(w, md)
+	}
+	if hasMore, ok := result["has_more"].(bool); ok && hasMore {
+		fmt.Fprintln(w, "\n--- more content available, use --offset and --limit to paginate ---")
+	}
 }

--- a/shortcuts/doc/docs_fetch_test.go
+++ b/shortcuts/doc/docs_fetch_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderFetchPretty(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		result         map[string]interface{}
+		omitTitle      bool
+		wantHas        []string
+		wantLacks      []string
+		wantFirstIsH1  bool
+		wantFirstIsNot string
+	}{
+		{
+			name: "default includes title as H1",
+			result: map[string]interface{}{
+				"title":    "My Doc",
+				"markdown": "body paragraph",
+			},
+			wantHas:       []string{"# My Doc", "body paragraph"},
+			wantFirstIsH1: true,
+		},
+		{
+			name: "omit-title strips the leading H1",
+			result: map[string]interface{}{
+				"title":    "My Doc",
+				"markdown": "body paragraph",
+			},
+			omitTitle:      true,
+			wantHas:        []string{"body paragraph"},
+			wantLacks:      []string{"# My Doc"},
+			wantFirstIsNot: "#",
+		},
+		{
+			name: "empty title does not emit an empty H1 even with omit-title=false",
+			result: map[string]interface{}{
+				"title":    "",
+				"markdown": "plain body",
+			},
+			wantHas:   []string{"plain body"},
+			wantLacks: []string{"# "},
+		},
+		{
+			name: "missing title field is not emitted",
+			result: map[string]interface{}{
+				"markdown": "only body",
+			},
+			wantHas:   []string{"only body"},
+			wantLacks: []string{"# "},
+		},
+		{
+			name: "has_more appends pagination hint",
+			result: map[string]interface{}{
+				"title":    "My Doc",
+				"markdown": "partial body",
+				"has_more": true,
+			},
+			wantHas: []string{"# My Doc", "partial body", "more content available"},
+		},
+		{
+			name: "has_more false omits pagination hint",
+			result: map[string]interface{}{
+				"markdown": "whole body",
+				"has_more": false,
+			},
+			wantLacks: []string{"more content available"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			renderFetchPretty(&buf, tt.result, tt.omitTitle)
+			got := buf.String()
+			for _, needle := range tt.wantHas {
+				if !strings.Contains(got, needle) {
+					t.Errorf("expected output to contain %q, got:\n%s", needle, got)
+				}
+			}
+			for _, forbidden := range tt.wantLacks {
+				if strings.Contains(got, forbidden) {
+					t.Errorf("expected output NOT to contain %q, got:\n%s", forbidden, got)
+				}
+			}
+			if tt.wantFirstIsH1 {
+				if !strings.HasPrefix(got, "# ") {
+					t.Errorf("expected output to start with '# ', got prefix %q", firstNChars(got, 20))
+				}
+			}
+			if tt.wantFirstIsNot != "" {
+				if strings.HasPrefix(got, tt.wantFirstIsNot) {
+					t.Errorf("expected output NOT to start with %q, got prefix %q", tt.wantFirstIsNot, firstNChars(got, 20))
+				}
+			}
+		})
+	}
+}
+
+// TestRenderFetchPrettyRoundTripSafety verifies that omit-title output, when
+// fed back as markdown body, does not carry a title line that would
+// accumulate on re-import — the core Case 13 invariant.
+func TestRenderFetchPrettyRoundTripSafety(t *testing.T) {
+	t.Parallel()
+
+	result := map[string]interface{}{
+		"title":    "My Doc",
+		"markdown": "## Section One\n\ncontent.\n",
+	}
+
+	var buf bytes.Buffer
+	renderFetchPretty(&buf, result, true)
+	body := buf.String()
+
+	// The exported body must not start with the title as an H1. Section
+	// headings deeper than H1 are fine and expected.
+	if strings.HasPrefix(body, "# My Doc") {
+		t.Fatalf("omit-title output still starts with the title H1; round-trip will accumulate duplicates:\n%s", body)
+	}
+	if !strings.Contains(body, "## Section One") {
+		t.Fatalf("section heading was dropped, got:\n%s", body)
+	}
+}
+
+func firstNChars(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -20,6 +20,10 @@ lark-cli docs +fetch --doc Z1FjxxxxxxxxxxxxxxxxxxxtnAc --offset 0 --limit 50
 
 # 人类可读格式输出
 lark-cli docs +fetch --doc Z1FjxxxxxxxxxxxxxxxxxxxtnAc --format pretty
+
+# Round-trip 安全的 body 输出（不带 `# <title>` 前缀）
+# 用于 fetch → edit → `docs +update --mode=overwrite` 流程，避免标题累积
+lark-cli docs +fetch --doc Z1FjxxxxxxxxxxxxxxxxxxxtnAc --format pretty --omit-title
 ```
 
 ## 参数
@@ -30,6 +34,7 @@ lark-cli docs +fetch --doc Z1FjxxxxxxxxxxxxxxxxxxxtnAc --format pretty
 | `--offset` | 否 | 分页偏移 |
 | `--limit` | 否 | 分页大小 |
 | `--format` | 否 | 输出格式：json（默认，含 title、markdown、has_more 等字段） \| pretty |
+| `--omit-title` | 否 | 在 `--format=pretty` 下略去开头的 `# <title>`。飞书文档的 title 是独立字段，`docs +update --mode=overwrite` 不会覆盖它；如果带标题回灌会在正文重复累积一行 H1。round-trip 场景下推荐开启 |
 
 ## 重要：图片、文件、画板的处理
 


### PR DESCRIPTION
## Summary

Addresses Case 13 in the lark-cli pitfall list: \`docs +fetch --format=pretty\` prepends \`# <title>\` for human readability, but Lark stores the document title as an independent field and \`docs +update --mode=overwrite\` only rewrites the body. Piping pretty output through overwrite therefore accumulates a duplicate H1 block on every round-trip — observed in practice as 6+ duplicate H1s on the PR-tracker doc before anyone noticed.

Add \`--omit-title\` (off by default) so round-trip callers get a clean body.

## Changes

- **\`shortcuts/doc/docs_fetch.go\`**: new \`--omit-title\` bool flag; extract \`renderFetchPretty\` from the Execute closure for testability.
- **\`shortcuts/doc/docs_fetch_test.go\`** (new): 6-case table-driven coverage + a dedicated round-trip-safety assertion.
- **\`skills/lark-doc/references/lark-doc-fetch.md\`**: document the flag and the round-trip use case.

## Scope notes

- Default behavior unchanged — human readers still see the H1 title up top.
- Only \`--format=pretty\` is affected; \`json\` / \`ndjson\` / \`csv\` / \`table\` never carried the synthetic prefix.
- This is the Option 2 resolution from the Case 13 brief (additive flag). Option 1 (change default) was rejected on breaking-change risk; Option 3 (auto-strip on overwrite) needs either an extra API call to learn the title or a fragile heuristic.

## Test Plan

- [x] \`go test ./shortcuts/doc/...\` passes
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l\` clean
- [ ] Manual smoke: run a fetch → overwrite cycle with and without the flag and confirm no H1 accumulates in the latter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--omit-title` flag to `docs +fetch` command for `--format=pretty` output, allowing users to exclude the initial title line from rendered markdown.

* **Documentation**
  * Updated documentation with new `--omit-title` flag examples and parameter descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->