### PR TITLE
Feat/task app members

### DIFF
--- a/shortcuts/task/shortcuts.go
+++ b/shortcuts/task/shortcuts.go
@@ -163,8 +163,8 @@ var CreateTask = common.Shortcut{
 	Flags: []common.Flag{
 		{Name: "summary", Desc: "task title"},
 		{Name: "description", Desc: "task description"},
-		{Name: "assignee", Desc: "task member id added during create"},
-		{Name: "follower", Desc: "task follower id added during create"},
+		{Name: "assignee", Desc: "task assignee id added during create; use open_id (ou_xxx) when assignee is user, use app id (cli_xxx) when assignee is app"},
+		{Name: "follower", Desc: "task follower id added during create; use open_id (ou_xxx) when follower is user, use app id (cli_xxx) when follower is app"},
 		{Name: "due", Desc: "due date (ISO 8601 / date:YYYY-MM-DD / relative:+2d / ms timestamp)"},
 		{Name: "tasklist-id", Desc: "tasklist id or applink URL"},
 		{Name: "idempotency-key", Desc: "client token for idempotency"},

--- a/shortcuts/task/shortcuts.go
+++ b/shortcuts/task/shortcuts.go
@@ -17,6 +17,21 @@ import (
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
+func inferTaskMemberType(id string) string {
+	if strings.HasPrefix(strings.TrimSpace(id), "cli_") {
+		return "app"
+	}
+	return "user"
+}
+
+func buildTaskMember(id, role string) map[string]interface{} {
+	return map[string]interface{}{
+		"id":   id,
+		"role": role,
+		"type": inferTaskMemberType(id),
+	}
+}
+
 // parseTaskTime converts a flexible time string into the Task API due/start object format.
 func parseTaskTime(timeStr string) (map[string]interface{}, error) {
 	var msTs string
@@ -96,14 +111,15 @@ func buildTaskCreateBody(runtime *common.RuntimeContext) (map[string]interface{}
 		body["description"] = desc
 	}
 
+	var members []map[string]interface{}
 	if assignee := runtime.Str("assignee"); assignee != "" {
-		body["members"] = []map[string]interface{}{
-			{
-				"id":   assignee,
-				"role": "assignee",
-				"type": "user",
-			},
-		}
+		members = append(members, buildTaskMember(assignee, "assignee"))
+	}
+	if follower := runtime.Str("follower"); follower != "" {
+		members = append(members, buildTaskMember(follower, "follower"))
+	}
+	if len(members) > 0 {
+		body["members"] = members
 	}
 
 	if tasklistId := runtime.Str("tasklist-id"); tasklistId != "" {
@@ -147,7 +163,8 @@ var CreateTask = common.Shortcut{
 	Flags: []common.Flag{
 		{Name: "summary", Desc: "task title"},
 		{Name: "description", Desc: "task description"},
-		{Name: "assignee", Desc: "assignee open_id"},
+		{Name: "assignee", Desc: "task member id added during create"},
+		{Name: "follower", Desc: "task follower id added during create"},
 		{Name: "due", Desc: "due date (ISO 8601 / date:YYYY-MM-DD / relative:+2d / ms timestamp)"},
 		{Name: "tasklist-id", Desc: "tasklist id or applink URL"},
 		{Name: "idempotency-key", Desc: "client token for idempotency"},

--- a/shortcuts/task/task_assign.go
+++ b/shortcuts/task/task_assign.go
@@ -28,8 +28,8 @@ var AssignTask = common.Shortcut{
 
 	Flags: []common.Flag{
 		{Name: "task-id", Desc: "task id", Required: true},
-		{Name: "add", Desc: "comma-separated open_ids to add as assignees"},
-		{Name: "remove", Desc: "comma-separated open_ids to remove from assignees"},
+		{Name: "add", Desc: "comma-separated member IDs to add as assignees"},
+		{Name: "remove", Desc: "comma-separated member IDs to remove from assignees"},
 		{Name: "idempotency-key", Desc: "client token for idempotency (used for add_members)"},
 	},
 
@@ -43,16 +43,15 @@ var AssignTask = common.Shortcut{
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		d := common.NewDryRunAPI()
 		taskId := url.PathEscape(runtime.Str("task-id"))
-
 		if addStr := runtime.Str("add"); addStr != "" {
-			body := buildMembersBody(addStr, runtime.Str("idempotency-key"))
+			body := buildMembersBody(addStr, "assignee", runtime.Str("idempotency-key"))
 			d.POST("/open-apis/task/v2/tasks/" + taskId + "/add_members").
 				Params(map[string]interface{}{"user_id_type": "open_id"}).
 				Body(body)
 		}
 
 		if removeStr := runtime.Str("remove"); removeStr != "" {
-			body := buildMembersBody(removeStr, "")
+			body := buildMembersBody(removeStr, "assignee", "")
 			d.POST("/open-apis/task/v2/tasks/" + taskId + "/remove_members").
 				Params(map[string]interface{}{"user_id_type": "open_id"}).
 				Body(body)
@@ -69,7 +68,7 @@ var AssignTask = common.Shortcut{
 		var lastData map[string]interface{}
 
 		if addStr := runtime.Str("add"); addStr != "" {
-			body := buildMembersBody(addStr, runtime.Str("idempotency-key"))
+			body := buildMembersBody(addStr, "assignee", runtime.Str("idempotency-key"))
 			apiResp, err := runtime.DoAPI(&larkcore.ApiReq{
 				HttpMethod:  http.MethodPost,
 				ApiPath:     "/open-apis/task/v2/tasks/" + taskId + "/add_members",
@@ -92,7 +91,7 @@ var AssignTask = common.Shortcut{
 		}
 
 		if removeStr := runtime.Str("remove"); removeStr != "" {
-			body := buildMembersBody(removeStr, "")
+			body := buildMembersBody(removeStr, "assignee", "")
 			apiResp, err := runtime.DoAPI(&larkcore.ApiReq{
 				HttpMethod:  http.MethodPost,
 				ApiPath:     "/open-apis/task/v2/tasks/" + taskId + "/remove_members",
@@ -125,21 +124,21 @@ var AssignTask = common.Shortcut{
 		}
 
 		runtime.OutFormat(outData, nil, func(w io.Writer) {
-			fmt.Fprintf(w, "✅ Task assignees updated successfully!\n")
+			fmt.Fprintf(w, "✅ Task members updated successfully!\n")
 			fmt.Fprintf(w, "Task ID: %s\n", taskId)
 			if urlVal != "" {
 				fmt.Fprintf(w, "Task URL: %s\n", urlVal)
 			}
 
 			if members, ok := task["members"].([]interface{}); ok {
-				fmt.Fprintf(w, "Current Assignees: %d\n", len(members))
+				fmt.Fprintf(w, "Current Members: %d\n", len(members))
 			}
 		})
 		return nil
 	},
 }
 
-func buildMembersBody(idsStr string, clientToken string) map[string]interface{} {
+func buildMembersBody(idsStr, role, clientToken string) map[string]interface{} {
 	ids := strings.Split(idsStr, ",")
 	var members []map[string]interface{}
 
@@ -148,11 +147,7 @@ func buildMembersBody(idsStr string, clientToken string) map[string]interface{} 
 		if id == "" {
 			continue
 		}
-		members = append(members, map[string]interface{}{
-			"id":   id,
-			"role": "assignee",
-			"type": "user",
-		})
+		members = append(members, buildTaskMember(id, role))
 	}
 
 	body := map[string]interface{}{

--- a/shortcuts/task/task_assign.go
+++ b/shortcuts/task/task_assign.go
@@ -28,8 +28,8 @@ var AssignTask = common.Shortcut{
 
 	Flags: []common.Flag{
 		{Name: "task-id", Desc: "task id", Required: true},
-		{Name: "add", Desc: "comma-separated member IDs to add as assignees"},
-		{Name: "remove", Desc: "comma-separated member IDs to remove from assignees"},
+		{Name: "add", Desc: "comma-separated assignee IDs to add; use open_id (ou_xxx) when assignee is user, use app id (cli_xxx) when assignee is app"},
+		{Name: "remove", Desc: "comma-separated assignee IDs to remove; use open_id (ou_xxx) when assignee is user, use app id (cli_xxx) when assignee is app"},
 		{Name: "idempotency-key", Desc: "client token for idempotency (used for add_members)"},
 	},
 
@@ -124,14 +124,14 @@ var AssignTask = common.Shortcut{
 		}
 
 		runtime.OutFormat(outData, nil, func(w io.Writer) {
-			fmt.Fprintf(w, "✅ Task members updated successfully!\n")
+			fmt.Fprintf(w, "✅ Task assignes updated successfully!\n")
 			fmt.Fprintf(w, "Task ID: %s\n", taskId)
 			if urlVal != "" {
 				fmt.Fprintf(w, "Task URL: %s\n", urlVal)
 			}
 
 			if members, ok := task["members"].([]interface{}); ok {
-				fmt.Fprintf(w, "Current Members: %d\n", len(members))
+				fmt.Fprintf(w, "Current Assignes: %d\n", len(members))
 			}
 		})
 		return nil

--- a/shortcuts/task/task_assign_test.go
+++ b/shortcuts/task/task_assign_test.go
@@ -6,14 +6,74 @@ package task
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/smartystreets/goconvey/convey"
 )
 
 func TestBuildMembersBody(t *testing.T) {
 	convey.Convey("Build with ids and token", t, func() {
-		body := buildMembersBody("u1, u2 , ", "token1")
+		body := buildMembersBody("u1, u2 , ", "assignee", "token1")
 		members := body["members"].([]map[string]interface{})
 		convey.So(len(members), convey.ShouldEqual, 2)
 		convey.So(body["client_token"], convey.ShouldEqual, "token1")
+		convey.So(members[0]["role"], convey.ShouldEqual, "assignee")
+		convey.So(members[0]["type"], convey.ShouldEqual, "user")
 	})
+
+	convey.Convey("Build infers app assignee members from cli prefix", t, func() {
+		body := buildMembersBody("cli_bot_1", "assignee", "")
+		members := body["members"].([]map[string]interface{})
+		convey.So(len(members), convey.ShouldEqual, 1)
+		convey.So(members[0]["id"], convey.ShouldEqual, "cli_bot_1")
+		convey.So(members[0]["role"], convey.ShouldEqual, "assignee")
+		convey.So(members[0]["type"], convey.ShouldEqual, "app")
+	})
+
+	convey.Convey("Build infers mixed member types in one list", t, func() {
+		body := buildMembersBody("ou_user_1, cli_bot_1", "assignee", "")
+		members := body["members"].([]map[string]interface{})
+		convey.So(len(members), convey.ShouldEqual, 2)
+		convey.So(members[0]["type"], convey.ShouldEqual, "user")
+		convey.So(members[1]["type"], convey.ShouldEqual, "app")
+	})
+}
+
+func TestBuildTaskCreateBodySupportsAssigneeAndFollower(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("summary", "", "")
+	cmd.Flags().String("description", "", "")
+	cmd.Flags().String("assignee", "", "")
+	cmd.Flags().String("follower", "", "")
+	cmd.Flags().String("due", "", "")
+	cmd.Flags().String("tasklist-id", "", "")
+	cmd.Flags().String("idempotency-key", "", "")
+	cmd.Flags().String("data", "", "")
+	_ = cmd.Flags().Set("summary", "bot task")
+	_ = cmd.Flags().Set("assignee", "cli_bot_xxx")
+	_ = cmd.Flags().Set("follower", "ou_follower_xxx")
+
+	runtime := &common.RuntimeContext{Cmd: cmd}
+	body, err := buildTaskCreateBody(runtime)
+	if err != nil {
+		t.Fatalf("buildTaskCreateBody() error = %v", err)
+	}
+
+	members := body["members"].([]map[string]interface{})
+	if len(members) != 2 {
+		t.Fatalf("members len = %d, want 2", len(members))
+	}
+	if got := members[0]["type"]; got != "app" {
+		t.Fatalf("member[0] type = %v, want app", got)
+	}
+	if got := members[0]["role"]; got != "assignee" {
+		t.Fatalf("member[0] role = %v, want assignee", got)
+	}
+	if got := members[1]["type"]; got != "user" {
+		t.Fatalf("member[1] type = %v, want user", got)
+	}
+	if got := members[1]["role"]; got != "follower" {
+		t.Fatalf("member[1] role = %v, want follower", got)
+	}
 }

--- a/shortcuts/task/task_followers.go
+++ b/shortcuts/task/task_followers.go
@@ -28,8 +28,8 @@ var FollowersTask = common.Shortcut{
 
 	Flags: []common.Flag{
 		{Name: "task-id", Desc: "task id", Required: true},
-		{Name: "add", Desc: "comma-separated open_ids to add as followers"},
-		{Name: "remove", Desc: "comma-separated open_ids to remove from followers"},
+		{Name: "add", Desc: "comma-separated member IDs to add as followers"},
+		{Name: "remove", Desc: "comma-separated member IDs to remove from followers"},
 		{Name: "idempotency-key", Desc: "client token for idempotency (used for add_members)"},
 	},
 
@@ -144,11 +144,7 @@ func buildFollowersBody(idsStr string, clientToken string) map[string]interface{
 		if id == "" {
 			continue
 		}
-		members = append(members, map[string]interface{}{
-			"id":   id,
-			"role": "follower",
-			"type": "user",
-		})
+		members = append(members, buildTaskMember(id, "follower"))
 	}
 
 	body := map[string]interface{}{

--- a/shortcuts/task/task_followers.go
+++ b/shortcuts/task/task_followers.go
@@ -28,8 +28,8 @@ var FollowersTask = common.Shortcut{
 
 	Flags: []common.Flag{
 		{Name: "task-id", Desc: "task id", Required: true},
-		{Name: "add", Desc: "comma-separated member IDs to add as followers"},
-		{Name: "remove", Desc: "comma-separated member IDs to remove from followers"},
+		{Name: "add", Desc: "comma-separated follower IDs to add; use open_id (ou_xxx) when follower is user, use app id (cli_xxx) when follower is app"},
+		{Name: "remove", Desc: "comma-separated follower IDs to remove; use open_id (ou_xxx) when follower is user, use app id (cli_xxx) when follower is app"},
 		{Name: "idempotency-key", Desc: "client token for idempotency (used for add_members)"},
 	},
 

--- a/shortcuts/task/task_followers_test.go
+++ b/shortcuts/task/task_followers_test.go
@@ -15,5 +15,24 @@ func TestBuildFollowersBody(t *testing.T) {
 		members := body["members"].([]map[string]interface{})
 		convey.So(len(members), convey.ShouldEqual, 2)
 		convey.So(body["client_token"], convey.ShouldEqual, "token1")
+		convey.So(members[0]["role"], convey.ShouldEqual, "follower")
+		convey.So(members[0]["type"], convey.ShouldEqual, "user")
+	})
+
+	convey.Convey("Build infers app followers", t, func() {
+		body := buildFollowersBody("cli_bot_1", "")
+		members := body["members"].([]map[string]interface{})
+		convey.So(len(members), convey.ShouldEqual, 1)
+		convey.So(members[0]["id"], convey.ShouldEqual, "cli_bot_1")
+		convey.So(members[0]["role"], convey.ShouldEqual, "follower")
+		convey.So(members[0]["type"], convey.ShouldEqual, "app")
+	})
+
+	convey.Convey("Build infers mixed follower types in one list", t, func() {
+		body := buildFollowersBody("ou_user_1, cli_bot_1", "")
+		members := body["members"].([]map[string]interface{})
+		convey.So(len(members), convey.ShouldEqual, 2)
+		convey.So(members[0]["type"], convey.ShouldEqual, "user")
+		convey.So(members[1]["type"], convey.ShouldEqual, "app")
 	})
 }


### PR DESCRIPTION
## Summary

Support app task members in task shortcuts by inferring member type from the input ID. This also adds follower support during task creation and keeps member construction consistent across assign/follower shortcuts.

## Changes

- infer task member type from ID (`cli_` => `app`, otherwise `user`)
- support `--follower` in `task +create`
- reuse the same task member builder across `+assign` and `+followers`
- add tests for inferred app/user member types and create/assign/follower flows

## Test Plan

- [x] Unit tests pass
- [x] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added follower support for task assignments, allowing tasks to include both assignees and followers.
  * Enhanced member identification to automatically distinguish between user and app members based on ID format.
  * Improved CLI flag documentation to clearly specify required ID formats for different member types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->