### PR TITLE
feat: add default TAT fallback for env accounts with app secret

### DIFF
--- a/internal/credential/credential_provider.go
+++ b/internal/credential/credential_provider.go
@@ -265,6 +265,21 @@ func resolveTokenFromSource(ctx context.Context, source credentialSource, req To
 	return result, nil
 }
 
+// shouldFallbackToDefaultTAT reports whether an env-selected account with a
+// real app secret may mint a TAT via the built-in default token resolver.
+// This keeps env-provided explicit TAT/UAT values authoritative while letting
+// env app credentials behave like config-backed app credentials for bot flows.
+func (p *CredentialProvider) shouldFallbackToDefaultTAT(ctx context.Context, source credentialSource, req TokenSpec) bool {
+	if req.Type != TokenTypeTAT || source == nil || source.Name() != "env" || p.defaultToken == nil {
+		return false
+	}
+	acct, err := p.ResolveAccount(ctx)
+	if err != nil || acct == nil {
+		return false
+	}
+	return HasRealAppSecret(acct.AppSecret)
+}
+
 // ResolveIdentityHint resolves default/auto identity guidance from the selected source.
 // NOTE: Uses sync.Once — only the context from the first call is used for resolution.
 // This matches ResolveAccount and keeps identity decisions stable within one CLI invocation.
@@ -307,7 +322,17 @@ func (p *CredentialProvider) ResolveToken(ctx context.Context, req TokenSpec) (*
 		return nil, err
 	}
 	if source != nil {
-		return resolveTokenFromSource(ctx, source, req)
+		result, found, err := source.TryResolveToken(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			return result, nil
+		}
+		if p.shouldFallbackToDefaultTAT(ctx, source, req) {
+			return resolveTokenFromSource(ctx, defaultTokenSource{resolver: p.defaultToken}, req)
+		}
+		return nil, &TokenUnavailableError{Source: source.Name(), Type: req.Type}
 	}
 
 	for _, prov := range p.providers {

--- a/internal/credential/credential_provider_test.go
+++ b/internal/credential/credential_provider_test.go
@@ -194,6 +194,66 @@ func TestCredentialProvider_SelectedSourceWithoutTokenReturnsUnavailableError(t 
 	}
 }
 
+func TestCredentialProvider_EnvAccountWithAppSecretFallsBackToDefaultForTAT(t *testing.T) {
+	cp := NewCredentialProvider(
+		[]extcred.Provider{&mockExtProvider{
+			name: "env",
+			account: &extcred.Account{
+				AppID:     "env_app",
+				AppSecret: "env_secret",
+				Brand:     "feishu",
+			},
+		}},
+		nil,
+		&mockDefaultToken{result: &TokenResult{Token: "default_tat"}},
+		nil,
+	)
+
+	if _, err := cp.ResolveAccount(context.Background()); err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+
+	result, err := cp.ResolveToken(context.Background(), TokenSpec{Type: TokenTypeTAT, AppID: "env_app"})
+	if err != nil {
+		t.Fatalf("ResolveToken() error = %v", err)
+	}
+	if result.Token != "default_tat" {
+		t.Fatalf("ResolveToken() token = %q, want %q", result.Token, "default_tat")
+	}
+}
+
+func TestCredentialProvider_EnvAccountWithAppSecretDoesNotFallBackToDefaultForUAT(t *testing.T) {
+	cp := NewCredentialProvider(
+		[]extcred.Provider{&mockExtProvider{
+			name: "env",
+			account: &extcred.Account{
+				AppID:     "env_app",
+				AppSecret: "env_secret",
+				Brand:     "feishu",
+			},
+		}},
+		nil,
+		&mockDefaultToken{result: &TokenResult{Token: "default_uat"}},
+		nil,
+	)
+
+	if _, err := cp.ResolveAccount(context.Background()); err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+
+	_, err := cp.ResolveToken(context.Background(), TokenSpec{Type: TokenTypeUAT, AppID: "env_app"})
+	if err == nil {
+		t.Fatal("ResolveToken() error = nil, want unavailable error")
+	}
+	var unavailableErr *TokenUnavailableError
+	if !errors.As(err, &unavailableErr) {
+		t.Fatalf("ResolveToken() error type = %T, want *TokenUnavailableError", err)
+	}
+	if unavailableErr.Source != "env" || unavailableErr.Type != TokenTypeUAT {
+		t.Fatalf("ResolveToken() unavailable error = %+v, want source env and type uat", unavailableErr)
+	}
+}
+
 func TestCredentialProvider_ResolveTokenPropagatesNonBlockExtensionError(t *testing.T) {
 	cp := NewCredentialProvider(
 		[]extcred.Provider{&mockExtProvider{name: "env", err: errors.New("provider exploded")}},


### PR DESCRIPTION
## Summary
This PR improves credential resolution for env-selected accounts that provide real app credentials. When an env account includes an app secret but does not explicitly provide a tenant access token, the CLI now falls back to the default TAT resolver so bot flows behave consistently with config-backed app credentials.

## Changes
- Added `shouldFallbackToDefaultTAT` to detect when an env-selected account with a real app secret is eligible to mint a TAT through the built-in default token resolver.
- Updated `ResolveToken` to distinguish between “source found a token” and “source selected but token unavailable”, enabling a controlled fallback path.
- Added a fallback from env-selected accounts to the default token resolver only for `TAT` requests.
- Kept env-provided explicit token values authoritative and preserved the existing unavailable error behavior when fallback does not apply.
- Explicitly prevented the fallback from applying to `UAT` requests.

## Test Plan
- [ ] Unit tests passed.
- [ ] Manually verified an env-backed account with `app_id` and `app_secret` can resolve a tenant access token without an explicitly provided env TAT.
- [ ] Manually verified env-backed user token flows still return an unavailable error when no explicit UAT is provided.
- [ ] Manually verified explicit env token values still take precedence over the default token resolver.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced token resolution logic to automatically fall back to default tokens when environment-based credentials with app secrets are available, improving credential handling robustness.
  * Improved error reporting for token unavailability scenarios.

* **Tests**
  * Added comprehensive tests validating token resolution behavior across different credential configurations and token types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->