### PR TITLE
chore(release): bump version to v1.0.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

- Bump `package.json` version from `1.0.20` to `1.0.21`
- Aligns published package version with CHANGELOG entry added in #697 (which only updated `CHANGELOG.md` but missed the `package.json` bump)

## Test plan

- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 1.0.21

<!-- end of auto-generated comment: release notes by coderabbit.ai -->