### PR TITLE
feat(mail): support calendar events in emails

### DIFF
--- a/shortcuts/mail/draft/model.go
+++ b/shortcuts/mail/draft/model.go
@@ -9,6 +9,7 @@ import (
 	"mime"
 	"net/mail"
 	"strings"
+	"time"
 
 	"github.com/larksuite/cli/extension/fileio"
 )
@@ -215,11 +216,24 @@ type PatchOp struct {
 	Target      AttachmentTarget `json:"target,omitempty"`
 	SignatureID string           `json:"signature_id,omitempty"`
 
+	// Calendar event fields, used by set_calendar. The raw ISO 8601 strings
+	// are shown in dry-run output; the shortcut layer pre-builds the ICS
+	// blob into CalendarICS below before Apply runs.
+	EventSummary  string `json:"event_summary,omitempty"`
+	EventStart    string `json:"event_start,omitempty"`
+	EventEnd      string `json:"event_end,omitempty"`
+	EventLocation string `json:"event_location,omitempty"`
+
 	// RenderedSignatureHTML is set by the shortcut layer (not from JSON) after
 	// fetching and interpolating the signature. The patch layer uses this
 	// pre-rendered content for insert_signature ops.
 	RenderedSignatureHTML string           `json:"-"`
 	SignatureImages       []SignatureImage `json:"-"`
+
+	// CalendarICS holds the pre-built RFC 5545 ICS blob for a set_calendar
+	// op. Populated by the shortcut layer after the snapshot is parsed and
+	// organizer/attendee addresses can be resolved. Not serialised.
+	CalendarICS []byte `json:"-"`
 }
 
 // SignatureImage holds pre-downloaded image data for signature inline images.
@@ -327,6 +341,26 @@ func (op PatchOp) Validate() error {
 		}
 	case "remove_signature":
 		// No required fields.
+	case "set_calendar":
+		if strings.TrimSpace(op.EventSummary) == "" {
+			return fmt.Errorf("set_calendar requires event_summary")
+		}
+		if strings.TrimSpace(op.EventStart) == "" || strings.TrimSpace(op.EventEnd) == "" {
+			return fmt.Errorf("set_calendar requires event_start and event_end")
+		}
+		start, err := parseISO8601(op.EventStart)
+		if err != nil {
+			return fmt.Errorf("set_calendar: event_start must be a valid ISO 8601 timestamp")
+		}
+		end, err := parseISO8601(op.EventEnd)
+		if err != nil {
+			return fmt.Errorf("set_calendar: event_end must be a valid ISO 8601 timestamp")
+		}
+		if !end.After(start) {
+			return fmt.Errorf("set_calendar: event_end must be after event_start")
+		}
+	case "remove_calendar":
+		// No required fields.
 	default:
 		return fmt.Errorf("unsupported op %q", op.Op)
 	}
@@ -399,4 +433,20 @@ func MustJSON(v interface{}) string {
 		panic(fmt.Sprintf("MustJSON: %v", err))
 	}
 	return string(data)
+}
+
+// parseISO8601 tries common ISO 8601 timestamp layouts, accepting both
+// with-seconds (RFC 3339) and without-seconds variants.
+func parseISO8601(s string) (time.Time, error) {
+	for _, layout := range []string{
+		time.RFC3339,
+		"2006-01-02T15:04Z07:00",
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04",
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cannot parse %q as ISO 8601", s)
 }

--- a/shortcuts/mail/draft/patch.go
+++ b/shortcuts/mail/draft/patch.go
@@ -136,6 +136,10 @@ func applyOp(dctx *DraftCtx, snapshot *DraftSnapshot, op PatchOp, options PatchO
 		return insertSignatureOp(snapshot, op)
 	case "remove_signature":
 		return removeSignatureOp(snapshot)
+	case "set_calendar":
+		return applyCalendarSet(snapshot, op.CalendarICS)
+	case "remove_calendar":
+		return applyCalendarRemove(snapshot)
 	default:
 		return fmt.Errorf("unsupported patch op %q", op.Op)
 	}

--- a/shortcuts/mail/draft/patch_calendar.go
+++ b/shortcuts/mail/draft/patch_calendar.go
@@ -122,8 +122,7 @@ func FindPartByMediaType(root *Part, mediaType string) *Part {
 }
 
 // findAllPartsByMediaType walks the MIME tree and returns every part with
-// the given media type. Used by setCalendarPart to update all copies of the
-// ICS (e.g. one inside multipart/alternative and one as an inline attachment).
+// the given media type. Used in tests to assert tree contents.
 func findAllPartsByMediaType(root *Part, mediaType string) []*Part {
 	if root == nil {
 		return nil

--- a/shortcuts/mail/draft/patch_calendar.go
+++ b/shortcuts/mail/draft/patch_calendar.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package draft
+
+import (
+	"fmt"
+	"strings"
+)
+
+const calendarMediaType = "text/calendar"
+
+// applyCalendarSet installs or replaces the text/calendar MIME part in the
+// snapshot. The caller is expected to have pre-built icsData using the
+// snapshot's From/To/Cc addresses.
+func applyCalendarSet(snapshot *DraftSnapshot, icsData []byte) error {
+	if len(icsData) == 0 {
+		return fmt.Errorf("set_calendar: ICS data is empty (shortcut layer must pre-build it)")
+	}
+	setCalendarPart(snapshot, icsData)
+	return nil
+}
+
+// applyCalendarRemove strips the text/calendar part from the snapshot.
+// No-op if no calendar part exists.
+func applyCalendarRemove(snapshot *DraftSnapshot) error {
+	removeCalendarPart(snapshot)
+	return nil
+}
+
+// setCalendarPart places exactly one text/calendar part inside
+// multipart/alternative, matching the Feishu client behavior. Any existing
+// text/calendar parts elsewhere in the tree are removed first.
+func setCalendarPart(snapshot *DraftSnapshot, icsData []byte) {
+	newPart := &Part{
+		MediaType:   calendarMediaType,
+		MediaParams: map[string]string{"charset": "UTF-8"},
+		Body:        icsData,
+		Dirty:       true,
+	}
+
+	if snapshot.Body == nil {
+		snapshot.Body = newPart
+		return
+	}
+
+	// Remove all existing text/calendar parts from everywhere in the tree.
+	if strings.EqualFold(snapshot.Body.MediaType, calendarMediaType) {
+		snapshot.Body = newPart
+		return
+	}
+	removeAllPartsByMediaType(snapshot.Body, calendarMediaType)
+
+	// Place inside the existing multipart/alternative.
+	if alt := FindPartByMediaType(snapshot.Body, "multipart/alternative"); alt != nil {
+		alt.Children = append(alt.Children, newPart)
+		alt.Dirty = true
+		return
+	}
+
+	// No multipart/alternative exists. If the body is a single leaf,
+	// wrap it in multipart/alternative together with the calendar.
+	if !snapshot.Body.IsMultipart() {
+		original := *snapshot.Body
+		snapshot.Body.MediaType = "multipart/alternative"
+		snapshot.Body.MediaParams = nil
+		snapshot.Body.Body = nil
+		snapshot.Body.TransferEncoding = ""
+		snapshot.Body.RawEntity = nil
+		snapshot.Body.Children = []*Part{&original, newPart}
+		snapshot.Body.Dirty = true
+		return
+	}
+
+	// Multipart body without an alternative sub-part (e.g. multipart/mixed
+	// with a text/html child). Find the first text/* child and wrap it in
+	// a new multipart/alternative that also contains the calendar.
+	for i, child := range snapshot.Body.Children {
+		if child != nil && strings.HasPrefix(strings.ToLower(child.MediaType), "text/") {
+			alt := &Part{
+				MediaType: "multipart/alternative",
+				Children:  []*Part{child, newPart},
+				Dirty:     true,
+			}
+			snapshot.Body.Children[i] = alt
+			snapshot.Body.Dirty = true
+			return
+		}
+	}
+
+	// Fallback: append to the root multipart container.
+	snapshot.Body.Children = append(snapshot.Body.Children, newPart)
+	snapshot.Body.Dirty = true
+}
+
+func removeCalendarPart(snapshot *DraftSnapshot) {
+	if snapshot.Body == nil {
+		return
+	}
+	if strings.EqualFold(snapshot.Body.MediaType, calendarMediaType) {
+		snapshot.Body = nil
+		return
+	}
+	removeAllPartsByMediaType(snapshot.Body, calendarMediaType)
+}
+
+// FindPartByMediaType walks the MIME tree and returns the first part with
+// the given media type, or nil when not found.
+func FindPartByMediaType(root *Part, mediaType string) *Part {
+	if root == nil {
+		return nil
+	}
+	if strings.EqualFold(root.MediaType, mediaType) {
+		return root
+	}
+	for _, child := range root.Children {
+		if found := FindPartByMediaType(child, mediaType); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// findAllPartsByMediaType walks the MIME tree and returns every part with
+// the given media type. Used by setCalendarPart to update all copies of the
+// ICS (e.g. one inside multipart/alternative and one as an inline attachment).
+func findAllPartsByMediaType(root *Part, mediaType string) []*Part {
+	if root == nil {
+		return nil
+	}
+	var result []*Part
+	if strings.EqualFold(root.MediaType, mediaType) {
+		result = append(result, root)
+	}
+	for _, child := range root.Children {
+		result = append(result, findAllPartsByMediaType(child, mediaType)...)
+	}
+	return result
+}
+
+// removePartByMediaType removes the first part with the given media type from
+// the MIME tree. The parent is marked dirty when a removal happens.
+func removePartByMediaType(root *Part, mediaType string) {
+	if root == nil {
+		return
+	}
+	for i, child := range root.Children {
+		if child != nil && strings.EqualFold(child.MediaType, mediaType) {
+			root.Children = append(root.Children[:i], root.Children[i+1:]...)
+			root.Dirty = true
+			return
+		}
+		removePartByMediaType(child, mediaType)
+	}
+}
+
+// removeAllPartsByMediaType removes every part with the given media type from
+// the MIME tree, at all nesting levels.
+func removeAllPartsByMediaType(root *Part, mediaType string) {
+	if root == nil {
+		return
+	}
+	var kept []*Part
+	removed := false
+	for _, child := range root.Children {
+		if child != nil && strings.EqualFold(child.MediaType, mediaType) {
+			removed = true
+			continue
+		}
+		kept = append(kept, child)
+	}
+	if removed {
+		root.Children = kept
+		root.Dirty = true
+	}
+	for _, child := range root.Children {
+		removeAllPartsByMediaType(child, mediaType)
+	}
+}

--- a/shortcuts/mail/draft/patch_calendar.go
+++ b/shortcuts/mail/draft/patch_calendar.go
@@ -62,11 +62,21 @@ func setCalendarPart(snapshot *DraftSnapshot, icsData []byte) {
 	// wrap it in multipart/alternative together with the calendar.
 	if !snapshot.Body.IsMultipart() {
 		original := *snapshot.Body
+		// Reset all header-carrying fields so the serializer constructs a fresh
+		// Content-Type from MediaType instead of reusing the stale leaf headers.
+		snapshot.Body.Headers = nil
 		snapshot.Body.MediaType = "multipart/alternative"
 		snapshot.Body.MediaParams = nil
+		snapshot.Body.ContentDisposition = ""
+		snapshot.Body.ContentDispositionArg = nil
+		snapshot.Body.ContentID = ""
+		snapshot.Body.PartID = ""
 		snapshot.Body.Body = nil
 		snapshot.Body.TransferEncoding = ""
 		snapshot.Body.RawEntity = nil
+		snapshot.Body.Preamble = nil
+		snapshot.Body.Epilogue = nil
+		snapshot.Body.EncodingProblem = false
 		snapshot.Body.Children = []*Part{&original, newPart}
 		snapshot.Body.Dirty = true
 		return

--- a/shortcuts/mail/draft/patch_calendar.go
+++ b/shortcuts/mail/draft/patch_calendar.go
@@ -34,7 +34,7 @@ func applyCalendarRemove(snapshot *DraftSnapshot) error {
 func setCalendarPart(snapshot *DraftSnapshot, icsData []byte) {
 	newPart := &Part{
 		MediaType:   calendarMediaType,
-		MediaParams: map[string]string{"charset": "UTF-8"},
+		MediaParams: map[string]string{"charset": "UTF-8", "method": "REQUEST"},
 		Body:        icsData,
 		Dirty:       true,
 	}

--- a/shortcuts/mail/draft/patch_calendar_test.go
+++ b/shortcuts/mail/draft/patch_calendar_test.go
@@ -94,6 +94,9 @@ Content-Type: text/html; charset=UTF-8
 	if string(part.Body) != fixtureCalData {
 		t.Errorf("calendar part body mismatch: got %q", part.Body)
 	}
+	if part.MediaParams["method"] != "REQUEST" {
+		t.Errorf("calendar part missing method=REQUEST in MediaParams: %v", part.MediaParams)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/shortcuts/mail/draft/patch_calendar_test.go
+++ b/shortcuts/mail/draft/patch_calendar_test.go
@@ -1,0 +1,426 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package draft
+
+import (
+	"strings"
+	"testing"
+)
+
+const fixtureCalData = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n"
+
+// ---------------------------------------------------------------------------
+// set_calendar — validate
+// ---------------------------------------------------------------------------
+
+func TestSetCalendar_ValidateRequiresSummary(t *testing.T) {
+	err := PatchOp{Op: "set_calendar", EventStart: "2026-04-25T10:00+08:00", EventEnd: "2026-04-25T11:00+08:00"}.Validate()
+	if err == nil || !strings.Contains(err.Error(), "event_summary") {
+		t.Errorf("expected event_summary error, got %v", err)
+	}
+}
+
+func TestSetCalendar_ValidateRequiresStartAndEnd(t *testing.T) {
+	err := PatchOp{Op: "set_calendar", EventSummary: "Meeting", EventStart: "2026-04-25T10:00+08:00"}.Validate()
+	if err == nil || !strings.Contains(err.Error(), "event_start and event_end") {
+		t.Errorf("expected start/end error, got %v", err)
+	}
+}
+
+func TestSetCalendar_ValidateInvalidStartFormat(t *testing.T) {
+	err := PatchOp{Op: "set_calendar", EventSummary: "M", EventStart: "not-a-date", EventEnd: "2026-04-25T11:00+08:00"}.Validate()
+	if err == nil || !strings.Contains(err.Error(), "event_start") {
+		t.Errorf("expected event_start error for bad format, got %v", err)
+	}
+}
+
+func TestSetCalendar_ValidateInvalidEndFormat(t *testing.T) {
+	err := PatchOp{Op: "set_calendar", EventSummary: "M", EventStart: "2026-04-25T10:00+08:00", EventEnd: "not-a-date"}.Validate()
+	if err == nil || !strings.Contains(err.Error(), "event_end") {
+		t.Errorf("expected event_end error for bad format, got %v", err)
+	}
+}
+
+func TestSetCalendar_ValidateEndNotAfterStart(t *testing.T) {
+	err := PatchOp{Op: "set_calendar", EventSummary: "M", EventStart: "2026-04-25T11:00+08:00", EventEnd: "2026-04-25T10:00+08:00"}.Validate()
+	if err == nil || !strings.Contains(err.Error(), "after") {
+		t.Errorf("expected end-after-start error, got %v", err)
+	}
+}
+
+func TestSetCalendar_ValidateOK(t *testing.T) {
+	err := PatchOp{
+		Op:           "set_calendar",
+		EventSummary: "Meeting",
+		EventStart:   "2026-04-25T10:00+08:00",
+		EventEnd:     "2026-04-25T11:00+08:00",
+	}.Validate()
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// set_calendar — Apply adds text/calendar part when none exists
+// ---------------------------------------------------------------------------
+
+func TestSetCalendar_AddsCalendarPartToHTMLDraft(t *testing.T) {
+	snapshot := mustParseFixtureDraft(t, `Subject: Meeting
+From: Alice <alice@example.com>
+To: Bob <bob@example.com>
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+
+<p>Hello</p>`)
+
+	err := Apply(&DraftCtx{FIO: testFIO}, snapshot, Patch{
+		Ops: []PatchOp{{
+			Op:           "set_calendar",
+			EventSummary: "Meeting",
+			EventStart:   "2026-04-25T10:00+08:00",
+			EventEnd:     "2026-04-25T11:00+08:00",
+			CalendarICS:  []byte(fixtureCalData),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	part := FindPartByMediaType(snapshot.Body, calendarMediaType)
+	if part == nil {
+		t.Fatal("text/calendar part not added to draft")
+	}
+	if string(part.Body) != fixtureCalData {
+		t.Errorf("calendar part body mismatch: got %q", part.Body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// set_calendar — Apply replaces existing text/calendar part
+// ---------------------------------------------------------------------------
+
+func TestSetCalendar_ReplacesExistingCalendarPart(t *testing.T) {
+	snapshot := mustParseFixtureDraft(t, `Subject: Meeting
+From: Alice <alice@example.com>
+To: Bob <bob@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="b1"
+
+--b1
+Content-Type: text/html; charset=UTF-8
+
+<p>Hello</p>
+--b1
+Content-Type: text/calendar; charset=UTF-8
+
+BEGIN:VCALENDAR
+VERSION:2.0
+SUMMARY:OLD
+END:VCALENDAR
+--b1--`)
+
+	newICS := []byte("BEGIN:VCALENDAR\r\nVERSION:2.0\r\nSUMMARY:NEW\r\nEND:VCALENDAR\r\n")
+	err := Apply(&DraftCtx{FIO: testFIO}, snapshot, Patch{
+		Ops: []PatchOp{{
+			Op:           "set_calendar",
+			EventSummary: "NEW",
+			EventStart:   "2026-04-25T10:00+08:00",
+			EventEnd:     "2026-04-25T11:00+08:00",
+			CalendarICS:  newICS,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	part := FindPartByMediaType(snapshot.Body, calendarMediaType)
+	if part == nil {
+		t.Fatal("text/calendar part missing")
+	}
+	if !strings.Contains(string(part.Body), "SUMMARY:NEW") {
+		t.Errorf("expected new SUMMARY, got %q", part.Body)
+	}
+	if strings.Contains(string(part.Body), "SUMMARY:OLD") {
+		t.Errorf("old SUMMARY not replaced")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// set_calendar — Apply requires pre-built ICS
+// ---------------------------------------------------------------------------
+
+func TestSetCalendar_EmptyICSIsError(t *testing.T) {
+	snapshot := mustParseFixtureDraft(t, `Subject: Meeting
+From: Alice <alice@example.com>
+To: Bob <bob@example.com>
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+
+<p>Hello</p>`)
+
+	err := Apply(&DraftCtx{FIO: testFIO}, snapshot, Patch{
+		Ops: []PatchOp{{
+			Op:           "set_calendar",
+			EventSummary: "Meeting",
+			EventStart:   "2026-04-25T10:00+08:00",
+			EventEnd:     "2026-04-25T11:00+08:00",
+			// CalendarICS intentionally nil — simulates missing pre-process.
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing CalendarICS")
+	}
+	if !strings.Contains(err.Error(), "ICS data is empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// remove_calendar
+// ---------------------------------------------------------------------------
+
+func TestRemoveCalendar_StripsCalendarPart(t *testing.T) {
+	snapshot := mustParseFixtureDraft(t, `Subject: Meeting
+From: Alice <alice@example.com>
+To: Bob <bob@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/alternative; boundary="b1"
+
+--b1
+Content-Type: text/html; charset=UTF-8
+
+<p>Hello</p>
+--b1
+Content-Type: text/calendar; charset=UTF-8
+
+BEGIN:VCALENDAR
+END:VCALENDAR
+--b1--`)
+
+	err := Apply(&DraftCtx{FIO: testFIO}, snapshot, Patch{
+		Ops: []PatchOp{{Op: "remove_calendar"}},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if part := FindPartByMediaType(snapshot.Body, calendarMediaType); part != nil {
+		t.Errorf("text/calendar part should be removed, but still found")
+	}
+}
+
+func TestRemoveCalendar_NoOpWhenAbsent(t *testing.T) {
+	snapshot := mustParseFixtureDraft(t, `Subject: Plain
+From: Alice <alice@example.com>
+To: Bob <bob@example.com>
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+
+<p>Hello</p>`)
+
+	err := Apply(&DraftCtx{FIO: testFIO}, snapshot, Patch{
+		Ops: []PatchOp{{Op: "remove_calendar"}},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// Body remains intact.
+	if snapshot.Body == nil {
+		t.Fatal("body unexpectedly nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Internal MIME helpers (coverage)
+// ---------------------------------------------------------------------------
+
+func TestFindPartByMediaType_CaseInsensitive(t *testing.T) {
+	root := &Part{
+		MediaType: "multipart/mixed",
+		Children: []*Part{
+			{MediaType: "TEXT/Calendar"},
+		},
+	}
+	got := FindPartByMediaType(root, "text/calendar")
+	if got == nil {
+		t.Fatal("expected to find part despite case mismatch")
+	}
+}
+
+func TestRemovePartByMediaType_MarksParentDirty(t *testing.T) {
+	root := &Part{
+		MediaType: "multipart/mixed",
+		Children: []*Part{
+			{MediaType: "text/calendar"},
+			{MediaType: "text/html"},
+		},
+	}
+	removePartByMediaType(root, "text/calendar")
+	if len(root.Children) != 1 {
+		t.Fatalf("expected 1 remaining child, got %d", len(root.Children))
+	}
+	if !root.Dirty {
+		t.Error("parent not marked dirty after removal")
+	}
+}
+
+func TestSetCalendar_CollapsesToOneInsideAlternative(t *testing.T) {
+	// Feishu client creates two text/calendar copies: one inside
+	// multipart/alternative and one as an inline attachment in
+	// multipart/mixed. set_calendar must collapse them to a single
+	// copy inside multipart/alternative.
+	snapshot := mustParseFixtureDraft(t, `Subject: Meeting
+From: Alice <alice@example.com>
+To: Bob <bob@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="outer"
+
+--outer
+Content-Type: multipart/alternative; boundary="inner"
+
+--inner
+Content-Type: text/html; charset=UTF-8
+
+<p>Hello</p>
+--inner
+Content-Type: text/calendar; charset=UTF-8
+
+BEGIN:VCALENDAR
+SUMMARY:OLD
+END:VCALENDAR
+--inner--
+--outer
+Content-Type: text/calendar; charset=UTF-8; name="invite.ics"
+Content-Id: <invite.ics>
+
+BEGIN:VCALENDAR
+SUMMARY:OLD
+END:VCALENDAR
+--outer--`)
+
+	newICS := []byte("BEGIN:VCALENDAR\r\nSUMMARY:NEW\r\nEND:VCALENDAR\r\n")
+	err := Apply(&DraftCtx{FIO: testFIO}, snapshot, Patch{
+		Ops: []PatchOp{{
+			Op:           "set_calendar",
+			EventSummary: "NEW",
+			EventStart:   "2026-04-25T10:00+08:00",
+			EventEnd:     "2026-04-25T11:00+08:00",
+			CalendarICS:  newICS,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Exactly one text/calendar part should remain, inside alternative.
+	parts := findAllPartsByMediaType(snapshot.Body, calendarMediaType)
+	if len(parts) != 1 {
+		t.Fatalf("expected 1 text/calendar part, got %d", len(parts))
+	}
+	if !strings.Contains(string(parts[0].Body), "SUMMARY:NEW") {
+		t.Errorf("expected SUMMARY:NEW, got %q", parts[0].Body)
+	}
+
+	// The calendar part must be a child of multipart/alternative.
+	alt := FindPartByMediaType(snapshot.Body, "multipart/alternative")
+	if alt == nil {
+		t.Fatal("multipart/alternative not found")
+	}
+	found := false
+	for _, child := range alt.Children {
+		if strings.EqualFold(child.MediaType, calendarMediaType) {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("text/calendar part not inside multipart/alternative")
+	}
+}
+
+func TestRemoveCalendar_RootLevelCalendarBody(t *testing.T) {
+	// When the snapshot body is itself a text/calendar leaf (no multipart
+	// wrapper), removeCalendarPart must nil out snapshot.Body rather than
+	// trying to remove it from a parent's children slice.
+	snapshot := &DraftSnapshot{
+		Body: &Part{
+			MediaType: "text/calendar",
+			Body:      []byte(fixtureCalData),
+		},
+	}
+	err := Apply(&DraftCtx{FIO: testFIO}, snapshot, Patch{
+		Ops: []PatchOp{{Op: "remove_calendar"}},
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if snapshot.Body != nil {
+		t.Errorf("snapshot.Body should be nil after removing root-level text/calendar, got %+v", snapshot.Body)
+	}
+}
+
+func TestSetCalendarPart_OnNilBodyCreatesLeaf(t *testing.T) {
+	snapshot := &DraftSnapshot{}
+	setCalendarPart(snapshot, []byte(fixtureCalData))
+	if snapshot.Body == nil {
+		t.Fatal("body should be created")
+	}
+	if !strings.EqualFold(snapshot.Body.MediaType, calendarMediaType) {
+		t.Errorf("expected %s leaf, got %s", calendarMediaType, snapshot.Body.MediaType)
+	}
+}
+
+func TestSetCalendarPart_MixedWithoutAlternativeWrapsTextChild(t *testing.T) {
+	// multipart/mixed with a text/html child but no alternative sub-part.
+	// setCalendarPart should wrap the text/html in a new alternative.
+	snapshot := &DraftSnapshot{
+		Body: &Part{
+			MediaType: "multipart/mixed",
+			Children: []*Part{
+				{MediaType: "text/html", Body: []byte("<p>Hi</p>")},
+				{MediaType: "application/pdf", Body: []byte("pdf-data")},
+			},
+		},
+	}
+	setCalendarPart(snapshot, []byte(fixtureCalData))
+
+	if snapshot.Body.MediaType != "multipart/mixed" {
+		t.Fatalf("root should stay multipart/mixed, got %s", snapshot.Body.MediaType)
+	}
+	alt := FindPartByMediaType(snapshot.Body, "multipart/alternative")
+	if alt == nil {
+		t.Fatal("expected a multipart/alternative child to be created")
+	}
+	if len(alt.Children) != 2 {
+		t.Fatalf("alternative should have 2 children, got %d", len(alt.Children))
+	}
+	if !strings.EqualFold(alt.Children[0].MediaType, "text/html") {
+		t.Errorf("first alternative child should be text/html, got %s", alt.Children[0].MediaType)
+	}
+	if !strings.EqualFold(alt.Children[1].MediaType, calendarMediaType) {
+		t.Errorf("second alternative child should be text/calendar, got %s", alt.Children[1].MediaType)
+	}
+}
+
+func TestSetCalendarPart_FallbackAppendsToMultipart(t *testing.T) {
+	// multipart/mixed with only non-text children (no text/* to wrap).
+	snapshot := &DraftSnapshot{
+		Body: &Part{
+			MediaType: "multipart/mixed",
+			Children: []*Part{
+				{MediaType: "application/pdf", Body: []byte("pdf-data")},
+			},
+		},
+	}
+	setCalendarPart(snapshot, []byte(fixtureCalData))
+
+	found := false
+	for _, child := range snapshot.Body.Children {
+		if strings.EqualFold(child.MediaType, calendarMediaType) {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("text/calendar should be appended as fallback child")
+	}
+}

--- a/shortcuts/mail/emlbuilder/builder.go
+++ b/shortcuts/mail/emlbuilder/builder.go
@@ -996,15 +996,33 @@ func writeSingleBodyPartHeaders(buf *bytes.Buffer, ct string, body []byte) {
 	writeFoldedBody(buf, encodeBodyContent(body, cte), lineWidthForCTE(cte))
 }
 
-// writeCalendarPart writes the text/calendar MIME part with the RFC 6047
-// method=REQUEST parameter. The part lives inside multipart/alternative
-// as an alternative representation of the message body.
+// writeCalendarPart writes the text/calendar MIME part. The method= parameter
+// is derived from the METHOD property in the ICS body (defaulting to REQUEST
+// when absent) so that passthrough ICS with METHOD:CANCEL or METHOD:REPLY
+// produce a Content-Type that matches the body.
 func writeCalendarPart(buf *bytes.Buffer, body []byte) {
+	method := extractICSMethod(body)
+	if method == "" {
+		method = "REQUEST"
+	}
 	cte := selectCTE(body)
-	fmt.Fprintf(buf, "Content-Type: text/calendar; method=REQUEST; charset=UTF-8\n")
+	fmt.Fprintf(buf, "Content-Type: text/calendar; method=%s; charset=UTF-8\n", method)
 	fmt.Fprintf(buf, "Content-Transfer-Encoding: %s\n\n", cte)
 	writeFoldedBody(buf, encodeBodyContent(body, cte), lineWidthForCTE(cte))
 	buf.WriteByte('\n')
+}
+
+// extractICSMethod scans the ICS body for the top-level METHOD property and
+// returns its value (e.g. "REQUEST", "CANCEL", "REPLY"). Returns "" when the
+// property is absent so callers can apply their own default.
+func extractICSMethod(body []byte) string {
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.HasPrefix(strings.ToUpper(line), "METHOD:") {
+			return strings.TrimSpace(line[7:])
+		}
+	}
+	return ""
 }
 
 // writeAttachmentPart writes a MIME attachment part.

--- a/shortcuts/mail/emlbuilder/builder.go
+++ b/shortcuts/mail/emlbuilder/builder.go
@@ -420,8 +420,9 @@ func (b Builder) HTMLBody(body []byte) Builder {
 }
 
 // CalendarBody sets the text/calendar body (e.g. for meeting invitations).
-// May be combined with TextBody and/or HTMLBody; the resulting parts are wrapped
-// in multipart/alternative.
+// When combined with TextBody or HTMLBody, the calendar part is placed inside
+// multipart/alternative alongside the body parts, matching the Feishu client
+// convention for calendar invitation emails.
 func (b Builder) CalendarBody(body []byte) Builder {
 	b.calendarBody = body
 	return b
@@ -731,6 +732,9 @@ func (b Builder) Build() ([]byte, error) {
 	// ── Body ───────────────────────────────────────────────────────────────────
 	// Full MIME hierarchy (outer layers only present when needed):
 	//   multipart/mixed → multipart/related → multipart/alternative → body parts
+	//
+	// text/calendar lives inside multipart/alternative as an alternative
+	// representation of the message body, matching the Feishu client behavior.
 	if len(b.attachments) > 0 {
 		outerB := newBoundary()
 		writeHeader(&buf, "Content-Type", "multipart/mixed; boundary="+outerB)
@@ -809,27 +813,27 @@ func writePrimaryBody(buf *bytes.Buffer, b Builder) {
 	}
 }
 
-// writeAlternativeOrSingleBody writes the text body block.
-// If multiple body types (text/plain, text/html, text/calendar) are present,
-// they are wrapped in multipart/alternative. Otherwise a single part is written.
+// writeAlternativeOrSingleBody writes the body block. When multiple content
+// types coexist (text/plain, text/html, text/calendar), they are wrapped in
+// multipart/alternative. text/calendar lives inside alternative as an
+// alternative representation, matching the Feishu client behavior.
 func writeAlternativeOrSingleBody(buf *bytes.Buffer, b Builder) {
 	hasText := len(b.textBody) > 0
 	hasHTML := len(b.htmlBody) > 0
 	hasCal := len(b.calendarBody) > 0
 
-	bodyCount := 0
+	partCount := 0
 	if hasText {
-		bodyCount++
+		partCount++
 	}
 	if hasHTML {
-		bodyCount++
+		partCount++
 	}
 	if hasCal {
-		bodyCount++
+		partCount++
 	}
 
-	switch {
-	case bodyCount > 1:
+	if partCount > 1 {
 		boundary := newBoundary()
 		writeHeader(buf, "Content-Type", "multipart/alternative; boundary="+boundary)
 		buf.WriteByte('\n')
@@ -840,15 +844,15 @@ func writeAlternativeOrSingleBody(buf *bytes.Buffer, b Builder) {
 			writeBodyPart(buf, boundary, "text/html", b.htmlBody)
 		}
 		if hasCal {
-			writeBodyPart(buf, boundary, "text/calendar", b.calendarBody)
+			fmt.Fprintf(buf, "--%s\n", boundary)
+			writeCalendarPart(buf, b.calendarBody)
 		}
 		fmt.Fprintf(buf, "--%s--\n", boundary)
-	case hasHTML:
+	} else if hasHTML {
 		writeSingleBodyPartHeaders(buf, "text/html", b.htmlBody)
-	case hasCal:
-		writeSingleBodyPartHeaders(buf, "text/calendar", b.calendarBody)
-	default:
-		// text/plain (also handles empty body)
+	} else if hasCal {
+		writeCalendarPart(buf, b.calendarBody)
+	} else {
 		writeSingleBodyPartHeaders(buf, "text/plain", b.textBody)
 	}
 }
@@ -990,6 +994,17 @@ func writeSingleBodyPartHeaders(buf *bytes.Buffer, ct string, body []byte) {
 	fmt.Fprintf(buf, "Content-Type: %s; charset=UTF-8\n", ct)
 	fmt.Fprintf(buf, "Content-Transfer-Encoding: %s\n\n", cte)
 	writeFoldedBody(buf, encodeBodyContent(body, cte), lineWidthForCTE(cte))
+}
+
+// writeCalendarPart writes the text/calendar MIME part with the RFC 6047
+// method=REQUEST parameter. The part lives inside multipart/alternative
+// as an alternative representation of the message body.
+func writeCalendarPart(buf *bytes.Buffer, body []byte) {
+	cte := selectCTE(body)
+	fmt.Fprintf(buf, "Content-Type: text/calendar; method=REQUEST; charset=UTF-8\n")
+	fmt.Fprintf(buf, "Content-Transfer-Encoding: %s\n\n", cte)
+	writeFoldedBody(buf, encodeBodyContent(body, cte), lineWidthForCTE(cte))
+	buf.WriteByte('\n')
 }
 
 // writeAttachmentPart writes a MIME attachment part.

--- a/shortcuts/mail/emlbuilder/builder_test.go
+++ b/shortcuts/mail/emlbuilder/builder_test.go
@@ -1361,3 +1361,35 @@ func TestHeaderValueTabAllowed(t *testing.T) {
 		t.Errorf("Header with tab in value: expected no error, got %v", err)
 	}
 }
+
+func TestWriteCalendarPart_MethodFromBody(t *testing.T) {
+	cases := []struct {
+		name   string
+		ics    string
+		wantCT string
+	}{
+		{"request", "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nEND:VCALENDAR\r\n", "method=REQUEST"},
+		{"cancel", "BEGIN:VCALENDAR\r\nMETHOD:CANCEL\r\nEND:VCALENDAR\r\n", "method=CANCEL"},
+		{"reply", "BEGIN:VCALENDAR\r\nMETHOD:REPLY\r\nEND:VCALENDAR\r\n", "method=REPLY"},
+		{"no method defaults to REQUEST", "BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n", "method=REQUEST"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eml, err := New().
+				From("", "sender@example.com").
+				To("", "recipient@example.com").
+				Subject("Test").
+				Date(fixedDate).
+				MessageID("test-method@x").
+				HTMLBody([]byte("<p>hi</p>")).
+				CalendarBody([]byte(tc.ics)).
+				Build()
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			if !strings.Contains(string(eml), tc.wantCT) {
+				t.Errorf("expected Content-Type to contain %q\n%s", tc.wantCT, eml)
+			}
+		})
+	}
+}

--- a/shortcuts/mail/emlbuilder/builder_test.go
+++ b/shortcuts/mail/emlbuilder/builder_test.go
@@ -678,6 +678,8 @@ func TestBuild_CalendarWithText(t *testing.T) {
 	}
 	eml := string(raw)
 
+	// text/calendar lives inside multipart/alternative as an alternative
+	// representation of the body, matching Feishu client behavior.
 	if !strings.Contains(eml, "multipart/alternative") {
 		t.Errorf("expected multipart/alternative for text+calendar:\n%s", eml)
 	}

--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -2523,8 +2523,9 @@ func validateEventFlags(runtime *common.RuntimeContext) error {
 	summary := runtime.Str("event-summary")
 	start := runtime.Str("event-start")
 	end := runtime.Str("event-end")
+	location := runtime.Str("event-location")
 
-	hasAny := summary != "" || start != "" || end != ""
+	hasAny := summary != "" || start != "" || end != "" || location != ""
 	hasAll := summary != "" && start != "" && end != ""
 
 	if hasAny && !hasAll {

--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -1496,10 +1496,10 @@ func buildMessageForCompose(msg map[string]interface{}, urlMap map[string]string
 					Attendees: parsed.Attendees,
 				}
 				if !parsed.Start.IsZero() {
-					ce.Start = parsed.Start.Format(time.RFC3339)
+					ce.Start = parsed.Start.UTC().Format(time.RFC3339)
 				}
 				if !parsed.End.IsZero() {
-					ce.End = parsed.End.Format(time.RFC3339)
+					ce.End = parsed.End.UTC().Format(time.RFC3339)
 				}
 				out.CalendarEvent = ce
 			}

--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
 	"github.com/larksuite/cli/shortcuts/mail/emlbuilder"
+	"github.com/larksuite/cli/shortcuts/mail/ics"
 )
 
 // hintIdentityFirst prints a one-line tip to stderr for read-only mail shortcuts
@@ -184,6 +185,15 @@ func printMessageOutputSchema(runtime *common.RuntimeContext) {
 			"attachments[].attachment_type":          "Attachment type. Values: 1 = normal, 2 = large attachment",
 			"attachments[].is_inline":                "true = inline image, false = regular attachment",
 			"attachments[].cid":                      "Content-ID for inline images (maps to <img src='cid:...'>)",
+			"calendar_event":                         "Parsed calendar invitation; present when the email contains a text/calendar part",
+			"calendar_event.method":                  "iTIP method, e.g. REQUEST, CANCEL, REPLY",
+			"calendar_event.uid":                     "Globally unique event identifier (UID property)",
+			"calendar_event.summary":                 "Event title (SUMMARY property)",
+			"calendar_event.start":                   "Event start time in RFC 3339 / ISO 8601 format (UTC)",
+			"calendar_event.end":                     "Event end time in RFC 3339 / ISO 8601 format (UTC)",
+			"calendar_event.location":                "Event location string; omitted when not set",
+			"calendar_event.organizer":               "Organizer email address",
+			"calendar_event.attendees":               "List of attendee email addresses",
 		},
 		"thread_extra_fields": map[string]string{
 			"thread_id":     "Thread ID",
@@ -1199,9 +1209,21 @@ type normalizedMessageForCompose struct {
 	BodyPlainText        string                   `json:"body_plain_text"`
 	BodyPreview          string                   `json:"body_preview"`
 	BodyHTML             string                   `json:"body_html,omitempty"`
+	CalendarEvent        *calendarEventOutput     `json:"calendar_event,omitempty"`
 	Attachments          []mailAttachmentOutput   `json:"attachments"`
 	Images               []mailImageOutput        `json:"images"`
 	Warnings             []warningEntry           `json:"warnings,omitempty"`
+}
+
+type calendarEventOutput struct {
+	Method    string   `json:"method,omitempty"`
+	UID       string   `json:"uid,omitempty"`
+	Summary   string   `json:"summary,omitempty"`
+	Start     string   `json:"start,omitempty"`
+	End       string   `json:"end,omitempty"`
+	Location  string   `json:"location,omitempty"`
+	Organizer string   `json:"organizer,omitempty"`
+	Attendees []string `json:"attendees,omitempty"`
 }
 
 // fetchAttachmentURLs fetches download URLs for the given attachment IDs in batches of 20.
@@ -1349,6 +1371,9 @@ func buildMessageOutput(msg map[string]interface{}, html bool) map[string]interf
 	if html && normalized.BodyHTML != "" {
 		out["body_html"] = normalized.BodyHTML
 	}
+	if normalized.CalendarEvent != nil {
+		out["calendar_event"] = normalized.CalendarEvent
+	}
 	out["attachments"] = buildPublicAttachments(msg)
 
 	return out
@@ -1456,6 +1481,29 @@ func buildMessageForCompose(msg map[string]interface{}, urlMap map[string]string
 	out.BodyPreview = preview
 	if html {
 		out.BodyHTML = decodeBase64URL(strVal(msg["body_html"]))
+	}
+
+	// Calendar event
+	if bodyCalendar := strVal(msg["body_calendar"]); bodyCalendar != "" {
+		if decoded := decodeBase64URL(bodyCalendar); decoded != "" {
+			if parsed := ics.ParseEvent(decoded); parsed != nil {
+				ce := &calendarEventOutput{
+					Method:    parsed.Method,
+					UID:       parsed.UID,
+					Summary:   parsed.Summary,
+					Location:  parsed.Location,
+					Organizer: parsed.Organizer,
+					Attendees: parsed.Attendees,
+				}
+				if !parsed.Start.IsZero() {
+					ce.Start = parsed.Start.Format(time.RFC3339)
+				}
+				if !parsed.End.IsZero() {
+					ce.End = parsed.End.Format(time.RFC3339)
+				}
+				out.CalendarEvent = ce
+			}
+		}
 	}
 
 	// Attachments
@@ -1568,6 +1616,7 @@ type composeSourceMessage struct {
 	ForwardAttachments  []forwardSourceAttachment
 	InlineImages        []inlineSourcePart
 	FailedAttachmentIDs map[string]bool
+	OriginalCalendarICS []byte // raw ICS bytes from body_calendar (for forward passthrough)
 }
 
 // fetchComposeSourceMessage loads a message via the +message pipeline and converts it
@@ -1576,6 +1625,12 @@ func fetchComposeSourceMessage(runtime *common.RuntimeContext, mailboxID, messag
 	msg, err := fetchFullMessage(runtime, mailboxID, messageID, true)
 	if err != nil {
 		return composeSourceMessage{}, err
+	}
+	var originalCalICS []byte
+	if bodyCalendar := strVal(msg["body_calendar"]); bodyCalendar != "" {
+		if decoded := decodeBase64URL(bodyCalendar); decoded != "" {
+			originalCalICS = []byte(decoded)
+		}
 	}
 	attIDs := extractAttachmentIDs(msg)
 	urlMap, warnings := fetchAttachmentURLs(runtime, mailboxID, messageID, attIDs)
@@ -1592,6 +1647,7 @@ func fetchComposeSourceMessage(runtime *common.RuntimeContext, mailboxID, messag
 		ForwardAttachments:  toForwardSourceAttachments(out),
 		InlineImages:        toInlineSourceParts(out),
 		FailedAttachmentIDs: failedIDs,
+		OriginalCalendarICS: originalCalICS,
 	}, nil
 }
 
@@ -2252,6 +2308,21 @@ func inlineSpecFilePaths(specs []InlineSpec) []string {
 	return paths
 }
 
+// validateEventSendTimeExclusion checks that --send-time and --event-* are not
+// used together. This is enforced here (in Validate, before Execute) because the
+// Shortcut framework does not expose a cobra-level hook for MarkFlagsMutuallyExclusive.
+func validateEventSendTimeExclusion(runtime *common.RuntimeContext) error {
+	if runtime.Str("send-time") == "" {
+		return nil
+	}
+	for _, f := range []string{"event-summary", "event-start", "event-end", "event-location"} {
+		if runtime.Str(f) != "" {
+			return common.FlagErrorf("--send-time and --event-* are mutually exclusive: a calendar invitation must be sent immediately so recipients can respond before the event")
+		}
+	}
+	return nil
+}
+
 // validateSendTime checks that --send-time, if provided, requires --confirm-send,
 // is a valid Unix timestamp in seconds, and is at least 5 minutes in the future.
 func validateSendTime(runtime *common.RuntimeContext) error {
@@ -2390,4 +2461,143 @@ func validateComposeInlineAndAttachments(fio fileio.FileIO, attachFlag, inlineFl
 		return err
 	}
 	return nil
+}
+
+// buildCalendarBodyFromArgs builds ICS from explicit string arguments (for draft-edit).
+// Callers are expected to have pre-validated startStr/endStr via parseEventTimeRange;
+// parse errors are silently ignored here and produce a zero-time DTSTART/DTEND.
+func buildCalendarBodyFromArgs(summary, startStr, endStr, location, senderEmail, toAddrs, ccAddrs string) []byte {
+	if summary == "" {
+		return nil
+	}
+	start, _ := parseISO8601(startStr)
+	end, _ := parseISO8601(endStr)
+
+	var attendees []ics.Address
+	for _, addr := range parseNetAddrs(toAddrs) {
+		if addr.Address != "" {
+			attendees = append(attendees, ics.Address{Name: addr.Name, Email: addr.Address})
+		}
+	}
+	for _, addr := range parseNetAddrs(ccAddrs) {
+		if addr.Address != "" {
+			attendees = append(attendees, ics.Address{Name: addr.Name, Email: addr.Address})
+		}
+	}
+
+	return ics.Build(ics.Event{
+		Summary:   summary,
+		Location:  location,
+		Start:     start,
+		End:       end,
+		Organizer: ics.Address{Email: senderEmail},
+		Attendees: attendees,
+	})
+}
+
+// joinAddresses joins draft Address list into comma-separated string.
+func joinAddresses(addrs []draftpkg.Address) string {
+	if len(addrs) == 0 {
+		return ""
+	}
+	parts := make([]string, len(addrs))
+	for i, a := range addrs {
+		parts[i] = a.Address
+	}
+	return strings.Join(parts, ",")
+}
+
+// Calendar event flag definitions, shared by all compose shortcuts.
+// Declared as individual vars (like priorityFlag and signatureFlag) so
+// callers can list them explicitly in their Flags slice without relying
+// on slice-index access.
+var (
+	eventSummaryFlag  = common.Flag{Name: "event-summary", Desc: "Calendar event title. Setting this enables calendar invitation mode."}
+	eventStartFlag    = common.Flag{Name: "event-start", Desc: "Event start time (ISO 8601, e.g. 2026-04-20T14:00+08:00). Required when --event-summary is set."}
+	eventEndFlag      = common.Flag{Name: "event-end", Desc: "Event end time (ISO 8601). Required when --event-summary is set."}
+	eventLocationFlag = common.Flag{Name: "event-location", Desc: "Event location (optional)."}
+)
+
+// validateEventFlags checks that --event-summary, --event-start, --event-end are either all set or all empty.
+func validateEventFlags(runtime *common.RuntimeContext) error {
+	summary := runtime.Str("event-summary")
+	start := runtime.Str("event-start")
+	end := runtime.Str("event-end")
+
+	hasAny := summary != "" || start != "" || end != ""
+	hasAll := summary != "" && start != "" && end != ""
+
+	if hasAny && !hasAll {
+		return fmt.Errorf("--event-summary, --event-start, and --event-end must all be provided together")
+	}
+	if summary == "" {
+		return nil
+	}
+	if _, _, err := parseEventTimeRange(start, end); err != nil {
+		return prefixEventRangeError("--event-", err)
+	}
+	return nil
+}
+
+// parseEventTimeRange parses start/end ISO 8601 strings and verifies that
+// end is strictly after start. Shared by validateEventFlags (compose path)
+// and buildDraftEditPatch (draft-edit path) so the rules stay in one place.
+func parseEventTimeRange(start, end string) (time.Time, time.Time, error) {
+	startT, err := parseISO8601(start)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("start: invalid ISO 8601 time %q", start)
+	}
+	endT, err := parseISO8601(end)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("end: invalid ISO 8601 time %q", end)
+	}
+	if !endT.After(startT) {
+		return time.Time{}, time.Time{}, fmt.Errorf("end time must be after start time")
+	}
+	return startT, endT, nil
+}
+
+// prefixEventRangeError rewrites parseEventTimeRange's "start:" / "end:"
+// error with the caller's flag-name prefix so users see the exact flag
+// that caused the failure.
+func prefixEventRangeError(flagPrefix string, err error) error {
+	msg := err.Error()
+	switch {
+	case strings.HasPrefix(msg, "start: "):
+		return fmt.Errorf("%sstart: %s", flagPrefix, strings.TrimPrefix(msg, "start: "))
+	case strings.HasPrefix(msg, "end: "):
+		return fmt.Errorf("%send: %s", flagPrefix, strings.TrimPrefix(msg, "end: "))
+	default:
+		return err
+	}
+}
+
+// parseISO8601 parses common ISO 8601 time formats.
+func parseISO8601(s string) (time.Time, error) {
+	formats := []string{
+		time.RFC3339,
+		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02T15:04Z07:00",
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04",
+		"2006-01-02",
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, s); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cannot parse %q as ISO 8601", s)
+}
+
+// buildCalendarBody generates an ICS VCALENDAR from compose flags and returns the bytes.
+// Returns nil if --event-summary is not set.
+func buildCalendarBody(runtime *common.RuntimeContext, senderEmail string, toAddrs, ccAddrs string) []byte {
+	return buildCalendarBodyFromArgs(
+		runtime.Str("event-summary"),
+		runtime.Str("event-start"),
+		runtime.Str("event-end"),
+		runtime.Str("event-location"),
+		senderEmail, toAddrs, ccAddrs,
+	)
 }

--- a/shortcuts/mail/helpers_test.go
+++ b/shortcuts/mail/helpers_test.go
@@ -1085,7 +1085,39 @@ func TestValidateSendTime_Valid(t *testing.T) {
 	}
 }
 
-// TestParsePriority verifies parse priority.
+func TestValidateEventSendTimeExclusion(t *testing.T) {
+	future := strconv.FormatInt(time.Now().Unix()+10*60, 10)
+	cases := []struct {
+		name      string
+		eventFlag string
+		eventVal  string
+	}{
+		{"event-summary triggers exclusion", "event-summary", "Team meeting"},
+		{"event-start triggers exclusion", "event-start", "2026-05-01T10:00+08:00"},
+		{"event-end triggers exclusion", "event-end", "2026-05-01T11:00+08:00"},
+		{"event-location triggers exclusion", "event-location", "Room 5F"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			cmd.Flags().String("send-time", "", "")
+			for _, f := range []string{"event-summary", "event-start", "event-end", "event-location"} {
+				cmd.Flags().String(f, "", "")
+			}
+			_ = cmd.Flags().Set("send-time", future)
+			_ = cmd.Flags().Set(tc.eventFlag, tc.eventVal)
+			rt := &common.RuntimeContext{Cmd: cmd}
+			err := validateEventSendTimeExclusion(rt)
+			if err == nil {
+				t.Fatalf("expected error when --send-time and --%s are both set", tc.eventFlag)
+			}
+			if !strings.Contains(err.Error(), "--event-*") {
+				t.Errorf("expected error to mention --event-*, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestParsePriority(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -1334,7 +1366,6 @@ func newRequestReceiptRuntime(t *testing.T, requestReceipt bool) *common.Runtime
 	return &common.RuntimeContext{Cmd: cmd}
 }
 
-// TestRequireSenderForRequestReceipt verifies require sender for request receipt.
 func TestRequireSenderForRequestReceipt(t *testing.T) {
 	cases := []struct {
 		name           string
@@ -1365,7 +1396,6 @@ func TestRequireSenderForRequestReceipt(t *testing.T) {
 	}
 }
 
-// TestShellQuoteForHint verifies shell quote for hint.
 func TestShellQuoteForHint(t *testing.T) {
 	cases := []struct {
 		name string
@@ -1391,7 +1421,6 @@ func TestShellQuoteForHint(t *testing.T) {
 	}
 }
 
-// TestSanitizeForSingleLine verifies sanitize for single line.
 func TestSanitizeForSingleLine(t *testing.T) {
 	cases := []struct {
 		name string
@@ -1415,7 +1444,6 @@ func TestSanitizeForSingleLine(t *testing.T) {
 	}
 }
 
-// TestValidateHeaderAddress verifies validate header address.
 func TestValidateHeaderAddress(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -1445,5 +1473,201 @@ func TestValidateHeaderAddress(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseEventTimeRange
+// ---------------------------------------------------------------------------
+
+func TestParseEventTimeRange_OK(t *testing.T) {
+	s, e, err := parseEventTimeRange("2026-04-25T14:00+08:00", "2026-04-25T15:00+08:00")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !e.After(s) {
+		t.Errorf("end should be after start; got start=%v end=%v", s, e)
+	}
+}
+
+func TestParseEventTimeRange_EndBeforeStart(t *testing.T) {
+	_, _, err := parseEventTimeRange("2026-04-25T15:00+08:00", "2026-04-25T14:00+08:00")
+	if err == nil {
+		t.Fatal("expected error when end < start")
+	}
+	if !strings.Contains(err.Error(), "end time must be after start time") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestParseEventTimeRange_EndEqualsStart(t *testing.T) {
+	_, _, err := parseEventTimeRange("2026-04-25T14:00+08:00", "2026-04-25T14:00+08:00")
+	if err == nil {
+		t.Fatal("expected error when end == start (zero duration)")
+	}
+}
+
+func TestParseEventTimeRange_InvalidStart(t *testing.T) {
+	_, _, err := parseEventTimeRange("not-a-time", "2026-04-25T15:00+08:00")
+	if err == nil || !strings.Contains(err.Error(), "start: invalid ISO 8601") {
+		t.Errorf("expected start parse error, got: %v", err)
+	}
+}
+
+func TestParseEventTimeRange_InvalidEnd(t *testing.T) {
+	_, _, err := parseEventTimeRange("2026-04-25T14:00+08:00", "not-a-time")
+	if err == nil || !strings.Contains(err.Error(), "end: invalid ISO 8601") {
+		t.Errorf("expected end parse error, got: %v", err)
+	}
+}
+
+func TestPrefixEventRangeError(t *testing.T) {
+	start := fmt.Errorf("start: invalid ISO 8601 time %q", "x")
+	if got := prefixEventRangeError("--event-", start).Error(); got != `--event-start: invalid ISO 8601 time "x"` {
+		t.Errorf("got %q", got)
+	}
+	end := fmt.Errorf("end: invalid ISO 8601 time %q", "x")
+	if got := prefixEventRangeError("--set-event-", end).Error(); got != `--set-event-end: invalid ISO 8601 time "x"` {
+		t.Errorf("got %q", got)
+	}
+	// Non-prefixed error passes through unchanged.
+	other := fmt.Errorf("end time must be after start time")
+	if got := prefixEventRangeError("--event-", other).Error(); got != "end time must be after start time" {
+		t.Errorf("got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validateEventFlags (runtime-backed)
+// ---------------------------------------------------------------------------
+
+func newEventFlagsRuntime(t *testing.T, summary, start, end string) *common.RuntimeContext {
+	t.Helper()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("event-summary", "", "")
+	cmd.Flags().String("event-start", "", "")
+	cmd.Flags().String("event-end", "", "")
+	cmd.Flags().String("event-location", "", "")
+	if summary != "" {
+		_ = cmd.Flags().Set("event-summary", summary)
+	}
+	if start != "" {
+		_ = cmd.Flags().Set("event-start", start)
+	}
+	if end != "" {
+		_ = cmd.Flags().Set("event-end", end)
+	}
+	return &common.RuntimeContext{Cmd: cmd}
+}
+
+func TestValidateEventFlags_AllEmptyOK(t *testing.T) {
+	rt := newEventFlagsRuntime(t, "", "", "")
+	if err := validateEventFlags(rt); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateEventFlags_AllSetOK(t *testing.T) {
+	rt := newEventFlagsRuntime(t, "Meeting", "2026-04-25T10:00+08:00", "2026-04-25T11:00+08:00")
+	if err := validateEventFlags(rt); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateEventFlags_PartialRejected(t *testing.T) {
+	cases := []struct {
+		name    string
+		summary string
+		start   string
+		end     string
+	}{
+		{"only_summary", "Meeting", "", ""},
+		{"only_start", "", "2026-04-25T10:00+08:00", ""},
+		{"only_end", "", "", "2026-04-25T11:00+08:00"},
+		{"missing_end", "Meeting", "2026-04-25T10:00+08:00", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := newEventFlagsRuntime(t, tc.summary, tc.start, tc.end)
+			err := validateEventFlags(rt)
+			if err == nil || !strings.Contains(err.Error(), "must all be provided together") {
+				t.Errorf("expected 'all together' error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateEventFlags_EndBeforeStartRejected(t *testing.T) {
+	rt := newEventFlagsRuntime(t, "Meeting", "2026-04-25T11:00+08:00", "2026-04-25T10:00+08:00")
+	err := validateEventFlags(rt)
+	if err == nil || !strings.Contains(err.Error(), "after start") {
+		t.Errorf("expected end-after-start error, got %v", err)
+	}
+}
+
+func TestValidateEventFlags_InvalidTimeFormatRejected(t *testing.T) {
+	rt := newEventFlagsRuntime(t, "Meeting", "not-a-time", "2026-04-25T11:00+08:00")
+	err := validateEventFlags(rt)
+	if err == nil || !strings.Contains(err.Error(), "--event-start") {
+		t.Errorf("expected --event-start error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildCalendarBodyFromArgs
+// ---------------------------------------------------------------------------
+
+func TestBuildCalendarBodyFromArgs_EmptySummaryReturnsNil(t *testing.T) {
+	got := buildCalendarBodyFromArgs("", "2026-04-25T10:00+08:00", "2026-04-25T11:00+08:00", "", "sender@example.com", "to@example.com", "")
+	if got != nil {
+		t.Errorf("expected nil for empty summary, got %d bytes", len(got))
+	}
+}
+
+func TestBuildCalendarBodyFromArgs_IncludesSummaryAndAddresses(t *testing.T) {
+	got := buildCalendarBodyFromArgs(
+		"Product Review",
+		"2026-04-25T14:00+08:00",
+		"2026-04-25T15:00+08:00",
+		"5F Room",
+		"sender@example.com",
+		"a@example.com,b@example.com",
+		"c@example.com",
+	)
+	if got == nil {
+		t.Fatal("expected non-nil ICS bytes")
+	}
+	s := string(got)
+	checks := []string{
+		"BEGIN:VCALENDAR",
+		"SUMMARY:Product Review",
+		"LOCATION:5F Room",
+		"sender@example.com",
+		"a@example.com",
+		"b@example.com",
+		"c@example.com",
+	}
+	for _, want := range checks {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %q in generated ICS:\n%s", want, s)
+		}
+	}
+}
+
+func TestBuildCalendarBodyFromArgs_NoCcWorks(t *testing.T) {
+	got := buildCalendarBodyFromArgs(
+		"Meeting",
+		"2026-04-25T10:00+08:00",
+		"2026-04-25T11:00+08:00",
+		"",
+		"sender@example.com",
+		"to@example.com",
+		"",
+	)
+	if got == nil {
+		t.Fatal("expected non-nil ICS bytes")
+	}
+	if !strings.Contains(string(got), "to@example.com") {
+		t.Error("attendee missing")
 	}
 }

--- a/shortcuts/mail/ics/builder.go
+++ b/shortcuts/mail/ics/builder.go
@@ -1,0 +1,180 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package ics provides RFC 5545 iCalendar generation and parsing for mail calendar invitations.
+package ics
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+)
+
+// Event holds the data needed to generate an ICS VCALENDAR invitation.
+type Event struct {
+	UID       string    // auto-generated if empty
+	Summary   string    // SUMMARY (required)
+	Location  string    // LOCATION (optional)
+	Start     time.Time // DTSTART (required)
+	End       time.Time // DTEND (required)
+	Organizer Address   // ORGANIZER
+	Attendees []Address // ATTENDEE list (To + Cc, excluding Bcc)
+}
+
+// Address represents a name + email pair for ORGANIZER / ATTENDEE.
+type Address struct {
+	Name  string
+	Email string
+}
+
+// Build generates a RFC 5545 VCALENDAR byte slice with METHOD:REQUEST.
+// The output is suitable for use as a text/calendar MIME part.
+func Build(event Event) []byte {
+	uid := event.UID
+	if uid == "" {
+		uid = uuid.New().String()
+	}
+
+	now := time.Now().UTC()
+	nowICS := formatICSTime(now)
+	var b strings.Builder
+
+	b.WriteString("BEGIN:VCALENDAR\r\n")
+	b.WriteString("CALSCALE:GREGORIAN\r\n")
+	b.WriteString("VERSION:2.0\r\n")
+	b.WriteString("PRODID:-//Lark CLI//EN\r\n")
+	b.WriteString("METHOD:REQUEST\r\n")
+	b.WriteString("X-LARK-MAIL-DRAFT:TRUE\r\n")
+	b.WriteString("BEGIN:VEVENT\r\n")
+	writeFolded(&b, "UID", uid)
+	writeFolded(&b, "DTSTAMP", nowICS)
+	writeFolded(&b, "CREATED", nowICS)
+	writeFolded(&b, "LAST-MODIFIED", nowICS)
+	writeFolded(&b, "DTSTART", formatICSTime(event.Start.UTC()))
+	writeFolded(&b, "DTEND", formatICSTime(event.End.UTC()))
+	writeFolded(&b, "SUMMARY", escapeTextValue(event.Summary))
+	if event.Location != "" {
+		writeFolded(&b, "LOCATION", escapeTextValue(event.Location))
+	}
+	b.WriteString("STATUS:CONFIRMED\r\n")
+	b.WriteString("TRANSP:OPAQUE\r\n")
+	b.WriteString("SEQUENCE:0\r\n")
+	if event.Organizer.Email != "" {
+		organizer := "ORGANIZER;ROLE=CHAIR"
+		if event.Organizer.Name != "" {
+			organizer += ";CN=" + quoteCNParam(event.Organizer.Name)
+		} else {
+			organizer += ";CN=" + quoteCNParam(event.Organizer.Email)
+		}
+		writeFolded(&b, organizer, mailtoScheme+sanitizeMailtoAddress(event.Organizer.Email))
+	}
+	for _, a := range event.Attendees {
+		attendee := "ATTENDEE;ROLE=REQ-PARTICIPANT;RSVP=TRUE;CUTYPE=INDIVIDUAL"
+		if a.Name != "" {
+			attendee += ";CN=" + quoteCNParam(a.Name)
+		} else {
+			attendee += ";CN=" + quoteCNParam(a.Email)
+		}
+		attendee += ";PARTSTAT=NEEDS-ACTION"
+		writeFolded(&b, attendee, mailtoScheme+sanitizeMailtoAddress(a.Email))
+	}
+	b.WriteString("END:VEVENT\r\n")
+	b.WriteString("END:VCALENDAR\r\n")
+
+	return []byte(b.String())
+}
+
+// formatICSTime formats a time.Time as ICS UTC: YYYYMMDDTHHMMSSZ.
+func formatICSTime(t time.Time) string {
+	return t.Format("20060102T150405Z")
+}
+
+// escapeTextValue escapes a string for use as an ICS TEXT value per RFC 5545
+// §3.3.11: backslash, newline, semicolon, and comma carry structural meaning
+// and must be escaped. Applied to SUMMARY, LOCATION, DESCRIPTION etc. — not
+// to identifiers (UID), date-times (DTSTART/DTEND), or URIs.
+//
+// Without this, a user-supplied summary containing a newline or colon would
+// let the payload inject a fake property line, e.g.
+//
+//	--event-summary "foo\nDTSTART:20000101T000000Z"
+//
+// would turn into a second DTSTART line after folding.
+func escapeTextValue(s string) string {
+	// Normalise CR / CRLF so downstream only sees LF.
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	// Order matters: escape backslash first so its own replacement is not
+	// picked up by later rules.
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, ";", `\;`)
+	s = strings.ReplaceAll(s, ",", `\,`)
+	return s
+}
+
+// quoteCNParam wraps a CN parameter value in double-quotes per RFC 5545 §3.2
+// when the value contains characters that are not allowed in an unquoted
+// paramtext (,  ; :). Characters that are illegal inside a quoted-string are
+// stripped: DQUOTE (%x22) is excluded by QSAFE-CHAR, and control characters
+// (%x00–%x08, %x0A–%x1F, %x7F) would break the property line structure.
+func quoteCNParam(s string) string {
+	s = strings.Map(func(r rune) rune {
+		if r == '"' || r < 0x09 || (r >= 0x0A && r <= 0x1F) || r == 0x7F {
+			return -1
+		}
+		return r
+	}, s)
+	if strings.ContainsAny(s, ",:;") {
+		return `"` + s + `"`
+	}
+	return s
+}
+
+// writeFolded writes a property line with RFC 5545 line folding (75-octet limit).
+// Long lines are folded by inserting CRLF + space at UTF-8 character boundaries.
+// Continuation lines begin with a single SPACE (1 octet), so their content is
+// limited to 74 octets to keep the total physical line at ≤ 75 octets.
+func writeFolded(b *strings.Builder, name, value string) {
+	line := fmt.Sprintf("%s:%s", name, value)
+	const maxLineOctets = 75 // RFC 5545 §3.1: lines SHOULD NOT be longer than 75 octets
+	limit := maxLineOctets
+	for len(line) > limit {
+		// Find the last complete UTF-8 character that fits within the limit.
+		cut := 0
+		for i := 0; i < len(line); {
+			_, size := utf8.DecodeRuneInString(line[i:])
+			if i+size > limit {
+				break
+			}
+			i += size
+			cut = i
+		}
+		if cut == 0 {
+			// Single character exceeds limit (shouldn't happen in practice).
+			cut = limit
+		}
+		b.WriteString(line[:cut])
+		b.WriteString("\r\n ")
+		line = line[cut:]
+		limit = maxLineOctets - 1 // continuation lines: 1-octet SPACE + 74 content = 75
+	}
+	b.WriteString(line)
+	b.WriteString("\r\n")
+}
+
+// sanitizeMailtoAddress strips control characters (CR, LF, and other chars
+// below 0x20 or equal to 0x7F) from an email address before embedding it in a
+// MAILTO: URI value. Prevents property-injection attacks analogous to the CN
+// parameter protection in quoteCNParam.
+func sanitizeMailtoAddress(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7F {
+			return -1
+		}
+		return r
+	}, s)
+}

--- a/shortcuts/mail/ics/ics_test.go
+++ b/shortcuts/mail/ics/ics_test.go
@@ -1,0 +1,678 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package ics
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuild_Basic(t *testing.T) {
+	event := Event{
+		UID:       "test-uid-123",
+		Summary:   "Product Review",
+		Start:     time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:       time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+		Organizer: Address{Name: "Sender", Email: "sender@example.com"},
+		Attendees: []Address{
+			{Name: "Alice", Email: "alice@example.com"},
+			{Name: "Bob", Email: "bob@example.com"},
+		},
+	}
+	// Unfold before assertion so long property lines (which exceed 75 octets and
+	// are folded per RFC 5545) can be matched as a single contiguous string.
+	ics := unfoldLines(string(Build(event)))
+
+	checks := []string{
+		"BEGIN:VCALENDAR",
+		"CALSCALE:GREGORIAN",
+		"VERSION:2.0",
+		"METHOD:REQUEST",
+		"X-LARK-MAIL-DRAFT:TRUE",
+		"BEGIN:VEVENT",
+		"UID:test-uid-123",
+		"DTSTAMP:",
+		"CREATED:",
+		"LAST-MODIFIED:",
+		"DTSTART:20260420T060000Z",
+		"DTEND:20260420T070000Z",
+		"SUMMARY:Product Review",
+		"STATUS:CONFIRMED",
+		"TRANSP:OPAQUE",
+		"SEQUENCE:0",
+		"ORGANIZER;ROLE=CHAIR;CN=Sender:MAILTO:sender@example.com",
+		"ATTENDEE;ROLE=REQ-PARTICIPANT;RSVP=TRUE;CUTYPE=INDIVIDUAL;CN=Alice;PARTSTAT=NEEDS-ACTION:MAILTO:alice@example.com",
+		"ATTENDEE;ROLE=REQ-PARTICIPANT;RSVP=TRUE;CUTYPE=INDIVIDUAL;CN=Bob;PARTSTAT=NEEDS-ACTION:MAILTO:bob@example.com",
+		"END:VEVENT",
+		"END:VCALENDAR",
+	}
+	for _, want := range checks {
+		if !strings.Contains(ics, want) {
+			t.Errorf("missing %q in ICS:\n%s", want, ics)
+		}
+	}
+}
+
+func TestBuild_OrganizerFallsBackToEmailWhenNoName(t *testing.T) {
+	event := Event{
+		Summary:   "Meeting",
+		Start:     time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:       time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+		Organizer: Address{Email: "o@e.com"},
+		Attendees: []Address{{Email: "a@e.com"}},
+	}
+	ics := unfoldLines(string(Build(event)))
+	if !strings.Contains(ics, "ORGANIZER;ROLE=CHAIR;CN=o@e.com:MAILTO:o@e.com") {
+		t.Errorf("ORGANIZER without name should fall back to email as CN:\n%s", ics)
+	}
+	if !strings.Contains(ics, "ATTENDEE;ROLE=REQ-PARTICIPANT;RSVP=TRUE;CUTYPE=INDIVIDUAL;CN=a@e.com;PARTSTAT=NEEDS-ACTION:MAILTO:a@e.com") {
+		t.Errorf("ATTENDEE without name should fall back to email as CN:\n%s", ics)
+	}
+}
+
+func TestBuild_WithLocation(t *testing.T) {
+	event := Event{
+		Summary:  "Meeting",
+		Location: "5F Conference Room",
+		Start:    time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:      time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+	}
+	ics := string(Build(event))
+	if !strings.Contains(ics, "LOCATION:5F Conference Room") {
+		t.Errorf("missing LOCATION in ICS:\n%s", ics)
+	}
+}
+
+func TestBuild_NoLocation(t *testing.T) {
+	event := Event{
+		Summary: "Meeting",
+		Start:   time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:     time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+	}
+	ics := string(Build(event))
+	if strings.Contains(ics, "LOCATION") {
+		t.Errorf("should not have LOCATION when empty:\n%s", ics)
+	}
+}
+
+func TestBuild_AutoUIDIsPureUUID(t *testing.T) {
+	event := Event{
+		Summary: "Test",
+		Start:   time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:     time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+	}
+	ics := string(Build(event))
+	if !strings.Contains(ics, "UID:") {
+		t.Fatal("missing UID")
+	}
+	// Extract the UID line to assert on its format.
+	var uid string
+	for _, line := range strings.Split(ics, "\r\n") {
+		if strings.HasPrefix(line, "UID:") {
+			uid = strings.TrimPrefix(line, "UID:")
+			break
+		}
+	}
+	if strings.Contains(uid, "@") {
+		t.Errorf("auto-generated UID should be pure UUID (no @host suffix), got %q", uid)
+	}
+	// UUID v4 has 36 chars (8-4-4-4-12 plus 4 dashes).
+	if len(uid) != 36 {
+		t.Errorf("auto-generated UID should be 36-char UUID, got %d chars: %q", len(uid), uid)
+	}
+}
+
+func TestBuild_EscapesTextValues(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"semicolon", "a;b", `a\;b`},
+		{"comma", "a,b", `a\,b`},
+		{"backslash", `a\b`, `a\\b`},
+		{"newline", "a\nb", `a\nb`},
+		{"crlf", "a\r\nb", `a\nb`},
+		{"mixed", `a;\,b` + "\n", `a\;\\\,b\n`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := escapeTextValue(tc.input); got != tc.want {
+				t.Errorf("escapeTextValue(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuild_RejectsInjectionViaSummary proves that a malicious SUMMARY
+// containing a newline plus a fake property line cannot inject a second
+// DTSTART into the rendered ICS — the newline is escaped into a literal
+// "\n" sequence inside the SUMMARY value.
+func TestBuild_RejectsInjectionViaSummary(t *testing.T) {
+	event := Event{
+		Summary: "harmless\nDTSTART:19700101T000000Z",
+		Start:   time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:     time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+	}
+	ics := unfoldLines(string(Build(event)))
+
+	// Count occurrences of DTSTART at the start of a line (i.e., as an
+	// actual property), ignoring the literal "DTSTART:" substring that
+	// now appears inside the escaped SUMMARY value.
+	dtstartPropertyLines := 0
+	for _, line := range strings.Split(ics, "\r\n") {
+		if strings.HasPrefix(line, "DTSTART:") {
+			dtstartPropertyLines++
+		}
+	}
+	if dtstartPropertyLines != 1 {
+		t.Errorf("expected exactly one DTSTART: property line, got %d in:\n%s", dtstartPropertyLines, ics)
+	}
+	if !strings.Contains(ics, `SUMMARY:harmless\nDTSTART:19700101T000000Z`) {
+		t.Errorf("expected escaped SUMMARY to contain literal \\n, got:\n%s", ics)
+	}
+}
+
+func TestBuild_CNWithSpecialCharsIsQuoted(t *testing.T) {
+	event := Event{
+		Summary:   "Meeting",
+		Start:     time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:       time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+		Organizer: Address{Name: "Smith, Alice", Email: "alice@example.com"},
+		Attendees: []Address{
+			{Name: "Doe; Bob", Email: "bob@example.com"},
+			{Name: "Plain Name", Email: "plain@example.com"},
+		},
+	}
+	ics := unfoldLines(string(Build(event)))
+	if !strings.Contains(ics, `CN="Smith, Alice"`) {
+		t.Errorf("expected quoted CN for organizer name with comma:\n%s", ics)
+	}
+	if !strings.Contains(ics, `CN="Doe; Bob"`) {
+		t.Errorf("expected quoted CN for attendee name with semicolon:\n%s", ics)
+	}
+	// Names without special chars must NOT be double-quoted.
+	if !strings.Contains(ics, "CN=Plain Name") || strings.Contains(ics, `CN="Plain Name"`) {
+		t.Errorf("plain name should be unquoted:\n%s", ics)
+	}
+}
+
+func TestBuild_EmailAddressSanitized(t *testing.T) {
+	// CR/LF inside an email address must not produce injected property lines.
+	event := Event{
+		Summary:   "Meeting",
+		Start:     time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:       time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+		Organizer: Address{Name: "Alice", Email: "alice@example.com\r\nX-INJECTED:bad"},
+		Attendees: []Address{{Name: "Bob", Email: "bob@example.com\nY-INJECTED:bad"}},
+	}
+	output := string(Build(event))
+	if strings.Contains(output, "\r\nX-INJECTED") {
+		t.Error("organizer email CR/LF injection not sanitized")
+	}
+	if strings.Contains(output, "\r\nY-INJECTED") {
+		t.Error("attendee email CR/LF injection not sanitized")
+	}
+}
+
+func TestBuild_CNStripsControlChars(t *testing.T) {
+	// A display name containing CR, LF, or other control characters must not
+	// produce extra ICS property lines (injection via CN parameter).
+	event := Event{
+		Summary:   "Meeting",
+		Start:     time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:       time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+		Organizer: Address{Name: "Alice\r\nDTSTART:99999999", Email: "alice@example.com"},
+		Attendees: []Address{
+			{Name: "Bob\nX-INJECTED:bad", Email: "bob@example.com"},
+		},
+	}
+	output := string(Build(event))
+	// Check that control chars don't produce injected property lines.
+	// A standalone ICS property line starts at the beginning of a CRLF-delimited line.
+	if strings.Contains(output, "\r\nDTSTART:99999999") {
+		t.Error("ICS output contains injected DTSTART property line via organizer CN")
+	}
+	if strings.Contains(output, "\r\nX-INJECTED") {
+		t.Error("ICS output contains injected X-INJECTED property line via attendee CN")
+	}
+}
+
+func TestBuild_LineFolding(t *testing.T) {
+	event := Event{
+		Summary: strings.Repeat("A", 100), // long summary triggers folding
+		Start:   time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:     time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+	}
+	ics := string(Build(event))
+	// Every physical line (first line and continuation lines alike) must be
+	// ≤ 75 octets excluding the CRLF terminator per RFC 5545 §3.1.
+	for _, line := range strings.Split(ics, "\r\n") {
+		if len(line) > 75 {
+			t.Errorf("line exceeds 75 octets: %q (len=%d)", line, len(line))
+		}
+	}
+}
+
+func TestParseEvent_Basic(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\r\n" +
+		"VERSION:2.0\r\n" +
+		"METHOD:REQUEST\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:abc123@larksuite.com\r\n" +
+		"DTSTART:20260420T060000Z\r\n" +
+		"DTEND:20260420T070000Z\r\n" +
+		"SUMMARY:Product Review\r\n" +
+		"LOCATION:5F Room\r\n" +
+		"ORGANIZER;CN=Sender:mailto:sender@example.com\r\n" +
+		"ATTENDEE;ROLE=REQ-PARTICIPANT;RSVP=TRUE;CN=Alice:mailto:alice@example.com\r\n" +
+		"ATTENDEE;ROLE=REQ-PARTICIPANT;RSVP=TRUE;CN=Bob:mailto:bob@example.com\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	event := ParseEvent(ics)
+	if event == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	if event.Method != "REQUEST" {
+		t.Errorf("Method = %q, want REQUEST", event.Method)
+	}
+	if event.IsLarkDraft {
+		t.Error("IsLarkDraft = true, want false (no X-LARK-MAIL-DRAFT in input)")
+	}
+	if event.UID != "abc123@larksuite.com" {
+		t.Errorf("UID = %q, want abc123@larksuite.com", event.UID)
+	}
+	if event.Summary != "Product Review" {
+		t.Errorf("Summary = %q, want Product Review", event.Summary)
+	}
+	if event.Location != "5F Room" {
+		t.Errorf("Location = %q, want 5F Room", event.Location)
+	}
+	if event.Organizer != "sender@example.com" {
+		t.Errorf("Organizer = %q, want sender@example.com", event.Organizer)
+	}
+	if len(event.Attendees) != 2 {
+		t.Fatalf("Attendees count = %d, want 2", len(event.Attendees))
+	}
+	if event.Attendees[0] != "alice@example.com" {
+		t.Errorf("Attendees[0] = %q, want alice@example.com", event.Attendees[0])
+	}
+	if event.Attendees[1] != "bob@example.com" {
+		t.Errorf("Attendees[1] = %q, want bob@example.com", event.Attendees[1])
+	}
+	wantStart := time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC)
+	if !event.Start.Equal(wantStart) {
+		t.Errorf("Start = %v, want %v", event.Start, wantStart)
+	}
+	wantEnd := time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC)
+	if !event.End.Equal(wantEnd) {
+		t.Errorf("End = %v, want %v", event.End, wantEnd)
+	}
+}
+
+func TestParseEvent_IsLarkDraft(t *testing.T) {
+	icsWithMarker := "BEGIN:VCALENDAR\r\n" +
+		"METHOD:REQUEST\r\n" +
+		"X-LARK-MAIL-DRAFT:TRUE\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:draft-test\r\n" +
+		"DTSTART:20260420T060000Z\r\n" +
+		"DTEND:20260420T070000Z\r\n" +
+		"SUMMARY:Draft Event\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+	event := ParseEvent(icsWithMarker)
+	if event == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	if !event.IsLarkDraft {
+		t.Error("IsLarkDraft = false, want true")
+	}
+
+	icsWithoutMarker := "BEGIN:VCALENDAR\r\n" +
+		"METHOD:REQUEST\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:external-test\r\n" +
+		"DTSTART:20260420T060000Z\r\n" +
+		"DTEND:20260420T070000Z\r\n" +
+		"SUMMARY:External Event\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+	event2 := ParseEvent(icsWithoutMarker)
+	if event2 == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	if event2.IsLarkDraft {
+		t.Error("IsLarkDraft = true, want false")
+	}
+}
+
+func TestParseEvent_WithTZID(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:tz-test\r\n" +
+		"DTSTART;TZID=Asia/Shanghai:20260420T140000\r\n" +
+		"DTEND;TZID=Asia/Shanghai:20260420T150000\r\n" +
+		"SUMMARY:TZ Test\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	event := ParseEvent(ics)
+	if event == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	// 14:00 Asia/Shanghai = 06:00 UTC
+	wantStart := time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC)
+	if !event.Start.Equal(wantStart) {
+		t.Errorf("Start = %v, want %v", event.Start, wantStart)
+	}
+}
+
+func TestParseEvent_FoldedLines(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:fold-test\r\n" +
+		"DTSTART:20260420T060000Z\r\n" +
+		"DTEND:20260420T070000Z\r\n" +
+		"SUMMARY:This is a very long summary that should be unfolded correctly by th\r\n" +
+		" e parser when processing\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	event := ParseEvent(ics)
+	if event == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	want := "This is a very long summary that should be unfolded correctly by the parser when processing"
+	if event.Summary != want {
+		t.Errorf("Summary = %q, want %q", event.Summary, want)
+	}
+}
+
+func TestParseEvent_FoldedLines_LFOnly(t *testing.T) {
+	// Some mail servers strip \r before storage, producing LF-only ICS.
+	ics := "BEGIN:VCALENDAR\n" +
+		"BEGIN:VEVENT\n" +
+		"UID:lf-fold-test\n" +
+		"DTSTART:20260420T060000Z\n" +
+		"DTEND:20260420T070000Z\n" +
+		"SUMMARY:This is a very long summary that should be unfolded correctly by th\n" +
+		" e parser when LF-only folding is used\n" +
+		"END:VEVENT\n" +
+		"END:VCALENDAR\n"
+
+	event := ParseEvent(ics)
+	if event == nil {
+		t.Fatal("ParseEvent returned nil for LF-only ICS")
+	}
+	want := "This is a very long summary that should be unfolded correctly by the parser when LF-only folding is used"
+	if event.Summary != want {
+		t.Errorf("Summary = %q, want %q", event.Summary, want)
+	}
+}
+
+func TestParseEvent_NoVEvent(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n"
+	event := ParseEvent(ics)
+	if event != nil {
+		t.Error("expected nil for ICS without VEVENT")
+	}
+}
+
+// TestParseEvent_OrganizerWithoutMailto covers the case where the backend
+// re-serializes our ICS and drops the "MAILTO:" scheme prefix. Observed in
+// practice on drafts returned by user_mailboxes/me/drafts.get.
+func TestParseEvent_OrganizerWithoutMailto(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:no-mailto-test\r\n" +
+		"DTSTART:20260420T060000Z\r\n" +
+		"DTEND:20260420T070000Z\r\n" +
+		"SUMMARY:Test\r\n" +
+		"ORGANIZER;CN=org@example.com:org@example.com\r\n" +
+		"ATTENDEE;PARTSTAT=NEEDS-ACTION;CN=att@example.com:att@example.com\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	event := ParseEvent(ics)
+	if event == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	if event.Organizer != "org@example.com" {
+		t.Errorf("Organizer = %q, want org@example.com (parser must accept bare email when mailto: is absent)", event.Organizer)
+	}
+	if len(event.Attendees) != 1 || event.Attendees[0] != "att@example.com" {
+		t.Errorf("Attendees = %v, want [att@example.com]", event.Attendees)
+	}
+}
+
+func TestParseEvent_MailtoCaseInsensitive(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:case-test\r\n" +
+		"DTSTART:20260420T060000Z\r\n" +
+		"DTEND:20260420T070000Z\r\n" +
+		"SUMMARY:Test\r\n" +
+		"ORGANIZER;CN=Sender:MAILTO:sender@example.com\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	event := ParseEvent(ics)
+	if event == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	if event.Organizer != "sender@example.com" {
+		t.Errorf("Organizer = %q, want sender@example.com (uppercase MAILTO: should be accepted)", event.Organizer)
+	}
+}
+
+func TestParseEvent_RecurrenceIDPopulatesOriginalTime(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:recurring-exception\r\n" +
+		"DTSTART:20260501T020000Z\r\n" +
+		"DTEND:20260501T030000Z\r\n" +
+		"RECURRENCE-ID:20260501T020000Z\r\n" +
+		"SUMMARY:Exception instance\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+	event := ParseEvent(ics)
+	if event == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	// 2026-05-01 02:00:00 UTC = 1777600800
+	if event.OriginalTime != 1777600800 {
+		t.Errorf("OriginalTime = %d, want 1777600800", event.OriginalTime)
+	}
+}
+
+func TestParseEvent_NoRecurrenceIDYieldsZero(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:single-event\r\n" +
+		"DTSTART:20260420T060000Z\r\n" +
+		"DTEND:20260420T070000Z\r\n" +
+		"SUMMARY:Single\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+	event := ParseEvent(ics)
+	if event == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	if event.OriginalTime != 0 {
+		t.Errorf("OriginalTime = %d, want 0 for non-recurring event", event.OriginalTime)
+	}
+}
+
+func TestUnescapeTextValue(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain", "hello", "hello"},
+		{"semicolon", `a\;b`, "a;b"},
+		{"comma", `a\,b`, "a,b"},
+		{"backslash", `a\\b`, `a\b`},
+		{"newline_lower", `a\nb`, "a\nb"},
+		{"newline_upper", `a\Nb`, "a\nb"},
+		{"mixed", `a\;\\\,b\n`, "a;\\,b\n"},
+		{"dangling_backslash_kept", `ends\`, `ends\`},
+		{"unknown_escape_kept", `\x`, `\x`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := unescapeTextValue(tc.input); got != tc.want {
+				t.Errorf("unescapeTextValue(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRoundTrip_SpecialCharsInSummaryAndLocation(t *testing.T) {
+	event := Event{
+		UID:      "rt-special",
+		Summary:  `Review;with,special\chars` + "\n" + `and newline`,
+		Location: `B1,Room 3;floor 2`,
+		Start:    time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:      time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+	}
+	parsed := ParseEvent(string(Build(event)))
+	if parsed == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	if !parsed.IsLarkDraft {
+		t.Error("IsLarkDraft = false after roundtrip, want true (Build should write X-LARK-MAIL-DRAFT)")
+	}
+	if parsed.Summary != event.Summary {
+		t.Errorf("Summary roundtrip: got %q, want %q", parsed.Summary, event.Summary)
+	}
+	if parsed.Location != event.Location {
+		t.Errorf("Location roundtrip: got %q, want %q", parsed.Location, event.Location)
+	}
+}
+
+func TestBuild_WriteFolded_SingleCharExceeds75Bytes(t *testing.T) {
+	// A single multibyte rune that is > 75 bytes is not reachable in practice,
+	// but we exercise the cut==0 fallback by constructing a fake line via a
+	// 75-octet name followed by a multi-octet rune that crosses the boundary.
+	// The simplest way: a name of exactly 74 chars + ':' = 75, then a multi-byte
+	// rune — the first iteration has cut==0, triggering the fallback.
+	var b strings.Builder
+	longName := strings.Repeat("A", 74)
+	// value starts with a 3-byte UTF-8 rune (€ = 0xE2 0x82 0xAC)
+	writeFolded(&b, longName, "€remainder")
+	result := b.String()
+	if !strings.Contains(result, "\r\n ") {
+		t.Errorf("expected line folding CRLF+SP in output:\n%q", result)
+	}
+}
+
+func TestSplitProperty_NoColon(t *testing.T) {
+	name, value := splitProperty("NOCOLON")
+	if name != "NOCOLON" || value != "" {
+		t.Errorf("splitProperty(no colon): got name=%q value=%q, want NOCOLON/\"\"", name, value)
+	}
+}
+
+func TestSplitProperty_QuotedColon(t *testing.T) {
+	// A colon inside a quoted CN param must not be treated as the separator.
+	name, value := splitProperty(`ORGANIZER;CN="Doe: Jane":mailto:alice@example.com`)
+	if name != `ORGANIZER;CN="Doe: Jane"` {
+		t.Errorf("name = %q, want ORGANIZER;CN=\"Doe: Jane\"", name)
+	}
+	if value != "mailto:alice@example.com" {
+		t.Errorf("value = %q, want mailto:alice@example.com", value)
+	}
+}
+
+func TestParseICSTime_TZIDCaseInsensitive(t *testing.T) {
+	// TZID parameter name is case-insensitive per RFC 5545 §3.2.
+	result := parseICSTime("20260420T140000", "DTSTART;tzid=Asia/Shanghai")
+	want := time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC)
+	if !result.Equal(want) {
+		t.Errorf("parseICSTime with lowercase tzid= = %v, want %v", result, want)
+	}
+}
+
+func TestParseICSTime_TZIDWithTrailingParam(t *testing.T) {
+	// Trailing parameters after TZID (e.g. ;VALUE=DATE-TIME) must not be
+	// included in the timezone name passed to time.LoadLocation.
+	result := parseICSTime("20260420T140000", "DTSTART;TZID=Asia/Shanghai;VALUE=DATE-TIME")
+	want := time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC)
+	if !result.Equal(want) {
+		t.Errorf("parseICSTime with trailing ;VALUE= = %v, want %v", result, want)
+	}
+}
+
+func TestParseICSTime_DateOnly(t *testing.T) {
+	// All-day event: YYYYMMDD format
+	result := parseICSTime("20260420", "DTSTART;VALUE=DATE")
+	want := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	if !result.Equal(want) {
+		t.Errorf("parseICSTime date-only = %v, want %v", result, want)
+	}
+}
+
+func TestParseICSTime_LocalWithoutTZ(t *testing.T) {
+	// Local time without timezone suffix (no Z, no TZID) — treated as UTC
+	result := parseICSTime("20260420T140000", "DTSTART")
+	want := time.Date(2026, 4, 20, 14, 0, 0, 0, time.UTC)
+	if !result.Equal(want) {
+		t.Errorf("parseICSTime local = %v, want %v", result, want)
+	}
+}
+
+func TestParseICSTime_InvalidReturnsZero(t *testing.T) {
+	result := parseICSTime("not-a-date", "DTSTART")
+	if !result.IsZero() {
+		t.Errorf("parseICSTime invalid = %v, want zero", result)
+	}
+}
+
+func TestExtractMailto_NoAt(t *testing.T) {
+	result := extractMailto("notanemail")
+	if result != "" {
+		t.Errorf("extractMailto(no @) = %q, want empty", result)
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	original := Event{
+		UID:       "roundtrip-test",
+		Summary:   "Roundtrip Meeting",
+		Location:  "Room 301",
+		Start:     time.Date(2026, 4, 20, 6, 0, 0, 0, time.UTC),
+		End:       time.Date(2026, 4, 20, 7, 0, 0, 0, time.UTC),
+		Organizer: Address{Name: "Sender", Email: "sender@example.com"},
+		Attendees: []Address{
+			{Name: "Alice", Email: "alice@example.com"},
+		},
+	}
+	icsBytes := Build(original)
+	parsed := ParseEvent(string(icsBytes))
+	if parsed == nil {
+		t.Fatal("ParseEvent returned nil on Build output")
+	}
+	if parsed.UID != original.UID {
+		t.Errorf("UID roundtrip: %q != %q", parsed.UID, original.UID)
+	}
+	if parsed.Summary != original.Summary {
+		t.Errorf("Summary roundtrip: %q != %q", parsed.Summary, original.Summary)
+	}
+	if parsed.Location != original.Location {
+		t.Errorf("Location roundtrip: %q != %q", parsed.Location, original.Location)
+	}
+	if !parsed.Start.Equal(original.Start) {
+		t.Errorf("Start roundtrip: %v != %v", parsed.Start, original.Start)
+	}
+	if parsed.Organizer != original.Organizer.Email {
+		t.Errorf("Organizer roundtrip: %q != %q", parsed.Organizer, original.Organizer.Email)
+	}
+	if len(parsed.Attendees) != 1 || parsed.Attendees[0] != "alice@example.com" {
+		t.Errorf("Attendees roundtrip: %v", parsed.Attendees)
+	}
+}

--- a/shortcuts/mail/ics/ics_test.go
+++ b/shortcuts/mail/ics/ics_test.go
@@ -676,3 +676,44 @@ func TestRoundTrip(t *testing.T) {
 		t.Errorf("Attendees roundtrip: %v", parsed.Attendees)
 	}
 }
+
+func TestParseEvent_LowercaseAndParameterizedProps(t *testing.T) {
+	ics := "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\n" +
+		"uid:lowercased-uid-value\r\n" +
+		"SUMMARY;LANGUAGE=en-US:Team Sync\r\n" +
+		"location;ALTREP=\"cid:part1\":Room 301\r\n" +
+		"DTSTART:20260501T100000Z\r\n" +
+		"DTEND:20260501T110000Z\r\n" +
+		"END:VEVENT\r\nEND:VCALENDAR\r\n"
+	ev := ParseEvent(ics)
+	if ev == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	if ev.UID != "lowercased-uid-value" {
+		t.Errorf("UID: got %q", ev.UID)
+	}
+	if ev.Summary != "Team Sync" {
+		t.Errorf("Summary: got %q", ev.Summary)
+	}
+	if ev.Location != "Room 301" {
+		t.Errorf("Location: got %q", ev.Location)
+	}
+}
+
+func TestParseEvent_StartEndUTCInOutput(t *testing.T) {
+	// Verify that times with TZID are parsed with correct offset
+	// (UTC normalization in output is done by the helpers layer; parser
+	// returns time.Time which callers can call .UTC() on).
+	ics := "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\n" +
+		"DTSTART;TZID=Asia/Shanghai:20260501T180000\r\n" +
+		"DTEND;TZID=Asia/Shanghai:20260501T190000\r\n" +
+		"END:VEVENT\r\nEND:VCALENDAR\r\n"
+	ev := ParseEvent(ics)
+	if ev == nil {
+		t.Fatal("ParseEvent returned nil")
+	}
+	wantStart := "2026-05-01T10:00:00Z"
+	if got := ev.Start.UTC().Format(time.RFC3339); got != wantStart {
+		t.Errorf("Start UTC: got %q, want %q", got, wantStart)
+	}
+}

--- a/shortcuts/mail/ics/parser.go
+++ b/shortcuts/mail/ics/parser.go
@@ -70,28 +70,30 @@ func ParseEvent(icsText string) *ParsedEvent {
 			continue
 		}
 
-		// VEVENT properties
+		// VEVENT properties — RFC 5545 §3.1: property names are
+		// case-insensitive and may carry parameters (NAME;PARAM=v:value).
 		name, value := splitProperty(line)
+		propUpper := strings.ToUpper(name)
 		switch {
-		case name == "UID":
+		case propUpper == "UID" || strings.HasPrefix(propUpper, "UID;"):
 			event.UID = value
-		case name == "SUMMARY":
+		case propUpper == "SUMMARY" || strings.HasPrefix(propUpper, "SUMMARY;"):
 			event.Summary = unescapeTextValue(value)
-		case name == "LOCATION":
+		case propUpper == "LOCATION" || strings.HasPrefix(propUpper, "LOCATION;"):
 			event.Location = unescapeTextValue(value)
-		case name == "DTSTART" || strings.HasPrefix(name, "DTSTART;"):
+		case propUpper == "DTSTART" || strings.HasPrefix(propUpper, "DTSTART;"):
 			event.Start = parseICSTime(value, name)
-		case name == "DTEND" || strings.HasPrefix(name, "DTEND;"):
+		case propUpper == "DTEND" || strings.HasPrefix(propUpper, "DTEND;"):
 			event.End = parseICSTime(value, name)
-		case name == "RECURRENCE-ID" || strings.HasPrefix(name, "RECURRENCE-ID;"):
+		case propUpper == "RECURRENCE-ID" || strings.HasPrefix(propUpper, "RECURRENCE-ID;"):
 			if t := parseICSTime(value, name); !t.IsZero() {
 				event.OriginalTime = t.Unix()
 			}
-		case name == "ORGANIZER" || strings.HasPrefix(name, "ORGANIZER;"):
+		case propUpper == "ORGANIZER" || strings.HasPrefix(propUpper, "ORGANIZER;"):
 			if email := extractMailto(value); email != "" {
 				event.Organizer = email
 			}
-		case name == "ATTENDEE" || strings.HasPrefix(name, "ATTENDEE;"):
+		case propUpper == "ATTENDEE" || strings.HasPrefix(propUpper, "ATTENDEE;"):
 			if email := extractMailto(value); email != "" {
 				event.Attendees = append(event.Attendees, email)
 			}

--- a/shortcuts/mail/ics/parser.go
+++ b/shortcuts/mail/ics/parser.go
@@ -1,0 +1,220 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package ics
+
+import (
+	"strings"
+	"time"
+)
+
+// mailtoScheme is the canonical case for the RFC 5545 ORGANIZER / ATTENDEE
+// CAL-ADDRESS URI scheme. Emitted by the builder in upper-case to match
+// Feishu client output; matched case-insensitively by the parser.
+const mailtoScheme = "MAILTO:"
+
+// ParsedEvent holds key fields extracted from an ICS VCALENDAR.
+type ParsedEvent struct {
+	Method       string    // VCALENDAR-level METHOD (REQUEST/REPLY/CANCEL)
+	IsLarkDraft  bool      // true when VCALENDAR contains X-LARK-MAIL-DRAFT (Feishu private property indicating the event is editable)
+	UID          string    // VEVENT UID
+	Summary      string    // VEVENT SUMMARY, RFC 5545 TEXT unescaped
+	Location     string    // VEVENT LOCATION, RFC 5545 TEXT unescaped
+	Start        time.Time // VEVENT DTSTART
+	End          time.Time // VEVENT DTEND
+	Organizer    string    // ORGANIZER email (from MAILTO: URI or bare email)
+	Attendees    []string  // ATTENDEE emails (from MAILTO: URIs or bare emails)
+	OriginalTime int64     // RECURRENCE-ID as Unix seconds, 0 if not present. Used together with UID to derive the Feishu calendar event_id = UID + "_" + OriginalTime.
+}
+
+// ParseEvent extracts key fields from an ICS VCALENDAR string.
+// Returns nil if no VEVENT is found.
+func ParseEvent(icsText string) *ParsedEvent {
+	// Step 1: line unfolding (RFC 5545 §3.1)
+	unfolded := unfoldLines(icsText)
+
+	lines := strings.Split(unfolded, "\n")
+	var event ParsedEvent
+	inVEvent := false
+	foundVEvent := false
+
+	for _, line := range lines {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+
+		upper := strings.ToUpper(line)
+
+		// VCALENDAR-level properties
+		if !inVEvent && strings.HasPrefix(upper, "METHOD:") {
+			event.Method = strings.TrimSpace(line[len("METHOD:"):])
+			continue
+		}
+		if !inVEvent && strings.HasPrefix(upper, "X-LARK-MAIL-DRAFT:") {
+			event.IsLarkDraft = true
+			continue
+		}
+
+		if upper == "BEGIN:VEVENT" {
+			inVEvent = true
+			continue
+		}
+		if upper == "END:VEVENT" {
+			inVEvent = false
+			foundVEvent = true
+			continue
+		}
+
+		if !inVEvent {
+			continue
+		}
+
+		// VEVENT properties
+		name, value := splitProperty(line)
+		switch {
+		case name == "UID":
+			event.UID = value
+		case name == "SUMMARY":
+			event.Summary = unescapeTextValue(value)
+		case name == "LOCATION":
+			event.Location = unescapeTextValue(value)
+		case name == "DTSTART" || strings.HasPrefix(name, "DTSTART;"):
+			event.Start = parseICSTime(value, name)
+		case name == "DTEND" || strings.HasPrefix(name, "DTEND;"):
+			event.End = parseICSTime(value, name)
+		case name == "RECURRENCE-ID" || strings.HasPrefix(name, "RECURRENCE-ID;"):
+			if t := parseICSTime(value, name); !t.IsZero() {
+				event.OriginalTime = t.Unix()
+			}
+		case name == "ORGANIZER" || strings.HasPrefix(name, "ORGANIZER;"):
+			if email := extractMailto(value); email != "" {
+				event.Organizer = email
+			}
+		case name == "ATTENDEE" || strings.HasPrefix(name, "ATTENDEE;"):
+			if email := extractMailto(value); email != "" {
+				event.Attendees = append(event.Attendees, email)
+			}
+		}
+	}
+
+	if !foundVEvent {
+		return nil
+	}
+	return &event
+}
+
+// unfoldLines reverses RFC 5545 line folding: CRLF (or bare LF) followed by
+// a single whitespace character is merged back into the preceding line.
+// CRLF forms are handled first so that "\r\n " is consumed as a unit and does
+// not leave a stray "\r" for the LF-only pass to mis-process.
+func unfoldLines(s string) string {
+	s = strings.ReplaceAll(s, "\r\n ", "")
+	s = strings.ReplaceAll(s, "\r\n\t", "")
+	// LF-only folding — produced by some mail servers that strip \r.
+	s = strings.ReplaceAll(s, "\n ", "")
+	s = strings.ReplaceAll(s, "\n\t", "")
+	return s
+}
+
+// splitProperty splits "NAME;PARAMS:VALUE" into (name-with-params, value).
+// It scans for the first colon that is not inside a double-quoted parameter
+// value (e.g. CN="Doe: Jane"), per RFC 5545 §3.1.
+func splitProperty(line string) (string, string) {
+	inQuote := false
+	for i := 0; i < len(line); i++ {
+		switch line[i] {
+		case '"':
+			inQuote = !inQuote
+		case ':':
+			if !inQuote {
+				return line[:i], line[i+1:]
+			}
+		}
+	}
+	return line, ""
+}
+
+// parseICSTime parses ICS datetime formats:
+//   - 20260420T060000Z        (UTC)
+//   - TZID=Asia/Shanghai:20260420T140000  (with timezone in property params)
+//   - 20260420T140000         (local, treated as UTC)
+func parseICSTime(value, propName string) time.Time {
+	value = strings.TrimSpace(value)
+
+	// Check for TZID in property params: DTSTART;TZID=Asia/Shanghai
+	// Case-insensitive search (RFC 5545 §3.2 param names are case-insensitive).
+	// Stop at the next ';' so trailing params like ;VALUE=DATE-TIME are excluded.
+	if idx := strings.Index(strings.ToUpper(propName), "TZID="); idx >= 0 {
+		tzPart := propName[idx+5:] // skip past "TZID="
+		if end := strings.IndexByte(tzPart, ';'); end >= 0 {
+			tzPart = tzPart[:end]
+		}
+		if loc, err := time.LoadLocation(tzPart); err == nil {
+			if t, err := time.ParseInLocation("20060102T150405", value, loc); err == nil {
+				return t
+			}
+		}
+	}
+
+	// UTC format: YYYYMMDDTHHMMSSZ
+	if t, err := time.Parse("20060102T150405Z", value); err == nil {
+		return t
+	}
+
+	// Date-only: YYYYMMDD (all-day events)
+	if t, err := time.Parse("20060102", value); err == nil {
+		return t
+	}
+
+	// Local time without timezone (treat as UTC)
+	if t, err := time.Parse("20060102T150405", value); err == nil {
+		return t
+	}
+
+	return time.Time{}
+}
+
+// unescapeTextValue reverses escapeTextValue per RFC 5545 §3.3.11, turning
+// the ICS on-wire representation back into a plain Go string. Only applied
+// to TEXT-typed properties (SUMMARY, LOCATION, DESCRIPTION, etc.) —
+// identifiers, date-times, and URIs are parsed as-is.
+func unescapeTextValue(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case 'n', 'N':
+				b.WriteByte('\n')
+				i++
+				continue
+			case '\\', ';', ',':
+				b.WriteByte(s[i+1])
+				i++
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// extractMailto extracts the email address from an ICS ORGANIZER/ATTENDEE value.
+// Accepts both "mailto:user@example.com" (RFC 5545 standard, case-insensitive per
+// RFC 3986 §3.1) and a bare "user@example.com" value (observed in backend-regenerated
+// ICS where the mailto: scheme prefix is dropped).
+func extractMailto(value string) string {
+	value = strings.TrimSpace(value)
+	lower := strings.ToLower(value)
+	if idx := strings.Index(lower, strings.ToLower(mailtoScheme)); idx >= 0 {
+		return strings.TrimSpace(value[idx+len(mailtoScheme):])
+	}
+	if strings.Contains(value, "@") && !strings.ContainsAny(value, " \t") {
+		return value
+	}
+	return ""
+}

--- a/shortcuts/mail/mail_calendar_shortcuts_test.go
+++ b/shortcuts/mail/mail_calendar_shortcuts_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+// calendarEventArgs are CLI flags that embed a calendar event in a compose command.
+var calendarEventArgs = []string{
+	"--event-summary", "Team Sync",
+	"--event-start", "2026-05-10T10:00+08:00",
+	"--event-end", "2026-05-10T11:00+08:00",
+}
+
+// extractEMLFromDraftsStub decodes the base64url EML from the captured request body.
+func extractEMLFromDraftsStub(t *testing.T, stub *httpmock.Stub) string {
+	t.Helper()
+	var reqBody map[string]interface{}
+	if err := json.Unmarshal(stub.CapturedBody, &reqBody); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+	raw, _ := reqBody["raw"].(string)
+	decoded, err := base64.URLEncoding.DecodeString(raw)
+	if err != nil {
+		t.Fatalf("base64url decode raw: %v", err)
+	}
+	return string(decoded)
+}
+
+// assertCalendarInEML checks that the decoded EML contains a text/calendar part.
+func assertCalendarInEML(t *testing.T, eml string) {
+	t.Helper()
+	if !strings.Contains(eml, "text/calendar") {
+		t.Errorf("expected text/calendar part in EML:\n%s", eml)
+	}
+	if !strings.Contains(eml, "method=REQUEST") {
+		t.Errorf("expected method=REQUEST in Content-Type:\n%s", eml)
+	}
+}
+
+// stubSourceMessage registers the minimum stubs to fetch a simple source message
+// (used by reply/forward/reply-all).
+func stubSourceMessage(reg *httpmock.Registry) {
+	reg.Register(&httpmock.Stub{
+		URL: "/user_mailboxes/me/messages/msg_001",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"message": map[string]interface{}{
+					"message_id":      "msg_001",
+					"thread_id":       "thread_001",
+					"smtp_message_id": "<msg_001@example.com>",
+					"subject":         "Re: Original",
+					"head_from":       map[string]interface{}{"mail_address": "sender@example.com", "name": "Sender"},
+					"to":              []map[string]interface{}{{"mail_address": "me@example.com", "name": "Me"}},
+					"cc":              []interface{}{},
+					"bcc":             []interface{}{},
+					"body_html":       base64.URLEncoding.EncodeToString([]byte("<p>Original</p>")),
+					"body_plain_text": base64.URLEncoding.EncodeToString([]byte("Original")),
+					"internal_date":   "1704067200000",
+					"attachments":     []interface{}{},
+				},
+			},
+		},
+	})
+}
+
+// ---------------------------------------------------------------------------
+// +reply with calendar event
+// ---------------------------------------------------------------------------
+
+func TestReply_WithCalendarEvent(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	stubSourceMessage(reg)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/profile",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"primary_email_address": "me@example.com"},
+		},
+	})
+	draftsStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "draft_001"},
+		},
+	}
+	reg.Register(draftsStub)
+
+	args := append([]string{
+		"+reply",
+		"--message-id", "msg_001",
+		"--body", "<p>Let us meet</p>",
+	}, calendarEventArgs...)
+	if err := runMountedMailShortcut(t, MailReply, args, f, stdout); err != nil {
+		t.Fatalf("+reply with calendar failed: %v", err)
+	}
+	assertCalendarInEML(t, extractEMLFromDraftsStub(t, draftsStub))
+}
+
+// ---------------------------------------------------------------------------
+// +reply-all with calendar event
+// ---------------------------------------------------------------------------
+
+func TestReplyAll_WithCalendarEvent(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	stubSourceMessage(reg)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/profile",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"primary_email_address": "me@example.com"},
+		},
+	})
+	draftsStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "draft_001"},
+		},
+	}
+	reg.Register(draftsStub)
+
+	args := append([]string{
+		"+reply-all",
+		"--message-id", "msg_001",
+		"--body", "<p>Let us meet</p>",
+	}, calendarEventArgs...)
+	if err := runMountedMailShortcut(t, MailReplyAll, args, f, stdout); err != nil {
+		t.Fatalf("+reply-all with calendar failed: %v", err)
+	}
+	assertCalendarInEML(t, extractEMLFromDraftsStub(t, draftsStub))
+}
+
+// ---------------------------------------------------------------------------
+// +forward with calendar event
+// ---------------------------------------------------------------------------
+
+func TestForward_WithCalendarEvent(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	stubSourceMessage(reg)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/profile",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"primary_email_address": "me@example.com"},
+		},
+	})
+	draftsStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "draft_001"},
+		},
+	}
+	reg.Register(draftsStub)
+
+	args := append([]string{
+		"+forward",
+		"--message-id", "msg_001",
+		"--to", "carol@example.com",
+		"--body", "<p>FYI</p>",
+	}, calendarEventArgs...)
+	if err := runMountedMailShortcut(t, MailForward, args, f, stdout); err != nil {
+		t.Fatalf("+forward with calendar failed: %v", err)
+	}
+	assertCalendarInEML(t, extractEMLFromDraftsStub(t, draftsStub))
+}

--- a/shortcuts/mail/mail_draft_create.go
+++ b/shortcuts/mail/mail_draft_create.go
@@ -56,6 +56,7 @@ var MailDraftCreate = common.Shortcut{
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's subject/body/to/cc/bcc/attachments are merged with user-supplied flags (user flags win). Requires --as user."},
 		signatureFlag,
 		priorityFlag,
+		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag,
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		mailboxID := resolveComposeMailboxID(runtime)
@@ -88,6 +89,9 @@ var MailDraftCreate = common.Shortcut{
 			return output.ErrValidation("--body is required; pass the full email body (or use --template-id)")
 		}
 		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+			return err
+		}
+		if err := validateEventFlags(runtime); err != nil {
 			return err
 		}
 		if err := validateComposeInlineAndAttachments(runtime.FileIO(), runtime.Str("attach"), runtime.Str("inline"), runtime.Bool("plain-text"), runtime.Str("body")); err != nil {
@@ -300,6 +304,9 @@ func buildRawEMLForDraftCreate(
 		return "", err
 	}
 	bld = applyPriority(bld, priority)
+	if calData := buildCalendarBody(runtime, senderEmail, input.To, input.CC); calData != nil {
+		bld = bld.CalendarBody(calData)
+	}
 	allInlinePaths := append(inlineSpecFilePaths(inlineSpecs), autoResolvedPaths...)
 	composedBodySize := int64(len(composedHTMLBody) + len(composedTextBody))
 	emlBase := estimateEMLBaseSize(runtime.FileIO(), composedBodySize, allInlinePaths, 0) + templateSmallBytes

--- a/shortcuts/mail/mail_draft_create_test.go
+++ b/shortcuts/mail/mail_draft_create_test.go
@@ -5,6 +5,8 @@ package mail
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -13,6 +15,30 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
 )
+
+// newRuntimeWithEventFlags creates a RuntimeContext with --from and calendar event flags.
+func newRuntimeWithEventFlags(from, summary, start, end, location string) *common.RuntimeContext {
+	cmd := &cobra.Command{Use: "test"}
+	for _, name := range []string{"from", "mailbox", "event-summary", "event-start", "event-end", "event-location"} {
+		cmd.Flags().String(name, "", "")
+	}
+	if from != "" {
+		_ = cmd.Flags().Set("from", from)
+	}
+	if summary != "" {
+		_ = cmd.Flags().Set("event-summary", summary)
+	}
+	if start != "" {
+		_ = cmd.Flags().Set("event-start", start)
+	}
+	if end != "" {
+		_ = cmd.Flags().Set("event-end", end)
+	}
+	if location != "" {
+		_ = cmd.Flags().Set("event-location", location)
+	}
+	return &common.RuntimeContext{Cmd: cmd}
+}
 
 // newRuntimeWithFrom creates a minimal RuntimeContext with --from flag set.
 func newRuntimeWithFrom(from string) *common.RuntimeContext {
@@ -269,6 +295,31 @@ func TestBuildRawEMLForDraftCreate_PlainTextSkipsResolve(t *testing.T) {
 	}
 }
 
+func TestBuildRawEMLForDraftCreate_WithCalendarEvent(t *testing.T) {
+	rt := newRuntimeWithEventFlags("sender@example.com", "Team Sync", "2026-05-10T10:00+08:00", "2026-05-10T11:00+08:00", "Room 301")
+	input := draftCreateInput{
+		From:    "sender@example.com",
+		To:      "alice@example.com",
+		Subject: "Team Sync",
+		Body:    "<p>Please join us</p>",
+	}
+
+	rawEML, err := buildRawEMLForDraftCreate(context.Background(), rt, input, nil, "", nil, "", "", nil, nil)
+	if err != nil {
+		t.Fatalf("buildRawEMLForDraftCreate() error = %v", err)
+	}
+	eml := decodeBase64URL(rawEML)
+	if !strings.Contains(eml, "text/calendar") {
+		t.Errorf("expected text/calendar part in EML:\n%s", eml)
+	}
+	if !strings.Contains(eml, "method=REQUEST") {
+		t.Errorf("expected method=REQUEST in Content-Type:\n%s", eml)
+	}
+	if !strings.Contains(eml, "multipart/alternative") {
+		t.Errorf("expected calendar inside multipart/alternative:\n%s", eml)
+	}
+}
+
 // TestMailDraftCreatePrettyOutputsReference verifies mail draft create pretty outputs reference.
 func TestMailDraftCreatePrettyOutputsReference(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
@@ -314,5 +365,58 @@ func TestMailDraftCreatePrettyOutputsReference(t *testing.T) {
 	}
 	if !strings.Contains(out, "reference: https://www.feishu.cn/mail?draftId=draft_001") {
 		t.Fatalf("expected reference in pretty output, got: %s", out)
+	}
+}
+
+func TestMailDraftCreate_WithCalendarEventFlags(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+
+	draftsStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "draft_cal_001"},
+		},
+	}
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/profile",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"primary_email_address": "me@example.com"},
+		},
+	})
+	reg.Register(draftsStub)
+
+	err := runMountedMailShortcut(t, MailDraftCreate, []string{
+		"+draft-create",
+		"--to", "alice@example.com",
+		"--subject", "Team Sync",
+		"--body", "<p>Please join us</p>",
+		"--event-summary", "Team Sync",
+		"--event-start", "2026-05-10T10:00+08:00",
+		"--event-end", "2026-05-10T11:00+08:00",
+		"--event-location", "Room 301",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("draft create with calendar failed: %v", err)
+	}
+
+	var reqBody map[string]interface{}
+	if err := json.Unmarshal(draftsStub.CapturedBody, &reqBody); err != nil {
+		t.Fatalf("unmarshal captured request body: %v", err)
+	}
+	raw, _ := reqBody["raw"].(string)
+	decoded, decErr := base64.URLEncoding.DecodeString(raw)
+	if decErr != nil {
+		t.Fatalf("base64url decode raw: %v", decErr)
+	}
+	eml := string(decoded)
+	if !strings.Contains(eml, "text/calendar") {
+		t.Errorf("expected text/calendar in EML:\n%s", eml)
+	}
+	if !strings.Contains(eml, "Team Sync") {
+		t.Errorf("expected event summary in ICS:\n%s", eml)
 	}
 }

--- a/shortcuts/mail/mail_draft_edit.go
+++ b/shortcuts/mail/mail_draft_edit.go
@@ -150,21 +150,9 @@ var MailDraftEdit = common.Shortcut{
 				if _, _, err := parseEventTimeRange(patch.Ops[i].EventStart, patch.Ops[i].EventEnd); err != nil {
 					return output.ErrValidation("set_calendar: %v", err)
 				}
-				// Use post-edit recipients if --set-to/--set-cc was also passed,
-				// so the ATTENDEE list reflects the final draft recipients.
-				toAddrs := snapshot.To
-				ccAddrs := snapshot.Cc
-				for _, op := range patch.Ops {
-					if op.Op != "set_recipients" {
-						continue
-					}
-					switch op.Field {
-					case "to":
-						toAddrs = op.Addresses
-					case "cc":
-						ccAddrs = op.Addresses
-					}
-				}
+				// Derive effective To/Cc by replaying all pending recipient ops so
+				// the ICS ATTENDEE list matches the final post-edit recipients.
+				toAddrs, ccAddrs := effectiveRecipients(snapshot, patch.Ops)
 				calData := buildCalendarBodyFromArgs(
 					patch.Ops[i].EventSummary,
 					patch.Ops[i].EventStart,
@@ -569,4 +557,46 @@ func buildDraftEditPatchTemplate() map[string]interface{} {
 		"command_example":    "lark-cli mail +draft-edit --print-patch-template",
 		"patch_file_example": "lark-cli mail +draft-edit --draft-id d_xxx --patch-file ./patch.json",
 	}
+}
+
+// effectiveRecipients returns the To and Cc address slices that will result
+// after all pending set_recipients / add_recipient / remove_recipient ops in
+// ops have been applied. Used by the set_calendar pre-processor to build ICS
+// with the correct post-edit ATTENDEE list before Apply() runs.
+func effectiveRecipients(snapshot *draftpkg.DraftSnapshot, ops []draftpkg.PatchOp) (to, cc []draftpkg.Address) {
+	to = append([]draftpkg.Address{}, snapshot.To...)
+	cc = append([]draftpkg.Address{}, snapshot.Cc...)
+
+	apply := func(addrs []draftpkg.Address, op draftpkg.PatchOp) []draftpkg.Address {
+		switch op.Op {
+		case "set_recipients":
+			return append([]draftpkg.Address{}, op.Addresses...)
+		case "add_recipient":
+			for _, a := range addrs {
+				if strings.EqualFold(a.Address, op.Address) {
+					return addrs
+				}
+			}
+			return append(addrs, draftpkg.Address{Name: op.Name, Address: op.Address})
+		case "remove_recipient":
+			next := addrs[:0:0]
+			for _, a := range addrs {
+				if !strings.EqualFold(a.Address, op.Address) {
+					next = append(next, a)
+				}
+			}
+			return next
+		}
+		return addrs
+	}
+
+	for _, op := range ops {
+		switch op.Field {
+		case "to":
+			to = apply(to, op)
+		case "cc":
+			cc = apply(cc, op)
+		}
+	}
+	return to, cc
 }

--- a/shortcuts/mail/mail_draft_edit.go
+++ b/shortcuts/mail/mail_draft_edit.go
@@ -150,14 +150,29 @@ var MailDraftEdit = common.Shortcut{
 				if _, _, err := parseEventTimeRange(patch.Ops[i].EventStart, patch.Ops[i].EventEnd); err != nil {
 					return output.ErrValidation("set_calendar: %v", err)
 				}
+				// Use post-edit recipients if --set-to/--set-cc was also passed,
+				// so the ATTENDEE list reflects the final draft recipients.
+				toAddrs := snapshot.To
+				ccAddrs := snapshot.Cc
+				for _, op := range patch.Ops {
+					if op.Op != "set_recipients" {
+						continue
+					}
+					switch op.Field {
+					case "to":
+						toAddrs = op.Addresses
+					case "cc":
+						ccAddrs = op.Addresses
+					}
+				}
 				calData := buildCalendarBodyFromArgs(
 					patch.Ops[i].EventSummary,
 					patch.Ops[i].EventStart,
 					patch.Ops[i].EventEnd,
 					patch.Ops[i].EventLocation,
 					draftFromEmail,
-					joinAddresses(snapshot.To),
-					joinAddresses(snapshot.Cc),
+					joinAddresses(toAddrs),
+					joinAddresses(ccAddrs),
 				)
 				if calData == nil {
 					return output.ErrValidation("set_calendar: failed to build ICS from event fields")

--- a/shortcuts/mail/mail_draft_edit.go
+++ b/shortcuts/mail/mail_draft_edit.go
@@ -383,6 +383,9 @@ func buildDraftEditPatch(runtime *common.RuntimeContext) (draftpkg.Patch, error)
 	// user-supplied fields and validate the flag combination.
 	hasEventSet := runtime.Str("set-event-summary") != ""
 	hasEventRemove := runtime.Bool("remove-event")
+	if !hasEventSet && (runtime.Str("set-event-start") != "" || runtime.Str("set-event-end") != "" || runtime.Str("set-event-location") != "") {
+		return patch, output.ErrValidation("--set-event-start, --set-event-end, and --set-event-location require --set-event-summary")
+	}
 	if hasEventSet && hasEventRemove {
 		return patch, output.ErrValidation("--set-event-summary and --remove-event are mutually exclusive")
 	}

--- a/shortcuts/mail/mail_draft_edit.go
+++ b/shortcuts/mail/mail_draft_edit.go
@@ -13,6 +13,7 @@ import (
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
+	"github.com/larksuite/cli/shortcuts/mail/ics"
 )
 
 // MailDraftEdit is the `+draft-edit` shortcut: update an existing draft
@@ -37,6 +38,11 @@ var MailDraftEdit = common.Shortcut{
 		{Name: "patch-file", Desc: "Edit entry point for body edits, incremental recipient changes, header edits, attachment changes, or inline-image changes. All body edits MUST go through --patch-file. Two body ops: set_body (full replacement including quote) and set_reply_body (replaces only user-authored content, auto-preserves quote block). Run --inspect first to check has_quoted_content, then --print-patch-template for the JSON structure. Relative path only."},
 		{Name: "print-patch-template", Type: "bool", Desc: "Print the JSON template and supported operations for the --patch-file flag. Recommended first step before generating a patch file. No draft read or write is performed."},
 		{Name: "set-priority", Desc: "Set email priority: high, normal, low. Setting 'normal' removes any existing priority header."},
+		{Name: "set-event-summary", Desc: "Set calendar event title. Must be used together with --set-event-start and --set-event-end."},
+		{Name: "set-event-start", Desc: "Set calendar event start time (ISO 8601)."},
+		{Name: "set-event-end", Desc: "Set calendar event end time (ISO 8601)."},
+		{Name: "set-event-location", Desc: "Set calendar event location."},
+		{Name: "remove-event", Type: "bool", Desc: "Remove the calendar event from the draft."},
 		{Name: "inspect", Type: "bool", Desc: "Inspect the draft without modifying it. Returns the draft projection including subject, recipients, body summary, has_quoted_content (whether the draft contains a reply/forward quote block), attachments_summary (with part_id and cid for each attachment), and inline_summary. Run this BEFORE editing body to check has_quoted_content: if true, use set_reply_body in --patch-file to preserve the quote; if false, use set_body."},
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the draft's sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed. Adds the Disposition-Notification-To header; existing value is overwritten."},
 	},
@@ -97,8 +103,9 @@ var MailDraftEdit = common.Shortcut{
 		if err != nil {
 			return output.ErrValidation("parse draft raw EML failed: %v", err)
 		}
-		// Pre-process insert_signature ops: resolve signature using the draft's
-		// From address so alias/shared-mailbox senders get correct template vars.
+		// Pre-process ops that need snapshot context: resolve signature using
+		// the draft's From address, and build ICS for set_calendar using the
+		// draft's From/To/Cc so organizer and attendee addresses are correct.
 		var draftFromEmail string
 		if len(snapshot.From) > 0 {
 			draftFromEmail = snapshot.From[0].Address
@@ -123,7 +130,8 @@ var MailDraftEdit = common.Shortcut{
 			})
 		}
 		for i := range patch.Ops {
-			if patch.Ops[i].Op == "insert_signature" {
+			switch patch.Ops[i].Op {
+			case "insert_signature":
 				sigResult, sigErr := resolveSignature(ctx, runtime, mailboxID, patch.Ops[i].SignatureID, draftFromEmail)
 				if sigErr != nil {
 					return sigErr
@@ -132,6 +140,29 @@ var MailDraftEdit = common.Shortcut{
 					patch.Ops[i].RenderedSignatureHTML = sigResult.RenderedContent
 					patch.Ops[i].SignatureImages = sigResult.Images
 				}
+			case "set_calendar":
+				if calPart := draftpkg.FindPartByMediaType(snapshot.Body, "text/calendar"); calPart != nil {
+					parsed := ics.ParseEvent(string(calPart.Body))
+					if parsed == nil || !parsed.IsLarkDraft {
+						return output.ErrValidation("set_calendar: calendar event has already been created and is read-only; use --remove-event to remove it, then --set-event-* to create a new one")
+					}
+				}
+				if _, _, err := parseEventTimeRange(patch.Ops[i].EventStart, patch.Ops[i].EventEnd); err != nil {
+					return output.ErrValidation("set_calendar: %v", err)
+				}
+				calData := buildCalendarBodyFromArgs(
+					patch.Ops[i].EventSummary,
+					patch.Ops[i].EventStart,
+					patch.Ops[i].EventEnd,
+					patch.Ops[i].EventLocation,
+					draftFromEmail,
+					joinAddresses(snapshot.To),
+					joinAddresses(snapshot.Cc),
+				)
+				if calData == nil {
+					return output.ErrValidation("set_calendar: failed to build ICS from event fields")
+				}
+				patch.Ops[i].CalendarICS = calData
 			}
 		}
 		// Pre-process add_attachment ops for large attachment support:
@@ -344,6 +375,36 @@ func buildDraftEditPatch(runtime *common.RuntimeContext) (draftpkg.Patch, error)
 		} else {
 			patch.Ops = append(patch.Ops, draftpkg.PatchOp{Op: "remove_header", Name: "X-Cli-Priority"})
 		}
+	}
+
+	// --set-event-* / --remove-event → set_calendar / remove_calendar op.
+	// The ICS blob itself is pre-built at Execute time once the snapshot's
+	// organizer/attendee addresses are available; here we only record the
+	// user-supplied fields and validate the flag combination.
+	hasEventSet := runtime.Str("set-event-summary") != ""
+	hasEventRemove := runtime.Bool("remove-event")
+	if hasEventSet && hasEventRemove {
+		return patch, output.ErrValidation("--set-event-summary and --remove-event are mutually exclusive")
+	}
+	if hasEventSet {
+		summary := runtime.Str("set-event-summary")
+		start := runtime.Str("set-event-start")
+		end := runtime.Str("set-event-end")
+		if summary == "" || start == "" || end == "" {
+			return patch, output.ErrValidation("--set-event-summary, --set-event-start, and --set-event-end must all be provided together")
+		}
+		if _, _, err := parseEventTimeRange(start, end); err != nil {
+			return patch, output.ErrValidation("%s", prefixEventRangeError("--set-event-", err).Error())
+		}
+		patch.Ops = append(patch.Ops, draftpkg.PatchOp{
+			Op:            "set_calendar",
+			EventSummary:  summary,
+			EventStart:    start,
+			EventEnd:      end,
+			EventLocation: runtime.Str("set-event-location"),
+		})
+	} else if hasEventRemove {
+		patch.Ops = append(patch.Ops, draftpkg.PatchOp{Op: "remove_calendar"})
 	}
 
 	if len(patch.Ops) == 0 && !runtime.Bool("request-receipt") {

--- a/shortcuts/mail/mail_draft_edit_test.go
+++ b/shortcuts/mail/mail_draft_edit_test.go
@@ -177,3 +177,55 @@ func TestBuildDraftEditPatch_SetEventMissingStartEnd(t *testing.T) {
 		t.Fatal("expected error when --set-event-summary set without start/end, got nil")
 	}
 }
+
+func TestEffectiveRecipients_SetReplaces(t *testing.T) {
+	snapshot := &draftpkg.DraftSnapshot{
+		To: []draftpkg.Address{{Address: "old@example.com"}},
+		Cc: []draftpkg.Address{{Address: "cc@example.com"}},
+	}
+	ops := []draftpkg.PatchOp{
+		{Op: "set_recipients", Field: "to", Addresses: []draftpkg.Address{{Address: "new@example.com"}}},
+	}
+	to, cc := effectiveRecipients(snapshot, ops)
+	if len(to) != 1 || to[0].Address != "new@example.com" {
+		t.Errorf("expected to=[new@example.com], got %v", to)
+	}
+	if len(cc) != 1 || cc[0].Address != "cc@example.com" {
+		t.Errorf("expected cc unchanged, got %v", cc)
+	}
+}
+
+func TestEffectiveRecipients_AddAndRemove(t *testing.T) {
+	snapshot := &draftpkg.DraftSnapshot{
+		To: []draftpkg.Address{{Address: "alice@example.com"}, {Address: "bob@example.com"}},
+	}
+	ops := []draftpkg.PatchOp{
+		{Op: "add_recipient", Field: "to", Address: "carol@example.com"},
+		{Op: "remove_recipient", Field: "to", Address: "bob@example.com"},
+	}
+	to, _ := effectiveRecipients(snapshot, ops)
+	if len(to) != 2 {
+		t.Fatalf("expected 2 recipients, got %v", to)
+	}
+	addrs := map[string]bool{}
+	for _, a := range to {
+		addrs[a.Address] = true
+	}
+	if !addrs["alice@example.com"] || !addrs["carol@example.com"] || addrs["bob@example.com"] {
+		t.Errorf("unexpected recipient set: %v", to)
+	}
+}
+
+func TestEffectiveRecipients_NoOpsReturnsCopy(t *testing.T) {
+	snapshot := &draftpkg.DraftSnapshot{
+		To: []draftpkg.Address{{Address: "alice@example.com"}},
+		Cc: []draftpkg.Address{{Address: "bob@example.com"}},
+	}
+	to, cc := effectiveRecipients(snapshot, nil)
+	if len(to) != 1 || to[0].Address != "alice@example.com" {
+		t.Errorf("unexpected to: %v", to)
+	}
+	if len(cc) != 1 || cc[0].Address != "bob@example.com" {
+		t.Errorf("unexpected cc: %v", cc)
+	}
+}

--- a/shortcuts/mail/mail_draft_edit_test.go
+++ b/shortcuts/mail/mail_draft_edit_test.go
@@ -18,9 +18,11 @@ func newDraftEditRuntime(flags map[string]string) *common.RuntimeContext {
 	for _, name := range []string{
 		"set-subject", "set-to", "set-cc", "set-bcc",
 		"set-priority", "patch-file",
+		"set-event-summary", "set-event-start", "set-event-end", "set-event-location",
 	} {
 		cmd.Flags().String(name, "", "")
 	}
+	cmd.Flags().Bool("remove-event", false, "")
 	for name, val := range flags {
 		_ = cmd.Flags().Set(name, val)
 	}
@@ -113,5 +115,65 @@ func TestPrettyDraftAddresses(t *testing.T) {
 				t.Errorf("prettyDraftAddresses() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildDraftEditPatch_SetEventEmitsSetCalendarOp(t *testing.T) {
+	rt := newDraftEditRuntime(map[string]string{
+		"set-event-summary":  "Team Sync",
+		"set-event-start":    "2026-05-10T10:00:00+08:00",
+		"set-event-end":      "2026-05-10T11:00:00+08:00",
+		"set-event-location": "Room 301",
+	})
+	patch, err := buildDraftEditPatch(rt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(patch.Ops) != 1 {
+		t.Fatalf("expected 1 op, got %d: %+v", len(patch.Ops), patch.Ops)
+	}
+	op := patch.Ops[0]
+	if op.Op != "set_calendar" {
+		t.Errorf("Op = %q, want set_calendar", op.Op)
+	}
+	if op.EventSummary != "Team Sync" {
+		t.Errorf("EventSummary = %q, want Team Sync", op.EventSummary)
+	}
+	if op.EventLocation != "Room 301" {
+		t.Errorf("EventLocation = %q, want Room 301", op.EventLocation)
+	}
+}
+
+func TestBuildDraftEditPatch_RemoveEventEmitsRemoveCalendarOp(t *testing.T) {
+	rt := newDraftEditRuntime(map[string]string{
+		"remove-event": "true",
+	})
+	patch, err := buildDraftEditPatch(rt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(patch.Ops) != 1 || patch.Ops[0].Op != "remove_calendar" {
+		t.Fatalf("expected single remove_calendar op, got %+v", patch.Ops)
+	}
+}
+
+func TestBuildDraftEditPatch_SetAndRemoveEventMutuallyExclusive(t *testing.T) {
+	rt := newDraftEditRuntime(map[string]string{
+		"set-event-summary": "Meeting",
+		"remove-event":      "true",
+	})
+	_, err := buildDraftEditPatch(rt)
+	if err == nil {
+		t.Fatal("expected error for --set-event-summary + --remove-event, got nil")
+	}
+}
+
+func TestBuildDraftEditPatch_SetEventMissingStartEnd(t *testing.T) {
+	rt := newDraftEditRuntime(map[string]string{
+		"set-event-summary": "Meeting",
+	})
+	_, err := buildDraftEditPatch(rt)
+	if err == nil {
+		t.Fatal("expected error when --set-event-summary set without start/end, got nil")
 	}
 }

--- a/shortcuts/mail/mail_forward.go
+++ b/shortcuts/mail/mail_forward.go
@@ -43,7 +43,8 @@ var MailForward = common.Shortcut{
 		{Name: "subject", Desc: "Optional. Override the auto-generated Fw: subject. When set, the shortcut uses this value verbatim instead of prefixing the original subject."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's body/to/cc/bcc/attachments are merged into the forward draft (template values appended to user flags / forward-derived values; no de-duplication)."},
 		signatureFlag,
-		priorityFlag},
+		priorityFlag,
+		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		messageId := runtime.Str("message-id")
 		to := runtime.Str("to")
@@ -74,6 +75,9 @@ var MailForward = common.Shortcut{
 		if err := validateConfirmSendScope(runtime); err != nil {
 			return err
 		}
+		if err := validateEventSendTimeExclusion(runtime); err != nil {
+			return err
+		}
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
@@ -85,6 +89,9 @@ var MailForward = common.Shortcut{
 			}
 		}
 		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+			return err
+		}
+		if err := validateEventFlags(runtime); err != nil {
 			return err
 		}
 		if err := validateComposeInlineAndAttachments(runtime.FileIO(), runtime.Str("attach"), runtime.Str("inline"), runtime.Bool("plain-text"), ""); err != nil {
@@ -295,6 +302,11 @@ var MailForward = common.Shortcut{
 			return err
 		}
 		bld = applyPriority(bld, priority)
+		if calData := buildCalendarBody(runtime, senderEmail, to, ccFlag); calData != nil {
+			bld = bld.CalendarBody(calData)
+		} else if len(sourceMsg.OriginalCalendarICS) > 0 {
+			bld = bld.CalendarBody(sourceMsg.OriginalCalendarICS)
+		}
 		// Download original attachments, separating normal from large.
 		type downloadedAtt struct {
 			content     []byte

--- a/shortcuts/mail/mail_reply.go
+++ b/shortcuts/mail/mail_reply.go
@@ -41,7 +41,8 @@ var MailReply = common.Shortcut{
 		{Name: "subject", Desc: "Optional. Override the auto-generated Re: subject. When set, the shortcut uses this value verbatim instead of prefixing the original subject."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's body/to/cc/bcc/attachments are appended to the reply-derived values (no de-duplication; see warning in Execute output)."},
 		signatureFlag,
-		priorityFlag},
+		priorityFlag,
+		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		messageId := runtime.Str("message-id")
 		confirmSend := runtime.Bool("confirm-send")
@@ -75,10 +76,16 @@ var MailReply = common.Shortcut{
 		if err := validateConfirmSendScope(runtime); err != nil {
 			return err
 		}
+		if err := validateEventSendTimeExclusion(runtime); err != nil {
+			return err
+		}
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
 		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+			return err
+		}
+		if err := validateEventFlags(runtime); err != nil {
 			return err
 		}
 		if err := validateComposeInlineAndAttachments(runtime.FileIO(), runtime.Str("attach"), runtime.Str("inline"), runtime.Bool("plain-text"), ""); err != nil {
@@ -287,6 +294,9 @@ var MailReply = common.Shortcut{
 			return err
 		}
 		bld = applyPriority(bld, priority)
+		if calData := buildCalendarBody(runtime, senderEmail, replyTo, ccFlag); calData != nil {
+			bld = bld.CalendarBody(calData)
+		}
 		allInlinePaths := append(inlineSpecFilePaths(inlineSpecs), autoResolvedPaths...)
 		composedBodySize := int64(len(composedHTMLBody) + len(composedTextBody))
 		emlBase := estimateEMLBaseSize(runtime.FileIO(), composedBodySize, allInlinePaths, srcInlineBytes) + templateSmallBytes

--- a/shortcuts/mail/mail_reply_all.go
+++ b/shortcuts/mail/mail_reply_all.go
@@ -42,7 +42,8 @@ var MailReplyAll = common.Shortcut{
 		{Name: "subject", Desc: "Optional. Override the auto-generated Re: subject. When set, the shortcut uses this value verbatim instead of prefixing the original subject."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's body/to/cc/bcc/attachments are appended to the reply-derived values (no de-duplication; see warning in Execute output)."},
 		signatureFlag,
-		priorityFlag},
+		priorityFlag,
+		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		messageId := runtime.Str("message-id")
 		confirmSend := runtime.Bool("confirm-send")
@@ -76,10 +77,16 @@ var MailReplyAll = common.Shortcut{
 		if err := validateConfirmSendScope(runtime); err != nil {
 			return err
 		}
+		if err := validateEventSendTimeExclusion(runtime); err != nil {
+			return err
+		}
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
 		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+			return err
+		}
+		if err := validateEventFlags(runtime); err != nil {
 			return err
 		}
 		if err := validateComposeInlineAndAttachments(runtime.FileIO(), runtime.Str("attach"), runtime.Str("inline"), runtime.Bool("plain-text"), ""); err != nil {
@@ -296,6 +303,9 @@ var MailReplyAll = common.Shortcut{
 			return err
 		}
 		bld = applyPriority(bld, priority)
+		if calData := buildCalendarBody(runtime, senderEmail, toList, ccList); calData != nil {
+			bld = bld.CalendarBody(calData)
+		}
 		allInlinePaths := append(inlineSpecFilePaths(inlineSpecs), autoResolvedPaths...)
 		composedBodySize := int64(len(composedHTMLBody) + len(composedTextBody))
 		emlBase := estimateEMLBaseSize(runtime.FileIO(), composedBodySize, allInlinePaths, srcInlineBytes) + templateSmallBytes

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -39,7 +39,8 @@ var MailSend = common.Shortcut{
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's subject/body/to/cc/bcc/attachments are merged with user-supplied flags (user flags win). Requires --as user."},
 		signatureFlag,
-		priorityFlag},
+		priorityFlag,
+		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		to := runtime.Str("to")
 		subject := runtime.Str("subject")
@@ -87,6 +88,9 @@ var MailSend = common.Shortcut{
 				return err
 			}
 		}
+		if err := validateEventSendTimeExclusion(runtime); err != nil {
+			return err
+		}
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
@@ -94,6 +98,9 @@ var MailSend = common.Shortcut{
 			return err
 		}
 		if err := validateComposeInlineAndAttachments(runtime.FileIO(), runtime.Str("attach"), runtime.Str("inline"), runtime.Bool("plain-text"), runtime.Str("body")); err != nil {
+			return err
+		}
+		if err := validateEventFlags(runtime); err != nil {
 			return err
 		}
 		return validatePriorityFlag(runtime)
@@ -249,6 +256,9 @@ var MailSend = common.Shortcut{
 			return err
 		}
 		bld = applyPriority(bld, priority)
+		if calData := buildCalendarBody(runtime, senderEmail, to, ccFlag); calData != nil {
+			bld = bld.CalendarBody(calData)
+		}
 		allInlinePaths := append(inlineSpecFilePaths(inlineSpecs), autoResolvedPaths...)
 		composedBodySize := int64(len(composedHTMLBody) + len(composedTextBody))
 		emlBase := estimateEMLBaseSize(runtime.FileIO(), composedBodySize, allInlinePaths, 0) + templateSmallBytes

--- a/shortcuts/mail/mail_send_confirm_output_test.go
+++ b/shortcuts/mail/mail_send_confirm_output_test.go
@@ -4,6 +4,9 @@
 package mail
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/internal/httpmock"
@@ -211,5 +214,57 @@ func TestMailSendSaveDraftOutputsReference(t *testing.T) {
 	}
 	if data["reference"] != "https://www.feishu.cn/mail?draftId=draft_001" {
 		t.Fatalf("reference = %v", data["reference"])
+	}
+}
+
+func TestMailSend_WithCalendarEventEmbedded(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+
+	draftsStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "draft_cal_001"},
+		},
+	}
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/profile",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"primary_email_address": "me@example.com"},
+		},
+	})
+	reg.Register(draftsStub)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--to", "alice@example.com",
+		"--subject", "Team Sync",
+		"--body", "<p>Please join us</p>",
+		"--event-summary", "Team Sync",
+		"--event-start", "2026-05-10T10:00+08:00",
+		"--event-end", "2026-05-10T11:00+08:00",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("mail send with calendar failed: %v", err)
+	}
+
+	var reqBody map[string]interface{}
+	if err := json.Unmarshal(draftsStub.CapturedBody, &reqBody); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+	raw, _ := reqBody["raw"].(string)
+	decoded, decErr := base64.URLEncoding.DecodeString(raw)
+	if decErr != nil {
+		t.Fatalf("base64url decode: %v", decErr)
+	}
+	eml := string(decoded)
+	if !strings.Contains(eml, "text/calendar") {
+		t.Errorf("expected text/calendar in EML:\n%s", eml)
+	}
+	if !strings.Contains(eml, "method=REQUEST") {
+		t.Errorf("expected method=REQUEST in Content-Type:\n%s", eml)
 	}
 }

--- a/skill-template/domains/mail.md
+++ b/skill-template/domains/mail.md
@@ -236,6 +236,34 @@ lark-cli mail user_mailbox.sent_messages get_recall_detail --as user \
 - 需要同时授权 mail 和 im 两个域的 scope
 - 分享的卡片包含邮件摘要信息，收件人可点击查看
 
+### 发送日程邀请邮件
+
+在邮件中嵌入日程邀请（`text/calendar`），收件人收信后可直接接受或拒绝日程。`To`/`Cc` 收件人自动成为参会人（ATTENDEE），发件人自动成为组织者（ORGANIZER）。
+
+```bash
+# 发送带日程邀请的新邮件（先保存草稿，确认后发送）
+lark-cli mail +send --as user \
+    --to alice@example.com --cc bob@example.com \
+    --subject '产品评审' \
+    --body '<p>请参加本次产品评审会议。</p>' \
+    --event-summary '产品评审' \
+    --event-start '2026-05-10T14:00+08:00' \
+    --event-end '2026-05-10T15:00+08:00' \
+    --event-location '5F 大会议室' \
+    --confirm-send
+```
+
+**参数说明：**
+- `--event-summary`：日程标题，设置此参数即开启日程邀请模式，需同时设置 `--event-start` 和 `--event-end`
+- `--event-start` / `--event-end`：ISO 8601 格式时间，如 `2026-05-10T14:00+08:00`
+- `--event-location`：可选，日程地点
+
+**约束：**
+- `--event-*` 与 `--send-time`（定时发送）互斥，不可同时使用
+- `Bcc` 收件人不会成为日程参会人；如果邮件同时包含 Bcc 和日程，后端在发送时会拒绝该请求
+
+读取含日程邀请的邮件时，`calendar_event` 字段包含日程详情（`method`、`summary`、`start`、`end`、`organizer`、`attendees` 等）。
+
 ### 正文格式：优先使用 HTML
 
 撰写邮件正文时，**默认使用 HTML 格式**（body 内容会被自动检测）。仅当用户明确要求纯文本时，才使用 `--plain-text` 标志强制纯文本模式。

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -250,6 +250,34 @@ lark-cli mail user_mailbox.sent_messages get_recall_detail --as user \
 - 需要同时授权 mail 和 im 两个域的 scope
 - 分享的卡片包含邮件摘要信息，收件人可点击查看
 
+### 发送日程邀请邮件
+
+在邮件中嵌入日程邀请（`text/calendar`），收件人收信后可直接接受或拒绝日程。`To`/`Cc` 收件人自动成为参会人（ATTENDEE），发件人自动成为组织者（ORGANIZER）。
+
+```bash
+# 发送带日程邀请的新邮件（先保存草稿，确认后发送）
+lark-cli mail +send --as user \
+    --to alice@example.com --cc bob@example.com \
+    --subject '产品评审' \
+    --body '<p>请参加本次产品评审会议。</p>' \
+    --event-summary '产品评审' \
+    --event-start '2026-05-10T14:00+08:00' \
+    --event-end '2026-05-10T15:00+08:00' \
+    --event-location '5F 大会议室' \
+    --confirm-send
+```
+
+**参数说明：**
+- `--event-summary`：日程标题，设置此参数即开启日程邀请模式，需同时设置 `--event-start` 和 `--event-end`
+- `--event-start` / `--event-end`：ISO 8601 格式时间，如 `2026-05-10T14:00+08:00`
+- `--event-location`：可选，日程地点
+
+**约束：**
+- `--event-*` 与 `--send-time`（定时发送）互斥，不可同时使用
+- `Bcc` 收件人不会成为日程参会人；如果邮件同时包含 Bcc 和日程，后端在发送时会拒绝该请求
+
+读取含日程邀请的邮件时，`calendar_event` 字段包含日程详情（`method`、`summary`、`start`、`end`、`organizer`、`attendees` 等）。
+
 ### 正文格式：优先使用 HTML
 
 撰写邮件正文时，**默认使用 HTML 格式**（body 内容会被自动检测）。仅当用户明确要求纯文本时，才使用 `--plain-text` 标志强制纯文本模式。

--- a/skills/lark-mail/references/lark-mail-draft-create.md
+++ b/skills/lark-mail/references/lark-mail-draft-create.md
@@ -48,13 +48,20 @@ lark-cli mail +draft-create --to alice@example.com --subject '测试' --body 'te
 | `--from <email>` | 否 | 发件人邮箱地址（EML From 头）。使用别名（send_as）发信时，设为别名地址并配合 `--mailbox` 指定所属邮箱。省略时使用邮箱主地址 |
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用，如通过别名或 send_as 地址发信。可通过 `accessible_mailboxes` 查询可用邮箱 |
 | `--cc <emails>` | 否 | 完整抄送列表，多个用逗号分隔 |
-| `--bcc <emails>` | 否 | 完整密送列表，多个用逗号分隔 |
+| `--bcc <emails>` | 否 | 完整密送列表，多个用逗号分隔。与 `--event-*` 不兼容（见 `+send` 日程邀请约束） |
 | `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
 | `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到正文末尾。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
 | `--request-receipt` | 否 | 请求已读回执（RFC 3798 Message Disposition Notification）。在草稿 EML 里写 `Disposition-Notification-To: <sender>` 头，发送时生效。收件人的邮件客户端可能弹出提示、自动发送或忽略——送达不保证 |
+| `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请。需同时设置 `--event-start` 和 `--event-end` |
+| `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601） |
+| `--event-end <time>` | 条件必填 | 日程结束时间（ISO 8601） |
+| `--event-location <text>` | 否 | 日程地点 |
+
+> **日程约束**：`--event-*` 与 `--send-time` 不可同时使用；`--to` 和 `--cc` 收件人自动成为日程参与者（ATTENDEE），`--bcc` 收件人不计入参与者。
+
 | `--format <mode>` | 否 | 输出格式：`json`（默认）/ `pretty` / `table` / `ndjson` / `csv` |
 | `--dry-run` | 否 | 仅打印请求，不执行 |
 

--- a/skills/lark-mail/references/lark-mail-draft-edit.md
+++ b/skills/lark-mail/references/lark-mail-draft-edit.md
@@ -73,6 +73,11 @@ lark-cli mail +draft-edit --draft-id <draft-id> --set-subject '测试' --dry-run
 | `--set-cc <emails>` | 否 | 用此处提供的地址替换整个 Cc 抄送列表 |
 | `--set-bcc <emails>` | 否 | 用此处提供的地址替换整个 Bcc 密送列表 |
 | `--set-priority <level>` | 否 | 设置邮件优先级：`high`、`normal`、`low`。设为 `normal` 会清除已有优先级 |
+| `--set-event-summary <text>` | 否 | 设置日程标题。需同时设置 `--set-event-start` 和 `--set-event-end` |
+| `--set-event-start <time>` | 条件必填 | 设置日程开始时间（ISO 8601） |
+| `--set-event-end <time>` | 条件必填 | 设置日程结束时间（ISO 8601） |
+| `--set-event-location <text>` | 否 | 设置日程地点 |
+| `--remove-event` | 否 | 移除草稿中的日程邀请。与 `--set-event-*` 互斥 |
 | `--patch-file <path>` | 否 | 所有正文编辑、增量收件人编辑、邮件头编辑、附件变更和内嵌图片变更的入口。相对路径。先运行 `--print-patch-template` 查看 JSON 结构 |
 | `--print-patch-template` | 否 | 打印 `--patch-file` 的 JSON 模板和支持的操作。建议在生成补丁文件前先运行此命令。不会读取或写入草稿 |
 | `--inspect` | 否 | 查看草稿但不修改。返回包含 `has_quoted_content`（是否有引用区）、`attachments_summary`（普通附件，含 `part_id`/`cid`/`filename`）、`large_attachments_summary`（超大附件，含 `token`/`filename`/`size_bytes`）和 `inline_summary` 的草稿投影 |

--- a/skills/lark-mail/references/lark-mail-forward.md
+++ b/skills/lark-mail/references/lark-mail-forward.md
@@ -64,13 +64,19 @@ lark-cli mail +forward --message-id <邮件ID> --to alice@example.com --dry-run
 | `--from <email>` | 否 | 发件人邮箱地址（EML From 头）。使用别名（send_as）发信时，设为别名地址并配合 `--mailbox` 指定所属邮箱。默认读取邮箱主地址 |
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用。可通过 `accessible_mailboxes` 查询可用邮箱 |
 | `--cc <emails>` | 否 | 抄送邮箱，多个用逗号分隔 |
-| `--bcc <emails>` | 否 | 密送邮箱，多个用逗号分隔 |
+| `--bcc <emails>` | 否 | 密送邮箱，多个用逗号分隔。与 `--event-*` 不兼容（见 `+send` 日程邀请约束） |
 | `--plain-text` | 否 | 强制纯文本模式，忽略所有 HTML 自动检测。不可与 `--inline` 同时使用 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔，追加在原邮件附件之后。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
 | `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到转发正文与引用块之间。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
+| `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请。需同时设置 `--event-start` 和 `--event-end` |
+| `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601） |
+| `--event-end <time>` | 条件必填 | 日程结束时间（ISO 8601） |
+| `--event-location <text>` | 否 | 日程地点 |
 | `--confirm-send` | 否 | 确认发送转发（默认只保存草稿）。仅在用户明确确认后使用 |
+
+> **日程约束**：`--event-*` 与 `--send-time` 不可同时使用；`--to` 和 `--cc` 收件人自动成为日程参与者（ATTENDEE），`--bcc` 收件人不计入参与者。
 | `--send-time <timestamp>` | 否 | 定时发送时间，Unix 时间戳（秒）。需至少为当前时间 + 5 分钟。配合 `--confirm-send` 使用可定时发送邮件 |
 | `--request-receipt` | 否 | 请求已读回执（RFC 3798 Message Disposition Notification）。在出站 EML 里写 `Disposition-Notification-To: <sender>` 头。收件人的邮件客户端可能弹出提示、自动发送或忽略——送达不保证 |
 | `--dry-run` | 否 | 仅打印请求，不执行 |

--- a/skills/lark-mail/references/lark-mail-message.md
+++ b/skills/lark-mail/references/lark-mail-message.md
@@ -192,6 +192,35 @@ lark-cli mail user_mailbox.message.attachments download_url \
 
 普通附件和内嵌图片使用同一个 `user_mailbox.message.attachments download_url` 原生 API（无 shortcut 封装），传入 `attachments[].id` 即可。
 
+## 日程邀请邮件
+
+当邮件包含日程邀请（`text/calendar`）时，输出中会包含 `calendar_event` 对象：
+
+```json
+{
+  "calendar_event": {
+    "method": "REQUEST",
+    "uid": "abc123",
+    "summary": "产品评审",
+    "start": "2026-04-20T14:00:00+08:00",
+    "end": "2026-04-20T15:00:00+08:00",
+    "location": "5F-大会议室",
+    "organizer": "sender@example.com",
+    "attendees": ["alice@example.com", "bob@example.com"]
+  }
+}
+```
+
+字段说明：
+
+- `method`：ICS `METHOD`，通常为 `REQUEST` / `REPLY` / `CANCEL`。
+- `uid`：日程 UID。
+- `summary`：日程标题。
+- `start` / `end`：开始 / 结束时间（RFC 3339 UTC）。
+- `location`：地点（可能为空）。
+- `organizer`：组织者邮箱。
+- `attendees`：参会人邮箱列表。
+
 ## 相关命令
 
 - `lark-cli mail +thread` — 读取会话中所有邮件

--- a/skills/lark-mail/references/lark-mail-reply-all.md
+++ b/skills/lark-mail/references/lark-mail-reply-all.md
@@ -67,13 +67,17 @@ lark-cli mail +reply-all --message-id <邮件ID> --body '测试' --dry-run
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用。可通过 `accessible_mailboxes` 查询可用邮箱 |
 | `--to <emails>` | 否 | 额外收件人，多个用逗号分隔（追加到自动聚合结果） |
 | `--cc <emails>` | 否 | 额外抄送，多个用逗号分隔 |
-| `--bcc <emails>` | 否 | 密送邮箱，多个用逗号分隔 |
+| `--bcc <emails>` | 否 | 密送邮箱，多个用逗号分隔。与 `--event-*` 不兼容（见 `+send` 日程邀请约束） |
 | `--remove <emails>` | 否 | 从自动聚合结果中排除的邮箱，多个用逗号分隔 |
 | `--plain-text` | 否 | 强制纯文本模式，忽略所有 HTML 自动检测。不可与 `--inline` 同时使用 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
 | `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到回复正文与引用块之间。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
+| `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请。需同时设置 `--event-start` 和 `--event-end` |
+| `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601） |
+| `--event-end <time>` | 条件必填 | 日程结束时间（ISO 8601） |
+| `--event-location <text>` | 否 | 日程地点 |
 | `--confirm-send` | 否 | 确认发送回复（默认只保存草稿）。仅在用户明确确认后使用 |
 | `--send-time <timestamp>` | 否 | 定时发送时间，Unix 时间戳（秒）。需至少为当前时间 + 5 分钟。配合 `--confirm-send` 使用可定时发送邮件 |
 | `--request-receipt` | 否 | 请求已读回执（RFC 3798 Message Disposition Notification）。在出站 EML 里写 `Disposition-Notification-To: <sender>` 头。收件人的邮件客户端可能弹出提示、自动发送或忽略——送达不保证 |

--- a/skills/lark-mail/references/lark-mail-reply.md
+++ b/skills/lark-mail/references/lark-mail-reply.md
@@ -71,12 +71,16 @@ lark-cli mail +reply --message-id <邮件ID> --body '<p>测试</p>' --dry-run
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用。可通过 `accessible_mailboxes` 查询可用邮箱 |
 | `--to <emails>` | 否 | 额外收件人，多个用逗号分隔（追加到原发件人） |
 | `--cc <emails>` | 否 | 抄送邮箱，多个用逗号分隔 |
-| `--bcc <emails>` | 否 | 密送邮箱，多个用逗号分隔 |
+| `--bcc <emails>` | 否 | 密送邮箱，多个用逗号分隔。与 `--event-*` 不兼容（见 `+send` 日程邀请约束） |
 | `--plain-text` | 否 | 强制纯文本模式，忽略所有 HTML 自动检测。不可与 `--inline` 同时使用 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
 | `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到回复正文与引用块之间。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
+| `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请。需同时设置 `--event-start` 和 `--event-end` |
+| `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601） |
+| `--event-end <time>` | 条件必填 | 日程结束时间（ISO 8601） |
+| `--event-location <text>` | 否 | 日程地点 |
 | `--confirm-send` | 否 | 确认发送回复（默认只保存草稿）。仅在用户明确确认后使用 |
 | `--send-time <timestamp>` | 否 | 定时发送时间，Unix 时间戳（秒）。需至少为当前时间 + 5 分钟。配合 `--confirm-send` 使用可定时发送邮件 |
 | `--request-receipt` | 否 | 请求已读回执（RFC 3798 Message Disposition Notification）。在出站 EML 里写 `Disposition-Notification-To: <sender>` 头。收件人的邮件客户端可能弹出提示、自动发送或忽略——送达不保证 |

--- a/skills/lark-mail/references/lark-mail-send.md
+++ b/skills/lark-mail/references/lark-mail-send.md
@@ -77,10 +77,22 @@ lark-cli mail +send --to alice@example.com --subject '测试' --body '<p>test</p
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
 | `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到正文末尾。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
+| `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请（text/calendar）。需同时设置 `--event-start` 和 `--event-end` |
+| `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601，如 `2026-04-20T14:00+08:00`） |
+| `--event-end <time>` | 条件必填 | 日程结束时间（ISO 8601） |
+| `--event-location <text>` | 否 | 日程地点 |
 | `--confirm-send` | 否 | 确认发送邮件（默认只保存草稿）。仅在用户明确确认收件人和内容后使用 |
 | `--send-time <timestamp>` | 否 | 定时发送时间，Unix 时间戳（秒）。需至少为当前时间 + 5 分钟。配合 `--confirm-send` 使用可定时发送邮件 |
 | `--request-receipt` | 否 | 请求已读回执（RFC 3798 Message Disposition Notification）。在出站 EML 里写 `Disposition-Notification-To: <sender>` 头。收件人的邮件客户端**可能**弹出提示询问是否回执、可能自动发送、也可能忽略——送达不保证 |
 | `--dry-run` | 否 | 仅打印请求，不执行 |
+
+### 日程邀请约束
+
+使用 `--event-*` 时需满足以下条件：
+
+- `--event-summary`、`--event-start`、`--event-end` 必须同时出现或同时不出现
+- 与 `--send-time` 互斥，不可同时使用（日程邀请必须立即发送，否则收件人可能在日程开始后才收到）
+- 不可与 `--bcc` 同时使用：日程参会人（ATTENDEE）仅来自 To 和 Cc，Bcc 收件人不在参会人列表中、无法 RSVP，且该组合将导致邮件发送失败。需要邀请某人参加日程请用 `--to` 或 `--cc`；如只想告知而不邀请，请单独发一封无日程的邮件
 
 ## 返回值
 


### PR DESCRIPTION
## Summary

Add support for embedding calendar invitations in outgoing emails and parsing calendar event data from received emails.

### Sending calendar invitations

Use `--event-*` flags with any compose command to attach an iCalendar invitation (`text/calendar`). Recipients receive a standard calendar invite and can accept or decline the event.

```bash
lark-cli mail +send \
  --to alice@example.com --cc bob@example.com \
  --subject "Team sync" \
  --body "<p>Please join our weekly sync.</p>" \
  --event-summary "Team sync" \
  --event-start "2026-05-10T14:00+08:00" \
  --event-end "2026-05-10T15:00+08:00" \
  --event-location "Meeting room 5F" \
  --confirm-send
```

**New flags** (available on `+send`, `+reply`, `+reply-all`, `+forward`, `+draft-create`):

| Flag | Required | Description |
|------|----------|-------------|
| `--event-summary <text>` | — | Event title. Enables calendar invitation mode when set. Requires `--event-start` and `--event-end`. |
| `--event-start <time>` | When `--event-summary` is set | Event start time (ISO 8601, e.g. `2026-05-10T14:00+08:00`) |
| `--event-end <time>` | When `--event-summary` is set | Event end time (ISO 8601) |
| `--event-location <text>` | No | Event location |

**Constraints:**
- `--event-summary`, `--event-start`, and `--event-end` must all be provided together
- `--event-*` flags are mutually exclusive with `--send-time` (scheduled delivery)
- `To` and `Cc` recipients are automatically added as attendees; `Bcc` recipients are not

### Editing calendar events in drafts

`+draft-edit` gains two new patch operations via `--patch-file`:

- `set_calendar` — attach or replace the calendar invitation in a draft
- `remove_calendar` — remove the calendar invitation from a draft

### Reading calendar invitations

When a received email contains a calendar invitation, `+message` output now includes a `calendar_event` field:

```json
{
  "calendar_event": {
    "method": "REQUEST",
    "uid": "abc123",
    "summary": "Team sync",
    "start": "2026-05-10T06:00:00Z",
    "end": "2026-05-10T07:00:00Z",
    "location": "Meeting room 5F",
    "organizer": "sender@example.com",
    "attendees": ["alice@example.com", "bob@example.com"]
  }
}
```

## Test plan

- [x] `+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` with `--event-*` flags produce valid RFC 5545 iCalendar output
- [x] `To` and `Cc` recipients appear as `ATTENDEE` entries; `Bcc` recipients are excluded
- [x] `--event-*` and `--send-time` cannot be used together (validated at input)
- [x] `set_calendar` and `remove_calendar` patch ops work correctly in `+draft-edit`
- [x] `+message` correctly parses and surfaces `calendar_event` from received invitation emails
- [x] CN parameter quoting handles special characters per RFC 5545
- [x] Line folding handles both CRLF and LF line endings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar invitation support in mail shortcuts (send, reply, reply-all, forward, draft-create, draft-edit) via --event-summary/--event-start/--event-end/--event-location (ISO‑8601). Produces a text/calendar part (placed under multipart/alternative), supports set/remove event edits, enforces start+end and end > start, and rejects use with scheduled send or Bcc.

* **New Features**
  * ICS generation and parsing with calendar_event exposure in message output.

* **Documentation**
  * CLI and mail docs updated with flags, examples, constraints, and output fields.

* **Tests**
  * Extensive unit and integration coverage for validation, MIME handling, ICS build/parse, and end-to-end flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->