### PR TITLE
feat: wrap no-wait verification url as markdown autolink

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -230,10 +230,10 @@ func authLoginRun(opts *LoginOptions) error {
 			fmt.Fprintf(f.IOStreams.ErrOut, "[lark-cli] [WARN] auth login: failed to cache requested scopes: %v\n", err)
 		}
 		data := map[string]interface{}{
-			"verification_url": authResp.VerificationUriComplete,
+			"verification_url": "<" + authResp.VerificationUriComplete + ">",
 			"device_code":      authResp.DeviceCode,
 			"expires_in":       authResp.ExpiresIn,
-			"hint":             fmt.Sprintf("Show verification_url to user, then immediately execute: lark-cli auth login --device-code %s (blocks until authorized or timeout). Do not instruct the user to run this command themselves.", authResp.DeviceCode),
+			"hint":             fmt.Sprintf("Show verification_url to the user verbatim — it is wrapped in <> as a markdown autolink so it renders correctly even when the URL contains underscores. Do not unwrap or modify it. Then immediately execute: lark-cli auth login --device-code %s (blocks until authorized or timeout). Do not instruct the user to run this command themselves.", authResp.DeviceCode),
 		}
 		encoder := json.NewEncoder(f.IOStreams.Out)
 		encoder.SetEscapeHTML(false)

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -230,10 +230,10 @@ func authLoginRun(opts *LoginOptions) error {
 			fmt.Fprintf(f.IOStreams.ErrOut, "[lark-cli] [WARN] auth login: failed to cache requested scopes: %v\n", err)
 		}
 		data := map[string]interface{}{
-			"verification_url": "<" + authResp.VerificationUriComplete + ">",
+			"verification_url": "[`" + authResp.VerificationUriComplete + "`](" + authResp.VerificationUriComplete + ")",
 			"device_code":      authResp.DeviceCode,
 			"expires_in":       authResp.ExpiresIn,
-			"hint":             fmt.Sprintf("Show verification_url to the user verbatim — it is wrapped in <> as a markdown autolink so it renders correctly even when the URL contains underscores. Do not unwrap or modify it. Then immediately execute: lark-cli auth login --device-code %s (blocks until authorized or timeout). Do not instruct the user to run this command themselves.", authResp.DeviceCode),
+			"hint":             fmt.Sprintf("Show verification_url to the user verbatim. It is pre-formatted as a markdown link `[`URL`](URL)`: the inner backticks render the URL as inline code so emphasis parsing cannot mangle underscores, while the outer link wrapper keeps it clickable. Do not unwrap, escape, or rewrite any part. Then immediately execute: lark-cli auth login --device-code %s (blocks until authorized or timeout). Do not instruct the user to run this command themselves.", authResp.DeviceCode),
 		}
 		encoder := json.NewEncoder(f.IOStreams.Out)
 		encoder.SetEscapeHTML(false)

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -904,6 +904,207 @@ func TestAuthLoginRun_JSONWriteFailure_DeviceAuthorizationReturnsWriterError(t *
 	}
 }
 
+func TestAuthLoginRun_NoWaitJSONWrapsVerificationURLAsAutolink(t *testing.T) {
+	keyring.MockInit()
+	setupLoginConfigDir(t)
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		ProfileName: "default",
+		AppID:       "cli_test",
+		AppSecret:   "secret",
+		Brand:       core.BrandFeishu,
+	})
+
+	const completeURL = "https://example.com/verify?state=abc_def_ghi&scope=mail:user_mailbox:readonly"
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    larkauth.PathDeviceAuthorization,
+		Body: map[string]interface{}{
+			"device_code":               "device-code",
+			"user_code":                 "user-code",
+			"verification_uri":          "https://example.com/verify",
+			"verification_uri_complete": completeURL,
+			"expires_in":                240,
+			"interval":                  0,
+		},
+	})
+
+	err := authLoginRun(&LoginOptions{
+		Factory: f,
+		Ctx:     context.Background(),
+		Scope:   "im:message:send",
+		NoWait:  true,
+	})
+	if err != nil {
+		t.Fatalf("authLoginRun() error = %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal stdout: %v\nstdout: %s", err, stdout.String())
+	}
+	got, ok := payload["verification_url"].(string)
+	if !ok {
+		t.Fatalf("verification_url missing or not string: %#v", payload)
+	}
+	want := "<" + completeURL + ">"
+	if got != want {
+		t.Fatalf("verification_url = %q, want %q (--no-wait wraps URL as markdown autolink)", got, want)
+	}
+	if _, exists := payload["verification_url_markdown"]; exists {
+		t.Fatalf("verification_url_markdown should not be a separate field, got payload: %#v", payload)
+	}
+}
+
+func TestAuthLoginRun_NoWaitHintInstructsVerbatimDisplay(t *testing.T) {
+	keyring.MockInit()
+	setupLoginConfigDir(t)
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		ProfileName: "default",
+		AppID:       "cli_test",
+		AppSecret:   "secret",
+		Brand:       core.BrandFeishu,
+	})
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    larkauth.PathDeviceAuthorization,
+		Body: map[string]interface{}{
+			"device_code":               "device-code",
+			"user_code":                 "user-code",
+			"verification_uri":          "https://example.com/verify",
+			"verification_uri_complete": "https://example.com/verify?state=a_b_c",
+			"expires_in":                240,
+			"interval":                  0,
+		},
+	})
+
+	err := authLoginRun(&LoginOptions{
+		Factory: f,
+		Ctx:     context.Background(),
+		Scope:   "im:message:send",
+		NoWait:  true,
+	})
+	if err != nil {
+		t.Fatalf("authLoginRun() error = %v", err)
+	}
+
+	var payload map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal stdout: %v", err)
+	}
+	hint, _ := payload["hint"].(string)
+	for _, want := range []string{
+		"verification_url",
+		"verbatim",
+	} {
+		if !strings.Contains(hint, want) {
+			t.Fatalf("hint missing %q, got: %s", want, hint)
+		}
+	}
+	if strings.Contains(hint, "verification_url_markdown") {
+		t.Fatalf("hint should not reference removed field verification_url_markdown, got: %s", hint)
+	}
+}
+
+func TestAuthLoginRun_InteractiveJSONKeepsRawURL(t *testing.T) {
+	keyring.MockInit()
+	setupLoginConfigDir(t)
+
+	original := pollDeviceToken
+	t.Cleanup(func() { pollDeviceToken = original })
+	pollDeviceToken = func(_ context.Context, _ *http.Client, _, _ string, _ core.LarkBrand, _ string, _, _ int, _ io.Writer) *larkauth.DeviceFlowResult {
+		return &larkauth.DeviceFlowResult{OK: false, Message: "stub"}
+	}
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		ProfileName: "default",
+		AppID:       "cli_test",
+		AppSecret:   "secret",
+		Brand:       core.BrandFeishu,
+	})
+
+	const completeURL = "https://example.com/verify?state=a_b_c&scope=mail:user_mailbox:readonly"
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    larkauth.PathDeviceAuthorization,
+		Body: map[string]interface{}{
+			"device_code":               "device-code",
+			"user_code":                 "user-code",
+			"verification_uri":          "https://example.com/verify",
+			"verification_uri_complete": completeURL,
+			"expires_in":                240,
+			"interval":                  0,
+		},
+	})
+
+	_ = authLoginRun(&LoginOptions{
+		Factory: f,
+		Ctx:     context.Background(),
+		Scope:   "im:message:send",
+		JSON:    true,
+	})
+
+	dec := json.NewDecoder(strings.NewReader(stdout.String()))
+	var first map[string]interface{}
+	if err := dec.Decode(&first); err != nil {
+		t.Fatalf("decode first JSON event: %v\nstdout: %s", err, stdout.String())
+	}
+	if first["verification_uri_complete"] != completeURL {
+		t.Fatalf("verification_uri_complete = %v, want raw URL %q", first["verification_uri_complete"], completeURL)
+	}
+	if _, exists := first["verification_uri_complete_markdown"]; exists {
+		t.Fatalf("interactive --json must not add markdown field; only --no-wait wraps URL. payload: %#v", first)
+	}
+}
+
+func TestAuthLoginRun_PlainTextStderrShowsBareURL(t *testing.T) {
+	keyring.MockInit()
+	setupLoginConfigDir(t)
+
+	original := pollDeviceToken
+	t.Cleanup(func() { pollDeviceToken = original })
+	pollDeviceToken = func(_ context.Context, _ *http.Client, _, _ string, _ core.LarkBrand, _ string, _, _ int, _ io.Writer) *larkauth.DeviceFlowResult {
+		return &larkauth.DeviceFlowResult{OK: false, Message: "stub"}
+	}
+
+	f, _, stderr, reg := cmdutil.TestFactory(t, &core.CliConfig{
+		ProfileName: "default",
+		AppID:       "cli_test",
+		AppSecret:   "secret",
+		Brand:       core.BrandFeishu,
+	})
+
+	const completeURL = "https://example.com/verify?state=a_b_c"
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    larkauth.PathDeviceAuthorization,
+		Body: map[string]interface{}{
+			"device_code":               "device-code",
+			"user_code":                 "user-code",
+			"verification_uri":          "https://example.com/verify",
+			"verification_uri_complete": completeURL,
+			"expires_in":                240,
+			"interval":                  0,
+		},
+	})
+
+	_ = authLoginRun(&LoginOptions{
+		Factory: f,
+		Ctx:     context.Background(),
+		Scope:   "im:message:send",
+	})
+
+	got := stderr.String()
+	if !strings.Contains(got, "  "+completeURL+"\n") {
+		t.Fatalf("stderr missing bare URL line, got:\n%s", got)
+	}
+	if strings.Contains(got, "<"+completeURL+">") {
+		t.Fatalf("stderr should not contain autolink form for human users, got:\n%s", got)
+	}
+}
+
 func TestGetDomainMetadata_ExcludesEvent(t *testing.T) {
 	domains := getDomainMetadata("zh")
 	for _, dm := range domains {

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -904,7 +904,7 @@ func TestAuthLoginRun_JSONWriteFailure_DeviceAuthorizationReturnsWriterError(t *
 	}
 }
 
-func TestAuthLoginRun_NoWaitJSONWrapsVerificationURLAsAutolink(t *testing.T) {
+func TestAuthLoginRun_NoWaitJSONWrapsVerificationURLAsCodedLink(t *testing.T) {
 	keyring.MockInit()
 	setupLoginConfigDir(t)
 
@@ -947,12 +947,9 @@ func TestAuthLoginRun_NoWaitJSONWrapsVerificationURLAsAutolink(t *testing.T) {
 	if !ok {
 		t.Fatalf("verification_url missing or not string: %#v", payload)
 	}
-	want := "<" + completeURL + ">"
+	want := "[`" + completeURL + "`](" + completeURL + ")"
 	if got != want {
-		t.Fatalf("verification_url = %q, want %q (--no-wait wraps URL as markdown autolink)", got, want)
-	}
-	if _, exists := payload["verification_url_markdown"]; exists {
-		t.Fatalf("verification_url_markdown should not be a separate field, got payload: %#v", payload)
+		t.Fatalf("verification_url = %q,\nwant %q\n(--no-wait wraps URL as [`URL`](URL): backticks shield text from emphasis parsing, link wrapper provides clickability)", got, want)
 	}
 }
 
@@ -998,13 +995,11 @@ func TestAuthLoginRun_NoWaitHintInstructsVerbatimDisplay(t *testing.T) {
 	for _, want := range []string{
 		"verification_url",
 		"verbatim",
+		"backtick",
 	} {
 		if !strings.Contains(hint, want) {
 			t.Fatalf("hint missing %q, got: %s", want, hint)
 		}
-	}
-	if strings.Contains(hint, "verification_url_markdown") {
-		t.Fatalf("hint should not reference removed field verification_url_markdown, got: %s", hint)
 	}
 }
 


### PR DESCRIPTION
## Summary

`auth login --no-wait --json` returns a `verification_url` for an AI agent to relay to the end user. URLs from the OAuth device-flow endpoint contain underscores in query parameters (e.g., `state`, `flow_id`, `user_code`); when the agent embeds the URL in a markdown reply, underscores are parsed as italic markers and the URL gets truncated by the renderer, breaking the OAuth flow.

This PR wraps the URL in angle brackets (`<...>`) so it is recognized as a markdown autolink. Renderers leave inner content unparsed, the URL stays clickable, and the user still sees the full URL for OAuth review (vs hiding it behind `[link](url)` link text).

## Changes

- `cmd/auth/login.go`: in the `--no-wait` JSON branch, wrap `verification_url` value as `<URL>` and update the `hint` field to instruct agents to display the value verbatim
- `cmd/auth/login_test.go`: 4 new tests covering the JSON contract — `--no-wait` wraps as autolink, hint instructs verbatim display, interactive `--json` keeps raw URL, plain-text stderr keeps bare URL

The change is scoped to `--no-wait`. Interactive `--json` output and plain-text stderr remain unchanged: those paths target programs and human terminal users where bare URLs are appropriate.

## Test Plan

- [x] `make unit-test` passed (all packages green; including 4 new `cmd/auth/` cases and the existing `TestAuthLoginRun_*` regression set)
- [x] `go vet ./...` passed (no `make validate` target in Makefile; vet is the closest equivalent)
- [ ] skipped: local-eval — change is JSON-contract only, fully covered by unit tests; no shortcut/skill behavior touched
- [ ] skipped: acceptance-reviewer — manual verification below covers the agent-rendering path end-to-end
- [x] manual verification: ran `./lark-cli auth login --no-wait --json --scope "im:message:send"` against the real Feishu device-authorization endpoint; confirmed `verification_url` is `<https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=...&user_code=...>` and the `hint` reads "Show verification_url to the user verbatim — it is wrapped in <> as a markdown autolink ..."

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JSON output for the login command in no-wait mode now emits the verification URL as a markdown autolink.
  * Updated on-screen instructions to tell users to present the verification URL verbatim (including backticks/markdown) and avoid altering it.

* **Tests**
  * Added tests covering URL formatting and companion-field behavior across interactive, no-wait, JSON, and plain-text modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->