### PR TITLE
chore(release): v1.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.24] - 2026-05-06
+
+### Features
+
+- **sheets**: Add sheet management shortcuts (#722)
+- **base**: Support batch record get and delete (#630)
+- **task**: Add upload task attachment shortcut (#736)
+- **drive**: Pre-flight 10000-rune total cap for `+add-comment` `reply_elements` (#605)
+
+### Bug Fixes
+
+- **auth**: Handle missing scopes and device flow improvements (#752)
+- Add url to markdown `+create` output (#753)
+
+### Documentation
+
+- Refine field update conversion guidance (#748)
+
 ## [v1.0.23] - 2026-04-30
 
 ### Features
@@ -579,6 +597,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.24]: https://github.com/larksuite/cli/releases/tag/v1.0.24
 [v1.0.23]: https://github.com/larksuite/cli/releases/tag/v1.0.23
 [v1.0.22]: https://github.com/larksuite/cli/releases/tag/v1.0.22
 [v1.0.21]: https://github.com/larksuite/cli/releases/tag/v1.0.21

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

- Cut v1.0.24 with the 7 commits that landed since v1.0.23
- Update `CHANGELOG.md` (entry + reference link) and bump `package.json` to `1.0.24`

### Highlights

- **sheets**: New sheet management shortcuts
- **base**: Batch record get and delete
- **task**: Upload task attachment shortcut
- **drive**: Pre-flight 10000-rune total cap for `+add-comment` `reply_elements`
- **auth**: Handle missing scopes and device flow improvements
- **markdown**: Add url to `+create` output
- **docs**: Refine field update conversion guidance

## Test plan

- [ ] `git diff main -- CHANGELOG.md package.json` matches expectations
- [ ] CHANGELOG link reference for `[v1.0.24]` resolves on GitHub once tagged
- [ ] No other version strings still pinned to `1.0.23`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v1.0.24

* **New Features**
  * Added support for sheets, base, task, and drive operations.

* **Bug Fixes**
  * Improved authentication scopes handling.
  * Fixed URL output in +create command.

* **Documentation**
  * Refined and updated documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->