### PR TITLE
test: align e2e --yes flags with high-risk-write meta data

### DIFF
--- a/tests/cli_e2e/calendar/calendar_create_event_test.go
+++ b/tests/cli_e2e/calendar/calendar_create_event_test.go
@@ -66,6 +66,7 @@ func TestCalendar_CreateEvent(t *testing.T) {
 					"calendar_id": calendarID,
 					"event_id":    eventID,
 				},
+				Yes: true,
 			})
 			clie2e.ReportCleanupFailure(parentT, "delete event "+eventID, deleteResult, deleteErr)
 		})

--- a/tests/cli_e2e/calendar/calendar_manage_calendar_test.go
+++ b/tests/cli_e2e/calendar/calendar_manage_calendar_test.go
@@ -75,6 +75,7 @@ func TestCalendar_ManageCalendar(t *testing.T) {
 				Params: map[string]any{
 					"calendar_id": createdCalendarID,
 				},
+				Yes: true,
 			})
 			clie2e.ReportCleanupFailure(parentT, "delete calendar "+createdCalendarID, deleteResult, deleteErr)
 		})

--- a/tests/cli_e2e/calendar/calendar_update_event_test.go
+++ b/tests/cli_e2e/calendar/calendar_update_event_test.go
@@ -68,6 +68,7 @@ func TestCalendar_UpdateEventWorkflow(t *testing.T) {
 					"calendar_id": calendarID,
 					"event_id":    eventID,
 				},
+				Yes: true,
 			})
 			clie2e.ReportCleanupFailure(parentT, "delete event "+eventID, deleteResult, deleteErr)
 		})
@@ -125,6 +126,7 @@ func TestCalendar_UpdateEventWorkflow(t *testing.T) {
 				"calendar_id": calendarID,
 				"event_id":    eventID,
 			},
+			Yes: true,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)

--- a/tests/cli_e2e/mail/mail_draft_lifecycle_workflow_test.go
+++ b/tests/cli_e2e/mail/mail_draft_lifecycle_workflow_test.go
@@ -46,6 +46,7 @@ func TestMail_DraftLifecycleWorkflowAsUser(t *testing.T) {
 				"user_mailbox_id": mailboxID,
 				"draft_id":        draftID,
 			},
+			Yes: true,
 		})
 		clie2e.ReportCleanupFailure(parentT, "delete draft "+draftID, result, err)
 	})
@@ -187,6 +188,7 @@ func TestMail_DraftLifecycleWorkflowAsUser(t *testing.T) {
 				"user_mailbox_id": mailboxID,
 				"draft_id":        draftID,
 			},
+			Yes: true,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)

--- a/tests/cli_e2e/mail/mail_send_workflow_test.go
+++ b/tests/cli_e2e/mail/mail_send_workflow_test.go
@@ -48,6 +48,7 @@ func TestMail_SendWorkflowAsUser(t *testing.T) {
 					"user_mailbox_id": mailboxID,
 					"draft_id":        replyDraftID,
 				},
+				Yes: true,
 			})
 			clie2e.ReportCleanupFailure(parentT, "delete reply draft "+replyDraftID, result, err)
 		}
@@ -63,6 +64,7 @@ func TestMail_SendWorkflowAsUser(t *testing.T) {
 					"user_mailbox_id": mailboxID,
 					"draft_id":        forwardDraftID,
 				},
+				Yes: true,
 			})
 			clie2e.ReportCleanupFailure(parentT, "delete forward draft "+forwardDraftID, result, err)
 		}

--- a/tests/cli_e2e/task/task_update_workflow_test.go
+++ b/tests/cli_e2e/task/task_update_workflow_test.go
@@ -132,7 +132,6 @@ func TestTask_UpdateWorkflow(t *testing.T) {
 				},
 				"update_fields": []string{"summary", "description"},
 			},
-			Yes: true,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)

--- a/tests/cli_e2e/task/tasklist_workflow_test.go
+++ b/tests/cli_e2e/task/tasklist_workflow_test.go
@@ -170,7 +170,6 @@ func TestTask_TasklistWorkflowAsUser(t *testing.T) {
 				"tasklist":      map[string]any{"name": patchedTasklistName},
 				"update_fields": []string{"name"},
 			},
-			Yes: true,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Calendar operations now include automatic confirmation in e2e tests for improved test reliability
  * Mail draft deletions standardized with automatic confirmation in cleanup workflows
  * Task operations updated for consistent confirmation behavior across e2e tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->