### PR TITLE
fix(install): make Windows zip extraction resilient (issue #603)

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -125,6 +125,37 @@ function download(url, destPath) {
   execFileSync("curl", args, { stdio: ["ignore", "ignore", "pipe"] });
 }
 
+function extractZipWindows(archivePath, destDir) {
+  const psOpts = ["-NoProfile", "-ExecutionPolicy", "Bypass", "-Command"];
+  const psStdio = ["ignore", "inherit", "inherit"];
+  const psEnv = {
+    ...process.env,
+    LARK_CLI_ARCHIVE: archivePath,
+    LARK_CLI_DEST: destDir,
+  };
+
+  try {
+    const dotnet =
+      "$ErrorActionPreference='Stop';" +
+      "Add-Type -AssemblyName System.IO.Compression.FileSystem;" +
+      "[System.IO.Compression.ZipFile]::ExtractToDirectory($env:LARK_CLI_ARCHIVE,$env:LARK_CLI_DEST)";
+    execFileSync("powershell.exe", [...psOpts, dotnet], { stdio: psStdio, env: psEnv });
+  } catch (primaryErr) {
+    try {
+      const cmdlet =
+        "$ErrorActionPreference='Stop';" +
+        "Expand-Archive -LiteralPath $env:LARK_CLI_ARCHIVE -DestinationPath $env:LARK_CLI_DEST -Force";
+      execFileSync("powershell.exe", [...psOpts, cmdlet], { stdio: psStdio, env: psEnv });
+    } catch (fallbackErr) {
+      throw new Error(
+        `Failed to extract ${archivePath}. ` +
+        `.NET ZipFile attempt: ${primaryErr.message}. ` +
+        `Expand-Archive fallback: ${fallbackErr.message}`
+      );
+    }
+  }
+}
+
 function install() {
   const mirrorUrls = getMirrorUrls(process.env);
   const downloadUrls = [GITHUB_URL, ...mirrorUrls];
@@ -156,10 +187,7 @@ function install() {
     verifyChecksum(archivePath, expectedHash);
 
     if (isWindows) {
-      execFileSync("powershell", [
-        "-Command",
-        `Expand-Archive -Path '${archivePath}' -DestinationPath '${tmpDir}'`,
-      ], { stdio: "ignore" });
+      extractZipWindows(archivePath, tmpDir);
     } else {
       execFileSync("tar", ["-xzf", archivePath, "-C", tmpDir], {
         stdio: "ignore",


### PR DESCRIPTION
## Summary

Windows postinstall used `powershell -Command Expand-Archive`, which fails on real-world environments outside the maintainer's machine:

- **Issue #603**: `Microsoft.PowerShell.Archive` is a script module (`.psm1`). Any environment where its loading is blocked — Microsoft Store pwsh 7 injecting a `WindowsApps` path into `PSModulePath`, or ExecutionPolicy `Restricted` from a GPO — causes `Expand-Archive` to fail with `module could not be loaded`, breaking install.
- **Path corruption**: archive / destination paths were string-interpolated into PowerShell single-quoted strings without escaping. A single quote in `TEMP` (legal Windows path char) breaks parsing entirely.
- **Silent failures**: `stdio: "ignore"` swallowed the underlying PowerShell error, leaving users with `Command failed: powershell ...` and no clue why.

## Changes

`scripts/install.js` — replace inline `Expand-Archive` with a new `extractZipWindows()`:

1. **Primary path**: `Add-Type -AssemblyName System.IO.Compression.FileSystem` + `[ZipFile]::ExtractToDirectory(...)`. Calls .NET BCL directly, doesn't traverse `PSModulePath`, doesn't load script modules. Available on .NET 4.5+ — Win 8 / Server 2012 by default, broadly on Win 7 SP1.
2. **Fallback**: `Expand-Archive -LiteralPath` for hosts without .NET 4.5 but with PowerShell 5.0+.
3. **Path safety**: archive / dest paths are passed through `$env:LARK_CLI_ARCHIVE` and `$env:LARK_CLI_DEST` instead of string interpolation. Env-var expansion is value-only, so quotes / wildcards / spaces in the path can't corrupt parsing. `-LiteralPath` adds belt-and-suspenders for `Expand-Archive`.
4. **Error visibility**: `$ErrorActionPreference='Stop'` propagates non-terminating cmdlet errors as non-zero exit codes; `stdio: ["ignore", "inherit", "inherit"]` lets stderr/stdout flow to the npm postinstall log.
5. **Hardening**: both invocations use `-NoProfile -ExecutionPolicy Bypass` to defend against user profile and system policy interference.

If both paths fail, the thrown `Error` includes both the .NET attempt's message and the `Expand-Archive` fallback's message, so postinstall logs are diagnosable.

## Test Plan

Verified on Windows 10 (PowerShell 5.1.19041, Node v22.11.0) via real `npm install -g <tarball>`:

- [x] **Issue #603 trigger** (shadow `Microsoft.PowerShell.Archive` in `PSModulePath` + `PSExecutionPolicyPreference=Restricted`):
  - Original `install.js` from `main`: fails with the exact `Failed to install lark-cli: Command failed: powershell -Command Expand-Archive ...` error from the issue report.
  - Patched `install.js`: succeeds (`added 7 packages in 16s`, `lark-cli version 1.0.21`).
- [x] **Single-quote in `TEMP`** (`C:\Users\Administrator\AppData\Local\Temp\lark'quote-h1test`):
  - Original: fails (`MissingEndParenthesisInMethodCall`).
  - Patched: succeeds.
- [x] **Fallback path end-to-end** (Node script forces primary to throw, runs fallback against an existing `mkdtempSync` destination): succeeds, files extracted.
- [x] **Normal environment, no regression**: succeeds in 16s.
- [x] Local unit tests: 16/16 pass (`node --test scripts/install.test.js`).

## Related Issues

- Closes #603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Windows installation reliability with enhanced archive extraction handling. The system now implements multiple fallback strategies to ensure more dependable package installation across various Windows configurations, reducing potential installation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->