### PR TITLE
fix: escape angle brackets in drive comment text

### DIFF
--- a/shortcuts/drive/drive_add_comment.go
+++ b/shortcuts/drive/drive_add_comment.go
@@ -564,7 +564,7 @@ func parseCommentReplyElements(raw string) ([]map[string]interface{}, error) {
 			}
 			replyElements = append(replyElements, map[string]interface{}{
 				"type": "text",
-				"text": input.Text,
+				"text": escapeCommentText(input.Text),
 			})
 		case "mention_user":
 			mentionUser := firstNonEmptyString(input.MentionUser, input.Text)
@@ -590,6 +590,14 @@ func parseCommentReplyElements(raw string) ([]map[string]interface{}, error) {
 	}
 
 	return replyElements, nil
+}
+
+func escapeCommentText(input string) string {
+	replacer := strings.NewReplacer(
+		"<", "&lt;",
+		">", "&gt;",
+	)
+	return replacer.Replace(input)
 }
 
 type sheetAnchor struct {

--- a/shortcuts/drive/drive_add_comment_test.go
+++ b/shortcuts/drive/drive_add_comment_test.go
@@ -223,6 +223,21 @@ func TestParseCommentReplyElements(t *testing.T) {
 	}
 }
 
+func TestParseCommentReplyElementsEscapesAngleBrackets(t *testing.T) {
+	t.Parallel()
+
+	got, err := parseCommentReplyElements(`[{"type":"text","text":"a < b > c"}]`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 reply element, got %d", len(got))
+	}
+	if got[0]["text"] != "a &lt; b &gt; c" {
+		t.Fatalf("expected escaped text, got %#v", got[0]["text"])
+	}
+}
+
 func TestParseCommentReplyElementsInvalid(t *testing.T) {
 	t.Parallel()
 

--- a/skills/lark-drive/SKILL.md
+++ b/skills/lark-drive/SKILL.md
@@ -127,6 +127,8 @@ Drive Folder (云空间文件夹)
 - 全文评论：未传 `--selection-with-ellipsis` / `--block-id` 时默认启用，也可显式传 `--full-comment`；支持 `docx`、旧版 `doc` URL，以及最终解析为 `doc`/`docx` 的 wiki URL。
 - 局部评论：传 `--selection-with-ellipsis` 或 `--block-id` 时启用；仅支持 `docx`，以及最终解析为 `docx` 的 wiki URL。
 - `drive +add-comment` 的 `--content` 需要传 `reply_elements` JSON 数组字符串，例如 `--content '[{"type":"text","text":"正文"}]'`。
+- 评论写入内容（添加评论、回复评论、编辑回复）里的文本不能直接出现 `<`、`>`；提交前必须先转义：`<` -> `&lt;`，`>` -> `&gt;`。
+- 使用 `drive +add-comment` 时，shortcut 会对 `type=text` 的文本元素自动做上述转义兜底；如果直接调用 `drive file.comments create_v2`、`drive file.comment.replys create`、`drive file.comment.replys update`，则需要在请求里自行传入已转义的内容。
 - 如果 wiki 解析后不是 `doc`/`docx`，不要用 `+add-comment`。
 - 如果需要更底层地直接调用评论 V2 协议，再走原生 API：先执行 `lark-cli schema drive.file.comments.create_v2`，再执行 `lark-cli drive file.comments create_v2 ...`。全文评论省略 `anchor`，局部评论传 `anchor.block_id`。
 

--- a/skills/lark-drive/references/lark-drive-add-comment.md
+++ b/skills/lark-drive/references/lark-drive-add-comment.md
@@ -91,7 +91,7 @@ lark-cli drive +add-comment \
 |------|------|------|
 | `--doc` | 是 | 文档 URL / token、sheet URL，或可解析到 `doc`/`docx`/`sheet` 的 wiki URL |
 | `--type` | 裸 token 时必填 | 文档类型：`doc`、`docx`、`sheet`。URL 输入时自动识别，无需传 |
-| `--content` | 是 | `reply_elements` JSON 数组字符串。示例：`'[{"type":"text","text":"文本"},{"type":"mention_user","text":"ou_xxx"},{"type":"link","text":"https://example.com"}]'` |
+| `--content` | 是 | `reply_elements` JSON 数组字符串。示例：`'[{"type":"text","text":"文本"},{"type":"mention_user","text":"ou_xxx"},{"type":"link","text":"https://example.com"}]'`。`type=text` 的文本里不能直接出现 `<`、`>`，应写成 `&lt;`、`&gt;`；shortcut 也会自动兜底转义。 |
 | `--full-comment` | 否 | 显式指定创建全文评论；未传 `--selection-with-ellipsis` / `--block-id` 时也会默认走全文评论（不适用于 sheet） |
 | `--selection-with-ellipsis` | 局部评论时二选一 | 目标文本定位表达式，支持纯文本或 `开头...结尾`；与 `--block-id` 互斥（不适用于 sheet） |
 | `--block-id` | 局部评论时二选一 | 已知目标块 ID 时直接使用；与 `--selection-with-ellipsis` 互斥。**Sheet 评论**：格式为 `<sheetId>!<cell>`（如 `a281f9!D6`） |
@@ -104,6 +104,7 @@ lark-cli drive +add-comment \
 - 全文评论支持 `docx`、旧版 `doc` URL，以及最终可解析为 `doc`/`docx` 的 wiki URL。
 - 传 `--selection-with-ellipsis` 或 `--block-id` 时，shortcut 创建**局部评论（划词评论）**；该模式仅支持 `docx`，以及最终可解析为 `docx` 的 wiki URL。
 - `--content` 接收结构化评论元素数组；`type` 支持 `text`、`mention_user`、`link`。为便于书写，`mention_user` / `link` 元素可以直接把用户 ID 或链接地址放在 `text` 字段中，shortcut 会转换成 OpenAPI 所需字段。
+- `type=text` 的评论文本不能直接包含 `<`、`>`；应优先传 `&lt;`、`&gt;`。shortcut 在发送前也会自动将 `<`、`>` 转义为 `&lt;`、`&gt;` 作为兜底。
 - 局部评论走 `locate-doc` 时，内部固定使用 `limit=10`。
 - 当 `locate-doc` 命中多处时，shortcut 会中止并提示用户继续收窄 `--selection-with-ellipsis`，不支持手动指定匹配序号。
 - 写入评论前会自动生成符合 OpenAPI 定义的请求体：


### PR DESCRIPTION
 ## Summary

  Fix drive comment text handling so < and > are safely escaped before comment creation, preventing invalid comment/reply content payloads.

  ## Changes

  - Added lark-drive skill guidance documenting that comment, reply, and reply-edit text must escape < as &lt; and > as &gt;.
  - Added drive +add-comment fallback escaping for type=text reply elements.
  - Added unit coverage for angle bracket escaping in comment text parsing.

  ## Test Plan

  - [x] Unit tests pass: go test ./shortcuts/drive
  - [ ] Manual local verification confirms the lark xxx command works as expected

  ## Related Issues

  - None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Comments and replies with angle brackets (`<` and `>`) are now automatically escaped to prevent display issues and formatting errors.

* **Tests**
  * Added test coverage verifying proper escaping of special characters in comment text elements.

* **Documentation**
  * Updated documentation to clarify text content handling requirements for comments, replies, and edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->