### PR TITLE
feat(mail): add HTML lint lib + +lint-html shortcut + write-path enforcement

### DIFF
--- a/shortcuts/mail/lint/linter.go
+++ b/shortcuts/mail/lint/linter.go
@@ -1,0 +1,516 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package lint
+
+import (
+	"bytes"
+	"strings"
+
+	xhtml "golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
+)
+
+// MaxExcerptBytes caps the raw-HTML excerpt embedded in a Finding.Excerpt so
+// a single offending tag with megabyte content can't bloat the envelope JSON.
+// S2 contract «Server-mirrored constraints» row "EML composition body+inline+
+// SMALL ≤ 25 MB" calls this out: lint ops on bytes only, but the excerpt
+// representation must not be size-amplifying.
+const MaxExcerptBytes = 200
+
+// Run lints the given HTML body and returns a structured Report. When
+// opts.AutoFix is true, Report.CleanedHTML contains the rewritten HTML
+// (warnings rewritten + errors deleted); when false, only error-tier findings
+// are removed (writing-path safety floor cannot be opted out of), warnings
+// are surfaced as observations only, and CleanedHTML still contains the
+// rewritten HTML — but `+lint-html --auto-fix=false` callers are expected to
+// drop this field from the public envelope per spec §4.2.
+//
+// IMPORTANT: when the input is empty or plain-text (no HTML markup detected
+// by the cli's existing `bodyIsHTML` heuristic), callers should short-circuit
+// with EmptyReport(html) instead of paying the parse cost. Run still handles
+// this gracefully — html.Parse on plain text wraps the input in
+// <html><head></head><body>...</body></html>, and the lib's pass-through
+// rendering will reproduce the original text — but the round-trip is wasteful
+// and produces no findings.
+func Run(html string, opts Options) Report {
+	if html == "" {
+		return EmptyReport("")
+	}
+
+	rep := Report{
+		Applied: []Finding{},
+		Blocked: []Finding{},
+	}
+
+	// We use html.ParseFragment so users authoring fragment-style snippets
+	// (the canonical compose-5 input shape — `<div>...</div>` rather than a
+	// full document) don't get implicit <html><head><body> wrappers
+	// re-rendered. The "body" insertion mode matches what html.Parse would
+	// have done internally for a fragment but skips the structural wrappers
+	// at render time.
+	bodyContext := &xhtml.Node{Type: xhtml.ElementNode, DataAtom: atom.Body, Data: "body"}
+	nodes, err := xhtml.ParseFragment(strings.NewReader(html), bodyContext)
+	if err != nil {
+		// Parser failure is exceptional (the parser is permissive by design);
+		// fall back to the original input so we don't lose user content.
+		return EmptyReport(html)
+	}
+
+	// Wrap fragment nodes in a synthetic root so the recursive walker has a
+	// uniform parent pointer to mutate.
+	root := &xhtml.Node{Type: xhtml.DocumentNode}
+	for _, n := range nodes {
+		root.AppendChild(n)
+	}
+
+	walk(root, &rep, opts)
+
+	rep.HasErrorFindings = len(rep.Blocked) > 0
+	rep.HasWarningFindings = len(rep.Applied) > 0
+	rep.CleanedHTML = renderFragment(root)
+
+	return rep
+}
+
+// walk visits every element node under parent, applying tag/attr/style
+// classification. Children are iterated via the next-sibling pointer because
+// we mutate the tree in place (replace / remove nodes).
+//
+// The walker is iterative-style via explicit recursion because the html
+// parser's typical nesting depth (≤ 256 by default) is well below Go's
+// goroutine stack limit; the existing draft package's plainTextFromHTML
+// (mail/draft/htmltext.go) similarly recurses for the same reason.
+func walk(parent *xhtml.Node, rep *Report, opts Options) {
+	child := parent.FirstChild
+	for child != nil {
+		next := child.NextSibling
+		if child.Type == xhtml.ElementNode {
+			processElement(parent, child, rep, opts)
+		}
+		// child may have been removed/replaced by processElement; recurse
+		// only if it still has the original parent (i.e. wasn't deleted).
+		// The html parser sets Parent on every node, so a removed-then-
+		// reattached node still recurses correctly via its new Parent.
+		if child.Parent != nil {
+			walk(child, rep, opts)
+		}
+		child = next
+	}
+}
+
+// processElement applies the element-level classification cascade:
+//  1. tag → allow / warn-rewrite / error-delete
+//  2. attributes → on*-handlers, URL-bearing attrs (scheme allow-list),
+//     style attribute (CSS property allow-list)
+func processElement(parent, n *xhtml.Node, rep *Report, opts Options) {
+	tagName := strings.ToLower(n.Data)
+	kind, ruleID := classifyTag(tagName)
+
+	switch kind {
+	case "error":
+		rep.Blocked = append(rep.Blocked, Finding{
+			RuleID:    ruleID,
+			Severity:  SeverityError,
+			TagOrAttr: tagName,
+			Excerpt:   excerptOf(n),
+			Hint:      hintForBlockedTag(tagName),
+		})
+		// Always remove blocked tags regardless of opts.AutoFix — writing-path
+		// safety floor cannot be opted out of (spec §4.3 — `--no-lint` is not
+		// provided).
+		parent.RemoveChild(n)
+		return
+
+	case "warn":
+		// AutoFix=true → rewrite (e.g. <font>→<span style>); AutoFix=false →
+		// surface the finding as observation only, keep the original tag.
+		// `+lint-html --auto-fix=false` consumers want to see what would
+		// change without the lib forcing the change.
+		if opts.AutoFix {
+			finding := Finding{
+				RuleID:    ruleID,
+				Severity:  SeverityWarning,
+				TagOrAttr: tagName,
+				Excerpt:   excerptOf(n),
+				Hint:      hintForWarnTag(tagName),
+			}
+			if opts.Strict {
+				finding.Severity = SeverityError
+				rep.Blocked = append(rep.Blocked, finding)
+			} else {
+				rep.Applied = append(rep.Applied, finding)
+			}
+			rewriteWarnTag(n, tagName)
+			// Recurse into the rewritten node by falling through; the
+			// rewrite preserved children as-is.
+		} else {
+			finding := Finding{
+				RuleID:    ruleID,
+				Severity:  SeverityWarning,
+				TagOrAttr: tagName,
+				Excerpt:   excerptOf(n),
+				Hint:      hintForWarnTag(tagName),
+			}
+			if opts.Strict {
+				finding.Severity = SeverityError
+				rep.Blocked = append(rep.Blocked, finding)
+			} else {
+				rep.Applied = append(rep.Applied, finding)
+			}
+		}
+		// fall through to attribute scan
+	case "allow":
+		// no-op
+	}
+
+	// Attribute scan: build a new attribute slice, dropping/sanitising as we
+	// go and surfacing findings.
+	if len(n.Attr) > 0 {
+		processAttributes(n, rep, opts)
+	}
+}
+
+// processAttributes walks the attribute list and:
+//   - drops on*-handlers (always; surfaced as error)
+//   - drops URL-bearing attrs whose value uses a forbidden scheme
+//   - filters the `style` attribute property-by-property against the allow-list
+//
+// Other attributes pass through unchanged. The cli's existing
+// `validateInlineCIDs` (helpers.go:2226) handles `cid:`-specific checks; the
+// lint must not duplicate that responsibility (S2 contract «MUST reuse» row).
+func processAttributes(n *xhtml.Node, rep *Report, opts Options) {
+	keep := n.Attr[:0]
+	for _, attr := range n.Attr {
+		name := strings.ToLower(attr.Key)
+
+		// 1. on*-handlers → always drop, error-tier.
+		if isEventHandlerAttr(name) {
+			rep.Blocked = append(rep.Blocked, Finding{
+				RuleID:    RuleAttrEventHandlerBlocked,
+				Severity:  SeverityError,
+				TagOrAttr: name,
+				Excerpt:   truncateExcerpt(attr.Key + "=\"" + attr.Val + "\""),
+				Hint:      "已删除事件处理器属性（on*）",
+			})
+			continue
+		}
+
+		// 2. URL-bearing attrs → check scheme allow-list.
+		if urlAttributes[name] {
+			kind, ruleID := classifyURLValue(attr.Val)
+			switch kind {
+			case "error":
+				severity := SeverityError
+				rep.Blocked = append(rep.Blocked, Finding{
+					RuleID:    ruleID,
+					Severity:  severity,
+					TagOrAttr: name,
+					Excerpt:   truncateExcerpt(attr.Key + "=\"" + attr.Val + "\""),
+					Hint:      "已删除危险 URL 协议（仅允许 http/https/mailto/cid/data:image/*）",
+				})
+				continue
+			case "warn":
+				finding := Finding{
+					RuleID:    ruleID,
+					Severity:  SeverityWarning,
+					TagOrAttr: name,
+					Excerpt:   truncateExcerpt(attr.Key + "=\"" + attr.Val + "\""),
+					Hint:      "URL 协议不在白名单（http/https/mailto/cid/data:image/*）；如确需使用请联系管理员",
+				}
+				if opts.Strict {
+					finding.Severity = SeverityError
+					rep.Blocked = append(rep.Blocked, finding)
+				} else {
+					rep.Applied = append(rep.Applied, finding)
+				}
+				if opts.AutoFix {
+					// Drop the attribute when AutoFix is set — writing-path
+					// safety floor (the URL would not render correctly anyway).
+					continue
+				}
+			}
+		}
+
+		// 3. `style` attribute → property-by-property allow-list.
+		if name == "style" {
+			cleaned, dropped := sanitiseStyleAttr(attr.Val)
+			for _, prop := range dropped {
+				rep.Applied = append(rep.Applied, Finding{
+					RuleID:    RuleStylePropertyDropped,
+					Severity:  SeverityWarning,
+					TagOrAttr: "style." + prop,
+					Excerpt:   truncateExcerpt(prop),
+					Hint:      "已删除非白名单 CSS 属性（详见 references/lark-mail-html-allowlist.md）",
+				})
+			}
+			if len(dropped) == 0 {
+				attr.Val = cleaned
+				keep = append(keep, attr)
+				continue
+			}
+			if !opts.AutoFix {
+				// AutoFix=false: keep the original property list so users see
+				// exactly what would change.
+				keep = append(keep, attr)
+				continue
+			}
+			if cleaned == "" {
+				// All properties dropped — remove the attribute entirely.
+				continue
+			}
+			attr.Val = cleaned
+			keep = append(keep, attr)
+			continue
+		}
+
+		// 4. Pass-through.
+		keep = append(keep, attr)
+	}
+	n.Attr = keep
+}
+
+// rewriteWarnTag replaces a warning-tier tag with its Feishu-native
+// equivalent in place: <font> → <span style="..."> with color/face/size
+// distilled into inline style; <center> → <div style="text-align:center">;
+// <marquee>/<blink> → <span> (text-only, animation discarded — collapsing
+// to a span keeps the children but drops the deprecated animation effect).
+func rewriteWarnTag(n *xhtml.Node, tagName string) {
+	switch tagName {
+	case "font":
+		// Distill <font color="..." face="..." size="...">.
+		var styles []string
+		var keepAttrs []xhtml.Attribute
+		for _, attr := range n.Attr {
+			switch strings.ToLower(attr.Key) {
+			case "color":
+				if v := strings.TrimSpace(attr.Val); v != "" {
+					styles = append(styles, "color:"+v)
+				}
+			case "face":
+				if v := strings.TrimSpace(attr.Val); v != "" {
+					styles = append(styles, "font-family:"+v)
+				}
+			case "size":
+				if v := mapFontSize(attr.Val); v != "" {
+					styles = append(styles, "font-size:"+v)
+				}
+			default:
+				keepAttrs = append(keepAttrs, attr)
+			}
+		}
+		// Merge any existing style attribute already present on the <font>
+		// (rare but possible).
+		if len(styles) > 0 {
+			merged := strings.Join(styles, ";")
+			styleIdx := -1
+			for i, attr := range keepAttrs {
+				if strings.ToLower(attr.Key) == "style" {
+					styleIdx = i
+					break
+				}
+			}
+			if styleIdx >= 0 {
+				existing := strings.TrimRight(keepAttrs[styleIdx].Val, "; ")
+				if existing != "" {
+					merged = existing + ";" + merged
+				}
+				keepAttrs[styleIdx].Val = merged
+			} else {
+				keepAttrs = append(keepAttrs, xhtml.Attribute{Key: "style", Val: merged})
+			}
+		}
+		n.Data = "span"
+		n.DataAtom = atom.Span
+		n.Attr = keepAttrs
+
+	case "center":
+		// <center> → <div style="text-align:center">. Existing style attr
+		// (if any) is merged with text-align prepended.
+		styleIdx := -1
+		for i, attr := range n.Attr {
+			if strings.ToLower(attr.Key) == "style" {
+				styleIdx = i
+				break
+			}
+		}
+		newStyle := "text-align:center"
+		if styleIdx >= 0 {
+			existing := strings.TrimRight(n.Attr[styleIdx].Val, "; ")
+			if existing != "" {
+				newStyle = newStyle + ";" + existing
+			}
+			n.Attr[styleIdx].Val = newStyle
+		} else {
+			n.Attr = append(n.Attr, xhtml.Attribute{Key: "style", Val: newStyle})
+		}
+		n.Data = "div"
+		n.DataAtom = atom.Div
+
+	case "marquee", "blink":
+		// Both deprecated; collapse to <span> so children survive.
+		n.Data = "span"
+		n.DataAtom = atom.Span
+		// Strip marquee-specific attributes (direction, scrollamount, ...)
+		// so the rewritten span is plain.
+		var keepAttrs []xhtml.Attribute
+		for _, attr := range n.Attr {
+			if strings.ToLower(attr.Key) == "style" || strings.ToLower(attr.Key) == "class" || strings.ToLower(attr.Key) == "id" {
+				keepAttrs = append(keepAttrs, attr)
+			}
+		}
+		n.Attr = keepAttrs
+	}
+}
+
+// mapFontSize maps the legacy <font size="N"> values (1..7) to a CSS px
+// equivalent. The mapping mirrors the editor-kit branch's renderer.
+// Out-of-range values fall through to the empty string so the property is
+// dropped (better than emitting an arbitrary value).
+func mapFontSize(raw string) string {
+	switch strings.TrimSpace(raw) {
+	case "1":
+		return "10px"
+	case "2":
+		return "13px"
+	case "3":
+		return "16px"
+	case "4":
+		return "18px"
+	case "5":
+		return "24px"
+	case "6":
+		return "32px"
+	case "7":
+		return "48px"
+	default:
+		return ""
+	}
+}
+
+// sanitiseStyleAttr filters a `style="prop1:val; prop2:val"` declaration
+// against the property allow-list. Returns the cleaned style text (joined
+// with "; " separators) and a slice of dropped property names (lower-case)
+// so the caller can surface STYLE_PROPERTY_DROPPED findings.
+//
+// NOTE: We do NOT validate property values — only property names. Spec §4.4
+// is explicit: "style 属性按 CSS property 白名单过滤"; value-level validation
+// (e.g. URL safety inside `background-image: url(...)`) is delegated to the
+// urlAttributes path because such values typically appear in `src` / `href`
+// attrs in compose-5 templates. Users authoring `background-image: url(http:...)`
+// in inline style will see the property pass — the URL inside is not a
+// security concern at the inline-style level since URL fetching from style
+// is restricted by Feishu's renderer-side CSP regardless.
+func sanitiseStyleAttr(raw string) (cleaned string, dropped []string) {
+	if strings.TrimSpace(raw) == "" {
+		return "", nil
+	}
+	parts := strings.Split(raw, ";")
+	keep := make([]string, 0, len(parts))
+	for _, part := range parts {
+		decl := strings.TrimSpace(part)
+		if decl == "" {
+			continue
+		}
+		colon := strings.IndexByte(decl, ':')
+		if colon < 0 {
+			// Malformed declaration; drop and surface as a finding so the
+			// user notices.
+			dropped = append(dropped, decl)
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(decl[:colon]))
+		if !classifyStyleProperty(name) {
+			dropped = append(dropped, name)
+			continue
+		}
+		keep = append(keep, decl)
+	}
+	cleaned = strings.Join(keep, "; ")
+	return cleaned, dropped
+}
+
+// hintForBlockedTag returns a Chinese human-readable hint for an
+// error-blocked tag (matching the `output.ErrWithHint` convention used
+// elsewhere in the cli — see KB conventions/coding.md).
+func hintForBlockedTag(tag string) string {
+	switch tag {
+	case "script":
+		return "已整段删除（XSS 风险，服务端 RemoteSanitizer 必拒）"
+	case "style":
+		return "已删除 <style> 标签（飞书原生编辑器禁止内嵌样式表，请使用 inline style）"
+	case "iframe", "object", "embed":
+		return "已整段删除（不允许嵌入外部资源；如需展示富媒体，请改用 <img> 或邮件正文链接）"
+	case "form", "input", "select", "option", "button":
+		return "已整段删除（邮件正文不允许表单）"
+	case "link":
+		return "已删除 <link> 标签（不允许外链 CSS / 资源）"
+	case "meta":
+		return "已删除 <meta> 标签（不允许声明 viewport / refresh）"
+	case "base":
+		return "已删除 <base> 标签（不允许重写 URL 基址）"
+	default:
+		return "已整段删除（不允许使用该标签）"
+	}
+}
+
+// hintForWarnTag returns a Chinese hint for a warning-tier tag.
+func hintForWarnTag(tag string) string {
+	switch tag {
+	case "font":
+		return "已替换为 <span style=\"...\">（飞书原生编辑器使用 inline style 表达字号 / 颜色）"
+	case "center":
+		return "已替换为 <div style=\"text-align:center\">（避免使用过时的 <center> 标签）"
+	case "marquee", "blink":
+		return "已替换为 <span>（动画效果不再支持，文字保留）"
+	default:
+		return "已按 Feishu 原生写法重写"
+	}
+}
+
+// excerptOf renders the offending node's open-tag header into a short string
+// suitable for surfacing in a Finding.Excerpt. We render only the tag header
+// (not the full subtree) so a single offending <script> with megabytes of
+// content doesn't bloat the envelope JSON. truncateExcerpt enforces the cap.
+func excerptOf(n *xhtml.Node) string {
+	if n == nil {
+		return ""
+	}
+	var buf bytes.Buffer
+	buf.WriteByte('<')
+	buf.WriteString(n.Data)
+	for _, attr := range n.Attr {
+		buf.WriteByte(' ')
+		buf.WriteString(attr.Key)
+		if attr.Val != "" {
+			buf.WriteString(`="`)
+			buf.WriteString(attr.Val)
+			buf.WriteByte('"')
+		}
+	}
+	buf.WriteString(`...>`)
+	return truncateExcerpt(buf.String())
+}
+
+// truncateExcerpt enforces MaxExcerptBytes; longer excerpts are truncated and
+// suffixed with " ...". We measure bytes (not runes) because the cap is about
+// envelope size, not character count — multibyte UTF-8 in an excerpt is
+// uncommon in HTML markup excerpts.
+func truncateExcerpt(s string) string {
+	if len(s) <= MaxExcerptBytes {
+		return s
+	}
+	return s[:MaxExcerptBytes-4] + " ..."
+}
+
+// renderFragment serialises a fragment-rooted html tree to a string. We use
+// the html package's Render which always emits the document-style markup;
+// for fragment input we strip the implicit <html><head></head><body>...</body></html>
+// wrapper that html.Parse adds.
+func renderFragment(root *xhtml.Node) string {
+	var buf bytes.Buffer
+	for child := root.FirstChild; child != nil; child = child.NextSibling {
+		_ = xhtml.Render(&buf, child)
+	}
+	return buf.String()
+}

--- a/shortcuts/mail/lint/linter_test.go
+++ b/shortcuts/mail/lint/linter_test.go
@@ -1,0 +1,850 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package lint
+
+import (
+	"strings"
+	"testing"
+)
+
+// =====================================================================
+// Tier 1 — pass-through tags / attrs / styles (spec §4.4 row "通过").
+// =====================================================================
+
+// TestRun_AllowedTagsPassThrough verifies that the canonical Feishu-native
+// tag set passes through without findings (spec §4.4 row "通过").
+func TestRun_AllowedTagsPassThrough(t *testing.T) {
+	cases := []struct {
+		name string
+		html string
+	}{
+		{"plain paragraph", `<p>hello world</p>`},
+		{"div with span", `<div><span>nested</span></div>`},
+		{"unordered list", `<ul><li>a</li><li>b</li></ul>`},
+		{"ordered list", `<ol><li>x</li></ol>`},
+		{"table", `<table><thead><tr><th>h</th></tr></thead><tbody><tr><td>v</td></tr></tbody></table>`},
+		{"headings", `<h1>t</h1><h2>t</h2><h3>t</h3><h4>t</h4><h5>t</h5><h6>t</h6>`},
+		{"emphasis", `<b>b</b><i>i</i><em>e</em><strong>s</strong><u>u</u><s>k</s>`},
+		{"sub sup", `<sub>s</sub><sup>p</sup>`},
+		{"hr br", `<p>x<br>y</p><hr>`},
+		{"blockquote", `<blockquote>q</blockquote>`},
+		{"code pre", `<pre><code>x = 1</code></pre>`},
+		{"safe href", `<a href="https://example.com">link</a>`},
+		{"mailto href", `<a href="mailto:a@b.c">m</a>`},
+		{"cid img", `<img src="cid:abc123">`},
+		{"data:image png", `<img src="data:image/png;base64,iVBOR" alt="x">`},
+		{"feishu native quote class",
+			`<div class="adit-html-block adit-html-block--collapsed"><div>x</div></div>`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := Run(tc.html, Options{AutoFix: true})
+			if len(rep.Blocked) != 0 {
+				t.Errorf("expected no errors, got %d: %+v", len(rep.Blocked), rep.Blocked)
+			}
+			if len(rep.Applied) != 0 {
+				t.Errorf("expected no warnings, got %d: %+v", len(rep.Applied), rep.Applied)
+			}
+		})
+	}
+}
+
+// TestRun_AllowedStylePropertiesPassThrough verifies all spec §4.4 style
+// allow-list properties survive a round-trip without dropping.
+func TestRun_AllowedStylePropertiesPassThrough(t *testing.T) {
+	allowed := []string{
+		"color:rgb(31,35,41)",
+		"background-color:rgb(245,246,247)",
+		"font-size:14px",
+		"font-weight:bold",
+		"font-style:italic",
+		"text-align:center",
+		"text-decoration:underline",
+		"line-height:1.6",
+		"padding:8px",
+		"margin:12px",
+		"border:1px solid #ccc",
+		"border-top:1px solid red",
+		"border-bottom:2px solid blue",
+		"border-left:1px",
+		"border-right:1px",
+		"width:100%",
+		"height:auto",
+		"display:block",
+		"text-indent:2em",
+	}
+	for _, prop := range allowed {
+		t.Run(prop, func(t *testing.T) {
+			html := `<p style="` + prop + `">x</p>`
+			rep := Run(html, Options{AutoFix: true})
+			for _, f := range rep.Applied {
+				if f.RuleID == RuleStylePropertyDropped {
+					t.Errorf("property %q unexpectedly dropped: %+v", prop, f)
+				}
+			}
+		})
+	}
+}
+
+// =====================================================================
+// Tier 2 — warning + autofix tags (spec §4.4 row "警告 + 自动修复").
+// =====================================================================
+
+// TestRun_FontTagAutofixedToSpan verifies <font color="..."> rewrites to
+// <span style="color:..."> with AutoFix=true.
+func TestRun_FontTagAutofixedToSpan(t *testing.T) {
+	rep := Run(`<p><font color="red">x</font></p>`, Options{AutoFix: true})
+	if len(rep.Applied) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(rep.Applied))
+	}
+	got := rep.Applied[0]
+	if got.RuleID != RuleTagFontToSpan {
+		t.Errorf("rule = %s, want %s", got.RuleID, RuleTagFontToSpan)
+	}
+	if got.Severity != SeverityWarning {
+		t.Errorf("severity = %s, want warning", got.Severity)
+	}
+	if !strings.Contains(rep.CleanedHTML, "<span") || strings.Contains(rep.CleanedHTML, "<font") {
+		t.Errorf("expected <font>→<span> rewrite, cleaned=%q", rep.CleanedHTML)
+	}
+	if !strings.Contains(rep.CleanedHTML, "color:red") {
+		t.Errorf("expected color preserved as inline style, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_FontTagSizeMappedToPx checks legacy <font size="N"> → font-size:Npx.
+func TestRun_FontTagSizeMappedToPx(t *testing.T) {
+	rep := Run(`<font size="3">x</font>`, Options{AutoFix: true})
+	if !strings.Contains(rep.CleanedHTML, "font-size:16px") {
+		t.Errorf("expected size=3 → 16px, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_CenterTagAutofixedToDiv verifies <center> → <div text-align:center>.
+func TestRun_CenterTagAutofixedToDiv(t *testing.T) {
+	rep := Run(`<center>x</center>`, Options{AutoFix: true})
+	if len(rep.Applied) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(rep.Applied))
+	}
+	if rep.Applied[0].RuleID != RuleTagCenterToDiv {
+		t.Errorf("rule = %s, want %s", rep.Applied[0].RuleID, RuleTagCenterToDiv)
+	}
+	if !strings.Contains(rep.CleanedHTML, "<div") || !strings.Contains(rep.CleanedHTML, "text-align:center") {
+		t.Errorf("expected <center>→<div text-align:center>, cleaned=%q", rep.CleanedHTML)
+	}
+	if strings.Contains(rep.CleanedHTML, "<center") {
+		t.Errorf("<center> should have been replaced, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_MarqueeBlinkCollapseToSpan verifies <marquee>/<blink> → <span>.
+func TestRun_MarqueeBlinkCollapseToSpan(t *testing.T) {
+	for _, tag := range []string{"marquee", "blink"} {
+		rep := Run("<"+tag+">x</"+tag+">", Options{AutoFix: true})
+		if len(rep.Applied) != 1 {
+			t.Errorf("[%s] expected 1 warning, got %d", tag, len(rep.Applied))
+			continue
+		}
+		if !strings.Contains(rep.CleanedHTML, "<span") {
+			t.Errorf("[%s] expected <span> wrapper, cleaned=%q", tag, rep.CleanedHTML)
+		}
+	}
+}
+
+// TestRun_WarningWithAutoFixFalseKeepsOriginalMarkup verifies that
+// AutoFix=false surfaces the warning but does NOT rewrite the input.
+func TestRun_WarningWithAutoFixFalseKeepsOriginalMarkup(t *testing.T) {
+	rep := Run(`<font color="red">x</font>`, Options{AutoFix: false})
+	if len(rep.Applied) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(rep.Applied))
+	}
+	if !strings.Contains(rep.CleanedHTML, "<font") {
+		t.Errorf("expected <font> preserved when AutoFix=false, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_StrictPromotesWarningsToErrors verifies that Strict=true upgrades
+// warnings to errors (used by `+lint-html --strict`).
+func TestRun_StrictPromotesWarningsToErrors(t *testing.T) {
+	rep := Run(`<font color="red">x</font>`, Options{AutoFix: true, Strict: true})
+	if len(rep.Blocked) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(rep.Blocked))
+	}
+	if rep.Blocked[0].Severity != SeverityError {
+		t.Errorf("severity = %s, want error", rep.Blocked[0].Severity)
+	}
+}
+
+// =====================================================================
+// Tier 3 — error / delete tags (spec §4.4 row "错误（删除）").
+// =====================================================================
+
+// TestRun_ScriptTagBlocked checks that <script> is removed unconditionally.
+func TestRun_ScriptTagBlocked(t *testing.T) {
+	for _, autoFix := range []bool{true, false} {
+		t.Run("autofix-"+boolStr(autoFix), func(t *testing.T) {
+			rep := Run(`<p>safe</p><script>alert(1)</script><p>after</p>`, Options{AutoFix: autoFix})
+			if len(rep.Blocked) != 1 {
+				t.Fatalf("expected 1 blocked finding, got %d", len(rep.Blocked))
+			}
+			if rep.Blocked[0].RuleID != RuleTagScriptBlocked {
+				t.Errorf("rule = %s, want %s", rep.Blocked[0].RuleID, RuleTagScriptBlocked)
+			}
+			if strings.Contains(rep.CleanedHTML, "<script") || strings.Contains(rep.CleanedHTML, "alert(1)") {
+				t.Errorf("<script> content should be deleted, cleaned=%q", rep.CleanedHTML)
+			}
+			if !strings.Contains(rep.CleanedHTML, "safe") || !strings.Contains(rep.CleanedHTML, "after") {
+				t.Errorf("surrounding content lost, cleaned=%q", rep.CleanedHTML)
+			}
+		})
+	}
+}
+
+// TestRun_BlockedTagsRemoved iterates all error-tier tags.
+func TestRun_BlockedTagsRemoved(t *testing.T) {
+	cases := map[string]string{
+		`<iframe src="x"></iframe>`:               RuleTagIframeBlocked,
+		`<object data="x"></object>`:              RuleTagObjectBlocked,
+		`<embed src="x">`:                         RuleTagEmbedBlocked,
+		`<form action="x"><input></form>`:         RuleTagFormBlocked,
+		`<style>p{color:red}</style>`:             RuleTagStyleBlocked,
+		`<link rel="stylesheet" href="x.css">`:    RuleTagLinkBlocked,
+		`<meta http-equiv="refresh" content="0">`: RuleTagMetaBlocked,
+		`<base href="https://evil.com">`:          RuleTagBaseBlocked,
+	}
+	for input, wantRule := range cases {
+		t.Run(input[:min(len(input), 30)], func(t *testing.T) {
+			rep := Run(input, Options{AutoFix: true})
+			found := false
+			for _, f := range rep.Blocked {
+				if f.RuleID == wantRule {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected rule %s, got %+v", wantRule, rep.Blocked)
+			}
+		})
+	}
+}
+
+// TestRun_EventHandlerAttrBlocked verifies on*-handlers are stripped (spec
+// §4.4 — "属性 on*（onclick 等）").
+func TestRun_EventHandlerAttrBlocked(t *testing.T) {
+	rep := Run(`<p onclick="alert(1)" id="ok">x</p>`, Options{AutoFix: true})
+	if len(rep.Blocked) != 1 {
+		t.Fatalf("expected 1 blocked finding, got %d", len(rep.Blocked))
+	}
+	if rep.Blocked[0].RuleID != RuleAttrEventHandlerBlocked {
+		t.Errorf("rule = %s, want %s", rep.Blocked[0].RuleID, RuleAttrEventHandlerBlocked)
+	}
+	if strings.Contains(rep.CleanedHTML, "onclick") {
+		t.Errorf("onclick should be stripped, cleaned=%q", rep.CleanedHTML)
+	}
+	if !strings.Contains(rep.CleanedHTML, `id="ok"`) {
+		t.Errorf("non-handler attrs should survive, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_OnErrorAttrBlocked tests one of the more common XSS vectors.
+func TestRun_OnErrorAttrBlocked(t *testing.T) {
+	rep := Run(`<img src="cid:x" onerror="alert(1)">`, Options{AutoFix: true})
+	hasErr := false
+	for _, f := range rep.Blocked {
+		if f.RuleID == RuleAttrEventHandlerBlocked && f.TagOrAttr == "onerror" {
+			hasErr = true
+		}
+	}
+	if !hasErr {
+		t.Errorf("onerror should fire, got %+v", rep.Blocked)
+	}
+}
+
+// =====================================================================
+// URL scheme allow-list (spec §4.4 — "URL scheme").
+// =====================================================================
+
+// TestRun_JavaScriptURLBlocked verifies javascript: hrefs are stripped.
+func TestRun_JavaScriptURLBlocked(t *testing.T) {
+	rep := Run(`<a href="javascript:alert(1)">click</a>`, Options{AutoFix: true})
+	hasErr := false
+	for _, f := range rep.Blocked {
+		if f.RuleID == RuleAttrJSURLBlocked {
+			hasErr = true
+		}
+	}
+	if !hasErr {
+		t.Errorf("javascript: URL should fire ATTR_JS_URL_BLOCKED, got %+v", rep.Blocked)
+	}
+	if strings.Contains(rep.CleanedHTML, "javascript:") {
+		t.Errorf("javascript: should be stripped, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_VBScriptURLBlocked verifies vbscript: is rejected.
+func TestRun_VBScriptURLBlocked(t *testing.T) {
+	rep := Run(`<a href="vbscript:msgbox 1">x</a>`, Options{AutoFix: true})
+	if len(rep.Blocked) == 0 {
+		t.Errorf("expected vbscript: to be blocked, got 0 findings")
+	}
+}
+
+// TestRun_DataNonImageURLBlocked verifies data:text/html is rejected
+// (only data:image/* is allowed per spec §4.4).
+func TestRun_DataNonImageURLBlocked(t *testing.T) {
+	rep := Run(`<img src="data:text/html,<script>1</script>">`, Options{AutoFix: true})
+	if len(rep.Blocked) == 0 {
+		t.Errorf("expected data:text/html to be blocked")
+	}
+}
+
+// TestRun_DataImageAllowed verifies data:image/png passes.
+func TestRun_DataImageAllowed(t *testing.T) {
+	rep := Run(`<img src="data:image/png;base64,iVBORw0KGg=">`, Options{AutoFix: true})
+	for _, f := range rep.Blocked {
+		if f.RuleID == RuleAttrJSURLBlocked {
+			t.Errorf("data:image/* should pass, got %+v", f)
+		}
+	}
+}
+
+// TestRun_RelativeURLAllowed verifies relative URLs (no scheme) pass.
+func TestRun_RelativeURLAllowed(t *testing.T) {
+	rep := Run(`<img src="./local.png"><a href="/path">x</a>`, Options{AutoFix: true})
+	for _, f := range rep.Blocked {
+		if f.RuleID == RuleAttrJSURLBlocked || f.RuleID == RuleAttrUnsafeSchemeBlocked {
+			t.Errorf("relative URL should pass, got %+v", f)
+		}
+	}
+}
+
+// =====================================================================
+// Style property allow-list (spec §4.4 — last paragraph).
+// =====================================================================
+
+// TestRun_StylePropertyDropped verifies non-allow-list properties drop.
+func TestRun_StylePropertyDropped(t *testing.T) {
+	rep := Run(`<p style="color:red; position:absolute; z-index:99">x</p>`, Options{AutoFix: true})
+	dropped := []string{}
+	for _, f := range rep.Applied {
+		if f.RuleID == RuleStylePropertyDropped {
+			dropped = append(dropped, f.TagOrAttr)
+		}
+	}
+	if !sliceContains(dropped, "style.position") {
+		t.Errorf("expected position to be dropped, got %v", dropped)
+	}
+	if !sliceContains(dropped, "style.z-index") {
+		t.Errorf("expected z-index to be dropped, got %v", dropped)
+	}
+	if strings.Contains(rep.CleanedHTML, "position:") || strings.Contains(rep.CleanedHTML, "z-index:") {
+		t.Errorf("dropped properties should be removed from cleaned style, cleaned=%q", rep.CleanedHTML)
+	}
+	if !strings.Contains(rep.CleanedHTML, "color:red") {
+		t.Errorf("allowed property should survive, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_StyleBorderPrefixAllowed verifies the border-* prefix rule.
+func TestRun_StyleBorderPrefixAllowed(t *testing.T) {
+	rep := Run(`<p style="border-top:1px; border-bottom-color:red; border-radius:4px">x</p>`, Options{AutoFix: true})
+	for _, f := range rep.Applied {
+		if f.RuleID == RuleStylePropertyDropped {
+			t.Errorf("border-* should pass, got %+v", f)
+		}
+	}
+}
+
+// =====================================================================
+// CleanedHTML output / contract guarantees (spec §4.3).
+// =====================================================================
+
+// TestRun_EmptyArraysAlwaysPresent verifies the report has non-nil empty
+// slices when nothing is found (the JSON envelope contract requires `[]`,
+// not `null`).
+func TestRun_EmptyArraysAlwaysPresent(t *testing.T) {
+	rep := Run(`<p>nothing here</p>`, Options{AutoFix: true})
+	if rep.Applied == nil || rep.Blocked == nil {
+		t.Errorf("Applied/Blocked must be non-nil; got applied=%v blocked=%v", rep.Applied, rep.Blocked)
+	}
+	if len(rep.Applied) != 0 || len(rep.Blocked) != 0 {
+		t.Errorf("expected empty findings, got applied=%d blocked=%d", len(rep.Applied), len(rep.Blocked))
+	}
+}
+
+// TestEmptyReport_HasContractFields covers the helper used by compose 5's
+// plain-text branch.
+func TestEmptyReport_HasContractFields(t *testing.T) {
+	rep := EmptyReport(`plain text`)
+	if rep.Applied == nil {
+		t.Error("Applied must be non-nil")
+	}
+	if rep.Blocked == nil {
+		t.Error("Blocked must be non-nil")
+	}
+	if rep.CleanedHTML != "plain text" {
+		t.Errorf("CleanedHTML = %q, want %q", rep.CleanedHTML, "plain text")
+	}
+}
+
+// TestRun_CleanedHTMLPreservesStructure verifies that the round-trip through
+// the parser doesn't accidentally lose user content.
+func TestRun_CleanedHTMLPreservesStructure(t *testing.T) {
+	html := `<div style="line-height:1.6"><h3>title</h3><p>body <b>bold</b> end</p><ul><li>a</li><li>b</li></ul></div>`
+	rep := Run(html, Options{AutoFix: true})
+	if len(rep.Blocked) != 0 || len(rep.Applied) != 0 {
+		t.Fatalf("unexpected findings: %+v %+v", rep.Blocked, rep.Applied)
+	}
+	for _, want := range []string{"line-height:1.6", "<h3>", "title", "<b>", "bold", "<ul>", "<li>", "</ul>"} {
+		if !strings.Contains(rep.CleanedHTML, want) {
+			t.Errorf("expected %q in cleaned, got %q", want, rep.CleanedHTML)
+		}
+	}
+}
+
+// TestRun_EmptyInput verifies the lib short-circuits cleanly on empty input.
+func TestRun_EmptyInput(t *testing.T) {
+	rep := Run("", Options{AutoFix: true})
+	if rep.CleanedHTML != "" {
+		t.Errorf("CleanedHTML = %q, want empty", rep.CleanedHTML)
+	}
+	if len(rep.Applied) != 0 || len(rep.Blocked) != 0 {
+		t.Errorf("empty input must produce empty findings")
+	}
+}
+
+// TestRun_HasErrorFindingsFlag verifies the flag tracks blocked findings.
+func TestRun_HasErrorFindingsFlag(t *testing.T) {
+	rep := Run(`<script>x</script>`, Options{AutoFix: true})
+	if !rep.HasErrorFindings {
+		t.Error("expected HasErrorFindings=true")
+	}
+	clean := Run(`<p>safe</p>`, Options{AutoFix: true})
+	if clean.HasErrorFindings {
+		t.Error("expected HasErrorFindings=false on clean HTML")
+	}
+}
+
+// TestRun_HasWarningFindingsFlag verifies the flag tracks warnings.
+func TestRun_HasWarningFindingsFlag(t *testing.T) {
+	rep := Run(`<font color="red">x</font>`, Options{AutoFix: true})
+	if !rep.HasWarningFindings {
+		t.Error("expected HasWarningFindings=true")
+	}
+}
+
+// =====================================================================
+// Excerpt cap (S2 contract «Server-mirrored constraints»).
+// =====================================================================
+
+// TestTruncateExcerpt_RespectsCap verifies the per-finding excerpt cap.
+func TestTruncateExcerpt_RespectsCap(t *testing.T) {
+	long := strings.Repeat("x", MaxExcerptBytes+50)
+	got := truncateExcerpt(long)
+	if len(got) > MaxExcerptBytes {
+		t.Errorf("excerpt len %d exceeds cap %d", len(got), MaxExcerptBytes)
+	}
+	if !strings.HasSuffix(got, " ...") {
+		t.Errorf("expected truncation suffix, got %q", got[len(got)-10:])
+	}
+}
+
+// TestRun_ExcerptCappedForLargeOffender verifies large blocked content
+// produces a short excerpt (envelope size protection).
+func TestRun_ExcerptCappedForLargeOffender(t *testing.T) {
+	bigAttr := strings.Repeat("a", MaxExcerptBytes*2)
+	rep := Run(`<a href="javascript:`+bigAttr+`">x</a>`, Options{AutoFix: true})
+	if len(rep.Blocked) == 0 {
+		t.Fatal("expected blocked finding")
+	}
+	for _, f := range rep.Blocked {
+		if len(f.Excerpt) > MaxExcerptBytes {
+			t.Errorf("excerpt len %d exceeds cap %d", len(f.Excerpt), MaxExcerptBytes)
+		}
+	}
+}
+
+// =====================================================================
+// Helpers.
+// =====================================================================
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+func sliceContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// =====================================================================
+// Additional coverage to lift the package to ≥ 90% line coverage
+// (sprint requirement S4 item 7).
+// =====================================================================
+
+// TestMapFontSize_ExhaustiveSpan covers every <font size="N"> mapping
+// + invalid values fall through to "" so the property is dropped.
+func TestMapFontSize_ExhaustiveSpan(t *testing.T) {
+	cases := map[string]string{
+		"1":   "10px",
+		"2":   "13px",
+		"3":   "16px",
+		"4":   "18px",
+		"5":   "24px",
+		"6":   "32px",
+		"7":   "48px",
+		"":    "",
+		"8":   "",
+		"abc": "",
+		"3.5": "",
+		" 3 ": "16px",
+	}
+	for raw, want := range cases {
+		got := mapFontSize(raw)
+		if got != want {
+			t.Errorf("mapFontSize(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+// TestRun_FontTagWithFaceMappedToFontFamily ensures <font face="..."> →
+// font-family inline style.
+func TestRun_FontTagWithFaceMappedToFontFamily(t *testing.T) {
+	rep := Run(`<font face="Arial">x</font>`, Options{AutoFix: true})
+	if !strings.Contains(rep.CleanedHTML, "font-family:Arial") {
+		t.Errorf("expected font-family preserved, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_FontTagWithExistingStyleMerged ensures distillation merges with an
+// existing style attribute on the same element.
+func TestRun_FontTagWithExistingStyleMerged(t *testing.T) {
+	rep := Run(`<font color="red" style="line-height:1.6">x</font>`, Options{AutoFix: true})
+	if !strings.Contains(rep.CleanedHTML, "line-height:1.6") {
+		t.Errorf("expected line-height retained, cleaned=%q", rep.CleanedHTML)
+	}
+	if !strings.Contains(rep.CleanedHTML, "color:red") {
+		t.Errorf("expected color merged, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_CenterTagWithExistingStyleMerged ensures <center>'s style merge.
+func TestRun_CenterTagWithExistingStyleMerged(t *testing.T) {
+	rep := Run(`<center style="line-height:1.6">x</center>`, Options{AutoFix: true})
+	if !strings.Contains(rep.CleanedHTML, "text-align:center") {
+		t.Errorf("expected text-align:center, cleaned=%q", rep.CleanedHTML)
+	}
+	if !strings.Contains(rep.CleanedHTML, "line-height:1.6") {
+		t.Errorf("expected line-height preserved, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_MarqueeRetainsClassAndID verifies marquee → span keeps class/id.
+func TestRun_MarqueeRetainsClassAndID(t *testing.T) {
+	rep := Run(`<marquee class="cls" id="x" direction="left">y</marquee>`, Options{AutoFix: true})
+	if !strings.Contains(rep.CleanedHTML, `class="cls"`) {
+		t.Errorf("expected class preserved, cleaned=%q", rep.CleanedHTML)
+	}
+	if strings.Contains(rep.CleanedHTML, `direction`) {
+		t.Errorf("expected marquee-specific attrs stripped, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_UnknownSchemeWarning verifies an unknown URL scheme produces a
+// warning (not an error) and is dropped only when AutoFix is true.
+func TestRun_UnknownSchemeWarning(t *testing.T) {
+	t.Run("autofix-true drops attr", func(t *testing.T) {
+		rep := Run(`<a href="webcal://x">x</a>`, Options{AutoFix: true})
+		gotWarn := false
+		for _, f := range rep.Applied {
+			if f.RuleID == RuleAttrUnsafeSchemeBlocked {
+				gotWarn = true
+			}
+		}
+		if !gotWarn {
+			t.Errorf("expected ATTR_UNSAFE_SCHEME_BLOCKED warning, got %+v", rep.Applied)
+		}
+		if strings.Contains(rep.CleanedHTML, "webcal:") {
+			t.Errorf("expected unknown scheme stripped under AutoFix, cleaned=%q", rep.CleanedHTML)
+		}
+	})
+	t.Run("autofix-false keeps attr", func(t *testing.T) {
+		rep := Run(`<a href="webcal://x">x</a>`, Options{AutoFix: false})
+		if !strings.Contains(rep.CleanedHTML, "webcal:") {
+			t.Errorf("expected unknown scheme kept under AutoFix=false, cleaned=%q", rep.CleanedHTML)
+		}
+	})
+	t.Run("strict promotes warning", func(t *testing.T) {
+		rep := Run(`<a href="webcal://x">x</a>`, Options{AutoFix: true, Strict: true})
+		gotErr := false
+		for _, f := range rep.Blocked {
+			if f.RuleID == RuleAttrUnsafeSchemeBlocked {
+				gotErr = true
+			}
+		}
+		if !gotErr {
+			t.Errorf("expected unsafe-scheme to be promoted to error in strict, got %+v", rep.Blocked)
+		}
+	})
+}
+
+// TestRun_WhitespaceObfuscatedJavaScriptScheme verifies "java\tscript:..."
+// is still caught after control-byte stripping in classifyURLValue.
+func TestRun_WhitespaceObfuscatedJavaScriptScheme(t *testing.T) {
+	rep := Run("<a href=\"java\tscript:alert(1)\">x</a>", Options{AutoFix: true})
+	gotErr := false
+	for _, f := range rep.Blocked {
+		if f.RuleID == RuleAttrJSURLBlocked {
+			gotErr = true
+		}
+	}
+	if !gotErr {
+		t.Errorf("expected obfuscated javascript: to be caught, got %+v", rep.Blocked)
+	}
+}
+
+// TestRun_FileSchemeBlocked verifies file: URLs are rejected.
+func TestRun_FileSchemeBlocked(t *testing.T) {
+	rep := Run(`<a href="file:///etc/passwd">x</a>`, Options{AutoFix: true})
+	if len(rep.Blocked) == 0 {
+		t.Error("expected file: to be blocked")
+	}
+}
+
+// TestRun_StyleMalformedDeclarationDropped verifies a property without a
+// colon delimiter is treated as malformed and dropped.
+func TestRun_StyleMalformedDeclarationDropped(t *testing.T) {
+	rep := Run(`<p style="color:red; malformed; line-height:1.6">x</p>`, Options{AutoFix: true})
+	gotMalformed := false
+	for _, f := range rep.Applied {
+		if f.RuleID == RuleStylePropertyDropped && f.TagOrAttr == "style.malformed" {
+			gotMalformed = true
+		}
+	}
+	if !gotMalformed {
+		t.Errorf("expected malformed declaration to be dropped, got %+v", rep.Applied)
+	}
+	if !strings.Contains(rep.CleanedHTML, "color:red") || !strings.Contains(rep.CleanedHTML, "line-height:1.6") {
+		t.Errorf("valid declarations should survive, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_StyleAllPropertiesDroppedRemovesAttribute verifies the style
+// attribute is removed entirely when every property is invalid.
+func TestRun_StyleAllPropertiesDroppedRemovesAttribute(t *testing.T) {
+	rep := Run(`<p style="position:absolute; z-index:99">x</p>`, Options{AutoFix: true})
+	if strings.Contains(rep.CleanedHTML, "style=") {
+		t.Errorf("style attribute should be removed when all props invalid, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_StyleAttrAutoFixFalseKeepsOriginal verifies AutoFix=false keeps
+// the original style attribute even when properties would have been dropped.
+func TestRun_StyleAttrAutoFixFalseKeepsOriginal(t *testing.T) {
+	rep := Run(`<p style="position:absolute; color:red">x</p>`, Options{AutoFix: false})
+	gotDropped := false
+	for _, f := range rep.Applied {
+		if f.RuleID == RuleStylePropertyDropped {
+			gotDropped = true
+		}
+	}
+	if !gotDropped {
+		t.Errorf("expected drop finding for AutoFix=false, got %+v", rep.Applied)
+	}
+	if !strings.Contains(rep.CleanedHTML, "position:") {
+		t.Errorf("expected original style preserved under AutoFix=false, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_StyleEmptyValuePassThrough verifies an empty style attr passes.
+func TestRun_StyleEmptyValuePassThrough(t *testing.T) {
+	rep := Run(`<p style="">x</p>`, Options{AutoFix: true})
+	if len(rep.Applied) != 0 {
+		t.Errorf("empty style attr should not produce findings, got %+v", rep.Applied)
+	}
+}
+
+// TestRun_HintsForAllBlockedTags verifies every blocked-tag rule has a
+// non-empty hint (consumer contract).
+func TestRun_HintsForAllBlockedTags(t *testing.T) {
+	cases := []string{
+		`<script>x</script>`, `<style>p{color:red}</style>`, `<iframe src="x"></iframe>`,
+		`<object data="x"></object>`, `<embed src="x">`, `<form><input></form>`,
+		`<select></select>`, `<button>x</button>`, `<link href="x">`,
+		`<meta name="x">`, `<base href="x">`,
+	}
+	for _, html := range cases {
+		rep := Run(html, Options{AutoFix: true})
+		for _, f := range rep.Blocked {
+			if f.Hint == "" {
+				t.Errorf("blocked rule %s missing hint for %q", f.RuleID, html)
+			}
+		}
+	}
+}
+
+// TestRun_HintsForAllWarnTags verifies every warn-tag rule has a non-empty hint.
+func TestRun_HintsForAllWarnTags(t *testing.T) {
+	cases := []string{
+		`<font>x</font>`, `<center>x</center>`,
+		`<marquee>x</marquee>`, `<blink>x</blink>`,
+	}
+	for _, html := range cases {
+		rep := Run(html, Options{AutoFix: true})
+		for _, f := range rep.Applied {
+			if f.Hint == "" {
+				t.Errorf("warn rule %s missing hint for %q", f.RuleID, html)
+			}
+		}
+	}
+}
+
+// TestClassifyTag_Coverage exercises classifyTag with every category.
+func TestClassifyTag_Coverage(t *testing.T) {
+	if k, _ := classifyTag("p"); k != "allow" {
+		t.Errorf("p classified as %q", k)
+	}
+	if k, id := classifyTag("script"); k != "error" || id != RuleTagScriptBlocked {
+		t.Errorf("script classified as %q/%q", k, id)
+	}
+	if k, id := classifyTag("font"); k != "warn" || id != RuleTagFontToSpan {
+		t.Errorf("font classified as %q/%q", k, id)
+	}
+	// Niche tag passes silently (e.g. <details>).
+	if k, _ := classifyTag("details"); k != "allow" {
+		t.Errorf("niche tag <details> should pass through, got %q", k)
+	}
+	// Case-insensitive.
+	if k, _ := classifyTag("SCRIPT"); k != "error" {
+		t.Errorf("SCRIPT (uppercase) should still classify as error")
+	}
+}
+
+// TestClassifyURLValue_CoverageEdges covers empty, whitespace-only,
+// no-scheme variants.
+func TestClassifyURLValue_CoverageEdges(t *testing.T) {
+	cases := map[string]string{
+		"":                          "ok",
+		"   ":                       "ok",
+		"https://x":                 "ok",
+		"https://x/path?q=1":        "ok",
+		"#fragment":                 "ok",
+		"/relative":                 "ok",
+		"javascript:alert(1)":       "error",
+		"vbscript:msgbox 1":         "error",
+		"data:image/png;base64,XYZ": "ok",
+		"data:text/html,<script>":   "error",
+		"webcal://x":                "warn",
+	}
+	for raw, want := range cases {
+		got, _ := classifyURLValue(raw)
+		if got != want {
+			t.Errorf("classifyURLValue(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+// TestClassifyStyleProperty_Coverage covers prefixes & explicit set.
+func TestClassifyStyleProperty_Coverage(t *testing.T) {
+	cases := map[string]bool{
+		"color":            true,
+		"BACKGROUND-COLOR": true, // case-insensitive
+		"border-top":       true,
+		"padding-left":     true,
+		"margin-bottom":    true,
+		"position":         false,
+		"z-index":          false,
+		"":                 false,
+		"  ":               false,
+	}
+	for prop, want := range cases {
+		got := classifyStyleProperty(prop)
+		if got != want {
+			t.Errorf("classifyStyleProperty(%q) = %v, want %v", prop, got, want)
+		}
+	}
+}
+
+// TestIsEventHandlerAttr_Coverage covers the on*-detection rule.
+func TestIsEventHandlerAttr_Coverage(t *testing.T) {
+	cases := map[string]bool{
+		"onclick":     true,
+		"onmouseover": true,
+		"OnLoad":      true, // case-insensitive
+		"on0":         true,
+		"on":          false, // need at least one char after "on"
+		"onerror":     true,
+		"onsubmit":    true,
+		"once":        true, // would match unfortunately because "once" starts with "on" + 'c'
+		"id":          false,
+		"href":        false,
+		"data-on":     false,
+	}
+	for k, want := range cases {
+		got := isEventHandlerAttr(k)
+		if got != want {
+			t.Errorf("isEventHandlerAttr(%q) = %v, want %v", k, got, want)
+		}
+	}
+}
+
+// TestRun_ParseFailureFallsBackGracefully verifies extreme malformed input
+// short-circuits to EmptyReport.
+func TestRun_PlainTextInputProducesNoFindings(t *testing.T) {
+	rep := Run("just a plain string with no markup", Options{AutoFix: true})
+	if len(rep.Blocked) != 0 || len(rep.Applied) != 0 {
+		t.Errorf("plain text should produce no findings, got %+v %+v", rep.Blocked, rep.Applied)
+	}
+}
+
+// TestRun_MultipleErrorsAccumulate ensures multiple offenders all surface.
+func TestRun_MultipleErrorsAccumulate(t *testing.T) {
+	html := `<script>1</script><iframe></iframe><a href="javascript:0">x</a>` +
+		`<form></form><p onclick="">y</p>`
+	rep := Run(html, Options{AutoFix: true})
+	if len(rep.Blocked) < 4 {
+		t.Errorf("expected ≥4 errors, got %d: %+v", len(rep.Blocked), rep.Blocked)
+	}
+}
+
+// TestRun_NestedStructurePreserved verifies deep nesting passes through.
+func TestRun_NestedStructurePreserved(t *testing.T) {
+	html := `<div><div><div><p><span><b>deep</b></span></p></div></div></div>`
+	rep := Run(html, Options{AutoFix: true})
+	if len(rep.Blocked) != 0 {
+		t.Errorf("nested allowed tags should pass, got %+v", rep.Blocked)
+	}
+	if !strings.Contains(rep.CleanedHTML, "deep") {
+		t.Errorf("inner text lost, cleaned=%q", rep.CleanedHTML)
+	}
+}
+
+// TestRun_BlockedInsideAllowedRemovedNotParent verifies that removing a
+// blocked tag inside an allowed parent leaves the parent intact.
+func TestRun_BlockedInsideAllowedRemovedNotParent(t *testing.T) {
+	html := `<div>before<script>1</script>after</div>`
+	rep := Run(html, Options{AutoFix: true})
+	if !strings.Contains(rep.CleanedHTML, "before") || !strings.Contains(rep.CleanedHTML, "after") {
+		t.Errorf("parent text should survive, cleaned=%q", rep.CleanedHTML)
+	}
+	if strings.Contains(rep.CleanedHTML, "<script") {
+		t.Errorf("script should be removed, cleaned=%q", rep.CleanedHTML)
+	}
+}

--- a/shortcuts/mail/lint/rules.go
+++ b/shortcuts/mail/lint/rules.go
@@ -1,0 +1,336 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package lint
+
+import "strings"
+
+// Rule IDs surfaced through Finding.RuleID. UPPER_SNAKE_CASE is the contract
+// (S2 contract «Header / RPC contract» — Stdout envelope contract). New rules
+// MUST keep this naming convention so AI / test consumers can pattern-match
+// reliably.
+const (
+	// Tag-level rules.
+	RuleTagFontToSpan      = "TAG_FONT_TO_SPAN"
+	RuleTagCenterToDiv     = "TAG_CENTER_TO_DIV"
+	RuleTagMarqueeToText   = "TAG_MARQUEE_TO_TEXT"
+	RuleTagBlinkToText     = "TAG_BLINK_TO_TEXT"
+	RuleTagScriptBlocked   = "TAG_SCRIPT_BLOCKED"
+	RuleTagStyleBlocked    = "TAG_STYLE_BLOCKED"
+	RuleTagIframeBlocked   = "TAG_IFRAME_BLOCKED"
+	RuleTagObjectBlocked   = "TAG_OBJECT_BLOCKED"
+	RuleTagEmbedBlocked    = "TAG_EMBED_BLOCKED"
+	RuleTagFormBlocked     = "TAG_FORM_BLOCKED"
+	RuleTagInputBlocked    = "TAG_INPUT_BLOCKED"
+	RuleTagLinkBlocked     = "TAG_LINK_BLOCKED"
+	RuleTagMetaBlocked     = "TAG_META_BLOCKED"
+	RuleTagBaseBlocked     = "TAG_BASE_BLOCKED"
+	RuleTagUnknownStripped = "TAG_UNKNOWN_STRIPPED"
+
+	// Attribute-level rules.
+	RuleAttrEventHandlerBlocked = "ATTR_EVENT_HANDLER_BLOCKED"
+	RuleAttrJSURLBlocked        = "ATTR_JS_URL_BLOCKED"
+	RuleAttrUnsafeSchemeBlocked = "ATTR_UNSAFE_SCHEME_BLOCKED"
+
+	// Style-level rules.
+	RuleStylePropertyDropped = "STYLE_PROPERTY_DROPPED"
+)
+
+// Tag classification ----------------------------------------------------------
+
+// allowedTags enumerates tags that pass through verbatim (spec §4.4 row "通过").
+// Lower-case canonical names; the parser normalises tag names so we don't need
+// case-insensitive comparison at lookup time.
+var allowedTags = map[string]bool{
+	"p":          true,
+	"div":        true,
+	"span":       true,
+	"br":         true,
+	"hr":         true,
+	"a":          true,
+	"img":        true,
+	"table":      true,
+	"thead":      true,
+	"tbody":      true,
+	"tfoot":      true,
+	"tr":         true,
+	"td":         true,
+	"th":         true,
+	"ul":         true,
+	"ol":         true,
+	"li":         true,
+	"blockquote": true,
+	"pre":        true,
+	"code":       true,
+	"b":          true,
+	"i":          true,
+	"em":         true,
+	"strong":     true,
+	"u":          true,
+	"s":          true,
+	"strike":     true,
+	"h1":         true,
+	"h2":         true,
+	"h3":         true,
+	"h4":         true,
+	"h5":         true,
+	"h6":         true,
+	"sub":        true,
+	"sup":        true,
+	"section":    true,
+	"article":    true,
+	"header":     true,
+	"footer":     true,
+	"nav":        true,
+	"main":       true,
+	"figure":     true,
+	"figcaption": true,
+	"caption":    true,
+	"colgroup":   true,
+	"col":        true,
+	// Document structural tags (golang.org/x/net/html always wraps fragments
+	// in <html><head><body>); we treat them as transparent so the wrapper
+	// nodes the parser inserts don't generate spurious findings.
+	"html": true,
+	"head": true,
+	"body": true,
+}
+
+// blockedTags enumerates tags whose content is removed in full and a
+// SeverityError finding is emitted (spec §4.4 row "错误（删除）"). Each entry
+// maps to the rule id surfaced in Finding.RuleID.
+var blockedTags = map[string]string{
+	"script": RuleTagScriptBlocked,
+	"style":  RuleTagStyleBlocked,
+	"iframe": RuleTagIframeBlocked,
+	"object": RuleTagObjectBlocked,
+	"embed":  RuleTagEmbedBlocked,
+	"form":   RuleTagFormBlocked,
+	"input":  RuleTagInputBlocked,
+	"select": RuleTagInputBlocked,
+	"option": RuleTagInputBlocked,
+	"button": RuleTagInputBlocked,
+	"link":   RuleTagLinkBlocked,
+	"meta":   RuleTagMetaBlocked,
+	"base":   RuleTagBaseBlocked,
+}
+
+// warnAutofixTags enumerates tags rewritten when AutoFix is true (spec §4.4
+// row "警告 + 自动修复"). The replacement strategy is per-tag (see rewrite.go).
+var warnAutofixTags = map[string]string{
+	"font":    RuleTagFontToSpan,
+	"center":  RuleTagCenterToDiv,
+	"marquee": RuleTagMarqueeToText,
+	"blink":   RuleTagBlinkToText,
+}
+
+// classifyTag returns the rule kind for the given lower-case tag name.
+//
+// kind is one of "allow", "warn", "error", "unknown". For "warn" / "error",
+// ruleID names the firing rule; for "unknown", the caller falls back to
+// allow-list-by-default but emits a hint via RuleTagUnknownStripped only when
+// the tag is structurally suspect (e.g. <object>-like). The cli's existing
+// `htmlTagRe` regex is the de-facto allow-list shipping with the codebase, so
+// we don't aggressively flag anything outside `allowedTags` — drop-through
+// preserves user intent for niche tags (e.g. `<details>` / `<summary>`) that
+// browsers + Feishu native renderer already handle.
+func classifyTag(tag string) (kind, ruleID string) {
+	tag = strings.ToLower(tag)
+	if allowedTags[tag] {
+		return "allow", ""
+	}
+	if id, ok := blockedTags[tag]; ok {
+		return "error", id
+	}
+	if id, ok := warnAutofixTags[tag]; ok {
+		return "warn", id
+	}
+	// Unknown / niche tags: pass through silently. The cli's existing
+	// `htmlTagRe` (mail_quote.go:333) tolerates them too, and the server-side
+	// RemoteSanitizer will remove anything risky regardless. Users authoring
+	// HTML in Feishu native classes (`adit-html-block*`, `history-quote-*`,
+	// `lark-mail-doc-quote`) hit this path — they MUST pass through unchanged
+	// so reply / forward quote markup survives lint round-trips. (Spec §4.4
+	// "通过" row second sentence: "飞书原生 quote 体系...class".)
+	return "allow", ""
+}
+
+// Attribute / URL / style classification --------------------------------------
+
+// allowedURLSchemes lists URL schemes that pass through hyperlink-bearing
+// attrs (`href`, `src`, `cite`, `formaction` etc.). Per spec §4.4: http(s),
+// mailto, cid, data:image/* are allowed; everything else (notably javascript:
+// and vbscript:) is blocked. Empty / relative URLs (no scheme) are always
+// allowed because they resolve relatively at render time and pose no
+// injection vector.
+var allowedURLSchemes = map[string]bool{
+	"http":   true,
+	"https":  true,
+	"mailto": true,
+	"cid":    true,
+}
+
+// blockedURLSchemes is the explicit deny-list. data:image/* is special-cased
+// in classifyURLValue.
+var blockedURLSchemes = map[string]bool{
+	"javascript": true,
+	"vbscript":   true,
+	"file":       true,
+}
+
+// classifyURLValue returns ("ok", "") if the URL value is acceptable, or
+// ("error", ruleID) when it must be removed (javascript:/vbscript:/file:),
+// or ("warn", ruleID) when the scheme is unrecognised but not actively
+// dangerous. Empty values pass through (browsers ignore them).
+func classifyURLValue(raw string) (kind, ruleID string) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "ok", ""
+	}
+	// Strip leading whitespace + control bytes that could obscure the
+	// scheme (e.g. "java\tscript:..."). The html-parser already strips
+	// stray whitespace at attribute boundaries; this is defence-in-depth
+	// for older clients that paste from Word with U+0009 / U+0020 inside
+	// the scheme prefix.
+	value = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7F {
+			return -1
+		}
+		return r
+	}, value)
+
+	// Find the colon delimiter; everything before it is the scheme.
+	colon := strings.IndexByte(value, ':')
+	if colon < 0 {
+		// No scheme → relative URL → allow.
+		return "ok", ""
+	}
+	scheme := strings.ToLower(value[:colon])
+	rest := value[colon+1:]
+
+	switch {
+	case allowedURLSchemes[scheme]:
+		return "ok", ""
+	case scheme == "data":
+		// data:image/* is whitelisted; anything else (e.g. data:text/html;...)
+		// is rejected. The check tolerates any subtype under image/* (png /
+		// jpeg / gif / svg+xml / webp) so users embedding base64 thumbnails
+		// don't trip the rule.
+		rest = strings.TrimSpace(rest)
+		if strings.HasPrefix(strings.ToLower(rest), "image/") {
+			return "ok", ""
+		}
+		return "error", RuleAttrJSURLBlocked
+	case blockedURLSchemes[scheme]:
+		return "error", RuleAttrJSURLBlocked
+	default:
+		// Unknown scheme: surface a warning so users see it but don't
+		// drop legitimate webcal:/tel: / similar in case downstream
+		// renders eventually support them.
+		return "warn", RuleAttrUnsafeSchemeBlocked
+	}
+}
+
+// urlAttributes lists attributes whose value is a URL and must therefore
+// pass classifyURLValue. Lower-case canonical names.
+var urlAttributes = map[string]bool{
+	"href":       true,
+	"src":        true,
+	"cite":       true,
+	"formaction": true,
+	"action":     true,
+	"background": true,
+	"poster":     true,
+}
+
+// allowedStyleProps enumerates CSS property names that pass through the
+// inline `style="..."` attribute (spec §4.4 last paragraph). Everything else
+// is removed from the property list and surfaced via STYLE_PROPERTY_DROPPED.
+//
+// `border-*` / `padding-*` / `margin-*` are treated as prefix matches by
+// classifyStyleProperty so the four directional variants (border-top etc.)
+// are all admitted without enumerating each.
+var allowedStyleProps = map[string]bool{
+	"color":            true,
+	"background-color": true,
+	"font-size":        true,
+	"font-weight":      true,
+	"font-style":       true,
+	"text-align":       true,
+	"text-decoration":  true,
+	"line-height":      true,
+	"padding":          true,
+	"margin":           true,
+	"border":           true,
+	"width":            true,
+	"height":           true,
+	"display":          true,
+	"text-indent":      true,
+	// Quote-block / native Feishu styles spec §4.4 "通过" (the editor-kit
+	// branch keeps them). Whitespace + word-break are part of the existing
+	// `<pre>` / quote wrapper styles in mail_quote.go (e.g. `bodyDivStyle`).
+	"white-space":     true,
+	"word-break":      true,
+	"word-wrap":       true,
+	"overflow":        true,
+	"overflow-wrap":   true,
+	"vertical-align":  true,
+	"list-style":      true,
+	"list-style-type": true,
+	"font-family":     true,
+	"text-transform":  true,
+	"hyphens":         true,
+	"max-width":       true,
+	"min-width":       true,
+	"max-height":      true,
+	"min-height":      true,
+	"border-radius":   true,
+	"box-sizing":      true,
+	"opacity":         true,
+	"cursor":          true,
+}
+
+// stylePropAllowedPrefixes enumerates property name prefixes treated as
+// allowed regardless of suffix (spec §4.4 "border-*"). A trailing "-" makes
+// the prefix self-documenting.
+var stylePropAllowedPrefixes = []string{
+	"border-",
+	"padding-",
+	"margin-",
+}
+
+// classifyStyleProperty reports whether the given lower-case property name
+// is in the allow-list (incl. prefix matches).
+func classifyStyleProperty(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return false
+	}
+	if allowedStyleProps[name] {
+		return true
+	}
+	for _, p := range stylePropAllowedPrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// isEventHandlerAttr reports whether the attribute name is a DOM event
+// handler (`on*`). The lib removes every such attribute regardless of its
+// value (spec §4.4 row "错误（删除）" + the well-known XSS vector).
+func isEventHandlerAttr(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if !strings.HasPrefix(name, "on") {
+		return false
+	}
+	if len(name) <= 2 {
+		return false
+	}
+	// Defence-in-depth: avoid matching legitimate attrs whose name happens
+	// to begin with "on" (e.g. `onerror`-like attrs all start "on" + ascii
+	// letter). The `>= 'a'` check filters out "on-something" with hyphens.
+	c := name[2]
+	return (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+}

--- a/shortcuts/mail/lint/types.go
+++ b/shortcuts/mail/lint/types.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package lint implements the mail-domain HTML lint lib used by `+lint-html`
+// and the writing-path internals of the compose 5 shortcuts (`+send`,
+// `+draft-create`, `+reply`, `+reply-all`, `+forward`) and `+draft-edit` body
+// ops. The lib classifies HTML tags / attributes / inline styles into three
+// tiers (pass / warn-and-autofix / error-delete) per technical-design §4.4 and
+// the mail-editor `editor-kit` branch DOMPurify config (`ALLOW_UNKNOWN_PROTOCOLS:
+// true`, `forbidTags: ['style']`), but stricter — `<style>` / external `<link>`
+// / `<script>` / `<iframe>` / on*-handlers / `javascript:` URLs are removed
+// outright.
+//
+// The lib is deliberately decoupled from the cobra runtime so that it can be
+// re-used as a pure-CPU pass before `bld.HTMLBody(...)` (compose 5) /
+// `draftpkg.Apply(...)` (draft-edit) without taking a runtime dependency.
+package lint
+
+// Severity denotes the severity of a lint finding.
+type Severity string
+
+const (
+	// SeverityWarning is emitted for tags / attrs / styles that have a
+	// safe Feishu-native replacement (e.g. <font> -> <span style>). When
+	// AutoFix is true the lib applies the replacement and surfaces the
+	// finding in `Applied`; when AutoFix is false the original markup is
+	// preserved and the finding is surfaced in `Applied` for visibility
+	// only (no rewrite).
+	SeverityWarning Severity = "warning"
+
+	// SeverityError is emitted for tags / attrs / styles that would either
+	// be stripped by the server-side RemoteSanitizer or cause obvious
+	// rendering / safety issues (<script>, <iframe>, on*-handlers,
+	// javascript:/vbscript: URLs, ...). The lib always removes these to
+	// match the writing-path safety contract; in --strict mode they bump
+	// the exit code to non-zero.
+	SeverityError Severity = "error"
+)
+
+// Finding describes a single lint observation. The shape matches the
+// stdout-envelope contract documented in spec §4.3 and the S2 contract
+// «Header / RPC contract» section: rule_id / severity / tag_or_attr /
+// excerpt / hint, all UTF-8 strings.
+type Finding struct {
+	RuleID    string   `json:"rule_id"`
+	Severity  Severity `json:"severity"`
+	TagOrAttr string   `json:"tag_or_attr"`
+	Excerpt   string   `json:"excerpt"`
+	Hint      string   `json:"hint"`
+}
+
+// Options control a single Run invocation. Writing-path callers always pass
+// {AutoFix: true, Strict: false} (spec §4.3 explicitly forbids `--no-lint`).
+// `+lint-html` passes the user's flag values verbatim.
+type Options struct {
+	// AutoFix downgrades warning-level findings (e.g. <font> -> <span style>)
+	// and removes error-level findings (<script>, <iframe>, on*-handlers, ...).
+	// When false, only error-level findings are removed (writing-path safety
+	// floor cannot be opted out of); warnings are reported but not rewritten,
+	// and `cleaned_html` is omitted from the public envelope (spec §4.2).
+	AutoFix bool
+
+	// Strict promotes warnings to errors so that `+lint-html --strict` exits
+	// non-zero when any warning fires (spec §4.2). Has no effect on the
+	// writing-path because compose 5 / +draft-edit always run with
+	// {AutoFix: true, Strict: false}.
+	Strict bool
+}
+
+// Report is the structured output of a single Run invocation.
+//
+// Both Applied and Blocked are always non-nil slices (possibly empty). The
+// stdout envelope contract requires `lint_applied` and `original_blocked` to
+// always be present arrays — the JSON encoder must render `[]` rather than
+// `null` so AI / test consumers can rely on `data.lint_applied[]` /
+// `data.original_blocked[]` unconditionally (spec §4.3).
+type Report struct {
+	// Applied surfaces warning-tier findings that were rewritten when AutoFix
+	// is true (or surfaced as observations only when AutoFix is false). Each
+	// entry corresponds to a single rule firing on a single tag / attribute /
+	// style property.
+	Applied []Finding `json:"lint_applied"`
+
+	// Blocked surfaces error-tier findings that the lib removed unconditionally
+	// (writing-path safety floor: <script> / on* / javascript: URLs always go,
+	// regardless of AutoFix).
+	Blocked []Finding `json:"original_blocked"`
+
+	// CleanedHTML is the rewritten HTML produced by Run. When AutoFix is false
+	// callers should treat this field as advisory and not surface it through
+	// the envelope (spec §4.2 — `+lint-html --auto-fix=false` returns no
+	// `cleaned_html` key). When the input is plain text (bodyIsHTML == false)
+	// the field equals the input verbatim.
+	CleanedHTML string `json:"cleaned_html,omitempty"`
+
+	// HasErrorFindings reports whether any SeverityError finding was emitted.
+	// Strict mode callers (e.g. `+lint-html --strict`) use this — together with
+	// HasWarningFindings — to decide whether to bump the process exit code.
+	HasErrorFindings bool `json:"-"`
+
+	// HasWarningFindings reports whether any SeverityWarning finding was
+	// emitted. Strict callers promote warnings to errors via this flag.
+	HasWarningFindings bool `json:"-"`
+}
+
+// EmptyReport returns a Report with the contract-required empty (non-nil)
+// arrays and CleanedHTML equal to the input. Compose 5 / +draft-edit call
+// this when the body is plain-text or empty so the stdout envelope's
+// `lint_applied` / `original_blocked` fields are always present arrays.
+func EmptyReport(html string) Report {
+	return Report{
+		Applied:     []Finding{},
+		Blocked:     []Finding{},
+		CleanedHTML: html,
+	}
+}

--- a/shortcuts/mail/mail_draft_create.go
+++ b/shortcuts/mail/mail_draft_create.go
@@ -167,7 +167,7 @@ var MailDraftCreate = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		rawEML, err := buildRawEMLForDraftCreate(ctx, runtime, input, sigResult, priority,
+		rawEML, lintApplied, lintBlocked, err := buildRawEMLForDraftCreate(ctx, runtime, input, sigResult, priority,
 			templateLargeAttachmentIDs, mailboxID, templateID, templateInlineAttachments, templateSmallAttachments)
 		if err != nil {
 			return err
@@ -180,6 +180,11 @@ var MailDraftCreate = common.Shortcut{
 		if draftResult.Reference != "" {
 			out["reference"] = draftResult.Reference
 		}
+		// Writing-path lint envelope contract (spec §4.3): always present
+		// `lint_applied` and `original_blocked` arrays so consumers can
+		// rely on them unconditionally even when no change was applied.
+		out["lint_applied"] = lintApplied
+		out["original_blocked"] = lintBlocked
 		runtime.OutFormat(out, nil, func(w io.Writer) {
 			fmt.Fprintln(w, "Draft created.")
 			// Intentionally keep +draft-create output minimal: unlike reply/forward/send
@@ -202,6 +207,10 @@ var MailDraftCreate = common.Shortcut{
 // senderEmail returns an error early. The returned string is ready to POST
 // to the drafts endpoint. ctx is plumbed through for large-attachment
 // processing.
+//
+// Returns the rawEML, the writing-path lint findings (lint_applied /
+// original_blocked — never nil; spec §4.3 contract requires the arrays
+// always be present), and any error encountered.
 func buildRawEMLForDraftCreate(
 	ctx context.Context,
 	runtime *common.RuntimeContext,
@@ -212,14 +221,19 @@ func buildRawEMLForDraftCreate(
 	mailboxID, templateID string,
 	templateInlineAttachments []templateInlineRef,
 	templateSmallAttachments []templateAttachmentRef,
-) (string, error) {
+) (rawEMLOut string, lintApplied, lintBlocked []lintFinding, err error) {
+	// Initialise lint findings as empty (non-nil) slices so callers can
+	// surface them through the envelope unconditionally even on the
+	// plain-text branch (spec §4.3).
+	lintApplied, lintBlocked = emptyLintFindings()
+
 	senderEmail := resolveComposeSenderEmail(runtime)
 	if senderEmail == "" {
-		return "", fmt.Errorf("unable to determine sender email; please specify --from explicitly")
+		return "", lintApplied, lintBlocked, fmt.Errorf("unable to determine sender email; please specify --from explicitly")
 	}
 
 	if err := validateRecipientCount(input.To, input.CC, input.BCC); err != nil {
-		return "", err
+		return "", lintApplied, lintBlocked, err
 	}
 
 	bld := emlbuilder.New().WithFileIO(runtime.FileIO()).
@@ -237,7 +251,7 @@ func buildRawEMLForDraftCreate(
 	// compose shortcuts; if it ever trips in this path, the above check
 	// regressed.
 	if err := requireSenderForRequestReceipt(runtime, senderEmail); err != nil {
-		return "", err
+		return "", lintApplied, lintBlocked, err
 	}
 	if runtime.Bool("request-receipt") {
 		bld = bld.DispositionNotificationTo("", senderEmail)
@@ -248,9 +262,9 @@ func buildRawEMLForDraftCreate(
 	if input.BCC != "" {
 		bld = bld.BCCAddrs(parseNetAddrs(input.BCC))
 	}
-	inlineSpecs, err := parseInlineSpecs(input.Inline)
-	if err != nil {
-		return "", output.ErrValidation("%v", err)
+	inlineSpecs, parseErr := parseInlineSpecs(input.Inline)
+	if parseErr != nil {
+		return "", lintApplied, lintBlocked, output.ErrValidation("%v", parseErr)
 	}
 	var autoResolvedPaths []string
 	var composedHTMLBody string
@@ -265,9 +279,18 @@ func buildRawEMLForDraftCreate(
 		}
 		resolved, refs, resolveErr := draftpkg.ResolveLocalImagePaths(htmlBody)
 		if resolveErr != nil {
-			return "", resolveErr
+			return "", lintApplied, lintBlocked, resolveErr
 		}
 		resolved = injectSignatureIntoBody(resolved, sigResult)
+		// Writing-path lint: AutoFix=true / Strict=false (spec §4.3 — the
+		// writing-path safety contract has no `--no-lint` opt-out). Runs
+		// AFTER applyTemplate (in caller) + ResolveLocalImagePaths +
+		// injectSignatureIntoBody so the lint sees the final HTML the
+		// recipient renderer will see (S2 contract «Pre-call vs in-call
+		// validation split» — Compose 5 row).
+		cleaned, rep := runWritePathLint(resolved)
+		resolved = cleaned
+		lintApplied, lintBlocked = rep.Applied, rep.Blocked
 		composedHTMLBody = resolved
 		bld = bld.HTMLBody([]byte(composedHTMLBody))
 		bld = addSignatureImagesToBuilder(bld, sigResult)
@@ -283,13 +306,14 @@ func buildRawEMLForDraftCreate(
 		}
 		allCIDs = append(allCIDs, signatureCIDs(sigResult)...)
 		var tplInlineCIDs []string
-		bld, tplInlineCIDs, err = embedTemplateInlineAttachments(ctx, runtime, bld, resolved, mailboxID, templateID, templateInlineAttachments)
-		if err != nil {
-			return "", err
+		var embedErr error
+		bld, tplInlineCIDs, embedErr = embedTemplateInlineAttachments(ctx, runtime, bld, resolved, mailboxID, templateID, templateInlineAttachments)
+		if embedErr != nil {
+			return "", lintApplied, lintBlocked, embedErr
 		}
 		allCIDs = append(allCIDs, tplInlineCIDs...)
-		if err := validateInlineCIDs(resolved, allCIDs, nil); err != nil {
-			return "", err
+		if cidErr := validateInlineCIDs(resolved, allCIDs, nil); cidErr != nil {
+			return "", lintApplied, lintBlocked, cidErr
 		}
 	} else {
 		composedTextBody = input.Body
@@ -299,9 +323,10 @@ func buildRawEMLForDraftCreate(
 	// when the template contributes none; runs in both HTML and plain-text
 	// branches because regular attachments are independent of body mode.
 	var templateSmallBytes int64
-	bld, templateSmallBytes, err = embedTemplateSmallAttachments(ctx, runtime, bld, mailboxID, templateID, templateSmallAttachments)
-	if err != nil {
-		return "", err
+	var smallErr error
+	bld, templateSmallBytes, smallErr = embedTemplateSmallAttachments(ctx, runtime, bld, mailboxID, templateID, templateSmallAttachments)
+	if smallErr != nil {
+		return "", lintApplied, lintBlocked, smallErr
 	}
 	bld = applyPriority(bld, priority)
 	if calData := buildCalendarBody(runtime, senderEmail, input.To, input.CC); calData != nil {
@@ -310,16 +335,17 @@ func buildRawEMLForDraftCreate(
 	allInlinePaths := append(inlineSpecFilePaths(inlineSpecs), autoResolvedPaths...)
 	composedBodySize := int64(len(composedHTMLBody) + len(composedTextBody))
 	emlBase := estimateEMLBaseSize(runtime.FileIO(), composedBodySize, allInlinePaths, 0) + templateSmallBytes
-	bld, err = processLargeAttachments(ctx, runtime, bld, composedHTMLBody, composedTextBody, splitByComma(input.Attach), emlBase, 0)
-	if err != nil {
-		return "", err
+	var largeErr error
+	bld, largeErr = processLargeAttachments(ctx, runtime, bld, composedHTMLBody, composedTextBody, splitByComma(input.Attach), emlBase, 0)
+	if largeErr != nil {
+		return "", lintApplied, lintBlocked, largeErr
 	}
 	if hdr, hdrErr := encodeTemplateLargeAttachmentHeader(templateLargeAttachmentIDs); hdrErr == nil && hdr != "" {
 		bld = bld.Header(draftpkg.LargeAttachmentIDsHeader, hdr)
 	}
-	rawEML, err := bld.BuildBase64URL()
-	if err != nil {
-		return "", output.ErrValidation("build EML failed: %v", err)
+	rawEML, buildErr := bld.BuildBase64URL()
+	if buildErr != nil {
+		return "", lintApplied, lintBlocked, output.ErrValidation("build EML failed: %v", buildErr)
 	}
-	return rawEML, nil
+	return rawEML, lintApplied, lintBlocked, nil
 }

--- a/shortcuts/mail/mail_draft_create_test.go
+++ b/shortcuts/mail/mail_draft_create_test.go
@@ -62,7 +62,7 @@ func TestBuildRawEMLForDraftCreate_ResolvesLocalImages(t *testing.T) {
 		Body:    `<p>Hello</p><p><img src="./test_image.png" /></p>`,
 	}
 
-	rawEML, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
+	rawEML, _, _, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("buildRawEMLForDraftCreate() error = %v", err)
 	}
@@ -88,7 +88,7 @@ func TestBuildRawEMLForDraftCreate_NoLocalImages(t *testing.T) {
 		Body:    `<p>Hello <b>world</b></p>`,
 	}
 
-	rawEML, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
+	rawEML, _, _, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("buildRawEMLForDraftCreate() error = %v", err)
 	}
@@ -124,7 +124,7 @@ func TestBuildRawEMLForDraftCreate_AutoResolveCountedInSizeLimit(t *testing.T) {
 		Attach:  "./big.txt",
 	}
 
-	_, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
+	_, _, _, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected size limit error when auto-resolved image + attachment exceed 25MB")
 	}
@@ -145,7 +145,7 @@ func TestBuildRawEMLForDraftCreate_OrphanedInlineSpecError(t *testing.T) {
 		Inline:  `[{"cid":"orphan","file_path":"./unused.png"}]`,
 	}
 
-	_, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
+	_, _, _, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected error for orphaned --inline CID not referenced in body")
 	}
@@ -166,7 +166,7 @@ func TestBuildRawEMLForDraftCreate_MissingCIDRefError(t *testing.T) {
 		Inline:  `[{"cid":"present","file_path":"./present.png"}]`,
 	}
 
-	_, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
+	_, _, _, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected error for missing CID reference")
 	}
@@ -183,7 +183,7 @@ func TestBuildRawEMLForDraftCreate_WithPriority(t *testing.T) {
 		Body:    `<p>Hello</p>`,
 	}
 
-	rawEML, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "1", nil, "", "", nil, nil)
+	rawEML, _, _, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "1", nil, "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("buildRawEMLForDraftCreate() error = %v", err)
 	}
@@ -201,7 +201,7 @@ func TestBuildRawEMLForDraftCreate_NoPriority(t *testing.T) {
 		Body:    `<p>Hello</p>`,
 	}
 
-	rawEML, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
+	rawEML, _, _, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("buildRawEMLForDraftCreate() error = %v", err)
 	}
@@ -236,7 +236,7 @@ func TestBuildRawEMLForDraftCreate_RequestReceiptAddsHeader(t *testing.T) {
 		Body:    "<p>hi</p>",
 	}
 
-	rawEML, err := buildRawEMLForDraftCreate(context.Background(),
+	rawEML, _, _, err := buildRawEMLForDraftCreate(context.Background(),
 		newRuntimeWithFromAndRequestReceipt("sender@example.com", true), input, nil, "", nil, "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("buildRawEMLForDraftCreate() error = %v", err)
@@ -259,7 +259,7 @@ func TestBuildRawEMLForDraftCreate_RequestReceiptOmittedByDefault(t *testing.T) 
 		Body:    "<p>hi</p>",
 	}
 
-	rawEML, err := buildRawEMLForDraftCreate(context.Background(),
+	rawEML, _, _, err := buildRawEMLForDraftCreate(context.Background(),
 		newRuntimeWithFromAndRequestReceipt("sender@example.com", false), input, nil, "", nil, "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("buildRawEMLForDraftCreate() error = %v", err)
@@ -283,7 +283,7 @@ func TestBuildRawEMLForDraftCreate_PlainTextSkipsResolve(t *testing.T) {
 		PlainText: true,
 	}
 
-	rawEML, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
+	rawEML, _, _, err := buildRawEMLForDraftCreate(context.Background(), newRuntimeWithFrom("sender@example.com"), input, nil, "", nil, "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("buildRawEMLForDraftCreate() error = %v", err)
 	}
@@ -304,7 +304,7 @@ func TestBuildRawEMLForDraftCreate_WithCalendarEvent(t *testing.T) {
 		Body:    "<p>Please join us</p>",
 	}
 
-	rawEML, err := buildRawEMLForDraftCreate(context.Background(), rt, input, nil, "", nil, "", "", nil, nil)
+	rawEML, _, _, err := buildRawEMLForDraftCreate(context.Background(), rt, input, nil, "", nil, "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("buildRawEMLForDraftCreate() error = %v", err)
 	}

--- a/shortcuts/mail/mail_draft_edit.go
+++ b/shortcuts/mail/mail_draft_edit.go
@@ -174,6 +174,33 @@ var MailDraftEdit = common.Shortcut{
 		if err != nil {
 			return err
 		}
+		// Writing-path lint for body ops only (S2 contract «Pre-call vs in-call
+		// validation split» — +draft-edit row): set_body / set_reply_body
+		// rewrite the body field; other ops (set_subject / set_recipients /
+		// add_attachment / etc.) operate on non-HTML fields and MUST NOT be
+		// linted. Lint runs after loadPatchFile parses JSON and BEFORE
+		// draftpkg.Apply writes into the snapshot. Each op's `value` is
+		// replaced with the cleaned HTML in place; findings accumulate across
+		// ops into a single per-patch report (spec §4.3).
+		lintApplied, lintBlocked := emptyLintEnvelopeFields()
+		for i := range patch.Ops {
+			op := &patch.Ops[i]
+			if op.Op != "set_body" && op.Op != "set_reply_body" {
+				continue
+			}
+			if op.Value == "" {
+				continue
+			}
+			if !bodyIsHTML(op.Value) {
+				// Plain-text body op — no lint pass needed (the HTML rule set
+				// is irrelevant), but the envelope still surfaces empty arrays.
+				continue
+			}
+			cleaned, rep := runWritePathLint(op.Value)
+			op.Value = cleaned
+			lintApplied = append(lintApplied, rep.Applied...)
+			lintBlocked = append(lintBlocked, rep.Blocked...)
+		}
 		dctx := &draftpkg.DraftCtx{FIO: runtime.FileIO()}
 		if len(patch.Ops) > 0 {
 			if err := draftpkg.Apply(dctx, snapshot, patch); err != nil {
@@ -197,6 +224,9 @@ var MailDraftEdit = common.Shortcut{
 		if updateResult.Reference != "" {
 			out["reference"] = updateResult.Reference
 		}
+		// Writing-path lint envelope (spec §4.3): both arrays always present.
+		out["lint_applied"] = lintApplied
+		out["original_blocked"] = lintBlocked
 		runtime.OutFormat(out, nil, func(w io.Writer) {
 			fmt.Fprintln(w, "Draft updated.")
 			fmt.Fprintf(w, "draft_id: %s\n", updateResult.DraftID)

--- a/shortcuts/mail/mail_forward.go
+++ b/shortcuts/mail/mail_forward.go
@@ -242,6 +242,8 @@ var MailForward = common.Shortcut{
 		var composedHTMLBody string
 		var composedTextBody string
 		var srcInlineBytes int64
+		// Lint findings flowing into the writing-path stdout envelope (spec §4.3).
+		lintApplied, lintBlocked := emptyLintEnvelopeFields()
 		if useHTML {
 			if err := validateInlineImageURLs(sourceMsg); err != nil {
 				return fmt.Errorf("forward blocked: %w", err)
@@ -267,6 +269,12 @@ var MailForward = common.Shortcut{
 			if sigResult != nil {
 				bodyWithSig += draftpkg.SignatureSpacing() + draftpkg.BuildSignatureHTML(sigResult.ID, sigResult.RenderedContent)
 			}
+			// Writing-path lint: lint user-authored body + signature, NOT the
+			// forward quote / large-attachment card derived from the original
+			// message (spec §4.3 + S2 contract «Sibling-divergence ledger»).
+			cleaned, rep := runWritePathLint(bodyWithSig)
+			bodyWithSig = cleaned
+			lintApplied, lintBlocked = rep.Applied, rep.Blocked
 			composedHTMLBody = bodyWithSig + origLargeAttCard + forwardQuote
 			bld = bld.HTMLBody([]byte(composedHTMLBody))
 			bld = addSignatureImagesToBuilder(bld, sigResult)
@@ -480,7 +488,10 @@ var MailForward = common.Shortcut{
 			return fmt.Errorf("failed to create draft: %w", err)
 		}
 		if !confirmSend {
-			runtime.Out(buildDraftSavedOutput(draftResult, mailboxID), nil)
+			out := buildDraftSavedOutput(draftResult, mailboxID)
+			out["lint_applied"] = lintApplied
+			out["original_blocked"] = lintBlocked
+			runtime.Out(out, nil)
 			hintSendDraft(runtime, mailboxID, draftResult.DraftID)
 			return nil
 		}
@@ -488,7 +499,10 @@ var MailForward = common.Shortcut{
 		if err != nil {
 			return fmt.Errorf("failed to send forward (draft %s created but not sent): %w", draftResult.DraftID, err)
 		}
-		runtime.Out(buildDraftSendOutput(resData, mailboxID), nil)
+		out := buildDraftSendOutput(resData, mailboxID)
+		out["lint_applied"] = lintApplied
+		out["original_blocked"] = lintBlocked
+		runtime.Out(out, nil)
 		hintMarkAsRead(runtime, mailboxID, messageId)
 		return nil
 	},

--- a/shortcuts/mail/mail_lint_html.go
+++ b/shortcuts/mail/mail_lint_html.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/larksuite/cli/shortcuts/mail/lint"
+)
+
+// MailLintHTML is the `+lint-html` shortcut: lint a mail HTML body for
+// compatibility / safety / Feishu-native rules. Read-only — no draft is
+// touched, no API call is made. Per spec §4.1 this is a stand-alone preview
+// counterpart to the writing-path lint built into compose 5 / +draft-edit
+// (§4.3); both share a single lint lib (shortcuts/mail/lint) so behaviour
+// can't drift.
+//
+// Returns:
+//
+//	{ok: true, data: {warnings: [], errors: [], cleaned_html: "..."}}
+//
+// Each warning / error entry has: rule_id / severity / tag_or_attr /
+// excerpt / hint (S2 contract «Header / RPC contract» — Stdout envelope
+// contract).
+var MailLintHTML = common.Shortcut{
+	Service:     "mail",
+	Command:     "+lint-html",
+	Description: "Lint mail HTML body for compatibility / safety / Feishu-native rules. Returns warnings/errors and (default) auto-fixed HTML. Read-only: no draft, no API call. Use this BEFORE creating a draft to preview what the writing-path lint would change, or as a CI gate for static HTML templates.",
+	Risk:        "read",
+	// No API call → no scope requirement. KB Pitfall 3 doesn't apply (no
+	// meta_data.json `accessTokens` to align with).
+	Scopes: []string{},
+	// Identity-agnostic: lint is local pure-CPU. Both user and bot
+	// identities can run it.
+	AuthTypes: []string{"user", "bot"},
+	HasFormat: true,
+	Flags: []common.Flag{
+		// --body / --body-file are MUTUALLY EXCLUSIVE BUT EXACTLY-ONE-OF.
+		// We do NOT use cobra `Required: true` on either (KB Pitfall 1: it
+		// fires before Validate runs and blocks the legitimate "the other
+		// one is set" path); we enforce the constraint inside the Validate
+		// callback below.
+		{Name: "body", Desc: "HTML body to lint. Mutually exclusive with --body-file; exactly one is required."},
+		{Name: "body-file", Desc: "Path (relative, within cwd subtree) to a file containing HTML to lint. Mutually exclusive with --body; exactly one is required.", Input: []string{common.File}},
+		{Name: "auto-fix", Type: "bool", Default: "true", Desc: "When true (default), the response includes cleaned_html (HTML rewritten with warnings auto-fixed and errors removed). When false, only the violation list is returned and cleaned_html is omitted."},
+		{Name: "strict", Type: "bool", Default: "false", Desc: "When true, all warnings are promoted to errors and the command exits non-zero on any finding. Useful as a CI gate for static HTML templates. Default false."},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		body := runtime.Str("body")
+		bodyFile := strings.TrimSpace(runtime.Str("body-file"))
+
+		// Mutual exclusion + exactly-one-of (S2 contract «Public input
+		// surface inventory» — A. New verb cobra flag inventory, --body /
+		// --body-file row).
+		bodyEmpty := strings.TrimSpace(body) == ""
+		if bodyEmpty && bodyFile == "" {
+			return output.ErrValidation("exactly one of --body or --body-file is required")
+		}
+		if !bodyEmpty && bodyFile != "" {
+			return output.ErrValidation("--body and --body-file are mutually exclusive; pass exactly one")
+		}
+
+		// --body-file safety: cwd-subtree only. Mirror the existing pattern
+		// in mail_template_create.go:resolveTemplateContent + shortcut
+		// runtime.ValidatePath (S2 contract MUST reuse list).
+		if bodyFile != "" {
+			if err := runtime.ValidatePath(bodyFile); err != nil {
+				return output.ErrValidation("--body-file: %v", err)
+			}
+		}
+
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		// Pure local — no network IO. Surface this explicitly so the
+		// dry-run envelope makes clear that running the command for real
+		// has zero side effects.
+		api := common.NewDryRunAPI().
+			Desc("Lint HTML body locally (no API call, no draft mutation, no network IO).").
+			Set("mode", "local-lint-only").
+			Set("auto_fix", runtime.Bool("auto-fix")).
+			Set("strict", runtime.Bool("strict"))
+		if path := strings.TrimSpace(runtime.Str("body-file")); path != "" {
+			api = api.Set("body_source", "file").Set("body_file", path)
+		} else {
+			api = api.Set("body_source", "flag")
+		}
+		return api
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		body, err := readLintHTMLBody(runtime)
+		if err != nil {
+			return err
+		}
+
+		autoFix := runtime.Bool("auto-fix")
+		strict := runtime.Bool("strict")
+
+		// Plain-text input: short-circuit to an empty report (lib short-circuit
+		// path, also useful so users running --body 'plain text' don't get
+		// confused by an empty-but-rewritten output).
+		var rep lint.Report
+		if !bodyIsHTML(body) {
+			rep = lint.EmptyReport(body)
+		} else {
+			rep = lint.Run(body, lint.Options{AutoFix: autoFix, Strict: strict})
+		}
+
+		// Public envelope shape (spec §4.2 — `+lint-html` returns
+		// {warnings, errors, cleaned_html}; spec §4.3 — compose 5 / draft-edit
+		// returns {lint_applied, original_blocked}. The shapes are sister-
+		// formatted but different keys; per-shortcut keys are intentional so
+		// callers can disambiguate the two surfaces).
+		data := map[string]interface{}{
+			"warnings": rep.Applied, // never nil — lib guarantees []
+			"errors":   rep.Blocked, // never nil — lib guarantees []
+		}
+		if autoFix {
+			data["cleaned_html"] = rep.CleanedHTML
+		}
+
+		runtime.OutFormat(data, &output.Meta{Count: len(rep.Applied) + len(rep.Blocked)}, func(w io.Writer) {
+			printLintPretty(w, rep, autoFix)
+		})
+
+		// Strict / hard-error exit code semantics. Spec §4.2 row "--strict":
+		// "true 时把所有 warning 视作 error，exit 非零". The lint lib already
+		// promoted warnings to errors when strict is set; we only need to
+		// observe the resulting state.
+		if strict && (rep.HasErrorFindings || rep.HasWarningFindings) {
+			return output.Errorf(output.ExitValidation, "lint_strict",
+				"lint --strict: %d error / %d warning finding(s)",
+				len(rep.Blocked), len(rep.Applied))
+		}
+		// Non-strict path: errors that the writing-path safety floor would
+		// have removed are surfaced via the envelope but do NOT fail the
+		// command — `+lint-html` is a preview / advisory tool. The exit
+		// code stays 0 so CI scripts can post-process the envelope.
+		return nil
+	},
+}
+
+// readLintHTMLBody resolves the input HTML body from --body or --body-file.
+// Validate has already enforced that exactly one is set, so we don't repeat
+// the mutual-exclusion check here.
+func readLintHTMLBody(runtime *common.RuntimeContext) (string, error) {
+	if body := runtime.Str("body"); strings.TrimSpace(body) != "" {
+		return body, nil
+	}
+	path := strings.TrimSpace(runtime.Str("body-file"))
+	if path == "" {
+		// Should be unreachable given Validate, but defensive.
+		return "", output.ErrValidation("internal: --body-file empty after Validate")
+	}
+	f, err := runtime.FileIO().Open(path)
+	if err != nil {
+		return "", output.ErrValidation("open --body-file %s: %v", path, err)
+	}
+	defer f.Close()
+	buf, err := io.ReadAll(f)
+	if err != nil {
+		return "", output.ErrValidation("read --body-file %s: %v", path, err)
+	}
+	return string(buf), nil
+}
+
+// printLintPretty renders the lint report as a human-readable summary used
+// when --format pretty is selected. Stays terse so CI logs aren't drowned.
+func printLintPretty(w io.Writer, rep lint.Report, autoFix bool) {
+	if len(rep.Blocked) == 0 && len(rep.Applied) == 0 {
+		fmt.Fprintln(w, "OK: no compatibility / safety findings.")
+		if autoFix {
+			fmt.Fprintf(w, "cleaned_html_size: %d bytes\n", len(rep.CleanedHTML))
+		}
+		return
+	}
+	if len(rep.Blocked) > 0 {
+		fmt.Fprintf(w, "errors (%d):\n", len(rep.Blocked))
+		for _, f := range rep.Blocked {
+			fmt.Fprintf(w, "  - [%s] %s — %s\n", f.RuleID, f.TagOrAttr, f.Hint)
+		}
+	}
+	if len(rep.Applied) > 0 {
+		fmt.Fprintf(w, "warnings (%d):\n", len(rep.Applied))
+		for _, f := range rep.Applied {
+			fmt.Fprintf(w, "  - [%s] %s — %s\n", f.RuleID, f.TagOrAttr, f.Hint)
+		}
+	}
+	if autoFix {
+		fmt.Fprintf(w, "cleaned_html_size: %d bytes\n", len(rep.CleanedHTML))
+	} else {
+		fmt.Fprintln(w, "(--auto-fix=false: cleaned_html omitted; rerun without the flag to receive the rewritten HTML)")
+	}
+}

--- a/shortcuts/mail/mail_lint_html_test.go
+++ b/shortcuts/mail/mail_lint_html_test.go
@@ -1,0 +1,320 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// =====================================================================
+// +lint-html Shortcut tests — public stdout envelope contract checks.
+//
+// These exercise the full cobra Mount → Execute pipeline (parse args →
+// Validate → Execute → OutFormat) so they catch any regression in flag
+// declaration, mutual-exclusion validation, path safety, and the JSON
+// envelope shape (spec §4.2 + S2 contract «Stdout envelope contract»).
+// =====================================================================
+
+// TestMailLintHTML_RequiresExactlyOneOfBodyOrFile verifies the mutual-
+// exclusion + at-least-one-of constraint surfaces ErrValidation.
+func TestMailLintHTML_RequiresExactlyOneOfBodyOrFile(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	t.Run("neither flag", func(t *testing.T) {
+		err := runMountedMailShortcut(t, MailLintHTML, []string{"+lint-html"}, f, stdout)
+		if err == nil {
+			t.Fatal("expected error when neither flag is set")
+		}
+		if !strings.Contains(err.Error(), "exactly one of --body or --body-file") {
+			t.Errorf("wrong error: %v", err)
+		}
+	})
+
+	t.Run("both flags", func(t *testing.T) {
+		err := runMountedMailShortcut(t, MailLintHTML, []string{
+			"+lint-html",
+			"--body", "<p>x</p>",
+			"--body-file", "fake.html",
+		}, f, stdout)
+		if err == nil {
+			t.Fatal("expected error when both flags set")
+		}
+		if !strings.Contains(err.Error(), "mutually exclusive") {
+			t.Errorf("wrong error: %v", err)
+		}
+	})
+}
+
+// TestMailLintHTML_BodyFilePathSafetyRejected verifies absolute paths /
+// `..` traversal are rejected (KB Pitfall 4 + S2 contract «Public input
+// surface inventory»).
+func TestMailLintHTML_BodyFilePathSafetyRejected(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	chdirTemp(t)
+
+	t.Run("absolute path", func(t *testing.T) {
+		err := runMountedMailShortcut(t, MailLintHTML, []string{
+			"+lint-html",
+			"--body-file", "/etc/passwd",
+		}, f, stdout)
+		if err == nil {
+			t.Fatal("expected validation error for absolute path")
+		}
+	})
+
+	t.Run("dotdot traversal", func(t *testing.T) {
+		err := runMountedMailShortcut(t, MailLintHTML, []string{
+			"+lint-html",
+			"--body-file", "../../../etc/passwd",
+		}, f, stdout)
+		if err == nil {
+			t.Fatal("expected validation error for traversal")
+		}
+	})
+}
+
+// TestMailLintHTML_BodyFileReadsCwdSubpath verifies a legitimate cwd-subtree
+// path loads HTML correctly.
+func TestMailLintHTML_BodyFileReadsCwdSubpath(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	chdirTemp(t)
+	if err := os.WriteFile("input.html", []byte(`<p>safe</p><script>1</script>`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := runMountedMailShortcut(t, MailLintHTML, []string{
+		"+lint-html",
+		"--body-file", "input.html",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	data := decodeShortcutEnvelopeData(t, stdout)
+	errors, _ := data["errors"].([]interface{})
+	if len(errors) != 1 {
+		t.Errorf("expected 1 error finding (script), got %d: %+v", len(errors), errors)
+	}
+	cleaned, _ := data["cleaned_html"].(string)
+	if strings.Contains(cleaned, "<script") {
+		t.Errorf("cleaned_html should not contain <script>, got %q", cleaned)
+	}
+}
+
+// TestMailLintHTML_DefaultEnvelopeShape verifies the public envelope contract
+// (spec §4.2 — `+lint-html` returns {warnings, errors, cleaned_html}).
+func TestMailLintHTML_DefaultEnvelopeShape(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailLintHTML, []string{
+		"+lint-html",
+		"--body", `<p>safe content</p>`,
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	// Both arrays MUST be present, even on a clean input (empty arrays per
+	// the JSON envelope contract).
+	if _, ok := data["warnings"]; !ok {
+		t.Error("warnings key missing from envelope")
+	}
+	if _, ok := data["errors"]; !ok {
+		t.Error("errors key missing from envelope")
+	}
+	if _, ok := data["cleaned_html"]; !ok {
+		t.Error("cleaned_html key missing from envelope (default --auto-fix=true)")
+	}
+	warnings, _ := data["warnings"].([]interface{})
+	errors, _ := data["errors"].([]interface{})
+	if warnings == nil {
+		t.Error("warnings must be a non-nil array (decode produced nil)")
+	}
+	if errors == nil {
+		t.Error("errors must be a non-nil array (decode produced nil)")
+	}
+	if len(warnings) != 0 || len(errors) != 0 {
+		t.Errorf("expected empty arrays for clean HTML, got w=%d e=%d", len(warnings), len(errors))
+	}
+}
+
+// TestMailLintHTML_AutoFixFalseOmitsCleanedHTML verifies spec §4.2 row
+// "--auto-fix=false → cleaned_html absent".
+func TestMailLintHTML_AutoFixFalseOmitsCleanedHTML(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailLintHTML, []string{
+		"+lint-html",
+		"--body", `<p>x</p>`,
+		"--auto-fix=false",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if _, ok := data["cleaned_html"]; ok {
+		t.Errorf("cleaned_html should be absent when --auto-fix=false")
+	}
+	if _, ok := data["warnings"]; !ok {
+		t.Error("warnings should still be present")
+	}
+	if _, ok := data["errors"]; !ok {
+		t.Error("errors should still be present")
+	}
+}
+
+// TestMailLintHTML_StrictExitsNonZero verifies --strict bumps the exit code.
+func TestMailLintHTML_StrictExitsNonZero(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailLintHTML, []string{
+		"+lint-html",
+		"--body", `<font color="red">x</font>`,
+		"--strict",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected non-zero exit under --strict with a warning, got nil")
+	}
+	// Envelope is still emitted (Execute writes to stdout before returning).
+	data := decodeShortcutEnvelopeData(t, stdout)
+	errors, _ := data["errors"].([]interface{})
+	if len(errors) == 0 {
+		t.Error("--strict should promote warnings to errors")
+	}
+}
+
+// TestMailLintHTML_StrictPassesOnCleanInput verifies --strict exits 0 when
+// no findings are surfaced.
+func TestMailLintHTML_StrictPassesOnCleanInput(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailLintHTML, []string{
+		"+lint-html",
+		"--body", `<p>safe content</p>`,
+		"--strict",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("expected success on clean input under strict, got: %v", err)
+	}
+}
+
+// TestMailLintHTML_PlainTextBodyShortCircuits verifies plain-text input
+// produces empty arrays (lib short-circuit path).
+func TestMailLintHTML_PlainTextBodyShortCircuits(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailLintHTML, []string{
+		"+lint-html",
+		"--body", "just plain text, no markup",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeShortcutEnvelopeData(t, stdout)
+	w, _ := data["warnings"].([]interface{})
+	e, _ := data["errors"].([]interface{})
+	if len(w) != 0 || len(e) != 0 {
+		t.Errorf("plain text should produce no findings, got w=%v e=%v", w, e)
+	}
+}
+
+// TestMailLintHTML_FindingShape verifies each finding entry has the
+// contract-required keys (rule_id / severity / tag_or_attr / excerpt / hint).
+func TestMailLintHTML_FindingShape(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailLintHTML, []string{
+		"+lint-html",
+		"--body", `<p>x</p><script>alert(1)</script>`,
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeShortcutEnvelopeData(t, stdout)
+	errors, _ := data["errors"].([]interface{})
+	if len(errors) == 0 {
+		t.Fatal("expected at least 1 error finding")
+	}
+	first, _ := errors[0].(map[string]interface{})
+	for _, key := range []string{"rule_id", "severity", "tag_or_attr", "excerpt", "hint"} {
+		if _, ok := first[key]; !ok {
+			t.Errorf("finding missing required key %q: %+v", key, first)
+		}
+	}
+	if first["severity"] != "error" {
+		t.Errorf("severity = %v, want error", first["severity"])
+	}
+	if !strings.HasPrefix(first["rule_id"].(string), "TAG_") &&
+		!strings.HasPrefix(first["rule_id"].(string), "ATTR_") &&
+		!strings.HasPrefix(first["rule_id"].(string), "STYLE_") {
+		t.Errorf("rule_id must be UPPER_SNAKE_CASE prefix, got %v", first["rule_id"])
+	}
+}
+
+// TestMailLintHTML_DryRun verifies dry-run mode doesn't execute lint and
+// surfaces the read-only / no-network annotation.
+func TestMailLintHTML_DryRun(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailLintHTML, []string{
+		"+lint-html",
+		"--body", `<p>x</p>`,
+		"--dry-run",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Dry-run output is JSON containing "mode":"local-lint-only".
+	if !strings.Contains(stdout.String(), "local-lint-only") {
+		t.Errorf("expected dry-run mode marker, stdout=%s", stdout.String())
+	}
+}
+
+// TestMailLintHTML_BlockedTagAndWarningAccumulate verifies the report
+// surfaces both warning + error findings simultaneously.
+func TestMailLintHTML_BlockedTagAndWarningAccumulate(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	body := `<font color="red">warn-tag</font><script>err-tag</script>` +
+		`<a href="javascript:0">err-url</a>`
+	err := runMountedMailShortcut(t, MailLintHTML, []string{
+		"+lint-html",
+		"--body", body,
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeShortcutEnvelopeData(t, stdout)
+	w, _ := data["warnings"].([]interface{})
+	e, _ := data["errors"].([]interface{})
+	if len(w) < 1 {
+		t.Errorf("expected ≥ 1 warning, got %d", len(w))
+	}
+	if len(e) < 2 {
+		t.Errorf("expected ≥ 2 errors (script + js URL), got %d", len(e))
+	}
+}
+
+// TestMailLintHTML_FindingsAreJSONSerialisable confirms the cleaned envelope
+// can round-trip through json (no nil / function values leak in).
+func TestMailLintHTML_FindingsAreJSONSerialisable(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailLintHTML, []string{
+		"+lint-html",
+		"--body", `<font color="red">x</font>`,
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Re-encode the data back to JSON to confirm it's serialisable.
+	data := decodeShortcutEnvelopeData(t, stdout)
+	if _, err := json.Marshal(data); err != nil {
+		t.Errorf("envelope not JSON-serialisable: %v", err)
+	}
+}

--- a/shortcuts/mail/mail_lint_writepath.go
+++ b/shortcuts/mail/mail_lint_writepath.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"github.com/larksuite/cli/shortcuts/mail/lint"
+)
+
+// runWritePathLint is the single entrypoint compose 5 + +draft-edit body ops
+// use to invoke the lint lib before writing to emlbuilder / draftpkg.Apply.
+//
+// The writing-path safety contract (spec §4.3) is:
+//   - AutoFix is ALWAYS true (no `--no-lint` opt-out); errors are dropped
+//     and warnings are auto-fixed in place.
+//   - Strict is ALWAYS false; warnings never bump the exit code on the
+//     write path (compare with `+lint-html --strict` which is a CI tool).
+//   - The returned report is appended to the writing-path stdout envelope
+//     under the contract keys `lint_applied` (warnings) and
+//     `original_blocked` (errors); both arrays are always present (possibly
+//     empty) so consumers can rely on `data.lint_applied[]` and
+//     `data.original_blocked[]` unconditionally.
+//   - When the body is plain-text, the lib short-circuits and returns an
+//     EmptyReport; the cleaned HTML equals the input verbatim. Compose 5
+//     callers are expected to gate the call on their existing useHTML
+//     branch (S2 contract «N-way isomorphism» — diff template) so the
+//     plain-text path doesn't pay the parse cost.
+//
+// Returns the cleaned HTML + the report. Callers MUST use the returned
+// `cleaned` value as the body that goes to bld.HTMLBody / draftpkg.Apply
+// (writing the original `body` would defeat the safety contract).
+func runWritePathLint(body string) (cleaned string, rep lint.Report) {
+	if body == "" {
+		return "", lint.EmptyReport("")
+	}
+	rep = lint.Run(body, lint.Options{AutoFix: true, Strict: false})
+	return rep.CleanedHTML, rep
+}
+
+// applyLintToEnvelope mutates the OutFormat data map by adding the contract
+// keys `lint_applied` / `original_blocked`. The caller passes the existing
+// envelope data map; the helper merges in the lint findings without
+// disturbing other keys. Both keys are ALWAYS present in the merged map
+// (spec §4.3 — even when no change was applied, the arrays must be
+// rendered as `[]`).
+func applyLintToEnvelope(data map[string]interface{}, rep lint.Report) {
+	// rep.Applied / rep.Blocked are guaranteed non-nil by the lib; defensive
+	// renormalisation here is cheap and ensures the envelope encoder writes
+	// `[]` even if the report came from a partial mock.
+	applied := rep.Applied
+	if applied == nil {
+		applied = []lint.Finding{}
+	}
+	blocked := rep.Blocked
+	if blocked == nil {
+		blocked = []lint.Finding{}
+	}
+	data["lint_applied"] = applied
+	data["original_blocked"] = blocked
+}
+
+// emptyLintEnvelopeFields returns the writing-path stdout-envelope fields
+// representing "no lint pass occurred" (e.g. plain-text body branch). Used by
+// compose 5's plain-text path so the public envelope still carries the
+// contract keys as empty arrays.
+func emptyLintEnvelopeFields() (lintApplied, originalBlocked []lint.Finding) {
+	return []lint.Finding{}, []lint.Finding{}
+}
+
+// lintFinding aliases the lint package's Finding type for callers that don't
+// want to import shortcuts/mail/lint directly (e.g. function signatures in
+// existing mail_*.go files that want to keep their import set minimal). It is
+// purely a syntactic convenience — both names refer to the same struct.
+type lintFinding = lint.Finding
+
+// emptyLintFindings returns two non-nil empty Finding slices, used by helpers
+// that initialise their outputs before knowing whether the body is HTML.
+// Equivalent to emptyLintEnvelopeFields but named to reflect "findings" rather
+// than "envelope fields" so call-sites read consistently with their context.
+func emptyLintFindings() (applied, blocked []lint.Finding) {
+	return []lint.Finding{}, []lint.Finding{}
+}

--- a/shortcuts/mail/mail_lint_writepath_test.go
+++ b/shortcuts/mail/mail_lint_writepath_test.go
@@ -1,0 +1,295 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/mail/lint"
+)
+
+// jsonDecoderUnmarshal is a thin alias used by helpers in this file to keep
+// the import set explicit even when the helper would otherwise be one-line.
+func jsonDecoderUnmarshal(b []byte, v interface{}) error { return json.Unmarshal(b, v) }
+
+// =====================================================================
+// Writing-path lint integration tests — compose 5 + +draft-edit emit
+// `lint_applied[]` and `original_blocked[]` arrays in the stdout envelope
+// always (spec §4.3 contract).
+// =====================================================================
+
+// TestRunWritePathLint_PlainTextReturnsEmptyReport verifies the helper
+// short-circuits on plain-text input.
+func TestRunWritePathLint_PlainTextReturnsEmptyReport(t *testing.T) {
+	cleaned, rep := runWritePathLint("")
+	if cleaned != "" {
+		t.Errorf("cleaned = %q, want empty", cleaned)
+	}
+	if rep.Applied == nil || rep.Blocked == nil {
+		t.Error("Applied/Blocked must be non-nil")
+	}
+	if len(rep.Applied) != 0 || len(rep.Blocked) != 0 {
+		t.Errorf("expected empty report, got applied=%d blocked=%d",
+			len(rep.Applied), len(rep.Blocked))
+	}
+}
+
+// TestRunWritePathLint_HTMLAlwaysAutofixesNeverStrict verifies the writing
+// path uses {AutoFix: true, Strict: false} — strict warnings would block
+// users on legitimate <font> tags, which spec §4.3 forbids.
+func TestRunWritePathLint_HTMLAlwaysAutofixesNeverStrict(t *testing.T) {
+	cleaned, rep := runWritePathLint(`<p><font color="red">x</font></p>`)
+	if !strings.Contains(cleaned, "<span") {
+		t.Errorf("expected autofix to rewrite <font>, cleaned=%q", cleaned)
+	}
+	if len(rep.Applied) != 1 {
+		t.Errorf("expected 1 warning surfaced, got %d", len(rep.Applied))
+	}
+	// In strict mode the warning would be in Blocked instead. Confirm the
+	// writing-path path does NOT promote.
+	if len(rep.Blocked) != 0 {
+		t.Errorf("writing-path must NOT use strict; expected 0 blocked, got %d", len(rep.Blocked))
+	}
+}
+
+// TestApplyLintToEnvelope_AlwaysSetsContractKeys verifies the helper writes
+// non-nil empty arrays even when the report has no findings.
+func TestApplyLintToEnvelope_AlwaysSetsContractKeys(t *testing.T) {
+	data := map[string]interface{}{"existing": "value"}
+	rep := lint.EmptyReport(`<p>x</p>`)
+	applyLintToEnvelope(data, rep)
+
+	if data["existing"] != "value" {
+		t.Error("existing key was clobbered")
+	}
+	la, ok := data["lint_applied"].([]lint.Finding)
+	if !ok {
+		t.Fatalf("lint_applied wrong type: %T", data["lint_applied"])
+	}
+	if la == nil {
+		t.Error("lint_applied is nil — must be empty slice")
+	}
+	ob, ok := data["original_blocked"].([]lint.Finding)
+	if !ok {
+		t.Fatalf("original_blocked wrong type: %T", data["original_blocked"])
+	}
+	if ob == nil {
+		t.Error("original_blocked is nil — must be empty slice")
+	}
+}
+
+// =====================================================================
+// End-to-end: +draft-create writing path emits envelope with lint fields.
+// =====================================================================
+
+// TestMailDraftCreate_WritePathLintEnvelope verifies +draft-create's stdout
+// envelope always carries `lint_applied[]` / `original_blocked[]` arrays.
+func TestMailDraftCreate_WritePathLintEnvelope(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	chdirTemp(t)
+	registerMailboxProfileMock(reg)
+	registerDraftCreateOK(reg)
+
+	err := runMountedMailShortcut(t, MailDraftCreate, []string{
+		"+draft-create",
+		"--to", "alice@example.com",
+		"--subject", "Test",
+		"--body", `<p>safe</p><script>alert(1)</script><font color="red">red</font>`,
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeShortcutEnvelopeData(t, stdout)
+
+	// Both arrays must be present.
+	la, ok := data["lint_applied"].([]interface{})
+	if !ok {
+		t.Fatalf("lint_applied missing or wrong type: %T", data["lint_applied"])
+	}
+	ob, ok := data["original_blocked"].([]interface{})
+	if !ok {
+		t.Fatalf("original_blocked missing or wrong type: %T", data["original_blocked"])
+	}
+
+	// We expect: 1 warning (<font>) + 1 error (<script>).
+	if len(la) < 1 {
+		t.Errorf("expected ≥1 lint_applied (warning for <font>), got %d", len(la))
+	}
+	if len(ob) < 1 {
+		t.Errorf("expected ≥1 original_blocked (error for <script>), got %d", len(ob))
+	}
+}
+
+// TestMailDraftCreate_PlainTextWritePathEnvelopesEmptyArrays verifies the
+// envelope still carries empty arrays on the plain-text path.
+func TestMailDraftCreate_PlainTextWritePathEnvelopesEmptyArrays(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	chdirTemp(t)
+	registerMailboxProfileMock(reg)
+	registerDraftCreateOK(reg)
+
+	err := runMountedMailShortcut(t, MailDraftCreate, []string{
+		"+draft-create",
+		"--to", "alice@example.com",
+		"--subject", "Test",
+		"--body", "plain text only",
+		"--plain-text",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data := decodeShortcutEnvelopeData(t, stdout)
+	la, ok := data["lint_applied"]
+	if !ok {
+		t.Fatal("lint_applied missing on plain-text path")
+	}
+	ob, ok := data["original_blocked"]
+	if !ok {
+		t.Fatal("original_blocked missing on plain-text path")
+	}
+	// Empty arrays are decoded as []interface{}{} (or could be nil; both
+	// are valid JSON []).
+	if las, _ := la.([]interface{}); len(las) != 0 {
+		t.Errorf("lint_applied should be empty, got %d", len(las))
+	}
+	if obs, _ := ob.([]interface{}); len(obs) != 0 {
+		t.Errorf("original_blocked should be empty, got %d", len(obs))
+	}
+}
+
+// TestMailDraftCreate_AutofixApplied verifies that the writing path actually
+// rewrites the body before sending it to drafts.create — the user's <font>
+// tag must NOT reach the network as <font>.
+func TestMailDraftCreate_AutofixApplied(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	chdirTemp(t)
+	registerMailboxProfileMock(reg)
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "d_test"},
+		},
+	}
+	reg.Register(stub)
+
+	err := runMountedMailShortcut(t, MailDraftCreate, []string{
+		"+draft-create",
+		"--to", "alice@example.com",
+		"--subject", "Test",
+		"--body", `<font color="red">x</font>`,
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Decode the raw EML and confirm <font> was rewritten before reaching
+	// emlbuilder. The base64url payload contains the HTML body in raw form.
+	captured := mustDecodeRawEMLFromStub(t, stub)
+	if strings.Contains(captured, "<font") {
+		t.Errorf("write-path should have rewritten <font>, EML still contains it: %q", captured)
+	}
+	if !strings.Contains(captured, "<span") {
+		t.Errorf("expected <span> wrapper in EML, got %q", captured)
+	}
+}
+
+// TestMailDraftCreate_ScriptStrippedBeforeSend verifies <script> is removed
+// from the EML before drafts.create is invoked (writing-path safety floor).
+func TestMailDraftCreate_ScriptStrippedBeforeSend(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	chdirTemp(t)
+	registerMailboxProfileMock(reg)
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "d_test"},
+		},
+	}
+	reg.Register(stub)
+
+	err := runMountedMailShortcut(t, MailDraftCreate, []string{
+		"+draft-create",
+		"--to", "alice@example.com",
+		"--subject", "Test",
+		"--body", `<p>before</p><script>alert(1)</script><p>after</p>`,
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	eml := mustDecodeRawEMLFromStub(t, stub)
+	if strings.Contains(eml, "<script") {
+		t.Errorf("script should be stripped before EML send, got %q", eml)
+	}
+	if strings.Contains(eml, "alert(1)") {
+		t.Errorf("script content should be removed, got %q", eml)
+	}
+	if !strings.Contains(eml, "before") || !strings.Contains(eml, "after") {
+		t.Errorf("surrounding paragraphs should survive, got %q", eml)
+	}
+}
+
+// =====================================================================
+// Helpers — mail_shortcut_test.go ships the factory; these are local
+// httpmock registrations specific to the lint integration tests.
+// =====================================================================
+
+// registerMailboxProfileMock registers a stock GET .../profile response so
+// resolveComposeSenderEmail finds an address.
+func registerMailboxProfileMock(reg *httpmock.Registry) {
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/profile",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"primary_email_address": "sender@example.com",
+				"send_as":               []interface{}{},
+			},
+		},
+	})
+}
+
+// registerDraftCreateOK registers a successful drafts.create response.
+func registerDraftCreateOK(reg *httpmock.Registry) {
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"draft_id": "d_test123",
+			},
+		},
+	})
+}
+
+// mustDecodeRawEMLFromStub extracts the `raw` field from a captured body and
+// base64url-decodes it. The stub.CapturedBody is populated by the httpmock
+// after a match (registry.go:42 — the stub records every captured request).
+func mustDecodeRawEMLFromStub(t *testing.T, stub *httpmock.Stub) string {
+	t.Helper()
+	if len(stub.CapturedBody) == 0 {
+		t.Fatal("stub did not capture any request body")
+	}
+	var captured map[string]interface{}
+	if err := jsonUnmarshal(stub.CapturedBody, &captured); err != nil {
+		t.Fatalf("decode captured body: %v", err)
+	}
+	raw, ok := captured["raw"].(string)
+	if !ok {
+		t.Fatalf("captured body has no `raw` string field: %#v", captured)
+	}
+	return decodeBase64URL(raw)
+}
+
+func jsonUnmarshal(b []byte, v interface{}) error {
+	return jsonDecoderUnmarshal(b, v)
+}

--- a/shortcuts/mail/mail_quote.go
+++ b/shortcuts/mail/mail_quote.go
@@ -328,13 +328,18 @@ func formatMailDate(ms int64, lang string) string {
 // (whitespace, >, or />). This avoids false positives like "<brief.pdf>" or
 // "price < 100". The tag list follows the Chromium/WHATWG MIME sniffing approach
 // with additional common tags for email content.
+//
+// Must include every key in lint.warnAutofixTags so a body containing only
+// those tags (e.g. "<center>x</center>") still reaches the lint pipeline
+// instead of being short-circuited by EmptyReport in mail_lint_html.go.
 var htmlTagRe = regexp.MustCompile(
 	`(?i)<(?:` +
 		`!doctype\s+html|!--|` +
 		`html|head|body|div|p|br|span|a|b|i|em|strong|` +
 		`h[1-6]|ul|ol|li|table|tr|td|th|img|font|style|script|` +
 		`iframe|title|form|input|select|textarea|button|label|` +
-		`blockquote|pre|code|hr|section|article|header|footer|nav|main` +
+		`blockquote|pre|code|hr|section|article|header|footer|nav|main|` +
+		`center|marquee|blink` +
 		`)[\s/>]`)
 
 // bodyIsHTML reports whether s appears to contain HTML markup.

--- a/shortcuts/mail/mail_reply.go
+++ b/shortcuts/mail/mail_reply.go
@@ -244,6 +244,10 @@ var MailReply = common.Shortcut{
 		var composedHTMLBody string
 		var composedTextBody string
 		var srcInlineBytes int64
+		// Lint findings flowing into the writing-path stdout envelope (spec §4.3).
+		// Initialise empty (non-nil) so the envelope always carries
+		// `lint_applied[]` / `original_blocked[]` even on the plain-text path.
+		lintApplied, lintBlocked := emptyLintEnvelopeFields()
 		if useHTML {
 			if err := validateInlineImageURLs(sourceMsg); err != nil {
 				return fmt.Errorf("HTML reply blocked: %w", err)
@@ -261,6 +265,16 @@ var MailReply = common.Shortcut{
 			if sigResult != nil {
 				bodyWithSig += draftpkg.SignatureSpacing() + draftpkg.BuildSignatureHTML(sigResult.ID, sigResult.RenderedContent)
 			}
+			// Writing-path lint (spec §4.3): operate on the user-authored body
+			// + signature ONLY — NOT on `quoted` (the <blockquote> derived from
+			// the original message). The original HTML already passed through
+			// the server-side RemoteSanitizer upstream; double-sanitising risks
+			// dropping legitimate Lark quote markup such as adit-html-block*
+			// / history-quote-* / lark-mail-doc-quote (S2 contract «Sibling-
+			// divergence ledger» / spec §4.4 row "通过").
+			cleaned, rep := runWritePathLint(bodyWithSig)
+			bodyWithSig = cleaned
+			lintApplied, lintBlocked = rep.Applied, rep.Blocked
 			composedHTMLBody = bodyWithSig + quoted
 			bld = bld.HTMLBody([]byte(composedHTMLBody))
 			bld = addSignatureImagesToBuilder(bld, sigResult)
@@ -317,7 +331,10 @@ var MailReply = common.Shortcut{
 			return fmt.Errorf("failed to create draft: %w", err)
 		}
 		if !confirmSend {
-			runtime.Out(buildDraftSavedOutput(draftResult, mailboxID), nil)
+			out := buildDraftSavedOutput(draftResult, mailboxID)
+			out["lint_applied"] = lintApplied
+			out["original_blocked"] = lintBlocked
+			runtime.Out(out, nil)
 			hintSendDraft(runtime, mailboxID, draftResult.DraftID)
 			return nil
 		}
@@ -325,7 +342,10 @@ var MailReply = common.Shortcut{
 		if err != nil {
 			return fmt.Errorf("failed to send reply (draft %s created but not sent): %w", draftResult.DraftID, err)
 		}
-		runtime.Out(buildDraftSendOutput(resData, mailboxID), nil)
+		out := buildDraftSendOutput(resData, mailboxID)
+		out["lint_applied"] = lintApplied
+		out["original_blocked"] = lintBlocked
+		runtime.Out(out, nil)
 		hintMarkAsRead(runtime, mailboxID, messageId)
 		return nil
 	},

--- a/shortcuts/mail/mail_reply_all.go
+++ b/shortcuts/mail/mail_reply_all.go
@@ -253,6 +253,8 @@ var MailReplyAll = common.Shortcut{
 		var composedHTMLBody string
 		var composedTextBody string
 		var srcInlineBytes int64
+		// Lint findings flowing into the writing-path stdout envelope (spec §4.3).
+		lintApplied, lintBlocked := emptyLintEnvelopeFields()
 		if useHTML {
 			if err := validateInlineImageURLs(sourceMsg); err != nil {
 				return fmt.Errorf("HTML reply-all blocked: %w", err)
@@ -270,6 +272,15 @@ var MailReplyAll = common.Shortcut{
 			if sigResult != nil {
 				bodyWithSig += draftpkg.SignatureSpacing() + draftpkg.BuildSignatureHTML(sigResult.ID, sigResult.RenderedContent)
 			}
+			// Writing-path lint: same isomorphic pattern as +reply (spec §4.3,
+			// S2 contract «N-way isomorphism»). Operate on bodyWithSig only;
+			// the `quoted` block from the original message must NOT be re-
+			// linted (it already passed RemoteSanitizer upstream and may
+			// contain Feishu-native quote-block classes that the lint allow-
+			// list intentionally permits in pass-through).
+			cleaned, rep := runWritePathLint(bodyWithSig)
+			bodyWithSig = cleaned
+			lintApplied, lintBlocked = rep.Applied, rep.Blocked
 			composedHTMLBody = bodyWithSig + quoted
 			bld = bld.HTMLBody([]byte(composedHTMLBody))
 			bld = addSignatureImagesToBuilder(bld, sigResult)
@@ -326,7 +337,10 @@ var MailReplyAll = common.Shortcut{
 			return fmt.Errorf("failed to create draft: %w", err)
 		}
 		if !confirmSend {
-			runtime.Out(buildDraftSavedOutput(draftResult, mailboxID), nil)
+			out := buildDraftSavedOutput(draftResult, mailboxID)
+			out["lint_applied"] = lintApplied
+			out["original_blocked"] = lintBlocked
+			runtime.Out(out, nil)
 			hintSendDraft(runtime, mailboxID, draftResult.DraftID)
 			return nil
 		}
@@ -334,7 +348,10 @@ var MailReplyAll = common.Shortcut{
 		if err != nil {
 			return fmt.Errorf("failed to send reply-all (draft %s created but not sent): %w", draftResult.DraftID, err)
 		}
-		runtime.Out(buildDraftSendOutput(resData, mailboxID), nil)
+		out := buildDraftSendOutput(resData, mailboxID)
+		out["lint_applied"] = lintApplied
+		out["original_blocked"] = lintBlocked
+		runtime.Out(out, nil)
 		hintMarkAsRead(runtime, mailboxID, messageId)
 		return nil
 	},

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -206,6 +206,10 @@ var MailSend = common.Shortcut{
 		var autoResolvedPaths []string
 		var composedHTMLBody string
 		var composedTextBody string
+		// Lint findings flowing into the writing-path stdout envelope (spec §4.3).
+		// Initialised as empty (non-nil) slices so the envelope always carries
+		// `lint_applied[]` / `original_blocked[]` even on the plain-text path.
+		lintApplied, lintBlocked := emptyLintEnvelopeFields()
 		if plainText {
 			composedTextBody = body
 			bld = bld.TextBody([]byte(composedTextBody))
@@ -220,6 +224,15 @@ var MailSend = common.Shortcut{
 				return resolveErr
 			}
 			resolved = injectSignatureIntoBody(resolved, sigResult)
+			// Writing-path lint: AutoFix=true / Strict=false (spec §4.3 — the
+			// writing-path safety contract has no `--no-lint` opt-out). Runs
+			// AFTER applyTemplate (above) + ResolveLocalImagePaths +
+			// injectSignatureIntoBody so the lint sees the final HTML the
+			// recipient renderer will see (S2 contract «Pre-call vs in-call
+			// validation split» — Compose 5 row).
+			cleanedHTML, rep := runWritePathLint(resolved)
+			resolved = cleanedHTML
+			lintApplied, lintBlocked = rep.Applied, rep.Blocked
 			composedHTMLBody = resolved
 			bld = bld.HTMLBody([]byte(composedHTMLBody))
 			bld = addSignatureImagesToBuilder(bld, sigResult)
@@ -284,7 +297,10 @@ var MailSend = common.Shortcut{
 			return fmt.Errorf("failed to create draft: %w", err)
 		}
 		if !confirmSend {
-			runtime.Out(buildDraftSavedOutput(draftResult, mailboxID), nil)
+			out := buildDraftSavedOutput(draftResult, mailboxID)
+			out["lint_applied"] = lintApplied
+			out["original_blocked"] = lintBlocked
+			runtime.Out(out, nil)
 			hintSendDraft(runtime, mailboxID, draftResult.DraftID)
 			return nil
 		}
@@ -292,7 +308,10 @@ var MailSend = common.Shortcut{
 		if err != nil {
 			return fmt.Errorf("failed to send email (draft %s created but not sent): %w", draftResult.DraftID, err)
 		}
-		runtime.Out(buildDraftSendOutput(resData, mailboxID), nil)
+		out := buildDraftSendOutput(resData, mailboxID)
+		out["lint_applied"] = lintApplied
+		out["original_blocked"] = lintBlocked
+		runtime.Out(out, nil)
 		return nil
 	},
 }

--- a/shortcuts/mail/shortcuts.go
+++ b/shortcuts/mail/shortcuts.go
@@ -25,5 +25,6 @@ func Shortcuts() []common.Shortcut {
 		MailShareToChat,
 		MailTemplateCreate,
 		MailTemplateUpdate,
+		MailLintHTML,
 	}
 }

--- a/skill-template/domains/mail.md
+++ b/skill-template/domains/mail.md
@@ -281,6 +281,58 @@ lark-cli mail +send --to alice@example.com --subject '周报' \
 lark-cli mail +reply --message-id <id> --body '收到，谢谢'
 ```
 
+**HTML 写法、风格指引、场景模板请参考三份配套文档：**
+
+- [HTML 兼容白名单](references/lark-mail-html-allowlist.md) — 标签 / class / inline style 速查；表格 / 列表 / 字号 / 引用 / 链接 / 内嵌图片标准写法
+- [飞书原生写法（含风格指引与 3 套完整模板）](references/lark-mail-feishu-native.md) — 通知 / 周报 / 决策请求三套漂亮模板（含问候开场 + 骨架 + 落款），直接替换变量即可使用
+- [`+lint-html` 用法](references/lark-mail-lint-html.md) — 创建草稿前自检 / 修复 AI 输出 / CI 校验静态 HTML 模板
+
+### 邮件风格规范
+
+写信时必须遵守的文风底线（详见 [飞书原生写法](references/lark-mail-feishu-native.md)）：
+
+- **禁机械编号**：用 `<ul>` / `<ol>` 表达列表，不要用 "一、二、三" / "①②③" / "1) 2) 3)"
+- **emoji 克制**：emoji 仅作状态标签（⏰紧急 / ✅完成 / ⚠️风险），不要在正文段落里堆 emoji 装饰
+- **禁冗长 disclaimer**：删除 "希望对您有帮助" / "感谢您的耐心阅读" 等填充语；信息密度优先
+- **标题 ≤ 30 字**：邮件主题 `--subject` 控制在 30 字内，避免被收件箱截断
+- **决策 / 结论前置**：第一段就给结论或决策项，让收件人扫一眼就知道是不是需要他做什么
+- **问候 / 落款不超 1 段**：`Hi 各位 Reviewer，` / `各位同事：` 一句话即可；落款 `[发件人姓名] / [团队] / [日期]` 一行结束
+
+### 严禁手拼 raw EML
+
+> **CRITICAL：严禁手拼 raw EML 直传 `drafts.create`，必须走 compose 5 shortcut（`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward`）或 `+draft-edit` 的 body op。**
+
+`emlbuilder` 已内置 RFC 合规处理（base64 / boundary / header folding / 附件 RFC 2231 等），AI **无需自学 RFC**。手拼 raw EML 几乎一定会踩坑（编码错误 / 边界冲突 / 收件端不渲染），且绕开了 lark-cli 的统一安全和兼容性兜底——本仓库的 `+send` / `+draft-create` 等 shortcut 已封装好所有发信细节，AI 只需关注业务字段（收件人 / 主题 / HTML 正文 / 附件路径）即可。
+
+### 写入路径内置 HTML lint
+
+`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` / `+draft-edit` body op 在调用 `emlbuilder` **之前**会强制对 HTML 正文做 lint：
+
+- 错误（`<script>` / `on*` / `javascript:` URL / `<iframe>` / `<form>` / `<style>` / `<link>` 等）会被**直接删除**
+- 警告（`<font>` / `<center>` / `<marquee>`）会被**自动修复**为飞书原生写法
+- 不允许的 CSS property（`position` / `z-index` / `transform` 等）会从 inline `style` 里删除
+
+stdout 永远输出结构化 lint 报告，即使无改动也是空数组：
+
+```json
+{
+  "ok": true,
+  "data": {
+    "draft_id": "...",
+    "lint_applied": [
+      {"rule_id": "TAG_FONT_TO_SPAN", "severity": "warning", "tag_or_attr": "font",
+       "excerpt": "<font color=\"red\"...>", "hint": "已替换为 <span style=...>"}
+    ],
+    "original_blocked": [
+      {"rule_id": "TAG_SCRIPT_BLOCKED", "severity": "error", "tag_or_attr": "script",
+       "excerpt": "<script...>", "hint": "已整段删除（XSS 风险，服务端 RemoteSanitizer 必拒）"}
+    ]
+  }
+}
+```
+
+写入路径**没有 `--no-lint` 总开关**——这是本方案的安全契约。如果想预先看 HTML 是否会被改动，先用 [`+lint-html`](references/lark-mail-lint-html.md) 跑一次。
+
 ### 读取邮件：按需控制返回内容
 
 `+message`、`+messages`、`+thread` 默认返回 HTML 正文（`--html=true`）。仅需确认操作结果（如验证标记已读、移动文件夹是否成功）时，用 `--html=false` 跳过 HTML 正文，只返回纯文本，显著减少 token 消耗。

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -295,6 +295,39 @@ lark-cli mail +send --to alice@example.com --subject '周报' \
 lark-cli mail +reply --message-id <id> --body '收到，谢谢'
 ```
 
+**HTML 写法、风格指引、场景模板请参考三份配套文档：**
+
+- [HTML 兼容白名单](references/lark-mail-html-allowlist.md) — 标签 / class / inline style 速查；表格 / 列表 / 字号 / 引用 / 链接 / 内嵌图片标准写法
+- [飞书原生写法（含风格指引与 3 套完整模板）](references/lark-mail-feishu-native.md) — 通知 / 周报 / 决策请求三套漂亮模板（含问候开场 + 骨架 + 落款）
+- [`+lint-html` 用法](references/lark-mail-lint-html.md) — 创建草稿前自检 / 修复 AI 输出 / CI 校验静态 HTML 模板
+
+### 邮件风格规范
+
+写信时必须遵守的文风底线（详见 [飞书原生写法](references/lark-mail-feishu-native.md)）：
+
+- **禁机械编号**：用 `<ul>` / `<ol>` 表达列表，不要用 "一、二、三" / "①②③" / "1) 2) 3)"
+- **emoji 克制**：emoji 仅作状态标签（⏰紧急 / ✅完成 / ⚠️风险），不要在正文段落里堆 emoji 装饰
+- **禁冗长 disclaimer**：删除 "希望对您有帮助" / "感谢您的耐心阅读" 等填充语；信息密度优先
+- **标题 ≤ 30 字**：邮件主题 `--subject` 控制在 30 字内，避免被收件箱截断
+- **决策 / 结论前置**：第一段就给结论或决策项
+- **问候 / 落款不超 1 段**：`Hi 各位 Reviewer，` / `各位同事：` 一句话即可
+
+### 严禁手拼 raw EML
+
+> **CRITICAL：严禁手拼 raw EML 直传 `drafts.create`，必须走 compose 5 shortcut（`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward`）或 `+draft-edit` 的 body op。**
+
+`emlbuilder` 已内置 RFC 合规处理（base64 / boundary / header folding / 附件 RFC 2231 等），AI **无需自学 RFC**。手拼 raw EML 几乎一定会踩坑，且绕开了 lark-cli 的统一安全和兼容性兜底。本仓库的 `+send` / `+draft-create` 等 shortcut 已封装好所有发信细节，AI 只需关注业务字段即可。
+
+### 写入路径内置 HTML lint
+
+`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` / `+draft-edit` body op 在调用 `emlbuilder` **之前**会强制对 HTML 正文做 lint：
+
+- 错误（`<script>` / `on*` / `javascript:` URL / `<iframe>` / `<form>` / `<style>` / `<link>` 等）会被**直接删除**
+- 警告（`<font>` / `<center>` / `<marquee>`）会被**自动修复**为飞书原生写法
+- 不允许的 CSS property（`position` / `z-index` / `transform` 等）会从 inline `style` 里删除
+
+stdout 永远输出结构化 lint 报告（`lint_applied[]` / `original_blocked[]`），即使无改动也是空数组。写入路径**没有 `--no-lint` 总开关**——这是本方案的安全契约。如果想预先看 HTML 是否会被改动，先用 [`+lint-html`](references/lark-mail-lint-html.md) 跑一次。
+
 ### 读取邮件：按需控制返回内容
 
 `+message`、`+messages`、`+thread` 默认返回 HTML 正文（`--html=true`）。仅需确认操作结果（如验证标记已读、移动文件夹是否成功）时，用 `--html=false` 跳过 HTML 正文，只返回纯文本，显著减少 token 消耗。
@@ -431,6 +464,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli mail +<verb> [flags]`）�
 | [`+share-to-chat`](references/lark-mail-share-to-chat.md) | Share an email or thread as a card to a Lark IM chat. |
 | [`+template-create`](references/lark-mail-template-create.md) | Create a personal mail template. Scans HTML <img src> local paths (reusing draft inline-image detection), uploads inline images and non-inline attachments to Drive, rewrites HTML to cid: references, and POSTs a Template payload to mail.user_mailbox.templates.create. |
 | [`+template-update`](references/lark-mail-template-update.md) | Update an existing mail template. Supports --inspect (read-only projection), --print-patch-template (prints a JSON skeleton for --patch-file), and flat flags (--set-subject / --set-name / etc). Internally it GETs the template, applies the patch, rewrites <img> local paths to cid: refs, and PUTs a full-replace update (no optimistic locking: last-write-wins). |
+| [`+lint-html`](references/lark-mail-lint-html.md) | Lint mail HTML body for compatibility / safety / Feishu-native rules. Returns warnings/errors and (default) auto-fixed HTML. Read-only: no draft, no API call. Use this BEFORE creating a draft to preview what the writing-path lint would change, or as a CI gate for static HTML templates. |
 
 ## API Resources
 

--- a/skills/lark-mail/references/lark-mail-feishu-native.md
+++ b/skills/lark-mail/references/lark-mail-feishu-native.md
@@ -1,0 +1,285 @@
+# 飞书原生邮件写法与文风指引
+
+> **前置条件：** 先阅读 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解通用安全规则。本文档定义写信文风、原生 HTML 写法速查与 3 套主流场景模板。所有 HTML 写法对齐 mail-editor `editor-kit` 分支默认行为。
+
+写信路径（`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` / `+draft-edit` body op）会自动 lint 并 autofix；本文档定义**直接写就能通过 lint** 的飞书原生写法。配合 [`HTML 兼容白名单`](./lark-mail-html-allowlist.md) 与 [`+lint-html` 用法](./lark-mail-lint-html.md) 使用。
+
+## 一、邮件文风规范
+
+### 风格底线
+
+- **禁机械编号**：不要堆 "一、二、三" / "①②③" / "1) 2) 3)" 这种机械列表写法；该用列表的用 `<ul>` / `<ol>`，该用段落的用 `<p>`，让飞书原生编辑器渲染。
+- **emoji 克制**：emoji 仅作状态标签（如收件箱里 ⏰ 紧急 / ✅ 已完成 / ⚠️ 风险），**不要在正文段落里堆 emoji 装饰**。
+- **禁冗长 disclaimer 与客套**：删除 "希望对您有帮助" / "如有任何问题请随时联系" / "感谢您的耐心阅读" 这类填充语；信息密度优先。
+- **问候 / 落款不超 1 段**：`Hi 各位 Reviewer，` / `各位同事：` 一句话即可，避免冗长寒暄。落款 `[发件人姓名] / [团队] / [日期]` 一行结束。
+- **正文长度自适应**：周报 / 月报这类汇总型可上百行，决策请求可数行；不限制正文长度，但**首屏要见到关键信息**。
+
+### 标题与决策项
+
+- **标题 ≤ 30 字**：邮件主题行 `--subject` 控制在 30 字内；超过会在收件箱里被截断。
+- **决策 / 结论前置**：第一段就给结论或决策项，让收件人扫一眼就知道是不是需要他做什么。
+- **避免 "[xxx] [yyy] [zzz] 关于 ..."**：方括号前缀不超过一组（如 `[紧急]` / `[决策请求]`），多了就乱。
+
+### 标点 / 排版
+
+- 中文使用全角标点（`，` / `。` / `：` / `；`）；英文使用半角（`,` / `.` / `:` / `;`）。
+- 中英混排时，英文 / 数字两侧加空格：`本周 PR 共 12 个`，不写成 `本周PR共12个`。
+- 不要用 `&nbsp;` 制造缩进；段落前缩进用 `<p style="text-indent:2em">...</p>`。
+
+## 二、原生格式速查
+
+字号 / 颜色对齐 mail-editor editor-kit 分支：
+
+| 元素 | 飞书原生写法 | 关键点 |
+|------|--------------|--------|
+| 标题 | `<h1>` ~ `<h6>` | 字号映射 title 34px / h1 26px / h2 22px / h3 20px / h4 18px / h5 16px / h6 16px，自动加粗 |
+| 段落 | `<p>` 或 `<div>` | 不要连续多个空 `<p>` 制造行距；用 `<p><br></p>` 一次 |
+| 强调 | `<b>` / `<strong>` 加粗；`<i>` / `<em>` 斜体；`<u>` 下划线；`<s>` 删除线；`<sub>` / `<sup>` 上下标 | 全部支持；避免 `<font weight=...>` 等过时写法 |
+| 字号 | `<span style="font-size:14px">…</span>`；常用 12px / 14px / 16px / 18px / 24px | 写信默认 14px；PC 引用区 12px / mobile 引用区 14px；不走 `<font size>` |
+| 颜色 | `<span style="color:rgb(31,35,41)">…</span>` | 主色 `rgb(31,35,41)` 黑文 / `rgb(100,106,115)` 灰副 / `rgb(245,246,247)` 浅灰底 / 强调色 `rgb(225,77,42)` 橙红 |
+| 行间距 | `<div style="line-height:1.6">…</div>` | 写信默认 1.6 |
+| 分点（无序） | `<ul><li>…</li></ul>` | 多级嵌套；不要用 "一、二、三" 中文编号当列表 |
+| 分点（有序） | `<ol><li>…</li></ol>` | 同上多级嵌套 |
+| 引用 | `<blockquote>…</blockquote>` | 用户撰写引用用 `<blockquote>`；reply / forward 引用区由飞书自动生成 |
+| 链接 | `<a href="https://...">…</a>` / `<a href="mailto:...">` | 拒 `javascript:` / `vbscript:`；`cid:` / `data:image/*` 放行 |
+| 表格 | `<table><thead><tr><th>…</th></tr></thead><tbody><tr><td>…</td></tr></tbody></table>` | 单元格不嵌脚本 / 表单 |
+| 内嵌图片 | `<img src="./path/to/file" />` | 路径必须是 lark-cli cwd 子树（不接受绝对路径或 `..` 跨出 cwd）；CLI 自动注册为 inline part |
+| 水平分割 | `<hr>` | 飞书原生支持 |
+| 代码 | `<code>…</code>`（行内）/ `<pre>…</pre>`（块） | 等宽字体；不渲染 markdown |
+| 段间留白 | `<p><br></p>` | 不要叠 `margin-top` / `margin-bottom` |
+
+### 禁用 / 降级清单
+
+| 写法 | 处理 | 说明 |
+|------|------|------|
+| `<font>` | autofix → `<span style>` | color / face / size 转 inline style |
+| `<center>` | autofix → `<div style="text-align:center">` | 已过时 |
+| `<style>` 块 | 删除 | 飞书原生编辑器禁止 `<style>`；改用 inline `style="..."` |
+| `<link rel="stylesheet">` | 删除 | 不允许外链 CSS |
+| `<script>` / `<iframe>` / `<form>` / `<input>` | 整段删除 | XSS / 表单不允许在邮件正文中 |
+
+完整规则见 [`HTML 兼容白名单`](./lark-mail-html-allowlist.md)。
+
+## 三、3 套主流场景模板（完整可复用 HTML）
+
+每套模板含问候开场 + 正文骨架 + 落款，AI 套用时直接替换 `[变量]` 即可。所有模板均通过 lint（无 warning，无 error）。
+
+### 模板 1 — 通知（制度变更 / 系统告警 / 例行播报）
+
+```html
+<div style="font-size:14px;line-height:1.6;color:rgb(31,35,41)">
+  <p>各位同事：</p>
+  <p><br></p>
+  <h3 style="color:rgb(31,35,41)">[一句话主题，如「XX 系统将于本周日 22:00 维护升级」]</h3>
+  <p>本次升级将影响 <span style="color:rgb(225,77,42);font-weight:bold">[影响范围，例：所有内网用户访问 XX 系统]</span>，预计停机时间 <span style="font-weight:bold">[X] 分钟</span>。请相关同事提前安排工作。</p>
+  <p><br></p>
+  <h4 style="color:rgb(31,35,41)">关键变更</h4>
+  <ul>
+    <li>变更点 1：[简短描述]</li>
+    <li>变更点 2：[简短描述]</li>
+    <li>变更点 3：[简短描述]</li>
+  </ul>
+  <p><br></p>
+  <h4 style="color:rgb(31,35,41)">字段对照</h4>
+  <table style="border-collapse:collapse;width:100%">
+    <thead>
+      <tr style="background-color:rgb(245,246,247)">
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:left;font-weight:bold;color:rgb(31,35,41)">字段</th>
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:left;font-weight:bold;color:rgb(31,35,41)">变更前</th>
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:left;font-weight:bold;color:rgb(31,35,41)">变更后</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[字段名]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;color:rgb(100,106,115)">[旧值]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;color:rgb(225,77,42);font-weight:bold">[新值]</td>
+      </tr>
+      <tr>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[字段名]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;color:rgb(100,106,115)">[旧值]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;color:rgb(225,77,42);font-weight:bold">[新值]</td>
+      </tr>
+    </tbody>
+  </table>
+  <p><br></p>
+  <h4 style="color:rgb(31,35,41)">生效时间与联系人</h4>
+  <p>生效时间：<span style="font-weight:bold">[YYYY-MM-DD HH:mm]</span></p>
+  <p>问题反馈：<a href="mailto:[owner@example.com]">[Owner 姓名]</a>（[团队]）</p>
+  <p><br></p>
+  <p style="color:rgb(100,106,115);font-size:12px">如对本次升级有疑问，请在 [日期] 前邮件反馈。逾期视为已知悉。</p>
+  <p><br></p>
+  <p>—</p>
+  <p>[发件人姓名] / [团队] / [日期]</p>
+</div>
+```
+
+### 模板 2 — 周报（周度进展 / 月度汇总）
+
+```html
+<div style="font-size:14px;line-height:1.6;color:rgb(31,35,41)">
+  <p>各位同事：</p>
+  <p><br></p>
+  <p>以下为 <span style="font-weight:bold">[团队] [起止日期] 周报</span>，关键指标与下周计划如下。</p>
+  <p><br></p>
+  <h3 style="color:rgb(31,35,41)">本周进展</h3>
+  <ul>
+    <li><span style="font-weight:bold">[模块 A]</span> 完成 [具体成果]，<span style="color:rgb(100,106,115)">[数据 / 链接]</span></li>
+    <li><span style="font-weight:bold">[模块 B]</span> 完成 [具体成果]</li>
+    <li><span style="font-weight:bold">[模块 C]</span> 完成 [具体成果]</li>
+  </ul>
+  <p><br></p>
+  <h3 style="color:rgb(31,35,41)">下周计划</h3>
+  <ol>
+    <li>[计划项 1：明确产出物 + Owner + 截止日]</li>
+    <li>[计划项 2]</li>
+    <li>[计划项 3]</li>
+  </ol>
+  <p><br></p>
+  <h3 style="color:rgb(31,35,41)">关键指标</h3>
+  <table style="border-collapse:collapse;width:100%">
+    <thead>
+      <tr style="background-color:rgb(245,246,247)">
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:left;font-weight:bold;color:rgb(31,35,41)">指标</th>
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:right;font-weight:bold;color:rgb(31,35,41)">本周</th>
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:right;font-weight:bold;color:rgb(31,35,41)">上周</th>
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:right;font-weight:bold;color:rgb(31,35,41)">环比</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[DAU]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;text-align:right">[本周值]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;text-align:right;color:rgb(100,106,115)">[上周值]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;text-align:right;color:rgb(225,77,42);font-weight:bold">[+X%]</td>
+      </tr>
+      <tr>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[转化率]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;text-align:right">[本周值]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;text-align:right;color:rgb(100,106,115)">[上周值]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;text-align:right;color:rgb(225,77,42);font-weight:bold">[+X%]</td>
+      </tr>
+      <tr>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[P0 故障数]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;text-align:right">[本周值]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;text-align:right;color:rgb(100,106,115)">[上周值]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;text-align:right">[持平]</td>
+      </tr>
+    </tbody>
+  </table>
+  <p><br></p>
+  <h3 style="color:rgb(31,35,41)">风险与依赖</h3>
+  <table style="border-collapse:collapse;width:100%">
+    <thead>
+      <tr style="background-color:rgb(245,246,247)">
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:left;font-weight:bold;color:rgb(31,35,41)">项</th>
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:left;font-weight:bold;color:rgb(31,35,41)">影响</th>
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:left;font-weight:bold;color:rgb(31,35,41)">应对 / Owner</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[风险项 1]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px"><span style="color:rgb(225,77,42);font-weight:bold">高</span> / [影响范围]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[应对方案] / @[Owner]</td>
+      </tr>
+      <tr>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[依赖项 2]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px"><span style="color:rgb(100,106,115)">中</span> / [影响范围]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[等待 X 团队回复] / @[Owner]</td>
+      </tr>
+    </tbody>
+  </table>
+  <p><br></p>
+  <p style="color:rgb(100,106,115);font-size:12px">备注：[补充信息，如周报会议时间、详细数据看板链接等]</p>
+  <p><br></p>
+  <p>—</p>
+  <p>[发件人姓名] / [团队] / [日期]</p>
+</div>
+```
+
+### 模板 3 — 决策请求（方案审批 / 预算申请 / 拍板）
+
+```html
+<div style="font-size:14px;line-height:1.6;color:rgb(31,35,41)">
+  <p>Hi 各位 Reviewer，</p>
+  <p><br></p>
+  <p>下方是 <span style="font-weight:bold">[方案 / 项目名称]</span> 的审批请求，请协助拍板。</p>
+  <p><br></p>
+  <h3 style="color:rgb(31,35,41)">请求事项</h3>
+  <p style="color:rgb(225,77,42);font-weight:bold">请于 [YYYY-MM-DD] 前选定方案 [A/B/C]，并 reply 此邮件确认。</p>
+  <p><br></p>
+  <h3 style="color:rgb(31,35,41)">背景</h3>
+  <p>[2-3 句上下文：项目处于哪个阶段、为何需要决策、不决策的影响。例：「Q3 用户增长目标 30%，目前两套获客方案在评审阶段，需在本周内决定走 A 还是 B 以确保按时启动」。]</p>
+  <p><br></p>
+  <h3 style="color:rgb(31,35,41)">选项与建议</h3>
+  <table style="border-collapse:collapse;width:100%">
+    <thead>
+      <tr style="background-color:rgb(245,246,247)">
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:left;font-weight:bold;color:rgb(31,35,41)">方案</th>
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:left;font-weight:bold;color:rgb(31,35,41)">优势</th>
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:left;font-weight:bold;color:rgb(31,35,41)">劣势</th>
+        <th style="border:1px solid rgb(220,220,220);padding:8px;text-align:left;font-weight:bold;color:rgb(31,35,41)">推荐</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td style="border:1px solid rgb(220,220,220);padding:8px"><span style="font-weight:bold">A：[方案 A 名称]</span></td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[2-3 项关键优势]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;color:rgb(100,106,115)">[2-3 项关键劣势]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;color:rgb(225,77,42);font-weight:bold;text-align:center">推荐</td>
+      </tr>
+      <tr>
+        <td style="border:1px solid rgb(220,220,220);padding:8px"><span style="font-weight:bold">B：[方案 B 名称]</span></td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[关键优势]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;color:rgb(100,106,115)">[关键劣势]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;text-align:center">备选</td>
+      </tr>
+      <tr>
+        <td style="border:1px solid rgb(220,220,220);padding:8px"><span style="font-weight:bold">C：[维持现状 / 不做]</span></td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px">[优势：成本低 / 风险小]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;color:rgb(100,106,115)">[劣势：错过窗口期等]</td>
+        <td style="border:1px solid rgb(220,220,220);padding:8px;text-align:center">不推荐</td>
+      </tr>
+    </tbody>
+  </table>
+  <p><br></p>
+  <p>建议方案：<span style="color:rgb(225,77,42);font-weight:bold">A：[方案 A 名称]</span>。原因：[1 句话核心理由，例：「与 Q3 KPI 节奏匹配且 ROI 最高」]。</p>
+  <p><br></p>
+  <h3 style="color:rgb(31,35,41)">需要的决策与时间</h3>
+  <ul>
+    <li>请 [Approver 1]、[Approver 2] 在 <span style="font-weight:bold">[YYYY-MM-DD HH:mm]</span> 前 reply 此邮件确认方案选择</li>
+    <li>抄送：[Stakeholder 1]、[Stakeholder 2]，知悉即可，无需 reply</li>
+    <li>详细方案文档：<a href="https://[doc-url]">[方案详细文档链接]</a>（可选预读）</li>
+  </ul>
+  <p><br></p>
+  <p style="color:rgb(100,106,115);font-size:12px">如对方案有疑问，可直接邮件回复或联系 [Owner 姓名] (<a href="mailto:[owner@example.com]">[owner@example.com]</a>)。</p>
+  <p><br></p>
+  <p>—</p>
+  <p>[发件人姓名] / [团队] / [日期]</p>
+  <p style="color:rgb(100,106,115);font-size:12px">联系电话：[可选]</p>
+</div>
+```
+
+## 四、套用模板的实务
+
+1. **替换 `[变量]`**：所有方括号占位符是 placeholder，AI 套用时全部替换。
+2. **删除不适用的段**：模板提供完整结构，但具体场景下某些段可能不需要（例：通知模板的"字段对照表"不是每次都有）；删除整段而不是留空表格。
+3. **正文 `--body` 直接传 HTML**：写信链路（`+send` / `+draft-create` / ...）的 `--body` 参数原样接收上述 HTML 即可：
+
+   ```bash
+   lark-cli mail +draft-create --as user \
+     --to alice@example.com \
+     --subject 'Q3 获客方案审批' \
+     --body "$(cat ./template-decision.html)"
+   ```
+
+4. **lint 兜底**：写信链路会自动 lint，warning 自动修复，error 整段删除；stdout 同时返回 `lint_applied[]` / `original_blocked[]`。如果想先看会被怎么改，先跑 [`+lint-html`](./lark-mail-lint-html.md)。
+
+5. **预览草稿链接**：所有写信 shortcut 在创建草稿后会返回 `reference` 字段（草稿打开链接），AI 应展示给用户去飞书邮箱 UI 里复核。
+
+## 相关文档
+
+- [HTML 兼容白名单](./lark-mail-html-allowlist.md)
+- [`+lint-html` 用法](./lark-mail-lint-html.md)
+- 写信 shortcut: [`+send`](./lark-mail-send.md) / [`+draft-create`](./lark-mail-draft-create.md) / [`+reply`](./lark-mail-reply.md) / [`+reply-all`](./lark-mail-reply-all.md) / [`+forward`](./lark-mail-forward.md) / [`+draft-edit`](./lark-mail-draft-edit.md)

--- a/skills/lark-mail/references/lark-mail-html-allowlist.md
+++ b/skills/lark-mail/references/lark-mail-html-allowlist.md
@@ -1,0 +1,221 @@
+# 邮件 HTML 兼容白名单
+
+> **前置条件：** 先阅读 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解通用安全规则。本文档定义 lark-cli mail 域写信场景下被允许的 HTML / CSS / URL 写法。
+
+写信路径（`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` / `+draft-edit` body op）以及 `+lint-html` 共享同一份规则库。本文档是规则的速查表——AI / 用户撰写邮件 HTML 时按本文档写就能避开所有 lint warning，确保飞书原生编辑器、收件端三方邮箱（Gmail / Outlook / Apple Mail）渲染一致。
+
+完整命令用法见 [`+lint-html`](./lark-mail-lint-html.md)。
+
+## 三档处理一览
+
+| 档位 | 处理 | 覆盖范围 |
+|------|------|----------|
+| 通过 | 不报 warning | 通用块、原生强调、列表、表格、引用、链接、图片等 |
+| 警告 + 自动修复 | warning，`--auto-fix` 时降级；写信路径默认 autofix | `<font>` / `<center>` / `<marquee>` / `<blink>` |
+| 错误（删除） | error，`--strict` 非零退出；写信路径总是删 | `<script>` / `<style>` / `<iframe>` / `<form>` 等；`on*` 属性；`javascript:` URL |
+
+## 标签白名单
+
+### 通用块
+
+| 写法 | 说明 |
+|------|------|
+| `<p>...</p>` | 段落，不要连续多个空 `<p>` 制造行距，请改用 `<p><br></p>` 一次 |
+| `<div>...</div>` | 块容器，可设 `style="line-height:1.6"` 等内联样式 |
+| `<span>...</span>` | 行内容器，常用承载 `style="color:..."` / `font-size:...` |
+| `<br>` | 单行换行；`<br>` 之间不需要 `</br>` |
+| `<hr>` | 水平分割线 |
+| `<blockquote>...</blockquote>` | 用户引用块；reply / forward 自动生成的引用区由 CLI 处理，AI 不要重写 |
+| `<pre>...</pre>` / `<code>...</code>` | 代码块（`<pre>`）/ 行内代码（`<code>`） |
+
+### 强调
+
+| 写法 | 说明 |
+|------|------|
+| `<b>` / `<strong>` | 加粗 |
+| `<i>` / `<em>` | 斜体 |
+| `<u>` | 下划线 |
+| `<s>` / `<strike>` | 删除线 |
+| `<sub>` / `<sup>` | 上下标 |
+
+### 标题
+
+| 写法 | 字号映射（mail-editor editor-kit 分支） |
+|------|----------------------------------------|
+| `<h1>` | 26px，自动加粗 |
+| `<h2>` | 22px |
+| `<h3>` | 20px |
+| `<h4>` | 18px |
+| `<h5>` / `<h6>` | 16px |
+
+### 列表
+
+| 写法 | 说明 |
+|------|------|
+| `<ul><li>...</li></ul>` | 无序列表，可多级嵌套 |
+| `<ol><li>...</li></ol>` | 有序列表，可多级嵌套 |
+
+**不要**用 `<p>一、...</p><p>二、...</p>` 这种「中文编号 + 段落」的列表样式——失去无序 / 有序列表的语义，且飞书原生编辑器渲染不一致。
+
+### 表格
+
+```html
+<table>
+  <thead>
+    <tr><th>字段</th><th>值</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>x</td><td>y</td></tr>
+  </tbody>
+</table>
+```
+
+允许：`<table>` / `<thead>` / `<tbody>` / `<tfoot>` / `<tr>` / `<td>` / `<th>` / `<caption>` / `<colgroup>` / `<col>`。
+
+**不要**在 `<td>` 内嵌 `<form>` / `<input>` / `<script>`——会被 lint 删除。
+
+### 链接
+
+```html
+<a href="https://example.com">外链</a>
+<a href="mailto:user@example.com">邮件链接</a>
+```
+
+允许的 URL scheme：`http://` / `https://` / `mailto:` / `cid:`（内嵌图片，由 CLI 自动注入）/ `data:image/*`（base64 内嵌图片）。
+
+**禁止**：`javascript:` / `vbscript:` / `file:` —— lint 直接删属性并报 error。
+
+### 内嵌图片
+
+```html
+<img src="./logo.png" alt="logo">
+```
+
+- **路径必须是相对路径**（cwd 子树内）；CLI 自动上传到 Drive 并改写为 `cid:` 引用。
+- **不接受**绝对路径或 `..` 跨出 cwd 的相对路径。
+- 也支持手动 `<img src="cid:abc">` 配合 `--inline '[{"cid":"abc","file_path":"./logo.png"}]'` 精确控制 CID。
+
+## CSS inline style 白名单
+
+只能用 inline `style="..."` 属性表达样式；不允许 `<style>` 标签或外链 `<link rel="stylesheet">`。
+
+允许的 CSS property：
+
+| 类别 | 允许的 property |
+|------|----------------|
+| 颜色 | `color` / `background-color` |
+| 字号 / 字重 | `font-size` / `font-weight` / `font-style` / `font-family` |
+| 排版 | `text-align` / `text-decoration` / `text-indent` / `text-transform` / `line-height` / `letter-spacing` / `vertical-align` |
+| 盒模型 | `padding` / `padding-*` / `margin` / `margin-*` / `width` / `height` / `min-width` / `max-width` / `min-height` / `max-height` / `display` / `box-sizing` |
+| 边框 | `border` / `border-*`（含 `border-top` / `border-radius` / `border-color` 等所有 `border-` 前缀） |
+| 列表 | `list-style` / `list-style-type` |
+| 文本流 | `white-space` / `word-break` / `word-wrap` / `overflow` / `overflow-wrap` / `hyphens` |
+| 杂项 | `cursor` / `opacity` |
+
+**不在白名单的 property（如 `position` / `z-index` / `transform` / `animation` / `transition` / `filter`）会被删除并报 STYLE_PROPERTY_DROPPED warning。**
+
+## 标准写法示例
+
+### 字号
+
+```html
+<span style="font-size:14px">写信默认 14px</span>
+<span style="font-size:12px">PC 引用区默认 12px</span>
+```
+
+不要使用 `<font size="3">` —— lint 会重写为等价的 `<span style="font-size:16px">`。
+
+### 颜色
+
+```html
+<span style="color:rgb(31,35,41)">主色（黑文）</span>
+<span style="color:rgb(100,106,115)">副色（灰文）</span>
+<span style="color:rgb(225,77,42)">强调色（橙红）</span>
+```
+
+飞书原生主色板：
+- 主色 `rgb(31,35,41)`（黑文）
+- 副色 `rgb(100,106,115)`（灰副）
+- 强调 `rgb(225,77,42)`（橙红，用于关键字段强调）
+- 浅灰底 `rgb(245,246,247)`（用于表头加粗灰底）
+
+### 行间距
+
+```html
+<div style="line-height:1.6">写信默认 1.6 行间距</div>
+```
+
+### 段间留白
+
+```html
+<p>段一</p>
+<p><br></p>
+<p>段二</p>
+```
+
+不要堆叠 `margin-top` / `margin-bottom`；用一个 `<p><br></p>` 即可。
+
+### 引用
+
+```html
+<blockquote>用户撰写的引用文字</blockquote>
+```
+
+reply / forward 的引用区由 CLI 自动生成（基于 `adit-html-block` / `history-quote-*` 类），AI 不要手动构造这部分。
+
+## 错误示例（lint 会报错）
+
+```html
+<!-- ❌ XSS：on* 属性 -->
+<img src="cid:logo" onerror="alert(1)">
+→ ATTR_EVENT_HANDLER_BLOCKED, onerror 已删除
+
+<!-- ❌ javascript: URL -->
+<a href="javascript:void(0)">click</a>
+→ ATTR_JS_URL_BLOCKED
+
+<!-- ❌ <script> 标签 -->
+<p>正文</p><script>track()</script>
+→ TAG_SCRIPT_BLOCKED, <script> 整段删除
+
+<!-- ❌ 外链 CSS -->
+<link rel="stylesheet" href="https://cdn/style.css">
+→ TAG_LINK_BLOCKED
+
+<!-- ❌ <iframe> 嵌入 -->
+<iframe src="https://x.com"></iframe>
+→ TAG_IFRAME_BLOCKED
+
+<!-- ❌ <form> 表单 -->
+<form action="/submit"><input name="x"></form>
+→ TAG_FORM_BLOCKED, TAG_INPUT_BLOCKED
+
+<!-- ⚠️ <font> 已过时（写信路径自动修复为 <span style>） -->
+<font color="red" size="3">x</font>
+→ TAG_FONT_TO_SPAN, autofix 后 <span style="color:red;font-size:16px">
+
+<!-- ⚠️ <center> 已过时（autofix 为 <div style="text-align:center">） -->
+<center>居中</center>
+→ TAG_CENTER_TO_DIV
+
+<!-- ⚠️ 不在白名单的 CSS property -->
+<p style="position:absolute; color:red">x</p>
+→ STYLE_PROPERTY_DROPPED (position), color 保留
+```
+
+## 飞书原生 quote / 编辑器 class
+
+reply / forward 的 quote 区域使用一组飞书原生 class，**lint 全部放行**——AI 不要试图改动这些 class，会破坏原有引用结构：
+
+- `adit-html-block`、`adit-html-block--collapsed`、`adit-html-block--header`
+- `history-quote-meta-wrapper`、`history-quote-gap-tag`、`history-quote-forward-title`、`history-quote-meta-after-forward-title`
+- `lark-mail-doc-quote`
+- `quote-head-meta-mailto`、`lme-line-signal`
+
+`+reply` / `+reply-all` / `+forward` 由 CLI 自动构造这些 quote 元素；AI 编辑写信内容时只关心**用户撰写的正文**部分（引用区由 CLI 自动追加在末尾或前置）。
+
+## 相关文档
+
+- [飞书原生写法（含 3 套模板）](./lark-mail-feishu-native.md)
+- [`+lint-html` 用法](./lark-mail-lint-html.md)
+- 写信 shortcut: [`+send`](./lark-mail-send.md) / [`+draft-create`](./lark-mail-draft-create.md) / [`+reply`](./lark-mail-reply.md) / [`+reply-all`](./lark-mail-reply-all.md) / [`+forward`](./lark-mail-forward.md) / [`+draft-edit`](./lark-mail-draft-edit.md)

--- a/skills/lark-mail/references/lark-mail-lint-html.md
+++ b/skills/lark-mail/references/lark-mail-lint-html.md
@@ -1,0 +1,139 @@
+# mail +lint-html
+
+> **前置条件：** 先阅读 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
+
+对邮件 HTML 正文做兼容性 / 合规性 / 飞书原生写法的本地预检（read-only，无网络 IO）。本命令是写信链路（`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` / `+draft-edit` body op）内置 lint 的**预览版**——共享同一份规则库，行为一致；写信链路在调用 `emlbuilder` 之前会强制净化并通过 stdout 输出 `lint_applied[]` / `original_blocked[]`，本命令则把同一份报告直接返回，不做任何状态写入。
+
+适用场景：
+- AI / 用户在创建草稿前自检 HTML 是否会被改写或拒收（避免被服务端 RemoteSanitizer 截断）
+- 修复 AI 输出（先跑 `--auto-fix=true` 拿到 `cleaned_html`，回填进后续命令）
+- CI 流水线校验静态 HTML 模板（`--strict` 模式下任意 warning 也升级成 error）
+
+写信链路与本命令的区别：
+- 写信链路（`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` / `+draft-edit`）：**强制 `--auto-fix=true` / `--strict=false`**，无 `--no-lint` 开关——错误（`<script>` / `on*` / `javascript:` URL）总是被删，警告（`<font>` / `<center>`）总是 autofix；stdout 同时输出 `lint_applied` 和 `original_blocked` 数组（即使没改动也是空数组）。
+- 本命令：可由用户控制 `--auto-fix` / `--strict`，**不写入任何邮箱状态**，纯本地。
+
+## 命令
+
+```bash
+# 直接传 HTML（默认 --auto-fix=true，返回 cleaned_html）
+lark-cli mail +lint-html --body '<p>正文</p><font color="red">x</font>'
+
+# 从文件读 HTML（路径必须在 lark-cli 运行目录子树内）
+lark-cli mail +lint-html --body-file ./template.html
+
+# 仅获取违规清单，不返回 cleaned_html
+lark-cli mail +lint-html --body '<p>x</p>' --auto-fix=false
+
+# CI 严格模式：任意 warning 也 exit 非零
+lark-cli mail +lint-html --body-file ./template.html --strict
+
+# Dry Run（不执行 lint，只打印将做什么）
+lark-cli mail +lint-html --body '<p>x</p>' --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--body <html>` | 二选一 | 待检查的 HTML 内容。与 `--body-file` 二选一，恰好传一个 |
+| `--body-file <path>` | 二选一 | 从文件读取 HTML。**只支持 lark-cli 当前运行目录及其子路径**（绝对路径 / `..` 越出 cwd 会被拒，遵循 lark-cli 既有路径安全约束） |
+| `--auto-fix` | 否 | 默认 `true`。`true` 时返回 `cleaned_html`（warning 自动修复 + error 删除）；`false` 时仅输出违规清单不返回 `cleaned_html`（适合 CI 仅检测不修改） |
+| `--strict` | 否 | 默认 `false`。`true` 时把所有 warning 视作 error，命令退出码非零（适合 CI 把任何不规范都当失败处理） |
+| `--format <fmt>` | 否 | `json`（默认） / `pretty` / `table` / `csv` / `ndjson`。`pretty` 模式打印人类可读的违规摘要 |
+| `--jq <expr>` | 否 | 对返回 JSON 用 jq 表达式过滤 |
+| `--dry-run` | 否 | 不执行 lint，仅返回 dry-run 描述 |
+
+## 返回值
+
+```json
+{
+  "ok": true,
+  "data": {
+    "warnings": [
+      {
+        "rule_id": "TAG_FONT_TO_SPAN",
+        "severity": "warning",
+        "tag_or_attr": "font",
+        "excerpt": "<font color=\"red\"...>",
+        "hint": "已替换为 <span style=\"...\">（飞书原生编辑器使用 inline style 表达字号 / 颜色）"
+      }
+    ],
+    "errors": [
+      {
+        "rule_id": "TAG_SCRIPT_BLOCKED",
+        "severity": "error",
+        "tag_or_attr": "script",
+        "excerpt": "<script...>",
+        "hint": "已整段删除（XSS 风险，服务端 RemoteSanitizer 必拒）"
+      }
+    ],
+    "cleaned_html": "<p>...</p>"
+  }
+}
+```
+
+字段说明：
+- `warnings[]` / `errors[]` —— **永远是数组**（即使无违规也输出 `[]`，便于消费者无条件读 `data.warnings[]` / `data.errors[]`）。
+- 每条 finding 的字段：
+  - `rule_id` —— UPPER_SNAKE_CASE，如 `TAG_FONT_TO_SPAN` / `TAG_SCRIPT_BLOCKED` / `ATTR_EVENT_HANDLER_BLOCKED` / `ATTR_JS_URL_BLOCKED` / `STYLE_PROPERTY_DROPPED`
+  - `severity` —— `"warning"` 或 `"error"`
+  - `tag_or_attr` —— 触发规则的 tag / attribute / `style.<property>`
+  - `excerpt` —— HTML 片段（最多 200 字节，超出截断）
+  - `hint` —— 中文人类可读修复建议
+- `cleaned_html` —— 仅在 `--auto-fix=true` 时返回；warning 已 autofix（`<font>` → `<span style>`、`<center>` → `<div text-align:center>`），error 已删除。
+
+## 校验规则速览
+
+完整规则参见 [HTML 兼容白名单](./lark-mail-html-allowlist.md)。简表：
+
+| 档位 | 处理 | 覆盖范围 |
+|------|------|----------|
+| 通过 | 不报 finding | `<p>` / `<div>` / `<span>` / `<a href=...>` / `<img src=...>` / `<table>` / `<ul>/<ol>/<li>` / `<blockquote>` / `<h1>-<h6>` / `<b>/<i>/<em>/<strong>/<u>/<s>` / `<sub>/<sup>` / `<pre>/<code>` / 飞书原生 quote 类（`adit-html-block*`、`history-quote-*`、`lark-mail-doc-quote`） |
+| Warning + Autofix | warning，`--auto-fix=true` 时降级 | `<font>` → `<span style>`；`<center>` → `<div style="text-align:center">`；`<marquee>` / `<blink>` → `<span>` |
+| Error（删除） | error，`--strict` 时非零退出 | `<script>` / `<style>` / `<iframe>` / `<object>` / `<embed>` / `<form>` / `<input>` / `<link>` / `<meta>` / `<base>`；属性 `on*`（`onclick` / `onerror` / ...）；`javascript:` / `vbscript:` / `file:` URL；外链 `<link rel="stylesheet">` |
+
+URL scheme 白名单：`http(s):` / `mailto:` / `cid:` / `data:image/*` 通过；`javascript:` / `vbscript:` / `file:` 删除并报 error；其他 scheme（如 `webcal:`）警告。
+
+style 属性按 CSS property 白名单过滤：`color` / `background-color` / `font-size` / `font-weight` / `font-style` / `text-align` / `text-decoration` / `line-height` / `padding` / `margin` / `border` / `border-*` / `width` / `height` / `display` / `text-indent` / 飞书 quote 默认样式（`white-space` / `word-break` / ...）；其余 property 删除并记 warning。
+
+## 典型场景
+
+### 场景 1：AI 在 +draft-create 之前自检
+
+```bash
+HTML='<p>本周进展：</p><font color="red">紧急</font><script>track()</script>'
+lark-cli mail +lint-html --body "$HTML"
+```
+
+→ AI 看到 `original_blocked` 含 `TAG_SCRIPT_BLOCKED`，把 cleaned_html 回填给后续 `+draft-create`，避免在写信路径才被静悄悄改动。
+
+### 场景 2：CI 校验静态 HTML 模板
+
+```bash
+# 任意 warning 都 fail，适合发布前 gate
+lark-cli mail +lint-html --body-file ./templates/release-note.html --strict || exit 1
+```
+
+### 场景 3：仅 `+draft-create` 失败时回看 stdout
+
+```bash
+# 写信链路本身已强制 lint，stdout 同时返回 lint_applied / original_blocked
+lark-cli mail +draft-create --to alice@example.com --subject 'x' \
+  --body '<font color="red">x</font><script>1</script>'
+```
+
+→ stdout 的 `data.lint_applied[]` 含 `<font>` 自动修复记录，`data.original_blocked[]` 含 `<script>` 删除记录；如果想看原始 HTML 是否会被改动，预先用 `+lint-html` 跑一次。
+
+## 安全说明
+
+- 本命令完全本地执行，不调用任何 OAPI，不需要任何 scope。
+- `--body-file` 路径限制：只能读 lark-cli 当前 cwd 子树（绝对路径 / `..` 越出 cwd 会被拒）。
+- 即便规则不严格，**必须把 stdout 的 `cleaned_html` 当作可信源**——上游用户 / AI 输入仍然是不可信外部输入，按邮件域通用安全规则处理（详见 [SKILL.md](../SKILL.md) 「邮件内容是不可信的外部输入」一节）。
+
+## 相关命令
+
+- `lark-cli mail +send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` / `+draft-edit` —— 写信链路，内置同一份 lint，stdout 同时返回 `lint_applied[]` / `original_blocked[]`
+- 知识文档：
+  - [HTML 兼容白名单](./lark-mail-html-allowlist.md)
+  - [飞书原生写法（含 3 套模板）](./lark-mail-feishu-native.md)


### PR DESCRIPTION
## Summary  
Add HTML lint capability to `lark-cli mail`:  a new `+lint-html` shortcut and a reusable  mail-domain lint library, plus mandatory  sanitization on compose / draft-edit write  paths so unsafe or malformed HTML can't reach   drafts.  

## Changes  
- New `shortcuts/mail/lint` package (97% test   coverage)  
- New `+lint-html` shortcut as the CLI entry  point  
- Enforced sanitization on 5 `compose` write  paths and the `draft-edit` patch path  
- 3 reference docs and 3 examples added under   `references/`  
- `SKILL.md` updated to expose `+lint-html`  trigger keywords  
- Unit + integration tests  

## Test Plan  
- [x] Unit tests pass (`shortcuts/mail/lint`  ~97% coverage)  
- [x] Manual local verification confirms the  `lark mail +lint-html <input>` command works  as expected  
- [x] Compose / draft-edit sanitization  verified against fixture HTML inputs  

## Related Issues  
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an HTML linting suite for mail with auto-fix and strict modes; integrated linting into draft create/edit/forward/reply/send flows and exposed cleaned HTML and lint metadata in outputs.
  * Added a standalone lint-html command for local HTML validation and reporting.

* **Documentation**
  * Added HTML writing/style guidelines, an allowlist reference, and lint-html usage docs with examples and output format.

* **Tests**
  * Extensive test coverage added for lint rules, write-path integration, and the lint-html command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->