### PR TITLE
fix: add url to markdown +create output

### DIFF
--- a/shortcuts/markdown/helpers.go
+++ b/shortcuts/markdown/helpers.go
@@ -489,6 +489,9 @@ func fetchMarkdownFileName(runtime *common.RuntimeContext, fileToken string) (st
 func prettyPrintMarkdownWrite(w io.Writer, data map[string]interface{}) {
 	fmt.Fprintf(w, "file_token: %s\n", common.GetString(data, "file_token"))
 	fmt.Fprintf(w, "file_name: %s\n", common.GetString(data, "file_name"))
+	if url := common.GetString(data, "url"); url != "" {
+		fmt.Fprintf(w, "url: %s\n", url)
+	}
 	version := common.GetString(data, "version")
 	if version == "" {
 		version = common.GetString(data, "data_version")

--- a/shortcuts/markdown/markdown_create.go
+++ b/shortcuts/markdown/markdown_create.go
@@ -79,6 +79,9 @@ var MarkdownCreate = common.Shortcut{
 			"file_name":  finalMarkdownFileName(spec),
 			"size_bytes": fileSize,
 		}
+		if u := common.BuildResourceURL(runtime.Config.Brand, "file", result.FileToken); u != "" {
+			out["url"] = u
+		}
 		if grant := common.AutoGrantCurrentUserDrivePermission(runtime, result.FileToken, "file"); grant != nil {
 			out["permission_grant"] = grant
 		}

--- a/shortcuts/markdown/markdown_test.go
+++ b/shortcuts/markdown/markdown_test.go
@@ -467,6 +467,9 @@ func TestMarkdownCreateSuccessUploadAll(t *testing.T) {
 	if !strings.Contains(stdout.String(), `"file_name": "README.md"`) {
 		t.Fatalf("stdout missing file_name: %s", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), `"url": "https://www.feishu.cn/file/box_md_create"`) {
+		t.Fatalf("stdout missing url: %s", stdout.String())
+	}
 }
 
 func TestMarkdownCreatePrettyOutputIncludesPermissionGrant(t *testing.T) {
@@ -496,6 +499,9 @@ func TestMarkdownCreatePrettyOutputIncludesPermissionGrant(t *testing.T) {
 	out := stdout.String()
 	if !strings.Contains(out, "file_token: box_md_create_pretty") {
 		t.Fatalf("pretty output missing file_token: %s", out)
+	}
+	if !strings.Contains(out, "url: https://www.feishu.cn/file/box_md_create_pretty") {
+		t.Fatalf("pretty output missing url: %s", out)
 	}
 	if !strings.Contains(out, "permission_grant.status: skipped") {
 		t.Fatalf("pretty output missing permission_grant.status: %s", out)


### PR DESCRIPTION
 ## Summary

  This change makes markdown +create return a user-facing url in its success output, matching the behavior of drive +upload. It also keeps the pretty-format output aligned so agents and humans can read the same link consistently.

  ## Changes

  - Add top-level url to markdown +create output using the same Drive file URL fallback pattern as drive +upload
  - Update markdown shortcut tests to verify the new url field in both JSON and pretty output

  ## Test Plan

  - [x] Unit tests pass
  - [ ] Manual local verification confirms the lark xxx command works as expected

  ## Related Issues

  - None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown file creation now includes a resource URL in the output for easier access to created files.

* **Tests**
  * Added test coverage to verify URL output in Markdown creation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->