### PR TITLE
chore(release): v1.0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.23] - 2026-04-30
+
+### Features
+
+- **drive**: Add `+pull` shortcut for one-way Drive → local mirror (#696)
+- **drive**: Add `+push` shortcut for one-way local → Drive mirror (#709)
+- **drive**: Add `+status` shortcut for content-hash diff (#692)
+- **drive**: Support `--file-name` for drive export (#685)
+- **base**: Add markdown output for record reads (#726)
+- **minutes**: Add media upload shortcut (#725)
+- **doc**: Warn when callout uses `type=` without `background-color` (#467)
+- **cmdutil**: Support `@file` for params and data (#724)
+- Add markdown shortcuts and skill docs (#704)
+
+### Documentation
+
+- **doc**: Guide lark-doc v2 usage (#710)
+- **minutes**: Clarify minutes file-to-notes routing (#732)
+
 ## [v1.0.22] - 2026-04-29
 
 ### Features
@@ -560,6 +579,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.23]: https://github.com/larksuite/cli/releases/tag/v1.0.23
 [v1.0.22]: https://github.com/larksuite/cli/releases/tag/v1.0.22
 [v1.0.21]: https://github.com/larksuite/cli/releases/tag/v1.0.21
 [v1.0.20]: https://github.com/larksuite/cli/releases/tag/v1.0.20

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

- Cut v1.0.23 with the 11 commits that landed since v1.0.22
- Update `CHANGELOG.md` (entry + reference link) and bump `package.json` to `1.0.23`

### Highlights

- **drive**: New `+pull` / `+push` / `+status` shortcuts for one-way sync and content-hash diff; `--file-name` for export
- **base**: Markdown output for record reads
- **minutes**: Media upload shortcut
- **doc**: Callout `type=` warning when `background-color` is missing; v2 usage guide
- **cmdutil**: `@file` support for params and data
- Markdown shortcuts and skill docs

## Test plan

- [ ] `git diff main -- CHANGELOG.md package.json` matches expectations
- [ ] CHANGELOG link reference for `[v1.0.23]` resolves on GitHub once tagged
- [ ] No other version strings still pinned to `1.0.22`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drive one-way mirror shortcut commands
  * Introduced additional flags and outputs for base, minutes, doc, and cmdutil
  * Enhanced markdown and skill documentation

* **Documentation**
  * Added Lark-doc v2 usage guidance
  * Clarified minutes routing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->