### PR TITLE
feat(doc): normalize exported sheet and video tags

### DIFF
--- a/shortcuts/doc/docs_content_compat.go
+++ b/shortcuts/doc/docs_content_compat.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var fetchedVideoTagRe = regexp.MustCompile(`<video\s+([^>]*?)></video>`)
+
+// normalizeDocInputContent keeps the current docs_ai request path intact while
+// accepting a small compatibility surface from the legacy converter pipeline.
+// Today this is intentionally limited to translating exported <video ...>
+// elements back into file blocks that docs_ai already understands.
+func normalizeDocInputContent(format, content string) string {
+	if strings.TrimSpace(content) == "" {
+		return content
+	}
+	switch strings.TrimSpace(format) {
+	case "xml", "markdown", "":
+		return normalizeInputVideoTags(content)
+	default:
+		return content
+	}
+}
+
+func normalizeInputVideoTags(content string) string {
+	return fetchedVideoTagRe.ReplaceAllStringFunc(content, func(tag string) string {
+		src := strings.TrimSpace(fetchedAttrValue(tag, "src"))
+		name := strings.TrimSpace(fetchedAttrValue(tag, "data-name"))
+		if src == "" || !strings.HasPrefix(src, "feishu://media/") {
+			return tag
+		}
+		token := strings.TrimPrefix(src, "feishu://media/")
+		if token == "" {
+			return tag
+		}
+
+		attrs := []string{fmt.Sprintf(`token="%s"`, token)}
+		if name != "" {
+			attrs = append(attrs, fmt.Sprintf(`name="%s"`, name))
+		}
+		if viewType := strings.TrimSpace(fetchedAttrValue(tag, "data-view-type")); viewType != "" {
+			attrs = append(attrs, fmt.Sprintf(`view-type="%s"`, viewType))
+		}
+		return fmt.Sprintf("<file %s/>", strings.Join(attrs, " "))
+	})
+}

--- a/shortcuts/doc/docs_content_compat_test.go
+++ b/shortcuts/doc/docs_content_compat_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+func newDocCompatRuntime(t *testing.T, stringFlags map[string]string) *common.RuntimeContext {
+	t.Helper()
+	cmd := &cobra.Command{Use: "docs-test"}
+	for name := range stringFlags {
+		cmd.Flags().String(name, "", "")
+	}
+	for name, value := range stringFlags {
+		if err := cmd.Flags().Set(name, value); err != nil {
+			t.Fatalf("set flag %s: %v", name, err)
+		}
+	}
+	return common.TestNewRuntimeContext(cmd, nil)
+}
+
+func TestNormalizeInputVideoTags(t *testing.T) {
+	t.Parallel()
+
+	input := `<video controls src="feishu://media/file_video_123" data-name="demo.mp4"></video>`
+	got := normalizeInputVideoTags(input)
+	want := `<file token="file_video_123" name="demo.mp4"/>`
+	if got != want {
+		t.Fatalf("normalizeInputVideoTags() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeInputVideoTagsPreservesViewType(t *testing.T) {
+	t.Parallel()
+
+	input := `<video controls src="feishu://media/file_video_123" data-name="demo.mp4" data-view-type="2"></video>`
+	got := normalizeInputVideoTags(input)
+	want := `<file token="file_video_123" name="demo.mp4" view-type="2"/>`
+	if got != want {
+		t.Fatalf("normalizeInputVideoTags() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeInputVideoTagsLeavesLocalSourceAlone(t *testing.T) {
+	t.Parallel()
+
+	input := `<video controls src="./demo.mp4"></video>`
+	if got := normalizeInputVideoTags(input); got != input {
+		t.Fatalf("normalizeInputVideoTags() = %q, want unchanged %q", got, input)
+	}
+}
+
+func TestNormalizeDocInputContentSkipsText(t *testing.T) {
+	t.Parallel()
+
+	input := `<video controls src="feishu://media/file_video_123"></video>`
+	if got := normalizeDocInputContent("text", input); got != input {
+		t.Fatalf("normalizeDocInputContent(text) = %q, want unchanged %q", got, input)
+	}
+}

--- a/shortcuts/doc/docs_create_test.go
+++ b/shortcuts/doc/docs_create_test.go
@@ -182,6 +182,20 @@ func TestDocsCreateV2BotAutoGrantFailureDoesNotFailCreate(t *testing.T) {
 	}
 }
 
+func TestBuildCreateBodyV2NormalizesVideoCompatMarkup(t *testing.T) {
+	t.Parallel()
+
+	runtime := newDocCompatRuntime(t, map[string]string{
+		"doc-format": "xml",
+		"content":    `<video controls src="feishu://media/file_video_123" data-name="demo.mp4" data-view-type="2"></video>`,
+	})
+
+	body := buildCreateBody(runtime)
+	if got := body["content"]; got != `<file token="file_video_123" name="demo.mp4" view-type="2"/>` {
+		t.Fatalf("buildCreateBody().content = %#v", got)
+	}
+}
+
 // ── V1 (MCP) tests ──
 
 func TestDocsCreateV1BotAutoGrantSuccess(t *testing.T) {

--- a/shortcuts/doc/docs_create_v2.go
+++ b/shortcuts/doc/docs_create_v2.go
@@ -56,9 +56,10 @@ func executeCreateV2(_ context.Context, runtime *common.RuntimeContext) error {
 }
 
 func buildCreateBody(runtime *common.RuntimeContext) map[string]interface{} {
+	format := runtime.Str("doc-format")
 	body := map[string]interface{}{
-		"format":  runtime.Str("doc-format"),
-		"content": runtime.Str("content"),
+		"format":  format,
+		"content": normalizeDocInputContent(format, runtime.Str("content")),
 	}
 	if v := runtime.Str("parent-token"); v != "" {
 		body["parent_token"] = v

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -81,8 +81,9 @@ func executeFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 }
 
 var (
-	fetchedVideoFileTagRe = regexp.MustCompile(`<file\s+([^>]*\btoken="([^"]+)"[^>]*\bname="([^"]+)"[^>]*)/>`)
-	fetchedSheetTagRe     = regexp.MustCompile(`<sheet\s+([^>]*?)token="([^"]+)"([^>]*?)/>`)
+	fetchedVideoFileTagRe   = regexp.MustCompile(`<file\s+([^>]*\btoken="([^"]+)"[^>]*\bname="([^"]+)"[^>]*)/>`)
+	fetchedVideoFigureTagRe = regexp.MustCompile(`<figure\s+([^>]*?)><source\s+([^>]*?)token="([^"]+)"([^>]*?)/></figure>`)
+	fetchedSheetIDTagRe     = regexp.MustCompile(`<sheet\s+([^>]*?)sheet-id="([^"]+)"([^>]*?)(?:></sheet>|/>)`)
 )
 
 // normalizeFetchedDocumentContent applies lightweight export rewrites so the
@@ -106,6 +107,28 @@ func normalizeFetchedDocumentContent(data map[string]interface{}, format string)
 }
 
 func normalizeFetchedVideoTags(content string) string {
+	content = fetchedVideoFigureTagRe.ReplaceAllStringFunc(content, func(tag string) string {
+		m := fetchedVideoFigureTagRe.FindStringSubmatch(tag)
+		if len(m) != 5 {
+			return tag
+		}
+		viewType := strings.TrimSpace(fetchedAttrValue(tag, "view-type"))
+		token := strings.TrimSpace(m[3])
+		mime := strings.TrimSpace(fetchedAttrValue(tag, "mime"))
+
+		attrs := []string{"controls"}
+		if token != "" {
+			attrs = append(attrs, fmt.Sprintf(`src="feishu://media/%s"`, token))
+		}
+		if mime != "" {
+			attrs = append(attrs, fmt.Sprintf(`data-mime="%s"`, mime))
+		}
+		if viewType != "" {
+			attrs = append(attrs, fmt.Sprintf(`data-view-type="%s"`, viewType))
+		}
+		return fmt.Sprintf("<video %s></video>", strings.Join(attrs, " "))
+	})
+
 	return fetchedVideoFileTagRe.ReplaceAllStringFunc(content, func(tag string) string {
 		m := fetchedVideoFileTagRe.FindStringSubmatch(tag)
 		if len(m) != 4 {
@@ -132,17 +155,16 @@ func normalizeFetchedVideoTags(content string) string {
 }
 
 func normalizeFetchedSheetTags(content string) string {
-	return fetchedSheetTagRe.ReplaceAllStringFunc(content, func(tag string) string {
-		m := fetchedSheetTagRe.FindStringSubmatch(tag)
+	return fetchedSheetIDTagRe.ReplaceAllStringFunc(content, func(tag string) string {
+		m := fetchedSheetIDTagRe.FindStringSubmatch(tag)
 		if len(m) != 4 || strings.Contains(tag, ` id="`) {
 			return tag
 		}
-		token := strings.TrimSpace(m[2])
-		prefix, id, ok := strings.Cut(token, "_")
-		if !ok || prefix == "" || id == "" {
+		sheetID := strings.TrimSpace(m[2])
+		if sheetID == "" {
 			return tag
 		}
-		return strings.Replace(tag, fmt.Sprintf(`token="%s"`, token), fmt.Sprintf(`token="%s" id="%s"`, prefix, id), 1)
+		return strings.Replace(tag, fmt.Sprintf(`sheet-id="%s"`, sheetID), fmt.Sprintf(`id="%s"`, sheetID), 1)
 	})
 }
 

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -67,6 +68,7 @@ func executeFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 	if err != nil {
 		return err
 	}
+	normalizeFetchedDocumentContent(data, runtime.Str("doc-format"))
 
 	runtime.OutFormatRaw(data, nil, func(w io.Writer) {
 		if doc, ok := data["document"].(map[string]interface{}); ok {
@@ -76,6 +78,106 @@ func executeFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 		}
 	})
 	return nil
+}
+
+var (
+	fetchedVideoFileTagRe = regexp.MustCompile(`<file\s+([^>]*\btoken="([^"]+)"[^>]*\bname="([^"]+)"[^>]*)/>`)
+	fetchedSheetTagRe     = regexp.MustCompile(`<sheet\s+([^>]*?)token="([^"]+)"([^>]*?)/>`)
+)
+
+// normalizeFetchedDocumentContent applies lightweight export rewrites so the
+// current CLI can surface a couple of higher-level compatibility behaviors from
+// the legacy converter pipeline without reintroducing that entire subsystem.
+func normalizeFetchedDocumentContent(data map[string]interface{}, format string) {
+	if strings.TrimSpace(format) == "text" {
+		return
+	}
+	doc, _ := data["document"].(map[string]interface{})
+	if doc == nil {
+		return
+	}
+	content, _ := doc["content"].(string)
+	if content == "" {
+		return
+	}
+	content = normalizeFetchedVideoTags(content)
+	content = normalizeFetchedSheetTags(content)
+	doc["content"] = content
+}
+
+func normalizeFetchedVideoTags(content string) string {
+	return fetchedVideoFileTagRe.ReplaceAllStringFunc(content, func(tag string) string {
+		m := fetchedVideoFileTagRe.FindStringSubmatch(tag)
+		if len(m) != 4 {
+			return tag
+		}
+		token := strings.TrimSpace(m[2])
+		name := strings.TrimSpace(m[3])
+		if !isFetchedVideoFilename(name) {
+			return tag
+		}
+
+		attrs := []string{"controls"}
+		if token != "" {
+			attrs = append(attrs, fmt.Sprintf(`src="feishu://media/%s"`, token))
+		}
+		if name != "" {
+			attrs = append(attrs, fmt.Sprintf(`data-name="%s"`, name))
+		}
+		if viewType := fetchedAttrValue(tag, "view-type"); viewType != "" {
+			attrs = append(attrs, fmt.Sprintf(`data-view-type="%s"`, viewType))
+		}
+		return fmt.Sprintf("<video %s></video>", strings.Join(attrs, " "))
+	})
+}
+
+func normalizeFetchedSheetTags(content string) string {
+	return fetchedSheetTagRe.ReplaceAllStringFunc(content, func(tag string) string {
+		m := fetchedSheetTagRe.FindStringSubmatch(tag)
+		if len(m) != 4 || strings.Contains(tag, ` id="`) {
+			return tag
+		}
+		token := strings.TrimSpace(m[2])
+		prefix, id, ok := strings.Cut(token, "_")
+		if !ok || prefix == "" || id == "" {
+			return tag
+		}
+		return strings.Replace(tag, fmt.Sprintf(`token="%s"`, token), fmt.Sprintf(`token="%s" id="%s"`, prefix, id), 1)
+	})
+}
+
+func fetchedAttrValue(tag, attr string) string {
+	needle := attr + `="`
+	idx := strings.Index(tag, needle)
+	if idx == -1 {
+		return ""
+	}
+	start := idx + len(needle)
+	end := strings.Index(tag[start:], `"`)
+	if end == -1 {
+		return ""
+	}
+	return tag[start : start+end]
+}
+
+func isFetchedVideoFilename(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	switch {
+	case strings.HasSuffix(name, ".mp4"):
+		return true
+	case strings.HasSuffix(name, ".mov"):
+		return true
+	case strings.HasSuffix(name, ".m4v"):
+		return true
+	case strings.HasSuffix(name, ".webm"):
+		return true
+	case strings.HasSuffix(name, ".avi"):
+		return true
+	case strings.HasSuffix(name, ".mkv"):
+		return true
+	default:
+		return false
+	}
 }
 
 func buildFetchBody(runtime *common.RuntimeContext) map[string]interface{} {

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import "testing"
+
+func TestNormalizeFetchedVideoTags(t *testing.T) {
+	t.Parallel()
+
+	input := `<file token="file_video_123" name="demo.mp4"/>`
+	got := normalizeFetchedVideoTags(input)
+	want := `<video controls src="feishu://media/file_video_123" data-name="demo.mp4"></video>`
+	if got != want {
+		t.Fatalf("normalizeFetchedVideoTags() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeFetchedVideoTagsPreservesViewType(t *testing.T) {
+	t.Parallel()
+
+	input := `<file token="file_video_123" name="demo.mp4" view-type="2"/>`
+	got := normalizeFetchedVideoTags(input)
+	want := `<video controls src="feishu://media/file_video_123" data-name="demo.mp4" data-view-type="2"></video>`
+	if got != want {
+		t.Fatalf("normalizeFetchedVideoTags() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeFetchedVideoTagsLeavesNonVideoFileAlone(t *testing.T) {
+	t.Parallel()
+
+	input := `<file token="file_doc_123" name="report.pdf"/>`
+	if got := normalizeFetchedVideoTags(input); got != input {
+		t.Fatalf("normalizeFetchedVideoTags() = %q, want unchanged %q", got, input)
+	}
+}
+
+func TestNormalizeFetchedSheetTags(t *testing.T) {
+	t.Parallel()
+
+	input := `<sheet token="sheet_xyz" rows="5" cols="8"/>`
+	got := normalizeFetchedSheetTags(input)
+	want := `<sheet token="sheet" id="xyz" rows="5" cols="8"/>`
+	if got != want {
+		t.Fatalf("normalizeFetchedSheetTags() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeFetchedSheetTagsLeavesExistingIDAlone(t *testing.T) {
+	t.Parallel()
+
+	input := `<sheet token="sheet" id="xyz" rows="5" cols="8"/>`
+	if got := normalizeFetchedSheetTags(input); got != input {
+		t.Fatalf("normalizeFetchedSheetTags() = %q, want unchanged %q", got, input)
+	}
+}
+
+func TestNormalizeFetchedDocumentContent(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]interface{}{
+		"document": map[string]interface{}{
+			"content": `<file token="file_video_123" name="demo.mp4"/>` + "\n" + `<sheet token="sheet_xyz" rows="5" cols="8"/>`,
+		},
+	}
+
+	normalizeFetchedDocumentContent(data, "xml")
+
+	doc := data["document"].(map[string]interface{})
+	got := doc["content"].(string)
+	want := `<video controls src="feishu://media/file_video_123" data-name="demo.mp4"></video>` + "\n" + `<sheet token="sheet" id="xyz" rows="5" cols="8"/>`
+	if got != want {
+		t.Fatalf("normalizeFetchedDocumentContent() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeFetchedDocumentContentSkipsTextFormat(t *testing.T) {
+	t.Parallel()
+
+	data := map[string]interface{}{
+		"document": map[string]interface{}{
+			"content": `<file token="file_video_123" name="demo.mp4"/>`,
+		},
+	}
+
+	normalizeFetchedDocumentContent(data, "text")
+
+	doc := data["document"].(map[string]interface{})
+	if got := doc["content"].(string); got != `<file token="file_video_123" name="demo.mp4"/>` {
+		t.Fatalf("text format should remain unchanged, got %q", got)
+	}
+}

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -16,6 +16,17 @@ func TestNormalizeFetchedVideoTags(t *testing.T) {
 	}
 }
 
+func TestNormalizeFetchedVideoFigureTags(t *testing.T) {
+	t.Parallel()
+
+	input := `<figure view-type="Preview"><source href="https://example.com/video" mime="video/quicktime" token="RXwJbGRG9orDqhxuYKvch0TqnBf"/></figure>`
+	got := normalizeFetchedVideoTags(input)
+	want := `<video controls src="feishu://media/RXwJbGRG9orDqhxuYKvch0TqnBf" data-mime="video/quicktime" data-view-type="Preview"></video>`
+	if got != want {
+		t.Fatalf("normalizeFetchedVideoTags() = %q, want %q", got, want)
+	}
+}
+
 func TestNormalizeFetchedVideoTagsPreservesViewType(t *testing.T) {
 	t.Parallel()
 
@@ -39,9 +50,9 @@ func TestNormalizeFetchedVideoTagsLeavesNonVideoFileAlone(t *testing.T) {
 func TestNormalizeFetchedSheetTags(t *testing.T) {
 	t.Parallel()
 
-	input := `<sheet token="sheet_xyz" rows="5" cols="8"/>`
+	input := `<sheet sheet-id="jkxrFs" token="FhJTsZVIihsBEStE5RVcr6Fbnrf"></sheet>`
 	got := normalizeFetchedSheetTags(input)
-	want := `<sheet token="sheet" id="xyz" rows="5" cols="8"/>`
+	want := `<sheet id="jkxrFs" token="FhJTsZVIihsBEStE5RVcr6Fbnrf"></sheet>`
 	if got != want {
 		t.Fatalf("normalizeFetchedSheetTags() = %q, want %q", got, want)
 	}
@@ -50,7 +61,7 @@ func TestNormalizeFetchedSheetTags(t *testing.T) {
 func TestNormalizeFetchedSheetTagsLeavesExistingIDAlone(t *testing.T) {
 	t.Parallel()
 
-	input := `<sheet token="sheet" id="xyz" rows="5" cols="8"/>`
+	input := `<sheet id="jkxrFs" token="FhJTsZVIihsBEStE5RVcr6Fbnrf"></sheet>`
 	if got := normalizeFetchedSheetTags(input); got != input {
 		t.Fatalf("normalizeFetchedSheetTags() = %q, want unchanged %q", got, input)
 	}
@@ -61,7 +72,7 @@ func TestNormalizeFetchedDocumentContent(t *testing.T) {
 
 	data := map[string]interface{}{
 		"document": map[string]interface{}{
-			"content": `<file token="file_video_123" name="demo.mp4"/>` + "\n" + `<sheet token="sheet_xyz" rows="5" cols="8"/>`,
+			"content": `<figure view-type="Preview"><source href="https://example.com/video" mime="video/quicktime" token="RXwJbGRG9orDqhxuYKvch0TqnBf"/></figure>` + "\n" + `<sheet sheet-id="jkxrFs" token="FhJTsZVIihsBEStE5RVcr6Fbnrf"></sheet>`,
 		},
 	}
 
@@ -69,7 +80,7 @@ func TestNormalizeFetchedDocumentContent(t *testing.T) {
 
 	doc := data["document"].(map[string]interface{})
 	got := doc["content"].(string)
-	want := `<video controls src="feishu://media/file_video_123" data-name="demo.mp4"></video>` + "\n" + `<sheet token="sheet" id="xyz" rows="5" cols="8"/>`
+	want := `<video controls src="feishu://media/RXwJbGRG9orDqhxuYKvch0TqnBf" data-mime="video/quicktime" data-view-type="Preview"></video>` + "\n" + `<sheet id="jkxrFs" token="FhJTsZVIihsBEStE5RVcr6Fbnrf"></sheet>`
 	if got != want {
 		t.Fatalf("normalizeFetchedDocumentContent() = %q, want %q", got, want)
 	}

--- a/shortcuts/doc/docs_update_test.go
+++ b/shortcuts/doc/docs_update_test.go
@@ -30,6 +30,21 @@ func TestValidCommandsV2(t *testing.T) {
 	}
 }
 
+func TestBuildUpdateBodyV2NormalizesVideoCompatMarkup(t *testing.T) {
+	t.Parallel()
+
+	runtime := newDocCompatRuntime(t, map[string]string{
+		"command":    "overwrite",
+		"doc-format": "xml",
+		"content":    `<video controls src="feishu://media/file_video_123" data-name="demo.mp4"></video>`,
+	})
+
+	body := buildUpdateBody(runtime)
+	if got := body["content"]; got != `<file token="file_video_123" name="demo.mp4"/>` {
+		t.Fatalf("buildUpdateBody().content = %#v", got)
+	}
+}
+
 // ── V1 tests ──
 
 func TestIsWhiteboardCreateMarkdown(t *testing.T) {

--- a/shortcuts/doc/docs_update_v2.go
+++ b/shortcuts/doc/docs_update_v2.go
@@ -135,6 +135,7 @@ func executeUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 
 func buildUpdateBody(runtime *common.RuntimeContext) map[string]interface{} {
 	cmd := runtime.Str("command")
+	format := runtime.Str("doc-format")
 
 	// append is a shorthand for block_insert_after with block_id "-1" (end of document)
 	blockID := runtime.Str("block-id")
@@ -144,14 +145,14 @@ func buildUpdateBody(runtime *common.RuntimeContext) map[string]interface{} {
 	}
 
 	body := map[string]interface{}{
-		"format":  runtime.Str("doc-format"),
+		"format":  format,
 		"command": cmd,
 	}
 	if v := runtime.Int("revision-id"); v != 0 {
 		body["revision_id"] = v
 	}
 	if v := runtime.Str("content"); v != "" {
-		body["content"] = v
+		body["content"] = normalizeDocInputContent(format, v)
 	}
 	if v := runtime.Str("pattern"); v != "" {
 		body["pattern"] = v


### PR DESCRIPTION
## 变更说明
- 将导出的电子表格标签从 `sheet-id` 规范化为 `id`
- 将导出的视频结构从 `<figure><source .../></figure>` 规范化为 `<video>` 标签
- 为真实的 docs_ai 导出结构补充对应测试

## 导出格式变更对比

### 电子表格

| 场景 | 导出形式 |
|---|---|
| PR 修改前 | `<sheet sheet-id="jkxrFs" token="FhJTsZVIihsBEStE5RVcr6Fbnrf"></sheet>` |
| PR 修改后 | `<sheet id="jkxrFs" token="FhJTsZVIihsBEStE5RVcr6Fbnrf"></sheet>` |

### 视频

| 场景 | 导出形式 |
|---|---|
| PR 修改前 | `<figure view-type="Preview"><source href="..." mime="video/quicktime" origin-height="1892.000000" origin-width="3016.000000" token="RXwJbGRG9orDqhxuYKvch0TqnBf"/></figure>` |
| PR 修改后 | `<video controls src="feishu://media/RXwJbGRG9orDqhxuYKvch0TqnBf" data-mime="video/quicktime" data-view-type="Preview"></video>` |

## 测试
- `go test ./shortcuts/doc`
