### PR TITLE
feat(doc): guard v2 markdown against custom-tag corruption; warn on whole-paragraph style

### DIFF
--- a/shortcuts/doc/docs_create_v2.go
+++ b/shortcuts/doc/docs_create_v2.go
@@ -27,6 +27,11 @@ func validateCreateV2(_ context.Context, runtime *common.RuntimeContext) error {
 	if runtime.Str("parent-token") != "" && runtime.Str("parent-position") != "" {
 		return common.FlagErrorf("--parent-token and --parent-position are mutually exclusive")
 	}
+	if runtime.Str("doc-format") == "markdown" {
+		if msg := CheckV2MarkdownCustomTags(runtime.Str("content")); msg != "" {
+			return common.FlagErrorf("%s", msg)
+		}
+	}
 	return nil
 }
 

--- a/shortcuts/doc/docs_create_v2.go
+++ b/shortcuts/doc/docs_create_v2.go
@@ -28,7 +28,7 @@ func validateCreateV2(_ context.Context, runtime *common.RuntimeContext) error {
 		return common.FlagErrorf("--parent-token and --parent-position are mutually exclusive")
 	}
 	if runtime.Str("doc-format") == "markdown" {
-		if msg := CheckV2MarkdownCustomTags(runtime.Str("content")); msg != "" {
+		if msg := checkV2MarkdownCustomTags(runtime.Str("content")); msg != "" {
 			return common.FlagErrorf("%s", msg)
 		}
 	}

--- a/shortcuts/doc/docs_update_check.go
+++ b/shortcuts/doc/docs_update_check.go
@@ -34,12 +34,20 @@ import (
 //     _**text**_   *__text__*
 //     Lark stores only one of the two emphases (usually italic), silently
 //     dropping the other. The user wanted both; they will get one.
+//
+//  3. Whole-paragraph style markers are not rendered by Lark. A line that
+//     consists entirely of *…* or **…** (no other content) is treated as a
+//     literal string rather than an italic or bold paragraph. The markers
+//     appear verbatim in the document instead of applying style.
 func docsUpdateWarnings(mode, markdown string) []string {
 	var warnings []string
 	if w := checkDocsUpdateReplaceMultilineMarkdown(mode, markdown); w != "" {
 		warnings = append(warnings, w)
 	}
 	if w := checkDocsUpdateBoldItalic(markdown); w != "" {
+		warnings = append(warnings, w)
+	}
+	if w := checkDocsUpdateWholeParagraphStyle(markdown); w != "" {
 		warnings = append(warnings, w)
 	}
 	return warnings
@@ -278,4 +286,70 @@ func leadingRun(s string, c byte) string {
 		i++
 	}
 	return s[:i]
+}
+
+// wholeParagraphStyleRe matches a line whose entire content is a single
+// emphasis span: *…* or **…** (at least one non-whitespace char inside).
+// CJK and ASCII content both match; we deliberately do NOT match ***…***
+// because that is already covered by checkDocsUpdateBoldItalic.
+var wholeParagraphStyleRe = regexp.MustCompile(`^\*{1,2}[^*\n]+\*{1,2}$`)
+
+// checkDocsUpdateWholeParagraphStyle warns when a markdown paragraph
+// consists entirely of *italic* or **bold** markers. Lark's markdown
+// parser treats such lines as literal strings (the markers appear verbatim)
+// rather than styled paragraphs. This is distinct from inline emphasis
+// embedded in mixed-content lines, which Lark handles correctly.
+func checkDocsUpdateWholeParagraphStyle(markdown string) string {
+	if markdown == "" {
+		return ""
+	}
+	sanitized := stripMarkdownCodeRegions(markdown)
+	for _, line := range strings.Split(sanitized, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if wholeParagraphStyleRe.MatchString(trimmed) {
+			return "line consisting entirely of *…* or **…** markers will not be rendered as italic/bold by Lark; " +
+				"the markers appear as literal characters. " +
+				"Mix the styled text with surrounding prose, or use Lark XML: <em>…</em> / <b>…</b>."
+		}
+	}
+	return ""
+}
+
+// v2MarkdownUnsupportedTags lists Lark custom XML tags that the v2
+// markdown parser does not understand. When present in markdown-mode
+// content, the parser silently strips or corrupts them — collapsing grid
+// columns, discarding lark-table rows, or escaping text-color tags to
+// literal characters. Use --doc-format xml to preserve these constructs.
+var v2MarkdownUnsupportedTags = []struct {
+	prefix  string
+	display string
+}{
+	{"<grid", "<grid>"},
+	{"<column", "<column>"},
+	{"<lark-table", "<lark-table>"},
+	{"<text color=", "<text color=...>"},
+	{"<text colour=", "<text colour=...>"},
+}
+
+// CheckV2MarkdownCustomTags returns a non-empty error message when content
+// contains Lark custom tags that the v2 markdown parser silently corrupts.
+// Callers in Validate should return this as an error; callers in DryRun
+// may choose to surface it as a warning instead.
+func CheckV2MarkdownCustomTags(content string) string {
+	if content == "" {
+		return ""
+	}
+	var found []string
+	for _, t := range v2MarkdownUnsupportedTags {
+		if strings.Contains(content, t.prefix) {
+			found = append(found, t.display)
+		}
+	}
+	if len(found) == 0 {
+		return ""
+	}
+	return "--doc-format markdown does not support Lark custom tags (" +
+		strings.Join(found, ", ") + "); " +
+		"the v2 API will silently strip or corrupt them. " +
+		"Switch to --doc-format xml (the default) to preserve these blocks."
 }

--- a/shortcuts/doc/docs_update_check.go
+++ b/shortcuts/doc/docs_update_check.go
@@ -345,9 +345,14 @@ func CheckV2MarkdownCustomTags(content string) string {
 	if content == "" {
 		return ""
 	}
+	// Strip fenced code blocks and inline code spans so that tags described
+	// inside a code fence (e.g. a tutorial showing <grid cols="2">) do not
+	// trigger a hard validation error — the v2 parser would render those as
+	// inert code text, not as live markup.
+	scanned := stripMarkdownCodeRegions(content)
 	var found []string
 	for _, t := range v2MarkdownUnsupportedTags {
-		if strings.Contains(content, t.prefix) {
+		if strings.Contains(scanned, t.prefix) {
 			found = append(found, t.display)
 		}
 	}

--- a/shortcuts/doc/docs_update_check.go
+++ b/shortcuts/doc/docs_update_check.go
@@ -4,6 +4,7 @@
 package doc
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -288,37 +289,56 @@ func leadingRun(s string, c byte) string {
 	return s[:i]
 }
 
-// wholeParagraphStyleRe matches a line whose entire content is a single
-// emphasis span: *…* or **…** (at least one non-whitespace char inside).
-// CJK and ASCII content both match; we deliberately do NOT match ***…***
-// because that is already covered by checkDocsUpdateBoldItalic.
 // wholeParagraphStyleRe matches a line whose entire content is exactly one
-// *italic* or **bold** span. Requirements: opener and closer must be the same
-// number of asterisks (1 or 2), content has no * or newline, and at least one
-// non-whitespace non-asterisk character is present (prevents `*   *` matches).
+// *italic* or **bold** span (asterisk style only). Requirements: opener and
+// closer must be the same number of asterisks (1 or 2), content has no * or
+// newline, and at least one non-whitespace non-asterisk character is present
+// (prevents `*   *` matches). ***…*** is deliberately excluded because that
+// shape is already covered by checkDocsUpdateBoldItalic.
+//
+// Note: underscore-style emphasis (_italic_ / __bold__) is not matched here.
+// Lark's markdown parser does render underscore emphasis correctly in
+// whole-paragraph lines, so the warning does not apply to them.
+//
+// Note: 4-space indented code blocks are not stripped before this check.
+// stripMarkdownCodeRegions only handles fenced code blocks (``` / ~~~) and
+// inline code spans. A line like "    *italic*" (indented as a code block per
+// CommonMark) could in theory produce a false positive, but such indentation
+// is rare in the AI-generated content this check targets and the impact is low.
 var wholeParagraphStyleRe = regexp.MustCompile(
 	`^(?:\*[^*\n]*[^\s*\n][^*\n]*\*|\*\*[^*\n]*[^\s*\n][^*\n]*\*\*)$`,
 )
 
-// checkDocsUpdateWholeParagraphStyle warns when a markdown paragraph
+// checkDocsUpdateWholeParagraphStyle warns when any markdown paragraph
 // consists entirely of *italic* or **bold** markers. Lark's markdown
 // parser treats such lines as literal strings (the markers appear verbatim)
 // rather than styled paragraphs. This is distinct from inline emphasis
 // embedded in mixed-content lines, which Lark handles correctly.
+//
+// All matching line numbers are collected and reported together so the user
+// can see the full extent of the issue in one pass.
 func checkDocsUpdateWholeParagraphStyle(markdown string) string {
 	if markdown == "" {
 		return ""
 	}
 	sanitized := stripMarkdownCodeRegions(markdown)
-	for _, line := range strings.Split(sanitized, "\n") {
+	var matchLines []int
+	for i, line := range strings.Split(sanitized, "\n") {
 		trimmed := strings.TrimSpace(line)
 		if wholeParagraphStyleRe.MatchString(trimmed) {
-			return "line consisting entirely of *…* or **…** markers will not be rendered as italic/bold by Lark; " +
-				"the markers appear as literal characters. " +
-				"Mix the styled text with surrounding prose, or use Lark XML: <em>…</em> / <b>…</b>."
+			matchLines = append(matchLines, i+1)
 		}
 	}
-	return ""
+	if len(matchLines) == 0 {
+		return ""
+	}
+	noun := "line"
+	if len(matchLines) > 1 {
+		noun = fmt.Sprintf("%d lines", len(matchLines))
+	}
+	return noun + " consisting entirely of *…* or **…** markers will not be rendered as italic/bold by Lark; " +
+		"the markers appear as literal characters. " +
+		"Mix the styled text with surrounding prose, or switch to --doc-format xml."
 }
 
 // v2MarkdownUnsupportedTags lists Lark custom XML tags that the v2
@@ -337,11 +357,11 @@ var v2MarkdownUnsupportedTags = []struct {
 	{"<text colour=", "<text colour=...>"},
 }
 
-// CheckV2MarkdownCustomTags returns a non-empty error message when content
+// checkV2MarkdownCustomTags returns a non-empty error message when content
 // contains Lark custom tags that the v2 markdown parser silently corrupts.
 // Callers in Validate should return this as an error; callers in DryRun
 // may choose to surface it as a warning instead.
-func CheckV2MarkdownCustomTags(content string) string {
+func checkV2MarkdownCustomTags(content string) string {
 	if content == "" {
 		return ""
 	}

--- a/shortcuts/doc/docs_update_check.go
+++ b/shortcuts/doc/docs_update_check.go
@@ -292,7 +292,13 @@ func leadingRun(s string, c byte) string {
 // emphasis span: *…* or **…** (at least one non-whitespace char inside).
 // CJK and ASCII content both match; we deliberately do NOT match ***…***
 // because that is already covered by checkDocsUpdateBoldItalic.
-var wholeParagraphStyleRe = regexp.MustCompile(`^\*{1,2}[^*\n]+\*{1,2}$`)
+// wholeParagraphStyleRe matches a line whose entire content is exactly one
+// *italic* or **bold** span. Requirements: opener and closer must be the same
+// number of asterisks (1 or 2), content has no * or newline, and at least one
+// non-whitespace non-asterisk character is present (prevents `*   *` matches).
+var wholeParagraphStyleRe = regexp.MustCompile(
+	`^(?:\*[^*\n]*[^\s*\n][^*\n]*\*|\*\*[^*\n]*[^\s*\n][^*\n]*\*\*)$`,
+)
 
 // checkDocsUpdateWholeParagraphStyle warns when a markdown paragraph
 // consists entirely of *italic* or **bold** markers. Lark's markdown

--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -441,6 +441,28 @@ func TestCheckV2MarkdownCustomTags(t *testing.T) {
 			wantHint: true,
 			wantTag:  "<grid>",
 		},
+		// fenced code fence guards — tags inside ``` must not trigger hard error
+		{
+			name:     "grid tag inside fenced code block is not flagged",
+			content:  "Here is an example:\n```html\n<grid cols=\"2\"><column>A</column></grid>\n```\nEnd.",
+			wantHint: false,
+		},
+		{
+			name:     "lark-table inside fenced code block is not flagged",
+			content:  "```\n<lark-table><lark-tr><lark-td>x</lark-td></lark-tr></lark-table>\n```",
+			wantHint: false,
+		},
+		{
+			name:     "tag inside inline code span is not flagged",
+			content:  "Use the `<grid cols=\"2\">` element to create columns.",
+			wantHint: false,
+		},
+		{
+			name:     "tag outside fence is still flagged even when same tag is also in fence",
+			content:  "```\n<grid cols=\"2\">\n```\n\nActual usage: <grid cols=\"3\">content</grid>",
+			wantHint: true,
+			wantTag:  "<grid>",
+		},
 	}
 
 	for _, tt := range tests {

--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -373,3 +373,136 @@ func TestDocsUpdateWarningsEmpty(t *testing.T) {
 		t.Fatalf("expected no warnings, got: %v", warnings)
 	}
 }
+
+func TestCheckV2MarkdownCustomTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		content  string
+		wantHint bool
+		wantTag  string
+	}{
+		{
+			name:     "empty content produces no warning",
+			content:  "",
+			wantHint: false,
+		},
+		{
+			name:     "plain markdown without custom tags is fine",
+			content:  "# Title\n\nSome **bold** paragraph.",
+			wantHint: false,
+		},
+		{
+			name:     "callout tag is safe (supported by v2)",
+			content:  `<callout emoji="💡">content</callout>`,
+			wantHint: false,
+		},
+		{
+			name:     "grid tag triggers warning",
+			content:  `<grid cols="2"><column width="50">A</column></grid>`,
+			wantHint: true,
+			wantTag:  "<grid>",
+		},
+		{
+			name:     "column tag triggers warning",
+			content:  `<column width="50">col content</column>`,
+			wantHint: true,
+			wantTag:  "<column>",
+		},
+		{
+			name:     "lark-table tag triggers warning",
+			content:  "<lark-table>\n<lark-tr><lark-td>cell</lark-td></lark-tr>\n</lark-table>",
+			wantHint: true,
+			wantTag:  "<lark-table>",
+		},
+		{
+			name:     "text color tag triggers warning",
+			content:  `<text color="red">colored text</text>`,
+			wantHint: true,
+			wantTag:  "<text color=...>",
+		},
+		{
+			name:     "multiple custom tags all appear in message",
+			content:  `<grid cols="2"><lark-table><lark-tr></lark-tr></lark-table></grid>`,
+			wantHint: true,
+			wantTag:  "<grid>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := CheckV2MarkdownCustomTags(tt.content)
+			hasHint := got != ""
+			if hasHint != tt.wantHint {
+				t.Fatalf("CheckV2MarkdownCustomTags(%q) = %q, wantHint=%v", tt.content, got, tt.wantHint)
+			}
+			if tt.wantTag != "" && !strings.Contains(got, tt.wantTag) {
+				t.Fatalf("expected message to contain %q, got: %q", tt.wantTag, got)
+			}
+		})
+	}
+}
+
+func TestCheckDocsUpdateWholeParagraphStyle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		markdown string
+		wantHint bool
+	}{
+		{
+			name:     "plain paragraph no warning",
+			markdown: "This is a normal paragraph.",
+			wantHint: false,
+		},
+		{
+			name:     "inline bold within mixed line is fine",
+			markdown: "See **important** detail here.",
+			wantHint: false,
+		},
+		{
+			name:     "whole line italic triggers warning",
+			markdown: "*为什么大家都选代码？*",
+			wantHint: true,
+		},
+		{
+			name:     "whole line bold triggers warning",
+			markdown: "**回到最初的问题：要用长期的耐心去打磨。**",
+			wantHint: true,
+		},
+		{
+			name:     "whole line italic inside larger doc triggers warning",
+			markdown: "# Title\n\nSome prose.\n\n*整段斜体行*\n\nMore prose.",
+			wantHint: true,
+		},
+		{
+			name:     "triple asterisk not matched (covered by bold+italic check)",
+			markdown: "***text***",
+			wantHint: false,
+		},
+		{
+			name:     "whole paragraph style inside code fence is ignored",
+			markdown: "```\n*not a paragraph*\n```",
+			wantHint: false,
+		},
+		{
+			name:     "empty markdown no warning",
+			markdown: "",
+			wantHint: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := checkDocsUpdateWholeParagraphStyle(tt.markdown)
+			hasHint := got != ""
+			if hasHint != tt.wantHint {
+				t.Fatalf("checkDocsUpdateWholeParagraphStyle(%q) = %q, wantHint=%v", tt.markdown, got, tt.wantHint)
+			}
+		})
+	}
+}

--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -364,6 +364,19 @@ func TestDocsUpdateWarningsAggregates(t *testing.T) {
 	}
 }
 
+func TestDocsUpdateWarningsWholeParagraphStyle(t *testing.T) {
+	t.Parallel()
+
+	// Whole-paragraph italic should surface via docsUpdateWarnings.
+	warnings := docsUpdateWarnings("append", "*整段斜体段落*")
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "*…*") {
+		t.Fatalf("unexpected warning text: %q", warnings[0])
+	}
+}
+
 func TestDocsUpdateWarningsEmpty(t *testing.T) {
 	t.Parallel()
 
@@ -481,6 +494,16 @@ func TestCheckDocsUpdateWholeParagraphStyle(t *testing.T) {
 		{
 			name:     "triple asterisk not matched (covered by bold+italic check)",
 			markdown: "***text***",
+			wantHint: false,
+		},
+		{
+			name:     "asymmetric markers not matched (*text**)",
+			markdown: "*text**",
+			wantHint: false,
+		},
+		{
+			name:     "whitespace-only inside markers not matched",
+			markdown: "*   *",
 			wantHint: false,
 		},
 		{

--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -468,10 +468,10 @@ func TestCheckV2MarkdownCustomTags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := CheckV2MarkdownCustomTags(tt.content)
+			got := checkV2MarkdownCustomTags(tt.content)
 			hasHint := got != ""
 			if hasHint != tt.wantHint {
-				t.Fatalf("CheckV2MarkdownCustomTags(%q) = %q, wantHint=%v", tt.content, got, tt.wantHint)
+				t.Fatalf("checkV2MarkdownCustomTags(%q) = %q, wantHint=%v", tt.content, got, tt.wantHint)
 			}
 			if tt.wantTag != "" && !strings.Contains(got, tt.wantTag) {
 				t.Fatalf("expected message to contain %q, got: %q", tt.wantTag, got)

--- a/shortcuts/doc/docs_update_v2.go
+++ b/shortcuts/doc/docs_update_v2.go
@@ -103,6 +103,11 @@ func validateUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 			return common.FlagErrorf("--command append requires --content")
 		}
 	}
+	if runtime.Str("doc-format") == "markdown" && content != "" {
+		if msg := CheckV2MarkdownCustomTags(content); msg != "" {
+			return common.FlagErrorf("%s", msg)
+		}
+	}
 	return nil
 }
 

--- a/shortcuts/doc/docs_update_v2.go
+++ b/shortcuts/doc/docs_update_v2.go
@@ -103,8 +103,8 @@ func validateUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 			return common.FlagErrorf("--command append requires --content")
 		}
 	}
-	if runtime.Str("doc-format") == "markdown" && content != "" {
-		if msg := CheckV2MarkdownCustomTags(content); msg != "" {
+	if runtime.Str("doc-format") == "markdown" {
+		if msg := checkV2MarkdownCustomTags(content); msg != "" {
 			return common.FlagErrorf("%s", msg)
 		}
 	}


### PR DESCRIPTION
## Summary

Two new pre-flight checks for the v2 docs create/update path that prevent silent data loss and surface rendering pitfalls before content is sent to the API.

## Changes

- **`shortcuts/doc/docs_update_check.go`**: two new check functions
  - `CheckV2MarkdownCustomTags`: detects Lark custom tags (`<grid>`, `<column>`, `<lark-table>`, `<text color=...>`) in markdown-mode content and returns an error message. Called from `validateCreateV2` and `validateUpdateV2`.
  - `checkDocsUpdateWholeParagraphStyle`: warns when a line consists entirely of `*…*` or `**…**` markers (Lark renders these as literal characters, not styled paragraphs). Integrated into `docsUpdateWarnings`.
- **`shortcuts/doc/docs_create_v2.go`** / **`shortcuts/doc/docs_update_v2.go`**: call `CheckV2MarkdownCustomTags` in Validate when `--doc-format markdown` is set.
- **`shortcuts/doc/docs_update_check_test.go`**: 16 new table-driven tests (8 per check).

## Motivation

**Case 15** (`<grid>`/`<lark-table>` corruption): the v2 markdown parser does not understand Lark custom tags but attempts to process them — collapsing grid columns to 1, discarding lark-table content entirely, escaping `<text color=...>` to literal characters. This caused complete structural collapse of a weekly report document. Blocking early in Validate is the only reliable defense before MCP-layer support lands.

**Case 14** (whole-paragraph style markers): a line like `*为什么？*` on its own renders as the literal string `*为什么？*` in Lark, not as italic text. This is a different failure mode from the existing bold+italic check (#569) and is worth a dedicated warning.

## Test Plan

- [x] Unit tests pass (`go test ./shortcuts/doc/...`)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean

## Related

- Case 15: v2 markdown mode corrupts Lark custom tags (grid/column/lark-table/text)
- Case 14: whole-paragraph style markers not rendered by Lark

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown validation now detects unsupported v2 custom tags and surfaces errors during document create and update flows.
  * Added detection and warnings for whole‑paragraph Markdown style issues (e.g., entire-line bold/italic).

* **Tests**
  * Added tests covering custom‑tag detection, whole‑paragraph style warnings, code‑block/inline exceptions, and related edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/750)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->