### PR TITLE
fix(auth): handle missing scopes and device flow improvements

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -348,7 +348,7 @@ func authLoginPollDeviceCode(opts *LoginOptions, config *core.CliConfig, msg *lo
 	}
 	log(msg.WaitingAuth)
 	result := pollDeviceToken(opts.Ctx, httpClient, config.AppID, config.AppSecret, config.Brand,
-		opts.DeviceCode, 5, 180, f.IOStreams.ErrOut)
+		opts.DeviceCode, 5, 600, f.IOStreams.ErrOut)
 
 	if !result.OK {
 		if shouldRemoveLoginRequestedScope(result) {

--- a/cmd/auth/login_result.go
+++ b/cmd/auth/login_result.go
@@ -200,9 +200,6 @@ func handleLoginScopeIssue(opts *LoginOptions, msg *loginMsg, f *cmdutil.Factory
 	if issue.Hint != "" {
 		fmt.Fprintln(f.IOStreams.ErrOut, issue.Hint)
 	}
-	if loginSucceeded {
-		return output.ErrBare(output.ExitAuth)
-	}
 	return output.ErrBare(output.ExitAuth)
 }
 

--- a/cmd/auth/login_result.go
+++ b/cmd/auth/login_result.go
@@ -169,7 +169,7 @@ func handleLoginScopeIssue(opts *LoginOptions, msg *loginMsg, f *cmdutil.Factory
 		if loginSucceeded {
 			b, _ := json.Marshal(authorizationCompletePayload(openId, userName, issue.Summary, issue))
 			fmt.Fprintln(f.IOStreams.Out, string(b))
-			return nil
+			return output.ErrBare(output.ExitAuth)
 		}
 		detail := map[string]interface{}{
 			"requested": issue.Summary.Requested,
@@ -201,7 +201,7 @@ func handleLoginScopeIssue(opts *LoginOptions, msg *loginMsg, f *cmdutil.Factory
 		fmt.Fprintln(f.IOStreams.ErrOut, issue.Hint)
 	}
 	if loginSucceeded {
-		return nil
+		return output.ErrBare(output.ExitAuth)
 	}
 	return output.ErrBare(output.ExitAuth)
 }

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/registry"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/zalando/go-keyring"
@@ -371,8 +372,12 @@ func TestHandleLoginScopeIssue_NonJSONAlignsWithLoginSuccess(t *testing.T) {
 			Granted:   []string{"base:app:copy"},
 		},
 	}, "ou_user", "tester")
-	if err != nil {
-		t.Fatalf("expected nil error, got %v", err)
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %v", err)
+	}
+	if exitErr.Code != output.ExitAuth {
+		t.Fatalf("exit code = %d, want %d", exitErr.Code, output.ExitAuth)
 	}
 	got := stderr.String()
 	for _, want := range []string{
@@ -410,8 +415,12 @@ func TestHandleLoginScopeIssue_JSONAlignsWithLoginSuccess(t *testing.T) {
 			Granted:   []string{"base:app:copy"},
 		},
 	}, "ou_user", "tester")
-	if err != nil {
-		t.Fatalf("expected nil error, got %v", err)
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %v", err)
+	}
+	if exitErr.Code != output.ExitAuth {
+		t.Fatalf("exit code = %d, want %d", exitErr.Code, output.ExitAuth)
 	}
 
 	var data map[string]interface{}
@@ -616,8 +625,12 @@ func TestAuthLoginRun_MissingRequestedScopeAlignsWithLoginSuccess(t *testing.T) 
 		Ctx:     context.Background(),
 		Scope:   "im:message:send",
 	})
-	if err != nil {
-		t.Fatalf("expected nil error, got %v", err)
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected ExitError, got %v", err)
+	}
+	if exitErr.Code != output.ExitAuth {
+		t.Fatalf("exit code = %d, want %d", exitErr.Code, output.ExitAuth)
 	}
 	got := stderr.String()
 	for _, want := range []string{

--- a/internal/auth/device_flow.go
+++ b/internal/auth/device_flow.go
@@ -142,8 +142,12 @@ func PollDeviceToken(ctx context.Context, httpClient *http.Client, appId, appSec
 		errOut = io.Discard
 	}
 
+	if interval < 1 {
+		interval = 5
+	}
+
 	const maxPollInterval = 60
-	const maxPollAttempts = 200
+	const maxPollAttempts = 600
 
 	endpoints := ResolveOAuthEndpoints(brand)
 	deadline := time.Now().Add(time.Duration(expiresIn) * time.Second)

--- a/internal/auth/device_flow_test.go
+++ b/internal/auth/device_flow_test.go
@@ -181,7 +181,7 @@ func TestLogAuthError_RecordsStructuredEntry(t *testing.T) {
 	}
 }
 
-func TestPollDeviceToken_DefaultsIntervalBelowOne(t *testing.T) {
+func TestPollDeviceToken_DefaultsZeroIntervalToFiveSeconds(t *testing.T) {
 	t.Parallel()
 
 	var requests atomic.Int32

--- a/internal/auth/device_flow_test.go
+++ b/internal/auth/device_flow_test.go
@@ -5,10 +5,12 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,6 +18,12 @@ import (
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/keychain"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
 
 // TestResolveOAuthEndpoints_Feishu validates endpoints for the Feishu brand.
 func TestResolveOAuthEndpoints_Feishu(t *testing.T) {
@@ -170,5 +178,35 @@ func TestLogAuthError_RecordsStructuredEntry(t *testing.T) {
 	}
 	if !strings.Contains(got, "cmdline=lark-cli auth login ...") {
 		t.Fatalf("expected truncated cmdline in log, got %q", got)
+	}
+}
+
+func TestPollDeviceToken_DefaultsIntervalBelowOne(t *testing.T) {
+	t.Parallel()
+
+	var requests atomic.Int32
+	client := &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			requests.Add(1)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       http.NoBody,
+			}, nil
+		}),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	t.Cleanup(cancel)
+
+	result := PollDeviceToken(ctx, client, "cli_a", "secret_b", core.BrandFeishu, "device-code", 0, 10, nil)
+	if result == nil {
+		t.Fatal("PollDeviceToken() returned nil result")
+	}
+	if result.Message != "Polling was cancelled" {
+		t.Fatalf("PollDeviceToken() message = %q, want polling cancellation", result.Message)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("PollDeviceToken() sent %d requests before context cancellation, want 0", got)
 	}
 }

--- a/internal/output/exitcode.go
+++ b/internal/output/exitcode.go
@@ -10,7 +10,7 @@ const (
 	ExitOK                   = 0  // 成功
 	ExitAPI                  = 1  // API / 通用错误（含 permission、not_found、conflict、rate_limit）
 	ExitValidation           = 2  // 参数校验失败
-	ExitAuth                 = 3  // 认证失败（token 无效 / 过期）
+	ExitAuth                 = 3  // 认证失败（token 无效 / 过期），或登录成功但请求 scopes 未全部授予
 	ExitNetwork              = 4  // 网络错误（连接超时、DNS 解析失败等）
 	ExitInternal             = 5  // 内部错误（不应发生）
 	ExitContentSafety        = 6  // content safety violation (block mode)


### PR DESCRIPTION
## Summary
This PR improves the auth login flow when requested scopes are not fully granted and makes device flow polling more robust. It aligns the login result with the expected auth exit behavior and adds safer polling defaults to avoid premature failures.

## Changes
- Returned `ExitAuth` consistently when login succeeds but the requested scopes are only partially granted, for both JSON and non-JSON output paths.
- Updated login tests to assert the auth exit code instead of treating the flow as a successful `nil` return.
- Added a default polling interval fallback when the device flow interval is less than 1.
- Increased the maximum number of device flow polling attempts from 200 to 600 to better tolerate longer authorization flows.
- Added a device flow test to verify that invalid low intervals fall back safely and do not send requests before context cancellation.
- Clarified the meaning of `ExitAuth` to also cover the case where login succeeds but requested scopes are not fully granted.

## Test Plan
- [ ] Unit tests passed.
- [ ] Manually verified `lark-cli auth login` returns the expected auth exit behavior when some requested scopes are missing.
- [ ] Manually verified device flow polling still works correctly for normal login flows and handles invalid low polling intervals safely.

## Related Issues
Closes #746 #747 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device-flow polling resilience: enforce a minimum poll interval (defaults to 5s), increase max attempts, and extend polling timeout.
  * Login now consistently returns an authentication exit when requested scopes are not fully granted.

* **Documentation**
  * Exit code docs clarified: authentication failures may occur even if login itself succeeds but scopes are missing.

* **Tests**
  * Updated tests to expect the adjusted login exit behavior and added tests covering polling defaults and transport behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->