### PR TITLE
test(im): fix unknown --yes flag on chats link e2e

### DIFF
--- a/tests/cli_e2e/im/chat_workflow_test.go
+++ b/tests/cli_e2e/im/chat_workflow_test.go
@@ -117,7 +117,6 @@ func TestIM_ChatsLinkWorkflow(t *testing.T) {
 			Data: map[string]any{
 				"validity_period": "week",
 			},
-			Yes: true,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)


### PR DESCRIPTION
## Summary

`TestIM_ChatsLinkWorkflow/get_chat_share_link_as_bot` fails on every run with `Error: unknown flag: --yes`. The test sets `Yes: true` in the e2e `Request`, which makes the runner append `--yes`, but `im chats link` is not classified as `high-risk-write` in the API metadata, so `cmd/service/service.go` never registers a `--yes` flag for it.

## Changes

- Drop `Yes: true` from the `clie2e.Request` for `im chats link` in `tests/cli_e2e/im/chat_workflow_test.go`.

## Test Plan

- [x] `go vet ./tests/cli_e2e/im/...` passes
- [ ] CI re-run: `TestIM_ChatsLinkWorkflow/get_chat_share_link_as_bot` no longer fails with `unknown flag: --yes`

## Related Issues

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated E2E test configuration for the chat link command to refine test parameters.

**Note:** This release contains test-level updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->