### PR TITLE
feat: request thread roots for chat message list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ tests/mail/reports/
 
 
 # Generated / test artifacts
+.hammer/
 internal/registry/meta_data.json
 cmd/api/download.bin
 app.log

--- a/shortcuts/im/builders_test.go
+++ b/shortcuts/im/builders_test.go
@@ -746,4 +746,29 @@ func TestShortcutDryRunShapes(t *testing.T) {
 			t.Fatalf("ImChatMessageList.DryRun().Format() = %s", formatted)
 		}
 	})
+
+	t.Run("ImChatMessageList dry run includes root-only query", func(t *testing.T) {
+		runtime := newTestRuntimeContext(t, map[string]string{
+			"chat-id":   "oc_123",
+			"page-size": "20",
+			"sort":      "desc",
+		}, nil)
+		formatted := ImChatMessageList.DryRun(context.Background(), runtime).Format()
+		if !strings.Contains(formatted, "only_thread_root_messages=true") {
+			t.Fatalf("ImChatMessageList.DryRun().Format() = %s, want only_thread_root_messages=true", formatted)
+		}
+	})
+}
+
+func TestChatMessageListOnlyThreadRootMessagesDryRun(t *testing.T) {
+	runtime := newTestRuntimeContext(t, map[string]string{
+		"chat-id":   "oc_123",
+		"page-size": "20",
+		"sort":      "desc",
+	}, nil)
+
+	formatted := ImChatMessageList.DryRun(context.Background(), runtime).Format()
+	if !strings.Contains(formatted, "only_thread_root_messages=true") {
+		t.Fatalf("ImChatMessageList.DryRun().Format() = %s, want only_thread_root_messages=true", formatted)
+	}
 }

--- a/shortcuts/im/coverage_additional_test.go
+++ b/shortcuts/im/coverage_additional_test.go
@@ -210,14 +210,15 @@ func TestBuildChatMessageListRequest(t *testing.T) {
 		}
 
 		want := larkcore.QueryParams{
-			"container_id_type":     {"chat"},
-			"container_id":          {"oc_123"},
-			"sort_type":             {"ByCreateTimeAsc"},
-			"page_size":             {"50"},
-			"card_msg_content_type": {"raw_card_content"},
-			"start_time":            {"1772294400"},
-			"end_time":              {"1772467199"},
-			"page_token":            {"next"},
+			"container_id_type":         {"chat"},
+			"container_id":              {"oc_123"},
+			"sort_type":                 {"ByCreateTimeAsc"},
+			"page_size":                 {"50"},
+			"only_thread_root_messages": {"true"},
+			"card_msg_content_type":     {"raw_card_content"},
+			"start_time":                {"1772294400"},
+			"end_time":                  {"1772467199"},
+			"page_token":                {"next"},
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("buildChatMessageListRequest() = %#v, want %#v", got, want)
@@ -243,6 +244,13 @@ func TestBuildChatMessageListRequest(t *testing.T) {
 			t.Fatalf("buildChatMessageListRequest() error = %v, want end validation", err)
 		}
 	})
+}
+
+func TestChatMessageListOnlyThreadRootMessagesParams(t *testing.T) {
+	got := buildChatMessageListParams("desc", "20", "oc_123")
+	if vals := got["only_thread_root_messages"]; !reflect.DeepEqual(vals, []string{"true"}) {
+		t.Fatalf("only_thread_root_messages = %#v, want true", vals)
+	}
 }
 
 func TestResolveChatIDForMessagesList(t *testing.T) {

--- a/shortcuts/im/im_chat_messages_list.go
+++ b/shortcuts/im/im_chat_messages_list.go
@@ -172,11 +172,12 @@ func buildChatMessageListParams(sortFlag, pageSizeStr, chatId string) larkcore.Q
 		pageSize = min(max(n, 1), 50)
 	}
 	return larkcore.QueryParams{
-		"container_id_type":     []string{"chat"},
-		"container_id":          []string{chatId},
-		"sort_type":             []string{sortType},
-		"page_size":             []string{strconv.Itoa(pageSize)},
-		"card_msg_content_type": []string{"raw_card_content"},
+		"container_id_type":         []string{"chat"},
+		"container_id":              []string{chatId},
+		"sort_type":                 []string{sortType},
+		"page_size":                 []string{strconv.Itoa(pageSize)},
+		"card_msg_content_type":     []string{"raw_card_content"},
+		"only_thread_root_messages": []string{"true"},
 	}
 }
 


### PR DESCRIPTION
## Summary
Update `im +chat-messages-list` to request only thread root messages from `/open-apis/im/v1/messages` by default. This aligns the shortcut request shape with topic-group usage and makes the intended API behavior explicit in both runtime params and dry-run output.

## Changes
- Add `only_thread_root_messages=true` to the shared query params built by `shortcuts/im/im_chat_messages_list.go`
- Extend dry-run coverage to verify the generated request includes the root-only query parameter
- Extend request-builder coverage to verify the runtime query params include `only_thread_root_messages`
- Ignore local Hammer artifacts by adding `.hammer/` to `.gitignore`

## Test Plan
- [x] `make unit-test`
- [x] Manual local verification confirms `lark-cli im +chat-messages-list --chat-id <oc_xxx> --page-size 5 --sort desc --dry-run --format json` includes `only_thread_root_messages=true`
- [x] Manual local verification confirms `lark-cli im +chat-messages-list --chat-id <oc_xxx> --page-size 5 --sort desc --format json` returns the expected root-level message set

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Chat message list now filters to display only thread root messages.

* **Tests**
  * Expanded test coverage for message list filtering behavior.

* **Chores**
  * Updated project ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->