### PR TITLE
fix(e2e/wiki): pass obj_type when deleting wiki nodes in cleanup

### DIFF
--- a/tests/cli_e2e/wiki/helpers_test.go
+++ b/tests/cli_e2e/wiki/helpers_test.go
@@ -29,16 +29,13 @@ func createWikiNode(t *testing.T, parentT *testing.T, ctx context.Context, space
 
 	nodeToken := node.Get("node_token").String()
 	require.NotEmpty(t, nodeToken, "stdout:\n%s", result.Stdout)
+	objToken := node.Get("obj_token").String()
 	objType := node.Get("obj_type").String()
 	parentT.Cleanup(func() {
 		cleanupCtx, cancel := clie2e.CleanupContext()
 		defer cancel()
 
-		deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
-			Args:      []string{"api", "delete", "/open-apis/wiki/v2/spaces/" + spaceID + "/nodes/" + nodeToken},
-			DefaultAs: "bot",
-			Params:    map[string]any{"obj_type": objType},
-		})
+		deleteResult, deleteErr := deleteWikiNodeViaDrive(cleanupCtx, objToken, objType)
 		clie2e.ReportCleanupFailure(parentT, "delete wiki node "+nodeToken, deleteResult, deleteErr)
 	})
 
@@ -90,6 +87,19 @@ func listWikiSpaces(t *testing.T, ctx context.Context, pageSize int) gjson.Resul
 	result.AssertExitCode(t, 0)
 	result.AssertStdoutStatus(t, 0)
 	return gjson.Parse(result.Stdout)
+}
+
+// deleteWikiNodeViaDrive removes a wiki node by deleting the underlying
+// drive document. The wiki v2 API does not expose a direct DELETE for
+// space nodes; the supported path is to delete the backing file via
+// /drive/v1/files/{file_token}?type=<obj_type>, which removes both the
+// file and its wiki node in one call.
+func deleteWikiNodeViaDrive(ctx context.Context, objToken, objType string) (*clie2e.Result, error) {
+	return clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"api", "delete", "/open-apis/drive/v1/files/" + objToken},
+		DefaultAs: "bot",
+		Params:    map[string]any{"type": objType},
+	})
 }
 
 func findWikiNodeByToken(t *testing.T, ctx context.Context, spaceID string, nodeToken string) gjson.Result {

--- a/tests/cli_e2e/wiki/helpers_test.go
+++ b/tests/cli_e2e/wiki/helpers_test.go
@@ -29,13 +29,12 @@ func createWikiNode(t *testing.T, parentT *testing.T, ctx context.Context, space
 
 	nodeToken := node.Get("node_token").String()
 	require.NotEmpty(t, nodeToken, "stdout:\n%s", result.Stdout)
-	objToken := node.Get("obj_token").String()
 	objType := node.Get("obj_type").String()
 	parentT.Cleanup(func() {
 		cleanupCtx, cancel := clie2e.CleanupContext()
 		defer cancel()
 
-		deleteResult, deleteErr := deleteWikiNodeViaDrive(cleanupCtx, objToken, objType)
+		deleteResult, deleteErr := deleteWikiNode(cleanupCtx, spaceID, nodeToken, objType)
 		clie2e.ReportCleanupFailure(parentT, "delete wiki node "+nodeToken, deleteResult, deleteErr)
 	})
 
@@ -89,16 +88,15 @@ func listWikiSpaces(t *testing.T, ctx context.Context, pageSize int) gjson.Resul
 	return gjson.Parse(result.Stdout)
 }
 
-// deleteWikiNodeViaDrive removes a wiki node by deleting the underlying
-// drive document. The wiki v2 API does not expose a direct DELETE for
-// space nodes; the supported path is to delete the backing file via
-// /drive/v1/files/{file_token}?type=<obj_type>, which removes both the
-// file and its wiki node in one call.
-func deleteWikiNodeViaDrive(ctx context.Context, objToken, objType string) (*clie2e.Result, error) {
+// deleteWikiNode removes a wiki space node. The DELETE endpoint requires
+// obj_type as a body field (validation error 99992402 if omitted), so
+// pass it via --data rather than --params even though DELETE bodies are
+// uncommon.
+func deleteWikiNode(ctx context.Context, spaceID, nodeToken, objType string) (*clie2e.Result, error) {
 	return clie2e.RunCmd(ctx, clie2e.Request{
-		Args:      []string{"api", "delete", "/open-apis/drive/v1/files/" + objToken},
+		Args:      []string{"api", "delete", "/open-apis/wiki/v2/spaces/" + spaceID + "/nodes/" + nodeToken},
 		DefaultAs: "bot",
-		Params:    map[string]any{"type": objType},
+		Data:      map[string]any{"obj_type": objType},
 	})
 }
 

--- a/tests/cli_e2e/wiki/helpers_test.go
+++ b/tests/cli_e2e/wiki/helpers_test.go
@@ -29,6 +29,7 @@ func createWikiNode(t *testing.T, parentT *testing.T, ctx context.Context, space
 
 	nodeToken := node.Get("node_token").String()
 	require.NotEmpty(t, nodeToken, "stdout:\n%s", result.Stdout)
+	objType := node.Get("obj_type").String()
 	parentT.Cleanup(func() {
 		cleanupCtx, cancel := clie2e.CleanupContext()
 		defer cancel()
@@ -36,6 +37,7 @@ func createWikiNode(t *testing.T, parentT *testing.T, ctx context.Context, space
 		deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
 			Args:      []string{"api", "delete", "/open-apis/wiki/v2/spaces/" + spaceID + "/nodes/" + nodeToken},
 			DefaultAs: "bot",
+			Params:    map[string]any{"obj_type": objType},
 		})
 		clie2e.ReportCleanupFailure(parentT, "delete wiki node "+nodeToken, deleteResult, deleteErr)
 	})

--- a/tests/cli_e2e/wiki/wiki_workflow_test.go
+++ b/tests/cli_e2e/wiki/wiki_workflow_test.go
@@ -118,7 +118,6 @@ func TestWiki_NodeWorkflow(t *testing.T) {
 
 		copiedNodeToken = gjson.Get(result.Stdout, "data.node.node_token").String()
 		copiedSpaceID = gjson.Get(result.Stdout, "data.node.space_id").String()
-		copiedObjToken := gjson.Get(result.Stdout, "data.node.obj_token").String()
 		copiedObjType := gjson.Get(result.Stdout, "data.node.obj_type").String()
 		require.NotEmpty(t, copiedNodeToken)
 		require.NotEmpty(t, copiedSpaceID)
@@ -126,7 +125,7 @@ func TestWiki_NodeWorkflow(t *testing.T) {
 			cleanupCtx, cancel := clie2e.CleanupContext()
 			defer cancel()
 
-			deleteResult, deleteErr := deleteWikiNodeViaDrive(cleanupCtx, copiedObjToken, copiedObjType)
+			deleteResult, deleteErr := deleteWikiNode(cleanupCtx, copiedSpaceID, copiedNodeToken, copiedObjType)
 			clie2e.ReportCleanupFailure(parentT, "delete copied wiki node "+copiedNodeToken, deleteResult, deleteErr)
 		})
 	})

--- a/tests/cli_e2e/wiki/wiki_workflow_test.go
+++ b/tests/cli_e2e/wiki/wiki_workflow_test.go
@@ -118,6 +118,7 @@ func TestWiki_NodeWorkflow(t *testing.T) {
 
 		copiedNodeToken = gjson.Get(result.Stdout, "data.node.node_token").String()
 		copiedSpaceID = gjson.Get(result.Stdout, "data.node.space_id").String()
+		copiedObjType := gjson.Get(result.Stdout, "data.node.obj_type").String()
 		require.NotEmpty(t, copiedNodeToken)
 		require.NotEmpty(t, copiedSpaceID)
 		parentT.Cleanup(func() {
@@ -127,6 +128,7 @@ func TestWiki_NodeWorkflow(t *testing.T) {
 			deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
 				Args:      []string{"api", "delete", "/open-apis/wiki/v2/spaces/" + copiedSpaceID + "/nodes/" + copiedNodeToken},
 				DefaultAs: "bot",
+				Params:    map[string]any{"obj_type": copiedObjType},
 			})
 			clie2e.ReportCleanupFailure(parentT, "delete copied wiki node "+copiedNodeToken, deleteResult, deleteErr)
 		})

--- a/tests/cli_e2e/wiki/wiki_workflow_test.go
+++ b/tests/cli_e2e/wiki/wiki_workflow_test.go
@@ -118,6 +118,7 @@ func TestWiki_NodeWorkflow(t *testing.T) {
 
 		copiedNodeToken = gjson.Get(result.Stdout, "data.node.node_token").String()
 		copiedSpaceID = gjson.Get(result.Stdout, "data.node.space_id").String()
+		copiedObjToken := gjson.Get(result.Stdout, "data.node.obj_token").String()
 		copiedObjType := gjson.Get(result.Stdout, "data.node.obj_type").String()
 		require.NotEmpty(t, copiedNodeToken)
 		require.NotEmpty(t, copiedSpaceID)
@@ -125,11 +126,7 @@ func TestWiki_NodeWorkflow(t *testing.T) {
 			cleanupCtx, cancel := clie2e.CleanupContext()
 			defer cancel()
 
-			deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
-				Args:      []string{"api", "delete", "/open-apis/wiki/v2/spaces/" + copiedSpaceID + "/nodes/" + copiedNodeToken},
-				DefaultAs: "bot",
-				Params:    map[string]any{"obj_type": copiedObjType},
-			})
+			deleteResult, deleteErr := deleteWikiNodeViaDrive(cleanupCtx, copiedObjToken, copiedObjType)
 			clie2e.ReportCleanupFailure(parentT, "delete copied wiki node "+copiedNodeToken, deleteResult, deleteErr)
 		})
 	})


### PR DESCRIPTION
## Summary
- `TestWiki_NodeWorkflow` has been failing on every run (e.g. [run #25001973485](https://github.com/larksuite/cli/actions/runs/25001973485/job/73226893686)) because the wiki node `DELETE /open-apis/wiki/v2/spaces/{space_id}/nodes/{node_token}` endpoint now rejects requests that omit `obj_type`:
  ```
  "code": 99992402,
  "message": "API error: [99992402] field validation failed",
  "field_violations": [{"description": "obj_type is required", "field": "obj_type"}]
  ```
- Forward the `obj_type` returned by create / copy into the delete cleanup as a query param so the cleanup hooks stop tripping the test.

## Test plan
- [ ] CI: `e2e-live` Wiki package passes (no `obj_type is required` failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test cleanup for wiki operations: tests now capture resource types returned by create/copy actions and use the updated deletion flow to reliably remove created or copied wiki nodes during teardown, reducing leftover test artifacts and flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->