### PR TITLE
fix(auth): support comma-separated multi-scope in `auth login --scope`

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -62,7 +62,7 @@ browser. Run it in the background and retrieve the verification URL from its out
 	}
 	cmdutil.SetSupportedIdentities(cmd, []string{"user"})
 
-	cmd.Flags().StringVar(&opts.Scope, "scope", "", "scopes to request (space-separated)")
+	cmd.Flags().StringVar(&opts.Scope, "scope", "", "scopes to request (space- or comma-separated)")
 	cmd.Flags().BoolVar(&opts.Recommend, "recommend", false, "request only recommended (auto-approve) scopes")
 	available := sortedKnownDomains()
 	cmd.Flags().StringSliceVar(&opts.Domains, "domain", nil,
@@ -185,7 +185,11 @@ func authLoginRun(opts *LoginOptions) error {
 		}
 	}
 
-	finalScope := opts.Scope
+	// Normalize --scope so users can pass either OAuth-standard space-separated
+	// values or the more natural comma-separated list. RFC 6749 §3.3 mandates
+	// space-delimited scopes in the wire request, so the device authorization
+	// endpoint rejects raw "a,b" strings as a single malformed scope.
+	finalScope := normalizeScopeInput(opts.Scope)
 
 	// Resolve scopes from domain/permission filters
 	if len(selectedDomains) > 0 || opts.Recommend {
@@ -530,6 +534,40 @@ func shortcutSupportsIdentity(sc common.Shortcut, identity string) bool {
 		}
 	}
 	return false
+}
+
+// normalizeScopeInput accepts a user-supplied --scope value that may use
+// commas, spaces, tabs, or newlines (or any mix) as separators and returns the
+// canonical OAuth 2.0 wire form: a single space-joined string with empties
+// trimmed and duplicates removed (first occurrence wins; order preserved).
+//
+// Examples:
+//
+//	"vc:note:read,vc:meeting.meetingevent:read" -> "vc:note:read vc:meeting.meetingevent:read"
+//	"a, b ,  c"                                 -> "a b c"
+//	"a b a"                                     -> "a b"
+//	""                                          -> ""
+func normalizeScopeInput(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	// Treat both commas and any whitespace as separators.
+	fields := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	})
+	if len(fields) == 0 {
+		return ""
+	}
+	seen := make(map[string]struct{}, len(fields))
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if _, ok := seen[f]; ok {
+			continue
+		}
+		seen[f] = struct{}{}
+		out = append(out, f)
+	}
+	return strings.Join(out, " ")
 }
 
 // suggestDomain finds the best "did you mean" match for an unknown domain.

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -70,6 +70,32 @@ func TestSuggestDomain_ExactMatch(t *testing.T) {
 	}
 }
 
+func TestNormalizeScopeInput(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"single", "vc:note:read", "vc:note:read"},
+		{"comma", "vc:note:read,vc:meeting.meetingevent:read", "vc:note:read vc:meeting.meetingevent:read"},
+		{"space", "vc:note:read vc:meeting.meetingevent:read", "vc:note:read vc:meeting.meetingevent:read"},
+		{"comma_and_spaces", "vc:note:read, vc:meeting.meetingevent:read", "vc:note:read vc:meeting.meetingevent:read"},
+		{"mixed_separators", "a, b\tc\nd  e", "a b c d e"},
+		{"trim_and_dedup", "  a , b , a  ", "a b"},
+		{"trailing_separators", "a,b,,", "a b"},
+		{"only_separators", " , , ", ""},
+		{"tab_separated", "im:message:send\toffline_access", "im:message:send offline_access"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeScopeInput(tc.in); got != tc.want {
+				t.Errorf("normalizeScopeInput(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestShortcutSupportsIdentity_DefaultUser(t *testing.T) {
 	// Empty AuthTypes defaults to ["user"]
 	sc := common.Shortcut{AuthTypes: nil}


### PR DESCRIPTION
## Bug repro

```bash
lark-cli auth login --scope "vc:note:read,vc:meeting.meetingevent:read"
```

fails with:

```
device authorization failed: The provided scope list contains invalid or malformed scopes.
```

A single scope (`--scope "vc:note:read"`) works, so the comma-joined value is the trigger.

## Root cause

`cmd/auth/login.go` reads `--scope` as a raw `StringVar` and passes it through unchanged to `RequestDeviceAuthorization`. OAuth 2.0 (RFC 6749 §3.3) requires the `scope` parameter to be a space-delimited list on the wire, so a comma-joined string is treated as one malformed scope by the auth endpoint.

The flag help advertises "space-separated" but most users (and AI agents synthesizing commands) reach for commas first because shell-quoting whitespace is awkward — and `--domain` already accepts `,` (`--domain calendar,task`), so the inconsistency is an easy footgun.

## Fix

Normalize `--scope` input before sending: split on commas/whitespace, trim, dedupe (first occurrence wins, order preserved), re-join with single spaces. Implementation is a pure helper `normalizeScopeInput` next to the other small helpers in `login.go` — no behavior change for already-valid space-separated inputs.

Updated flag help string from `space-separated` to `space- or comma-separated`.

## Test cases

Added `TestNormalizeScopeInput` covering:

- empty input
- single scope
- comma-separated (the failing case)
- space-separated (existing behavior)
- mixed separators (comma + space + tab + newline)
- whitespace trimming
- duplicate elimination
- trailing/leading/repeated separators
- only-separator input

Existing 87 tests in `cmd/auth/...` all still pass.

## User scenario

I keep adding new VC API endpoints to my agent workflows, and every new endpoint means another `auth login` to grant the scope. Composing the command via shell or AI agent, `--scope "a,b"` is the natural reach — with this fix it just works, instead of returning a confusing "malformed scopes" error that requires reading docs to learn the OAuth wire format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `auth login` command's `--scope` flag now accepts comma-, space-, or mixed-separated inputs; inputs are trimmed, empties removed, duplicates deduplicated (preserving first-seen order), and normalized to a single space-delimited scope string for device authorization.

* **Tests**
  * Added unit tests covering various scope input formats, trimming, deduplication, and edge cases to ensure consistent normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->