### PR TITLE
chore(makefile): refuse `make install` in non-interactive mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 # Copyright (c) 2026 Lark Technologies Pte. Ltd.
 # SPDX-License-Identifier: MIT
+#
+# END USERS / AI ASSISTANTS: To upgrade an existing lark-cli install, run
+# `lark-cli update`. `make install` here is for CONTRIBUTORS building from
+# source — it will NOT match official release artifacts and may break the
+# self-update flow.
 
 BINARY   := lark-cli
 MODULE   := github.com/larksuite/cli
@@ -28,6 +33,22 @@ integration-test: build
 test: vet unit-test integration-test
 
 install: build
+	@if [ -n "$$I_AM_A_CONTRIBUTOR" ]; then \
+		: ; \
+	elif [ -t 0 ] && [ -t 1 ]; then \
+		echo "" ; \
+		echo "  make install builds from source — for CONTRIBUTORS only." ; \
+		echo "  To upgrade an existing lark-cli, run: lark-cli update" ; \
+		echo "" ; \
+		printf "  Continue installing from source? (y/N) " ; \
+		read ans ; \
+		case "$$ans" in y|Y|yes|YES) ;; *) echo "Aborted." ; exit 1 ;; esac ; \
+	else \
+		echo "make install: refusing in non-interactive mode." ; \
+		echo "  To upgrade lark-cli: run \`lark-cli update\`." ; \
+		echo "  To install from source non-interactively: I_AM_A_CONTRIBUTOR=1 make install" ; \
+		exit 1 ; \
+	fi
 	install -d $(PREFIX)/bin
 	install -m755 $(BINARY) $(PREFIX)/bin/$(BINARY)
 	@echo "OK: $(PREFIX)/bin/$(BINARY) ($(VERSION))"


### PR DESCRIPTION
## Why

`make install` builds from source and produces a binary that won't match official release artifacts (different version metadata, no codesigning, breaks the self-update flow). When the CLI shows a "new version available" notice, AI coding assistants tend to pattern-match to `make install` and silently clobber the user's properly-installed binary — a real scenario we saw recently with Claude Code.

## What

Add a TTY gate to the `install` target:

- **Non-interactive (AI Bash tool, CI, pipes)** → refuses with a message pointing at `lark-cli update`.
- **Real terminal (contributor)** → prompts `y/N` confirmation, then proceeds.
- **`I_AM_A_CONTRIBUTOR=1 make install`** → escape hatch for scripted contributor workflows.

Also adds a banner comment at the top of the Makefile so anyone (including AI) reading the file sees the intended audience first.

## Test plan

- [x] `echo "" | make install` (simulating non-TTY) → refuses with exit 1, prints `lark-cli update` hint.
- [x] `I_AM_A_CONTRIBUTOR=1 make install` → bypasses gate.
- [ ] Run `make install` in a real terminal → prompts y/N; `y` proceeds, anything else aborts.

## Follow-ups (separate PRs)

- Update notice text + JSON `_notice.update.command` field so the suggested command is explicit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved installation process with clearer guidance for end-users to use the standard update command instead of direct installation.
  * Enhanced installation workflow with automatic permission for contributors while requiring confirmation in interactive environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->