### PR TITLE
chore: release v1.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.18] - 2026-04-23
+
+### Features
+
+- **base**: Support `.base` import and export for bitable (#599)
+- **config**: Add `config bind` for per-Agent credential isolation (#515)
+- **slides**: Add `+replace-slide` shortcut for block-level XML edits (#516)
+- **wiki**: Add `+delete-space` shortcut with async task polling (#610)
+- **doc**: Add `--from-clipboard` flag to `docs +media-insert` (#508)
+- **minutes**: Unify minute artifacts output to `./minutes/{minute_token}/` (#604)
+- Add configurable content-safety scanning (#606)
+- **install**: Add SHA-256 checksum verification to `install.js` (#592)
+- **whiteboard**: Pin `whiteboard-cli` to `^0.2.9` (#617)
+
+### Bug Fixes
+
+- **drive**: Escape angle brackets in comment text (#632)
+- **im**: Unify `messages-search` pagination int flags (#446)
+- **im**: Fix markdown URL rendering issues in post content (#206)
+
+### Documentation
+
+- **base**: Refine record cell value guidance (#636)
+
 ## [v1.0.17] - 2026-04-22
 
 ### Features
@@ -464,6 +488,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.18]: https://github.com/larksuite/cli/releases/tag/v1.0.18
 [v1.0.17]: https://github.com/larksuite/cli/releases/tag/v1.0.17
 [v1.0.16]: https://github.com/larksuite/cli/releases/tag/v1.0.16
 [v1.0.15]: https://github.com/larksuite/cli/releases/tag/v1.0.15

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

Release **v1.0.18** (2026-04-23). Bumps `package.json` from `1.0.17` to `1.0.18` and appends the v1.0.18 section to `CHANGELOG.md`.

### Included PRs (13)

**Features**
- base: Support `.base` import and export for bitable (#599)
- config: Add `config bind` for per-Agent credential isolation (#515)
- slides: Add `+replace-slide` shortcut for block-level XML edits (#516)
- wiki: Add `+delete-space` shortcut with async task polling (#610)
- doc: Add `--from-clipboard` flag to `docs +media-insert` (#508)
- minutes: Unify minute artifacts output to `./minutes/{minute_token}/` (#604)
- Add configurable content-safety scanning (#606)
- install: Add SHA-256 checksum verification to `install.js` (#592)
- whiteboard: Pin `whiteboard-cli` to `^0.2.9` (#617)

**Bug Fixes**
- drive: Escape angle brackets in comment text (#632)
- im: Unify `messages-search` pagination int flags (#446)
- im: Fix markdown URL rendering issues in post content (#206)

**Documentation**
- base: Refine record cell value guidance (#636)

## Test plan

- [ ] CI passes on `release/v1.0.18`
- [ ] After merge, tag `v1.0.18` and publish release
- [ ] npm publish `@larksuite/cli@1.0.18`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: v1.0.18

* **New Features**
  * Added base import/export functionality
  * Introduced config bind, slides and wiki shortcuts, wiki polling, docs clipboard flag
  * Unified minutes output directory
  * Added content-safety scanning and install SHA-256 verification
  * Pinned whiteboard CLI version

* **Bug Fixes**
  * Fixed drive comment escaping, IM pagination flag, and markdown URL rendering

* **Documentation**
  * Documentation refinement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->