### PR TITLE
chore(release): v1.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.19] - 2026-04-24
+
+### Features
+
+- **mail**: Add read receipt support — `--request-receipt` on compose, `+send-receipt` / `+decline-receipt` for response
+- **doc**: Add v2 API for `docs +create` / `+fetch` / `+update` (#638)
+- **im**: Request thread roots for chat message list (#635)
+- **drive**: Support wiki node targets in `+upload` (#611)
+- **config**: Block `auth` / `config` when external credential provider is active (#627)
+- **whiteboard**: Pin `whiteboard-cli` to `v0.2.10` in `lark-whiteboard` skill (#649)
+
 ## [v1.0.18] - 2026-04-23
 
 ### Features
@@ -488,6 +499,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.19]: https://github.com/larksuite/cli/releases/tag/v1.0.19
 [v1.0.18]: https://github.com/larksuite/cli/releases/tag/v1.0.18
 [v1.0.17]: https://github.com/larksuite/cli/releases/tag/v1.0.17
 [v1.0.16]: https://github.com/larksuite/cli/releases/tag/v1.0.16

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

Release v1.0.19. Bumps `package.json` and adds the `CHANGELOG.md` entry for the 6 changes merged since v1.0.18.

### Features

- **mail**: Add read receipt support — `--request-receipt` on compose, `+send-receipt` / `+decline-receipt` for response
- **doc**: Add v2 API for `docs +create` / `+fetch` / `+update` (#638)
- **im**: Request thread roots for chat message list (#635)
- **drive**: Support wiki node targets in `+upload` (#611)
- **config**: Block `auth` / `config` when external credential provider is active (#627)
- **whiteboard**: Pin `whiteboard-cli` to `v0.2.10` in `lark-whiteboard` skill (#649)

(The `fix e2e pagination assumptions` commit #639 is test-only and omitted from the user-facing changelog.)

## Test plan

- [ ] CI green
- [ ] Tag `v1.0.19` after merge, verify GoReleaser pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mail receipt commands
  * Introduced Docs v2 APIs
  * Updates across messaging, drive, configuration, and whiteboard modules

* **Chores**
  * Released version 1.0.19

<!-- end of auto-generated comment: release notes by coderabbit.ai -->