### PR TITLE
feat(mail): add +template-get read-only shortcut

### DIFF
--- a/shortcuts/mail/mail_template_get.go
+++ b/shortcuts/mail/mail_template_get.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"regexp"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/util"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// templateIDPattern matches a non-empty decimal integer string (no sign, no
+// leading zero requirement). Validation runs in the Validate stage before
+// any API call, so the user gets a structured errno instead of a server
+// 4xx round-trip.
+var templateIDPattern = regexp.MustCompile(`^\d+$`)
+
+// MailTemplateGet is the `+template-get` shortcut: fetch a personal mail
+// template by ID. Returns subject / body / recipient and attachment metadata
+// for a single template under a user mailbox.
+var MailTemplateGet = common.Shortcut{
+	Service:     "mail",
+	Command:     "+template-get",
+	Description: "Use when reading a single personal mail template by ID. Returns subject, body, recipient lists and attachment metadata.",
+	Risk:        "read",
+	Scopes:      []string{"mail:user_mailbox.template:readonly"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "mailbox", Default: "me", Desc: "email address (default: me)"},
+		{Name: "template-id", Desc: "Required. Personal mail template ID (decimal integer string)", Required: true},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		tid := runtime.Str("template-id")
+		if tid == "" {
+			return output.ErrValidation("--template-id is required")
+		}
+		if !templateIDPattern.MatchString(tid) {
+			return output.ErrValidation("--template-id: must be a decimal integer string")
+		}
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		mailboxID := resolveMailboxID(runtime)
+		templateID := runtime.Str("template-id")
+		return common.NewDryRunAPI().
+			Desc("Fetch one mail template").
+			GET(mailboxPath(mailboxID, "templates", templateID))
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		mailboxID := resolveMailboxID(runtime)
+		hintIdentityFirst(runtime, mailboxID)
+		templateID := runtime.Str("template-id")
+
+		raw, err := runtime.RawAPI("GET", mailboxPath(mailboxID, "templates", templateID), nil, nil)
+		if err != nil {
+			return fmt.Errorf("failed to fetch mail template: %w", err)
+		}
+		respMap, ok := raw.(map[string]interface{})
+		if !ok {
+			return output.Errorf(output.ExitAPI, "api_error", "unexpected response shape from mail template API")
+		}
+		if code, hasCode := respMap["code"]; hasCode {
+			if codeFloat, ok := util.ToFloat64(code); ok && codeFloat != 0 {
+				msg, _ := respMap["msg"].(string)
+				return output.ErrAPI(int(codeFloat), msg, respMap["error"])
+			}
+		}
+
+		runtime.OutFormat(raw, &output.Meta{Count: 1}, func(w io.Writer) {
+			data := extractTemplateData(respMap)
+			renderTemplatePretty(w, data)
+		})
+		return nil
+	},
+}
+
+// extractTemplateData unwraps the OAPI envelope's data field. Falls back to
+// the response itself when no `data` wrapper is present (for unit tests that
+// pass through a plain object).
+func extractTemplateData(resp map[string]interface{}) map[string]interface{} {
+	if data, ok := resp["data"].(map[string]interface{}); ok {
+		return data
+	}
+	return resp
+}
+
+// recipientCount sums the lengths of to/cc/bcc lists, defensively handling
+// both `to` and `to_recipients` style keys to match whichever the actual
+// OAPI response uses.
+func recipientCount(data map[string]interface{}) int {
+	total := 0
+	for _, key := range []string{"to", "to_recipients", "cc", "cc_recipients", "bcc", "bcc_recipients"} {
+		if list, ok := data[key].([]interface{}); ok {
+			total += len(list)
+		}
+	}
+	return total
+}
+
+// attachmentCount returns len(data.attachments) defensively.
+func attachmentCount(data map[string]interface{}) int {
+	if list, ok := data["attachments"].([]interface{}); ok {
+		return len(list)
+	}
+	return 0
+}
+
+// renderTemplatePretty writes the human-readable summary of a mail template
+// for `--format pretty`. `template_content` is rune-truncated to 200 chars
+// to keep the output single-screen even when templates carry multi-MB HTML.
+func renderTemplatePretty(w io.Writer, data map[string]interface{}) {
+	templateID, _ := data["template_id"].(string)
+	name, _ := data["name"].(string)
+	subject, _ := data["subject"].(string)
+	content, _ := data["template_content"].(string)
+
+	fmt.Fprintf(w, "template_id:      %s\n", templateID)
+	fmt.Fprintf(w, "name:             %s\n", name)
+	fmt.Fprintf(w, "subject:          %s\n", subject)
+	fmt.Fprintf(w, "template_content: %s\n", common.TruncateStr(content, 200))
+	fmt.Fprintf(w, "attachments:      %d\n", attachmentCount(data))
+	fmt.Fprintf(w, "recipients:       %d\n", recipientCount(data))
+}

--- a/shortcuts/mail/mail_template_get_test.go
+++ b/shortcuts/mail/mail_template_get_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestMailTemplateGet_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "non-decimal template-id",
+			args:    []string{"+template-get", "--template-id", "abc"},
+			wantErr: "decimal integer string",
+		},
+		{
+			name:    "negative template-id",
+			args:    []string{"+template-get", "--template-id", "-1"},
+			wantErr: "decimal integer string",
+		},
+		{
+			name:    "template-id with whitespace",
+			args:    []string{"+template-get", "--template-id", "12 3"},
+			wantErr: "decimal integer string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			err := runMountedMailShortcut(t, MailTemplateGet, tt.args, f, stdout)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestMailTemplateGet_MissingRequiredFlag(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	err := runMountedMailShortcut(t, MailTemplateGet, []string{"+template-get"}, f, stdout)
+	if err == nil {
+		t.Fatal("expected error for missing --template-id, got nil")
+	}
+	if !strings.Contains(err.Error(), "template-id") {
+		t.Fatalf("expected error to mention --template-id, got %q", err.Error())
+	}
+}
+
+func TestMailTemplateGet_ExecuteJSONPassThrough(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/templates/12345",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"template_id":      "12345",
+				"name":             "Quarterly report",
+				"subject":          "Hello",
+				"template_content": "<p>body</p>",
+				"to":               []interface{}{map[string]interface{}{"mail_address": "a@example.com"}},
+				"cc":               []interface{}{map[string]interface{}{"mail_address": "b@example.com"}},
+				"bcc":              []interface{}{},
+				"attachments":      []interface{}{map[string]interface{}{"id": "att_1"}},
+			},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailTemplateGet, []string{
+		"+template-get", "--template-id", "12345",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := stdout.String()
+	// json.Marshal HTML-escapes `<` / `>` to `<` / `>`.
+	for _, want := range []string{`"template_id"`, `"12345"`, `"Quarterly report"`, `"template_content"`, "\\u003cp\\u003ebody\\u003c/p\\u003e"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected JSON pass-through output to contain %q, got %s", want, out)
+		}
+	}
+}
+
+func TestMailTemplateGet_PathEscapesMailbox(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		// `@` is a sub-delim that url.PathEscape leaves untouched, so the
+		// outgoing URL keeps the literal `@`. mailboxPath would still escape
+		// reserved chars (e.g. `/`); this guards against accidental raw
+		// fmt.Sprintf regression on the segment.
+		URL: "/user_mailboxes/user@example.com/templates/9",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"template_id": "9",
+				"name":        "x",
+				"subject":     "y",
+			},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailTemplateGet, []string{
+		"+template-get", "--mailbox", "user@example.com", "--template-id", "9",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestMailTemplateGet_APIError(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/templates/77",
+		Body: map[string]interface{}{
+			"code": 99991663,
+			"msg":  "template not found",
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailTemplateGet, []string{
+		"+template-get", "--template-id", "77",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected error for non-zero API code, got nil")
+	}
+	if !strings.Contains(err.Error(), "template not found") {
+		t.Errorf("expected error to surface server msg, got %q", err.Error())
+	}
+}
+
+func TestMailTemplateGet_PrettyTruncation(t *testing.T) {
+	long := strings.Repeat("a", 500)
+	data := map[string]interface{}{
+		"template_id":      "1",
+		"name":             "n",
+		"subject":          "s",
+		"template_content": long,
+		"to":               []interface{}{map[string]interface{}{}, map[string]interface{}{}},
+		"cc":               []interface{}{map[string]interface{}{}},
+		"attachments":      []interface{}{map[string]interface{}{}, map[string]interface{}{}, map[string]interface{}{}},
+	}
+
+	if got := attachmentCount(data); got != 3 {
+		t.Errorf("attachmentCount = %d, want 3", got)
+	}
+	if got := recipientCount(data); got != 3 {
+		t.Errorf("recipientCount = %d, want 3", got)
+	}
+	// Defensive recipient key fallback.
+	dataAlt := map[string]interface{}{
+		"to_recipients":  []interface{}{map[string]interface{}{}},
+		"cc_recipients":  []interface{}{map[string]interface{}{}},
+		"bcc_recipients": []interface{}{map[string]interface{}{}, map[string]interface{}{}},
+	}
+	if got := recipientCount(dataAlt); got != 4 {
+		t.Errorf("recipientCount fallback = %d, want 4", got)
+	}
+
+	var buf strings.Builder
+	renderTemplatePretty(&buf, data)
+	out := buf.String()
+	if !strings.Contains(out, strings.Repeat("a", 200)) {
+		t.Errorf("expected 200 a's in pretty output")
+	}
+	if strings.Contains(out, strings.Repeat("a", 201)) {
+		t.Errorf("template_content was not truncated to 200 runes")
+	}
+}

--- a/shortcuts/mail/shortcuts.go
+++ b/shortcuts/mail/shortcuts.go
@@ -23,5 +23,6 @@ func Shortcuts() []common.Shortcut {
 		MailDeclineReceipt,
 		MailSignature,
 		MailShareToChat,
+		MailTemplateGet,
 	}
 }

--- a/skills/lark-mail/references/lark-mail-template-get.md
+++ b/skills/lark-mail/references/lark-mail-template-get.md
@@ -1,0 +1,69 @@
+# mail +template-get
+
+> **前置条件：** 先阅读 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
+
+按 ID 读取个人邮件模板（subject / body / 收件人 / 附件元信息）。
+
+本 skill 对应 shortcut `lark-cli mail +template-get`，内部步骤：
+1. `GET /open-apis/mail/v1/user_mailboxes/{mailbox}/templates/{template_id}` — 获取模板详情
+
+## 命令
+
+```bash
+# 读取一个模板
+lark-cli mail +template-get --template-id <template-id>
+
+# 指定邮箱
+lark-cli mail +template-get --mailbox user@example.com --template-id <template-id>
+
+# JSON 输出（直出原始响应，含完整 template_content）
+lark-cli mail +template-get --template-id <template-id> --format json
+
+# Dry Run
+lark-cli mail +template-get --template-id <template-id> --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+|------|------|--------|------|
+| `--template-id <id>` | 是 | — | 模板 ID（十进制整数字符串） |
+| `--mailbox <email>` | 否 | 当前用户 | 邮箱地址（`user_mailbox_id`） |
+| `--format <mode>` | 否 | json | 输出格式：`json`（默认）/ `pretty` / `table` / `ndjson` / `csv` |
+| `--dry-run` | 否 | — | 仅打印请求，不执行 |
+
+## 返回值
+
+`--format json`（默认）直出 OAPI 原始响应，便于脚本使用：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "code": 0,
+    "data": {
+      "template_id":      "12345",
+      "name":             "季度汇报",
+      "subject":          "Q1 Status",
+      "template_content": "<p>...</p>",
+      "to":               [{"mail_address": "boss@example.com"}],
+      "cc":               [],
+      "bcc":              [],
+      "attachments":      [{"id": "att_1", "filename": "report.pdf"}]
+    }
+  }
+}
+```
+
+`--format pretty` 仅展示概览：`template_id` / `name` / `subject` / `template_content`（截断到 200 字符）/ `attachments`（数量）/ `recipients`（to + cc + bcc 总数）。
+
+## 注意事项
+
+- `template_content` 可能是 HTML 且体积较大（最大 3 MB）。pretty 模式只展示前 200 字符；查看完整内容请用 `--format json | jq -r '.data.data.template_content'`。
+- 仅查看模板内容，不会创建 / 编辑 / 删除模板。
+- `template_id` 服务端为 int64，传输使用十进制字符串；CLI Validate 阶段对格式做前置校验，避免无效请求。
+
+## 相关命令
+
+- `lark-cli mail +send` / `+draft-create` — 基于模板发送或起草邮件（参见各自的 skill 文档）
+- `lark-cli mail +signature` — 列出 / 查看邮件签名


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Task ID**: smoke-cli-mail-template-mini-20260427-160723
- **Branch**: harness/smoke-cli-mail-template-mini-20260427-160723
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Synthesize transport contract for larksuite/cli | passed | — |
| S2 | Add `mail +template-get` read-only shortcut | passed | c6513fc1 |

## Source specs

- /tmp/harness-test/smoke-cli-mail-template-mini-20260427-160723/input/spec.md

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mail +template-get` command to retrieve personal mail templates by template ID with client-side validation. Supports multiple output formats (JSON, pretty, table, NDJSON, CSV) and dry-run mode. Pretty output displays truncated template content and recipient counts.

* **Documentation**
  * Added reference guide for the new mail template retrieval command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->