### PR TITLE
fix: handle negative truncate lengths

### DIFF
--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -5,6 +5,9 @@ package util
 
 // TruncateStr truncates s to at most n runes, safe for multi-byte (e.g. CJK) characters.
 func TruncateStr(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
 	r := []rune(s)
 	if len(r) <= n {
 		return s
@@ -14,6 +17,9 @@ func TruncateStr(s string, n int) string {
 
 // TruncateStrWithEllipsis truncates s to at most n runes (including "..." suffix).
 func TruncateStrWithEllipsis(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
 	r := []rune(s)
 	if len(r) <= n {
 		return s

--- a/internal/util/strings_test.go
+++ b/internal/util/strings_test.go
@@ -17,6 +17,7 @@ func TestTruncateStr(t *testing.T) {
 		{"truncate", "hello world", 5, "hello"},
 		{"empty", "", 5, ""},
 		{"zero limit", "hello", 0, ""},
+		{"negative limit", "hello", -1, ""},
 		{"CJK characters", "你好世界测试", 4, "你好世界"},
 	}
 	for _, tt := range tests {
@@ -41,6 +42,8 @@ func TestTruncateStrWithEllipsis(t *testing.T) {
 		{"limit less than 3", "hello", 2, "he"},
 		{"limit equals 3", "hello world", 3, "..."},
 		{"empty", "", 5, ""},
+		{"zero limit", "hello", 0, ""},
+		{"negative limit", "hello", -1, ""},
 		{"CJK with ellipsis", "你好世界测试", 5, "你好..."},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- return an empty string for non-positive truncate limits
- prevent negative lengths from panicking in truncate helpers
- add regression coverage for negative limits and ellipsis zero limits

## Validation
- env GOCACHE=/tmp/cli-gocache GOMODCACHE=/tmp/cli-gomodcache go test ./internal/util
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * String truncation now returns an empty string when given a non-positive limit, preventing unexpected output for zero or negative values.
* **Tests**
  * Unit tests updated to cover zero and negative truncation limits, ensuring consistent behavior across cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->