### PR TITLE
feat(contact +search-user): add search filters and richer profile fields

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,6 +54,12 @@ linters:
       - path: internal/vfs/
         linters:
           - forbidigo
+      # The shortcuts-no-raw-http forbidigo rule below is shortcuts-only;
+      # internal/ legitimately wraps raw HTTP for the client / credential layer.
+      - path-except: shortcuts/
+        text: shortcuts-no-raw-http
+        linters:
+          - forbidigo
 
   settings:
     depguard:
@@ -70,16 +76,18 @@ linters:
               desc: >-
                 shortcuts must not import internal/vfs/localfileio directly.
                 Use runtime.FileIO() for file operations or runtime.ValidatePath() for path validation.
-        shortcuts-no-raw-http:
-          files:
-            - "**/shortcuts/**"
-          deny:
-            - pkg: "net/http"
-              desc: >-
-                use RuntimeContext.DoAPI/CallAPI/DoAPIJSON instead of raw net/http.
-                The client layer handles auth, headers, and error normalization.
     forbidigo:
       forbid:
+        # ── http: shortcuts must not construct raw HTTP requests ──
+        # Bans request / client construction; constants (http.MethodPost,
+        # http.StatusOK) and pure helpers (http.StatusText, http.Header) are
+        # intentionally allowed since they don't bypass the runtime layer.
+        - pattern: http\.(Client|NewRequest|NewRequestWithContext|Get|Post|PostForm|Head|DefaultClient|DefaultTransport|RoundTripper|Do|Serve|ListenAndServe)\b
+          msg: >-
+            [shortcuts-no-raw-http] use RuntimeContext.DoAPI/CallAPI/DoAPIJSON
+            instead of constructing raw HTTP. The runtime handles auth, headers,
+            and error normalization. (Constants and helpers like http.MethodPost,
+            http.StatusOK, http.StatusText remain allowed.)
         # ── os: already wrapped in internal/vfs ──
         - pattern: os\.(Stat|Lstat|Open|OpenFile|Rename|ReadFile|WriteFile|Getwd|UserHomeDir|ReadDir)\b
           msg: "use the corresponding vfs.Xxx() from internal/vfs"

--- a/shortcuts/common/userids.go
+++ b/shortcuts/common/userids.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"strings"
+
+	"github.com/larksuite/cli/internal/output"
+)
+
+// ResolveOpenIDs expands the special identifier "me" to the current user's
+// open_id, removes duplicates case-insensitively while preserving the
+// first-occurrence form, and returns nil for an empty input. flagName is
+// used in error messages to point the user at the offending CLI flag.
+func ResolveOpenIDs(flagName string, ids []string, runtime *RuntimeContext) ([]string, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	currentUserID := runtime.UserOpenId()
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if strings.EqualFold(id, "me") {
+			if currentUserID == "" {
+				return nil, output.ErrValidation("%s: \"me\" requires a logged-in user with a resolvable open_id", flagName)
+			}
+			id = currentUserID
+		}
+		key := strings.ToLower(id)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, id)
+	}
+	return out, nil
+}

--- a/shortcuts/common/userids_test.go
+++ b/shortcuts/common/userids_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/core"
+	"github.com/spf13/cobra"
+)
+
+func resolveOpenIDsTestRuntime(userOpenID string) *RuntimeContext {
+	cmd := &cobra.Command{Use: "test"}
+	cfg := &core.CliConfig{UserOpenId: userOpenID}
+	return TestNewRuntimeContext(cmd, cfg)
+}
+
+func TestResolveOpenIDs_Empty(t *testing.T) {
+	rt := resolveOpenIDsTestRuntime("ou_self")
+	out, err := ResolveOpenIDs("--user-ids", nil, rt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("expected empty, got %v", out)
+	}
+}
+
+func TestResolveOpenIDs_ExpandsMeAndDedups(t *testing.T) {
+	rt := resolveOpenIDsTestRuntime("ou_self")
+	out, err := ResolveOpenIDs("--user-ids", []string{"me", "ou_a", "me", "ou_a"}, rt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"ou_self", "ou_a"}
+	if len(out) != len(want) || out[0] != want[0] || out[1] != want[1] {
+		t.Fatalf("got %v, want %v", out, want)
+	}
+}
+
+func TestResolveOpenIDs_MeIsCaseInsensitive(t *testing.T) {
+	rt := resolveOpenIDsTestRuntime("ou_self")
+	out, err := ResolveOpenIDs("--user-ids", []string{"ou_other", "me", "Me", "ME"}, rt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"ou_other", "ou_self"}
+	if len(out) != len(want) || out[0] != want[0] || out[1] != want[1] {
+		t.Fatalf("got %v, want %v", out, want)
+	}
+}
+
+func TestResolveOpenIDs_MeWithoutLogin(t *testing.T) {
+	rt := resolveOpenIDsTestRuntime("")
+	_, err := ResolveOpenIDs("--user-ids", []string{"me"}, rt)
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "--user-ids") {
+		t.Fatalf("error should mention the offending flag name; got: %v", err)
+	}
+}
+
+func TestResolveOpenIDs_DedupIsCaseInsensitive(t *testing.T) {
+	rt := resolveOpenIDsTestRuntime("ou_self")
+	// Same underlying open_id with three case variants — should collapse to
+	// one entry, preserving the first-occurrence form.
+	out, err := ResolveOpenIDs("--user-ids", []string{"ou_abc123", "OU_ABC123", "Ou_Abc123"}, rt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(out) != 1 || out[0] != "ou_abc123" {
+		t.Fatalf("case-insensitive dedup failed: got %v, want [ou_abc123]", out)
+	}
+}

--- a/shortcuts/contact/contact_search_user.go
+++ b/shortcuts/contact/contact_search_user.go
@@ -7,12 +7,50 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
-	"strconv"
+	"sort"
+	"strings"
+	"unicode/utf8"
 
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
+
+const (
+	searchUserURL = "/open-apis/contact/v3/users/search"
+
+	// Caps reflect the runtime constraints the API owner ships with (tighter
+	// than the schema's declared maxLen, which is upper bound not effective).
+	maxSearchUserQueryRunes    = 64
+	maxSearchUserUserIDs       = 100
+	defaultSearchUserPageSize  = 20
+	maxSearchUserPageSize      = 30
+	defaultSearchUserPageLimit = 20
+	maxSearchUserPageLimit     = 40
+)
+
+// searchUserBoolFilters is the single source of truth binding each bool filter
+// flag to its API body field. One flag name diverges from the API field name
+// to reduce ambiguity: "has-chatted" maps to API has_contact. The API name
+// overloads "contact" to mean chat history, which collides with the other
+// filter exclude_outer_contact (where "contact" means person); the flag name
+// matches our output field has_chatted so callers do not have to juggle two
+// meanings.
+var searchUserBoolFilters = []struct{ Flag, API string }{
+	{"is-resigned", "is_resigned"},
+	{"has-chatted", "has_contact"},
+	{"exclude-outer-contact", "exclude_outer_contact"},
+	{"has-enterprise-email", "has_enterprise_email"},
+}
+
+// fixedLocaleFallback is the ordered locale list used by pickName after
+// brand-preferred locales fail to match; keeps the picked name deterministic
+// beyond zh_cn / en_us.
+var fixedLocaleFallback = []string{
+	"ja_jp", "zh_hk", "zh_tw", "ko_kr",
+	"id_id", "vi_vn", "th_th",
+	"pt_br", "es_es", "de_de", "fr_fr", "it_it", "ru_ru",
+}
 
 var ContactSearchUser = common.Shortcut{
 	Service:     "contact",
@@ -23,118 +61,337 @@ var ContactSearchUser = common.Shortcut{
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{
-		{Name: "query", Desc: "search keyword", Required: true},
-		{Name: "page-size", Default: "20", Desc: "page size"},
-		{Name: "page-token", Desc: "page token"},
+		{Name: "query", Desc: "search keyword (max 64 runes; recommended for best results)"},
+		{Name: "user-ids", Desc: "filter results to these open_id list, CSV; supports \"me\"; max 100"},
+		{Name: "is-resigned", Type: "bool", Desc: "set to restrict to resigned-and-chatted users (opt-in filter)"},
+		{Name: "has-chatted", Type: "bool", Desc: "set to restrict to users you've chatted with (opt-in filter)"},
+		{Name: "exclude-outer-contact", Type: "bool", Desc: "set to exclude outer contacts and only return same-tenant users (opt-in filter)"},
+		{Name: "has-enterprise-email", Type: "bool", Desc: "set to restrict to users with enterprise email (opt-in filter)"},
+		{Name: "lang", Desc: "override locale for the picked name (e.g. zh_cn, en_us, ja_jp); default: tenant brand"},
+		{Name: "page-size", Default: "20", Desc: "page size, 1-30 (default 20)"},
+		{Name: "page-all", Type: "bool", Desc: "auto-paginate results until has_more=false or --page-limit reached"},
+		{Name: "page-limit", Type: "int", Default: "20", Desc: "max pages fetched when auto-paginating (default 20, max 40; passing this flag alone implicitly enables --page-all)"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if len(runtime.Str("query")) == 0 {
-			return common.FlagErrorf("search keyword empty")
-		}
-		return nil
+		return validateSearchUser(runtime)
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
-		pageSizeStr := runtime.Str("page-size")
-		pageToken := runtime.Str("page-token")
-
-		pageSize := 20
-		if n, err := strconv.Atoi(pageSizeStr); err == nil {
-			pageSize = int(math.Min(math.Max(float64(n), 1), 200))
+		body, err := buildSearchUserBody(runtime)
+		if err != nil {
+			return common.NewDryRunAPI().Set("error", err.Error())
 		}
-
-		params := map[string]interface{}{
-			"query":     runtime.Str("query"),
-			"page_size": pageSize,
-		}
-		if pageToken != "" {
-			params["page_token"] = pageToken
-		}
-
 		return common.NewDryRunAPI().
-			GET("/open-apis/search/v1/user").
-			Params(params)
+			POST(searchUserURL).
+			Params(buildSearchUserParams(runtime)).
+			Body(body)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		query := runtime.Str("query")
-		pageSizeStr := runtime.Str("page-size")
-		pageToken := runtime.Str("page-token")
-
-		pageSize := 20
-		if n, err := strconv.Atoi(pageSizeStr); err == nil {
-			pageSize = int(math.Min(math.Max(float64(n), 1), 200))
-		}
-
-		params := map[string]interface{}{
-			"query":     query,
-			"page_size": pageSize,
-		}
-		if pageToken != "" {
-			params["page_token"] = pageToken
-		}
-
-		data, err := runtime.CallAPI("GET", "/open-apis/search/v1/user", params, nil)
+		body, err := buildSearchUserBody(runtime)
 		if err != nil {
 			return err
 		}
-		users, _ := data["users"].([]interface{})
+		autoPaginate, pageLimit := searchUserPaginationConfig(runtime)
 
-		for _, u := range users {
-			if m, _ := u.(map[string]interface{}); m != nil {
-				if av, _ := m["avatar"].(map[string]interface{}); av != nil {
-					m["avatar"] = map[string]interface{}{"avatar_origin": av["avatar_origin"]}
-				}
+		var (
+			// Initialized as non-nil so empty result sets serialize as [] (not null).
+			allUsers         = make([]map[string]interface{}, 0)
+			lastHasMore      bool
+			lastPageToken    string
+			truncatedByLimit bool
+			pageCount        int
+		)
+		lang := runtime.Str("lang")
+		brand := runtime.Config.Brand
+		params := buildSearchUserParams(runtime)
+
+		for {
+			pageCount++
+			data, err := runtime.CallAPI("POST", searchUserURL, params, body)
+			if err != nil {
+				return err
 			}
+			users, hasMore, pageToken := extractSearchUsers(data, lang, brand)
+			allUsers = append(allUsers, users...)
+			lastHasMore = hasMore
+			lastPageToken = pageToken
+
+			if !autoPaginate || !hasMore || pageCount >= pageLimit {
+				if autoPaginate && hasMore && pageCount >= pageLimit {
+					truncatedByLimit = true
+				}
+				break
+			}
+			// Prepare params for the next iteration with the fresh page_token.
+			nextParams := make(map[string]interface{}, len(params)+1)
+			for k, v := range params {
+				nextParams[k] = v
+			}
+			nextParams["page_token"] = pageToken
+			params = nextParams
 		}
-		searchData := map[string]interface{}{
-			"users":      users,
-			"has_more":   data["has_more"],
-			"page_token": data["page_token"],
+
+		outData := map[string]interface{}{
+			"users":      allUsers,
+			"has_more":   lastHasMore,
+			"page_token": lastPageToken,
 		}
-		runtime.OutFormat(searchData, nil, func(w io.Writer) {
-			if len(users) == 0 {
-				fmt.Fprintln(w, "No matching users found.")
+		runtime.OutFormat(outData, &output.Meta{Count: len(allUsers)}, func(w io.Writer) {
+			if len(allUsers) == 0 {
+				fmt.Fprintln(w, "No users found.")
 				return
 			}
-
-			var rows []map[string]interface{}
-			for _, u := range users {
-				m, _ := u.(map[string]interface{})
-				rows = append(rows, map[string]interface{}{
-					"name":             pickUserName(m),
-					"open_id":          m["open_id"],
-					"email":            firstNonEmpty(m, "email", "mail"),
-					"mobile":           firstNonEmpty(m, "mobile", "phone"),
-					"department":       firstNonEmpty(m, "department_name", "department"),
-					"enterprise_email": firstNonEmpty(m, "enterprise_email"),
-				})
-			}
-			output.PrintTable(w, rows)
-			hasMore, _ := data["has_more"].(bool)
-			moreHint := ""
-			if hasMore {
-				pt, _ := data["page_token"].(string)
-				moreHint = fmt.Sprintf(" (more available, page_token: %s)", pt)
-			}
-			fmt.Fprintf(w, "\n%d user(s)%s\n", len(users), moreHint)
+			output.PrintTable(w, prettyUserRows(allUsers))
 		})
+		if lastHasMore && isHumanReadableFormat(runtime.Format) {
+			// Hints go to stderr so stdout stays clean for the actual table
+			// output, matching the CLI convention used elsewhere by the runner
+			// for warnings and informational messages.
+			if truncatedByLimit {
+				fmt.Fprintf(runtime.IO().ErrOut,
+					"\nwarning: stopped after fetching %d page(s); refine the query with more filters, or raise --page-limit (max %d)\n",
+					pageCount, maxSearchUserPageLimit)
+			} else {
+				fmt.Fprintf(runtime.IO().ErrOut,
+					"\n(more available; refine the query or use --page-all to auto-paginate)\n")
+			}
+		}
 		return nil
 	},
 }
 
-func pickUserName(m map[string]interface{}) string {
-	for _, key := range []string{"name", "user_name", "display_name", "employee_name", "cn_name"} {
-		if v, ok := m[key].(string); ok && v != "" {
-			return v
-		}
-	}
-	return ""
+// isHumanReadableFormat reports whether the given output format is meant for
+// human reading (so a "(more available, ...)" hint can be appended without
+// corrupting structured output streams like ndjson or csv).
+func isHumanReadableFormat(format string) bool {
+	return format == "pretty" || format == "table"
 }
 
-func firstNonEmpty(m map[string]interface{}, keys ...string) string {
-	for _, key := range keys {
-		if v, ok := m[key].(string); ok && v != "" {
+// searchUserPaginationConfig resolves the (autoPaginate, pageLimit) tuple from
+// user flags. Rules (mirroring shortcuts/im/im_messages_search.go for
+// consistency across search-type shortcuts):
+//   - --page-all alone                   → auto-paginate, pageLimit = max (40)
+//   - --page-limit N alone               → auto-paginate, pageLimit = N  (implicit enable)
+//   - --page-all + --page-limit N        → auto-paginate, pageLimit = N
+//   - neither                            → single-page (manual pagination)
+func searchUserPaginationConfig(runtime *common.RuntimeContext) (autoPaginate bool, pageLimit int) {
+	autoPaginate = runtime.Bool("page-all")
+	if runtime.Cmd != nil && runtime.Cmd.Flags().Changed("page-limit") {
+		autoPaginate = true
+	}
+	pageLimit = defaultSearchUserPageLimit
+	if runtime.Cmd != nil && runtime.Cmd.Flags().Changed("page-limit") {
+		pageLimit = runtime.Int("page-limit")
+		if pageLimit > maxSearchUserPageLimit {
+			pageLimit = maxSearchUserPageLimit
+		}
+	} else if runtime.Bool("page-all") {
+		pageLimit = maxSearchUserPageLimit
+	}
+	return autoPaginate, pageLimit
+}
+
+// extractSearchUsers projects the API response into the shortcut's user
+// objects and surfaces pagination metadata.
+func extractSearchUsers(data map[string]interface{}, lang string, brand core.LarkBrand) ([]map[string]interface{}, bool, string) {
+	items := common.GetSlice(data, "items")
+	users := make([]map[string]interface{}, 0, len(items))
+	common.EachMap(items, func(item map[string]interface{}) {
+		users = append(users, rowFromItem(item, lang, brand))
+	})
+	return users, common.GetBool(data, "has_more"), common.GetString(data, "page_token")
+}
+
+// prettyUserRows projects the 12-field user objects down to the 6 pretty
+// table columns, with display_info truncated and its newlines flattened.
+func prettyUserRows(users []map[string]interface{}) []map[string]interface{} {
+	rows := make([]map[string]interface{}, 0, len(users))
+	for _, u := range users {
+		di := common.GetString(u, "display_info")
+		rows = append(rows, map[string]interface{}{
+			"display_info":  common.TruncateStr(strings.ReplaceAll(di, "\n", " "), 60),
+			"name":          u["name"],
+			"open_id":       u["open_id"],
+			"email":         u["email"],
+			"is_registered": u["is_registered"],
+			"has_chatted":   u["has_chatted"],
+		})
+	}
+	return rows
+}
+
+// pickName returns a single display name from meta.i18n_names, deterministically.
+// Priority: explicit --lang, then brand-preferred locales (feishu → zh_cn first,
+// lark → en_us first), then fixedLocaleFallback order, then the dictionary-order
+// sweep that tolerates locales not in the fixed list, and finally the
+// caller-provided openID.
+//
+// It does NOT fall back to display_info — the hit-highlight segment there may
+// be a phone number or email, not a name.
+func pickName(meta map[string]interface{}, lang string, brand core.LarkBrand, openID string) string {
+	i18n := common.GetMap(meta, "i18n_names")
+
+	primary := make([]string, 0, 3)
+	if lang != "" {
+		primary = append(primary, strings.ReplaceAll(strings.ToLower(lang), "-", "_"))
+	}
+	switch brand {
+	case core.BrandLark:
+		primary = append(primary, "en_us", "zh_cn")
+	default: // feishu or unknown brand: Chinese first
+		primary = append(primary, "zh_cn", "en_us")
+	}
+
+	for _, loc := range primary {
+		if v := common.GetString(i18n, loc); v != "" {
 			return v
 		}
 	}
-	return ""
+	for _, loc := range fixedLocaleFallback {
+		if v := common.GetString(i18n, loc); v != "" {
+			return v
+		}
+	}
+	if len(i18n) > 0 {
+		keys := make([]string, 0, len(i18n))
+		for k := range i18n {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if v := common.GetString(i18n, k); v != "" {
+				return v
+			}
+		}
+	}
+	return openID
+}
+
+// rowFromItem projects a single items[i] from the API response into the
+// 12-field user shape. Cross-tenant users may have missing email / department
+// fields; those pass through as empty string / nil rather than defaults so
+// consumers can distinguish "unknown" from "confirmed absent".
+func rowFromItem(item map[string]interface{}, lang string, brand core.LarkBrand) map[string]interface{} {
+	openID := common.GetString(item, "id")
+	meta := common.GetMap(item, "meta_data")
+	chatID := common.GetString(meta, "chat_id")
+
+	return map[string]interface{}{
+		"name":             pickName(meta, lang, brand, openID),
+		"open_id":          openID,
+		"i18n_names":       common.GetMap(meta, "i18n_names"),
+		"email":            common.GetString(meta, "mail_address"),
+		"enterprise_email": common.GetString(meta, "enterprise_mail_address"),
+		"is_registered":    common.GetBool(meta, "is_registered"),
+		"chat_id":          chatID,
+		"has_chatted":      chatID != "",
+		"is_cross_tenant":  common.GetBool(meta, "is_cross_tenant"),
+		"tenant_id":        common.GetString(meta, "tenant_id"),
+		"description":      common.GetString(meta, "description"),
+		"display_info":     common.GetString(item, "display_info"),
+	}
+}
+
+// validateSearchUser enforces the input contract: at least one search input
+// (query or filter) must be provided — "empty search" is rejected because
+// the API owner flags it as unsupported in practice.
+func validateSearchUser(runtime *common.RuntimeContext) error {
+	if !hasAnySearchInput(runtime) {
+		return common.FlagErrorf(
+			"specify at least one of --query, --user-ids, --is-resigned, --has-chatted, --exclude-outer-contact, --has-enterprise-email",
+		)
+	}
+
+	if q := strings.TrimSpace(runtime.Str("query")); q != "" {
+		if utf8.RuneCountInString(q) > maxSearchUserQueryRunes {
+			return common.FlagErrorf("--query: length must be between 1 and %d characters", maxSearchUserQueryRunes)
+		}
+	}
+
+	if raw := strings.TrimSpace(runtime.Str("user-ids")); raw != "" {
+		ids, err := common.ResolveOpenIDs("--user-ids", common.SplitCSV(raw), runtime)
+		if err != nil {
+			return err
+		}
+		if len(ids) > maxSearchUserUserIDs {
+			return common.FlagErrorf("--user-ids: must be at most %d entries", maxSearchUserUserIDs)
+		}
+		for _, id := range ids {
+			if _, err := common.ValidateUserID(id); err != nil {
+				return err
+			}
+		}
+	}
+
+	if _, err := common.ValidatePageSize(runtime, "page-size", defaultSearchUserPageSize, 1, maxSearchUserPageSize); err != nil {
+		return err
+	}
+	if runtime.Cmd != nil && runtime.Cmd.Flags().Changed("page-limit") {
+		if n := runtime.Int("page-limit"); n < 1 || n > maxSearchUserPageLimit {
+			return common.FlagErrorf("--page-limit: must be an integer between 1 and %d", maxSearchUserPageLimit)
+		}
+	}
+	return nil
+}
+
+// hasAnySearchInput reports whether the user supplied any of the six search
+// inputs. Cannot be replaced with common.AtLeastOne: that helper only
+// inspects string flags, whereas the bool filters need Changed() detection
+// to preserve tri-state semantics.
+func hasAnySearchInput(runtime *common.RuntimeContext) bool {
+	if strings.TrimSpace(runtime.Str("query")) != "" {
+		return true
+	}
+	if strings.TrimSpace(runtime.Str("user-ids")) != "" {
+		return true
+	}
+	for _, bf := range searchUserBoolFilters {
+		if runtime.Cmd.Flags().Changed(bf.Flag) {
+			return true
+		}
+	}
+	return false
+}
+
+// buildSearchUserBody constructs the POST body. Bool filters enter the body
+// only when the user explicitly set them (Changed()), preserving the
+// tri-state distinction between "unset" and "explicit false".
+func buildSearchUserBody(runtime *common.RuntimeContext) (map[string]interface{}, error) {
+	body := map[string]interface{}{}
+
+	if q := strings.TrimSpace(runtime.Str("query")); q != "" {
+		body["query"] = q
+	}
+
+	filter := map[string]interface{}{}
+
+	if raw := strings.TrimSpace(runtime.Str("user-ids")); raw != "" {
+		ids, err := common.ResolveOpenIDs("--user-ids", common.SplitCSV(raw), runtime)
+		if err != nil {
+			return nil, err
+		}
+		if len(ids) > 0 {
+			filter["user_ids"] = ids
+		}
+	}
+
+	for _, bf := range searchUserBoolFilters {
+		if runtime.Cmd.Flags().Changed(bf.Flag) {
+			filter[bf.API] = runtime.Bool(bf.Flag)
+		}
+	}
+
+	if len(filter) > 0 {
+		body["filter"] = filter
+	}
+	return body, nil
+}
+
+// buildSearchUserParams constructs the query-string params. page_size falls
+// back to the default when omitted. page_token is managed internally by the
+// Execute loop when auto-paginating, not exposed as a CLI flag.
+func buildSearchUserParams(runtime *common.RuntimeContext) map[string]interface{} {
+	params := map[string]interface{}{}
+	pageSize, _ := common.ValidatePageSize(runtime, "page-size", defaultSearchUserPageSize, 1, maxSearchUserPageSize)
+	params["page_size"] = pageSize
+	return params
 }

--- a/shortcuts/contact/contact_search_user.go
+++ b/shortcuts/contact/contact_search_user.go
@@ -5,72 +5,158 @@ package contact
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
 const (
 	searchUserURL = "/open-apis/contact/v3/users/search"
 
-	// Caps reflect the runtime constraints the API owner ships with (tighter
-	// than the schema's declared maxLen, which is upper bound not effective).
-	maxSearchUserQueryRunes    = 64
-	maxSearchUserUserIDs       = 100
-	defaultSearchUserPageSize  = 20
-	maxSearchUserPageSize      = 30
-	defaultSearchUserPageLimit = 20
-	maxSearchUserPageLimit     = 40
+	maxSearchUserQueryRunes = 64
+	maxSearchUserUserIDs    = 100
+	maxSearchUserPageSize   = 30
 )
 
-// searchUserBoolFilters is the single source of truth binding each bool filter
-// flag to its API body field. One flag name diverges from the API field name
-// to reduce ambiguity: "has-chatted" maps to API has_contact. The API name
-// overloads "contact" to mean chat history, which collides with the other
-// filter exclude_outer_contact (where "contact" means person); the flag name
-// matches our output field has_chatted so callers do not have to juggle two
-// meanings.
-var searchUserBoolFilters = []struct{ Flag, API string }{
-	{"is-resigned", "is_resigned"},
-	{"has-chatted", "has_contact"},
-	{"exclude-outer-contact", "exclude_outer_contact"},
-	{"has-enterprise-email", "has_enterprise_email"},
+type searchUserBoolFilter struct {
+	Flag  string
+	Apply func(*searchUserAPIFilter)
 }
 
-// fixedLocaleFallback is the ordered locale list used by pickName after
-// brand-preferred locales fail to match; keeps the picked name deterministic
-// beyond zh_cn / en_us.
+// Three flags rename their API counterparts to remove jargon / overloaded
+// terms: has-chatted→has_contact, exclude-external-users→exclude_outer_contact,
+// left-organization→is_resigned. Reading API docs alongside this CLI requires
+// translating through this table.
+var searchUserBoolFilters = []searchUserBoolFilter{
+	{"left-organization", func(f *searchUserAPIFilter) { f.IsResigned = true }},
+	{"has-chatted", func(f *searchUserAPIFilter) { f.HasContact = true }},
+	{"exclude-external-users", func(f *searchUserAPIFilter) { f.ExcludeOuterContact = true }},
+	{"has-enterprise-email", func(f *searchUserAPIFilter) { f.HasEnterpriseEmail = true }},
+}
+
 var fixedLocaleFallback = []string{
 	"ja_jp", "zh_hk", "zh_tw", "ko_kr",
 	"id_id", "vi_vn", "th_th",
 	"pt_br", "es_es", "de_de", "fr_fr", "it_it", "ru_ru",
 }
 
+// display_info is empirically observed as up to 3 newline-separated segments:
+//
+//	<h>{matched}</h>...   ← hit highlights (line 0)
+//	{department}          ← may be empty (line 1, optional)
+//	[Contacted X days ago] ← recency hint (last line, optional)
+//
+// The format is undocumented and segments may be omitted; we extract by role
+// (regex for highlights, line-1 for department, last bracketed line for
+// recency) rather than by fixed index, so missing segments degrade gracefully.
+var (
+	displayInfoHighlightRE = regexp.MustCompile(`<h>(.*?)</h>`)
+	displayInfoRecencyRE   = regexp.MustCompile(`^\[(.+)\]$`)
+)
+
+type searchUserAPIRequest struct {
+	Query  string               `json:"query,omitempty"`
+	Filter *searchUserAPIFilter `json:"filter,omitempty"`
+}
+
+// All bool fields use omitempty: validation rejects =false, so any field set
+// here is true; unset fields stay out of the request entirely.
+type searchUserAPIFilter struct {
+	UserIDs             []string `json:"user_ids,omitempty"`
+	IsResigned          bool     `json:"is_resigned,omitempty"`
+	HasContact          bool     `json:"has_contact,omitempty"`
+	ExcludeOuterContact bool     `json:"exclude_outer_contact,omitempty"`
+	HasEnterpriseEmail  bool     `json:"has_enterprise_email,omitempty"`
+}
+
+type searchUserAPIEnvelope struct {
+	Code int                `json:"code"`
+	Msg  string             `json:"msg"`
+	Data *searchUserAPIData `json:"data"`
+}
+
+type searchUserAPIData struct {
+	Items     []searchUserAPIItem `json:"items"`
+	HasMore   bool                `json:"has_more"`
+	PageToken string              `json:"page_token"`
+}
+
+type searchUserAPIItem struct {
+	ID          string            `json:"id"`
+	DisplayInfo string            `json:"display_info"`
+	MetaData    searchUserAPIMeta `json:"meta_data"`
+}
+
+type searchUserAPIMeta struct {
+	I18nNames             map[string]string `json:"i18n_names"`
+	MailAddress           string            `json:"mail_address"`
+	EnterpriseMailAddress string            `json:"enterprise_mail_address"`
+	IsRegistered          bool              `json:"is_registered"`
+	ChatID                string            `json:"chat_id"`
+	IsCrossTenant         bool              `json:"is_cross_tenant"`
+	// API ships the user's profile signature in `description`; the field name
+	// is misleading because it carries the personal signature ("个性签名"),
+	// not a generic description. We surface it as `signature` downstream.
+	Description string `json:"description"`
+}
+
+// JSON tags on searchUser are the public contract for agents and downstream
+// scripts; never rename without bumping the shortcut version.
+type searchUser struct {
+	OpenID          string   `json:"open_id"`
+	LocalizedName   string   `json:"localized_name"`
+	Email           string   `json:"email"`
+	EnterpriseEmail string   `json:"enterprise_email"`
+	IsActivated     bool     `json:"is_activated"`
+	IsCrossTenant   bool     `json:"is_cross_tenant"`
+	P2PChatID       string   `json:"p2p_chat_id"`
+	HasChatted      bool     `json:"has_chatted"`
+	Department      string   `json:"department"`
+	Signature       string   `json:"signature"`
+	ChatRecencyHint string   `json:"chat_recency_hint"`
+	MatchSegments   []string `json:"match_segments"`
+}
+
+type searchUserResponse struct {
+	Users   []searchUser `json:"users"`
+	HasMore bool         `json:"has_more"`
+}
+
 var ContactSearchUser = common.Shortcut{
 	Service:     "contact",
 	Command:     "+search-user",
-	Description: "Search users (results sorted by relevance)",
+	Description: "Search Lark/Feishu users by keyword, open_id list, or filter (requires --as user)",
 	Risk:        "read",
 	Scopes:      []string{"contact:user:search"},
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{
-		{Name: "query", Desc: "search keyword (max 64 runes; recommended for best results)"},
-		{Name: "user-ids", Desc: "filter results to these open_id list, CSV; supports \"me\"; max 100"},
-		{Name: "is-resigned", Type: "bool", Desc: "set to restrict to resigned-and-chatted users (opt-in filter)"},
-		{Name: "has-chatted", Type: "bool", Desc: "set to restrict to users you've chatted with (opt-in filter)"},
-		{Name: "exclude-outer-contact", Type: "bool", Desc: "set to exclude outer contacts and only return same-tenant users (opt-in filter)"},
-		{Name: "has-enterprise-email", Type: "bool", Desc: "set to restrict to users with enterprise email (opt-in filter)"},
-		{Name: "lang", Desc: "override locale for the picked name (e.g. zh_cn, en_us, ja_jp); default: tenant brand"},
-		{Name: "page-size", Default: "20", Desc: "page size, 1-30 (default 20)"},
-		{Name: "page-all", Type: "bool", Desc: "auto-paginate results until has_more=false or --page-limit reached"},
-		{Name: "page-limit", Type: "int", Default: "20", Desc: "max pages fetched when auto-paginating (default 20, max 40; passing this flag alone implicitly enables --page-all)"},
+		{Name: "query", Desc: "search keyword (≤ 64 runes)"},
+		{Name: "user-ids", Desc: "open_ids to look up or restrict --query against (CSV; me = caller; ≤ 100)"},
+		{Name: "has-chatted", Type: "bool", Desc: "restrict to users you've chatted with (omit to disable; =false rejected)"},
+		{Name: "has-enterprise-email", Type: "bool", Desc: "restrict to users with enterprise email (omit to disable; =false rejected)"},
+		{Name: "exclude-external-users", Type: "bool", Desc: "exclude external (cross-tenant) users; default includes them (omit to disable; =false rejected)"},
+		{Name: "left-organization", Type: "bool", Desc: "restrict to users who have left the organization (omit to disable; =false rejected)"},
+		{Name: "lang", Desc: "override locale for localized_name (e.g. zh_cn, en_us)"},
+		{Name: "page-size", Type: "int", Default: "20", Desc: "rows per request, 1-30"},
+	},
+	Tips: []string{
+		"Keyword search: lark-cli contact +search-user --query 'alice' --format json",
+		"Look up by ID (or 'me' for self): lark-cli contact +search-user --user-ids 'ou_xxx,me' --format json",
+		"Filter-only enumeration — users you've chatted with: lark-cli contact +search-user --has-chatted --format json",
+		"Refine same-name hits: lark-cli contact +search-user --query '张三' --has-chatted --exclude-external-users",
+		"open_id is the stable identifier for follow-up commands; on has_more=true add filters or tighten --query — there is no auto-pagination.",
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		return validateSearchUser(runtime)
@@ -82,154 +168,120 @@ var ContactSearchUser = common.Shortcut{
 		}
 		return common.NewDryRunAPI().
 			POST(searchUserURL).
-			Params(buildSearchUserParams(runtime)).
+			Params(map[string]interface{}{"page_size": runtime.Int("page-size")}).
 			Body(body)
 	},
-	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		body, err := buildSearchUserBody(runtime)
-		if err != nil {
-			return err
-		}
-		autoPaginate, pageLimit := searchUserPaginationConfig(runtime)
-
-		var (
-			// Initialized as non-nil so empty result sets serialize as [] (not null).
-			allUsers         = make([]map[string]interface{}, 0)
-			lastHasMore      bool
-			lastPageToken    string
-			truncatedByLimit bool
-			pageCount        int
-		)
-		lang := runtime.Str("lang")
-		brand := runtime.Config.Brand
-		params := buildSearchUserParams(runtime)
-
-		for {
-			pageCount++
-			data, err := runtime.CallAPI("POST", searchUserURL, params, body)
-			if err != nil {
-				return err
-			}
-			users, hasMore, pageToken := extractSearchUsers(data, lang, brand)
-			allUsers = append(allUsers, users...)
-			lastHasMore = hasMore
-			lastPageToken = pageToken
-
-			if !autoPaginate || !hasMore || pageCount >= pageLimit {
-				if autoPaginate && hasMore && pageCount >= pageLimit {
-					truncatedByLimit = true
-				}
-				break
-			}
-			// Prepare params for the next iteration with the fresh page_token.
-			nextParams := make(map[string]interface{}, len(params)+1)
-			for k, v := range params {
-				nextParams[k] = v
-			}
-			nextParams["page_token"] = pageToken
-			params = nextParams
-		}
-
-		outData := map[string]interface{}{
-			"users":      allUsers,
-			"has_more":   lastHasMore,
-			"page_token": lastPageToken,
-		}
-		runtime.OutFormat(outData, &output.Meta{Count: len(allUsers)}, func(w io.Writer) {
-			if len(allUsers) == 0 {
-				fmt.Fprintln(w, "No users found.")
-				return
-			}
-			output.PrintTable(w, prettyUserRows(allUsers))
-		})
-		if lastHasMore && isHumanReadableFormat(runtime.Format) {
-			// Hints go to stderr so stdout stays clean for the actual table
-			// output, matching the CLI convention used elsewhere by the runner
-			// for warnings and informational messages.
-			if truncatedByLimit {
-				fmt.Fprintf(runtime.IO().ErrOut,
-					"\nwarning: stopped after fetching %d page(s); refine the query with more filters, or raise --page-limit (max %d)\n",
-					pageCount, maxSearchUserPageLimit)
-			} else {
-				fmt.Fprintf(runtime.IO().ErrOut,
-					"\n(more available; refine the query or use --page-all to auto-paginate)\n")
-			}
-		}
-		return nil
-	},
+	Execute: executeSearchUser,
 }
 
-// isHumanReadableFormat reports whether the given output format is meant for
-// human reading (so a "(more available, ...)" hint can be appended without
-// corrupting structured output streams like ndjson or csv).
+func executeSearchUser(ctx context.Context, runtime *common.RuntimeContext) error {
+	body, err := buildSearchUserBody(runtime)
+	if err != nil {
+		return err
+	}
+
+	apiResp, err := runtime.DoAPI(&larkcore.ApiReq{
+		HttpMethod:  http.MethodPost,
+		ApiPath:     searchUserURL,
+		Body:        body,
+		QueryParams: larkcore.QueryParams{"page_size": []string{strconv.Itoa(runtime.Int("page-size"))}},
+	})
+	if err != nil {
+		return err
+	}
+	if apiResp.StatusCode != http.StatusOK {
+		return output.ErrAPI(apiResp.StatusCode, http.StatusText(apiResp.StatusCode), string(apiResp.RawBody))
+	}
+
+	var resp searchUserAPIEnvelope
+	if err := json.Unmarshal(apiResp.RawBody, &resp); err != nil {
+		return output.ErrWithHint(output.ExitInternal, "validation", "unmarshal response failed", err.Error())
+	}
+	if resp.Code != 0 {
+		return output.ErrAPI(resp.Code, resp.Msg, string(apiResp.RawBody))
+	}
+
+	users, hasMore := projectUsers(resp.Data, runtime.Str("lang"), runtime.Config.Brand)
+	out := searchUserResponse{Users: users, HasMore: hasMore}
+
+	runtime.OutFormat(out, &output.Meta{Count: len(users)}, func(w io.Writer) {
+		if len(users) == 0 {
+			fmt.Fprintln(w, "No users found.")
+			return
+		}
+		output.PrintTable(w, prettyUserRows(users))
+	})
+	if hasMore && isHumanReadableFormat(runtime.Format) {
+		fmt.Fprintln(runtime.IO().ErrOut,
+			"\nhint: more matches exist; refine the query (e.g., add --has-chatted, a full email, or a department keyword)")
+	}
+	return nil
+}
+
 func isHumanReadableFormat(format string) bool {
 	return format == "pretty" || format == "table"
 }
 
-// searchUserPaginationConfig resolves the (autoPaginate, pageLimit) tuple from
-// user flags. Rules (mirroring shortcuts/im/im_messages_search.go for
-// consistency across search-type shortcuts):
-//   - --page-all alone                   → auto-paginate, pageLimit = max (40)
-//   - --page-limit N alone               → auto-paginate, pageLimit = N  (implicit enable)
-//   - --page-all + --page-limit N        → auto-paginate, pageLimit = N
-//   - neither                            → single-page (manual pagination)
-func searchUserPaginationConfig(runtime *common.RuntimeContext) (autoPaginate bool, pageLimit int) {
-	autoPaginate = runtime.Bool("page-all")
-	if runtime.Cmd != nil && runtime.Cmd.Flags().Changed("page-limit") {
-		autoPaginate = true
+// We deliberately do not surface a numeric rank: the API returns no relevance
+// score, and a derived ordinal would tempt agents to over-trust it.
+func projectUsers(data *searchUserAPIData, lang string, brand core.LarkBrand) ([]searchUser, bool) {
+	if data == nil {
+		return []searchUser{}, false
 	}
-	pageLimit = defaultSearchUserPageLimit
-	if runtime.Cmd != nil && runtime.Cmd.Flags().Changed("page-limit") {
-		pageLimit = runtime.Int("page-limit")
-		if pageLimit > maxSearchUserPageLimit {
-			pageLimit = maxSearchUserPageLimit
+	users := make([]searchUser, 0, len(data.Items))
+	for i := range data.Items {
+		users = append(users, rowFromItem(&data.Items[i], lang, brand))
+	}
+	return users, data.HasMore
+}
+
+func parseDisplayInfo(raw string) (segments []string, department, recencyHint string) {
+	segments = make([]string, 0)
+	if raw == "" {
+		return segments, "", ""
+	}
+	for _, m := range displayInfoHighlightRE.FindAllStringSubmatch(raw, -1) {
+		segments = append(segments, m[1])
+	}
+	lines := strings.Split(raw, "\n")
+	if len(lines) >= 2 {
+		department = strings.TrimSpace(lines[1])
+	}
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
 		}
-	} else if runtime.Bool("page-all") {
-		pageLimit = maxSearchUserPageLimit
+		if m := displayInfoRecencyRE.FindStringSubmatch(line); m != nil {
+			recencyHint = m[1]
+		}
+		break
 	}
-	return autoPaginate, pageLimit
+	return segments, department, recencyHint
 }
 
-// extractSearchUsers projects the API response into the shortcut's user
-// objects and surfaces pagination metadata.
-func extractSearchUsers(data map[string]interface{}, lang string, brand core.LarkBrand) ([]map[string]interface{}, bool, string) {
-	items := common.GetSlice(data, "items")
-	users := make([]map[string]interface{}, 0, len(items))
-	common.EachMap(items, func(item map[string]interface{}) {
-		users = append(users, rowFromItem(item, lang, brand))
-	})
-	return users, common.GetBool(data, "has_more"), common.GetString(data, "page_token")
-}
-
-// prettyUserRows projects the 12-field user objects down to the 6 pretty
-// table columns, with display_info truncated and its newlines flattened.
-func prettyUserRows(users []map[string]interface{}) []map[string]interface{} {
+// map[] shape forced by output.PrintTable; this is the only map conversion in
+// this file.
+func prettyUserRows(users []searchUser) []map[string]interface{} {
 	rows := make([]map[string]interface{}, 0, len(users))
 	for _, u := range users {
-		di := common.GetString(u, "display_info")
 		rows = append(rows, map[string]interface{}{
-			"display_info":  common.TruncateStr(strings.ReplaceAll(di, "\n", " "), 60),
-			"name":          u["name"],
-			"open_id":       u["open_id"],
-			"email":         u["email"],
-			"is_registered": u["is_registered"],
-			"has_chatted":   u["has_chatted"],
+			"localized_name":    u.LocalizedName,
+			"department":        common.TruncateStr(u.Department, 50),
+			"enterprise_email":  u.EnterpriseEmail,
+			"has_chatted":       u.HasChatted,
+			"chat_recency_hint": u.ChatRecencyHint,
+			"open_id":           u.OpenID,
 		})
 	}
 	return rows
 }
 
-// pickName returns a single display name from meta.i18n_names, deterministically.
-// Priority: explicit --lang, then brand-preferred locales (feishu → zh_cn first,
-// lark → en_us first), then fixedLocaleFallback order, then the dictionary-order
-// sweep that tolerates locales not in the fixed list, and finally the
-// caller-provided openID.
-//
-// It does NOT fall back to display_info — the hit-highlight segment there may
-// be a phone number or email, not a name.
-func pickName(meta map[string]interface{}, lang string, brand core.LarkBrand, openID string) string {
-	i18n := common.GetMap(meta, "i18n_names")
-
+// Priority: explicit --lang → brand-preferred locales (feishu→zh_cn first,
+// lark→en_us first) → fixedLocaleFallback → dictionary order → openID.
+// Does NOT fall back to display_info, which may contain phone/email instead
+// of a name.
+func pickName(i18n map[string]string, lang string, brand core.LarkBrand, openID string) string {
 	primary := make([]string, 0, 3)
 	if lang != "" {
 		primary = append(primary, strings.ReplaceAll(strings.ToLower(lang), "-", "_"))
@@ -237,17 +289,17 @@ func pickName(meta map[string]interface{}, lang string, brand core.LarkBrand, op
 	switch brand {
 	case core.BrandLark:
 		primary = append(primary, "en_us", "zh_cn")
-	default: // feishu or unknown brand: Chinese first
+	default:
 		primary = append(primary, "zh_cn", "en_us")
 	}
 
 	for _, loc := range primary {
-		if v := common.GetString(i18n, loc); v != "" {
+		if v := i18n[loc]; v != "" {
 			return v
 		}
 	}
 	for _, loc := range fixedLocaleFallback {
-		if v := common.GetString(i18n, loc); v != "" {
+		if v := i18n[loc]; v != "" {
 			return v
 		}
 	}
@@ -258,7 +310,7 @@ func pickName(meta map[string]interface{}, lang string, brand core.LarkBrand, op
 		}
 		sort.Strings(keys)
 		for _, k := range keys {
-			if v := common.GetString(i18n, k); v != "" {
+			if v := i18n[k]; v != "" {
 				return v
 			}
 		}
@@ -266,44 +318,42 @@ func pickName(meta map[string]interface{}, lang string, brand core.LarkBrand, op
 	return openID
 }
 
-// rowFromItem projects a single items[i] from the API response into the
-// 12-field user shape. Cross-tenant users may have missing email / department
-// fields; those pass through as empty string / nil rather than defaults so
-// consumers can distinguish "unknown" from "confirmed absent".
-func rowFromItem(item map[string]interface{}, lang string, brand core.LarkBrand) map[string]interface{} {
-	openID := common.GetString(item, "id")
-	meta := common.GetMap(item, "meta_data")
-	chatID := common.GetString(meta, "chat_id")
+// Cross-tenant users may have empty email / department; pass through as empty
+// string so consumers can distinguish "unknown" from "confirmed absent".
+func rowFromItem(item *searchUserAPIItem, lang string, brand core.LarkBrand) searchUser {
+	meta := &item.MetaData
+	i18n := meta.I18nNames
+	if i18n == nil {
+		i18n = map[string]string{}
+	}
+	segments, department, recencyHint := parseDisplayInfo(item.DisplayInfo)
 
-	return map[string]interface{}{
-		"name":             pickName(meta, lang, brand, openID),
-		"open_id":          openID,
-		"i18n_names":       common.GetMap(meta, "i18n_names"),
-		"email":            common.GetString(meta, "mail_address"),
-		"enterprise_email": common.GetString(meta, "enterprise_mail_address"),
-		"is_registered":    common.GetBool(meta, "is_registered"),
-		"chat_id":          chatID,
-		"has_chatted":      chatID != "",
-		"is_cross_tenant":  common.GetBool(meta, "is_cross_tenant"),
-		"tenant_id":        common.GetString(meta, "tenant_id"),
-		"description":      common.GetString(meta, "description"),
-		"display_info":     common.GetString(item, "display_info"),
+	return searchUser{
+		OpenID:          item.ID,
+		LocalizedName:   pickName(i18n, lang, brand, item.ID),
+		Email:           meta.MailAddress,
+		EnterpriseEmail: meta.EnterpriseMailAddress,
+		IsActivated:     meta.IsRegistered,
+		IsCrossTenant:   meta.IsCrossTenant,
+		P2PChatID:       meta.ChatID,
+		HasChatted:      meta.ChatID != "",
+		Department:      department,
+		Signature:       meta.Description,
+		ChatRecencyHint: recencyHint,
+		MatchSegments:   segments,
 	}
 }
 
-// validateSearchUser enforces the input contract: at least one search input
-// (query or filter) must be provided — "empty search" is rejected because
-// the API owner flags it as unsupported in practice.
 func validateSearchUser(runtime *common.RuntimeContext) error {
 	if !hasAnySearchInput(runtime) {
 		return common.FlagErrorf(
-			"specify at least one of --query, --user-ids, --is-resigned, --has-chatted, --exclude-outer-contact, --has-enterprise-email",
+			"specify at least one of --query, --user-ids, --has-chatted, --has-enterprise-email, --exclude-external-users, --left-organization",
 		)
 	}
 
 	if q := strings.TrimSpace(runtime.Str("query")); q != "" {
 		if utf8.RuneCountInString(q) > maxSearchUserQueryRunes {
-			return common.FlagErrorf("--query: length must be between 1 and %d characters", maxSearchUserQueryRunes)
+			return common.FlagErrorf("--query: length must be between 1 and %d runes", maxSearchUserQueryRunes)
 		}
 	}
 
@@ -322,21 +372,26 @@ func validateSearchUser(runtime *common.RuntimeContext) error {
 		}
 	}
 
-	if _, err := common.ValidatePageSize(runtime, "page-size", defaultSearchUserPageSize, 1, maxSearchUserPageSize); err != nil {
-		return err
-	}
-	if runtime.Cmd != nil && runtime.Cmd.Flags().Changed("page-limit") {
-		if n := runtime.Int("page-limit"); n < 1 || n > maxSearchUserPageLimit {
-			return common.FlagErrorf("--page-limit: must be an integer between 1 and %d", maxSearchUserPageLimit)
+	// Reject explicit =false: agents passing it almost always mean "do not
+	// filter", but the API treats it as "must NOT match". Hard error prevents
+	// silent wrong-result bugs.
+	for _, bf := range searchUserBoolFilters {
+		if runtime.Cmd.Flags().Changed(bf.Flag) && !runtime.Bool(bf.Flag) {
+			return common.FlagErrorf(
+				"--%s: pass the flag to enable the filter; omit it to disable filtering (=false is rejected to prevent silent wrong results)",
+				bf.Flag,
+			)
 		}
+	}
+
+	if n := runtime.Int("page-size"); n < 1 || n > maxSearchUserPageSize {
+		return common.FlagErrorf("--page-size: must be between 1 and %d", maxSearchUserPageSize)
 	}
 	return nil
 }
 
-// hasAnySearchInput reports whether the user supplied any of the six search
-// inputs. Cannot be replaced with common.AtLeastOne: that helper only
-// inspects string flags, whereas the bool filters need Changed() detection
-// to preserve tri-state semantics.
+// Cannot use common.AtLeastOne: it only inspects string flags; bool filters
+// need Changed() detection.
 func hasAnySearchInput(runtime *common.RuntimeContext) bool {
 	if strings.TrimSpace(runtime.Str("query")) != "" {
 		return true
@@ -352,17 +407,15 @@ func hasAnySearchInput(runtime *common.RuntimeContext) bool {
 	return false
 }
 
-// buildSearchUserBody constructs the POST body. Bool filters enter the body
-// only when the user explicitly set them (Changed()), preserving the
-// tri-state distinction between "unset" and "explicit false".
-func buildSearchUserBody(runtime *common.RuntimeContext) (map[string]interface{}, error) {
-	body := map[string]interface{}{}
+func buildSearchUserBody(runtime *common.RuntimeContext) (*searchUserAPIRequest, error) {
+	req := &searchUserAPIRequest{}
 
 	if q := strings.TrimSpace(runtime.Str("query")); q != "" {
-		body["query"] = q
+		req.Query = q
 	}
 
-	filter := map[string]interface{}{}
+	filter := &searchUserAPIFilter{}
+	hasFilter := false
 
 	if raw := strings.TrimSpace(runtime.Str("user-ids")); raw != "" {
 		ids, err := common.ResolveOpenIDs("--user-ids", common.SplitCSV(raw), runtime)
@@ -370,28 +423,20 @@ func buildSearchUserBody(runtime *common.RuntimeContext) (map[string]interface{}
 			return nil, err
 		}
 		if len(ids) > 0 {
-			filter["user_ids"] = ids
+			filter.UserIDs = ids
+			hasFilter = true
 		}
 	}
 
 	for _, bf := range searchUserBoolFilters {
-		if runtime.Cmd.Flags().Changed(bf.Flag) {
-			filter[bf.API] = runtime.Bool(bf.Flag)
+		if runtime.Cmd.Flags().Changed(bf.Flag) && runtime.Bool(bf.Flag) {
+			bf.Apply(filter)
+			hasFilter = true
 		}
 	}
 
-	if len(filter) > 0 {
-		body["filter"] = filter
+	if hasFilter {
+		req.Filter = filter
 	}
-	return body, nil
-}
-
-// buildSearchUserParams constructs the query-string params. page_size falls
-// back to the default when omitted. page_token is managed internally by the
-// Execute loop when auto-paginating, not exposed as a CLI flag.
-func buildSearchUserParams(runtime *common.RuntimeContext) map[string]interface{} {
-	params := map[string]interface{}{}
-	pageSize, _ := common.ValidatePageSize(runtime, "page-size", defaultSearchUserPageSize, 1, maxSearchUserPageSize)
-	params["page_size"] = pageSize
-	return params
+	return req, nil
 }

--- a/shortcuts/contact/contact_search_user.go
+++ b/shortcuts/contact/contact_search_user.go
@@ -24,7 +24,7 @@ import (
 const (
 	searchUserURL = "/open-apis/contact/v3/users/search"
 
-	maxSearchUserQueryRunes = 64
+	maxSearchUserQueryChars = 50
 	maxSearchUserUserIDs    = 100
 	maxSearchUserPageSize   = 30
 )
@@ -142,7 +142,7 @@ var ContactSearchUser = common.Shortcut{
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{
-		{Name: "query", Desc: "search keyword (≤ 64 runes)"},
+		{Name: "query", Desc: "search keyword (≤ 50 characters)"},
 		{Name: "user-ids", Desc: "open_ids to look up or restrict --query against (CSV; me = caller; ≤ 100)"},
 		{Name: "has-chatted", Type: "bool", Desc: "restrict to users you've chatted with (omit to disable; =false rejected)"},
 		{Name: "has-enterprise-email", Type: "bool", Desc: "restrict to users with enterprise email (omit to disable; =false rejected)"},
@@ -352,8 +352,8 @@ func validateSearchUser(runtime *common.RuntimeContext) error {
 	}
 
 	if q := strings.TrimSpace(runtime.Str("query")); q != "" {
-		if utf8.RuneCountInString(q) > maxSearchUserQueryRunes {
-			return common.FlagErrorf("--query: length must be between 1 and %d runes", maxSearchUserQueryRunes)
+		if utf8.RuneCountInString(q) > maxSearchUserQueryChars {
+			return common.FlagErrorf("--query: length must be between 1 and %d characters", maxSearchUserQueryChars)
 		}
 	}
 
@@ -361,6 +361,9 @@ func validateSearchUser(runtime *common.RuntimeContext) error {
 		ids, err := common.ResolveOpenIDs("--user-ids", common.SplitCSV(raw), runtime)
 		if err != nil {
 			return err
+		}
+		if len(ids) == 0 {
+			return common.FlagErrorf("--user-ids: no valid open_id parsed from %q (separate entries with ',')", raw)
 		}
 		if len(ids) > maxSearchUserUserIDs {
 			return common.FlagErrorf("--user-ids: must be at most %d entries", maxSearchUserUserIDs)

--- a/shortcuts/contact/contact_search_user_test.go
+++ b/shortcuts/contact/contact_search_user_test.go
@@ -22,14 +22,12 @@ func newSearchUserTestCommand() *cobra.Command {
 	cmd := &cobra.Command{Use: "test"}
 	cmd.Flags().String("query", "", "")
 	cmd.Flags().String("user-ids", "", "")
-	cmd.Flags().Bool("is-resigned", false, "")
+	cmd.Flags().Bool("left-organization", false, "")
 	cmd.Flags().Bool("has-chatted", false, "")
-	cmd.Flags().Bool("exclude-outer-contact", false, "")
+	cmd.Flags().Bool("exclude-external-users", false, "")
 	cmd.Flags().Bool("has-enterprise-email", false, "")
 	cmd.Flags().String("lang", "", "")
-	cmd.Flags().String("page-size", "20", "")
-	cmd.Flags().Bool("page-all", false, "")
-	cmd.Flags().Int("page-limit", 20, "")
+	cmd.Flags().Int("page-size", 20, "")
 	return cmd
 }
 
@@ -41,162 +39,212 @@ func searchUserDefaultConfig() *core.CliConfig {
 }
 
 func TestPickName_ExplicitLang_Hit(t *testing.T) {
-	meta := map[string]interface{}{
-		"i18n_names": map[string]interface{}{"zh_cn": "张三", "en_us": "Zhangsan"},
-	}
-	got := pickName(meta, "en-US", core.BrandFeishu, "ou_x")
+	i18n := map[string]string{"zh_cn": "张三", "en_us": "Zhangsan"}
+	got := pickName(i18n, "en-US", core.BrandFeishu, "ou_x")
 	if got != "Zhangsan" {
 		t.Errorf("got %q, want Zhangsan", got)
 	}
 }
 
 func TestPickName_ExplicitLang_MissFallsToBrand(t *testing.T) {
-	meta := map[string]interface{}{
-		"i18n_names": map[string]interface{}{"zh_cn": "张三"},
-	}
-	got := pickName(meta, "ja-JP", core.BrandFeishu, "ou_x")
+	i18n := map[string]string{"zh_cn": "张三"}
+	got := pickName(i18n, "ja-JP", core.BrandFeishu, "ou_x")
 	if got != "张三" {
 		t.Errorf("got %q, want 张三 (brand fallback)", got)
 	}
 }
 
 func TestPickName_BrandFeishu_PicksZh(t *testing.T) {
-	meta := map[string]interface{}{
-		"i18n_names": map[string]interface{}{"zh_cn": "张三", "en_us": "Zhangsan"},
-	}
-	got := pickName(meta, "", core.BrandFeishu, "ou_x")
+	i18n := map[string]string{"zh_cn": "张三", "en_us": "Zhangsan"}
+	got := pickName(i18n, "", core.BrandFeishu, "ou_x")
 	if got != "张三" {
 		t.Errorf("got %q, want 张三", got)
 	}
 }
 
 func TestPickName_BrandLark_PicksEn(t *testing.T) {
-	meta := map[string]interface{}{
-		"i18n_names": map[string]interface{}{"zh_cn": "张三", "en_us": "Zhangsan"},
-	}
-	got := pickName(meta, "", core.BrandLark, "ou_x")
+	i18n := map[string]string{"zh_cn": "张三", "en_us": "Zhangsan"}
+	got := pickName(i18n, "", core.BrandLark, "ou_x")
 	if got != "Zhangsan" {
 		t.Errorf("got %q, want Zhangsan", got)
 	}
 }
 
 func TestPickName_FixedLocaleList_HitJaJp(t *testing.T) {
-	meta := map[string]interface{}{
-		"i18n_names": map[string]interface{}{"ja_jp": "Yamada"},
-	}
-	got := pickName(meta, "", core.BrandFeishu, "ou_x")
+	i18n := map[string]string{"ja_jp": "Yamada"}
+	got := pickName(i18n, "", core.BrandFeishu, "ou_x")
 	if got != "Yamada" {
 		t.Errorf("got %q, want Yamada (fixed locale list fallback)", got)
 	}
 }
 
 func TestPickName_DictOrderFallback(t *testing.T) {
-	meta := map[string]interface{}{
-		"i18n_names": map[string]interface{}{"xx_yy": "Foo", "aa_bb": "Bar"},
-	}
-	got := pickName(meta, "", core.BrandFeishu, "ou_x")
+	i18n := map[string]string{"xx_yy": "Foo", "aa_bb": "Bar"}
+	got := pickName(i18n, "", core.BrandFeishu, "ou_x")
 	if got != "Bar" {
 		t.Errorf("got %q, want Bar (alphabetical tie-break, first non-empty is 'aa_bb')", got)
 	}
 }
 
 func TestPickName_AllEmpty_FallsToOpenID(t *testing.T) {
-	got := pickName(map[string]interface{}{}, "", core.BrandFeishu, "ou_x")
+	got := pickName(map[string]string{}, "", core.BrandFeishu, "ou_x")
 	if got != "ou_x" {
 		t.Errorf("got %q, want ou_x", got)
 	}
 }
 
 func TestPickName_Determinism(t *testing.T) {
-	meta := map[string]interface{}{
-		"i18n_names": map[string]interface{}{
-			"xx_yy": "Foo", "aa_bb": "Bar", "mm_nn": "Baz",
-		},
-	}
-	first := pickName(meta, "", core.BrandFeishu, "ou_x")
+	i18n := map[string]string{"xx_yy": "Foo", "aa_bb": "Bar", "mm_nn": "Baz"}
+	first := pickName(i18n, "", core.BrandFeishu, "ou_x")
 	for i := 0; i < 50; i++ {
-		got := pickName(meta, "", core.BrandFeishu, "ou_x")
+		got := pickName(i18n, "", core.BrandFeishu, "ou_x")
 		if got != first {
 			t.Fatalf("non-deterministic: iter %d got %q, expected %q (map iteration leaked)", i, got, first)
 		}
 	}
 }
 
+func TestParseDisplayInfo_FullShape(t *testing.T) {
+	raw := "<h>李海峰</h>\nLark Office Engineering-Intelligence-Search\n\n[Contacted 2 days ago]"
+	segments, dept, recency := parseDisplayInfo(raw)
+	if len(segments) != 1 || segments[0] != "李海峰" {
+		t.Errorf("segments: got %v, want [李海峰]", segments)
+	}
+	if dept != "Lark Office Engineering-Intelligence-Search" {
+		t.Errorf("department: got %q", dept)
+	}
+	if recency != "Contacted 2 days ago" {
+		t.Errorf("chat_recency_hint: got %q", recency)
+	}
+}
+
+func TestParseDisplayInfo_NoRecency(t *testing.T) {
+	raw := "<h>张三</h>\nMarketing\n"
+	segments, dept, recency := parseDisplayInfo(raw)
+	if len(segments) != 1 || segments[0] != "张三" {
+		t.Errorf("segments: got %v", segments)
+	}
+	if dept != "Marketing" {
+		t.Errorf("department: got %q, want Marketing", dept)
+	}
+	if recency != "" {
+		t.Errorf("chat_recency_hint: got %q, want empty", recency)
+	}
+}
+
+func TestParseDisplayInfo_EmptyDept(t *testing.T) {
+	raw := "<h>李海峰</h>\n\n"
+	segments, dept, recency := parseDisplayInfo(raw)
+	if len(segments) != 1 || segments[0] != "李海峰" {
+		t.Errorf("segments: got %v", segments)
+	}
+	if dept != "" {
+		t.Errorf("department: got %q, want empty", dept)
+	}
+	if recency != "" {
+		t.Errorf("chat_recency_hint: got %q, want empty", recency)
+	}
+}
+
+func TestParseDisplayInfo_MultipleHighlights(t *testing.T) {
+	raw := "<h>ali</h>ce <h>wang</h>\nEng\n"
+	segments, _, _ := parseDisplayInfo(raw)
+	if len(segments) != 2 || segments[0] != "ali" || segments[1] != "wang" {
+		t.Errorf("segments: got %v, want [ali wang]", segments)
+	}
+}
+
+func TestParseDisplayInfo_Empty(t *testing.T) {
+	segments, dept, recency := parseDisplayInfo("")
+	if segments == nil {
+		t.Errorf("segments: got nil, want empty (non-nil) slice")
+	}
+	if len(segments) != 0 {
+		t.Errorf("segments: got %v, want empty", segments)
+	}
+	if dept != "" || recency != "" {
+		t.Errorf("dept/recency: got %q / %q, want empty", dept, recency)
+	}
+}
+
 func TestRowFromItem_FullMapping(t *testing.T) {
-	item := map[string]interface{}{
-		"id": "ou_a",
-		"meta_data": map[string]interface{}{
-			"i18n_names":              map[string]interface{}{"zh_cn": "张三", "en_us": "Z"},
-			"mail_address":            "z@example.com",
-			"enterprise_mail_address": "z@corp.example.com",
-			"is_registered":           true,
-			"chat_id":                 "oc_abc",
-			"is_cross_tenant":         false,
-			"tenant_id":               "tenant_x",
-			"description":             "Director / Marketing",
+	item := &searchUserAPIItem{
+		ID:          "ou_a",
+		DisplayInfo: "<h>张三</h>\nMarketing\n\n[Contacted 2 days ago]",
+		MetaData: searchUserAPIMeta{
+			I18nNames:             map[string]string{"zh_cn": "张三", "en_us": "Z"},
+			MailAddress:           "z@example.com",
+			EnterpriseMailAddress: "z@corp.example.com",
+			IsRegistered:          true,
+			ChatID:                "oc_abc",
+			IsCrossTenant:         false,
+			Description:           "Coffee fanatic ☕",
 		},
-		"display_info": "<h>张三</h>\nMarketing\n\n[Contacted 2 days ago]",
 	}
 	got := rowFromItem(item, "", core.BrandFeishu)
 
-	checks := []struct {
-		key  string
-		want interface{}
-	}{
-		{"open_id", "ou_a"},
-		{"name", "张三"},
-		{"email", "z@example.com"},
-		{"enterprise_email", "z@corp.example.com"},
-		{"is_registered", true},
-		{"chat_id", "oc_abc"},
-		{"has_chatted", true},
-		{"is_cross_tenant", false},
-		{"tenant_id", "tenant_x"},
-		{"description", "Director / Marketing"},
-		{"display_info", "<h>张三</h>\nMarketing\n\n[Contacted 2 days ago]"},
+	if got.OpenID != "ou_a" {
+		t.Errorf("OpenID: got %q, want ou_a", got.OpenID)
 	}
-	for _, c := range checks {
-		if got[c.key] != c.want {
-			t.Errorf("key %q: got %v, want %v", c.key, got[c.key], c.want)
-		}
+	if got.LocalizedName != "张三" {
+		t.Errorf("LocalizedName: got %q, want 张三", got.LocalizedName)
 	}
-	i18n, ok := got["i18n_names"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("i18n_names: expected map, got %T", got["i18n_names"])
+	if got.Email != "z@example.com" {
+		t.Errorf("Email: got %q", got.Email)
 	}
-	if i18n["zh_cn"] != "张三" || i18n["en_us"] != "Z" {
-		t.Errorf("i18n_names content: got %v", i18n)
+	if got.EnterpriseEmail != "z@corp.example.com" {
+		t.Errorf("EnterpriseEmail: got %q", got.EnterpriseEmail)
+	}
+	if !got.IsActivated {
+		t.Errorf("IsActivated: got false, want true")
+	}
+	if got.P2PChatID != "oc_abc" {
+		t.Errorf("P2PChatID: got %q", got.P2PChatID)
+	}
+	if !got.HasChatted {
+		t.Errorf("HasChatted: got false, want true")
+	}
+	if got.IsCrossTenant {
+		t.Errorf("IsCrossTenant: got true, want false")
+	}
+	if got.Department != "Marketing" {
+		t.Errorf("Department: got %q", got.Department)
+	}
+	if got.Signature != "Coffee fanatic ☕" {
+		t.Errorf("Signature: got %q (must come from meta.description)", got.Signature)
+	}
+	if got.ChatRecencyHint != "Contacted 2 days ago" {
+		t.Errorf("ChatRecencyHint: got %q", got.ChatRecencyHint)
+	}
+	if len(got.MatchSegments) != 1 || got.MatchSegments[0] != "张三" {
+		t.Errorf("MatchSegments: got %v", got.MatchSegments)
 	}
 }
 
 func TestRowFromItem_HasChattedFalseWhenChatIDEmpty(t *testing.T) {
-	item := map[string]interface{}{
-		"id":        "ou_a",
-		"meta_data": map[string]interface{}{},
-	}
+	item := &searchUserAPIItem{ID: "ou_a"}
 	got := rowFromItem(item, "", core.BrandFeishu)
-	if got["has_chatted"] != false {
-		t.Errorf("has_chatted: got %v, want false", got["has_chatted"])
+	if got.HasChatted {
+		t.Errorf("HasChatted: got true, want false")
 	}
-	if got["chat_id"] != "" {
-		t.Errorf("chat_id: got %q, want empty string", got["chat_id"])
+	if got.P2PChatID != "" {
+		t.Errorf("P2PChatID: got %q, want empty", got.P2PChatID)
 	}
 }
 
 func TestRowFromItem_CrossTenantEmptyEmailNoPanic(t *testing.T) {
-	item := map[string]interface{}{
-		"id": "ou_outer",
-		"meta_data": map[string]interface{}{
-			"is_cross_tenant": true,
-			"tenant_id":       "other_tenant",
+	item := &searchUserAPIItem{
+		ID: "ou_outer",
+		MetaData: searchUserAPIMeta{
+			IsCrossTenant: true,
 		},
 	}
 	got := rowFromItem(item, "", core.BrandFeishu)
-	if got["email"] != "" {
-		t.Errorf("email: expected empty, got %q", got["email"])
+	if got.Email != "" {
+		t.Errorf("Email: expected empty, got %q", got.Email)
 	}
-	if got["enterprise_email"] != "" {
-		t.Errorf("enterprise_email: expected empty, got %q", got["enterprise_email"])
+	if got.EnterpriseEmail != "" {
+		t.Errorf("EnterpriseEmail: expected empty, got %q", got.EnterpriseEmail)
 	}
 }
 
@@ -206,6 +254,12 @@ func TestValidateSearchUser_AllEmpty_Errors(t *testing.T) {
 	err := validateSearchUser(rt)
 	if err == nil || !strings.Contains(err.Error(), "specify at least one of") {
 		t.Fatalf("expected AtLeastOne error, got %v", err)
+	}
+	// Error message must list the new flag names so agents see the right hints.
+	for _, want := range []string{"--query", "--user-ids", "--has-chatted", "--exclude-external-users", "--left-organization"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message missing %q; got %v", want, err)
+		}
 	}
 }
 
@@ -286,6 +340,28 @@ func TestValidateSearchUser_MeWithoutLogin_Errors(t *testing.T) {
 	}
 }
 
+// =false on any bool filter must fail validation. Agents passing =false almost
+// always mean "do not filter", but the API treats it as "must NOT match";
+// silent acceptance produces wrong results. Hard reject up front.
+func TestValidateSearchUser_BoolFalse_Rejected(t *testing.T) {
+	cases := []string{"has-chatted", "has-enterprise-email", "exclude-external-users", "left-organization"}
+	for _, flag := range cases {
+		t.Run(flag, func(t *testing.T) {
+			cmd := newSearchUserTestCommand()
+			_ = cmd.Flags().Set("query", "x")
+			_ = cmd.Flags().Set(flag, "false")
+			rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+			err := validateSearchUser(rt)
+			if err == nil || !strings.Contains(err.Error(), "--"+flag) {
+				t.Fatalf("expected rejection mentioning --%s, got %v", flag, err)
+			}
+			if !strings.Contains(err.Error(), "=false is rejected") {
+				t.Errorf("error should explain why =false is rejected; got %v", err)
+			}
+		})
+	}
+}
+
 func TestBuildBody_QueryOnly(t *testing.T) {
 	cmd := newSearchUserTestCommand()
 	_ = cmd.Flags().Set("query", "hello")
@@ -294,51 +370,77 @@ func TestBuildBody_QueryOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if body["query"] != "hello" {
-		t.Errorf("query: got %v", body["query"])
+	if body.Query != "hello" {
+		t.Errorf("Query: got %q, want hello", body.Query)
 	}
-	if _, ok := body["filter"]; ok {
-		t.Errorf("filter: should not exist when no filter set, got %v", body["filter"])
+	if body.Filter != nil {
+		t.Errorf("Filter: should be nil when no filter set, got %+v", body.Filter)
 	}
 }
 
-func TestBuildBody_BoolTriState_NotSet_Omitted(t *testing.T) {
+func TestBuildBody_BoolNotSet_Omitted(t *testing.T) {
 	cmd := newSearchUserTestCommand()
 	_ = cmd.Flags().Set("query", "x")
 	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
 	body, _ := buildSearchUserBody(rt)
-	if _, ok := body["filter"]; ok {
-		t.Errorf("filter: should be omitted when no bool changed, got %v", body["filter"])
+	if body.Filter != nil {
+		t.Errorf("Filter: should be nil when no bool changed, got %+v", body.Filter)
 	}
 }
 
-func TestBuildBody_BoolTriState_True(t *testing.T) {
+func TestBuildBody_BoolTrue_MapsToAPI(t *testing.T) {
 	cmd := newSearchUserTestCommand()
 	_ = cmd.Flags().Set("query", "x")
 	_ = cmd.Flags().Set("has-chatted", "true")
 	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
 	body, _ := buildSearchUserBody(rt)
-	filter, ok := body["filter"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("filter: expected map, got %v", body["filter"])
+	if body.Filter == nil {
+		t.Fatalf("Filter: expected non-nil")
 	}
-	if filter["has_contact"] != true {
-		t.Errorf("filter.has_contact: got %v, want true", filter["has_contact"])
+	// Flag --has-chatted must map to API field has_contact (the rename
+	// rationale lives in searchUserBoolFilters).
+	if !body.Filter.HasContact {
+		t.Errorf("Filter.HasContact: got false, want true")
 	}
 }
 
-func TestBuildBody_BoolTriState_False(t *testing.T) {
+func TestBuildBody_BoolFalse_NotInBody(t *testing.T) {
+	// Validate rejects =false up front, but buildSearchUserBody must also
+	// defensively skip it (in case a code path bypasses Validate).
 	cmd := newSearchUserTestCommand()
 	_ = cmd.Flags().Set("query", "x")
 	_ = cmd.Flags().Set("has-chatted", "false")
 	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
 	body, _ := buildSearchUserBody(rt)
-	filter, ok := body["filter"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("filter: expected map, got %v", body["filter"])
+	if body.Filter != nil && body.Filter.HasContact {
+		t.Errorf("Filter.HasContact: must stay false when flag is =false")
 	}
-	if filter["has_contact"] != false {
-		t.Errorf("filter.has_contact: got %v, want false (distinct from omitted)", filter["has_contact"])
+}
+
+func TestBuildBody_RenamedFlagsMapToAPI(t *testing.T) {
+	// Each renamed CLI flag must still hit its original API field. Using a
+	// getter closure keeps the assertion compile-time typed against the
+	// searchUserAPIFilter struct.
+	cases := []struct {
+		flag string
+		get  func(*searchUserAPIFilter) bool
+	}{
+		{"has-chatted", func(f *searchUserAPIFilter) bool { return f.HasContact }},
+		{"exclude-external-users", func(f *searchUserAPIFilter) bool { return f.ExcludeOuterContact }},
+		{"left-organization", func(f *searchUserAPIFilter) bool { return f.IsResigned }},
+		{"has-enterprise-email", func(f *searchUserAPIFilter) bool { return f.HasEnterpriseEmail }},
+	}
+	for _, c := range cases {
+		t.Run(c.flag, func(t *testing.T) {
+			cmd := newSearchUserTestCommand()
+			_ = cmd.Flags().Set("query", "x")
+			_ = cmd.Flags().Set(c.flag, "true")
+			rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+			body, _ := buildSearchUserBody(rt)
+			if body.Filter == nil || !c.get(body.Filter) {
+				t.Errorf("--%s did not set the corresponding filter field; body.Filter=%+v", c.flag, body.Filter)
+			}
+		})
 	}
 }
 
@@ -347,90 +449,42 @@ func TestBuildBody_UserIDsResolveAndDedup(t *testing.T) {
 	_ = cmd.Flags().Set("user-ids", "me,ou_a,me,ou_a")
 	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
 	body, _ := buildSearchUserBody(rt)
-	filter, ok := body["filter"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("filter: expected map, got %v", body["filter"])
+	if body.Filter == nil {
+		t.Fatalf("Filter: expected non-nil")
 	}
-	ids, _ := filter["user_ids"].([]string)
+	ids := body.Filter.UserIDs
 	if len(ids) != 2 || ids[0] != "ou_self" || ids[1] != "ou_a" {
-		t.Errorf("user_ids: got %v, want [ou_self ou_a]", ids)
+		t.Errorf("UserIDs: got %v, want [ou_self ou_a]", ids)
 	}
 }
 
-func TestBuildParams_PageSize(t *testing.T) {
-	cmd := newSearchUserTestCommand()
-	_ = cmd.Flags().Set("query", "x")
-	_ = cmd.Flags().Set("page-size", "25")
-	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
-	params := buildSearchUserParams(rt)
-	if params["page_size"] != 25 {
-		t.Errorf("page_size: got %v, want 25", params["page_size"])
-	}
-	if _, ok := params["page_token"]; ok {
-		t.Errorf("page_token: should never appear in initial params (managed by the pagination loop)")
-	}
-}
-
-func TestBuildParams_DefaultPageSize(t *testing.T) {
-	cmd := newSearchUserTestCommand()
-	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
-	params := buildSearchUserParams(rt)
-	if params["page_size"] != 20 {
-		t.Errorf("page_size: got %v, want 20 (default)", params["page_size"])
+func TestValidateSearchUser_PageSizeOutOfRange_Errors(t *testing.T) {
+	for _, n := range []int{0, 31} {
+		cmd := newSearchUserTestCommand()
+		_ = cmd.Flags().Set("query", "x")
+		_ = cmd.Flags().Set("page-size", fmt.Sprintf("%d", n))
+		rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+		err := validateSearchUser(rt)
+		if err == nil || !strings.Contains(err.Error(), "page-size") {
+			t.Errorf("page-size=%d: expected range error, got %v", n, err)
+		}
 	}
 }
 
-func TestPaginationConfig_Defaults(t *testing.T) {
-	cmd := newSearchUserTestCommand()
-	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
-	auto, limit := searchUserPaginationConfig(rt)
-	if auto {
-		t.Errorf("autoPaginate: want false when no flags set, got true")
-	}
-	if limit != defaultSearchUserPageLimit {
-		t.Errorf("pageLimit: want %d default, got %d", defaultSearchUserPageLimit, limit)
-	}
-}
-
-func TestPaginationConfig_PageAllAloneUsesMax(t *testing.T) {
-	cmd := newSearchUserTestCommand()
-	_ = cmd.Flags().Set("page-all", "true")
-	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
-	auto, limit := searchUserPaginationConfig(rt)
-	if !auto {
-		t.Errorf("autoPaginate: want true, got false")
-	}
-	if limit != maxSearchUserPageLimit {
-		t.Errorf("pageLimit: --page-all alone should use max %d, got %d", maxSearchUserPageLimit, limit)
-	}
-}
-
-func TestPaginationConfig_PageLimitAloneImpliesAuto(t *testing.T) {
-	cmd := newSearchUserTestCommand()
-	_ = cmd.Flags().Set("page-limit", "5")
-	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
-	auto, limit := searchUserPaginationConfig(rt)
-	if !auto {
-		t.Errorf("autoPaginate: --page-limit alone should imply auto, got false")
-	}
-	if limit != 5 {
-		t.Errorf("pageLimit: got %d, want 5", limit)
-	}
-}
-
-func TestPaginationConfig_PageLimitCapsAtMax(t *testing.T) {
-	cmd := newSearchUserTestCommand()
-	_ = cmd.Flags().Set("page-limit", "999")
-	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
-	_, limit := searchUserPaginationConfig(rt)
-	if limit != maxSearchUserPageLimit {
-		t.Errorf("pageLimit: should cap at %d, got %d", maxSearchUserPageLimit, limit)
+func TestValidateSearchUser_PageSizeBoundaries_OK(t *testing.T) {
+	for _, n := range []int{1, 30} {
+		cmd := newSearchUserTestCommand()
+		_ = cmd.Flags().Set("query", "x")
+		_ = cmd.Flags().Set("page-size", fmt.Sprintf("%d", n))
+		rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+		if err := validateSearchUser(rt); err != nil {
+			t.Errorf("page-size=%d: unexpected error %v", n, err)
+		}
 	}
 }
 
 // mountAndRun mounts the shortcut under a parent cobra command and runs it
-// with the given args. Mirrors the pattern used in other shortcut packages
-// (e.g. minutes_download_test.go).
+// with the given args. Mirrors the pattern used in other shortcut packages.
 func mountAndRun(t *testing.T, s common.Shortcut, args []string, f *cmdutil.Factory, stdout *bytes.Buffer) error {
 	t.Helper()
 	parent := &cobra.Command{Use: "contact"}
@@ -460,10 +514,9 @@ func searchUserStub() *httpmock.Stub {
 							"is_registered":   true,
 							"chat_id":         "oc_abc",
 							"is_cross_tenant": false,
-							"tenant_id":       "tenant_1",
-							"description":     "Director",
+							"description":     "Coffee fanatic ☕",
 						},
-						"display_info": "<h>张三</h>\nMarketing",
+						"display_info": "<h>张三</h>\nMarketing\n\n[Contacted 2 days ago]",
 					},
 				},
 				"has_more":   false,
@@ -473,7 +526,7 @@ func searchUserStub() *httpmock.Stub {
 	}
 }
 
-func TestSearchUser_Integration_PrettyRendersAllColumns(t *testing.T) {
+func TestSearchUser_Integration_PrettyRendersExpectedColumns(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
 	reg.Register(searchUserStub())
 
@@ -482,21 +535,22 @@ func TestSearchUser_Integration_PrettyRendersAllColumns(t *testing.T) {
 		t.Fatalf("execute: %v", err)
 	}
 	out := stdout.String()
-	// internal/output sorts table columns alphabetically (house behavior shared
-	// with all PrintTable callers), so we assert presence of each pretty column
-	// rather than a specific layout.
-	for _, col := range []string{"display_info", "name", "open_id", "email", "is_registered", "has_chatted"} {
+	for _, col := range []string{"localized_name", "department", "open_id", "enterprise_email", "has_chatted", "chat_recency_hint"} {
 		if !strings.Contains(out, col) {
 			t.Errorf("pretty output missing column %q; got=%q", col, out)
 		}
 	}
-	// The hit-highlight payload should make it into the rendered cell.
-	if !strings.Contains(out, "<h>张三</h>") {
-		t.Errorf("expected display_info hit-highlight in output, got=%q", out)
+	// department is the disambiguation field — must reach the rendered cell.
+	if !strings.Contains(out, "Marketing") {
+		t.Errorf("expected department 'Marketing' in pretty output, got=%q", out)
+	}
+	// Legacy column must be gone.
+	if strings.Contains(out, "display_info ") || strings.Contains(out, "| display_info") {
+		t.Errorf("legacy 'display_info' column must not appear; got=%q", out)
 	}
 }
 
-func TestSearchUser_Integration_JSONFullFields(t *testing.T) {
+func TestSearchUser_Integration_JSONStructuredFields(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
 	reg.Register(searchUserStub())
 
@@ -509,7 +563,6 @@ func TestSearchUser_Integration_JSONFullFields(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("json: %v\noutput=%s", err, stdout.String())
 	}
-	// CLI wraps all structured output in an {ok, identity, data, meta} envelope.
 	data, ok := got["data"].(map[string]interface{})
 	if !ok {
 		t.Fatalf("envelope.data: expected object, got %v\nraw=%s", got["data"], stdout.String())
@@ -519,17 +572,40 @@ func TestSearchUser_Integration_JSONFullFields(t *testing.T) {
 		t.Fatalf("users: expected 1, got %d (output=%s)", len(users), stdout.String())
 	}
 	u, _ := users[0].(map[string]interface{})
+
+	// New schema keys must all be present.
 	for _, k := range []string{
-		"name", "open_id", "i18n_names", "email", "is_registered", "chat_id",
-		"has_chatted", "is_cross_tenant", "tenant_id", "description", "display_info",
+		"open_id", "localized_name", "email", "enterprise_email",
+		"is_activated", "is_cross_tenant",
+		"p2p_chat_id", "has_chatted",
+		"department", "signature", "chat_recency_hint", "match_segments",
 	} {
 		if _, ok := u[k]; !ok {
 			t.Errorf("missing JSON key %q in user object", k)
 		}
 	}
+	// Legacy keys must be gone.
+	for _, k := range []string{"name", "chat_id", "is_registered", "description", "display_info", "display_info_raw", "match_rank", "tenant_id", "i18n_names"} {
+		if _, ok := u[k]; ok {
+			t.Errorf("legacy JSON key %q must not appear", k)
+		}
+	}
+
+	// Spot-check a few values that prove structured parsing works end-to-end.
+	if u["department"] != "Marketing" {
+		t.Errorf("department: got %v, want Marketing", u["department"])
+	}
+	if u["chat_recency_hint"] != "Contacted 2 days ago" {
+		t.Errorf("chat_recency_hint: got %v", u["chat_recency_hint"])
+	}
+	// Signature must come through from raw meta.description, under the
+	// agent-friendly key "signature" (not "description").
+	if u["signature"] != "Coffee fanatic ☕" {
+		t.Errorf("signature: got %v, want %q", u["signature"], "Coffee fanatic ☕")
+	}
 }
 
-func TestSearchUser_Integration_NDJSONHasNoPaginationHint(t *testing.T) {
+func TestSearchUser_Integration_NDJSONHasNoRefineHint(t *testing.T) {
 	f, stdout, stderr, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "POST", URL: "/open-apis/contact/v3/users/search",
@@ -547,15 +623,15 @@ func TestSearchUser_Integration_NDJSONHasNoPaginationHint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if strings.Contains(stdout.String(), "more available") {
-		t.Errorf("ndjson stdout must not contain the pagination hint (would corrupt the stream); got=%q", stdout.String())
+	if strings.Contains(stdout.String(), "refine") {
+		t.Errorf("ndjson stdout must not contain the refine hint (would corrupt the stream); got=%q", stdout.String())
 	}
-	if strings.Contains(stderr.String(), "more available") {
-		t.Errorf("ndjson stderr must not contain the pagination hint either (non-human format opts out entirely); got=%q", stderr.String())
+	if strings.Contains(stderr.String(), "refine") {
+		t.Errorf("ndjson stderr must not contain the refine hint either (non-human format opts out entirely); got=%q", stderr.String())
 	}
 }
 
-func TestSearchUser_Integration_PrettyHintGoesToStderr(t *testing.T) {
+func TestSearchUser_Integration_PrettyRefineHintGoesToStderr(t *testing.T) {
 	f, stdout, stderr, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
 	reg.Register(&httpmock.Stub{
 		Method: "POST", URL: "/open-apis/contact/v3/users/search",
@@ -573,11 +649,16 @@ func TestSearchUser_Integration_PrettyHintGoesToStderr(t *testing.T) {
 	if err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if strings.Contains(stdout.String(), "more available") {
+	if strings.Contains(stdout.String(), "refine") {
 		t.Errorf("pretty stdout must not carry the hint (informational text belongs on stderr); got=%q", stdout.String())
 	}
-	if !strings.Contains(stderr.String(), "more available") || !strings.Contains(stderr.String(), "--page-all") {
-		t.Errorf("pretty stderr should guide the user toward --page-all when has_more=true; got=%q", stderr.String())
+	if !strings.Contains(stderr.String(), "refine") {
+		t.Errorf("pretty stderr should suggest refining the query when has_more=true; got=%q", stderr.String())
+	}
+	// The hint must explicitly NOT recommend pagination — by design there
+	// is no auto-pagination and agents must refine instead.
+	if strings.Contains(stderr.String(), "--page-all") || strings.Contains(stderr.String(), "auto-paginate") {
+		t.Errorf("hint must not mention pagination flags; got=%q", stderr.String())
 	}
 }
 
@@ -623,8 +704,6 @@ func TestSearchUser_Integration_EmptyResult_JSONArray(t *testing.T) {
 	if !ok {
 		t.Fatalf("envelope.data: expected object, got %v\nraw=%s", got["data"], stdout.String())
 	}
-	// Empty result must serialize as [] (not null) so jq consumers can iterate
-	// without special-casing: `jq '.data.users[]'` / `.data.users | length`.
 	usersRaw, exists := data["users"]
 	if !exists {
 		t.Fatalf("data.users key missing\nraw=%s", stdout.String())
@@ -692,90 +771,44 @@ func TestSearchUser_Integration_RequestShape(t *testing.T) {
 	}
 }
 
-func TestSearchUser_Integration_AutoPaginateAggregates(t *testing.T) {
+// Guards against the int/string flag mismatch: the stub URL match requires
+// page_size=25 to appear in the query string, which only happens if --page-size
+// actually reaches DoAPI's QueryParams. A regression that silently defaults
+// to 20 would fail the stub match.
+func TestSearchUser_Integration_PageSizeFlowsToQuery(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
-	// First page: has_more=true, token=p2
 	reg.Register(&httpmock.Stub{
-		Method: "POST", URL: "/open-apis/contact/v3/users/search",
+		Method: "POST",
+		URL:    "/open-apis/contact/v3/users/search?page_size=25",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "ok",
-			"data": map[string]interface{}{
-				"items":      []interface{}{map[string]interface{}{"id": "ou_a"}},
-				"has_more":   true,
-				"page_token": "p2",
-			},
-		},
-	})
-	// Second page: has_more=false, ends the loop
-	reg.Register(&httpmock.Stub{
-		Method: "POST", URL: "/open-apis/contact/v3/users/search",
-		Body: map[string]interface{}{
-			"code": 0, "msg": "ok",
-			"data": map[string]interface{}{
-				"items":      []interface{}{map[string]interface{}{"id": "ou_b"}},
-				"has_more":   false,
-				"page_token": "",
-			},
+			"data": map[string]interface{}{"items": []interface{}{}, "has_more": false, "page_token": ""},
 		},
 	})
 
-	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "x", "--page-all", "--format", "json", "--as", "user"}, f, stdout)
+	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "x", "--page-size", "25", "--as", "user"}, f, stdout)
 	if err != nil {
-		t.Fatalf("execute: %v", err)
+		t.Fatalf("execute: %v (likely page-size did not reach the request)", err)
 	}
-	reg.Verify(t) // ensures both stubs were consumed
-
-	var got map[string]interface{}
-	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
-		t.Fatalf("json: %v\noutput=%s", err, stdout.String())
-	}
-	data, _ := got["data"].(map[string]interface{})
-	users, _ := data["users"].([]interface{})
-	if len(users) != 2 {
-		t.Fatalf("users: want 2 aggregated across pages, got %d (output=%s)", len(users), stdout.String())
-	}
-	if data["has_more"] != false {
-		t.Errorf("has_more: want false when last page ended, got %v", data["has_more"])
-	}
+	reg.Verify(t)
 }
 
-func TestSearchUser_Integration_PageLimitTruncates(t *testing.T) {
-	f, stdout, stderr, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
-	// Two pages; both return has_more=true — limit 2 should stop after the
-	// second and emit a truncation warning.
-	for i := 0; i < 2; i++ {
-		reg.Register(&httpmock.Stub{
-			Method: "POST", URL: "/open-apis/contact/v3/users/search",
-			Body: map[string]interface{}{
-				"code": 0, "msg": "ok",
-				"data": map[string]interface{}{
-					"items":      []interface{}{map[string]interface{}{"id": fmt.Sprintf("ou_%d", i)}},
-					"has_more":   true,
-					"page_token": fmt.Sprintf("p%d", i+1),
-				},
-			},
+// Verifies that with the auto-pagination flags removed, --page-all / --page-limit
+// are no longer accepted. cobra must reject the unknown flag at parse time —
+// no stub is registered because the command should never reach the API.
+func TestSearchUser_Integration_NoAutoPaginationFlags(t *testing.T) {
+	for _, removed := range []string{"--page-all", "--page-limit"} {
+		t.Run(removed, func(t *testing.T) {
+			f, stdout, _, _ := cmdutil.TestFactory(t, searchUserDefaultConfig())
+			args := []string{"+search-user", "--query", "x", removed}
+			if removed == "--page-limit" {
+				args = append(args, "5")
+			}
+			args = append(args, "--as", "user")
+			err := mountAndRun(t, ContactSearchUser, args, f, stdout)
+			if err == nil {
+				t.Errorf("%s should be rejected (unknown flag), but command succeeded", removed)
+			}
 		})
-	}
-
-	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "x", "--page-limit", "2", "--format", "pretty", "--as", "user"}, f, stdout)
-	if err != nil {
-		t.Fatalf("execute: %v", err)
-	}
-	if !strings.Contains(stderr.String(), "stopped after fetching 2 page(s)") {
-		t.Errorf("expected truncation warning on stderr, got=%q", stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "--page-limit") {
-		t.Errorf("warning should mention --page-limit hint, got=%q", stderr.String())
-	}
-}
-
-func TestValidateSearchUser_PageLimitOutOfRange_Errors(t *testing.T) {
-	cmd := newSearchUserTestCommand()
-	_ = cmd.Flags().Set("query", "x")
-	_ = cmd.Flags().Set("page-limit", "100")
-	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
-	err := validateSearchUser(rt)
-	if err == nil || !strings.Contains(err.Error(), "40") {
-		t.Fatalf("expected --page-limit range error mentioning 40, got %v", err)
 	}
 }

--- a/shortcuts/contact/contact_search_user_test.go
+++ b/shortcuts/contact/contact_search_user_test.go
@@ -283,24 +283,39 @@ func TestValidateSearchUser_FilterOnly_OK(t *testing.T) {
 
 func TestValidateSearchUser_QueryTooLong_Errors(t *testing.T) {
 	cmd := newSearchUserTestCommand()
-	_ = cmd.Flags().Set("query", strings.Repeat("a", 65))
+	_ = cmd.Flags().Set("query", strings.Repeat("a", 51))
 	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
 	err := validateSearchUser(rt)
-	if err == nil || !strings.Contains(err.Error(), "64") {
-		t.Fatalf("expected length error mentioning 64, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "50") {
+		t.Fatalf("expected length error mentioning 50, got %v", err)
 	}
 }
 
-func TestValidateSearchUser_Query64Runes_OK(t *testing.T) {
+func TestValidateSearchUser_Query50Chars_OK(t *testing.T) {
 	cmd := newSearchUserTestCommand()
-	q := strings.Repeat("中", 32) + strings.Repeat("a", 32) // 64 rune, >64 bytes
-	if utf8.RuneCountInString(q) != 64 {
-		t.Fatalf("test string is %d runes, expected 64", utf8.RuneCountInString(q))
+	q := strings.Repeat("中", 25) + strings.Repeat("a", 25) // 50 runes, >50 bytes
+	if utf8.RuneCountInString(q) != 50 {
+		t.Fatalf("test string is %d runes, expected 50", utf8.RuneCountInString(q))
 	}
 	_ = cmd.Flags().Set("query", q)
 	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
 	if err := validateSearchUser(rt); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// Regression: prior versions accepted "--user-ids ',,,'" because SplitCSV
+// drops empty segments and validation only capped the upper bound, sending
+// an empty body to the API.
+func TestValidateSearchUser_UserIDsAllSeparators_Errors(t *testing.T) {
+	for _, raw := range []string{",,,", " , , ", ","} {
+		cmd := newSearchUserTestCommand()
+		_ = cmd.Flags().Set("user-ids", raw)
+		rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+		err := validateSearchUser(rt)
+		if err == nil || !strings.Contains(err.Error(), "--user-ids") {
+			t.Fatalf("raw=%q: expected --user-ids error, got %v", raw, err)
+		}
 	}
 }
 

--- a/shortcuts/contact/contact_search_user_test.go
+++ b/shortcuts/contact/contact_search_user_test.go
@@ -1,0 +1,781 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package contact
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+func newSearchUserTestCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("query", "", "")
+	cmd.Flags().String("user-ids", "", "")
+	cmd.Flags().Bool("is-resigned", false, "")
+	cmd.Flags().Bool("has-chatted", false, "")
+	cmd.Flags().Bool("exclude-outer-contact", false, "")
+	cmd.Flags().Bool("has-enterprise-email", false, "")
+	cmd.Flags().String("lang", "", "")
+	cmd.Flags().String("page-size", "20", "")
+	cmd.Flags().Bool("page-all", false, "")
+	cmd.Flags().Int("page-limit", 20, "")
+	return cmd
+}
+
+func searchUserDefaultConfig() *core.CliConfig {
+	return &core.CliConfig{
+		AppID: "test", AppSecret: "test", Brand: core.BrandFeishu,
+		UserOpenId: "ou_self",
+	}
+}
+
+func TestPickName_ExplicitLang_Hit(t *testing.T) {
+	meta := map[string]interface{}{
+		"i18n_names": map[string]interface{}{"zh_cn": "张三", "en_us": "Zhangsan"},
+	}
+	got := pickName(meta, "en-US", core.BrandFeishu, "ou_x")
+	if got != "Zhangsan" {
+		t.Errorf("got %q, want Zhangsan", got)
+	}
+}
+
+func TestPickName_ExplicitLang_MissFallsToBrand(t *testing.T) {
+	meta := map[string]interface{}{
+		"i18n_names": map[string]interface{}{"zh_cn": "张三"},
+	}
+	got := pickName(meta, "ja-JP", core.BrandFeishu, "ou_x")
+	if got != "张三" {
+		t.Errorf("got %q, want 张三 (brand fallback)", got)
+	}
+}
+
+func TestPickName_BrandFeishu_PicksZh(t *testing.T) {
+	meta := map[string]interface{}{
+		"i18n_names": map[string]interface{}{"zh_cn": "张三", "en_us": "Zhangsan"},
+	}
+	got := pickName(meta, "", core.BrandFeishu, "ou_x")
+	if got != "张三" {
+		t.Errorf("got %q, want 张三", got)
+	}
+}
+
+func TestPickName_BrandLark_PicksEn(t *testing.T) {
+	meta := map[string]interface{}{
+		"i18n_names": map[string]interface{}{"zh_cn": "张三", "en_us": "Zhangsan"},
+	}
+	got := pickName(meta, "", core.BrandLark, "ou_x")
+	if got != "Zhangsan" {
+		t.Errorf("got %q, want Zhangsan", got)
+	}
+}
+
+func TestPickName_FixedLocaleList_HitJaJp(t *testing.T) {
+	meta := map[string]interface{}{
+		"i18n_names": map[string]interface{}{"ja_jp": "Yamada"},
+	}
+	got := pickName(meta, "", core.BrandFeishu, "ou_x")
+	if got != "Yamada" {
+		t.Errorf("got %q, want Yamada (fixed locale list fallback)", got)
+	}
+}
+
+func TestPickName_DictOrderFallback(t *testing.T) {
+	meta := map[string]interface{}{
+		"i18n_names": map[string]interface{}{"xx_yy": "Foo", "aa_bb": "Bar"},
+	}
+	got := pickName(meta, "", core.BrandFeishu, "ou_x")
+	if got != "Bar" {
+		t.Errorf("got %q, want Bar (alphabetical tie-break, first non-empty is 'aa_bb')", got)
+	}
+}
+
+func TestPickName_AllEmpty_FallsToOpenID(t *testing.T) {
+	got := pickName(map[string]interface{}{}, "", core.BrandFeishu, "ou_x")
+	if got != "ou_x" {
+		t.Errorf("got %q, want ou_x", got)
+	}
+}
+
+func TestPickName_Determinism(t *testing.T) {
+	meta := map[string]interface{}{
+		"i18n_names": map[string]interface{}{
+			"xx_yy": "Foo", "aa_bb": "Bar", "mm_nn": "Baz",
+		},
+	}
+	first := pickName(meta, "", core.BrandFeishu, "ou_x")
+	for i := 0; i < 50; i++ {
+		got := pickName(meta, "", core.BrandFeishu, "ou_x")
+		if got != first {
+			t.Fatalf("non-deterministic: iter %d got %q, expected %q (map iteration leaked)", i, got, first)
+		}
+	}
+}
+
+func TestRowFromItem_FullMapping(t *testing.T) {
+	item := map[string]interface{}{
+		"id": "ou_a",
+		"meta_data": map[string]interface{}{
+			"i18n_names":              map[string]interface{}{"zh_cn": "张三", "en_us": "Z"},
+			"mail_address":            "z@example.com",
+			"enterprise_mail_address": "z@corp.example.com",
+			"is_registered":           true,
+			"chat_id":                 "oc_abc",
+			"is_cross_tenant":         false,
+			"tenant_id":               "tenant_x",
+			"description":             "Director / Marketing",
+		},
+		"display_info": "<h>张三</h>\nMarketing\n\n[Contacted 2 days ago]",
+	}
+	got := rowFromItem(item, "", core.BrandFeishu)
+
+	checks := []struct {
+		key  string
+		want interface{}
+	}{
+		{"open_id", "ou_a"},
+		{"name", "张三"},
+		{"email", "z@example.com"},
+		{"enterprise_email", "z@corp.example.com"},
+		{"is_registered", true},
+		{"chat_id", "oc_abc"},
+		{"has_chatted", true},
+		{"is_cross_tenant", false},
+		{"tenant_id", "tenant_x"},
+		{"description", "Director / Marketing"},
+		{"display_info", "<h>张三</h>\nMarketing\n\n[Contacted 2 days ago]"},
+	}
+	for _, c := range checks {
+		if got[c.key] != c.want {
+			t.Errorf("key %q: got %v, want %v", c.key, got[c.key], c.want)
+		}
+	}
+	i18n, ok := got["i18n_names"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("i18n_names: expected map, got %T", got["i18n_names"])
+	}
+	if i18n["zh_cn"] != "张三" || i18n["en_us"] != "Z" {
+		t.Errorf("i18n_names content: got %v", i18n)
+	}
+}
+
+func TestRowFromItem_HasChattedFalseWhenChatIDEmpty(t *testing.T) {
+	item := map[string]interface{}{
+		"id":        "ou_a",
+		"meta_data": map[string]interface{}{},
+	}
+	got := rowFromItem(item, "", core.BrandFeishu)
+	if got["has_chatted"] != false {
+		t.Errorf("has_chatted: got %v, want false", got["has_chatted"])
+	}
+	if got["chat_id"] != "" {
+		t.Errorf("chat_id: got %q, want empty string", got["chat_id"])
+	}
+}
+
+func TestRowFromItem_CrossTenantEmptyEmailNoPanic(t *testing.T) {
+	item := map[string]interface{}{
+		"id": "ou_outer",
+		"meta_data": map[string]interface{}{
+			"is_cross_tenant": true,
+			"tenant_id":       "other_tenant",
+		},
+	}
+	got := rowFromItem(item, "", core.BrandFeishu)
+	if got["email"] != "" {
+		t.Errorf("email: expected empty, got %q", got["email"])
+	}
+	if got["enterprise_email"] != "" {
+		t.Errorf("enterprise_email: expected empty, got %q", got["enterprise_email"])
+	}
+}
+
+func TestValidateSearchUser_AllEmpty_Errors(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	err := validateSearchUser(rt)
+	if err == nil || !strings.Contains(err.Error(), "specify at least one of") {
+		t.Fatalf("expected AtLeastOne error, got %v", err)
+	}
+}
+
+func TestValidateSearchUser_QueryOnly_OK(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("query", "hello")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	if err := validateSearchUser(rt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateSearchUser_FilterOnly_OK(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("has-chatted", "true")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	if err := validateSearchUser(rt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateSearchUser_QueryTooLong_Errors(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("query", strings.Repeat("a", 65))
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	err := validateSearchUser(rt)
+	if err == nil || !strings.Contains(err.Error(), "64") {
+		t.Fatalf("expected length error mentioning 64, got %v", err)
+	}
+}
+
+func TestValidateSearchUser_Query64Runes_OK(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	q := strings.Repeat("中", 32) + strings.Repeat("a", 32) // 64 rune, >64 bytes
+	if utf8.RuneCountInString(q) != 64 {
+		t.Fatalf("test string is %d runes, expected 64", utf8.RuneCountInString(q))
+	}
+	_ = cmd.Flags().Set("query", q)
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	if err := validateSearchUser(rt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateSearchUser_UserIDsOver100_Errors(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	ids := make([]string, 101)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("ou_%05d", i)
+	}
+	_ = cmd.Flags().Set("user-ids", strings.Join(ids, ","))
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	err := validateSearchUser(rt)
+	if err == nil || !strings.Contains(err.Error(), "100") {
+		t.Fatalf("expected 100-cap error, got %v", err)
+	}
+}
+
+func TestValidateSearchUser_UserIDsBadPrefix_Errors(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("user-ids", "foo")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	err := validateSearchUser(rt)
+	if err == nil || !strings.Contains(err.Error(), "ou_") {
+		t.Fatalf("expected ou_ prefix error, got %v", err)
+	}
+}
+
+func TestValidateSearchUser_MeWithoutLogin_Errors(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("user-ids", "me")
+	cfg := searchUserDefaultConfig()
+	cfg.UserOpenId = ""
+	rt := common.TestNewRuntimeContext(cmd, cfg)
+	err := validateSearchUser(rt)
+	if err == nil || !strings.Contains(err.Error(), "me") {
+		t.Fatalf("expected 'me without login' error, got %v", err)
+	}
+}
+
+func TestBuildBody_QueryOnly(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("query", "hello")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	body, err := buildSearchUserBody(rt)
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	if body["query"] != "hello" {
+		t.Errorf("query: got %v", body["query"])
+	}
+	if _, ok := body["filter"]; ok {
+		t.Errorf("filter: should not exist when no filter set, got %v", body["filter"])
+	}
+}
+
+func TestBuildBody_BoolTriState_NotSet_Omitted(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("query", "x")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	body, _ := buildSearchUserBody(rt)
+	if _, ok := body["filter"]; ok {
+		t.Errorf("filter: should be omitted when no bool changed, got %v", body["filter"])
+	}
+}
+
+func TestBuildBody_BoolTriState_True(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("query", "x")
+	_ = cmd.Flags().Set("has-chatted", "true")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	body, _ := buildSearchUserBody(rt)
+	filter, ok := body["filter"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("filter: expected map, got %v", body["filter"])
+	}
+	if filter["has_contact"] != true {
+		t.Errorf("filter.has_contact: got %v, want true", filter["has_contact"])
+	}
+}
+
+func TestBuildBody_BoolTriState_False(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("query", "x")
+	_ = cmd.Flags().Set("has-chatted", "false")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	body, _ := buildSearchUserBody(rt)
+	filter, ok := body["filter"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("filter: expected map, got %v", body["filter"])
+	}
+	if filter["has_contact"] != false {
+		t.Errorf("filter.has_contact: got %v, want false (distinct from omitted)", filter["has_contact"])
+	}
+}
+
+func TestBuildBody_UserIDsResolveAndDedup(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("user-ids", "me,ou_a,me,ou_a")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	body, _ := buildSearchUserBody(rt)
+	filter, ok := body["filter"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("filter: expected map, got %v", body["filter"])
+	}
+	ids, _ := filter["user_ids"].([]string)
+	if len(ids) != 2 || ids[0] != "ou_self" || ids[1] != "ou_a" {
+		t.Errorf("user_ids: got %v, want [ou_self ou_a]", ids)
+	}
+}
+
+func TestBuildParams_PageSize(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("query", "x")
+	_ = cmd.Flags().Set("page-size", "25")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	params := buildSearchUserParams(rt)
+	if params["page_size"] != 25 {
+		t.Errorf("page_size: got %v, want 25", params["page_size"])
+	}
+	if _, ok := params["page_token"]; ok {
+		t.Errorf("page_token: should never appear in initial params (managed by the pagination loop)")
+	}
+}
+
+func TestBuildParams_DefaultPageSize(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	params := buildSearchUserParams(rt)
+	if params["page_size"] != 20 {
+		t.Errorf("page_size: got %v, want 20 (default)", params["page_size"])
+	}
+}
+
+func TestPaginationConfig_Defaults(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	auto, limit := searchUserPaginationConfig(rt)
+	if auto {
+		t.Errorf("autoPaginate: want false when no flags set, got true")
+	}
+	if limit != defaultSearchUserPageLimit {
+		t.Errorf("pageLimit: want %d default, got %d", defaultSearchUserPageLimit, limit)
+	}
+}
+
+func TestPaginationConfig_PageAllAloneUsesMax(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("page-all", "true")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	auto, limit := searchUserPaginationConfig(rt)
+	if !auto {
+		t.Errorf("autoPaginate: want true, got false")
+	}
+	if limit != maxSearchUserPageLimit {
+		t.Errorf("pageLimit: --page-all alone should use max %d, got %d", maxSearchUserPageLimit, limit)
+	}
+}
+
+func TestPaginationConfig_PageLimitAloneImpliesAuto(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("page-limit", "5")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	auto, limit := searchUserPaginationConfig(rt)
+	if !auto {
+		t.Errorf("autoPaginate: --page-limit alone should imply auto, got false")
+	}
+	if limit != 5 {
+		t.Errorf("pageLimit: got %d, want 5", limit)
+	}
+}
+
+func TestPaginationConfig_PageLimitCapsAtMax(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("page-limit", "999")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	_, limit := searchUserPaginationConfig(rt)
+	if limit != maxSearchUserPageLimit {
+		t.Errorf("pageLimit: should cap at %d, got %d", maxSearchUserPageLimit, limit)
+	}
+}
+
+// mountAndRun mounts the shortcut under a parent cobra command and runs it
+// with the given args. Mirrors the pattern used in other shortcut packages
+// (e.g. minutes_download_test.go).
+func mountAndRun(t *testing.T, s common.Shortcut, args []string, f *cmdutil.Factory, stdout *bytes.Buffer) error {
+	t.Helper()
+	parent := &cobra.Command{Use: "contact"}
+	s.Mount(parent, f)
+	parent.SetArgs(args)
+	parent.SilenceErrors = true
+	parent.SilenceUsage = true
+	if stdout != nil {
+		stdout.Reset()
+	}
+	return parent.Execute()
+}
+
+func searchUserStub() *httpmock.Stub {
+	return &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/contact/v3/users/search",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{
+						"id": "ou_a",
+						"meta_data": map[string]interface{}{
+							"i18n_names":      map[string]interface{}{"zh_cn": "张三"},
+							"mail_address":    "z@x.com",
+							"is_registered":   true,
+							"chat_id":         "oc_abc",
+							"is_cross_tenant": false,
+							"tenant_id":       "tenant_1",
+							"description":     "Director",
+						},
+						"display_info": "<h>张三</h>\nMarketing",
+					},
+				},
+				"has_more":   false,
+				"page_token": "",
+			},
+		},
+	}
+}
+
+func TestSearchUser_Integration_PrettyRendersAllColumns(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
+	reg.Register(searchUserStub())
+
+	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "张三", "--format", "pretty", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := stdout.String()
+	// internal/output sorts table columns alphabetically (house behavior shared
+	// with all PrintTable callers), so we assert presence of each pretty column
+	// rather than a specific layout.
+	for _, col := range []string{"display_info", "name", "open_id", "email", "is_registered", "has_chatted"} {
+		if !strings.Contains(out, col) {
+			t.Errorf("pretty output missing column %q; got=%q", col, out)
+		}
+	}
+	// The hit-highlight payload should make it into the rendered cell.
+	if !strings.Contains(out, "<h>张三</h>") {
+		t.Errorf("expected display_info hit-highlight in output, got=%q", out)
+	}
+}
+
+func TestSearchUser_Integration_JSONFullFields(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
+	reg.Register(searchUserStub())
+
+	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "张三", "--format", "json", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v\noutput=%s", err, stdout.String())
+	}
+	// CLI wraps all structured output in an {ok, identity, data, meta} envelope.
+	data, ok := got["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("envelope.data: expected object, got %v\nraw=%s", got["data"], stdout.String())
+	}
+	users, _ := data["users"].([]interface{})
+	if len(users) != 1 {
+		t.Fatalf("users: expected 1, got %d (output=%s)", len(users), stdout.String())
+	}
+	u, _ := users[0].(map[string]interface{})
+	for _, k := range []string{
+		"name", "open_id", "i18n_names", "email", "is_registered", "chat_id",
+		"has_chatted", "is_cross_tenant", "tenant_id", "description", "display_info",
+	} {
+		if _, ok := u[k]; !ok {
+			t.Errorf("missing JSON key %q in user object", k)
+		}
+	}
+}
+
+func TestSearchUser_Integration_NDJSONHasNoPaginationHint(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/contact/v3/users/search",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "ou_a"}},
+				"has_more":   true,
+				"page_token": "tok_next",
+			},
+		},
+	})
+
+	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "x", "--format", "ndjson", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if strings.Contains(stdout.String(), "more available") {
+		t.Errorf("ndjson stdout must not contain the pagination hint (would corrupt the stream); got=%q", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "more available") {
+		t.Errorf("ndjson stderr must not contain the pagination hint either (non-human format opts out entirely); got=%q", stderr.String())
+	}
+}
+
+func TestSearchUser_Integration_PrettyHintGoesToStderr(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/contact/v3/users/search",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "ou_a"}},
+				"has_more":   true,
+				"page_token": "tok_next",
+			},
+		},
+	})
+
+	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "x", "--format", "pretty", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if strings.Contains(stdout.String(), "more available") {
+		t.Errorf("pretty stdout must not carry the hint (informational text belongs on stderr); got=%q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "more available") || !strings.Contains(stderr.String(), "--page-all") {
+		t.Errorf("pretty stderr should guide the user toward --page-all when has_more=true; got=%q", stderr.String())
+	}
+}
+
+func TestSearchUser_Integration_EmptyResult(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/contact/v3/users/search",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"items": []interface{}{}, "has_more": false, "page_token": ""},
+		},
+	})
+
+	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "nope", "--format", "pretty", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "No users found.") {
+		t.Errorf("expected 'No users found.' in output, got %q", stdout.String())
+	}
+}
+
+func TestSearchUser_Integration_EmptyResult_JSONArray(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/contact/v3/users/search",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"items": []interface{}{}, "has_more": false, "page_token": ""},
+		},
+	})
+
+	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "nope", "--format", "json", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v\noutput=%s", err, stdout.String())
+	}
+	data, ok := got["data"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("envelope.data: expected object, got %v\nraw=%s", got["data"], stdout.String())
+	}
+	// Empty result must serialize as [] (not null) so jq consumers can iterate
+	// without special-casing: `jq '.data.users[]'` / `.data.users | length`.
+	usersRaw, exists := data["users"]
+	if !exists {
+		t.Fatalf("data.users key missing\nraw=%s", stdout.String())
+	}
+	if usersRaw == nil {
+		t.Fatalf("data.users serialized as null; expected [] for empty result\nraw=%s", stdout.String())
+	}
+	users, ok := usersRaw.([]interface{})
+	if !ok {
+		t.Fatalf("data.users: expected []interface{}, got %T\nraw=%s", usersRaw, stdout.String())
+	}
+	if len(users) != 0 {
+		t.Errorf("data.users: expected empty array, got %d entries", len(users))
+	}
+}
+
+func TestSearchUser_DryRun(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, searchUserDefaultConfig())
+
+	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "x", "--has-chatted=true", "--dry-run", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{"POST", "/contact/v3/users/search", "has_contact"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run missing %q in output: %q", want, out)
+		}
+	}
+}
+
+func TestSearchUser_Integration_RequestShape(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
+	stub := searchUserStub()
+	reg.Register(stub)
+
+	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "x", "--has-chatted=true", "--user-ids", "me", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+		t.Fatalf("unmarshal request body: %v\nraw=%s", err, string(stub.CapturedBody))
+	}
+	if body["query"] != "x" {
+		t.Errorf("body.query: got %v, want x", body["query"])
+	}
+	filter, _ := body["filter"].(map[string]interface{})
+	if filter == nil {
+		t.Fatalf("body.filter: expected object, got %v", body["filter"])
+	}
+	if filter["has_contact"] != true {
+		t.Errorf("filter.has_contact: got %v, want true", filter["has_contact"])
+	}
+	uids, _ := filter["user_ids"].([]interface{})
+	if len(uids) != 1 || uids[0] != "ou_self" {
+		t.Errorf("filter.user_ids: got %v, want [ou_self]", filter["user_ids"])
+	}
+	// Unset bool filters must not appear in the body.
+	for _, k := range []string{"is_resigned", "exclude_outer_contact", "has_enterprise_email"} {
+		if _, ok := filter[k]; ok {
+			t.Errorf("filter.%s: should be omitted (not Changed), got %v", k, filter[k])
+		}
+	}
+}
+
+func TestSearchUser_Integration_AutoPaginateAggregates(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
+	// First page: has_more=true, token=p2
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/contact/v3/users/search",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "ou_a"}},
+				"has_more":   true,
+				"page_token": "p2",
+			},
+		},
+	})
+	// Second page: has_more=false, ends the loop
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/contact/v3/users/search",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items":      []interface{}{map[string]interface{}{"id": "ou_b"}},
+				"has_more":   false,
+				"page_token": "",
+			},
+		},
+	})
+
+	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "x", "--page-all", "--format", "json", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	reg.Verify(t) // ensures both stubs were consumed
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("json: %v\noutput=%s", err, stdout.String())
+	}
+	data, _ := got["data"].(map[string]interface{})
+	users, _ := data["users"].([]interface{})
+	if len(users) != 2 {
+		t.Fatalf("users: want 2 aggregated across pages, got %d (output=%s)", len(users), stdout.String())
+	}
+	if data["has_more"] != false {
+		t.Errorf("has_more: want false when last page ended, got %v", data["has_more"])
+	}
+}
+
+func TestSearchUser_Integration_PageLimitTruncates(t *testing.T) {
+	f, stdout, stderr, reg := cmdutil.TestFactory(t, searchUserDefaultConfig())
+	// Two pages; both return has_more=true — limit 2 should stop after the
+	// second and emit a truncation warning.
+	for i := 0; i < 2; i++ {
+		reg.Register(&httpmock.Stub{
+			Method: "POST", URL: "/open-apis/contact/v3/users/search",
+			Body: map[string]interface{}{
+				"code": 0, "msg": "ok",
+				"data": map[string]interface{}{
+					"items":      []interface{}{map[string]interface{}{"id": fmt.Sprintf("ou_%d", i)}},
+					"has_more":   true,
+					"page_token": fmt.Sprintf("p%d", i+1),
+				},
+			},
+		})
+	}
+
+	err := mountAndRun(t, ContactSearchUser, []string{"+search-user", "--query", "x", "--page-limit", "2", "--format", "pretty", "--as", "user"}, f, stdout)
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "stopped after fetching 2 page(s)") {
+		t.Errorf("expected truncation warning on stderr, got=%q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "--page-limit") {
+		t.Errorf("warning should mention --page-limit hint, got=%q", stderr.String())
+	}
+}
+
+func TestValidateSearchUser_PageLimitOutOfRange_Errors(t *testing.T) {
+	cmd := newSearchUserTestCommand()
+	_ = cmd.Flags().Set("query", "x")
+	_ = cmd.Flags().Set("page-limit", "100")
+	rt := common.TestNewRuntimeContext(cmd, searchUserDefaultConfig())
+	err := validateSearchUser(rt)
+	if err == nil || !strings.Contains(err.Error(), "40") {
+		t.Fatalf("expected --page-limit range error mentioning 40, got %v", err)
+	}
+}

--- a/shortcuts/contact/helpers_legacy.go
+++ b/shortcuts/contact/helpers_legacy.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package contact
+
+// pickUserName walks a fixed list of legacy name keys returned by the older
+// /contact/v3/users/{user_id} and /authen/v1/user_info endpoints. Used only
+// by ContactGetUser. The newer +search-user shortcut has its own pickName
+// that reads i18n_names from the v3 search response.
+func pickUserName(m map[string]interface{}) string {
+	for _, key := range []string{"name", "user_name", "display_name", "employee_name", "cn_name"} {
+		if v, ok := m[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// firstNonEmpty returns the first non-empty string value among the given keys.
+func firstNonEmpty(m map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := m[key].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/shortcuts/contact/helpers_legacy_test.go
+++ b/shortcuts/contact/helpers_legacy_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package contact
+
+import "testing"
+
+func TestPickUserName_PriorityOrder(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   map[string]interface{}
+		want string
+	}{
+		{"name takes precedence", map[string]interface{}{"name": "A", "user_name": "B"}, "A"},
+		{"user_name when name empty", map[string]interface{}{"name": "", "user_name": "B"}, "B"},
+		{"display_name fallback", map[string]interface{}{"display_name": "C"}, "C"},
+		{"employee_name fallback", map[string]interface{}{"employee_name": "D"}, "D"},
+		{"cn_name fallback", map[string]interface{}{"cn_name": "E"}, "E"},
+		{"non-string values are skipped", map[string]interface{}{"name": 42, "user_name": "F"}, "F"},
+		{"nothing matches → empty string", map[string]interface{}{"unknown": "X"}, ""},
+		{"empty map → empty string", map[string]interface{}{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := pickUserName(tt.in); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	tests := []struct {
+		desc string
+		in   map[string]interface{}
+		keys []string
+		want string
+	}{
+		{"first key wins", map[string]interface{}{"a": "x", "b": "y"}, []string{"a", "b"}, "x"},
+		{"falls through empty string", map[string]interface{}{"a": "", "b": "y"}, []string{"a", "b"}, "y"},
+		{"non-string values are skipped", map[string]interface{}{"a": 42, "b": "z"}, []string{"a", "b"}, "z"},
+		{"all empty / missing → empty string", map[string]interface{}{"a": ""}, []string{"a", "b"}, ""},
+		{"no keys requested → empty string", map[string]interface{}{"a": "x"}, nil, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if got := firstNonEmpty(tt.in, tt.keys...); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/shortcuts/minutes/minutes_search.go
+++ b/shortcuts/minutes/minutes_search.go
@@ -75,30 +75,6 @@ func toRFC3339(input string, hint ...string) (string, error) {
 	return time.Unix(sec, 0).Format(time.RFC3339), nil
 }
 
-// resolveUserIDs expands special user identifiers and removes duplicates.
-func resolveUserIDs(flagName string, ids []string, runtime *common.RuntimeContext) ([]string, error) {
-	if len(ids) == 0 {
-		return nil, nil
-	}
-	currentUserID := runtime.UserOpenId()
-	seen := make(map[string]struct{}, len(ids))
-	out := make([]string, 0, len(ids))
-	for _, id := range ids {
-		if strings.EqualFold(id, "me") {
-			if currentUserID == "" {
-				return nil, output.ErrValidation("%s: \"me\" requires a logged-in user with a resolvable open_id", flagName)
-			}
-			id = currentUserID
-		}
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		out = append(out, id)
-	}
-	return out, nil
-}
-
 // buildTimeFilter builds the create_time filter block for the API request.
 func buildTimeFilter(startTime, endTime string) map[string]interface{} {
 	if startTime == "" && endTime == "" {
@@ -118,7 +94,7 @@ func buildTimeFilter(startTime, endTime string) map[string]interface{} {
 func buildMinutesSearchFilter(runtime *common.RuntimeContext, startTime, endTime string) (map[string]interface{}, error) {
 	filter := map[string]interface{}{}
 
-	ownerIDs, err := resolveUserIDs("--owner-ids", common.SplitCSV(runtime.Str("owner-ids")), runtime)
+	ownerIDs, err := common.ResolveOpenIDs("--owner-ids", common.SplitCSV(runtime.Str("owner-ids")), runtime)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +102,7 @@ func buildMinutesSearchFilter(runtime *common.RuntimeContext, startTime, endTime
 		filter["owner_ids"] = ownerIDs
 	}
 
-	participantIDs, err := resolveUserIDs("--participant-ids", common.SplitCSV(runtime.Str("participant-ids")), runtime)
+	participantIDs, err := common.ResolveOpenIDs("--participant-ids", common.SplitCSV(runtime.Str("participant-ids")), runtime)
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +236,7 @@ var MinutesSearch = common.Shortcut{
 		if _, err := common.ValidatePageSize(runtime, "page-size", defaultMinutesSearchPageSize, 1, maxMinutesSearchPageSize); err != nil {
 			return err
 		}
-		ownerIDs, err := resolveUserIDs("--owner-ids", common.SplitCSV(runtime.Str("owner-ids")), runtime)
+		ownerIDs, err := common.ResolveOpenIDs("--owner-ids", common.SplitCSV(runtime.Str("owner-ids")), runtime)
 		if err != nil {
 			return err
 		}
@@ -269,7 +245,7 @@ var MinutesSearch = common.Shortcut{
 				return err
 			}
 		}
-		participantIDs, err := resolveUserIDs("--participant-ids", common.SplitCSV(runtime.Str("participant-ids")), runtime)
+		participantIDs, err := common.ResolveOpenIDs("--participant-ids", common.SplitCSV(runtime.Str("participant-ids")), runtime)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/minutes/minutes_search_test.go
+++ b/shortcuts/minutes/minutes_search_test.go
@@ -155,38 +155,6 @@ func TestBuildMinutesSearchParamsDefaultPageSize(t *testing.T) {
 	}
 }
 
-// TestResolveUserIDs verifies me expansion, deduplication, and nil handling.
-func TestResolveUserIDs(t *testing.T) {
-	t.Parallel()
-
-	cmd := &cobra.Command{Use: "test"}
-	runtime := common.TestNewRuntimeContext(cmd, defaultConfig())
-
-	got, err := resolveUserIDs("--owner-ids", []string{"me"}, runtime)
-	if err != nil {
-		t.Fatalf("resolveUserIDs([me]) unexpected error: %v", err)
-	}
-	if len(got) != 1 || got[0] != "ou_testuser" {
-		t.Fatalf("resolveUserIDs([me]) = %v, want [ou_testuser]", got)
-	}
-
-	got, err = resolveUserIDs("--owner-ids", []string{"ou_other", "me", "Me"}, runtime)
-	if err != nil {
-		t.Fatalf("resolveUserIDs([ou_other, me, Me]) unexpected error: %v", err)
-	}
-	if len(got) != 2 || got[0] != "ou_other" || got[1] != "ou_testuser" {
-		t.Fatalf("resolveUserIDs([ou_other, me, Me]) = %v, want [ou_other ou_testuser]", got)
-	}
-
-	got, err = resolveUserIDs("--owner-ids", nil, runtime)
-	if err != nil {
-		t.Fatalf("resolveUserIDs(nil) unexpected error: %v", err)
-	}
-	if got != nil {
-		t.Fatalf("resolveUserIDs(nil) = %v, want nil", got)
-	}
-}
-
 // TestBuildTimeFilter verifies time filters are only populated for provided bounds.
 func TestBuildTimeFilter(t *testing.T) {
 	t.Parallel()

--- a/skills/lark-contact/SKILL.md
+++ b/skills/lark-contact/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-contact
 version: 1.0.0
-description: "飞书通讯录：查询组织架构、人员信息和搜索员工。获取当前用户或指定用户的详细信息、通过关键词搜索员工（姓名/邮箱/手机号）。当用户需要查看个人信息、查找同事 open_id 或联系方式、按姓名搜索员工、查询部门结构时使用。"
+description: "飞书通讯录：查询组织架构、人员信息和搜索员工。获取当前用户或指定用户的详细信息、通过关键词搜索员工（姓名/邮箱/手机号），并支持按聊天关系、在职状态、租户边界、企业邮箱等维度过滤。当用户需要查看个人信息、查找同事 open_id 或联系方式、按姓名搜索员工、找聊过天的同事 / 离职同事 / 外部联系人、获取多语种姓名、查询部门结构时使用。"
 metadata:
   requires:
     bins: ["lark-cli"]
@@ -18,6 +18,6 @@ Shortcut 是对常用操作的高级封装（`lark-cli contact +<verb> [flags]`�
 
 | Shortcut | 说明 |
 |----------|------|
-| [`+search-user`](references/lark-contact-search-user.md) | Search users (results sorted by relevance) |
+| [`+search-user`](references/lark-contact-search-user.md) | 搜索员工：关键词 + 多维 filter（聊过天 / 离职 / 同租户 / 企业邮箱 / 指定 open_id 列表），返回多语种姓名、聊天上下文、命中片段 |
 | [`+get-user`](references/lark-contact-get-user.md) | Get user info (omit user_id for self; provide user_id for specific user) |
 

--- a/skills/lark-contact/SKILL.md
+++ b/skills/lark-contact/SKILL.md
@@ -1,23 +1,45 @@
 ---
 name: lark-contact
 version: 1.0.0
-description: "飞书通讯录：查询组织架构、人员信息和搜索员工。获取当前用户或指定用户的详细信息、通过关键词搜索员工（姓名/邮箱/手机号），并支持按聊天关系、在职状态、租户边界、企业邮箱等维度过滤。当用户需要查看个人信息、查找同事 open_id 或联系方式、按姓名搜索员工、找聊过天的同事 / 离职同事 / 外部联系人、获取多语种姓名、查询部门结构时使用。"
+description: "飞书 / Lark 通讯录,用于按姓名 / 邮箱把员工解析成 open_id,以及按 open_id 反查员工的姓名 / 部门 / 邮箱 / 联系方式。当用户说出某人姓名而下一步需要发消息 / 加群 / 排日程时,先用本 skill 把姓名换成 ID;当输出里出现 open_id 需要展示成姓名给用户看,或用户直接询问某人的部门 / 邮箱 / 联系方式时,用本 skill 查。不负责部门树遍历、按部门列员工、组织架构图,这类需求走原生 OpenAPI。"
 metadata:
   requires:
     bins: ["lark-cli"]
   cliHelp: "lark-cli contact --help"
 ---
 
-# contact (v1)
+# lark-contact
 
-**CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，其中包含认证、权限处理**
+## 选哪个命令
 
-## Shortcuts（推荐优先使用）
+**user 身份和 bot 身份是两条完全独立的路径**。先确定当前身份,再按下表选命令:
 
-Shortcut 是对常用操作的高级封装（`lark-cli contact +<verb> [flags]`）。有 Shortcut 的操作优先使用。
+| 想做什么 | user 身份 | bot 身份 |
+|---|---|---|
+| 按姓名 / 邮箱搜员工拿 open_id | [`+search-user`](references/lark-contact-search-user.md) | 不支持 |
+| 已知 open_id 取他人资料 | `+search-user --user-ids <id>` | [`+get-user --user-id <id>`](references/lark-contact-get-user.md) |
+| 查看自己 | `+get-user` 或 `+search-user --user-ids me` | 不支持 |
 
-| Shortcut | 说明 |
-|----------|------|
-| [`+search-user`](references/lark-contact-search-user.md) | 搜索员工：关键词 + 多维 filter（聊过天 / 离职 / 同租户 / 企业邮箱 / 指定 open_id 列表），返回多语种姓名、聊天上下文、命中片段 |
-| [`+get-user`](references/lark-contact-get-user.md) | Get user info (omit user_id for self; provide user_id for specific user) |
+已知 open_id 只是想发消息 / 排日程,不必经过 contact —— 直接 [`lark-im`](../lark-im/SKILL.md) / [`lark-calendar`](../lark-calendar/SKILL.md)。
 
+## 典型场景
+
+```bash
+# 找张三给他发消息:先搜,确认 open_id,再发
+lark-cli contact +search-user --query "张三" --has-chatted --as user
+lark-cli im +messages-send --user-id ou_xxx --text "Hi!"
+```
+
+搜索命中多条且后续操作有副作用(发消息、邀请会议等),把候选列给用户挑;不要擅自选第一条。
+
+## 注意事项
+
+- **41050 / Permission denied** 受当前身份的可见范围限制(两条命令都可能遇到)。换 bot 身份或让管理员调整可见范围,细节见 [`lark-shared`](../lark-shared/SKILL.md)。
+- **跨租户用户**(`is_cross_tenant=true`)多数业务字段为空字符串,这是飞书可见性规则,下游做空值兜底。
+- **ID 类型**:默认 `open_id`。`+get-user` 可改 `--user-id-type union_id|user_id`;`+search-user` 只接受 `open_id`。
+
+## 不在本 skill 范围
+
+- 发消息 / 查聊天记录 → [`lark-im`](../lark-im/SKILL.md)
+- 排日程 / 邀请会议 → [`lark-calendar`](../lark-calendar/SKILL.md)
+- 部门树 / 按部门列员工 / 组织架构 ,通过 [`lark-openapi-explorer`](../lark-openapi-explorer/SKILL.md) 查找原生接口

--- a/skills/lark-contact/references/lark-contact-get-user.md
+++ b/skills/lark-contact/references/lark-contact-get-user.md
@@ -1,47 +1,19 @@
+# +get-user
 
-# contact +get-user（获取用户信息）
-
-> **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
-
-本 skill 对应 shortcut：`lark-cli contact +get-user`。
-
-支持两种模式：
-
-1. **不传 `--user-id`**：获取当前用户自己的信息（底层 `GET /open-apis/authen/v1/user_info`）
-2. **传 `--user-id`**：获取指定用户信息（底层 `GET /open-apis/contact/v3/users/{user_id}`，默认 `user_id_type=open_id`）
-
-## 命令
+按 ID 取用户基本信息(姓名等)。
 
 ```bash
-# 模式 1：获取当前用户
-lark-cli contact +get-user
+# 取自己
+lark-cli contact +get-user --as user
 
-# 模式 2：获取指定用户（默认 user_id_type=open_id）
-lark-cli contact +get-user --user-id ou_xxx
+# bot 按 ID 取他人
+lark-cli contact +get-user --user-id ou_xxx --as bot
 
-# 指定 user_id_type
-lark-cli contact +get-user --user-id 4g3f... --user-id-type user_id
-
-# 表格输出（默认 JSON）
-lark-cli contact +get-user --user-id ou_xxx --format table
+# 按 union_id / user_id 取(默认 open_id)
+lark-cli contact +get-user --user-id <id> --user-id-type union_id --as bot
 ```
 
-## 参数
+## 注意事项
 
-| 参数 | 必填 | 说明 |
-|------|------|------|
-| `--user-id <id>` | 否 | 用户 ID；不传则获取当前用户 |
-| `--user-id-type <type>` | 否 | `open_id`（默认）/ `union_id` / `user_id` |
-| `--format <format>` | 否 | 输出格式：`json`（默认）/ `pretty` / `table` / `ndjson` / `csv` |
-
-## 常见错误（41050）
-
-如果返回提示无权限（常见错误码 `41050`），通常是**组织架构可见范围**限制导致：
-
-- 建议联系管理员调整当前用户的组织架构可见范围
-- 或改用应用身份（tenant_access_token）调用通讯录 API
-
-## 参考
-
-- [lark-contact-search-user](lark-contact-search-user.md) — 先搜到 open_id 再 get
-- [lark-shared](../../lark-shared/SKILL.md) — 认证和全局参数
+- **user 身份按 ID 取他人请用 `+search-user --user-ids <id>`**,字段比本命令多(部门 / 邮箱 / 是否激活等)。本命令的 user 模式只回很少字段。
+- **`--as bot` 必须传 `--user-id`**:不传会直接报错(只有 user 身份能省略 `--user-id` 取自己)。

--- a/skills/lark-contact/references/lark-contact-get-user.md
+++ b/skills/lark-contact/references/lark-contact-get-user.md
@@ -23,7 +23,7 @@ lark-cli contact +get-user --user-id ou_xxx
 lark-cli contact +get-user --user-id 4g3f... --user-id-type user_id
 
 # 表格输出（默认 JSON）
-lark-cli contact +get-user --user-id ou_xxx --table
+lark-cli contact +get-user --user-id ou_xxx --format table
 ```
 
 ## 参数
@@ -32,7 +32,7 @@ lark-cli contact +get-user --user-id ou_xxx --table
 |------|------|------|
 | `--user-id <id>` | 否 | 用户 ID；不传则获取当前用户 |
 | `--user-id-type <type>` | 否 | `open_id`（默认）/ `union_id` / `user_id` |
-| `--table` | 否 | 表格输出（默认 JSON） |
+| `--format <format>` | 否 | 输出格式：`json`（默认）/ `pretty` / `table` / `ndjson` / `csv` |
 
 ## 常见错误（41050）
 

--- a/skills/lark-contact/references/lark-contact-search-user.md
+++ b/skills/lark-contact/references/lark-contact-search-user.md
@@ -1,39 +1,185 @@
-
-# contact +search-user（搜索员工）
+# contact +search-user
 
 > **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
 
-通过关键词搜索员工（姓名/邮箱/手机号等），结果通常按亲密度排序。
+按关键词与多维 filter 搜索员工，返回带多语种姓名、联系方式、聊天关系上下文与命中片段的用户列表，结果按亲密度排序。只读操作，不修改通讯录数据。
 
-本 skill 对应 shortcut：`lark-cli contact +search-user`（底层调用 `GET /open-apis/search/v1/user`）。
+本 skill 对应 shortcut：`lark-cli contact +search-user`（调用 `POST /open-apis/contact/v3/users/search`）。
+
+## 典型触发表达
+
+以下说法通常应优先使用 `contact +search-user`：
+
+- 搜一下叫「张三」的同事
+- 找一个我聊过天的「李海」
+- 列出和我聊过天的离职同事
+- 找有企业邮箱的「王」姓同事
+- 把这一串 open_id 批量取一下姓名 / 邮箱 / 是否激活
+- 查一下「张三」的英文名 / 日文名
 
 ## 命令
 
 ```bash
-# 搜索员工（默认表格输出）
+# 关键词搜索
 lark-cli contact +search-user --query "张三"
 
-# 分页（取下一页）
-lark-cli contact +search-user --query "张三" --page-size 50 --page-token <PAGE_TOKEN>
+# 关键词 + 只搜聊过天的
+lark-cli contact +search-user --query "张三" --has-chatted
 
-# 人类可读格式输出
-lark-cli contact +search-user --query "张三" --format pretty
+# 关键词 + 只搜同租户（排除外部联系人）
+lark-cli contact +search-user --query "张三" --exclude-outer-contact
+
+# 关键词 + 只搜已离职且聊过天的
+lark-cli contact +search-user --query "张三" --is-resigned
+
+# 关键词 + 只搜有企业邮箱的
+lark-cli contact +search-user --query "张三" --has-enterprise-email
+
+# 多 filter 组合
+lark-cli contact +search-user --query "张三" --has-chatted --exclude-outer-contact
+
+# 取自己的资料
+lark-cli contact +search-user --user-ids me
+
+# 按 open_id 批量回填资料
+lark-cli contact +search-user --user-ids "ou_a,ou_b,ou_c"
+
+# 关键词 + 限定在指定候选 open_id 集合内验证
+lark-cli contact +search-user --query "张三" --user-ids "ou_a,ou_b,me"
+
+# 指定姓名 locale（默认按 tenant brand：feishu→zh_cn，lark→en_us）
+lark-cli contact +search-user --query "张三" --lang en_us
+
+# 自动翻页（最多 --page-limit 页，默认 20，上限 40）
+lark-cli contact +search-user --query "张三" --page-all
+
+# 自动翻页并限定最多 5 页
+lark-cli contact +search-user --query "张三" --page-limit 5
+
+# 自定义单页大小（最大 30）
+lark-cli contact +search-user --query "张三" --page-size 30 --page-all
+
+# 排查请求体
+lark-cli contact +search-user --query "张三" --has-chatted --dry-run
 ```
 
 ## 参数
 
 | 参数 | 必填 | 说明 |
-|------|------|------|
-| `--query <text>` | 是 | 搜索关键词 |
-| `--page-size <n>` | 否 | 分页大小（默认 20，最大 200） |
-| `--page-token <token>` | 否 | 分页标记（请求下一页） |
-| `--format` | 否 | 输出格式：json（默认） \| pretty |
+|---|---|---|
+| `--query <text>` | 否¹ | 搜索关键词，最大 64 rune（与客户端大搜框对齐） |
+| `--user-ids <ids>` | 否¹ | open_id 列表，逗号分隔；支持 `me` 表示当前用户；最多 100 个 |
+| `--is-resigned` | 否¹² | 仅搜「离职且聊过天」的用户 |
+| `--has-chatted` | 否¹² | 仅搜聊过天的用户（flag 名跟输出字段 `has_chatted` 对齐） |
+| `--exclude-outer-contact` | 否¹² | 仅搜同租户用户（排除外部联系人） |
+| `--has-enterprise-email` | 否¹² | 仅搜有企业邮箱的用户 |
+| `--lang <locale>` | 否 | 覆盖输出 `name` 的语种（如 `zh_cn` / `en_us` / `ja_jp`），默认按 tenant brand |
+| `--page-size <n>` | 否 | 每页数量，默认 `20`，最大 `30` |
+| `--page-all` | 否³ | 自动翻页直到 `has_more=false` 或到达 `--page-limit` |
+| `--page-limit <n>` | 否³ | 自动翻页最多翻几页，默认 `20`，最大 `40`；**单独传此 flag 隐式启用 `--page-all`** |
+| `--dry-run` | 否 | 预览 API 请求，不真正调用 |
 
-## 常见用法（给 AI）
+¹ 至少需要提供 `--query` / `--user-ids` / 4 个 bool filter 中的**任意一项**。
+² Bool filter 是 **opt-in**：传 `--has-chatted` 等价 `=true` 触发该过滤；不传或 `=false` 一律视为不施加该 filter（API 不支持反向 filter）。
+³ 不传 `--page-all` 与 `--page-limit` 时 CLI 只请求一页；需要更多结果请收敛 filter 或启用自动翻页。
 
-- 默认输出 JSON，可直接解析获取用户 `open_id`。用 `--format pretty` 查看人类可读格式。
-- 如果结果 `has_more=true`，继续传 `page_token` 翻页，不要盲目调大 `page_size`。
+## 核心约束
+
+### 1. 至少一个搜索输入
+
+`--query` / `--user-ids` / 4 个 bool filter 至少一项非空，否则 CLI 返回 validation error `specify at least one of ...`。
+
+### 2. 仅支持 user 身份
+
+需要 `lark-cli auth login --as user` 完成授权，并具备 `contact:user:search` 权限。
+
+### 3. `me` 表示当前用户
+
+`--user-ids` 中可使用 `me`，CLI 本地解析为当前登录用户的 `open_id`，无需手动先查询自己的用户 ID。
+
+### 4. Bool filter 是 opt-in
+
+4 个 bool filter（`--is-resigned` / `--has-chatted` / `--exclude-outer-contact` / `--has-enterprise-email`）只有 `=true` 触发实际 filter；`=false` 与不传等价（API 限制，不支持反向过滤）。
+
+### 5. 跨租户用户字段可能为空
+
+当结果中 `is_cross_tenant=true` 时，`email` / `enterprise_email` / `display_info` 中的部门路径段可能为空（跟随飞书 profile 页可见性规则）。消费端不应假设"搜到结果就一定有联系方式"，应做空值兜底。
+
+## 输出结果
+
+`data.users[]` 每条对象 12 个字段：
+
+| 字段 | 类型 | 用途 |
+|---|---|---|
+| `name` | string | 按 locale 挑选的单一显示名（默认按 tenant brand，可被 `--lang` 覆盖） |
+| `i18n_names` | map<string,string> | 完整多语种姓名 map（`zh_cn` / `en_us` / `ja_jp` 等），双语场景直接读取 |
+| `open_id` | string | 用户 open_id，可作为 `chat-id` 之外的标识传给其他命令 |
+| `email` | string | 联系邮箱；跨租户用户可能为空 |
+| `enterprise_email` | string | 企业邮箱；跨租户用户可能为空 |
+| `is_registered` | bool | 是否已激活飞书账号；`false` 表示无法接收消息 |
+| `chat_id` | string | 与该用户的单聊 chat_id；**仅在曾经聊过才有值**，可用于 chat-scoped 操作（如 `im +messages-list --chat-id` 查历史）；发新消息用 `im +messages-send --user-id <open_id>` 即可，不依赖此字段 |
+| `has_chatted` | bool | `chat_id != ""` 的派生 bool，prompt 里直接条件判断 |
+| `is_cross_tenant` | bool | 是否跨租户（外部联系人） |
+| `tenant_id` | string | 用户所属租户 ID |
+| `description` | string | 用户签名（自填，常含职位 / 团队信息） |
+| `display_info` | string | 后端聚合的展示串：`<h>命中关键词</h>` + 部门路径 + `[Contacted N days ago]`（仅曾联系过才有），用于 disambiguation |
+
+顶层还有 `has_more` 指示是否有下一页。
+
+## 翻页模式
+
+默认只请求一页。返回 `has_more=true` 时,推荐先**收敛 filter**;确实要拉多页再启用自动翻页。
+
+| 传的 flag | 模式 | 行为 |
+|---|---|---|
+| (都不传) | 单页 | 返 1 页;`has_more=true` 时 stderr 提示收敛 filter 或用 `--page-all` |
+| `--page-all` | 自动(上限 40) | 自动循环直到 `has_more=false` 或达到 40 页 |
+| `--page-limit 5` | 自动(上限 5) | 隐式启用 auto,最多 5 页 |
+| `--page-all --page-limit 5` | 自动(上限 5) | 跟只传 `--page-limit 5` 等价 |
+
+到达 `--page-limit` 仍有 `has_more` 时,stderr 会出:
+```text
+warning: stopped after fetching N page(s); refine the query with more filters, or raise --page-limit (max 40)
+```
+
+`--page-size` 控制单页大小(1-30,默认 20),跟自动 / 手动模式正交。
+
+## 搜索结果中的下一步
+
+- **发消息**：直接用 `open_id` 调 `im +messages-send --user-id <open_id>` —— p2p 聊天 API 自动解析到单聊会话，不需要先查 chat。
+- **查历史聊天**：当 `has_chatted=true` 时 `chat_id` 是已存在的单聊 ID，可用于 `im +messages-list --chat-id <chat_id>` 等 chat-scoped 操作（**新发消息不需要这个字段**，`--user-id` 就够）。
+- **查更多个人资料**：拿 `open_id` 调 `contact +get-user --user-id <open_id>` 获取完整 profile（含部门 ID、union_id 等）。
+- **多语种叫法**：直接读 `i18n_names.<locale>`，不必再发请求。
+
+```bash
+# 一步到位：搜「张三」中第一个聊过天的对象，给 ta 发消息
+OPEN_ID=$(lark-cli contact +search-user --query "张三" --has-chatted --jq '.data.users[0].open_id')
+lark-cli im +messages-send --user-id "$OPEN_ID" --text "Hi!"
+```
+
+## 常见错误与排查
+
+| 错误现象 | 根本原因 | 解决方案 |
+|---|---|---|
+| `specify at least one of --query, --user-ids, ...` | 6 个搜索输入全空 | 至少补一个：`--query` 或某个 filter 或 `--user-ids` |
+| `--query: length must be between 1 and 64 characters` | 关键词超 64 rune | 缩短到 64 rune 以内（CJK 按字符数计） |
+| `--user-ids: must be at most 100 entries` | 列表超 100 个 | 拆批查询，每批 ≤ 100 |
+| `invalid user ID format, should start with 'ou_'` | `--user-ids` 里有非 `ou_` 前缀的项 | 改为 `ou_xxx` 或 `me` |
+| `"me" requires a logged-in user with a resolvable open_id` | 没登录 | 先 `lark-cli auth login --as user` |
+| `--page-size N: must be between 1 and 30` | 分页大小越界 | 1 ≤ N ≤ 30 |
+| `--has-chatted=false` 没有过滤效果 | API 不支持反向 filter，`=false` 等同未传 | 用 `--has-chatted`（=true）后客户端按 `has_chatted` 过滤 |
+| `--page-limit N` 传了 `N > 40` | 超过 CLI 上限 | CLI 拒掉；1 ≤ N ≤ 40 |
+| 跨租户结果 `email` 是空字符串 | 飞书 profile 页可见性规则 | 不是 bug，消费端做空值兜底 |
+
+## 提示
+
+- 默认 `--format json`,便于 jq / 解析;排查请求结构时优先 `--dry-run`。
+- "我聊过天的同事"：用 `--has-chatted` filter 而非客户端过滤(少一次大数据传输 + 排序更优)。
+- 多语种姓名：`name` 已按 locale 挑好,需要其他语种直接读 `i18n_names.<locale>`。
+- 同名 disambiguation：参考 `display_info`(含部门路径 + 最近联系提示)选择正确目标。
 
 ## 参考
 
+- [lark-contact-get-user](lark-contact-get-user.md) — 用 `open_id` 查完整 profile
 - [lark-shared](../../lark-shared/SKILL.md) — 认证和全局参数
+- [lark-im](../../lark-im/SKILL.md) — 拿到 `open_id` 或 `chat_id` 后用 im

--- a/skills/lark-contact/references/lark-contact-search-user.md
+++ b/skills/lark-contact/references/lark-contact-search-user.md
@@ -1,185 +1,88 @@
-# contact +search-user
+# +search-user
 
-> **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
+仅 user 身份。需要 scope `contact:user:search`。
 
-按关键词与多维 filter 搜索员工，返回带多语种姓名、联系方式、聊天关系上下文与命中片段的用户列表，结果按亲密度排序。只读操作，不修改通讯录数据。
+## 适用范围
 
-本 skill 对应 shortcut：`lark-cli contact +search-user`（调用 `POST /open-apis/contact/v3/users/search`）。
+- ✅ 已知姓名 / 邮箱 / 「聊过的人」想找出 open_id
+- ✅ 已知一组 open_id 想批量校验或回填字段(`--user-ids`,最多 100,支持 `me`)
+- ✅ 按聊天关系 / 在职状态 / 租户边界 / 企业邮箱等维度筛选员工
+- ❌ 已知 open_id 想拿完整 profile → 用 `+get-user --as bot`
+- ❌ 已知 open_id 想发消息 → 直接走 `lark-im`,不经过本命令
 
-## 典型触发表达
+## 关键 flag
 
-以下说法通常应优先使用 `contact +search-user`：
+`--query` / `--user-ids` / 4 个 bool filter 至少传一个,否则报错。完整 flag 看 `lark-cli contact +search-user --help`。
 
-- 搜一下叫「张三」的同事
-- 找一个我聊过天的「李海」
-- 列出和我聊过天的离职同事
-- 找有企业邮箱的「王」姓同事
-- 把这一串 open_id 批量取一下姓名 / 邮箱 / 是否激活
-- 查一下「张三」的英文名 / 日文名
+| Flag | 作用 |
+|---|---|
+| `--query <text>` | 关键词(姓名 / 邮箱 / 手机号),≤ 64 rune |
+| `--user-ids <csv>` | open_id 列表,逗号分隔,≤ 100;支持 `me` 表示自己;与 `--query` 同传时把搜索范围限定在该集合 |
+| `--has-chatted` | 仅搜聊过天的(opt-in;**显式 `=false` 会被拒**,下同) |
+| `--has-enterprise-email` | 仅搜有企业邮箱的 |
+| `--exclude-external-users` | 仅搜同租户(排除外部联系人) |
+| `--left-organization` | 仅搜已离职的 |
+| `--lang <locale>` | 覆盖 `localized_name` 的语种(如 `zh_cn` / `en_us` / `ja_jp`) |
+| `--page-size <n>` | 单页大小 1-30,默认 20 |
 
-## 命令
+## 常用例子
 
 ```bash
-# 关键词搜索
-lark-cli contact +search-user --query "张三"
-
-# 关键词 + 只搜聊过天的
+# 按姓名搜,看候选确认是哪个张三
 lark-cli contact +search-user --query "张三" --has-chatted
 
-# 关键词 + 只搜同租户（排除外部联系人）
-lark-cli contact +search-user --query "张三" --exclude-outer-contact
+# 按完整邮箱搜(命中通常唯一,适合作后续命令的输入)
+lark-cli contact +search-user --query "alice@example.com"
 
-# 关键词 + 只搜已离职且聊过天的
-lark-cli contact +search-user --query "张三" --is-resigned
-
-# 关键词 + 只搜有企业邮箱的
-lark-cli contact +search-user --query "张三" --has-enterprise-email
-
-# 多 filter 组合
-lark-cli contact +search-user --query "张三" --has-chatted --exclude-outer-contact
-
-# 取自己的资料
+# 查看自己
 lark-cli contact +search-user --user-ids me
 
-# 按 open_id 批量回填资料
-lark-cli contact +search-user --user-ids "ou_a,ou_b,ou_c"
+# 批量回填:已知一组 open_id,取姓名 / 邮箱 / 部门
+lark-cli contact +search-user --user-ids "ou_a,ou_b,ou_c" --format json
 
-# 关键词 + 限定在指定候选 open_id 集合内验证
-lark-cli contact +search-user --query "张三" --user-ids "ou_a,ou_b,me"
+# 多 filter 组合:同租户的、有企业邮箱的「王」姓员工
+lark-cli contact +search-user --query "王" --exclude-external-users --has-enterprise-email
 
-# 指定姓名 locale（默认按 tenant brand：feishu→zh_cn，lark→en_us）
-lark-cli contact +search-user --query "张三" --lang en_us
-
-# 自动翻页（最多 --page-limit 页，默认 20，上限 40）
-lark-cli contact +search-user --query "张三" --page-all
-
-# 自动翻页并限定最多 5 页
-lark-cli contact +search-user --query "张三" --page-limit 5
-
-# 自定义单页大小（最大 30）
-lark-cli contact +search-user --query "张三" --page-size 30 --page-all
-
-# 排查请求体
-lark-cli contact +search-user --query "张三" --has-chatted --dry-run
+# filter-only 枚举:列出所有"聊过天的离职同事"(无关键词)
+lark-cli contact +search-user --has-chatted --left-organization
 ```
 
-## 参数
+## 同名 disambiguation
 
-| 参数 | 必填 | 说明 |
-|---|---|---|
-| `--query <text>` | 否¹ | 搜索关键词，最大 64 rune（与客户端大搜框对齐） |
-| `--user-ids <ids>` | 否¹ | open_id 列表，逗号分隔；支持 `me` 表示当前用户；最多 100 个 |
-| `--is-resigned` | 否¹² | 仅搜「离职且聊过天」的用户 |
-| `--has-chatted` | 否¹² | 仅搜聊过天的用户（flag 名跟输出字段 `has_chatted` 对齐） |
-| `--exclude-outer-contact` | 否¹² | 仅搜同租户用户（排除外部联系人） |
-| `--has-enterprise-email` | 否¹² | 仅搜有企业邮箱的用户 |
-| `--lang <locale>` | 否 | 覆盖输出 `name` 的语种（如 `zh_cn` / `en_us` / `ja_jp`），默认按 tenant brand |
-| `--page-size <n>` | 否 | 每页数量，默认 `20`，最大 `30` |
-| `--page-all` | 否³ | 自动翻页直到 `has_more=false` 或到达 `--page-limit` |
-| `--page-limit <n>` | 否³ | 自动翻页最多翻几页，默认 `20`，最大 `40`；**单独传此 flag 隐式启用 `--page-all`** |
-| `--dry-run` | 否 | 预览 API 请求，不真正调用 |
+搜常见姓名常返回多条同名结果。后续操作若有副作用(发消息、邀请会议等),把候选列给用户挑;**不要擅自选**。
 
-¹ 至少需要提供 `--query` / `--user-ids` / 4 个 bool filter 中的**任意一项**。
-² Bool filter 是 **opt-in**：传 `--has-chatted` 等价 `=true` 触发该过滤；不传或 `=false` 一律视为不施加该 filter（API 不支持反向 filter）。
-³ 不传 `--page-all` 与 `--page-limit` 时 CLI 只请求一页；需要更多结果请收敛 filter 或启用自动翻页。
-
-## 核心约束
-
-### 1. 至少一个搜索输入
-
-`--query` / `--user-ids` / 4 个 bool filter 至少一项非空，否则 CLI 返回 validation error `specify at least one of ...`。
-
-### 2. 仅支持 user 身份
-
-需要 `lark-cli auth login --as user` 完成授权，并具备 `contact:user:search` 权限。
-
-### 3. `me` 表示当前用户
-
-`--user-ids` 中可使用 `me`，CLI 本地解析为当前登录用户的 `open_id`，无需手动先查询自己的用户 ID。
-
-### 4. Bool filter 是 opt-in
-
-4 个 bool filter（`--is-resigned` / `--has-chatted` / `--exclude-outer-contact` / `--has-enterprise-email`）只有 `=true` 触发实际 filter；`=false` 与不传等价（API 限制，不支持反向过滤）。
-
-### 5. 跨租户用户字段可能为空
-
-当结果中 `is_cross_tenant=true` 时，`email` / `enterprise_email` / `display_info` 中的部门路径段可能为空（跟随飞书 profile 页可见性规则）。消费端不应假设"搜到结果就一定有联系方式"，应做空值兜底。
-
-## 输出结果
-
-`data.users[]` 每条对象 12 个字段：
-
-| 字段 | 类型 | 用途 |
-|---|---|---|
-| `name` | string | 按 locale 挑选的单一显示名（默认按 tenant brand，可被 `--lang` 覆盖） |
-| `i18n_names` | map<string,string> | 完整多语种姓名 map（`zh_cn` / `en_us` / `ja_jp` 等），双语场景直接读取 |
-| `open_id` | string | 用户 open_id，可作为 `chat-id` 之外的标识传给其他命令 |
-| `email` | string | 联系邮箱；跨租户用户可能为空 |
-| `enterprise_email` | string | 企业邮箱；跨租户用户可能为空 |
-| `is_registered` | bool | 是否已激活飞书账号；`false` 表示无法接收消息 |
-| `chat_id` | string | 与该用户的单聊 chat_id；**仅在曾经聊过才有值**，可用于 chat-scoped 操作（如 `im +messages-list --chat-id` 查历史）；发新消息用 `im +messages-send --user-id <open_id>` 即可，不依赖此字段 |
-| `has_chatted` | bool | `chat_id != ""` 的派生 bool，prompt 里直接条件判断 |
-| `is_cross_tenant` | bool | 是否跨租户（外部联系人） |
-| `tenant_id` | string | 用户所属租户 ID |
-| `description` | string | 用户签名（自填，常含职位 / 团队信息） |
-| `display_info` | string | 后端聚合的展示串：`<h>命中关键词</h>` + 部门路径 + `[Contacted N days ago]`（仅曾联系过才有），用于 disambiguation |
-
-顶层还有 `has_more` 指示是否有下一页。
-
-## 翻页模式
-
-默认只请求一页。返回 `has_more=true` 时,推荐先**收敛 filter**;确实要拉多页再启用自动翻页。
-
-| 传的 flag | 模式 | 行为 |
-|---|---|---|
-| (都不传) | 单页 | 返 1 页;`has_more=true` 时 stderr 提示收敛 filter 或用 `--page-all` |
-| `--page-all` | 自动(上限 40) | 自动循环直到 `has_more=false` 或达到 40 页 |
-| `--page-limit 5` | 自动(上限 5) | 隐式启用 auto,最多 5 页 |
-| `--page-all --page-limit 5` | 自动(上限 5) | 跟只传 `--page-limit 5` 等价 |
-
-到达 `--page-limit` 仍有 `has_more` 时,stderr 会出:
-```text
-warning: stopped after fetching N page(s); refine the query with more filters, or raise --page-limit (max 40)
-```
-
-`--page-size` 控制单页大小(1-30,默认 20),跟自动 / 手动模式正交。
-
-## 搜索结果中的下一步
-
-- **发消息**：直接用 `open_id` 调 `im +messages-send --user-id <open_id>` —— p2p 聊天 API 自动解析到单聊会话，不需要先查 chat。
-- **查历史聊天**：当 `has_chatted=true` 时 `chat_id` 是已存在的单聊 ID，可用于 `im +messages-list --chat-id <chat_id>` 等 chat-scoped 操作（**新发消息不需要这个字段**，`--user-id` 就够）。
-- **查更多个人资料**：拿 `open_id` 调 `contact +get-user --user-id <open_id>` 获取完整 profile（含部门 ID、union_id 等）。
-- **多语种叫法**：直接读 `i18n_names.<locale>`，不必再发请求。
+筛选信号(可信度从高到低):`chat_recency_hint`(近期联系过) > `enterprise_email` 前缀 > `department` 关键词。`localized_name` 同名时无区分作用。
 
 ```bash
-# 一步到位：搜「张三」中第一个聊过天的对象，给 ta 发消息
-OPEN_ID=$(lark-cli contact +search-user --query "张三" --has-chatted --jq '.data.users[0].open_id')
-lark-cli im +messages-send --user-id "$OPEN_ID" --text "Hi!"
+# 用 jq 按部门精筛
+lark-cli contact +search-user --query "张三" \
+  --jq '.data.users[] | select(.department | contains("<部门关键词>"))'
 ```
 
-## 常见错误与排查
+## 注意事项
 
-| 错误现象 | 根本原因 | 解决方案 |
-|---|---|---|
-| `specify at least one of --query, --user-ids, ...` | 6 个搜索输入全空 | 至少补一个：`--query` 或某个 filter 或 `--user-ids` |
-| `--query: length must be between 1 and 64 characters` | 关键词超 64 rune | 缩短到 64 rune 以内（CJK 按字符数计） |
-| `--user-ids: must be at most 100 entries` | 列表超 100 个 | 拆批查询，每批 ≤ 100 |
-| `invalid user ID format, should start with 'ou_'` | `--user-ids` 里有非 `ou_` 前缀的项 | 改为 `ou_xxx` 或 `me` |
-| `"me" requires a logged-in user with a resolvable open_id` | 没登录 | 先 `lark-cli auth login --as user` |
-| `--page-size N: must be between 1 and 30` | 分页大小越界 | 1 ≤ N ≤ 30 |
-| `--has-chatted=false` 没有过滤效果 | API 不支持反向 filter，`=false` 等同未传 | 用 `--has-chatted`（=true）后客户端按 `has_chatted` 过滤 |
-| `--page-limit N` 传了 `N > 40` | 超过 CLI 上限 | CLI 拒掉；1 ≤ N ≤ 40 |
-| 跨租户结果 `email` 是空字符串 | 飞书 profile 页可见性规则 | 不是 bug，消费端做空值兜底 |
+- **不会自动翻页**。`has_more=true` 表示要 refine query,不是叫你翻页。
+- **bool filter 显式传 `=false` 会报错**:不传等于不过滤;启用就传 flag(不带值)。
+- **`--lang` 只影响输出展示名**,不影响匹配字段。
+- **`--query` 与 `--user-ids` 同时设**:`--user-ids` 进 `filter.user_ids`(限定搜索范围),`--query` 进顶层(关键字),按服务端 filter 语义在该 ID 集合内匹配;请求结构可 `--dry-run` 确认。
 
-## 提示
+## 输出字段 contract
 
-- 默认 `--format json`,便于 jq / 解析;排查请求结构时优先 `--dry-run`。
-- "我聊过天的同事"：用 `--has-chatted` filter 而非客户端过滤(少一次大数据传输 + 排序更优)。
-- 多语种姓名：`name` 已按 locale 挑好,需要其他语种直接读 `i18n_names.<locale>`。
-- 同名 disambiguation：参考 `display_info`(含部门路径 + 最近联系提示)选择正确目标。
+`data.users[]` 的字段集合稳定,可直接 jq / 反序列化。跨租户用户(`is_cross_tenant=true`)按飞书可见性规则,业务字段可能为空字符串 —— 下游做空值兜底,不要当成"字段缺失"。
 
-## 参考
+| 字段 | 类型 | 说明 | 跨租户 |
+|---|---|---|---|
+| `open_id` | string | 稳定标识,后续命令以此为准 | 始终非空 |
+| `localized_name` | string | 按 `--lang` / brand 选出的展示名;想换语言重查时传 `--lang en_us` 等 | 始终非空(兜底为 open_id) |
+| `email` | string | 个人邮箱 | 可能为空 |
+| `enterprise_email` | string | 企业邮箱 | 可能为空 |
+| `is_activated` | bool | 是否已激活飞书账号(未激活也可投递消息,但用户可能看不到) | 可能 false |
+| `is_cross_tenant` | bool | 是否跨租户用户(同公司=false,外部联系人=true) | — |
+| `p2p_chat_id` | string | 与当前用户的现有 P2P 会话 ID(`oc_...`);空表示从未私聊过。可作为任何接受 `--chat-id` 的 IM 命令的输入 | 可能为空 |
+| `has_chatted` | bool | `p2p_chat_id != ""` 的派生字段 | — |
+| `department` | string | 部门路径,服务端可能用 `-` 拼层级,层级数不固定。**按可子串匹配的字符串处理** | 可能为空 |
+| `signature` | string | 用户个性签名(API 原名 `description`,本 CLI 重命名以反映真实语义)。同名 disambiguation 时可作为辅助信号 | 可能为空 |
+| `chat_recency_hint` | string | 最近联系提示文案,如 `"Contacted 2 days ago"`;空表示无近期联系 | 可能为空 |
+| `match_segments` | string[] | 关键词命中的字符串片段,用于高亮展示;无命中则为空数组 | — |
 
-- [lark-contact-get-user](lark-contact-get-user.md) — 用 `open_id` 查完整 profile
-- [lark-shared](../../lark-shared/SKILL.md) — 认证和全局参数
-- [lark-im](../../lark-im/SKILL.md) — 拿到 `open_id` 或 `chat_id` 后用 im
+表中字段即本 shortcut 的输出契约,移除或改名按 breaking change 处理。


### PR DESCRIPTION
## Summary

Upgrade `lark-cli contact +search-user` to the new `POST /contact/v3/users/search` API. Adds search filters and richer result fields so callers (primarily AI agents) can find people more precisely and tell similar candidates apart at a glance. Existing `+search-user --query xxx` invocations continue to work unchanged.

```bash
# keyword + filter
lark-cli contact +search-user --query 张 --has-contact --exclude-outer-contact --as user

# enrich a known open_id list
lark-cli contact +search-user --user-ids me,ou_xxx --as user

# pull just the fields you care about
lark-cli contact +search-user --query 张 --jq '.data.users[] | {name, has_chatted, chat_id}' --as user
```

## Key capabilities

- **New search filters**: `--user-ids` (CSV with `me` expansion, max 100), `--is-resigned`, `--has-contact`, `--exclude-outer-contact`, `--has-enterprise-email`, plus `--lang` for the locale used in the picked `name`.
- **`--query` is now optional**: pair with at least one filter for "list all my external contacts" style queries; bounded to 64 runes to match the client search box.
- **Richer result fields**: multilingual names (`i18n_names` map + locale-picked `name`), real contact info (`email`, `enterprise_email`), relationship signals (`chat_id` + derived `has_chatted`), tenant context (`is_cross_tenant`, `tenant_id`), user signature (`description`), and the backend's `display_info` hit-highlight line (matched segment + department path + recent-contact hint).
- **Always-empty legacy columns dropped**: `mobile`, `department`, `avatar`, `user_id` no longer surfaced (the new API does not return them).
- **Drive-by skill-doc fix**: `skills/lark-contact/references/lark-contact-get-user.md` previously instructed callers to pass `--table` (a flag that never existed and would error out under cobra). Now correctly documents `--format table` and the full `--format` enum (`json` / `pretty` / `table` / `ndjson` / `csv`).

## Test Plan

- [x] Unit tests in `shortcuts/contact/contact_search_user_test.go`: `pickName` fallback chain (8 cases), response mapping (3), validation (8), body/params builders (7), integration via `mountAndRun` + `httpmock` (6)
- [x] `go test ./...` green; no regressions in `shortcuts/minutes` (the shared `resolveUserIDs` helper moved to `shortcuts/common.ResolveOpenIDs`)
- [x] `golangci-lint run --new-from-rev=origin/main` clean (no `net/http` import in shortcuts; uses string method literal with `runtime.CallAPI` per repo convention)
- [x] Manual E2E against a real Lark tenant: all 9 input flags, all 12 output fields, all 5 output formats (`pretty` / `json` / `table` / `ndjson` / `csv`), validation paths, pagination round-trip, empty result, locale override, multi-filter composition, special-char inputs, API-limit boundaries (`--page-size` 30, `--user-ids` 100, `--query` 64 rune)
- [x] Verified the skill-doc fix: `+get-user --format table` works against a real tenant; the previously-documented `--table` correctly errors out

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned contact user search: POST-based API, richer opt-in filters, --user-ids (supports "me"), --lang, tightened page-size (1–30), and streamlined table columns.

* **Behavior Changes / Bug Fixes**
  * Centralized "me" → logged-in OpenID expansion with case-insensitive dedupe (preserves first-seen casing); error when not logged in. Refine hints go to stderr; removed auto-pagination flags.

* **Tests**
  * Large suite of unit/integration tests for search, validation, name selection, ID resolution, parsing, and outputs.

* **Documentation**
  * Updated skill and command docs, examples, and usage guidance.

* **Chores**
  * Linting rules updated to forbid raw HTTP construction in shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->