### PR TITLE
test(im): drop --yes from chats link e2e (not high-risk-write)

### DIFF
--- a/tests/cli_e2e/im/chat_workflow_test.go
+++ b/tests/cli_e2e/im/chat_workflow_test.go
@@ -117,7 +117,6 @@ func TestIM_ChatsLinkWorkflow(t *testing.T) {
 			Data: map[string]any{
 				"validity_period": "week",
 			},
-			Yes: true,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)


### PR DESCRIPTION
## Summary

Fixes the failing `TestIM_ChatsLinkWorkflow/get_chat_share_link_as_bot` on `main` (and on every open PR) by removing a stray `Yes: true` from the e2e Request.

## Root cause

`im chats link` is a generic service method whose metadata does **not** carry `risk: "high-risk-write"`, so `cmd/service/service.go` never registers the `--yes` flag on it. Once #633 landed and added `Yes: true` to this test, the e2e runner started appending `--yes` to every invocation; cobra rejects it before the request is dispatched:

```
Error: unknown flag: --yes
```

That tanks `AssertExitCode(t, 0)`, then `AssertStdoutStatus`, then the `share_link should not be empty` check. CI run on `main` confirming the regression: https://github.com/larksuite/cli/actions/runs/25056050086

## Why drop the flag instead of marking the API as high-risk-write

Generating a chat share link with a configurable validity period is non-destructive — it doesn't delete data, doesn't alter membership, and the link can be invalidated. The other tests touched in #633 (calendar event delete, sheets filter remove, task delete, etc.) genuinely flipped to high-risk-write at the metadata layer; `im.chats.link` did not. So the `Yes: true` here is leftover from the bulk pass, not a missing metadata flip.

If product later decides share-link creation should require confirmation, the right move is to flip the metadata risk and re-add `Yes: true` together — not to keep a flag that the binary doesn't accept.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./tests/cli_e2e/im/...`
- [ ] e2e-live job green on this PR (the only assertion this PR touches)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update includes internal test infrastructure modifications only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->