### PR TITLE
fix: preserve filenames for file uploads

### DIFF
--- a/internal/cmdutil/fileupload.go
+++ b/internal/cmdutil/fileupload.go
@@ -112,12 +112,11 @@ func BuildFormdata(fileIO fileio.FileIO, fieldName, filePath string, isStdin boo
 		if err != nil {
 			return nil, output.ErrValidation("cannot open file: %s", filePath)
 		}
-		defer f.Close()
-		data, err := io.ReadAll(f)
-		if err != nil {
-			return nil, output.ErrValidation("--file: failed to read %s: %v", filePath, err)
-		}
-		fd.AddFile(fieldName, bytes.NewReader(data))
+		// Keep the concrete file reader instead of copying it into a
+		// bytes.Reader. The Lark SDK preserves multipart filenames only when
+		// it receives an *os.File; replacing it with an anonymous reader makes
+		// the SDK fall back to "unknown-file".
+		fd.AddFile(fieldName, f)
 	}
 
 	// Add top-level JSON keys as text form fields.

--- a/internal/cmdutil/fileupload_test.go
+++ b/internal/cmdutil/fileupload_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -276,6 +277,10 @@ func TestBuildFormdata(t *testing.T) {
 		if fd == nil {
 			t.Fatal("expected non-nil Formdata")
 		}
+
+		if got := formdataFieldTypeName(t, fd, "photo"); got != "*os.File" {
+			t.Fatalf("formdata file field type = %s, want *os.File", got)
+		}
 	})
 
 	t.Run("file not found", func(t *testing.T) {
@@ -335,6 +340,23 @@ func TestBuildFormdata(t *testing.T) {
 			t.Fatal("expected non-nil Formdata")
 		}
 	})
+}
+
+func formdataFieldTypeName(t *testing.T, fd any, field string) string {
+	t.Helper()
+
+	fields := reflect.ValueOf(fd).Elem().FieldByName("fields")
+	if !fields.IsValid() {
+		t.Fatal("Formdata.fields is not available")
+	}
+	value := fields.MapIndex(reflect.ValueOf(field))
+	if !value.IsValid() {
+		t.Fatalf("Formdata field %q is missing", field)
+	}
+	if value.Kind() == reflect.Interface {
+		value = value.Elem()
+	}
+	return value.Type().String()
 }
 
 // TestFormatFormFieldValue locks in the fix for the float64 -> scientific


### PR DESCRIPTION
## Summary

Fix generic `--file` uploads so multipart filenames are preserved for local files.

`BuildFormdata` previously opened a local file, read it into memory, and passed a `bytes.Reader` to the Lark SDK. The SDK only preserves multipart filenames when the form field is a concrete `*os.File`; anonymous readers fall back to `unknown-file`.

This change passes the opened local file directly to `Formdata.AddFile`, allowing the SDK to use `filepath.Base(f.Name())` as the multipart filename.

Fixes #729

## Tests

- `go test ./internal/cmdutil`
- `go test ./cmd/api ./cmd/service`
- `make build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file upload performance by streamlining data processing, reducing memory consumption during uploads and enabling better handling of larger files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->