### PR TITLE
feat: support extra auth param for docs media download

### DIFF
--- a/shortcuts/doc/doc_media_download.go
+++ b/shortcuts/doc/doc_media_download.go
@@ -27,6 +27,7 @@ var DocMediaDownload = common.Shortcut{
 		{Name: "token", Desc: "resource token (file_token or whiteboard_id)", Required: true},
 		{Name: "output", Desc: "local save path", Required: true},
 		{Name: "type", Default: "media", Desc: "resource type: media (default) | whiteboard"},
+		{Name: "extra", Desc: "extra query string for drive media download auth, for example advanced-permission bitable attachments"},
 		{Name: "overwrite", Type: "bool", Desc: "overwrite existing output file"},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
@@ -39,15 +40,20 @@ var DocMediaDownload = common.Shortcut{
 				Desc("(when --type=whiteboard) Download whiteboard as image").
 				Set("token", token).Set("output", outputPath)
 		}
-		return common.NewDryRunAPI().
+		dry := common.NewDryRunAPI().
 			GET("/open-apis/drive/v1/medias/:token/download").
 			Desc("(when --type=media) Download document media file").
 			Set("token", token).Set("output", outputPath)
+		if extra := runtime.Str("extra"); extra != "" {
+			dry.Params(map[string]interface{}{"extra": extra})
+		}
+		return dry
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token := runtime.Str("token")
 		outputPath := runtime.Str("output")
 		mediaType := runtime.Str("type")
+		extra := runtime.Str("extra")
 		overwrite := runtime.Bool("overwrite")
 
 		if err := validate.ResourceName(token, "--token"); err != nil {
@@ -68,10 +74,17 @@ var DocMediaDownload = common.Shortcut{
 			apiPath = fmt.Sprintf("/open-apis/drive/v1/medias/%s/download", encodedToken)
 		}
 
-		resp, err := runtime.DoAPIStream(ctx, &larkcore.ApiReq{
+		req := &larkcore.ApiReq{
 			HttpMethod: http.MethodGet,
 			ApiPath:    apiPath,
-		})
+		}
+		if mediaType != "whiteboard" && extra != "" {
+			req.QueryParams = larkcore.QueryParams{
+				"extra": []string{extra},
+			}
+		}
+
+		resp, err := runtime.DoAPIStream(ctx, req)
 		if err != nil {
 			return output.ErrNetwork("download failed: %v", err)
 		}

--- a/shortcuts/doc/doc_media_test.go
+++ b/shortcuts/doc/doc_media_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -648,6 +649,35 @@ func TestDocMediaPreviewDryRunUsesMediaEndpoint(t *testing.T) {
 	}
 }
 
+func TestDocMediaDownloadDryRunIncludesExtraQueryParam(t *testing.T) {
+	cmd := &cobra.Command{Use: "docs +media-download"}
+	cmd.Flags().String("token", "", "")
+	cmd.Flags().String("output", "", "")
+	cmd.Flags().String("type", "", "")
+	cmd.Flags().String("extra", "", "")
+	if err := cmd.Flags().Set("token", "tok_preview"); err != nil {
+		t.Fatalf("set --token: %v", err)
+	}
+	if err := cmd.Flags().Set("output", "./asset"); err != nil {
+		t.Fatalf("set --output: %v", err)
+	}
+	extra := `{"bitablePerm":{"tableId":"tblO6OeNZxfabcef","attachments":{"fld32zZi5I":{"rec0BuOHq":["boxbcsQNT0JsmrztOnX530abcef"]}}}}`
+	if err := cmd.Flags().Set("extra", extra); err != nil {
+		t.Fatalf("set --extra: %v", err)
+	}
+
+	dry := decodeDocDryRun(t, DocMediaDownload.DryRun(context.Background(), common.TestNewRuntimeContext(cmd, nil)))
+	if len(dry.API) != 1 {
+		t.Fatalf("expected 1 API call, got %d", len(dry.API))
+	}
+	if dry.API[0].URL != "/open-apis/drive/v1/medias/tok_preview/download" {
+		t.Fatalf("URL = %q, want media download endpoint", dry.API[0].URL)
+	}
+	if got, _ := dry.API[0].Params["extra"].(string); got != extra {
+		t.Fatalf("extra = %q, want %q", got, extra)
+	}
+}
+
 func TestDocMediaPreviewRejectsOverwriteWithoutFlag(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-preview-overwrite-app"))
 	reg.Register(&httpmock.Stub{
@@ -807,6 +837,43 @@ func TestDocMediaDownloadAppendsExtensionFromContentTypeMapping(t *testing.T) {
 
 	got := decodeDocCommandOutput(t, stdout)
 	wantPath := mustDocSafeOutputPath(t, "typed.csv")
+	if got.Data.SavedPath != wantPath {
+		t.Fatalf("saved_path = %q, want %q", got.Data.SavedPath, wantPath)
+	}
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected downloaded file at %q: %v", wantPath, err)
+	}
+}
+
+func TestDocMediaDownloadIncludesExtraQueryParam(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-download-extra-app"))
+	extra := `{"bitablePerm":{"tableId":"tblO6OeNZxfabcef","attachments":{"fld32zZi5I":{"rec0BuOHq":["tok_123"]}}}}`
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/drive/v1/medias/tok_123/download?" + url.Values{"extra": []string{extra}}.Encode(),
+		Status: 200,
+		Body:   []byte("payload"),
+		Headers: http.Header{
+			"Content-Type": []string{"application/octet-stream"},
+		},
+	})
+
+	tmpDir := t.TempDir()
+	withDocsWorkingDir(t, tmpDir)
+
+	err := mountAndRunDocs(t, DocMediaDownload, []string{
+		"+media-download",
+		"--token", "tok_123",
+		"--output", "download.bin",
+		"--extra", extra,
+		"--as", "bot",
+	}, f, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := decodeDocCommandOutput(t, stdout)
+	wantPath := mustDocSafeOutputPath(t, "download.bin")
 	if got.Data.SavedPath != wantPath {
 		t.Fatalf("saved_path = %q, want %q", got.Data.SavedPath, wantPath)
 	}

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -114,6 +114,7 @@ Drive Folder (云空间文件夹)
 ## 快速决策
 - 用户说“看一下文档里的图片/附件/素材”“预览素材”，优先用 `lark-cli docs +media-preview`。
 - 用户明确说“下载素材”，再用 `lark-cli docs +media-download`。
+- 如果目标是开启了高级权限的多维表格附件，下载时要额外传 `--extra '<json>'`；把**未 URL 编码**的 JSON 字符串直接传给 CLI。
 - 如果目标明确是画板 / whiteboard / 画板缩略图，只能用 `lark-cli docs +media-download --type whiteboard`，不要用 `+media-preview`。
 - 用户说“找一个表格”“按名称搜电子表格”“找报表”“最近打开的表格”，先用 `lark-cli docs +search` 做资源发现。
 - `docs +search` 不是只搜文档 / Wiki；结果里会直接返回 `SHEET` 等云空间对象。

--- a/skills/lark-doc/references/lark-doc-media-download.md
+++ b/skills/lark-doc/references/lark-doc-media-download.md
@@ -9,6 +9,7 @@
 
 - 用户明确说“下载素材”时，使用 `docs +media-download`
 - 用户只是想查看、预览图片或文件素材时，优先使用 [`docs +media-preview`](lark-doc-media-preview.md)
+- 如果素材来自**开启了高级权限**的多维表格附件，必须额外传 `--extra`
 - 如果目标明确是画板 / whiteboard / 画板缩略图，继续使用 `docs +media-download --type whiteboard`；`+media-preview` 不支持画板
 
 ## 命令
@@ -19,6 +20,12 @@ lark-cli docs +media-download --token "Z1Fjxxxxxxxx" --output ./asset
 
 # 指定输出文件名（带扩展名则不会自动补全）
 lark-cli docs +media-download --token "Z1Fjxxxxxxxx" --output ./asset.png
+
+# 下载开启高级权限的多维表格附件
+lark-cli docs +media-download \
+  --token "box_masked_file_token" \
+  --output ./asset \
+  --extra '{"bitablePerm":{"tableId":"tbl_masked_table_id","attachments":{"fld_masked_field_id":{"rec_masked_record_id":["box_masked_file_token"]}}}}'
 
 # 下载画板缩略图（whiteboard token）
 lark-cli docs +media-download --type whiteboard --token "wbcnxxxxxxxx" --output ./whiteboard
@@ -31,6 +38,7 @@ lark-cli docs +media-download --type whiteboard --token "wbcnxxxxxxxx" --output 
 | `--token <token>` | 是 | 资源 token：素材为 `file_token`，画板为 `whiteboard_id` |
 | `--output <path>` | 是 | 本地保存路径；不带扩展名会自动补全 |
 | `--type <type>` | 否 | `media`（默认）或 `whiteboard` |
+| `--extra <json>` | 否 | 仅 `--type media` 使用。开启了高级权限的多维表格附件下载时必填；传**未 URL 编码**的 JSON 字符串，CLI 会负责放入 query 参数 |
 
 ## token 从哪里来
 
@@ -39,8 +47,49 @@ lark-cli docs +media-download --type whiteboard --token "wbcnxxxxxxxx" --output 
   - 文件：`<file token="..." name="..."/>`
   - 画板：`<whiteboard token="..."/>`
 
+## 高级权限多维表格附件的 `--extra`
+
+当附件来自**开启了高级权限**的多维表格时，下载接口必须追加 `extra` 鉴权；否则通常会返回 `HTTP 400`。
+
+### 传参规则
+
+- 传给 CLI 的值必须是**原始 JSON 字符串**，不要自己做 URL 编码
+- 如果你拿到的是记录接口返回的附件 `url` / `tmp_url`，其中 query 里的 `extra` 往往已经被编码过；先 URL decode 一次，再把解码后的 JSON 字符串传给 `--extra`
+- `attachments` 建议始终带上；官方说明里这是构造高级权限附件下载鉴权时的必填部分
+
+### 推荐构造格式
+
+```json
+{"bitablePerm":{"tableId":"tbl_masked_table_id","attachments":{"fld_masked_field_id":{"rec_masked_record_id":["box_masked_file_token"]}}}}
+```
+
+字段含义：
+
+- `extra`：下载接口的 query 参数，类型是字符串；值内容是一个 JSON 对象序列化后的字符串
+- `extra.bitablePerm`：多维表格高级权限附件下载使用的鉴权对象
+- `extra.bitablePerm.tableId`：附件所在数据表的 `tableId`
+- `extra.bitablePerm.attachments`：附件定位信息对象；key 是附件字段的 `field_id`
+- `extra.bitablePerm.attachments.<field_id>`：某个附件字段下的记录映射对象；key 是 `record_id`
+- `extra.bitablePerm.attachments.<field_id>.<record_id>`：文件 token 数组，表示这条记录在该附件字段下要下载的文件集合
+- `extra.bitablePerm.attachments.<field_id>.<record_id>[i]`：单个附件的 `file_token`
+
+按上面的脱敏示例展开后，对应关系如下：
+
+- `tbl_masked_table_id`：占位符，表示真实 `tableId`
+- `fld_masked_field_id`：占位符，表示真实附件字段 `field_id`
+- `rec_masked_record_id`：占位符，表示真实 `record_id`
+- `box_masked_file_token`：占位符，表示真实附件 `file_token`
+
+### 典型来源
+
+- `base +record-get` / `base +record-search` 返回的附件字段
+- 附件对象中的 `url` 或 `tmp_url`
+
+如果附件对象已经返回完整下载链接，优先复用该链接里的 `extra` 信息，不要自行猜 `tableId / field_id / record_id`。
+
 ## 排障
 
+- 如果是多维表格附件并返回 `HTTP 400`，先检查是否漏传 `--extra`，或是否把已经编码过的 `extra` 又编码了一次
 - 如果报错返回的信息包含 `HTTP 403`，且目标是图片/文件素材，可以改成调用 [`docs +media-preview`](lark-doc-media-preview.md) 看是否能先预览内容
 
 ## 参考


### PR DESCRIPTION
 ## Summary
  This PR adds `--extra` support to `docs +media-download` so advanced-permission Base attachments can be downloaded through the Drive media API. It also updates the related skill docs to explain the `extra` payload structure, usage rules, and masked examples.

  ## Changes
  - Add `--extra` to `docs +media-download` and pass it through as the media download query parameter for `--type media`
  - Update dry-run output and shortcut tests to cover `extra` handling and query encoding
  - Add a dry-run E2E test for `docs +media-download --extra`
  - Update `lark-doc` and `lark-base` skill docs to document `--extra`, explain each nested field, and replace example IDs/tokens with masked placeholders

  ## Test Plan
  - [x] Unit tests pass
  - [ ] Manual local verification confirms the `lark xxx` command works as expected

  Additional verification:
  - `go test ./shortcuts/doc -run 'TestDocMediaDownload|TestDocMediaPreviewDryRunUsesMediaEndpoint'`
  - `go test ./tests/cli_e2e/dryrun -run TestDocs_MediaDownloadDryRunIncludesExtraQueryParam`
  - `make build`

  ## Related Issues
  - None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--extra` flag to document media download command for handling multi-dimensional table attachments with advanced permissions.

* **Tests**
  * Added test coverage for the new flag in dry-run and execution modes.

* **Documentation**
  * Updated documentation with command examples, parameter requirements, and troubleshooting guidance for the new flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->