### PR TITLE
feat(auth): mint tenant access token from env app credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- **auth**: env credential provider now exchanges `LARKSUITE_CLI_APP_ID` + `LARKSUITE_CLI_APP_SECRET` for a tenant access token on demand, enabling zero-config bot auth for remote AI agents, CI jobs, and ephemeral containers with no keychain or `auth login` step. The token is cached per-process until it expires.
+- **auth**: infer `SupportsBot` and `DefaultAs=bot` from `LARKSUITE_CLI_APP_SECRET` so commands work without an explicit `--as bot` flag when only app credentials are provided.
+
+### Refactor
+
+- **auth**: extract the tenant_access_token exchange into a shared `auth.FetchTenantAccessToken` helper, reused by the default and env credential providers.
+
+### Documentation
+
+- README / README.zh: document environment-based credential resolution under the Authentication section, with a pointer from the Quick Start (AI Agent) for headless setups.
+- `lark-shared` skill: note env-based bot auth as an alternative to `config init` + `auth login` for headless agents.
+
 ## [v1.0.17] - 2026-04-22
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ export LARKSUITE_CLI_APP_SECRET=yyy
 lark-cli docs +create --as bot --title "Report" --markdown "# Hello"
 ```
 
-Environment credentials take priority over any `config init` profile on the same machine, so the same binary works interactively on a workstation and headlessly in CI without extra flags. Because user identity requires an interactive authorization step, env-only setups can call bot-capable commands only; mix in `LARKSUITE_CLI_USER_ACCESS_TOKEN` to enable `--as user`.
+Environment credentials take priority over any `config init` profile on the same machine, so the same binary works interactively on a workstation and headlessly in CI without extra flags. User identity normally requires an interactive `auth login`, so `APP_ID + APP_SECRET` alone grants bot identity. To run `--as user` purely from environment, issue a user access token ahead of time and export it as `LARKSUITE_CLI_USER_ACCESS_TOKEN` alongside `LARKSUITE_CLI_APP_ID`.
 
 ## Three-Layer Command System
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ lark-cli calendar +agenda
 ## Quick Start (AI Agent)
 
 > The following steps are for AI Agents. Some steps require the user to complete actions in a browser.
+>
+> **Headless environments (remote agents, CI jobs, containers without a browser):** skip Steps 2–3 and inject `LARKSUITE_CLI_APP_ID` + `LARKSUITE_CLI_APP_SECRET` as environment variables instead. See [Environment-based credentials](#environment-based-credentials-agents--ci) for the full variable list.
 
 **Step 1 — Install**
 
@@ -189,6 +191,30 @@ lark-cli auth login --device-code <DEVICE_CODE>
 lark-cli calendar +agenda --as user
 lark-cli im +messages-send --as bot --chat-id "oc_xxx" --text "Hello"
 ```
+
+### Environment-based credentials (agents & CI)
+
+Remote AI agents, CI jobs, and ephemeral containers often cannot run a browser-based device flow or rely on an OS keychain. `lark-cli` resolves credentials from environment variables with no prior `config init` or `auth login`:
+
+| Variable | Purpose |
+| -------- | ------- |
+| `LARKSUITE_CLI_APP_ID` | App ID from the Lark/Feishu open platform. |
+| `LARKSUITE_CLI_APP_SECRET` | App secret. Setting this unlocks bot identity: the CLI exchanges it for a tenant access token on demand and caches the result in-process until it expires. |
+| `LARKSUITE_CLI_BRAND` | `feishu` (default) or `lark`. |
+| `LARKSUITE_CLI_TENANT_ACCESS_TOKEN` | Pre-issued TAT. When set, the CLI uses it directly and skips the app-secret exchange. |
+| `LARKSUITE_CLI_USER_ACCESS_TOKEN` | Pre-issued UAT. Enables user-identity commands without running `auth login`. |
+| `LARKSUITE_CLI_DEFAULT_AS` | `user`, `bot`, or `auto`. Controls the default `--as` identity; inferred from available credentials when omitted. |
+| `LARKSUITE_CLI_STRICT_MODE` | `user`, `bot`, or `off`. Locks the CLI to a single identity. |
+
+Minimal bot setup — no keychain, no login, no profile:
+
+```bash
+export LARKSUITE_CLI_APP_ID=cli_xxx
+export LARKSUITE_CLI_APP_SECRET=yyy
+lark-cli docs +create --as bot --title "Report" --markdown "# Hello"
+```
+
+Environment credentials take priority over any `config init` profile on the same machine, so the same binary works interactively on a workstation and headlessly in CI without extra flags. Because user identity requires an interactive authorization step, env-only setups can call bot-capable commands only; mix in `LARKSUITE_CLI_USER_ACCESS_TOKEN` to enable `--as user`.
 
 ## Three-Layer Command System
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -215,7 +215,7 @@ export LARKSUITE_CLI_APP_SECRET=yyy
 lark-cli docs +create --as bot --title "报告" --markdown "# 你好"
 ```
 
-同一机器上环境变量凭证优先级高于 `config init` 写入的 profile，因此同一个二进制既能在开发机上交互使用，又能在 CI 中无头运行，无需额外参数切换。user 身份需要交互式授权，仅使用环境变量时只能调用 bot 可用的命令；若需 `--as user`，请额外导出 `LARKSUITE_CLI_USER_ACCESS_TOKEN`。
+同一机器上环境变量凭证优先级高于 `config init` 写入的 profile，因此同一个二进制既能在开发机上交互使用，又能在 CI 中无头运行，无需额外参数切换。user 身份通常需要走 `auth login` 的交互式授权，所以仅设 `APP_ID + APP_SECRET` 时只授予 bot 身份。若要在纯环境变量下跑 `--as user`，请提前签发 user access token 并导出为 `LARKSUITE_CLI_USER_ACCESS_TOKEN`（配合 `LARKSUITE_CLI_APP_ID`）。
 
 ## 三层命令调用
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -96,6 +96,8 @@ lark-cli calendar +agenda
 ### 快速开始（AI Agent）
 
 > 以下步骤面向 AI Agent，部分步骤需要用户在浏览器中配合完成。
+>
+> **无人值守场景（远程 Agent、CI、无浏览器容器）**：跳过第 2–3 步，改为注入 `LARKSUITE_CLI_APP_ID` + `LARKSUITE_CLI_APP_SECRET` 环境变量。完整变量列表见[基于环境变量的凭证](#基于环境变量的凭证agent--ci)。
 
 **第 1 步 — 安装**
 
@@ -190,6 +192,30 @@ lark-cli auth login --device-code <DEVICE_CODE>
 lark-cli calendar +agenda --as user
 lark-cli im +messages-send --as bot --chat-id "oc_xxx" --text "Hello"
 ```
+
+### 基于环境变量的凭证（Agent & CI）
+
+远程 AI Agent、CI 任务和短生命周期的容器通常无法运行基于浏览器的 device flow，也没有 OS keychain。`lark-cli` 会从环境变量读取凭证，无需预先执行 `config init` 或 `auth login`：
+
+| 变量 | 用途 |
+| ---- | ---- |
+| `LARKSUITE_CLI_APP_ID` | 飞书/Lark 开放平台的 App ID。 |
+| `LARKSUITE_CLI_APP_SECRET` | App Secret。设置后自动解锁 bot 身份：CLI 会按需调用 `tenant_access_token/internal` 换取 TAT，并在进程内缓存至过期。 |
+| `LARKSUITE_CLI_BRAND` | `feishu`（默认）或 `lark`。 |
+| `LARKSUITE_CLI_TENANT_ACCESS_TOKEN` | 预先签发的 TAT。设置后 CLI 直接使用该 token，跳过 app secret 换取流程。 |
+| `LARKSUITE_CLI_USER_ACCESS_TOKEN` | 预先签发的 UAT。启用 user 身份命令，无需运行 `auth login`。 |
+| `LARKSUITE_CLI_DEFAULT_AS` | `user`、`bot` 或 `auto`。控制默认 `--as` 身份；省略时根据已有凭证自动推断。 |
+| `LARKSUITE_CLI_STRICT_MODE` | `user`、`bot` 或 `off`。将 CLI 锁定到单一身份。 |
+
+最小 bot 配置 — 无 keychain、无登录、无 profile：
+
+```bash
+export LARKSUITE_CLI_APP_ID=cli_xxx
+export LARKSUITE_CLI_APP_SECRET=yyy
+lark-cli docs +create --as bot --title "报告" --markdown "# 你好"
+```
+
+同一机器上环境变量凭证优先级高于 `config init` 写入的 profile，因此同一个二进制既能在开发机上交互使用，又能在 CI 中无头运行，无需额外参数切换。user 身份需要交互式授权，仅使用环境变量时只能调用 bot 可用的命令；若需 `--as user`，请额外导出 `LARKSUITE_CLI_USER_ACCESS_TOKEN`。
 
 ## 三层命令调用
 

--- a/extension/credential/env/env.go
+++ b/extension/credential/env/env.go
@@ -1,19 +1,70 @@
 // Copyright (c) 2026 Lark Technologies Pte. Ltd.
 // SPDX-License-Identifier: MIT
 
+// Package env implements a credential.Provider that resolves app credentials
+// and access tokens from environment variables. It is the primary auth path
+// for headless callers — remote AI agents, CI jobs, and short-lived
+// containers — where interactive device flow and OS keychains are unavailable.
+//
+// See the Provider type for the full list of supported environment variables.
 package env
 
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
+	"sync"
+	"time"
 
 	"github.com/larksuite/cli/extension/credential"
+	"github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/envvars"
 )
 
+// tatSafetyMargin is subtracted from the server-reported expiry so callers
+// always see a token with enough remaining life to complete a request.
+const tatSafetyMargin = 30 * time.Second
+
+// tatFetcher performs the app_id + app_secret → tenant_access_token exchange.
+// Exposed as a package-level variable so tests can stub it out.
+var tatFetcher = func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error) {
+	ep := core.ResolveEndpoints(core.LarkBrand(brand))
+	res, err := auth.FetchTenantAccessToken(ctx, hc, ep.Open, appID, appSecret)
+	if err != nil {
+		return "", 0, err
+	}
+	return res.Token, res.ExpiresIn, nil
+}
+
 // Provider resolves credentials from environment variables.
-type Provider struct{}
+//
+// Supported modes:
+//
+//   - Bot via app secret: LARKSUITE_CLI_APP_ID + LARKSUITE_CLI_APP_SECRET.
+//     The provider exchanges these for a tenant access token on demand
+//     and caches the result in-process until it expires. This is the
+//     preferred mode for ephemeral, non-interactive callers (CI jobs,
+//     remote agents) since no keychain or profile setup is required.
+//   - Bot via pre-issued token: LARKSUITE_CLI_APP_ID + LARKSUITE_CLI_TENANT_ACCESS_TOKEN.
+//   - User via pre-issued token: LARKSUITE_CLI_APP_ID + LARKSUITE_CLI_USER_ACCESS_TOKEN
+//     (optionally combined with LARKSUITE_CLI_APP_SECRET for bot fallback).
+type Provider struct {
+	// HTTPClient is used for the tenant_access_token exchange. A nil value
+	// falls back to http.DefaultClient.
+	HTTPClient *http.Client
+
+	tatMu    sync.Mutex
+	tatCache tatCacheEntry
+}
+
+type tatCacheEntry struct {
+	token     string
+	expiresAt time.Time
+	appID     string
+	brand     credential.Brand
+}
 
 func (p *Provider) Name() string { return "env" }
 
@@ -68,11 +119,12 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 	case "off":
 		acct.SupportedIdentities = credential.SupportsAll
 	case "":
-		// Infer from available tokens
+		// Infer from available tokens. An app_secret unlocks bot identity
+		// because a tenant access token can be minted on demand.
 		if hasUAT {
 			acct.SupportedIdentities |= credential.SupportsUser
 		}
-		if hasTAT {
+		if hasTAT || appSecret != "" {
 			acct.SupportedIdentities |= credential.SupportsBot
 		}
 	default:
@@ -86,7 +138,7 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 		switch {
 		case hasUAT:
 			acct.DefaultAs = credential.IdentityUser
-		case hasTAT:
+		case hasTAT, appSecret != "":
 			acct.DefaultAs = credential.IdentityBot
 		}
 	}
@@ -95,20 +147,88 @@ func (p *Provider) ResolveAccount(ctx context.Context) (*credential.Account, err
 }
 
 func (p *Provider) ResolveToken(ctx context.Context, req credential.TokenSpec) (*credential.Token, error) {
-	var envKey string
 	switch req.Type {
 	case credential.TokenTypeUAT:
-		envKey = envvars.CliUserAccessToken
+		token := os.Getenv(envvars.CliUserAccessToken)
+		if token == "" {
+			return nil, nil
+		}
+		return &credential.Token{Value: token, Source: "env:" + envvars.CliUserAccessToken}, nil
+
 	case credential.TokenTypeTAT:
-		envKey = envvars.CliTenantAccessToken
+		if token := os.Getenv(envvars.CliTenantAccessToken); token != "" {
+			return &credential.Token{Value: token, Source: "env:" + envvars.CliTenantAccessToken}, nil
+		}
+		return p.mintTenantAccessToken(ctx, req.AppID)
+
 	default:
 		return nil, nil
 	}
-	token := os.Getenv(envKey)
-	if token == "" {
+}
+
+// mintTenantAccessToken exchanges app_id + app_secret for a tenant access token.
+// Returns nil, nil when app_secret is absent so the credential layer surfaces a
+// clean TokenUnavailableError rather than a harder-to-debug exchange failure.
+func (p *Provider) mintTenantAccessToken(ctx context.Context, requestedAppID string) (*credential.Token, error) {
+	appID := os.Getenv(envvars.CliAppID)
+	appSecret := os.Getenv(envvars.CliAppSecret)
+	if appID == "" || appSecret == "" {
 		return nil, nil
 	}
-	return &credential.Token{Value: token, Source: "env:" + envKey}, nil
+	if requestedAppID != "" && requestedAppID != appID {
+		return nil, &credential.BlockError{
+			Provider: "env",
+			Reason:   fmt.Sprintf("requested app_id %q does not match %s=%q", requestedAppID, envvars.CliAppID, appID),
+		}
+	}
+	brand := credential.Brand(os.Getenv(envvars.CliBrand))
+	if brand == "" {
+		brand = credential.BrandFeishu
+	}
+
+	p.tatMu.Lock()
+	defer p.tatMu.Unlock()
+	if token := p.cachedTAT(appID, brand); token != "" {
+		return &credential.Token{Value: token, Source: "env:" + envvars.CliAppSecret + "(cached)"}, nil
+	}
+
+	hc := p.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	token, expiresIn, err := tatFetcher(ctx, hc, brand, appID, appSecret)
+	if err != nil {
+		return nil, fmt.Errorf("env provider: tenant_access_token exchange failed: %w", err)
+	}
+	if token == "" {
+		return nil, fmt.Errorf("env provider: tenant_access_token exchange returned empty token")
+	}
+	ttl := time.Duration(expiresIn) * time.Second
+	if ttl > tatSafetyMargin {
+		ttl -= tatSafetyMargin
+	}
+	p.tatCache = tatCacheEntry{
+		token:     token,
+		expiresAt: time.Now().Add(ttl),
+		appID:     appID,
+		brand:     brand,
+	}
+	return &credential.Token{Value: token, Source: "env:" + envvars.CliAppSecret}, nil
+}
+
+// cachedTAT returns a still-valid cached token for (appID, brand) or "".
+// Caller must hold p.tatMu.
+func (p *Provider) cachedTAT(appID string, brand credential.Brand) string {
+	if p.tatCache.token == "" {
+		return ""
+	}
+	if p.tatCache.appID != appID || p.tatCache.brand != brand {
+		return ""
+	}
+	if time.Now().After(p.tatCache.expiresAt) {
+		return ""
+	}
+	return p.tatCache.token
 }
 
 func init() {

--- a/extension/credential/env/env.go
+++ b/extension/credential/env/env.go
@@ -233,16 +233,19 @@ func (p *Provider) mintTenantAccessToken(ctx context.Context, requestedAppID str
 	if token == "" {
 		return nil, fmt.Errorf("env provider: tenant_access_token exchange returned empty token")
 	}
-	ttl := time.Duration(expiresIn) * time.Second
-	if ttl > tatSafetyMargin {
-		ttl -= tatSafetyMargin
+	ttl := time.Duration(expiresIn)*time.Second - tatSafetyMargin
+	if ttl > 0 {
+		p.tatCache = tatCacheEntry{
+			token:     token,
+			expiresAt: time.Now().Add(ttl),
+			appID:     appID,
+			brand:     brand,
+		}
 	}
-	p.tatCache = tatCacheEntry{
-		token:     token,
-		expiresAt: time.Now().Add(ttl),
-		appID:     appID,
-		brand:     brand,
-	}
+	// If ttl <= 0 (server-reported life too short to honour the safety
+	// margin, or expiresIn==0), surface the token once without caching so
+	// the next call re-mints rather than returning a token that already
+	// violates the margin invariant.
 	return &credential.Token{Value: token, Source: "env:" + envvars.CliAppSecret}, nil
 }
 

--- a/extension/credential/env/env.go
+++ b/extension/credential/env/env.go
@@ -27,15 +27,29 @@ import (
 // always see a token with enough remaining life to complete a request.
 const tatSafetyMargin = 30 * time.Second
 
-// tatFetcher performs the app_id + app_secret → tenant_access_token exchange.
-// Exposed as a package-level variable so tests can stub it out.
-var tatFetcher = func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error) {
+// defaultTATTimeout bounds the token-exchange call when the Provider's
+// HTTPClient field is nil. A finite timeout prevents a hung TCP connection
+// from indefinitely blocking concurrent callers on the minter lock.
+const defaultTATTimeout = 30 * time.Second
+
+// tatFetcherFunc performs the app_id + app_secret → tenant_access_token exchange.
+// Production code uses realTATFetcher; tests substitute a stub on Provider.
+type tatFetcherFunc func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error)
+
+// realTATFetcher is the production implementation wired by default.
+func realTATFetcher(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error) {
 	ep := core.ResolveEndpoints(core.LarkBrand(brand))
 	res, err := auth.FetchTenantAccessToken(ctx, hc, ep.Open, appID, appSecret)
 	if err != nil {
 		return "", 0, err
 	}
 	return res.Token, res.ExpiresIn, nil
+}
+
+// defaultHTTPClient returns a timeout-protected client used when the caller
+// does not supply one via Provider.HTTPClient.
+func defaultHTTPClient() *http.Client {
+	return &http.Client{Timeout: defaultTATTimeout}
 }
 
 // Provider resolves credentials from environment variables.
@@ -52,8 +66,14 @@ var tatFetcher = func(ctx context.Context, hc *http.Client, brand credential.Bra
 //     (optionally combined with LARKSUITE_CLI_APP_SECRET for bot fallback).
 type Provider struct {
 	// HTTPClient is used for the tenant_access_token exchange. A nil value
-	// falls back to http.DefaultClient.
+	// falls back to a dedicated client with a 30-second timeout so a hung
+	// exchange cannot wedge the minter lock indefinitely.
 	HTTPClient *http.Client
+
+	// fetchTAT overrides the production TAT exchange for tests. Unit tests
+	// assign a stub here instead of mutating package state so concurrent
+	// tests cannot interfere with each other.
+	fetchTAT tatFetcherFunc
 
 	tatMu    sync.Mutex
 	tatCache tatCacheEntry
@@ -169,6 +189,12 @@ func (p *Provider) ResolveToken(ctx context.Context, req credential.TokenSpec) (
 // mintTenantAccessToken exchanges app_id + app_secret for a tenant access token.
 // Returns nil, nil when app_secret is absent so the credential layer surfaces a
 // clean TokenUnavailableError rather than a harder-to-debug exchange failure.
+//
+// The lock is intentionally held across the HTTP exchange: concurrent callers
+// share the same result and do not stampede the auth endpoint. The default
+// HTTP client carries a 30-second timeout (see defaultTATTimeout) so a hung
+// exchange cannot wedge the mutex indefinitely; callers needing a different
+// budget should set Provider.HTTPClient or pass a context with a deadline.
 func (p *Provider) mintTenantAccessToken(ctx context.Context, requestedAppID string) (*credential.Token, error) {
 	appID := os.Getenv(envvars.CliAppID)
 	appSecret := os.Getenv(envvars.CliAppSecret)
@@ -194,9 +220,13 @@ func (p *Provider) mintTenantAccessToken(ctx context.Context, requestedAppID str
 
 	hc := p.HTTPClient
 	if hc == nil {
-		hc = http.DefaultClient
+		hc = defaultHTTPClient()
 	}
-	token, expiresIn, err := tatFetcher(ctx, hc, brand, appID, appSecret)
+	fetch := p.fetchTAT
+	if fetch == nil {
+		fetch = realTATFetcher
+	}
+	token, expiresIn, err := fetch(ctx, hc, brand, appID, appSecret)
 	if err != nil {
 		return nil, fmt.Errorf("env provider: tenant_access_token exchange failed: %w", err)
 	}

--- a/extension/credential/env/env_test.go
+++ b/extension/credential/env/env_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,12 +17,14 @@ import (
 )
 
 // withStubFetcher installs a TAT fetcher stub on p and returns a pointer to a
-// call counter. Scoping the stub to a single Provider avoids cross-test
-// interference when tests run in parallel.
-func withStubFetcher(p *Provider, fn func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error)) *int {
-	calls := 0
+// goroutine-safe call counter. Scoping the stub to a single Provider avoids
+// cross-test interference when tests run in parallel, and the atomic counter
+// keeps race-detector runs clean even if a future test drives the stub
+// concurrently.
+func withStubFetcher(p *Provider, fn func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error)) *atomic.Int32 {
+	var calls atomic.Int32
 	p.fetchTAT = func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error) {
-		calls++
+		calls.Add(1)
 		return fn(ctx, hc, brand, appID, appSecret)
 	}
 	return &calls
@@ -331,8 +334,8 @@ func TestResolveToken_TATMintedFromAppSecret(t *testing.T) {
 	if tok == nil || tok.Value != "minted-tat" {
 		t.Fatalf("unexpected token: %+v", tok)
 	}
-	if *calls != 1 {
-		t.Errorf("expected 1 fetch call, got %d", *calls)
+	if calls.Load() != 1 {
+		t.Errorf("expected 1 fetch call, got %d", calls.Load())
 	}
 
 	// Second call within TTL should hit the cache, not refetch.
@@ -343,8 +346,8 @@ func TestResolveToken_TATMintedFromAppSecret(t *testing.T) {
 	if tok2.Value != "minted-tat" {
 		t.Errorf("cached value mismatch: %+v", tok2)
 	}
-	if *calls != 1 {
-		t.Errorf("cache miss: expected 1 fetch call total, got %d", *calls)
+	if calls.Load() != 1 {
+		t.Errorf("cache miss: expected 1 fetch call total, got %d", calls.Load())
 	}
 }
 
@@ -366,8 +369,8 @@ func TestResolveToken_TATPreferredOverMintWhenEnvSet(t *testing.T) {
 	if tok.Value != "env-tat" {
 		t.Errorf("expected env TAT, got %q", tok.Value)
 	}
-	if *calls != 0 {
-		t.Errorf("expected 0 fetcher calls, got %d", *calls)
+	if calls.Load() != 0 {
+		t.Errorf("expected 0 fetcher calls, got %d", calls.Load())
 	}
 }
 
@@ -391,8 +394,8 @@ func TestResolveToken_TATRefetchAfterExpiry(t *testing.T) {
 	if _, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"}); err != nil {
 		t.Fatal(err)
 	}
-	if *calls != 2 {
-		t.Errorf("expected 2 fetch calls across cache expiry, got %d", *calls)
+	if calls.Load() != 2 {
+		t.Errorf("expected 2 fetch calls across cache expiry, got %d", calls.Load())
 	}
 }
 
@@ -429,6 +432,40 @@ func TestResolveToken_TATReturnsNilWhenSecretMissing(t *testing.T) {
 	}
 	if tok != nil {
 		t.Errorf("expected nil token when app_secret missing, got %+v", tok)
+	}
+	if p.tatCache != (tatCacheEntry{}) {
+		t.Errorf("expected empty tat cache, got %+v", p.tatCache)
+	}
+}
+
+func TestResolveToken_TATShortLifetimeNotCached(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "app")
+	t.Setenv(envvars.CliAppSecret, "secret")
+
+	p := &Provider{}
+	calls := withStubFetcher(p, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
+		// expiresIn well under the safety margin; caching would violate
+		// the margin invariant, so mintTenantAccessToken must re-mint
+		// on the next call instead of serving a nearly-dead entry.
+		return "short-life", 1, nil
+	})
+
+	tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Value != "short-life" {
+		t.Errorf("unexpected token value: %q", tok.Value)
+	}
+	if p.tatCache != (tatCacheEntry{}) {
+		t.Errorf("expected empty cache when ttl <= safety margin, got %+v", p.tatCache)
+	}
+
+	if _, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"}); err != nil {
+		t.Fatal(err)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("expected re-mint when prior call was not cached, got %d calls", calls.Load())
 	}
 }
 

--- a/extension/credential/env/env_test.go
+++ b/extension/credential/env/env_test.go
@@ -15,16 +15,15 @@ import (
 	"github.com/larksuite/cli/internal/envvars"
 )
 
-// stubTATFetcher replaces tatFetcher for the duration of t and counts calls.
-func stubTATFetcher(t *testing.T, fn func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error)) *int {
-	t.Helper()
-	orig := tatFetcher
+// withStubFetcher installs a TAT fetcher stub on p and returns a pointer to a
+// call counter. Scoping the stub to a single Provider avoids cross-test
+// interference when tests run in parallel.
+func withStubFetcher(p *Provider, fn func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error)) *int {
 	calls := 0
-	tatFetcher = func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error) {
+	p.fetchTAT = func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error) {
 		calls++
 		return fn(ctx, hc, brand, appID, appSecret)
 	}
-	t.Cleanup(func() { tatFetcher = orig })
 	return &calls
 }
 
@@ -314,7 +313,8 @@ func TestResolveToken_TATMintedFromAppSecret(t *testing.T) {
 	t.Setenv(envvars.CliAppID, "app")
 	t.Setenv(envvars.CliAppSecret, "secret")
 
-	calls := stubTATFetcher(t, func(_ context.Context, _ *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error) {
+	p := &Provider{}
+	calls := withStubFetcher(p, func(_ context.Context, _ *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error) {
 		if appID != "app" || appSecret != "secret" {
 			t.Fatalf("unexpected creds passed to fetcher: appID=%q appSecret=%q", appID, appSecret)
 		}
@@ -324,7 +324,6 @@ func TestResolveToken_TATMintedFromAppSecret(t *testing.T) {
 		return "minted-tat", 7200, nil
 	})
 
-	p := &Provider{}
 	tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"})
 	if err != nil {
 		t.Fatal(err)
@@ -354,12 +353,13 @@ func TestResolveToken_TATPreferredOverMintWhenEnvSet(t *testing.T) {
 	t.Setenv(envvars.CliAppSecret, "secret")
 	t.Setenv(envvars.CliTenantAccessToken, "env-tat")
 
-	calls := stubTATFetcher(t, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
+	p := &Provider{}
+	calls := withStubFetcher(p, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
 		t.Fatal("fetcher should not be called when TAT env var is set")
 		return "", 0, nil
 	})
 
-	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"})
+	tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +376,7 @@ func TestResolveToken_TATRefetchAfterExpiry(t *testing.T) {
 	t.Setenv(envvars.CliAppSecret, "secret")
 
 	p := &Provider{}
-	calls := stubTATFetcher(t, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
+	calls := withStubFetcher(p, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
 		return "fresh", 1, nil
 	})
 
@@ -400,12 +400,13 @@ func TestResolveToken_TATRequestedAppIDMismatchBlocks(t *testing.T) {
 	t.Setenv(envvars.CliAppID, "app")
 	t.Setenv(envvars.CliAppSecret, "secret")
 
-	stubTATFetcher(t, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
+	p := &Provider{}
+	withStubFetcher(p, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
 		t.Fatal("fetcher should not be called on app_id mismatch")
 		return "", 0, nil
 	})
 
-	_, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "other"})
+	_, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "other"})
 	var blockErr *credential.BlockError
 	if !errors.As(err, &blockErr) {
 		t.Fatalf("expected BlockError, got %v", err)
@@ -416,12 +417,13 @@ func TestResolveToken_TATReturnsNilWhenSecretMissing(t *testing.T) {
 	t.Setenv(envvars.CliAppID, "app")
 	t.Setenv(envvars.CliUserAccessToken, "u-tok") // keeps ResolveAccount valid, but no secret for mint
 
-	stubTATFetcher(t, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
+	p := &Provider{}
+	withStubFetcher(p, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
 		t.Fatal("fetcher should not be called without app_secret")
 		return "", 0, nil
 	})
 
-	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"})
+	tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/extension/credential/env/env_test.go
+++ b/extension/credential/env/env_test.go
@@ -6,12 +6,27 @@ package env
 import (
 	"context"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/larksuite/cli/extension/credential"
 	"github.com/larksuite/cli/internal/envvars"
 )
+
+// stubTATFetcher replaces tatFetcher for the duration of t and counts calls.
+func stubTATFetcher(t *testing.T, fn func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error)) *int {
+	t.Helper()
+	orig := tatFetcher
+	calls := 0
+	tatFetcher = func(ctx context.Context, hc *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error) {
+		calls++
+		return fn(ctx, hc, brand, appID, appSecret)
+	}
+	t.Cleanup(func() { tatFetcher = orig })
+	return &calls
+}
 
 func TestProvider_Name(t *testing.T) {
 	if (&Provider{}).Name() != "env" {
@@ -189,11 +204,27 @@ func TestResolveAccount_InferFromUATOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !acct.SupportedIdentities.UserOnly() {
-		t.Errorf("expected user-only from UAT inference, got %d", acct.SupportedIdentities)
+	// app_secret alone is enough to mint a tenant token, so bot is also supported.
+	if acct.SupportedIdentities != credential.SupportsAll {
+		t.Errorf("expected SupportsAll (user from UAT + bot from app_secret), got %d", acct.SupportedIdentities)
 	}
 	if acct.DefaultAs != "user" {
 		t.Errorf("expected default-as user from UAT inference, got %q", acct.DefaultAs)
+	}
+}
+
+func TestResolveAccount_InferFromUATWithoutSecret(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "app")
+	t.Setenv(envvars.CliUserAccessToken, "u-tok")
+	acct, err := (&Provider{}).ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acct.SupportedIdentities.UserOnly() {
+		t.Errorf("expected user-only when only UAT is available, got %d", acct.SupportedIdentities)
+	}
+	if acct.DefaultAs != "user" {
+		t.Errorf("expected default-as user, got %q", acct.DefaultAs)
 	}
 }
 
@@ -260,6 +291,142 @@ func TestResolveAccount_InvalidStrictModeRejected(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), envvars.CliStrictMode) {
 		t.Fatalf("error = %v, want mention of %s", err, envvars.CliStrictMode)
+	}
+}
+
+func TestResolveAccount_InferSupportsBotFromAppSecret(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "app")
+	t.Setenv(envvars.CliAppSecret, "secret")
+
+	acct, err := (&Provider{}).ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acct.SupportedIdentities.Has(credential.SupportsBot) {
+		t.Errorf("expected SupportsBot to be inferred from app_secret, got %d", acct.SupportedIdentities)
+	}
+	if acct.DefaultAs != credential.IdentityBot {
+		t.Errorf("expected DefaultAs=bot when only app_secret is available, got %q", acct.DefaultAs)
+	}
+}
+
+func TestResolveToken_TATMintedFromAppSecret(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "app")
+	t.Setenv(envvars.CliAppSecret, "secret")
+
+	calls := stubTATFetcher(t, func(_ context.Context, _ *http.Client, brand credential.Brand, appID, appSecret string) (string, int, error) {
+		if appID != "app" || appSecret != "secret" {
+			t.Fatalf("unexpected creds passed to fetcher: appID=%q appSecret=%q", appID, appSecret)
+		}
+		if brand != credential.BrandFeishu {
+			t.Fatalf("unexpected brand: %q", brand)
+		}
+		return "minted-tat", 7200, nil
+	})
+
+	p := &Provider{}
+	tok, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok == nil || tok.Value != "minted-tat" {
+		t.Fatalf("unexpected token: %+v", tok)
+	}
+	if *calls != 1 {
+		t.Errorf("expected 1 fetch call, got %d", *calls)
+	}
+
+	// Second call within TTL should hit the cache, not refetch.
+	tok2, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok2.Value != "minted-tat" {
+		t.Errorf("cached value mismatch: %+v", tok2)
+	}
+	if *calls != 1 {
+		t.Errorf("cache miss: expected 1 fetch call total, got %d", *calls)
+	}
+}
+
+func TestResolveToken_TATPreferredOverMintWhenEnvSet(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "app")
+	t.Setenv(envvars.CliAppSecret, "secret")
+	t.Setenv(envvars.CliTenantAccessToken, "env-tat")
+
+	calls := stubTATFetcher(t, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
+		t.Fatal("fetcher should not be called when TAT env var is set")
+		return "", 0, nil
+	})
+
+	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok.Value != "env-tat" {
+		t.Errorf("expected env TAT, got %q", tok.Value)
+	}
+	if *calls != 0 {
+		t.Errorf("expected 0 fetcher calls, got %d", *calls)
+	}
+}
+
+func TestResolveToken_TATRefetchAfterExpiry(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "app")
+	t.Setenv(envvars.CliAppSecret, "secret")
+
+	p := &Provider{}
+	calls := stubTATFetcher(t, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
+		return "fresh", 1, nil
+	})
+
+	if _, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"}); err != nil {
+		t.Fatal(err)
+	}
+	// Force cache expiry by rewinding the stored expiry.
+	p.tatMu.Lock()
+	p.tatCache.expiresAt = time.Now().Add(-time.Second)
+	p.tatMu.Unlock()
+
+	if _, err := p.ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"}); err != nil {
+		t.Fatal(err)
+	}
+	if *calls != 2 {
+		t.Errorf("expected 2 fetch calls across cache expiry, got %d", *calls)
+	}
+}
+
+func TestResolveToken_TATRequestedAppIDMismatchBlocks(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "app")
+	t.Setenv(envvars.CliAppSecret, "secret")
+
+	stubTATFetcher(t, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
+		t.Fatal("fetcher should not be called on app_id mismatch")
+		return "", 0, nil
+	})
+
+	_, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "other"})
+	var blockErr *credential.BlockError
+	if !errors.As(err, &blockErr) {
+		t.Fatalf("expected BlockError, got %v", err)
+	}
+}
+
+func TestResolveToken_TATReturnsNilWhenSecretMissing(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "app")
+	t.Setenv(envvars.CliUserAccessToken, "u-tok") // keeps ResolveAccount valid, but no secret for mint
+
+	stubTATFetcher(t, func(_ context.Context, _ *http.Client, _ credential.Brand, _, _ string) (string, int, error) {
+		t.Fatal("fetcher should not be called without app_secret")
+		return "", 0, nil
+	})
+
+	tok, err := (&Provider{}).ResolveToken(context.Background(), credential.TokenSpec{Type: credential.TokenTypeTAT, AppID: "app"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tok != nil {
+		t.Errorf("expected nil token when app_secret missing, got %+v", tok)
 	}
 }
 

--- a/internal/auth/paths.go
+++ b/internal/auth/paths.go
@@ -15,6 +15,9 @@ const (
 	PathUserInfoV1 = "/open-apis/authen/v1/user_info"
 	// PathApplicationInfoV6Prefix is the prefix endpoint for fetching application info.
 	PathApplicationInfoV6Prefix = "/open-apis/application/v6/applications/"
+	// PathTenantAccessTokenInternal is the endpoint for exchanging app_id/app_secret
+	// for a tenant access token (internal app flow).
+	PathTenantAccessTokenInternal = "/open-apis/auth/v3/tenant_access_token/internal"
 )
 
 // ApplicationInfoPath returns the full API path for querying an application's information.

--- a/internal/auth/tat_fetch.go
+++ b/internal/auth/tat_fetch.go
@@ -11,7 +11,14 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 )
+
+// defaultTATExchangeTimeout bounds the TAT exchange request when the caller
+// supplies a nil *http.Client. http.DefaultClient has no timeout, so a slow
+// or stalled server would otherwise hang a call indefinitely (especially
+// problematic for callers that also serialize TAT mints behind a mutex).
+const defaultTATExchangeTimeout = 30 * time.Second
 
 // TenantAccessTokenResult holds the result of a TAT exchange.
 type TenantAccessTokenResult struct {
@@ -23,11 +30,15 @@ type TenantAccessTokenResult struct {
 // using the internal-app flow. openBaseURL must be the Open API base URL
 // (e.g. "https://open.feishu.cn"), resolved by the caller from brand.
 //
+// Pass a *http.Client that carries a request timeout; if hc is nil the helper
+// falls back to a local client with a 30s timeout rather than http.DefaultClient
+// so a hung TCP connection cannot block the caller indefinitely.
+//
 // The returned token is short-lived; callers should cache it for less than
 // ExpiresIn seconds.
 func FetchTenantAccessToken(ctx context.Context, hc *http.Client, openBaseURL, appID, appSecret string) (*TenantAccessTokenResult, error) {
 	if hc == nil {
-		hc = http.DefaultClient
+		hc = &http.Client{Timeout: defaultTATExchangeTimeout}
 	}
 	if appID == "" {
 		return nil, fmt.Errorf("app id is empty")
@@ -66,8 +77,8 @@ func FetchTenantAccessToken(ctx context.Context, hc *http.Client, openBaseURL, a
 
 	if resp.StatusCode != http.StatusOK {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		if trimmed := bytes.TrimSpace(snippet); len(trimmed) > 0 {
-			return nil, fmt.Errorf("TAT API returned HTTP %d: %s", resp.StatusCode, trimmed)
+		if body := bytes.TrimSpace(snippet); len(body) > 0 {
+			return nil, fmt.Errorf("TAT API returned HTTP %d: %s", resp.StatusCode, body)
 		}
 		return nil, fmt.Errorf("TAT API returned HTTP %d", resp.StatusCode)
 	}

--- a/internal/auth/tat_fetch.go
+++ b/internal/auth/tat_fetch.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -34,7 +35,14 @@ func FetchTenantAccessToken(ctx context.Context, hc *http.Client, openBaseURL, a
 	if appSecret == "" {
 		return nil, fmt.Errorf("app secret is empty")
 	}
-	url := strings.TrimRight(openBaseURL, "/") + PathTenantAccessTokenInternal
+	trimmed := strings.TrimRight(openBaseURL, "/")
+	if trimmed == "" {
+		return nil, fmt.Errorf("open base URL is empty")
+	}
+	if !strings.HasPrefix(trimmed, "http://") && !strings.HasPrefix(trimmed, "https://") {
+		return nil, fmt.Errorf("open base URL must start with http:// or https://, got %q", openBaseURL)
+	}
+	url := trimmed + PathTenantAccessTokenInternal
 
 	body, err := json.Marshal(map[string]string{
 		"app_id":     appID,
@@ -57,6 +65,10 @@ func FetchTenantAccessToken(ctx context.Context, hc *http.Client, openBaseURL, a
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		if trimmed := bytes.TrimSpace(snippet); len(trimmed) > 0 {
+			return nil, fmt.Errorf("TAT API returned HTTP %d: %s", resp.StatusCode, trimmed)
+		}
 		return nil, fmt.Errorf("TAT API returned HTTP %d", resp.StatusCode)
 	}
 

--- a/internal/auth/tat_fetch.go
+++ b/internal/auth/tat_fetch.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// TenantAccessTokenResult holds the result of a TAT exchange.
+type TenantAccessTokenResult struct {
+	Token     string
+	ExpiresIn int // seconds until the token expires
+}
+
+// FetchTenantAccessToken exchanges app_id + app_secret for a tenant access token
+// using the internal-app flow. openBaseURL must be the Open API base URL
+// (e.g. "https://open.feishu.cn"), resolved by the caller from brand.
+//
+// The returned token is short-lived; callers should cache it for less than
+// ExpiresIn seconds.
+func FetchTenantAccessToken(ctx context.Context, hc *http.Client, openBaseURL, appID, appSecret string) (*TenantAccessTokenResult, error) {
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	if appID == "" {
+		return nil, fmt.Errorf("app id is empty")
+	}
+	if appSecret == "" {
+		return nil, fmt.Errorf("app secret is empty")
+	}
+	url := strings.TrimRight(openBaseURL, "/") + PathTenantAccessTokenInternal
+
+	body, err := json.Marshal(map[string]string{
+		"app_id":     appID,
+		"app_secret": appSecret,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal TAT request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("TAT API returned HTTP %d", resp.StatusCode)
+	}
+
+	var parsed struct {
+		Code              int    `json:"code"`
+		Msg               string `json:"msg"`
+		TenantAccessToken string `json:"tenant_access_token"`
+		Expire            int    `json:"expire"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("parse TAT response: %w", err)
+	}
+	if parsed.Code != 0 {
+		return nil, fmt.Errorf("TAT API error: [%d] %s", parsed.Code, parsed.Msg)
+	}
+	if parsed.TenantAccessToken == "" {
+		return nil, fmt.Errorf("TAT API returned empty token")
+	}
+	return &TenantAccessTokenResult{Token: parsed.TenantAccessToken, ExpiresIn: parsed.Expire}, nil
+}

--- a/internal/auth/tat_fetch_test.go
+++ b/internal/auth/tat_fetch_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestFetchTenantAccessToken_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method %q", r.Method)
+		}
+		if r.URL.Path != PathTenantAccessTokenInternal {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"app_id":"app"`) || !strings.Contains(string(body), `"app_secret":"sec"`) {
+			t.Fatalf("unexpected request body: %s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"code":0,"msg":"ok","tenant_access_token":"t-abc","expire":7200}`)
+	}))
+	defer srv.Close()
+
+	res, err := FetchTenantAccessToken(context.Background(), srv.Client(), srv.URL, "app", "sec")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Token != "t-abc" || res.ExpiresIn != 7200 {
+		t.Errorf("unexpected result: %+v", res)
+	}
+}
+
+func TestFetchTenantAccessToken_RejectsEmptyURL(t *testing.T) {
+	_, err := FetchTenantAccessToken(context.Background(), http.DefaultClient, "", "app", "sec")
+	if err == nil {
+		t.Fatal("expected error for empty openBaseURL")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention empty URL, got: %v", err)
+	}
+}
+
+func TestFetchTenantAccessToken_RejectsMissingScheme(t *testing.T) {
+	_, err := FetchTenantAccessToken(context.Background(), http.DefaultClient, "open.feishu.cn", "app", "sec")
+	if err == nil {
+		t.Fatal("expected error for missing scheme")
+	}
+	if !strings.Contains(err.Error(), "http://") {
+		t.Errorf("error should mention scheme requirement, got: %v", err)
+	}
+}
+
+func TestFetchTenantAccessToken_RejectsEmptyAppID(t *testing.T) {
+	_, err := FetchTenantAccessToken(context.Background(), http.DefaultClient, "https://open.feishu.cn", "", "sec")
+	if err == nil {
+		t.Fatal("expected error for empty app id")
+	}
+	if !strings.Contains(err.Error(), "app id") {
+		t.Errorf("error should mention app id, got: %v", err)
+	}
+}
+
+func TestFetchTenantAccessToken_Non200IncludesBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"code":10012,"msg":"invalid app_id"}`)
+	}))
+	defer srv.Close()
+
+	_, err := FetchTenantAccessToken(context.Background(), srv.Client(), srv.URL, "app", "sec")
+	if err == nil {
+		t.Fatal("expected error on HTTP 400")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error should include status code: %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid app_id") {
+		t.Errorf("error should include server body snippet: %v", err)
+	}
+}
+
+func TestFetchTenantAccessToken_APIErrorCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"code":10003,"msg":"app_secret invalid"}`)
+	}))
+	defer srv.Close()
+
+	_, err := FetchTenantAccessToken(context.Background(), srv.Client(), srv.URL, "app", "sec")
+	if err == nil {
+		t.Fatal("expected error on non-zero API code")
+	}
+	if !strings.Contains(err.Error(), "app_secret invalid") {
+		t.Errorf("error should surface API msg, got: %v", err)
+	}
+}
+
+func TestFetchTenantAccessToken_TrimsTrailingSlash(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"code":0,"msg":"ok","tenant_access_token":"t","expire":7200}`)
+	}))
+	defer srv.Close()
+
+	if _, err := FetchTenantAccessToken(context.Background(), srv.Client(), srv.URL+"/", "app", "sec"); err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != PathTenantAccessTokenInternal {
+		t.Errorf("expected single-slash path %q, got %q", PathTenantAccessTokenInternal, gotPath)
+	}
+}

--- a/internal/auth/tat_fetch_test.go
+++ b/internal/auth/tat_fetch_test.go
@@ -68,6 +68,16 @@ func TestFetchTenantAccessToken_RejectsEmptyAppID(t *testing.T) {
 	}
 }
 
+func TestFetchTenantAccessToken_RejectsEmptyAppSecret(t *testing.T) {
+	_, err := FetchTenantAccessToken(context.Background(), http.DefaultClient, "https://open.feishu.cn", "app", "")
+	if err == nil {
+		t.Fatal("expected error for empty app secret")
+	}
+	if !strings.Contains(err.Error(), "app secret") {
+		t.Errorf("error should mention app secret, got: %v", err)
+	}
+}
+
 func TestFetchTenantAccessToken_Non200IncludesBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)

--- a/internal/credential/default_provider.go
+++ b/internal/credential/default_provider.go
@@ -4,9 +4,7 @@
 package credential
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -136,41 +134,9 @@ func (p *DefaultTokenProvider) doResolveTAT(ctx context.Context) (*TokenResult, 
 		return nil, err
 	}
 	ep := core.ResolveEndpoints(acct.Brand)
-	url := ep.Open + "/open-apis/auth/v3/tenant_access_token/internal"
-
-	body, err := json.Marshal(map[string]string{
-		"app_id":     acct.AppID,
-		"app_secret": acct.AppSecret,
-	})
+	res, err := auth.FetchTenantAccessToken(ctx, httpClient, ep.Open, acct.AppID, acct.AppSecret)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal TAT request: %w", err)
+		return nil, fmt.Errorf("fetch tenant access token: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("TAT API returned HTTP %d", resp.StatusCode)
-	}
-
-	var result struct {
-		Code              int    `json:"code"`
-		Msg               string `json:"msg"`
-		TenantAccessToken string `json:"tenant_access_token"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("failed to parse TAT response: %w", err)
-	}
-	if result.Code != 0 {
-		return nil, fmt.Errorf("TAT API error: [%d] %s", result.Code, result.Msg)
-	}
-	return &TokenResult{Token: result.TenantAccessToken}, nil
+	return &TokenResult{Token: res.Token}, nil
 }

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -29,7 +29,14 @@ export LARKSUITE_CLI_APP_SECRET=yyy        # 自动换取并缓存 tenant_access
 # 可选：export LARKSUITE_CLI_BRAND=lark    # 国际版
 ```
 
-该模式仅支持 `--as bot` 身份；若需 `--as user`，请额外 `export LARKSUITE_CLI_USER_ACCESS_TOKEN=<uat>`。环境变量优先级高于同机器的 `config init` profile。
+环境变量路径支持两种身份，取决于导出的变量：
+
+| 目标身份 | 必需环境变量 |
+| -------- | ------------ |
+| `--as bot` | `LARKSUITE_CLI_APP_ID` + `LARKSUITE_CLI_APP_SECRET`（自动换取并缓存 TAT），或直接提供 `LARKSUITE_CLI_TENANT_ACCESS_TOKEN` |
+| `--as user` | `LARKSUITE_CLI_APP_ID` + `LARKSUITE_CLI_USER_ACCESS_TOKEN`（预先签发的 UAT） |
+
+环境变量优先级高于同机器的 `config init` profile。
 
 ## 认证
 

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -19,6 +19,18 @@ description: "飞书/Lark CLI 共享基础：应用配置初始化、认证登�
 lark-cli config init --new
 ```
 
+### 无人值守 / 远程 Agent 场景
+
+如果你作为远程 AI Agent 运行在容器、沙盒或 CI 中，**无法打开浏览器**完成 device flow，优先走环境变量路径。CLI 会直接从环境读取凭证，不需要 `config init`、不需要 `auth login`、不写 keychain：
+
+```bash
+export LARKSUITE_CLI_APP_ID=cli_xxx
+export LARKSUITE_CLI_APP_SECRET=yyy        # 自动换取并缓存 tenant_access_token
+# 可选：export LARKSUITE_CLI_BRAND=lark    # 国际版
+```
+
+该模式仅支持 `--as bot` 身份；若需 `--as user`，请额外 `export LARKSUITE_CLI_USER_ACCESS_TOKEN=<uat>`。环境变量优先级高于同机器的 `config init` profile。
+
 ## 认证
 
 ### 身份类型
@@ -28,7 +40,7 @@ lark-cli config init --new
 | 身份 | 标识 | 获取方式 | 适用场景 |
 |------|------|---------|---------|
 | user 用户身份 | `--as user` | `lark-cli auth login` 等 | 访问用户自己的资源（日历、云空间等） |
-| bot 应用身份 | `--as bot` | 自动，只需 appId + appSecret | 应用级操作,访问bot自己的资源 |
+| bot 应用身份 | `--as bot` | 自动：`config init` 写入的 appId + appSecret，或 `LARKSUITE_CLI_APP_ID` + `LARKSUITE_CLI_APP_SECRET` 环境变量 | 应用级操作,访问bot自己的资源 |
 
 ### 身份选择原则
 


### PR DESCRIPTION
## Summary

Enable headless callers — remote AI agents, CI jobs, and ephemeral containers — to authenticate with bot identity using only environment variables, eliminating the need for `config init`, `auth login`, or an OS keychain.

When `LARKSUITE_CLI_APP_ID` and `LARKSUITE_CLI_APP_SECRET` are set, the env credential provider now exchanges them for a tenant access token on demand and caches the result in-process until it expires. Existing env-var combinations (pre-issued UAT / TAT, strict-mode overrides, etc.) continue to work unchanged.

Motivation: AGENTS.md notes the CLI's primary consumers are AI agents, and many of those agents run in environments without a browser or a writable keychain. Previously, setting only `APP_ID + APP_SECRET` left the env provider unable to produce a TAT, surfacing `TokenUnavailableError` instead of falling through to the app-secret exchange flow that the default provider already implements.

## Changes

- **auth**: new shared `auth.FetchTenantAccessToken` helper that performs the `/open-apis/auth/v3/tenant_access_token/internal` exchange. Both the default and env credential providers reuse it.
- **auth**: env provider mints and caches a TAT from `APP_ID + APP_SECRET` when `LARKSUITE_CLI_TENANT_ACCESS_TOKEN` is not set. Cache honours the server-reported expiry with a 30-second safety margin; app_id and brand are keyed into the cache; explicit TAT env vars still take priority.
- **auth**: `SupportedIdentities` and `DefaultAs` now include bot when `APP_SECRET` is available, so commands work without an explicit `--as bot` flag when only app credentials are provided. Strict-mode overrides continue to win.
- **docs**: new "Environment-based credentials (agents & CI)" section in `README.md` / `README.zh.md`; headless pointer added to the Quick Start (AI Agent) section; `lark-shared` skill documents the env path and updated identity table; `[Unreleased]` entry in `CHANGELOG.md`.

## Test Plan

- [x] Unit tests pass — `go test -race -count=1 ./extension/credential/env/... ./internal/auth/... ./internal/credential/...`
  - New cases cover mint, cache hit, env-TAT precedence, post-expiry refetch, app_id mismatch block, and missing-secret fallthrough.
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go mod tidy` produces no drift
- [x] `golangci-lint run --new-from-rev=origin/main` reports 0 issues
- [x] Manual local verification against a live Feishu app:
  - `lark-cli auth status` reports `identity: bot`, `defaultAs: bot` with only env vars set.
  - `lark-cli api GET /open-apis/bot/v3/info` returns `code: 0` end-to-end (TAT exchange + SDK transport + API round-trip).
  - `lark-cli docs +create --as bot --title ... --markdown ...` successfully creates a doc.
  - Setting a bogus `LARKSUITE_CLI_TENANT_ACCESS_TOKEN` forces the server to reject the request, confirming explicit env TAT takes precedence over minting.

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Env-var authentication for headless/CI use
  * Automatic bot identity detection from app credentials
  * Lazy tenant access token minting with in-process caching

* **Documentation**
  * Added headless/CI guides to README and README.zh
  * Documented env var names, precedence, and identity selection
  * Updated skill docs for non-interactive bot auth workflow

* **Refactor**
  * Shared tenant-access-token exchange logic extracted

* **Tests**
  * Added tests for token exchange, caching and identity inference
<!-- end of auto-generated comment: release notes by coderabbit.ai -->