### PR TITLE
feat(minutes): enforce deterministic search ordering

### DIFF
--- a/shortcuts/minutes/minutes_search.go
+++ b/shortcuts/minutes/minutes_search.go
@@ -136,6 +136,9 @@ func buildMinutesSearchBody(runtime *common.RuntimeContext, startTime, endTime s
 		body["filter"] = filter
 	}
 
+	// Force a deterministic ordering for paginated minutes search results.
+	body["sorter"] = "create_time_desc"
+
 	return body, nil
 }
 

--- a/shortcuts/minutes/minutes_search_test.go
+++ b/shortcuts/minutes/minutes_search_test.go
@@ -119,6 +119,9 @@ func TestBuildMinutesSearchParams(t *testing.T) {
 	if body["query"] != "budget" {
 		t.Fatalf("body.query = %v, want budget", body["query"])
 	}
+	if got, _ := body["sorter"].(string); got != "create_time_desc" {
+		t.Fatalf("body.sorter = %q, want create_time_desc", got)
+	}
 	filter, _ := body["filter"].(map[string]interface{})
 	if filter == nil {
 		t.Fatalf("body.filter = nil, want filter object")


### PR DESCRIPTION
## Summary

Enforce deterministic ordering for `minutes +search` by always setting `sorter=create_time_desc` in the request body. This makes paginated results more stable and predictable.

## Changes

- Always include `sorter: create_time_desc` in `shortcuts/minutes/minutes_search.go`
- Update `shortcuts/minutes/minutes_search_test.go` to verify the sorter is present in the built request body

## Test Plan

- [x] `go test ./shortcuts/minutes`

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **feature enhance**
  * Minutes search results are now consistently sorted by creation time in descending order, ensuring stable and predictable pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->