### PR TITLE
docs(lark-drive): add missing import command examples

### DIFF
--- a/skills/lark-drive/references/lark-drive-import.md
+++ b/skills/lark-drive/references/lark-drive-import.md
@@ -12,11 +12,27 @@
 ## 命令
 
 ```bash
+# 导入 Word 为新版文档 (docx)
+lark-cli drive +import --file ./report.docx --type docx
+lark-cli drive +import --file ./legacy.doc --type docx
+
 # 导入 Markdown 为新版文档 (docx)
 lark-cli drive +import --file ./README.md --type docx
 
+# 导入纯文本为新版文档 (docx)
+lark-cli drive +import --file ./notes.txt --type docx
+
+# 导入 HTML 为新版文档 (docx)
+lark-cli drive +import --file ./page.html --type docx
+
 # 导入 Excel 为电子表格 (sheet)
 lark-cli drive +import --file ./data.xlsx --type sheet
+
+# 导入 Excel 97-2003 (.xls) 为电子表格 (sheet)
+lark-cli drive +import --file ./legacy.xls --type sheet
+
+# 导入 CSV 为电子表格 (sheet)
+lark-cli drive +import --file ./data.csv --type sheet
 
 # 导入 Excel 为多维表格 / Base (bitable)
 lark-cli drive +import --file ./crm.xlsx --type bitable --name "客户台账"


### PR DESCRIPTION
## Summary
- Adds example commands to the "命令" section of `skills/lark-drive/references/lark-drive-import.md` for file types that are declared in the supported-conversions table but had no example.
- New examples cover: `.docx` / `.doc` (Office Word), `.txt`, `.html`, `.xls -> sheet`, and `.csv -> sheet`.
- Documentation only — no behavior changes.

## Test plan
All six examples were executed end-to-end against the real Lark Import API with `--as user`. Each produced an `ok: true` response with a valid online doc URL.

| Local file | `--type` | Result |
|------------|----------|--------|
| `.docx` | `docx` | ✅ |
| `.doc` | `docx` | ✅ |
| `.txt` | `docx` | ✅ |
| `.html` | `docx` | ✅ |
| `.xls` | `sheet` | ✅ |
| `.csv` | `sheet` | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)