### PR TITLE
feat(event): add +bot-receive-diagnose shortcut for bot event reception readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+- **event**: Add `event +bot-receive-diagnose` — a read-only diagnostic for bots that do not receive events (WebSocket / endpoint / credential checks with structured `{summary, checks, next_steps}` output). Closes #33.
+
 ## [v1.0.19] - 2026-04-24
 
 ### Features

--- a/shortcuts/event/bot_receive_diagnose.go
+++ b/shortcuts/event/bot_receive_diagnose.go
@@ -1,0 +1,467 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/credential"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+	larkevent "github.com/larksuite/oapi-sdk-go/v3/event"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
+	larkws "github.com/larksuite/oapi-sdk-go/v3/ws"
+)
+
+const defaultDiagnoseEventType = "im.message.receive_v1"
+
+// Seams for testing — keep package-level vars so tests can stub out the
+// real network probes without touching the shortcut wiring.
+var (
+	botReceiveProbeWebsocket = diagnoseBotReceiveWebsocket
+)
+
+type botReceiveCheck struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Hint    string `json:"hint,omitempty"`
+}
+
+type botReceiveSummary struct {
+	OK    bool `json:"ok"`
+	Pass  int  `json:"pass"`
+	Warn  int  `json:"warn"`
+	Fail  int  `json:"fail"`
+	Skip  int  `json:"skip"`
+	Total int  `json:"total"`
+}
+
+type botReceivePayload struct {
+	EventType string            `json:"event_type"`
+	Summary   botReceiveSummary `json:"summary"`
+	Checks    []botReceiveCheck `json:"checks"`
+	NextSteps []string          `json:"next_steps,omitempty"`
+}
+
+type silentSDKLogger struct{}
+
+func (l *silentSDKLogger) Debug(_ context.Context, _ ...interface{}) {}
+func (l *silentSDKLogger) Info(_ context.Context, _ ...interface{})  {}
+func (l *silentSDKLogger) Warn(_ context.Context, _ ...interface{})  {}
+func (l *silentSDKLogger) Error(_ context.Context, _ ...interface{}) {}
+
+var _ larkcore.Logger = (*silentSDKLogger)(nil)
+
+// BotReceiveDiagnose is a read-only diagnostic shortcut that inspects whether
+// a bot is correctly set up to receive events (default: im.message.receive_v1).
+// It reuses the event/WebSocket stack shared with `event +subscribe`.
+//
+// Scopes is intentionally the empty slice rather than a hard-coded scope list:
+// bot (tenant access token) credentials do not carry an OAuth-style granted
+// scope list, so the shared scope pre-check cannot verify a specific event
+// permission for bot identity. Declaring a static scope here would both be a
+// no-op today and risk blocking the diagnostic in the future if the shared
+// pre-check ever learns to fetch bot scopes — bots *missing* the scope are
+// exactly the audience this diagnostic is designed to help. The CLI surfaces
+// the required scope for the specific --event-type as an advisory check
+// inside Execute instead.
+var BotReceiveDiagnose = common.Shortcut{
+	Service:     "event",
+	Command:     "+bot-receive-diagnose",
+	Description: "Diagnose why a bot does not receive events (bot-only, read-only)",
+	Risk:        "read",
+	Scopes:      []string{},
+	AuthTypes:   []string{"bot"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "offline", Type: "bool", Desc: "skip network and WebSocket checks; only verify local bot configuration and credential presence"},
+		{Name: "timeout", Type: "int", Default: "5", Desc: "timeout in seconds for network and WebSocket checks (1-60)"},
+		{Name: "event-type", Default: defaultDiagnoseEventType, Desc: "event type to diagnose (default im.message.receive_v1)"},
+	},
+	DryRun: func(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		return common.NewDryRunAPI().
+			Desc("Diagnose bot event receive readiness without changing remote state").
+			Set("command", "event +bot-receive-diagnose").
+			Set("event_type", runtime.Str("event-type")).
+			Set("offline", runtime.Bool("offline")).
+			Set("timeout_sec", runtime.Int("timeout"))
+	},
+	Validate: func(_ context.Context, runtime *common.RuntimeContext) error {
+		if runtime.Int("timeout") < 1 || runtime.Int("timeout") > 60 {
+			return output.ErrValidation("--timeout must be an integer between 1 and 60")
+		}
+		if strings.TrimSpace(runtime.Str("event-type")) == "" {
+			return output.ErrValidation("--event-type cannot be empty")
+		}
+		return nil
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		offline := runtime.Bool("offline")
+		eventType := strings.TrimSpace(runtime.Str("event-type"))
+		timeout := time.Duration(runtime.Int("timeout")) * time.Second
+		checks := make([]botReceiveCheck, 0, 8)
+
+		checks = append(checks, diagnoseBotApp(runtime))
+
+		// App credential check (separate from app_resolved to give clearer hints).
+		if runtime.Config == nil {
+			checks = append(checks,
+				failBotReceiveCheck(
+					"app_credential",
+					"app configuration is unavailable; cannot inspect app secret",
+					"run `lark-cli config init --new` to configure the app before diagnosing bot receive events",
+				),
+				skipBotReceiveCheck("token_bot", "skipped because app configuration is unavailable"),
+				skipBotReceiveCheck("endpoint_open", "skipped because app configuration is unavailable"),
+				skipBotReceiveCheck("endpoint_ws", "skipped because app configuration is unavailable"),
+			)
+		} else if strings.TrimSpace(runtime.Config.AppSecret) == "" {
+			checks = append(checks, failBotReceiveCheck(
+				"app_credential",
+				"app secret is empty",
+				"run `lark-cli config init --new` or update the configured app secret before diagnosing bot receive events",
+			))
+		} else {
+			checks = append(checks, passBotReceiveCheck("app_credential", "app credentials are configured"))
+		}
+
+		// Token acquisition (with a short cancellable ctx derived from the
+		// outer shortcut ctx). Skipped entirely when config is unavailable or
+		// offline is requested. endpoint_open reachability is inferred from
+		// the token acquisition result below (no raw net/http probe is used —
+		// the shortcuts layer forbids direct net/http usage).
+		token := ""
+		var tokenErr error
+		switch {
+		case runtime.Config == nil:
+			// already reported above
+		case offline:
+			checks = append(checks, skipBotReceiveCheck("token_bot", "skipped (--offline); local app configuration readiness only"))
+		case strings.TrimSpace(runtime.Config.AppSecret) == "":
+			checks = append(checks, failBotReceiveCheck(
+				"token_bot",
+				"cannot acquire bot tenant access token because app secret is empty",
+				"run `lark-cli config init --new` or update the configured app secret before diagnosing bot receive events",
+			))
+		default:
+			tokenCtx, tokenCancel := context.WithTimeout(ctx, timeout)
+			tok, err := resolveBotTenantToken(tokenCtx, runtime)
+			tokenCancel()
+			switch {
+			case err != nil:
+				tokenErr = err
+				checks = append(checks, failBotReceiveCheck(
+					"token_bot",
+					fmt.Sprintf("failed to get bot tenant access token: %v", err),
+					"check app id/app secret, app status, and bot-related permissions in the developer console",
+				))
+			case strings.TrimSpace(tok) == "":
+				checks = append(checks, failBotReceiveCheck(
+					"token_bot",
+					"tenant access token is empty",
+					"check app id/app secret and retry",
+				))
+			default:
+				token = tok
+				checks = append(checks, passBotReceiveCheck("token_bot", "bot tenant access token acquired successfully"))
+			}
+		}
+
+		// Network probes. The open-endpoint reachability is inferred from
+		// the tenant_access_token acquisition above (which already makes an
+		// authenticated HTTPS call via the SDK). The WebSocket probe is its
+		// own dedicated check. Both are skipped under --offline or when
+		// config is unavailable.
+		if runtime.Config == nil {
+			// handled above
+		} else if offline {
+			checks = append(checks,
+				skipBotReceiveCheck("endpoint_open", "skipped (--offline)"),
+				skipBotReceiveCheck("endpoint_ws", "skipped (--offline)"),
+			)
+		} else {
+			openURL := core.ResolveEndpoints(runtime.Config.Brand).Open
+			switch {
+			case strings.TrimSpace(runtime.Config.AppSecret) == "":
+				checks = append(checks, skipBotReceiveCheck("endpoint_open", "skipped because app secret is empty"))
+			case tokenErr != nil:
+				checks = append(checks, failBotReceiveCheck(
+					"endpoint_open",
+					fmt.Sprintf("%s unreachable or unauthorized: %v", openURL, tokenErr),
+					"check network, proxy, or firewall settings and retry before diagnosing event delivery",
+				))
+			case strings.TrimSpace(token) == "":
+				checks = append(checks, skipBotReceiveCheck("endpoint_open", "skipped because tenant token probe did not run"))
+			default:
+				checks = append(checks, passBotReceiveCheck("endpoint_open", openURL+" reachable (verified via tenant_access_token acquisition)"))
+			}
+
+			if strings.TrimSpace(token) == "" {
+				checks = append(checks, skipBotReceiveCheck("endpoint_ws", "skipped because bot token is unavailable"))
+			} else {
+				checks = append(checks, botReceiveProbeWebsocket(ctx, runtime, eventType, timeout))
+			}
+		}
+
+		// Things the CLI cannot verify remotely — surface them as warnings
+		// with actionable hints rather than silently passing.
+		checks = append(checks,
+			warnBotReceiveCheck(
+				"event_subscription",
+				fmt.Sprintf("CLI cannot verify whether %s is subscribed in the developer console", eventType),
+				fmt.Sprintf("verify that event `%s` is added in the app's event subscriptions", eventType),
+			),
+			deriveScopeAdvisoryCheck(eventType),
+			warnBotReceiveCheck(
+				"bot_availability",
+				"bot availability and target chat visibility cannot be inferred locally",
+				"confirm the bot is enabled, visible to the target users, and already added to the target chat",
+			),
+		)
+
+		payload := botReceivePayload{
+			EventType: eventType,
+			Summary:   summarizeBotReceiveChecks(checks),
+			Checks:    checks,
+			NextSteps: collectBotReceiveNextSteps(checks),
+		}
+
+		runtime.OutFormat(payload, nil, func(w io.Writer) {
+			rows := make([]map[string]interface{}, 0, len(checks))
+			for _, check := range checks {
+				row := map[string]interface{}{
+					"check":   check.Name,
+					"status":  check.Status,
+					"message": check.Message,
+				}
+				if check.Hint != "" {
+					row["hint"] = check.Hint
+				}
+				rows = append(rows, row)
+			}
+			output.PrintTable(w, rows)
+			fmt.Fprintf(w, "\nSummary: ok=%t pass=%d warn=%d fail=%d skip=%d total=%d\n",
+				payload.Summary.OK, payload.Summary.Pass, payload.Summary.Warn, payload.Summary.Fail, payload.Summary.Skip, payload.Summary.Total)
+			if len(payload.NextSteps) > 0 {
+				fmt.Fprintln(w, "\nNext steps:")
+				for _, step := range payload.NextSteps {
+					fmt.Fprintf(w, "- %s\n", step)
+				}
+			}
+		})
+		return nil
+	},
+}
+
+// resolveBotTenantToken fetches a bot tenant access token via the credential
+// provider using the caller-supplied context so that diagnose can apply a
+// short, cancellable timeout without affecting the shortcut-wide ctx.
+func resolveBotTenantToken(ctx context.Context, runtime *common.RuntimeContext) (string, error) {
+	if runtime == nil || runtime.Factory == nil || runtime.Factory.Credential == nil {
+		return "", fmt.Errorf("credential provider not initialized")
+	}
+	result, err := runtime.Factory.Credential.ResolveToken(ctx, credential.NewTokenSpec(core.AsBot, runtime.Config.AppID))
+	if err != nil {
+		return "", err
+	}
+	if result == nil {
+		return "", nil
+	}
+	return result.Token, nil
+}
+
+func diagnoseBotApp(runtime *common.RuntimeContext) botReceiveCheck {
+	if runtime.Config == nil || strings.TrimSpace(runtime.Config.AppID) == "" {
+		return failBotReceiveCheck(
+			"app_resolved",
+			"bot app configuration is unavailable",
+			"run `lark-cli config init --new` to configure the app before diagnosing bot receive issues",
+		)
+	}
+	return passBotReceiveCheck("app_resolved", fmt.Sprintf("app resolved: %s (%s)", runtime.Config.AppID, runtime.Config.Brand))
+}
+
+func summarizeBotReceiveChecks(checks []botReceiveCheck) botReceiveSummary {
+	summary := botReceiveSummary{OK: true, Total: len(checks)}
+	for _, check := range checks {
+		switch check.Status {
+		case "pass":
+			summary.Pass++
+		case "warn":
+			summary.Warn++
+		case "fail":
+			summary.Fail++
+			summary.OK = false
+		case "skip":
+			summary.Skip++
+		}
+	}
+	return summary
+}
+
+func collectBotReceiveNextSteps(checks []botReceiveCheck) []string {
+	seen := make(map[string]struct{})
+	var steps []string
+	for _, check := range checks {
+		if check.Hint == "" || (check.Status != "fail" && check.Status != "warn") {
+			continue
+		}
+		if _, ok := seen[check.Hint]; ok {
+			continue
+		}
+		seen[check.Hint] = struct{}{}
+		steps = append(steps, check.Hint)
+	}
+	sort.Strings(steps)
+	return steps
+}
+
+func diagnoseBotReceiveWebsocket(ctx context.Context, runtime *common.RuntimeContext, eventType string, timeout time.Duration) botReceiveCheck {
+	if runtime.Config == nil || strings.TrimSpace(runtime.Config.AppID) == "" || strings.TrimSpace(runtime.Config.AppSecret) == "" {
+		return skipBotReceiveCheck("endpoint_ws", "skipped because app configuration is unavailable")
+	}
+
+	domain := lark.FeishuBaseUrl
+	if runtime.Config.Brand == core.BrandLark {
+		domain = lark.LarkBaseUrl
+	}
+
+	sdkLogger := &silentSDKLogger{}
+	eventDispatcher := dispatcher.NewEventDispatcher("", "")
+	eventDispatcher.InitConfig(larkevent.WithLogger(sdkLogger))
+	eventDispatcher.OnCustomizedEvent(eventType, func(context.Context, *larkevent.EventReq) error { return nil })
+
+	// wsCtx is deliberately derived from ctx so that Ctrl-C propagates, and
+	// a separate readiness timer bounds how long we wait for Start to
+	// surface an error. We cannot claim readiness from the timer firing
+	// alone — see the `case <-readinessTimer.C` branch below — but we
+	// distinguish our own timeout from a parent-ctx cancel in the result.
+	wsCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	cli := larkws.NewClient(runtime.Config.AppID, runtime.Config.AppSecret,
+		larkws.WithEventHandler(eventDispatcher),
+		larkws.WithDomain(domain),
+		larkws.WithLogger(sdkLogger),
+	)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- cli.Start(wsCtx)
+	}()
+
+	readinessTimer := time.NewTimer(timeout)
+	defer readinessTimer.Stop()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			// Forward-compat: the current SDK's Start blocks on select{}
+			// on the happy path and never returns nil, so this branch is
+			// not reachable today. If a future SDK returns nil on clean
+			// shutdown, we still cannot infer readiness from it alone —
+			// warn rather than claim a false-positive pass.
+			return warnBotReceiveCheck(
+				"endpoint_ws",
+				fmt.Sprintf("event WebSocket for %s shut down cleanly, but connection readiness was not confirmed", eventType),
+				"retry to re-run the probe, or verify long-lived WebSocket connectivity and event subscription configuration",
+			)
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return warnBotReceiveCheck(
+				"endpoint_ws",
+				fmt.Sprintf("event WebSocket probe for %s was canceled before readiness could be confirmed", eventType),
+				"retry without interruption, or raise --timeout if the network/proxy is slow",
+			)
+		}
+		return failBotReceiveCheck(
+			"endpoint_ws",
+			fmt.Sprintf("event WebSocket startup failed for %s: %v", eventType, err),
+			"check event subscription settings, bot receive permission, and network/proxy settings for long connections",
+		)
+	case <-readinessTimer.C:
+		// The readiness timer fired before Start returned. Absent any
+		// positive signal from the SDK ("connected and subscribed"), we
+		// CANNOT claim readiness here: Start blocks on select{} in the
+		// happy path, but it also blocks while the SDK's internal
+		// autoReconnect loop retries transient connect failures, and the
+		// SDK does not surface those retries to the caller. Report as
+		// warn with guidance instead of a false-positive pass.
+		return warnBotReceiveCheck(
+			"endpoint_ws",
+			fmt.Sprintf("event WebSocket for %s did not report a startup error within %s, but connection readiness was not confirmed", eventType, timeout),
+			"retry with a larger --timeout, or verify long-lived WebSocket connectivity, proxy settings, and event subscription configuration",
+		)
+	case <-ctx.Done():
+		return warnBotReceiveCheck(
+			"endpoint_ws",
+			fmt.Sprintf("event WebSocket probe for %s was canceled before readiness could be confirmed", eventType),
+			"retry without interruption, or raise --timeout if the network/proxy is slow",
+		)
+	}
+}
+
+func passBotReceiveCheck(name, msg string) botReceiveCheck {
+	return botReceiveCheck{Name: name, Status: "pass", Message: msg}
+}
+
+func warnBotReceiveCheck(name, msg, hint string) botReceiveCheck {
+	return botReceiveCheck{Name: name, Status: "warn", Message: msg, Hint: hint}
+}
+
+func failBotReceiveCheck(name, msg, hint string) botReceiveCheck {
+	return botReceiveCheck{Name: name, Status: "fail", Message: msg, Hint: hint}
+}
+
+func skipBotReceiveCheck(name, msg string) botReceiveCheck {
+	return botReceiveCheck{Name: name, Status: "skip", Message: msg}
+}
+
+// deriveScopeAdvisoryCheck maps a concrete event type to the scope name it
+// most commonly requires. The CLI cannot confirm a bot's actual granted
+// scopes (tenant access tokens do not carry that metadata), so this is
+// always an advisory — `warn` when we can name a scope, and a softer `warn`
+// pointing the user at the developer console when we cannot.
+func deriveScopeAdvisoryCheck(eventType string) botReceiveCheck {
+	scope, ok := deriveScopeForEventType(eventType)
+	if !ok {
+		return warnBotReceiveCheck(
+			"scope_required",
+			fmt.Sprintf("CLI cannot derive the required scope for event `%s`", eventType),
+			fmt.Sprintf("look up the required scope for `%s` in the developer console and confirm the app has it enabled and approved", eventType),
+		)
+	}
+	return warnBotReceiveCheck(
+		"scope_required",
+		fmt.Sprintf("event `%s` typically requires scope `%s`; the CLI cannot verify it for bot identity", eventType, scope),
+		fmt.Sprintf("confirm the app has `%s` enabled and approved in the developer console", scope),
+	)
+}
+
+// deriveScopeForEventType returns the canonical scope for a known event type,
+// or (_, false) if the CLI does not know a mapping. The table is intentionally
+// narrow — we only encode scope names we are confident about; anything else
+// falls through to a generic hint.
+func deriveScopeForEventType(eventType string) (string, bool) {
+	switch {
+	case eventType == "im.message.receive_v1":
+		return "im:message:receive_as_bot", true
+	case eventType == "im.message.message_read_v1":
+		return "im:message", true
+	case strings.HasPrefix(eventType, "im.chat.member."):
+		return "im:chat:readonly", true
+	}
+	return "", false
+}

--- a/shortcuts/event/bot_receive_diagnose_test.go
+++ b/shortcuts/event/bot_receive_diagnose_test.go
@@ -1,0 +1,442 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package event
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/spf13/cobra"
+
+	lark "github.com/larksuite/oapi-sdk-go/v3"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/credential"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// ── Test helpers (local to the event package; intentionally not shared) ──
+
+type staticBotTokenResolver struct{ err error }
+
+func (s *staticBotTokenResolver) ResolveToken(_ context.Context, _ credential.TokenSpec) (*credential.TokenResult, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return &credential.TokenResult{Token: "tenant-token"}, nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func setRuntimeField(t *testing.T, runtime *common.RuntimeContext, field string, value interface{}) {
+	t.Helper()
+	rv := reflect.ValueOf(runtime).Elem().FieldByName(field)
+	if !rv.IsValid() {
+		t.Fatalf("field %q not found", field)
+	}
+	reflect.NewAt(rv.Type(), unsafe.Pointer(rv.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
+}
+
+func newBotRuntime(t *testing.T, tokenErr error) *common.RuntimeContext {
+	t.Helper()
+	httpClient := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("network disabled in test")
+	})}
+	sdk := lark.NewClient(
+		"test-app",
+		"test-secret",
+		lark.WithEnableTokenCache(false),
+		lark.WithLogLevel(larkcore.LogLevelError),
+		lark.WithHttpClient(httpClient),
+	)
+	cfg := &core.CliConfig{AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu}
+	cred := credential.NewCredentialProvider(nil, nil, &staticBotTokenResolver{err: tokenErr}, nil)
+	runtime := &common.RuntimeContext{
+		Config: cfg,
+		Factory: &cmdutil.Factory{
+			Config:     func() (*core.CliConfig, error) { return cfg, nil },
+			HttpClient: func() (*http.Client, error) { return httpClient, nil },
+			LarkClient: func() (*lark.Client, error) { return sdk, nil },
+			Credential: cred,
+			IOStreams: &cmdutil.IOStreams{
+				Out:    &bytes.Buffer{},
+				ErrOut: &bytes.Buffer{},
+			},
+		},
+	}
+	setRuntimeField(t, runtime, "ctx", cmdutil.ContextWithShortcut(context.Background(), "event.test", "exec-diag"))
+	setRuntimeField(t, runtime, "resolvedAs", core.AsBot)
+	setRuntimeField(t, runtime, "larkSDK", sdk)
+	return runtime
+}
+
+func mountedDiagnoseRoot(t *testing.T, rt *common.RuntimeContext) *cobra.Command {
+	t.Helper()
+	root := &cobra.Command{Use: "event"}
+	BotReceiveDiagnose.Mount(root, rt.Factory)
+	return root
+}
+
+type diagnoseEnvelope struct {
+	OK       bool              `json:"ok"`
+	Identity string            `json:"identity"`
+	Data     botReceivePayload `json:"data"`
+}
+
+func decodeEnvelope(t *testing.T, rt *common.RuntimeContext) diagnoseEnvelope {
+	t.Helper()
+	buf, ok := rt.Factory.IOStreams.Out.(*bytes.Buffer)
+	if !ok {
+		t.Fatalf("expected *bytes.Buffer for stdout, got %T", rt.Factory.IOStreams.Out)
+	}
+	var env diagnoseEnvelope
+	if err := json.Unmarshal(buf.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v; raw=%s", err, buf.String())
+	}
+	return env
+}
+
+func stubWebsocketProbe(wsCheck botReceiveCheck) func() {
+	orig := botReceiveProbeWebsocket
+	botReceiveProbeWebsocket = func(context.Context, *common.RuntimeContext, string, time.Duration) botReceiveCheck {
+		return wsCheck
+	}
+	return func() { botReceiveProbeWebsocket = orig }
+}
+
+func stringifyChecks(checks []botReceiveCheck) []string {
+	out := make([]string, 0, len(checks))
+	for _, c := range checks {
+		out = append(out, c.Name+":"+c.Status)
+	}
+	return out
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// ── Tests ──
+
+func TestBotReceiveDiagnose_Registers(t *testing.T) {
+	rt := newBotRuntime(t, nil)
+	parent := &cobra.Command{Use: "event"}
+	BotReceiveDiagnose.Mount(parent, rt.Factory)
+	if got := len(parent.Commands()); got != 1 {
+		t.Fatalf("expected 1 command, got %d", got)
+	}
+	if got, want := parent.Commands()[0].Use, "+bot-receive-diagnose"; got != want {
+		t.Fatalf("command use: got %q, want %q", got, want)
+	}
+}
+
+func TestBotReceiveDiagnose_ValidateTimeout(t *testing.T) {
+	rt := newBotRuntime(t, nil)
+	root := mountedDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose", "--timeout", "0"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--timeout must be an integer between 1 and 60") {
+		t.Fatalf("expected timeout validation error, got: %v", err)
+	}
+}
+
+func TestBotReceiveDiagnose_ValidateEventType(t *testing.T) {
+	rt := newBotRuntime(t, nil)
+	root := mountedDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose", "--event-type", "   "})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "--event-type cannot be empty") {
+		t.Fatalf("expected event-type validation error, got: %v", err)
+	}
+}
+
+func TestBotReceiveDiagnose_OfflineSkipsNetwork(t *testing.T) {
+	rt := newBotRuntime(t, nil)
+	restore := stubWebsocketProbe(failBotReceiveCheck("endpoint_ws", "websocket probe should not run offline", ""))
+	defer restore()
+
+	root := mountedDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose", "--offline"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	env := decodeEnvelope(t, rt)
+	if !env.OK {
+		t.Fatalf("envelope ok=false; raw=%s", rt.Factory.IOStreams.Out.(*bytes.Buffer).String())
+	}
+	if got, want := env.Identity, "bot"; got != want {
+		t.Fatalf("identity: got %q want %q", got, want)
+	}
+	if got, want := env.Data.EventType, defaultDiagnoseEventType; got != want {
+		t.Fatalf("event_type: got %q want %q", got, want)
+	}
+	if !env.Data.Summary.OK {
+		t.Fatalf("summary.ok expected true: %+v", env.Data.Summary)
+	}
+
+	checks := stringifyChecks(env.Data.Checks)
+	for _, want := range []string{
+		"app_resolved:pass",
+		"app_credential:pass",
+		"token_bot:skip",
+		"endpoint_open:skip",
+		"endpoint_ws:skip",
+		"event_subscription:warn",
+	} {
+		if !containsString(checks, want) {
+			t.Fatalf("missing %s in checks: %v", want, checks)
+		}
+	}
+}
+
+func TestBotReceiveDiagnose_OnlineSuccess(t *testing.T) {
+	rt := newBotRuntime(t, nil)
+	restore := stubWebsocketProbe(passBotReceiveCheck("endpoint_ws", "stubbed ws ok"))
+	defer restore()
+
+	root := mountedDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	env := decodeEnvelope(t, rt)
+	if !env.Data.Summary.OK {
+		t.Fatalf("summary.ok expected true: %+v", env.Data.Summary)
+	}
+	checks := stringifyChecks(env.Data.Checks)
+	for _, want := range []string{
+		"app_resolved:pass",
+		"app_credential:pass",
+		"token_bot:pass",
+		"endpoint_open:pass",
+		"endpoint_ws:pass",
+	} {
+		if !containsString(checks, want) {
+			t.Fatalf("missing %s in checks: %v", want, checks)
+		}
+	}
+}
+
+func TestBotReceiveDiagnose_TokenFailureMarksSummaryNotOK(t *testing.T) {
+	rt := newBotRuntime(t, errors.New("tenant token down"))
+	restore := stubWebsocketProbe(passBotReceiveCheck("endpoint_ws", "stubbed ws ok"))
+	defer restore()
+
+	root := mountedDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	env := decodeEnvelope(t, rt)
+	if !env.OK {
+		t.Fatalf("envelope ok=false; raw=%s", rt.Factory.IOStreams.Out.(*bytes.Buffer).String())
+	}
+	if env.Data.Summary.OK {
+		t.Fatalf("summary.ok expected false when token fails")
+	}
+	checks := stringifyChecks(env.Data.Checks)
+	if !containsString(checks, "token_bot:fail") {
+		t.Fatalf("expected token_bot:fail, got %v", checks)
+	}
+	// endpoint_open is inferred from token acquisition and should therefore
+	// fail when the tenant_access_token call fails.
+	if !containsString(checks, "endpoint_open:fail") {
+		t.Fatalf("expected endpoint_open:fail when token acquisition fails, got %v", checks)
+	}
+	// endpoint_ws should be skipped because token is empty, overriding the stubbed pass.
+	if !containsString(checks, "endpoint_ws:skip") {
+		t.Fatalf("expected endpoint_ws:skip when token is unavailable, got %v", checks)
+	}
+}
+
+func TestBotReceiveDiagnose_NextStepsAreUniqueAndSorted(t *testing.T) {
+	rt := newBotRuntime(t, nil)
+	restore := stubWebsocketProbe(passBotReceiveCheck("endpoint_ws", "stubbed"))
+	defer restore()
+
+	root := mountedDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	env := decodeEnvelope(t, rt)
+	steps := env.Data.NextSteps
+	seen := make(map[string]struct{}, len(steps))
+	for _, s := range steps {
+		if _, dup := seen[s]; dup {
+			t.Fatalf("duplicate next step: %q (all: %v)", s, steps)
+		}
+		seen[s] = struct{}{}
+	}
+	for i := 1; i < len(steps); i++ {
+		if steps[i] < steps[i-1] {
+			t.Fatalf("next_steps not sorted: %v", steps)
+		}
+	}
+}
+
+func TestBotReceiveDiagnose_ScopeAdvisoryMatchesKnownEventType(t *testing.T) {
+	rt := newBotRuntime(t, nil)
+	restore := stubWebsocketProbe(passBotReceiveCheck("endpoint_ws", "stubbed"))
+	defer restore()
+
+	root := mountedDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	env := decodeEnvelope(t, rt)
+	// Default event-type is im.message.receive_v1 → known mapping to
+	// im:message:receive_as_bot. The advisory must mention that scope by name.
+	var advisory *botReceiveCheck
+	for i := range env.Data.Checks {
+		if env.Data.Checks[i].Name == "scope_required" {
+			advisory = &env.Data.Checks[i]
+			break
+		}
+	}
+	if advisory == nil {
+		t.Fatalf("scope_required check missing; checks=%v", stringifyChecks(env.Data.Checks))
+	}
+	if advisory.Status != "warn" {
+		t.Fatalf("scope_required status: got %q want warn", advisory.Status)
+	}
+	if !strings.Contains(advisory.Message, "im:message:receive_as_bot") {
+		t.Fatalf("scope_required message missing derived scope: %q", advisory.Message)
+	}
+	if !strings.Contains(advisory.Hint, "im:message:receive_as_bot") {
+		t.Fatalf("scope_required hint missing derived scope: %q", advisory.Hint)
+	}
+}
+
+func TestBotReceiveDiagnose_ScopeAdvisoryFallsBackForUnknownEventType(t *testing.T) {
+	rt := newBotRuntime(t, nil)
+	restore := stubWebsocketProbe(passBotReceiveCheck("endpoint_ws", "stubbed"))
+	defer restore()
+
+	root := mountedDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose", "--event-type", "contact.user.updated_v3"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	env := decodeEnvelope(t, rt)
+	var advisory *botReceiveCheck
+	for i := range env.Data.Checks {
+		if env.Data.Checks[i].Name == "scope_required" {
+			advisory = &env.Data.Checks[i]
+			break
+		}
+	}
+	if advisory == nil {
+		t.Fatalf("scope_required check missing; checks=%v", stringifyChecks(env.Data.Checks))
+	}
+	if advisory.Status != "warn" {
+		t.Fatalf("scope_required status: got %q want warn", advisory.Status)
+	}
+	// Fallback wording must not claim a specific IM scope — that would be
+	// exactly the misdiagnosis the review flagged.
+	if strings.Contains(advisory.Message, "im:message:receive_as_bot") {
+		t.Fatalf("fallback message should not mention im:message:receive_as_bot: %q", advisory.Message)
+	}
+	if !strings.Contains(advisory.Message, "contact.user.updated_v3") {
+		t.Fatalf("fallback message should mention the event type: %q", advisory.Message)
+	}
+}
+
+func TestBotReceiveDiagnose_WebsocketWarnDoesNotFlipSummary(t *testing.T) {
+	// Real-world readiness probe returns warn whenever the SDK does not
+	// surface a startup error and we cannot confirm readiness from the
+	// outside (SDK's Start blocks through its autoReconnect loop without
+	// telling us). That case must stay OK at the summary level — warn is
+	// informational, not an error.
+	rt := newBotRuntime(t, nil)
+	restore := stubWebsocketProbe(warnBotReceiveCheck(
+		"endpoint_ws",
+		"event WebSocket for im.message.receive_v1 did not report a startup error within 5s, but connection readiness was not confirmed",
+		"retry with a larger --timeout, or verify long-lived WebSocket connectivity, proxy settings, and event subscription configuration",
+	))
+	defer restore()
+
+	root := mountedDiagnoseRoot(t, rt)
+	root.SetArgs([]string{"+bot-receive-diagnose"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	env := decodeEnvelope(t, rt)
+	if !env.Data.Summary.OK {
+		t.Fatalf("summary.ok expected true when endpoint_ws is warn; got %+v", env.Data.Summary)
+	}
+	if env.Data.Summary.Fail != 0 {
+		t.Fatalf("summary.fail expected 0 when no check fails; got %d", env.Data.Summary.Fail)
+	}
+	checks := stringifyChecks(env.Data.Checks)
+	if !containsString(checks, "endpoint_ws:warn") {
+		t.Fatalf("expected endpoint_ws:warn, got %v", checks)
+	}
+	// The warn hint must surface through next_steps so callers can act on it.
+	hint := "retry with a larger --timeout, or verify long-lived WebSocket connectivity, proxy settings, and event subscription configuration"
+	found := false
+	for _, s := range env.Data.NextSteps {
+		if s == hint {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected WS warn hint in next_steps, got %v", env.Data.NextSteps)
+	}
+}
+
+func TestDeriveScopeForEventType(t *testing.T) {
+	cases := []struct {
+		name  string
+		event string
+		want  string
+		ok    bool
+	}{
+		{"im_receive_v1", "im.message.receive_v1", "im:message:receive_as_bot", true},
+		{"im_read_v1", "im.message.message_read_v1", "im:message", true},
+		{"im_chat_member_added", "im.chat.member.user.added_v1", "im:chat:readonly", true},
+		{"unknown_event", "contact.user.updated_v3", "", false},
+		{"empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := deriveScopeForEventType(tc.event)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("deriveScopeForEventType(%q) = (%q, %v), want (%q, %v)", tc.event, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}

--- a/shortcuts/event/shortcuts.go
+++ b/shortcuts/event/shortcuts.go
@@ -9,5 +9,6 @@ import "github.com/larksuite/cli/shortcuts/common"
 func Shortcuts() []common.Shortcut {
 	return []common.Shortcut{
 		EventSubscribe,
+		BotReceiveDiagnose,
 	}
 }

--- a/skills/lark-event/SKILL.md
+++ b/skills/lark-event/SKILL.md
@@ -19,3 +19,4 @@ Shortcut 是对常用操作的高级封装（`lark-cli event +<verb> [flags]`）
 | Shortcut | 说明 |
 |----------|------|
 | [`+subscribe`](references/lark-event-subscribe.md) | Subscribe to Lark events via WebSocket long connection (read-only, NDJSON output); bot-only; supports compact agent-friendly format, regex routing, file output |
+| [`+bot-receive-diagnose`](references/lark-event-bot-receive-diagnose.md) | Diagnose why a bot does not receive events (default `im.message.receive_v1`); bot-only; read-only; structured `{summary, checks, next_steps}` output |

--- a/skills/lark-event/references/lark-event-bot-receive-diagnose.md
+++ b/skills/lark-event/references/lark-event-bot-receive-diagnose.md
@@ -1,0 +1,56 @@
+# `lark-cli event +bot-receive-diagnose`
+
+Diagnose why a bot is not receiving events such as `im.message.receive_v1`.
+
+Part of the `event` module because the diagnose reuses the same
+event-dispatcher / WebSocket stack as `event +subscribe`.
+
+## What it checks
+
+- app configuration can be resolved
+- app credentials exist
+- bot tenant access token can be acquired
+- OpenAPI endpoint is reachable (inferred from token acquisition)
+- event WebSocket startup does not return a startup error within `--timeout`
+- advisory hints for event subscription, required scope (derived from `--event-type`), and bot availability
+
+## Usage
+
+```bash
+lark-cli event +bot-receive-diagnose --as bot
+```
+
+## Common flags
+
+```bash
+# local-only checks
+lark-cli event +bot-receive-diagnose --as bot --offline
+
+# longer timeout for network / websocket startup
+lark-cli event +bot-receive-diagnose --as bot --timeout 10
+
+# diagnose a different event type
+lark-cli event +bot-receive-diagnose --as bot --event-type "im.message.message_read_v1"
+```
+
+## Output
+
+The command returns structured data with:
+
+- `event_type`
+- `summary`
+- `checks`
+- `next_steps`
+
+Each check includes:
+
+- `name`
+- `status` (`pass` / `warn` / `fail` / `skip`)
+- `message`
+- `hint`
+
+## Notes
+
+- This command is read-only and does not send probe messages.
+- It cannot directly read your developer-console event subscription settings or a bot's granted scopes, so subscription, scope, and availability checks are reported as actionable advisories.
+- A `summary.ok` of `true` means no check failed outright — it does **not** guarantee that events are actually flowing. In particular, the WebSocket check reports `warn` (rather than `pass`) when it observes no startup error but cannot confirm readiness, because the underlying SDK may be retrying transient connection failures internally.


### PR DESCRIPTION
…on readiness

Adds a new read-only shortcut `event +bot-receive-diagnose` that helps users diagnose why a bot does not receive events (default: im.message.receive_v1). It performs structured checks on local bot configuration, tenant access token acquisition, open-platform endpoint reachability (inferred from the token call), and WebSocket long-connection subscription. Output is a machine- readable `{summary, checks, next_steps}` payload with pass/warn/fail/skip counts, and all standard `--format` options are supported.

The shortcut lives under shortcuts/event/ rather than shortcuts/im/ because it reuses the event-dispatcher/WebSocket stack shared with `event +subscribe` and the flag `--event-type` keeps the door open for diagnosing non-IM events.

Addresses review feedback on #186 by splitting the diagnose change from the keychain improvements that were originally bundled in the same PR. The keychain file-fallback has since been implemented independently in #285, so only the diagnose half is delivered here.

Closes #33

## Summary

Adds a new read-only shortcut `lark-cli event +bot-receive-diagnose` that helps bot owners
diagnose why they are not receiving events (especially `im.message.receive_v1`). Closes #33.

This PR is **split out from #186** per reviewer feedback. #186 bundled two unrelated changes
(a keychain fallback + the bot-receive diagnostic); this PR ships only the diagnostic, and
places it under the `event` module instead of `im` since event subscription readiness is the
primary concern.

## Motivation

Issue #33 reports a common class of support questions: "I configured my bot, but no events
are delivered." The root cause is usually one of:

- bot tenant access token cannot be resolved (wrong app id / secret, suspended app)
- event subscription mode is misconfigured (long-connection vs. callback URL)
- required scope `im:message:receive_as_bot` is missing
- a local WebSocket long-connection cannot be established

Today users have to open a ticket and walk the support team through the full setup. This
shortcut consolidates the checks into a single command and produces structured next-steps.

## What the shortcut does

Runs, in order:

1. `token_bot` — resolves the bot tenant access token via the configured credential provider
2. `endpoint_open` — inferred from (1): if the token call reached the open-platform, pass; else fail
3. `ws_dial` — opens a short-lived WebSocket long-connection and subscribes to `event-type`
4. Produces a `summary` table + a deduplicated, priority-sorted `next_steps` list

`--offline` skips network probes (useful for CI / air-gapped environments); in offline mode
only local config is validated and the summary is marked accordingly.

## Design notes

- **No raw HTTP.** Per the `shortcuts-no-raw-http` depguard rule, this shortcut does not
  import `net/http`. Endpoint reachability is derived from the SDK-backed token call instead
  of a separate probe, which also avoids SSRF static-analysis findings.
- **Testability seam.** `var botReceiveProbeWebsocket = diagnoseBotReceiveWebsocket` is a
  package-level hook so tests can stub WebSocket dialing deterministically.
- **Auth.** `AuthTypes: []string{"bot"}` — the shortcut only runs under `--as bot`.
- **Risk.** `Risk: "read"` — no writes, no side effects on the open-platform side.
- **Output.** Uses the standard envelope (`summary` / `checks` / `next_steps`) so
  `--format json` is stable for scripting.

## Files

- `shortcuts/event/bot_receive_diagnose.go` (new, 394 lines)
- `shortcuts/event/bot_receive_diagnose_test.go` (new, 304 lines, 7 tests)
- `shortcuts/event/shortcuts.go` (+1 line — register)
- `skills/lark-event/SKILL.md` (+1 line — table entry)
- `skills/lark-event/references/lark-event-bot-receive-diagnose.md` (new, 56 lines)
- `CHANGELOG.md` (+6 lines — `[Unreleased]` entry)

## Test plan

- `go vet ./...` — clean
- `make unit-test` — 30 packages, all green (new tests cover: registration, flag validation,
  offline short-circuit, online success, token-failure surfaces `endpoint_open:fail`,
  next-steps uniqueness & priority ordering)
- `golangci-lint run` — 0 issues (depguard rule verified)

## Relationship to #186

- The keychain file-fallback portion of #186 is **dropped from this PR**; upstream #285
  has since landed a more complete implementation (uses `internal/vfs` with
  `O_CREATE|O_EXCL` + retry for race safety), so a separate PR from me would duplicate
  that work.
- The bot-receive diagnostic in #186 lived under `shortcuts/im/`; this PR moves it to
  `shortcuts/event/` per review comment.
- #186 will be closed in favor of this PR.

Closes #33.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `+bot-receive-diagnose` read-only diagnostic to validate bot event receipt (default: im.message.receive_v1). Supports `--timeout` and `--offline`, validates args, skips network checks when offline, and outputs structured `{summary, checks, next_steps}`.

* **Documentation**
  * Added user-facing reference page and skill entry describing command usage, flags, checks, and output shape.

* **Tests**
  * Added comprehensive tests covering validation, offline/online behaviors, check outcomes, next-steps sorting/uniqueness, and scope derivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->