### PR TITLE
feat(drive): extend +add-comment to support slides targets

### DIFF
--- a/shortcuts/drive/drive_add_comment.go
+++ b/shortcuts/drive/drive_add_comment.go
@@ -64,7 +64,7 @@ const (
 var DriveAddComment = common.Shortcut{
 	Service:     "drive",
 	Command:     "+add-comment",
-	Description: "Add a full-document or local comment to doc/docx/sheet, also supports wiki URL resolving to doc/docx/sheet",
+	Description: "Add a comment to doc/docx/sheet/slides, also supports wiki URL resolving to doc/docx/sheet/slides",
 	Risk:        "write",
 	Scopes: []string{
 		"docx:document:readonly",
@@ -73,12 +73,12 @@ var DriveAddComment = common.Shortcut{
 	},
 	AuthTypes: []string{"user", "bot"},
 	Flags: []common.Flag{
-		{Name: "doc", Desc: "document URL/token, sheet URL, or wiki URL that resolves to doc/docx/sheet", Required: true},
-		{Name: "type", Desc: "document type: doc, docx, sheet (required when --doc is a bare token; auto-detected for URLs)", Enum: []string{"doc", "docx", "sheet"}},
+		{Name: "doc", Desc: "document URL/token, sheet/slides URL, or wiki URL that resolves to doc/docx/sheet/slides", Required: true},
+		{Name: "type", Desc: "document type: doc, docx, sheet, slides (required when --doc is a bare token; auto-detected for URLs)", Enum: []string{"doc", "docx", "sheet", "slides"}},
 		{Name: "content", Desc: "reply_elements JSON string", Required: true},
 		{Name: "full-comment", Type: "bool", Desc: "create a full-document comment; also the default when no location is provided"},
 		{Name: "selection-with-ellipsis", Desc: "target content locator (plain text or 'start...end')"},
-		{Name: "block-id", Desc: "for docx: anchor block ID; for sheet: <sheetId>!<cell> (e.g. a281f9!D6)"},
+		{Name: "block-id", Desc: "for docx: anchor block ID; for sheet: <sheetId>!<cell> (e.g. a281f9!D6); for slides: <slide-block-type>!<xml-id> (e.g. shape!bPq)"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		docRef, err := parseCommentDocRef(runtime.Str("doc"), runtime.Str("type"))
@@ -104,6 +104,18 @@ var DriveAddComment = common.Shortcut{
 			}
 			return nil
 		}
+		if docRef.Kind == "slides" {
+			if _, _, err := parseSlidesBlockRef(runtime.Str("block-id")); err != nil {
+				return err
+			}
+			if runtime.Bool("full-comment") {
+				return output.ErrValidation("--full-comment is not applicable for slide comments; use --block-id <slide-block-type>!<xml-id>")
+			}
+			if strings.TrimSpace(runtime.Str("selection-with-ellipsis")) != "" {
+				return output.ErrValidation("--selection-with-ellipsis is not applicable for slide comments; use --block-id <slide-block-type>!<xml-id>")
+			}
+			return nil
+		}
 
 		selection := runtime.Str("selection-with-ellipsis")
 		blockID := strings.TrimSpace(runtime.Str("block-id"))
@@ -116,7 +128,7 @@ var DriveAddComment = common.Shortcut{
 
 		mode := resolveCommentMode(runtime.Bool("full-comment"), selection, blockID)
 		if mode == commentModeLocal && docRef.Kind == "doc" {
-			return output.ErrValidation("local comments only support docx and sheet; old doc format only supports full comments")
+			return output.ErrValidation("local comments only support docx, sheet, and slides; old doc format only supports full comments")
 		}
 
 		return nil
@@ -124,7 +136,9 @@ var DriveAddComment = common.Shortcut{
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		docRef, _ := parseCommentDocRef(runtime.Str("doc"), runtime.Str("type"))
 		replyElements, _ := parseCommentReplyElements(runtime.Str("content"))
+		selection := runtime.Str("selection-with-ellipsis")
 		blockID := strings.TrimSpace(runtime.Str("block-id"))
+		mode := resolveCommentMode(runtime.Bool("full-comment"), selection, blockID)
 
 		// For wiki URLs, resolve the actual target type via API so dry-run
 		// matches real execution behavior instead of guessing from --block-id.
@@ -133,11 +147,12 @@ var DriveAddComment = common.Shortcut{
 		isWiki := false
 		if docRef.Kind == "wiki" {
 			isWiki = true
-			target, err := resolveCommentTarget(ctx, runtime, runtime.Str("doc"), commentModeFull)
-			if err == nil {
-				resolvedKind = target.FileType
-				resolvedToken = target.FileToken
+			target, err := resolveCommentTarget(ctx, runtime, runtime.Str("doc"), mode)
+			if err != nil {
+				return common.NewDryRunAPI().Set("error", err.Error())
 			}
+			resolvedKind = target.FileType
+			resolvedToken = target.FileToken
 		}
 
 		// Sheet comment dry-run.
@@ -146,7 +161,7 @@ var DriveAddComment = common.Shortcut{
 			if anchor == nil {
 				anchor = &sheetAnchor{SheetID: "<sheetId>", Col: 0, Row: 0}
 			}
-			commentBody := buildCommentCreateV2Request("sheet", "", replyElements, anchor)
+			commentBody := buildCommentCreateV2Request("sheet", "", "", replyElements, anchor)
 			desc := "1-step request: create sheet comment"
 			if isWiki {
 				desc = "2-step orchestration: resolve wiki -> create sheet comment"
@@ -157,15 +172,28 @@ var DriveAddComment = common.Shortcut{
 				Body(commentBody).
 				Set("file_token", resolvedToken)
 		}
+		if resolvedKind == "slides" {
+			slideAnchorBlockID, slideBlockType, err := parseSlidesBlockRef(blockID)
+			if err != nil {
+				return common.NewDryRunAPI().Set("error", err.Error())
+			}
+			commentBody := buildCommentCreateV2Request("slides", slideAnchorBlockID, slideBlockType, replyElements, nil)
+			desc := "1-step request: create slide block comment"
+			if isWiki {
+				desc = "2-step orchestration: resolve wiki -> create slide block comment"
+			}
+			return common.NewDryRunAPI().
+				Desc(desc).
+				POST("/open-apis/drive/v1/files/:file_token/new_comments").
+				Body(commentBody).
+				Set("file_token", resolvedToken)
+		}
 
 		// Doc/docx comment dry-run.
-		selection := runtime.Str("selection-with-ellipsis")
-		mode := resolveCommentMode(runtime.Bool("full-comment"), selection, blockID)
-
 		createPath := "/open-apis/drive/v1/files/:file_token/new_comments"
-		commentBody := buildCommentCreateV2Request(resolvedKind, "", replyElements, nil)
+		commentBody := buildCommentCreateV2Request(resolvedKind, "", "", replyElements, nil)
 		if mode == commentModeLocal {
-			commentBody = buildCommentCreateV2Request(resolvedKind, anchorBlockIDForDryRun(blockID), replyElements, nil)
+			commentBody = buildCommentCreateV2Request(resolvedKind, anchorBlockIDForDryRun(blockID), "", replyElements, nil)
 		}
 
 		mcpEndpoint := common.MCPEndpoint(runtime.Config.Brand)
@@ -240,6 +268,9 @@ var DriveAddComment = common.Shortcut{
 		if docRef.Kind == "sheet" {
 			return executeSheetComment(runtime, docRef)
 		}
+		if docRef.Kind == "slides" {
+			return executeSlidesComment(runtime, docRef)
+		}
 
 		selection := runtime.Str("selection-with-ellipsis")
 		blockID := strings.TrimSpace(runtime.Str("block-id"))
@@ -253,6 +284,9 @@ var DriveAddComment = common.Shortcut{
 		// Wiki resolved to sheet: redirect to sheet comment path.
 		if target.FileType == "sheet" {
 			return executeSheetComment(runtime, commentDocRef{Kind: "sheet", Token: target.FileToken})
+		}
+		if target.FileType == "slides" {
+			return executeSlidesComment(runtime, commentDocRef{Kind: "slides", Token: target.FileToken})
 		}
 
 		replyElements, err := parseCommentReplyElements(runtime.Str("content"))
@@ -283,9 +317,9 @@ var DriveAddComment = common.Shortcut{
 		}
 
 		requestPath := fmt.Sprintf("/open-apis/drive/v1/files/%s/new_comments", validate.EncodePathSegment(target.FileToken))
-		requestBody := buildCommentCreateV2Request(target.FileType, "", replyElements, nil)
+		requestBody := buildCommentCreateV2Request(target.FileType, "", "", replyElements, nil)
 		if mode == commentModeLocal {
-			requestBody = buildCommentCreateV2Request(target.FileType, blockID, replyElements, nil)
+			requestBody = buildCommentCreateV2Request(target.FileType, blockID, "", replyElements, nil)
 		}
 
 		if mode == commentModeLocal {
@@ -358,6 +392,9 @@ func parseCommentDocRef(input, docType string) (commentDocRef, error) {
 	if token, ok := extractURLToken(raw, "/sheets/"); ok {
 		return commentDocRef{Kind: "sheet", Token: token}, nil
 	}
+	if token, ok := extractURLToken(raw, "/slides/"); ok {
+		return commentDocRef{Kind: "slides", Token: token}, nil
+	}
 	if token, ok := extractURLToken(raw, "/docx/"); ok {
 		return commentDocRef{Kind: "docx", Token: token}, nil
 	}
@@ -365,7 +402,7 @@ func parseCommentDocRef(input, docType string) (commentDocRef, error) {
 		return commentDocRef{Kind: "doc", Token: token}, nil
 	}
 	if strings.Contains(raw, "://") {
-		return commentDocRef{}, output.ErrValidation("unsupported --doc input %q: use a doc/docx/sheet URL, a token with --type, or a wiki URL that resolves to doc/docx/sheet", raw)
+		return commentDocRef{}, output.ErrValidation("unsupported --doc input %q: use a doc/docx/sheet/slides URL, a token with --type, or a wiki URL that resolves to doc/docx/sheet/slides", raw)
 	}
 	if strings.ContainsAny(raw, "/?#") {
 		return commentDocRef{}, output.ErrValidation("unsupported --doc input %q: use a token with --type, or a wiki URL", raw)
@@ -374,7 +411,7 @@ func parseCommentDocRef(input, docType string) (commentDocRef, error) {
 	// Bare token: --type is required.
 	docType = strings.TrimSpace(docType)
 	if docType == "" {
-		return commentDocRef{}, output.ErrValidation("--type is required when --doc is a bare token (allowed values: doc, docx, sheet)")
+		return commentDocRef{}, output.ErrValidation("--type is required when --doc is a bare token (allowed values: doc, docx, sheet, slides)")
 	}
 	return commentDocRef{Kind: docType, Token: raw}, nil
 }
@@ -385,9 +422,9 @@ func resolveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, i
 		return resolvedCommentTarget{}, err
 	}
 
-	if docRef.Kind == "docx" || docRef.Kind == "doc" || docRef.Kind == "sheet" {
-		if mode == commentModeLocal && docRef.Kind != "docx" && docRef.Kind != "sheet" {
-			return resolvedCommentTarget{}, output.ErrValidation("local comments only support docx and sheet; old doc format only supports full comments")
+	if docRef.Kind == "docx" || docRef.Kind == "doc" || docRef.Kind == "sheet" || docRef.Kind == "slides" {
+		if mode == commentModeLocal && docRef.Kind != "docx" && docRef.Kind != "sheet" && docRef.Kind != "slides" {
+			return resolvedCommentTarget{}, output.ErrValidation("local comments only support docx, sheet, and slides; old doc format only supports full comments")
 		}
 		return resolvedCommentTarget{
 			DocID:      docRef.Token,
@@ -414,6 +451,12 @@ func resolveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, i
 	if objType == "" || objToken == "" {
 		return resolvedCommentTarget{}, output.Errorf(output.ExitAPI, "api_error", "wiki get_node returned incomplete node data")
 	}
+	if objType == "slides" && mode == commentModeFull {
+		return resolvedCommentTarget{}, output.ErrValidation("wiki resolved to %q, but slide comments require --block-id <slide-block-type>!<xml-id>; --full-comment is not applicable", objType)
+	}
+	if objType == "slides" && strings.TrimSpace(runtime.Str("selection-with-ellipsis")) != "" {
+		return resolvedCommentTarget{}, output.ErrValidation("wiki resolved to %q, but --selection-with-ellipsis is not applicable for slide comments; use --block-id <slide-block-type>!<xml-id>", objType)
+	}
 	if objType == "sheet" {
 		// Sheet comments are handled via the sheet fast path in Execute.
 		fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to %s: %s\n", objType, common.MaskToken(objToken))
@@ -425,11 +468,21 @@ func resolveCommentTarget(ctx context.Context, runtime *common.RuntimeContext, i
 			WikiToken:  docRef.Token,
 		}, nil
 	}
+	if objType == "slides" {
+		fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to %s: %s\n", objType, common.MaskToken(objToken))
+		return resolvedCommentTarget{
+			DocID:      objToken,
+			FileToken:  objToken,
+			FileType:   "slides",
+			ResolvedBy: "wiki",
+			WikiToken:  docRef.Token,
+		}, nil
+	}
 	if mode == commentModeLocal && objType != "docx" {
-		return resolvedCommentTarget{}, output.ErrValidation("wiki resolved to %q, but local comments only support docx and sheet; for sheet use --block-id <sheetId>!<cell>", objType)
+		return resolvedCommentTarget{}, output.ErrValidation("wiki resolved to %q, but local comments only support docx, sheet, and slides; for sheet use --block-id <sheetId>!<cell>, for slides use --block-id <slide-block-type>!<xml-id>", objType)
 	}
 	if mode == commentModeFull && objType != "docx" && objType != "doc" {
-		return resolvedCommentTarget{}, output.ErrValidation("wiki resolved to %q, but comments only support doc/docx/sheet", objType)
+		return resolvedCommentTarget{}, output.ErrValidation("wiki resolved to %q, but comments only support doc/docx/sheet/slides", objType)
 	}
 
 	fmt.Fprintf(runtime.IO().ErrOut, "Resolved wiki to %s: %s\n", objType, common.MaskToken(objToken))
@@ -606,7 +659,7 @@ type sheetAnchor struct {
 	Row     int
 }
 
-func buildCommentCreateV2Request(fileType, blockID string, replyElements []map[string]interface{}, sheet *sheetAnchor) map[string]interface{} {
+func buildCommentCreateV2Request(fileType, blockID, slideBlockType string, replyElements []map[string]interface{}, sheet *sheetAnchor) map[string]interface{} {
 	body := map[string]interface{}{
 		"file_type":      fileType,
 		"reply_elements": replyElements,
@@ -621,6 +674,9 @@ func buildCommentCreateV2Request(fileType, blockID string, replyElements []map[s
 		body["anchor"] = map[string]interface{}{
 			"block_id": blockID,
 		}
+		if strings.TrimSpace(slideBlockType) != "" {
+			body["anchor"].(map[string]interface{})["slide_block_type"] = strings.TrimSpace(slideBlockType)
+		}
 	}
 	return body
 }
@@ -630,6 +686,24 @@ func anchorBlockIDForDryRun(blockID string) string {
 		return strings.TrimSpace(blockID)
 	}
 	return "<anchor_block_id>"
+}
+
+func parseSlidesBlockRef(blockID string) (string, string, error) {
+	blockID = strings.TrimSpace(blockID)
+	if blockID == "" {
+		return "", "", output.ErrValidation("slide comments require --block-id in <slide-block-type>!<xml-id> format")
+	}
+
+	parts := strings.SplitN(blockID, "!", 2)
+	if len(parts) != 2 {
+		return "", "", output.ErrValidation("slide --block-id must be <slide-block-type>!<xml-id> (e.g. shape!bPq), got %q", blockID)
+	}
+	parsedType := strings.TrimSpace(parts[0])
+	parsedID := strings.TrimSpace(parts[1])
+	if parsedType == "" || parsedID == "" {
+		return "", "", output.ErrValidation("slide --block-id must be <slide-block-type>!<xml-id> (e.g. shape!bPq), got %q", blockID)
+	}
+	return parsedID, parsedType, nil
 }
 
 func firstNonEmptyString(values ...string) string {
@@ -703,7 +777,7 @@ func executeSheetComment(runtime *common.RuntimeContext, docRef commentDocRef) e
 	}
 
 	requestPath := fmt.Sprintf("/open-apis/drive/v1/files/%s/new_comments", validate.EncodePathSegment(docRef.Token))
-	requestBody := buildCommentCreateV2Request("sheet", "", replyElements, anchor)
+	requestBody := buildCommentCreateV2Request("sheet", "", "", replyElements, anchor)
 
 	fmt.Fprintf(runtime.IO().ErrOut, "Creating sheet comment in %s (sheet=%s, col=%d, row=%d)\n",
 		common.MaskToken(docRef.Token), anchor.SheetID, anchor.Col, anchor.Row)
@@ -719,6 +793,43 @@ func executeSheetComment(runtime *common.RuntimeContext, docRef commentDocRef) e
 		"file_type":    "sheet",
 		"comment_mode": "sheet",
 		"block_id":     blockID,
+	}
+	if createdAt := firstPresentValue(data, "created_at", "create_time"); createdAt != nil {
+		out["created_at"] = createdAt
+	}
+	runtime.Out(out, nil)
+	return nil
+}
+
+func executeSlidesComment(runtime *common.RuntimeContext, docRef commentDocRef) error {
+	replyElements, err := parseCommentReplyElements(runtime.Str("content"))
+	if err != nil {
+		return err
+	}
+
+	blockID, slideBlockType, err := parseSlidesBlockRef(runtime.Str("block-id"))
+	if err != nil {
+		return err
+	}
+
+	requestPath := fmt.Sprintf("/open-apis/drive/v1/files/%s/new_comments", validate.EncodePathSegment(docRef.Token))
+	requestBody := buildCommentCreateV2Request("slides", blockID, slideBlockType, replyElements, nil)
+
+	fmt.Fprintf(runtime.IO().ErrOut, "Creating slide block comment in %s (block_id=%s, slide_block_type=%s)\n",
+		common.MaskToken(docRef.Token), blockID, slideBlockType)
+
+	data, err := runtime.CallAPI("POST", requestPath, nil, requestBody)
+	if err != nil {
+		return err
+	}
+
+	out := map[string]interface{}{
+		"comment_id":       data["comment_id"],
+		"file_token":       docRef.Token,
+		"file_type":        "slides",
+		"comment_mode":     "slide_block",
+		"anchor_block_id":  blockID,
+		"slide_block_type": slideBlockType,
 	}
 	if createdAt := firstPresentValue(data, "created_at", "create_time"); createdAt != nil {
 		out["created_at"] = createdAt

--- a/shortcuts/drive/drive_add_comment_test.go
+++ b/shortcuts/drive/drive_add_comment_test.go
@@ -4,12 +4,53 @@
 package drive
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/httpmock"
 )
+
+func decodeJSONMap(t *testing.T, raw string) map[string]interface{} {
+	t.Helper()
+
+	var data map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &data); err != nil {
+		t.Fatalf("failed to decode JSON output: %v\nstdout:\n%s", err, raw)
+	}
+	return data
+}
+
+func mustMapValue(t *testing.T, value interface{}, path string) map[string]interface{} {
+	t.Helper()
+
+	got, ok := value.(map[string]interface{})
+	if !ok {
+		t.Fatalf("%s is %T, want map[string]interface{}", path, value)
+	}
+	return got
+}
+
+func mustSliceValue(t *testing.T, value interface{}, path string) []interface{} {
+	t.Helper()
+
+	got, ok := value.([]interface{})
+	if !ok {
+		t.Fatalf("%s is %T, want []interface{}", path, value)
+	}
+	return got
+}
+
+func mustStringField(t *testing.T, m map[string]interface{}, key, path string) string {
+	t.Helper()
+
+	got, ok := m[key].(string)
+	if !ok {
+		t.Fatalf("%s is %T, want string", path, m[key])
+	}
+	return got
+}
 
 func TestParseCommentDocRef(t *testing.T) {
 	t.Parallel()
@@ -49,6 +90,13 @@ func TestParseCommentDocRef(t *testing.T) {
 			wantToken: "shtToken",
 		},
 		{
+			name:      "raw token with type slides",
+			input:     "slideToken",
+			docType:   "slides",
+			wantKind:  "slides",
+			wantToken: "slideToken",
+		},
+		{
 			name:      "raw token with type doc",
 			input:     "docToken",
 			docType:   "doc",
@@ -65,6 +113,12 @@ func TestParseCommentDocRef(t *testing.T) {
 			input:     "https://example.larksuite.com/doc/xxxxxx",
 			wantKind:  "doc",
 			wantToken: "xxxxxx",
+		},
+		{
+			name:      "slides url",
+			input:     "https://example.larksuite.com/slides/pres_123?from=share",
+			wantKind:  "slides",
+			wantToken: "pres_123",
 		},
 		{
 			name:    "unsupported url",
@@ -288,7 +342,7 @@ func TestBuildCommentCreateV2RequestFull(t *testing.T) {
 			"text": "全文评论",
 		},
 	}
-	got := buildCommentCreateV2Request("docx", "", replyElements, nil)
+	got := buildCommentCreateV2Request("docx", "", "", replyElements, nil)
 
 	if got["file_type"] != "docx" {
 		t.Fatalf("expected file_type docx, got %#v", got["file_type"])
@@ -318,7 +372,7 @@ func TestBuildCommentCreateV2RequestLocal(t *testing.T) {
 			"text": "评论内容",
 		},
 	}
-	got := buildCommentCreateV2Request("docx", "blk_123", replyElements, nil)
+	got := buildCommentCreateV2Request("docx", "blk_123", "", replyElements, nil)
 
 	if got["file_type"] != "docx" {
 		t.Fatalf("expected file_type docx, got %#v", got["file_type"])
@@ -337,6 +391,32 @@ func TestBuildCommentCreateV2RequestLocal(t *testing.T) {
 	}
 	if gotReplyElements[0]["type"] != "text" || gotReplyElements[0]["text"] != "评论内容" {
 		t.Fatalf("unexpected reply element: %#v", gotReplyElements[0])
+	}
+}
+
+func TestBuildCommentCreateV2RequestSlides(t *testing.T) {
+	t.Parallel()
+
+	replyElements := []map[string]interface{}{
+		{
+			"type": "text",
+			"text": "slide comment",
+		},
+	}
+	got := buildCommentCreateV2Request("slides", "shape_123", "shape", replyElements, nil)
+
+	if got["file_type"] != "slides" {
+		t.Fatalf("expected file_type slides, got %#v", got["file_type"])
+	}
+	anchor, ok := got["anchor"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected anchor map, got %#v", got["anchor"])
+	}
+	if anchor["block_id"] != "shape_123" {
+		t.Fatalf("expected block_id shape_123, got %#v", anchor["block_id"])
+	}
+	if anchor["slide_block_type"] != "shape" {
+		t.Fatalf("expected slide_block_type shape, got %#v", anchor["slide_block_type"])
 	}
 }
 
@@ -369,7 +449,7 @@ func TestBuildCommentCreateV2RequestSheet(t *testing.T) {
 	replyElements := []map[string]interface{}{
 		{"type": "text", "text": "请修正此单元格"},
 	}
-	got := buildCommentCreateV2Request("sheet", "", replyElements, &sheetAnchor{
+	got := buildCommentCreateV2Request("sheet", "", "", replyElements, &sheetAnchor{
 		SheetID: "abc123",
 		Col:     3,
 		Row:     5,
@@ -399,7 +479,7 @@ func TestBuildCommentCreateV2RequestSheetOverridesBlockID(t *testing.T) {
 		{"type": "text", "text": "test"},
 	}
 	// When both sheet anchor and blockID are provided, sheet anchor wins.
-	got := buildCommentCreateV2Request("sheet", "should_be_ignored", replyElements, &sheetAnchor{
+	got := buildCommentCreateV2Request("sheet", "should_be_ignored", "", replyElements, &sheetAnchor{
 		SheetID: "s1",
 		Col:     0,
 		Row:     0,
@@ -453,6 +533,59 @@ func TestParseSheetCellRefInvalid(t *testing.T) {
 			_, err := parseSheetCellRef(input)
 			if err == nil {
 				t.Fatalf("expected error for %q", input)
+			}
+		})
+	}
+}
+
+func TestParseSlidesBlockRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		blockID       string
+		wantBlockID   string
+		wantSlideType string
+		wantErr       string
+	}{
+		{
+			name:          "compound block id",
+			blockID:       "shape!bPq",
+			wantBlockID:   "bPq",
+			wantSlideType: "shape",
+		},
+		{
+			name:    "missing block id",
+			wantErr: "slide comments require --block-id",
+		},
+		{
+			name:    "invalid compound",
+			blockID: "shape!",
+			wantErr: "<slide-block-type>!<xml-id>",
+		},
+		{
+			name:    "missing separator",
+			blockID: "bPq",
+			wantErr: "<slide-block-type>!<xml-id>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotBlockID, gotSlideType, err := parseSlidesBlockRef(tt.blockID)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotBlockID != tt.wantBlockID || gotSlideType != tt.wantSlideType {
+				t.Fatalf("expected (%q, %q), got (%q, %q)", tt.wantBlockID, tt.wantSlideType, gotBlockID, gotSlideType)
 			}
 		})
 	}
@@ -514,6 +647,182 @@ func TestSheetCommentValidateRejectsSelectionWithEllipsis(t *testing.T) {
 	}, f, stdout)
 	if err == nil || !strings.Contains(err.Error(), "not applicable for sheet") {
 		t.Fatalf("expected incompatible flags error, got: %v", err)
+	}
+}
+
+// ── Slides comment validate tests ───────────────────────────────────────────
+
+func TestSlidesCommentValidateMissingBlockID(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/slides/presToken",
+		"--content", `[{"type":"text","text":"test"}]`,
+		"--as", "user",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "slide comments require --block-id") {
+		t.Fatalf("expected block-id required error, got: %v", err)
+	}
+}
+
+func TestSlidesCommentValidateRejectsFullComment(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/slides/presToken",
+		"--content", `[{"type":"text","text":"test"}]`,
+		"--block-id", "shape!shape_1",
+		"--full-comment",
+		"--as", "user",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "not applicable for slide comments") {
+		t.Fatalf("expected incompatible flags error, got: %v", err)
+	}
+}
+
+func TestSlidesCommentValidateRejectsSelectionWithEllipsis(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/slides/presToken",
+		"--content", `[{"type":"text","text":"test"}]`,
+		"--block-id", "shape!shape_1",
+		"--selection-with-ellipsis", "something",
+		"--as", "user",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "not applicable for slide comments") {
+		t.Fatalf("expected incompatible flags error, got: %v", err)
+	}
+}
+
+func TestSlidesCommentValidateRejectsLegacyBlockID(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/slides/presToken",
+		"--content", `[{"type":"text","text":"test"}]`,
+		"--block-id", "shape_1",
+		"--as", "user",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "<slide-block-type>!<xml-id>") {
+		t.Fatalf("expected compound block-id format error, got: %v", err)
+	}
+}
+
+func TestSlidesCommentValidateCompoundBlockID(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/slides/presToken",
+		"--content", `[{"type":"text","text":"test"}]`,
+		"--block-id", "shape!shape_1",
+		"--dry-run",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ── Slides comment execute tests ────────────────────────────────────────────
+
+func TestSlidesCommentExecuteSuccess(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/drive/v1/files/presToken/new_comments",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{"comment_id": "slideComment123", "created_at": 1700000000},
+		},
+	})
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/slides/presToken",
+		"--content", `[{"type":"text","text":"请看这个元素"}]`,
+		"--block-id", "shape!shape_1",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "slideComment123") {
+		t.Fatalf("stdout missing comment_id: %s", stdout.String())
+	}
+	out := decodeJSONMap(t, stdout.String())
+	data := mustMapValue(t, out["data"], "data")
+	if got := mustStringField(t, data, "file_type", "data.file_type"); got != "slides" {
+		t.Fatalf("stdout file_type = %q, want slides\nstdout:\n%s", got, stdout.String())
+	}
+	if got := mustStringField(t, data, "slide_block_type", "data.slide_block_type"); got != "shape" {
+		t.Fatalf("stdout slide_block_type = %q, want shape\nstdout:\n%s", got, stdout.String())
+	}
+}
+
+func TestSlidesCommentExecuteSuccessWithCompoundBlockID(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/drive/v1/files/presToken/new_comments",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{"comment_id": "slideCommentCompound"},
+		},
+	})
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/slides/presToken",
+		"--content", `[{"type":"text","text":"请看这个元素"}]`,
+		"--block-id", "shape!shape_9",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "slideCommentCompound") {
+		t.Fatalf("stdout missing comment_id: %s", stdout.String())
+	}
+	out := decodeJSONMap(t, stdout.String())
+	data := mustMapValue(t, out["data"], "data")
+	if got := mustStringField(t, data, "anchor_block_id", "data.anchor_block_id"); got != "shape_9" {
+		t.Fatalf("stdout anchor_block_id = %q, want shape_9\nstdout:\n%s", got, stdout.String())
+	}
+	if got := mustStringField(t, data, "slide_block_type", "data.slide_block_type"); got != "shape" {
+		t.Fatalf("stdout slide_block_type = %q, want shape\nstdout:\n%s", got, stdout.String())
+	}
+}
+
+func TestSlidesCommentViaWikiResolve(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":  "slides",
+					"obj_token": "presResolved",
+				},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST", URL: "/open-apis/drive/v1/files/presResolved/new_comments",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{"comment_id": "wikiSlideComment"},
+		},
+	})
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/wiki/wikiSlidesToken",
+		"--content", `[{"type":"text","text":"wiki slide comment"}]`,
+		"--block-id", "shape!shape_7",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "wikiSlideComment") {
+		t.Fatalf("stdout missing comment_id: %s", stdout.String())
 	}
 }
 
@@ -695,6 +1004,133 @@ func TestDryRunWikiResolvesToDocxFull(t *testing.T) {
 	}
 }
 
+func TestDryRunSlidesDirectURL(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/slides/presToken",
+		"--content", `[{"type":"text","text":"test"}]`,
+		"--block-id", "shape!shape_1",
+		"--dry-run", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "slide block comment") {
+		t.Fatalf("dry-run output missing slide block comment: %s", stdout.String())
+	}
+	out := decodeJSONMap(t, stdout.String())
+	api := mustSliceValue(t, out["api"], "api")
+	call := mustMapValue(t, api[0], "api[0]")
+	body := mustMapValue(t, call["body"], "api[0].body")
+	anchor := mustMapValue(t, body["anchor"], "api[0].body.anchor")
+	if got := mustStringField(t, body, "file_type", "api[0].body.file_type"); got != "slides" {
+		t.Fatalf("dry-run body.file_type = %q, want slides\nstdout:\n%s", got, stdout.String())
+	}
+	if got := mustStringField(t, anchor, "slide_block_type", "api[0].body.anchor.slide_block_type"); got != "shape" {
+		t.Fatalf("dry-run body.anchor.slide_block_type = %q, want shape\nstdout:\n%s", got, stdout.String())
+	}
+}
+
+func TestDryRunWikiResolvesToSlides(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{"obj_type": "slides", "obj_token": "presResolved"},
+			},
+		},
+	})
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/wiki/wikiToken",
+		"--content", `[{"type":"text","text":"test"}]`,
+		"--block-id", "shape!shape_2",
+		"--dry-run", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "slide block comment") {
+		t.Fatalf("dry-run output missing slide block comment: %s", stdout.String())
+	}
+	out := decodeJSONMap(t, stdout.String())
+	api := mustSliceValue(t, out["api"], "api")
+	call := mustMapValue(t, api[0], "api[0]")
+	body := mustMapValue(t, call["body"], "api[0].body")
+	anchor := mustMapValue(t, body["anchor"], "api[0].body.anchor")
+	if got := mustStringField(t, body, "file_type", "api[0].body.file_type"); got != "slides" {
+		t.Fatalf("dry-run body.file_type = %q, want slides\nstdout:\n%s", got, stdout.String())
+	}
+	if got := mustStringField(t, anchor, "slide_block_type", "api[0].body.anchor.slide_block_type"); got != "shape" {
+		t.Fatalf("dry-run body.anchor.slide_block_type = %q, want shape\nstdout:\n%s", got, stdout.String())
+	}
+}
+
+func TestDryRunWikiSlidesInvalidBlockIDSurfaces(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{"obj_type": "slides", "obj_token": "presResolved"},
+			},
+		},
+	})
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/wiki/wikiToken",
+		"--content", `[{"type":"text","text":"test"}]`,
+		"--block-id", "shape_2",
+		"--dry-run", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "slide --block-id must be") || !strings.Contains(stdout.String(), "shape_2") {
+		t.Fatalf("dry-run output missing block-id format error: %s", stdout.String())
+	}
+	out := decodeJSONMap(t, stdout.String())
+	api := mustSliceValue(t, out["api"], "api")
+	if len(api) != 0 {
+		t.Fatalf("dry-run should not preview API calls with malformed block-id: %s", stdout.String())
+	}
+	if _, ok := out["error"].(string); !ok {
+		t.Fatalf("dry-run output missing structured error: %s", stdout.String())
+	}
+}
+
+func TestDryRunWikiSlidesResolutionErrorSurfaces(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{"obj_type": "slides", "obj_token": "presResolved"},
+			},
+		},
+	})
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/wiki/wikiToken",
+		"--content", `[{"type":"text","text":"test"}]`,
+		"--dry-run", "--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "slide comments require --block-id") {
+		t.Fatalf("dry-run output missing resolution error: %s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "/open-apis/drive/v1/files/wikiToken/new_comments") {
+		t.Fatalf("dry-run should not fall back to unresolved wiki token: %s", stdout.String())
+	}
+}
+
 func TestDryRunDocxLocalWithBlockID(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())
 	err := mountAndRunDrive(t, DriveAddComment, []string{
@@ -779,8 +1215,54 @@ func TestResolveWikiToUnsupportedType(t *testing.T) {
 		"--content", `[{"type":"text","text":"test"}]`,
 		"--as", "user",
 	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "only support doc/docx/sheet") {
+	if err == nil || !strings.Contains(err.Error(), "only support doc/docx/sheet/slides") {
 		t.Fatalf("expected unsupported type error, got: %v", err)
+	}
+}
+
+func TestResolveWikiToSlidesFullCommentRejected(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{"obj_type": "slides", "obj_token": "presToken"},
+			},
+		},
+	})
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/wiki/wikiSlidesToken",
+		"--content", `[{"type":"text","text":"test"}]`,
+		"--full-comment",
+		"--as", "user",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "slide comments require --block-id") {
+		t.Fatalf("expected slides full-comment rejection, got: %v", err)
+	}
+}
+
+func TestResolveWikiToSlidesSelectionRejected(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "success",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{"obj_type": "slides", "obj_token": "presToken"},
+			},
+		},
+	})
+	err := mountAndRunDrive(t, DriveAddComment, []string{
+		"+add-comment",
+		"--doc", "https://example.larksuite.com/wiki/wikiSlidesToken",
+		"--content", `[{"type":"text","text":"test"}]`,
+		"--selection-with-ellipsis", "something",
+		"--as", "user",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "--selection-with-ellipsis is not applicable for slide comments") {
+		t.Fatalf("expected slides selection rejection, got: %v", err)
 	}
 }
 
@@ -815,7 +1297,7 @@ func TestDocOldFormatLocalCommentRejected(t *testing.T) {
 		"--block-id", "blk_123",
 		"--as", "user",
 	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "only support docx and sheet") {
+	if err == nil || !strings.Contains(err.Error(), "only support docx, sheet, and slides") {
 		t.Fatalf("expected local comment rejection for old doc, got: %v", err)
 	}
 }

--- a/skills/lark-drive/SKILL.md
+++ b/skills/lark-drive/SKILL.md
@@ -116,7 +116,7 @@ Drive Folder (云空间文件夹)
 | 操作 | 需要的 Token | 说明 |
 |------|-------------|------|
 | 读取文档内容 | `file_token` / 通过 `docs +fetch --api-version v2` 自动处理 | `docs +fetch` 支持直接传入 URL |
-| 添加局部评论（划词评论） | `file_token` | 传 `--block-id` 时，`drive +add-comment` 会创建局部评论；仅支持 `docx`，以及最终解析为 `docx` 的 wiki URL |
+| 添加局部评论（划词评论） | `file_token` | 传 `--block-id` 时，`drive +add-comment` 会创建局部评论；`docx` 支持文本定位或 block_id，`slides` 仅支持 block_id，且都支持最终解析到对应类型的 wiki URL |
 | 添加全文评论 | `file_token` | 不传 `--block-id` 时，`drive +add-comment` 默认创建全文评论；支持 `docx`、旧版 `doc` URL，以及最终解析为 `doc`/`docx` 的 wiki URL |
 | 下载文件 | `file_token` | 从文件 URL 中直接提取 |
 | 上传文件 | `folder_token` / `wiki_node_token` | 目标位置的 token |
@@ -128,9 +128,11 @@ Drive Folder (云空间文件夹)
 - 全文评论：未传 `--block-id` 时默认启用，也可显式传 `--full-comment`；支持 `docx`、旧版 `doc` URL，以及最终解析为 `doc`/`docx` 的 wiki URL。
 - 局部评论：传 `--block-id` 时启用；仅支持 `docx`，以及最终解析为 `docx` 的 wiki URL。block ID 可通过 `docs +fetch --api-version v2 --detail with-ids` 获取。
 - `drive +add-comment` 的 `--content` 需要传 `reply_elements` JSON 数组字符串，例如 `--content '[{"type":"text","text":"正文"}]'`。
+- `slides` 评论要求显式传 `--block-id <slide-block-type>!<xml-id>`；CLI 会将其拆分后写入 `anchor.block_id` 和 `anchor.slide_block_type`。其中 `<xml-id>` 是 PPT XML 协议中的元素 `id`；不支持 `--selection-with-ellipsis` 和 `--full-comment`。
+
 - 评论写入内容（添加评论、回复评论、编辑回复）里的文本不能直接出现 `<`、`>`；提交前必须先转义：`<` -> `&lt;`，`>` -> `&gt;`。
 - 使用 `drive +add-comment` 时，shortcut 会对 `type=text` 的文本元素自动做上述转义兜底；如果直接调用 `drive file.comments create_v2`、`drive file.comment.replys create`、`drive file.comment.replys update`，则需要在请求里自行传入已转义的内容。
-- 如果 wiki 解析后不是 `doc`/`docx`，不要用 `+add-comment`。
+- 如果 wiki 解析后不是 `doc`/`docx`/`sheet`/`slides`，不要用 `+add-comment`。
 - 如果需要更底层地直接调用评论 V2 协议，再走原生 API：先执行 `lark-cli schema drive.file.comments.create_v2`，再执行 `lark-cli drive file.comments create_v2 ...`。全文评论省略 `anchor`，局部评论传 `anchor.block_id`。
 
 ### 评论查询与统计口径（关键！）
@@ -194,7 +196,7 @@ lark-cli drive file.comments list --params '{"file_token": "xxx", "file_type": "
 |----------|------|----------|
 | `not exist` | 使用了错误的 token | 检查 token 类型，wiki 链接必须先查询获取 `obj_token` |
 | `permission denied` | 没有相关操作权限 | 引导用户检查当前身份对文档/文件是否有相应操作权限；如果需要，可以授予相应权限 |
-| `invalid file_type` | file_type 参数错误 | 根据 `obj_type` 传入正确的 file_type（docx/doc/sheet） |
+| `invalid file_type` | file_type 参数错误 | 根据 `obj_type` 传入正确的 file_type（docx/doc/sheet/slides） |
 
 ### 授权当前应用访问文档
 
@@ -213,7 +215,7 @@ lark-cli drive permission.members create \
 
 > **注意**：此方式仅适用于需要授权给**当前应用**的场景。授权给其他用户时，直接使用对方的 open_id 即可，无需调用 bot info 接口。
 
-`<resource_type>` 可选值：`doc`、`docx`、`sheet`、`bitable`、`file`、`folder`、`wiki`。
+`<resource_type>` 可选值：`doc`、`docx`、`sheet`、`bitable`、`file`、`folder`、`wiki`、`slides`。
 
 ## Shortcuts（推荐优先使用）
 
@@ -225,7 +227,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli drive +<verb> [flags]`）
 | [`+create-folder`](references/lark-drive-create-folder.md) | Create a Drive folder, optionally under a parent folder, with bot auto-grant support |
 | [`+download`](references/lark-drive-download.md) | Download a file from Drive to local |
 | [`+create-shortcut`](references/lark-drive-create-shortcut.md) | Create a shortcut to an existing Drive file in another folder |
-| [`+add-comment`](references/lark-drive-add-comment.md) | Add a full-document comment, or a local comment to selected docx text (also supports wiki URL resolving to doc/docx) |
+| [`+add-comment`](references/lark-drive-add-comment.md) | Add a comment to doc/docx/sheet/slides, also supports wiki URL resolving to doc/docx/sheet/slides |
 | [`+export`](references/lark-drive-export.md) | Export a doc/docx/sheet/bitable to a local file with limited polling |
 | [`+export-download`](references/lark-drive-export-download.md) | Download an exported file by file_token |
 | [`+import`](references/lark-drive-import.md) | Import a local file to Drive as a cloud document (docx, sheet, bitable) |

--- a/skills/lark-drive/references/lark-drive-add-comment.md
+++ b/skills/lark-drive/references/lark-drive-add-comment.md
@@ -3,7 +3,7 @@
 
 > **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
 
-给文档或电子表格添加评论。底层统一走 `/open-apis/drive/v1/files/:file_token/new_comments`（`create_v2`）接口；未指定位置时省略 `anchor` 创建全文评论，指定 `--block-id` 时传入 `anchor.block_id` 创建局部评论。支持直接传 docx URL/token、旧版 doc URL（仅全文评论）、sheet URL，也支持传最终可解析为 doc/docx/sheet 的 wiki URL。
+给文档、电子表格或飞书幻灯片添加评论。底层统一走 `/open-apis/drive/v1/files/:file_token/new_comments`（`create_v2`）接口；未指定位置时省略 `anchor` 创建全文评论，指定 `--block-id` 时传入 `anchor.block_id` 创建局部评论。支持直接传 docx URL/token、旧版 doc URL（仅全文评论）、sheet URL、slides URL，也支持传最终可解析为 doc/docx/sheet/slides 的 wiki URL。
 
 ## 命令
 
@@ -54,6 +54,39 @@ lark-cli drive +add-comment \
   --block-id "<SHEET_ID>!A1" \
   --content '[{"type":"text","text":"请 "},{"type":"mention_user","text":"ou_xxx"},{"type":"text","text":" 确认"}]'
 
+# 给幻灯片元素添加评论（--block-id 格式为 <slide-block-type>!<xml-id>）
+lark-cli drive +add-comment \
+  --doc "https://example.larksuite.com/slides/<PRESENTATION_ID>" \
+  --block-id "<SLIDE_BLOCK_TYPE>!<XML_ELEMENT_ID>" \
+  --content '[{"type":"text","text":"请调整这个元素的位置"}]'
+
+# 例如：给整页 slide 添加评论
+# <slide id="pkk"> ... </slide>  =>  --block-id slide!pkk
+lark-cli drive +add-comment \
+  --doc "https://example.larksuite.com/slides/<PRESENTATION_ID>" \
+  --block-id "slide!pkk" \
+  --content '[{"type":"text","text":"这一页需要补充过渡说明"}]'
+
+# 例如：给图片元素添加评论
+# <img id="bPk" ... />  =>  --block-id img!bPk
+lark-cli drive +add-comment \
+  --doc "https://example.larksuite.com/slides/<PRESENTATION_ID>" \
+  --block-id "img!bPk" \
+  --content '[{"type":"text","text":"这张图片建议换成更清晰的版本"}]'
+
+# 例如：给文本 shape 添加评论
+# <shape type="text" id="bPq"> ... </shape>  =>  --block-id shape!bPq
+lark-cli drive +add-comment \
+  --doc "https://example.larksuite.com/slides/<PRESENTATION_ID>" \
+  --block-id "shape!bPq" \
+  --content '[{"type":"text","text":"这段文案可以再精简"}]'
+
+# wiki 链接指向的 slides 也支持
+lark-cli drive +add-comment \
+  --doc "https://example.larksuite.com/wiki/<WIKI_TOKEN>" \
+  --block-id "<SLIDE_BLOCK_TYPE>!<XML_ELEMENT_ID>" \
+  --content '[{"type":"text","text":"这里需要补充说明"}]'
+
 # 传裸 token 时需要 --type 指定文档类型
 lark-cli drive +add-comment \
   --doc "<SHEET_TOKEN>" --type sheet \
@@ -63,6 +96,12 @@ lark-cli drive +add-comment \
 lark-cli drive +add-comment \
   --doc "<DOCX_TOKEN>" --type docx \
   --content '[{"type":"text","text":"全文评论"}]'
+
+# 裸 token + 已知 block_id 的局部评论
+lark-cli drive +add-comment \
+  --doc "<PRESENTATION_ID>" --type slides \
+  --block-id "<SLIDE_BLOCK_TYPE>!<XML_ELEMENT_ID>" \
+  --content '[{"type":"text","text":"slide block comment"}]'
 
 # 裸 token + 已知 block_id 的局部评论
 lark-cli drive +add-comment \
@@ -89,8 +128,8 @@ lark-cli drive +add-comment \
 
 | 参数 | 必填 | 说明 |
 |------|------|------|
-| `--doc` | 是 | 文档 URL / token、sheet URL，或可解析到 `doc`/`docx`/`sheet` 的 wiki URL |
-| `--type` | 裸 token 时必填 | 文档类型：`doc`、`docx`、`sheet`。URL 输入时自动识别，无需传 |
+| `--doc` | 是 | 文档 URL / token、sheet / slides URL，或可解析到 `doc`/`docx`/`sheet`/`slides` 的 wiki URL |
+| `--type` | 裸 token 时必填 | 文档类型：`doc`、`docx`、`sheet`、`slides`。URL 输入时自动识别，无需传 |
 | `--content` | 是 | `reply_elements` JSON 数组字符串。示例：`'[{"type":"text","text":"文本"},{"type":"mention_user","text":"ou_xxx"},{"type":"link","text":"https://example.com"}]'` |
 | `--full-comment` | 否 | 显式指定创建全文评论；未传 `--block-id` 时也会默认走全文评论（不适用于 sheet） |
 | `--block-id` | 局部评论时必填 | 目标块 ID，可通过 `docs +fetch --api-version v2 --detail with-ids` 获取。**Sheet 评论**：格式为 `<sheetId>!<cell>`（如 `a281f9!D6`） |
@@ -99,8 +138,14 @@ lark-cli drive +add-comment \
 
 - **局部评论需要先获取 block ID**：先调用 `docs +fetch --api-version v2 --doc <TOKEN> --detail with-ids` 获取带有 block ID 的文档内容，然后使用 `--block-id` 指定目标块。
 - 未传 `--block-id` 时，shortcut 默认创建**全文评论**；也可以显式传 `--full-comment`。全文评论支持 `docx`、旧版 `doc` URL，以及最终可解析为 `doc`/`docx` 的 wiki URL。
-- 传 `--block-id` 时，shortcut 创建**局部评论（划词评论）**；该模式仅支持 `docx`，以及最终可解析为 `docx` 的 wiki URL。
+- 传 `--block-id` 时，shortcut 创建**局部评论（划词评论）**；该模式支持 `docx`、`slides`，以及最终可解析为这些类型的 wiki URL。
 - **Sheet 评论**：当 `--doc` 为 sheet URL 或 wiki 解析为 sheet 时，使用 `--block-id "<sheetId>!<cell>"` 指定单元格（如 `a281f9!D6`）；sheet 没有全文评论，`--full-comment` 不可用。
+- **Slide 评论**：当 `--doc` 为 slides URL、`--type slides`，或 wiki 解析为 slides 时，必须传 `--block-id "<SLIDE_BLOCK_TYPE>!<XML_ELEMENT_ID>"`。CLI 会将其拆分映射到 `anchor.block_id` / `anchor.slide_block_type`。此时 `--full-comment` 和 `--selection-with-ellipsis` 不可用。
+- **Slide 参数映射示例**：`--block-id` 由 PPT XML 元素类型和元素 `id` 组成。例如：
+    - `<slide id="pkk">` 对应 `--block-id slide!pkk`，表示给整页评论。
+    - `<img id="bPk" ... />` 对应 `--block-id img!bPk`，表示给图片元素评论。
+    - `<shape type="text" id="bPq">...</shape>` 对应 `--block-id shape!bPq`，表示给文本 shape 评论。
+
 - `--content` 接收结构化评论元素数组；`type` 支持 `text`、`mention_user`、`link`。为便于书写，`mention_user` / `link` 元素可以直接把用户 ID 或链接地址放在 `text` 字段中，shortcut 会转换成 OpenAPI 所需字段。
 - `type=text` 的评论文本不能直接包含 `<`、`>`；应优先传 `&lt;`、`&gt;`。shortcut 在发送前也会自动将 `<`、`>` 转义为 `&lt;`、`&gt;` 作为兜底。
 - 写入评论前会自动生成符合 OpenAPI 定义的请求体：


### PR DESCRIPTION
 ## Summary
  Extend `drive +add-comment` to support slides targets in addition to existing doc/docx flows. This also improves wiki target resolution, validation, dry-run behavior, and skill
  documentation so agents can call the command with clearer and more reliable inputs.

  ## Changes
  - Add slides support to `drive +add-comment`
  - Support resolving wiki URLs to `doc` / `docx` / `slides` targets before creating comments
  - Add validation for slides-specific anchor format:
    - slides require `--block-id <slide-block-type>!<xml-id>`
    - slides do not allow `--full-comment` or `--selection-with-ellipsis`
  - Improve dry-run request generation so it reflects resolved target type and actual API flow
  - Expand unit tests for doc parsing, mode resolution, locate-doc fallback, reply element parsing, and slides comment flows
  - Update `lark-drive` skill docs and examples for doc/docx/slides comment creation

  ## Test Plan
  - [x] Added/updated unit tests in `shortcuts/drive/drive_add_comment_test.go`
  - [ ] Unit tests pass
  - [ ] Manual local verification confirms the `lark xxx` command works as expected

  ## Related Issues
  - None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add-comment now supports Slides; slide comments require a compound --block-id (<slide-block-type>!<xml-id>) and include slide_block_type in outputs and requests. Dry-run and execution route slide-specific flows and wiki-resolved slides.

* **Documentation**
  * CLI docs, examples, and flag help updated to include slides, allowed --doc/--type inputs, required block-id format, and unsupported flags (--full-comment, --selection-with-ellipsis) for slides.

* **Tests**
  * Added unit and end-to-end tests for slide parsing, validation, dry-run, execution, responses, and error cases.

* **Bug Fixes**
  * Dry-run now computes comment mode earlier and surfaces wiki resolution errors instead of continuing silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->