### PR TITLE
feat: add flag shortcuts for lark im

### DIFF
--- a/internal/registry/service_descriptions.json
+++ b/internal/registry/service_descriptions.json
@@ -27,6 +27,10 @@
     "en": { "title": "Event", "description": "Event subscription management" },
     "zh": { "title": "事件订阅", "description": "WebSocket 实时推送" }
   },
+  "flag": {
+    "en": { "title": "Flag", "description": "Bookmark (标记) on messages and threads" },
+    "zh": { "title": "标记", "description": "消息与 thread 标记的创建、取消、列表" }
+  },
   "im": {
     "en": { "title": "Messenger", "description": "Message and group chat management" },
     "zh": { "title": "消息与群组", "description": "消息发送、群聊管理" }

--- a/shortcuts/im/helpers.go
+++ b/shortcuts/im/helpers.go
@@ -1432,3 +1432,166 @@ func uploadFileFromReader(ctx context.Context, runtime *common.RuntimeContext, r
 	}
 	return fileKey, nil
 }
+
+// FlagType enumerates the kind of bookmark (标记).
+// Aligned with server-side constants: Unknown=0, Feed=1, Message=2.
+type FlagType int
+
+const (
+	FlagTypeUnknown FlagType = 0
+	FlagTypeFeed    FlagType = 1
+	FlagTypeMessage FlagType = 2
+)
+
+// ItemType enumerates the kind of thing being bookmarked.
+// Server-side constants (only the types used by IM flags):
+//
+//	default=0, thread=4, msg_thread=11.
+//
+// Note on the two thread-shaped item types:
+//   - ItemTypeThread (4)     — thread inside a topic-style chat (话题群中的话题)
+//   - ItemTypeMsgThread (11) — thread inside a regular chat (普通群中的话题)
+type ItemType int
+
+const (
+	ItemTypeDefault   ItemType = 0
+	ItemTypeThread    ItemType = 4  // thread in a topic-style chat (话题群)
+	ItemTypeMsgThread ItemType = 11 // thread in a regular chat (普通群)
+)
+
+// flagItem is one entry in the flags API body. The server expects numeric
+// enums serialized as strings.
+type flagItem struct {
+	ItemID   string `json:"item_id"`
+	ItemType string `json:"item_type"`
+	FlagType string `json:"flag_type"`
+}
+
+// parseItemID inspects an om_/omt_ prefix and returns a best-guess
+// (itemType, flagType) pair. Used when the user omits the explicit enums.
+//   - om_xxx  → (default, message)
+//   - omt_xxx → (thread, feed)
+func parseItemID(id string) (ItemType, FlagType, error) {
+	id = strings.TrimSpace(id)
+	switch {
+	case strings.HasPrefix(id, "omt_"):
+		return ItemTypeThread, FlagTypeFeed, nil
+	case strings.HasPrefix(id, "om_"):
+		return ItemTypeDefault, FlagTypeMessage, nil
+	case id == "":
+		return 0, 0, output.ErrValidation("--item-id / --message-id / --thread-id cannot be empty")
+	default:
+		return 0, 0, output.ErrValidation(
+			"cannot infer item type from id %q: expected om_ (message) or omt_ (thread) prefix; "+
+				"pass --item-type and --flag-type explicitly if you are using a different id format", id)
+	}
+}
+
+// parseItemType converts a user-facing string to the server enum.
+func parseItemType(s string) (ItemType, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "default", "message":
+		return ItemTypeDefault, nil
+	case "thread":
+		return ItemTypeThread, nil
+	case "msg_thread":
+		return ItemTypeMsgThread, nil
+	}
+	return 0, output.ErrValidation("invalid --item-type %q: expected one of default|thread|msg_thread", s)
+}
+
+// parseFlagType converts a user-facing string to the server enum.
+func parseFlagType(s string) (FlagType, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "", "message":
+		return FlagTypeMessage, nil
+	case "feed":
+		return FlagTypeFeed, nil
+	case "unknown":
+		return FlagTypeUnknown, nil
+	}
+	return 0, output.ErrValidation("invalid --flag-type %q: expected one of message|feed", s)
+}
+
+// The only pairs the server accepts today:
+//
+//	(default, message)  — regular chat message
+//	(thread, feed)      — thread as feed-layer flag
+//	(msg_thread, feed)  — message-thread as feed-layer flag
+func isValidCombo(it ItemType, ft FlagType) bool {
+	return (it == ItemTypeDefault && ft == FlagTypeMessage) ||
+		(it == ItemTypeThread && ft == FlagTypeFeed) ||
+		(it == ItemTypeMsgThread && ft == FlagTypeFeed)
+}
+
+// newFlagItem builds a payload entry with numeric-stringified enums.
+func newFlagItem(itemID string, it ItemType, ft FlagType) flagItem {
+	return flagItem{
+		ItemID:   itemID,
+		ItemType: fmt.Sprintf("%d", int(it)),
+		FlagType: fmt.Sprintf("%d", int(ft)),
+	}
+}
+
+// checkIsThreadRoot queries the message API to check if a message is a thread root.
+// Returns (isThreadRoot, chatID, error). chatID is empty when the message is not a thread root.
+func checkIsThreadRoot(rt *common.RuntimeContext, messageID string) (bool, string, error) {
+	data, err := rt.DoAPIJSON("GET", "/open-apis/im/v1/messages/"+messageID, nil, nil)
+	if err != nil {
+		return false, "", err
+	}
+
+	// Check items array in response
+	items, _ := data["items"].([]any)
+	if len(items) == 0 {
+		return false, "", nil
+	}
+
+	msg, _ := items[0].(map[string]any)
+	threadID, _ := msg["thread_id"].(string)
+	chatID, _ := msg["chat_id"].(string)
+	return threadID != "", chatID, nil
+}
+
+// resolveThreadFeedItemType determines the correct feed-layer ItemType for a thread
+// by querying the chat API for chat_mode.
+//   - topic-style chat (话题群) → ItemTypeThread
+//   - regular chat (普通群)    → ItemTypeMsgThread
+//
+// Falls back to ItemTypeMsgThread if the chat query fails.
+func resolveThreadFeedItemType(rt *common.RuntimeContext, chatID string) ItemType {
+	data, err := rt.DoAPIJSON("GET", "/open-apis/im/v1/chats/"+chatID, nil, nil)
+	if err != nil {
+		return ItemTypeMsgThread
+	}
+
+	// DoAPIJSON returns envelope.Data, so chat_mode is at the top level
+	chatMode, _ := data["chat_mode"].(string)
+	if chatMode == "topic" {
+		return ItemTypeThread
+	}
+	return ItemTypeMsgThread
+}
+
+// resolveThreadFeedItemTypeFromThread resolves the feed-layer ItemType for an omt_ thread ID.
+// It queries the message API to get the chat_id, then queries the chat API for chat_mode.
+// Falls back to ItemTypeThread if any query fails.
+func resolveThreadFeedItemTypeFromThread(rt *common.RuntimeContext, threadID string) ItemType {
+	data, err := rt.DoAPIJSON("GET", "/open-apis/im/v1/messages/"+threadID, nil, nil)
+	if err != nil {
+		return ItemTypeThread
+	}
+
+	items, _ := data["items"].([]any)
+	if len(items) == 0 {
+		return ItemTypeThread
+	}
+
+	msg, _ := items[0].(map[string]any)
+	chatID, _ := msg["chat_id"].(string)
+	if chatID == "" {
+		return ItemTypeThread
+	}
+
+	return resolveThreadFeedItemType(rt, chatID)
+}

--- a/shortcuts/im/helpers_test.go
+++ b/shortcuts/im/helpers_test.go
@@ -868,6 +868,9 @@ func TestShortcuts(t *testing.T) {
 		"+messages-search",
 		"+messages-send",
 		"+threads-messages-list",
+		"+flag-create",
+		"+flag-cancel",
+		"+flag-list",
 	}
 	if !reflect.DeepEqual(commands, want) {
 		t.Fatalf("Shortcuts() commands = %#v, want %#v", commands, want)

--- a/shortcuts/im/im_flag_cancel.go
+++ b/shortcuts/im/im_flag_cancel.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var ImFlagCancel = common.Shortcut{
+	Service: "im",
+	Command: "+flag-cancel",
+	Description: "Cancel (remove) a bookmark (标记). When no --flag-type is given, " +
+		"checks if the message is a thread root message; if so, cancels both message and feed layers",
+	Risk:       "write",
+	UserScopes: []string{"im:feed.flag:write"},
+	AuthTypes:  []string{"user"},
+	HasFormat:  true,
+	Flags: []common.Flag{
+		{Name: "message-id", Desc: "message ID (om_xxx); mutually exclusive with --thread-id"},
+		{Name: "thread-id", Desc: "thread ID (omt_xxx); mutually exclusive with --message-id"},
+		{Name: "item-type", Desc: "item type override: default|chat|doc|thread|box|open_app|subscription|msg_thread|my_ai|app_feed|knowledge_ai"},
+		{Name: "flag-type", Desc: "flag type override: message|feed; omit to auto-detect based on message type"},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := common.MutuallyExclusive(runtime, "message-id", "thread-id"); err != nil {
+			return err
+		}
+		if err := common.AtLeastOne(runtime, "message-id", "thread-id"); err != nil {
+			return err
+		}
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		items, _, _ := buildCancelItemsDryRun(runtime)
+		d := common.NewDryRunAPI().
+			POST("/open-apis/im/v1/flags/cancel").
+			Body(map[string]any{"flag_items": items})
+		if len(items) > 1 {
+			d.Desc("double-cancel: message is a thread root, so both message and feed layers are removed")
+		}
+		return d
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		items, err := buildCancelItems(runtime)
+		if err != nil {
+			return err
+		}
+		data, err := runtime.DoAPIJSON(http.MethodPost, "/open-apis/im/v1/flags/cancel", nil,
+			map[string]any{"flag_items": items})
+		if err != nil {
+			// Fallback: if the feed item type is wrong, retry with the alternate type.
+			// This can happen when chat_mode lookup failed or returned an unexpected value.
+			altItems := alternateFeedItemType(items)
+			if altItems != nil {
+				if altData, altErr := runtime.DoAPIJSON(http.MethodPost, "/open-apis/im/v1/flags/cancel", nil,
+					map[string]any{"flag_items": altItems}); altErr == nil {
+					runtime.Out(altData, nil)
+					return nil
+				}
+			}
+			return err
+		}
+		runtime.Out(data, nil)
+		return nil
+	},
+}
+
+// buildCancelItemsDryRun is used by DryRun to preview without API calls.
+// It assumes worst-case (double-cancel) for om_xxx since we can't query the message.
+func buildCancelItemsDryRun(rt *common.RuntimeContext) ([]flagItem, bool, error) {
+	id := rt.Str("message-id")
+	if id == "" {
+		id = rt.Str("thread-id")
+	}
+	if strings.TrimSpace(id) == "" {
+		return nil, false, output.ErrValidation("--message-id / --thread-id is required")
+	}
+
+	itOverride := strings.TrimSpace(rt.Str("item-type"))
+	ftOverride := strings.TrimSpace(rt.Str("flag-type"))
+
+	// Explicit override provided → single targeted delete
+	if itOverride != "" || ftOverride != "" {
+		item, err := buildSingleCancelItem(id, itOverride, ftOverride)
+		if err != nil {
+			return nil, false, err
+		}
+		return []flagItem{item}, false, nil
+	}
+
+	// No override: for dry-run, assume double-cancel for om_xxx
+	if strings.HasPrefix(id, "omt_") {
+		return []flagItem{
+			newFlagItem(id, ItemTypeThread, FlagTypeFeed),
+			newFlagItem(id, ItemTypeDefault, FlagTypeMessage),
+		}, true, nil
+	}
+	// om_xxx: assume could be thread root for dry-run preview
+	return []flagItem{
+		newFlagItem(id, ItemTypeDefault, FlagTypeMessage),
+		newFlagItem(id, ItemTypeMsgThread, FlagTypeFeed),
+	}, true, nil
+}
+
+// buildCancelItems picks the (item_type, flag_type) pairs to cancel.
+//
+// Logic:
+//  1. If --flag-type is explicitly provided, do a single targeted delete.
+//  2. For omt_xxx (thread ID), query the chat API to determine chat_mode,
+//     then double-cancel with the correct feed-layer item_type:
+//     - 话题群 (chat_mode=topic) → (thread, feed) + (default, message)
+//     - 普通群 (chat_mode=group) → (msg_thread, feed) + (default, message)
+//  3. For om_xxx (message ID), query the message to check if it's a thread root:
+//     - If thread_id is present, query the chat API to determine chat_mode:
+//     - 话题群 (chat_mode=topic) → (thread, feed) + (default, message)
+//     - 普通群 (chat_mode=group) → (msg_thread, feed) + (default, message)
+//     - If thread_id is absent → single cancel (default, message)
+func buildCancelItems(rt *common.RuntimeContext) ([]flagItem, error) {
+	id := rt.Str("message-id")
+	if id == "" {
+		id = rt.Str("thread-id")
+	}
+	if strings.TrimSpace(id) == "" {
+		return nil, output.ErrValidation("--message-id / --thread-id is required")
+	}
+
+	itOverride := strings.TrimSpace(rt.Str("item-type"))
+	ftOverride := strings.TrimSpace(rt.Str("flag-type"))
+
+	// Explicit override provided → single targeted delete
+	if itOverride != "" || ftOverride != "" {
+		item, err := buildSingleCancelItem(id, itOverride, ftOverride)
+		if err != nil {
+			return nil, err
+		}
+		return []flagItem{item}, nil
+	}
+
+	// omt_xxx (thread ID) → need chat_mode to choose between thread vs msg_thread
+	if strings.HasPrefix(id, "omt_") {
+		feedIT := resolveThreadFeedItemTypeFromThread(rt, id)
+		return []flagItem{
+			newFlagItem(id, feedIT, FlagTypeFeed),
+			newFlagItem(id, ItemTypeDefault, FlagTypeMessage),
+		}, nil
+	}
+
+	// om_xxx: query message to check if it's a thread root
+	isThreadRoot, chatID, err := checkIsThreadRoot(rt, id)
+	if err != nil {
+		// If query fails, fall back to single delete to avoid permission errors
+		return []flagItem{newFlagItem(id, ItemTypeDefault, FlagTypeMessage)}, nil
+	}
+
+	if isThreadRoot {
+		// Thread root message: determine feed-layer item_type from chat_mode
+		feedIT := resolveThreadFeedItemType(rt, chatID)
+		return []flagItem{
+			newFlagItem(id, ItemTypeDefault, FlagTypeMessage),
+			newFlagItem(id, feedIT, FlagTypeFeed),
+		}, nil
+	}
+
+	// Regular message: single cancel
+	return []flagItem{newFlagItem(id, ItemTypeDefault, FlagTypeMessage)}, nil
+}
+
+// buildSingleCancelItem builds a single cancel item when user provides explicit flags.
+func buildSingleCancelItem(id, itOverride, ftOverride string) (flagItem, error) {
+	var itemType ItemType
+	var flagType FlagType
+
+	if itOverride != "" {
+		it, err := parseItemType(itOverride)
+		if err != nil {
+			return flagItem{}, err
+		}
+		itemType = it
+	}
+	if ftOverride != "" {
+		ft, err := parseFlagType(ftOverride)
+		if err != nil {
+			return flagItem{}, err
+		}
+		flagType = ft
+	}
+	if itOverride == "" || ftOverride == "" {
+		inferIT, inferFT, err := parseItemID(id)
+		if err != nil {
+			return flagItem{}, err
+		}
+		if itOverride == "" {
+			itemType = inferIT
+		}
+		if ftOverride == "" {
+			flagType = inferFT
+		}
+	}
+	return newFlagItem(id, itemType, flagType), nil
+}
+
+// alternateFeedItemType swaps any feed-layer item between ItemTypeThread and ItemTypeMsgThread.
+// Returns nil if no feed item is found (nothing to swap).
+// Used as a fallback when the first cancel attempt fails due to item_type mismatch.
+func alternateFeedItemType(items []flagItem) []flagItem {
+	var result []flagItem
+	swapped := false
+	for _, it := range items {
+		if it.FlagType == fmt.Sprintf("%d", int(FlagTypeFeed)) && !swapped {
+			parsedIT := parseItemTypeFromRaw(it.ItemType)
+			var altIT ItemType
+			switch parsedIT {
+			case ItemTypeThread:
+				altIT = ItemTypeMsgThread
+			case ItemTypeMsgThread:
+				altIT = ItemTypeThread
+			default:
+				result = append(result, it)
+				continue
+			}
+			result = append(result, newFlagItem(it.ItemID, altIT, FlagTypeFeed))
+			swapped = true
+		} else {
+			result = append(result, it)
+		}
+	}
+	if !swapped {
+		return nil
+	}
+	return result
+}
+
+// parseItemTypeFromRaw parses a stringified numeric item_type back to ItemType.
+func parseItemTypeFromRaw(s string) ItemType {
+	switch s {
+	case "0":
+		return ItemTypeDefault
+	case "4":
+		return ItemTypeThread
+	case "11":
+		return ItemTypeMsgThread
+	}
+	return ItemTypeDefault
+}

--- a/shortcuts/im/im_flag_create.go
+++ b/shortcuts/im/im_flag_create.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var ImFlagCreate = common.Shortcut{
+	Service:     "im",
+	Command:     "+flag-create",
+	Description: "Create a bookmark (标记) on a message or thread",
+	Risk:        "write",
+	UserScopes:  []string{"im:feed.flag:write"},
+	AuthTypes:   []string{"user"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "message-id", Desc: "message ID (om_xxx); mutually exclusive with --thread-id"},
+		{Name: "thread-id", Desc: "thread ID (omt_xxx); mutually exclusive with --message-id"},
+		{Name: "item-type", Desc: "item type override: default|chat|doc|thread|box|open_app|subscription|msg_thread|my_ai|app_feed|knowledge_ai"},
+		{Name: "flag-type", Desc: "flag type override: message|feed"},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := common.MutuallyExclusive(runtime, "message-id", "thread-id"); err != nil {
+			return err
+		}
+		if err := common.AtLeastOne(runtime, "message-id", "thread-id"); err != nil {
+			return err
+		}
+		item, err := buildCreateItem(runtime)
+		if err != nil {
+			return err
+		}
+		// Validate (item_type, flag_type) combination before DryRun/Execute.
+		if !isValidCombo(mustParseItemType(item.ItemType), mustParseFlagType(item.FlagType)) {
+			return output.ErrValidation(
+				"invalid (item_type=%s, flag_type=%s) combination; the server only accepts "+
+					"(default, message), (thread, feed), or (msg_thread, feed)",
+				item.ItemType, item.FlagType)
+		}
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		item, _ := buildCreateItem(runtime)
+		return common.NewDryRunAPI().
+			POST("/open-apis/im/v1/flags").
+			Body(map[string]any{"flag_items": []flagItem{item}})
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		item, err := buildCreateItem(runtime)
+		if err != nil {
+			return err
+		}
+		// Combo validation already done in Validate, but double-check as a safety net.
+		if !isValidCombo(mustParseItemType(item.ItemType), mustParseFlagType(item.FlagType)) {
+			return output.ErrValidation(
+				"invalid (item_type=%s, flag_type=%s) combination; the server only accepts "+
+					"(default, message), (thread, feed), or (msg_thread, feed)",
+				item.ItemType, item.FlagType)
+		}
+		data, err := runtime.DoAPIJSON(http.MethodPost, "/open-apis/im/v1/flags", nil,
+			map[string]any{"flag_items": []flagItem{item}})
+		if err != nil {
+			return err
+		}
+		runtime.Out(data, nil)
+		return nil
+	},
+}
+
+// buildCreateItem derives a flagItem for the create path.
+//
+// Product rule: when the caller does not explicitly say whether to flag a
+// message or a feed, default to flagging the message — i.e. (ItemTypeDefault,
+// FlagTypeMessage). This applies uniformly:
+//   - regular message ids (om_xxx)     → (default, message)
+//   - thread ids (omt_xxx)             → (default, message)
+//   - thread root messages (om_xxx anchoring a thread, which can be flagged
+//     either as message or as feed) → (default, message)
+//
+// Feed-layer flagging — (thread, feed) for 话题群 or (msg_thread, feed) for
+// 普通群 — is an opt-in and must be requested explicitly via both --item-type
+// and --flag-type.
+//
+// Resolution order:
+//  1. User passed --item-type and/or --flag-type → both are required, honor verbatim.
+//  2. Otherwise → (default, message).
+func buildCreateItem(rt *common.RuntimeContext) (flagItem, error) {
+	id := rt.Str("message-id")
+	if id == "" {
+		id = rt.Str("thread-id")
+	}
+	if strings.TrimSpace(id) == "" {
+		return flagItem{}, output.ErrValidation("--message-id or --thread-id is required")
+	}
+
+	itOverride := strings.TrimSpace(rt.Str("item-type"))
+	ftOverride := strings.TrimSpace(rt.Str("flag-type"))
+
+	// Explicit override path — honor both.
+	if itOverride != "" || ftOverride != "" {
+		if itOverride == "" || ftOverride == "" {
+			return flagItem{}, output.ErrValidation(
+				"--item-type and --flag-type must be provided together when overriding the default message route")
+		}
+		it, err := parseItemType(itOverride)
+		if err != nil {
+			return flagItem{}, err
+		}
+		ft, err := parseFlagType(ftOverride)
+		if err != nil {
+			return flagItem{}, err
+		}
+		return newFlagItem(id, it, ft), nil
+	}
+
+	// Default path — always (default, message), regardless of id prefix.
+	return newFlagItem(id, ItemTypeDefault, FlagTypeMessage), nil
+}
+
+// helpers used inside Execute to re-parse the stringified enum back to int for
+// the combo-validity check.
+func mustParseItemType(s string) ItemType {
+	switch s {
+	case "0":
+		return ItemTypeDefault
+	case "4":
+		return ItemTypeThread
+	case "11":
+		return ItemTypeMsgThread
+	}
+	return ItemTypeDefault
+}
+
+func mustParseFlagType(s string) FlagType {
+	switch s {
+	case "1":
+		return FlagTypeFeed
+	case "2":
+		return FlagTypeMessage
+	}
+	return FlagTypeUnknown
+}

--- a/shortcuts/im/im_flag_list.go
+++ b/shortcuts/im/im_flag_list.go
@@ -1,0 +1,251 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
+)
+
+var ImFlagList = common.Shortcut{
+	Service: "im",
+	Command: "+flag-list",
+	Description: "List bookmarks (标记). Feed-type thread entries are auto-enriched with message " +
+		"content because the API returns only ids for that shape",
+	Risk:       "read",
+	UserScopes: []string{"im:feed.flag:read", "im:message:readonly"},
+	AuthTypes:  []string{"user"},
+	HasFormat:  true,
+	Flags: []common.Flag{
+		{Name: "page-size", Type: "int", Default: "50", Desc: "page size (1-50)"},
+		{Name: "page-token", Desc: "pagination token for next page"},
+		{Name: "page-all", Type: "bool", Desc: "automatically paginate through all pages"},
+		{Name: "page-limit", Type: "int", Default: "20", Desc: "max pages when auto-pagination is enabled (default 20, max 40)"},
+		{Name: "enrich-feed-thread", Type: "bool", Default: "true", Desc: "fetch message content for feed-type thread entries (default true); skipped when the server already returned `messages` in the response"},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if n := runtime.Int("page-size"); n < 1 || n > 50 {
+			return output.ErrValidation("--page-size must be an integer between 1 and 50")
+		}
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		return common.NewDryRunAPI().
+			GET("/open-apis/im/v1/flags").
+			Params(map[string]any{
+				"page_size":  strconv.Itoa(runtime.Int("page-size")),
+				"page_token": runtime.Str("page-token"),
+			})
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		// When --page-token is explicitly provided, the user wants a specific page —
+		// no auto-pagination regardless of --page-all.
+		if runtime.Bool("page-all") && !runtime.Cmd.Flags().Changed("page-token") {
+			return executeListAllPages(runtime)
+		}
+
+		data, err := runtime.DoAPIJSON(http.MethodGet, "/open-apis/im/v1/flags", listQuery(runtime), nil)
+		if err != nil {
+			return err
+		}
+		if runtime.Bool("enrich-feed-thread") {
+			if err := enrichFeedThreadItems(runtime, data); err != nil {
+				fmt.Fprintf(runtime.IO().ErrOut, "warning: feed-thread enrichment failed: %v\n", err)
+			}
+		}
+		runtime.Out(data, nil)
+		return nil
+	},
+}
+
+func listQuery(rt *common.RuntimeContext) larkcore.QueryParams {
+	// page_token is required by the server even on the first page — pass empty
+	// string when the user hasn't supplied one.
+	return larkcore.QueryParams{
+		"page_size":  []string{strconv.Itoa(rt.Int("page-size"))},
+		"page_token": []string{rt.Str("page-token")},
+	}
+}
+
+// enrichFeedThreadItems attaches message body to feed-shape thread entries
+// by calling messages/mget. The list API returns only IDs for feed-shape entries,
+// so this enrichment is needed to provide full message content.
+func enrichFeedThreadItems(rt *common.RuntimeContext, data map[string]any) error {
+	// Only enrich active flags (flag_items), not canceled flags (delete_flag_items).
+	// Canceled message-type flags don't show message content, so thread-type flags don't need it either.
+	items, _ := data["flag_items"].([]any)
+	if len(items) == 0 {
+		return nil
+	}
+
+	// Index any messages the server already returned — saves a mget round-trip
+	// (ItemType=default+FlagType=Message responses already carry the message body).
+	byID := make(map[string]map[string]any)
+	if inline, ok := data["messages"].([]any); ok {
+		for _, m := range inline {
+			mm, _ := m.(map[string]any)
+			if mm == nil {
+				continue
+			}
+			if id := asString(mm["message_id"]); id != "" {
+				byID[id] = mm
+			}
+		}
+	}
+
+	// Collect feed-thread ids whose message body wasn't inlined — dedup to cut mget calls.
+	need := map[string]bool{}
+	for _, it := range items {
+		m, _ := it.(map[string]any)
+		if m == nil {
+			continue
+		}
+		ft := asString(m["flag_type"])
+		itStr := asString(m["item_type"])
+		if ft != strconv.Itoa(int(FlagTypeFeed)) {
+			continue
+		}
+		if itStr != strconv.Itoa(int(ItemTypeThread)) && itStr != strconv.Itoa(int(ItemTypeMsgThread)) {
+			continue
+		}
+		id := asString(m["item_id"])
+		if id == "" {
+			continue
+		}
+		if _, inlined := byID[id]; !inlined {
+			need[id] = true
+		}
+	}
+
+	if len(need) > 0 {
+		ids := make([]string, 0, len(need))
+		for id := range need {
+			ids = append(ids, id)
+		}
+		// /messages/mget accepts repeated `message_ids` params — larkcore.QueryParams
+		// serializes each slice value as a separate query pair.
+		got, err := rt.DoAPIJSON(http.MethodGet, "/open-apis/im/v1/messages/mget",
+			larkcore.QueryParams{"message_ids": ids}, nil)
+		if err != nil {
+			return err
+		}
+		fetched, _ := got["items"].([]any)
+		for _, m := range fetched {
+			mm, _ := m.(map[string]any)
+			if mm == nil {
+				continue
+			}
+			if id := asString(mm["message_id"]); id != "" {
+				byID[id] = mm
+			}
+		}
+	}
+
+	if len(byID) == 0 {
+		return nil
+	}
+	// Attach message payload to the matching list entries.
+	for _, it := range items {
+		m, _ := it.(map[string]any)
+		if m == nil {
+			continue
+		}
+		ft := asString(m["flag_type"])
+		itType := asString(m["item_type"])
+		if ft != strconv.Itoa(int(FlagTypeFeed)) {
+			continue
+		}
+		if itType != strconv.Itoa(int(ItemTypeThread)) && itType != strconv.Itoa(int(ItemTypeMsgThread)) {
+			continue
+		}
+		if msg, ok := byID[asString(m["item_id"])]; ok {
+			m["message"] = msg
+		}
+	}
+	return nil
+}
+
+func asString(v any) string {
+	switch x := v.(type) {
+	case string:
+		return x
+	case float64:
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(x)
+	}
+	return ""
+}
+
+// executeListAllPages fetches all pages and merges the results into a single response.
+// The flag list API returns items sorted by update_time ascending, so the last page
+// contains the newest items.
+func executeListAllPages(rt *common.RuntimeContext) error {
+	maxPages := rt.Int("page-limit")
+	if maxPages < 1 {
+		maxPages = 20
+	}
+	if maxPages > 40 {
+		maxPages = 40
+	}
+
+	var allFlagItems, allDeleteFlagItems, allMessages []any
+	var lastHasMore bool
+	var lastPageToken string
+
+	for page := 0; page < maxPages; page++ {
+		token := ""
+		if page > 0 {
+			token = lastPageToken
+		}
+		data, err := rt.DoAPIJSON(http.MethodGet, "/open-apis/im/v1/flags",
+			larkcore.QueryParams{
+				"page_size":  []string{strconv.Itoa(rt.Int("page-size"))},
+				"page_token": []string{token},
+			}, nil)
+		if err != nil {
+			return err
+		}
+
+		if v, ok := data["flag_items"].([]any); ok {
+			allFlagItems = append(allFlagItems, v...)
+		}
+		if v, ok := data["delete_flag_items"].([]any); ok {
+			allDeleteFlagItems = append(allDeleteFlagItems, v...)
+		}
+		if v, ok := data["messages"].([]any); ok {
+			allMessages = append(allMessages, v...)
+		}
+
+		lastHasMore, _ = data["has_more"].(bool)
+		lastPageToken, _ = data["page_token"].(string)
+
+		if !lastHasMore || lastPageToken == "" {
+			break
+		}
+	}
+
+	merged := map[string]any{
+		"flag_items":        allFlagItems,
+		"delete_flag_items": allDeleteFlagItems,
+		"messages":          allMessages,
+		"has_more":          lastHasMore,
+		"page_token":        lastPageToken,
+	}
+
+	if rt.Bool("enrich-feed-thread") {
+		if err := enrichFeedThreadItems(rt, merged); err != nil {
+			fmt.Fprintf(rt.IO().ErrOut, "warning: feed-thread enrichment failed: %v\n", err)
+		}
+	}
+
+	rt.Out(merged, nil)
+	return nil
+}

--- a/shortcuts/im/im_flag_test.go
+++ b/shortcuts/im/im_flag_test.go
@@ -1,0 +1,688 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+func TestParseItemType(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    ItemType
+		wantErr bool
+	}{
+		{name: "default", input: "default", want: ItemTypeDefault},
+		{name: "message alias", input: "message", want: ItemTypeDefault},
+		{name: "empty string defaults to default", input: "", want: ItemTypeDefault},
+		{name: "thread", input: "thread", want: ItemTypeThread},
+		{name: "msg_thread", input: "msg_thread", want: ItemTypeMsgThread},
+		{name: "case insensitive", input: "THREAD", want: ItemTypeThread},
+		{name: "with whitespace", input: " thread ", want: ItemTypeThread},
+		{name: "invalid", input: "invalid_type", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseItemType(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseItemType(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseItemType(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseItemType(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFlagType(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    FlagType
+		wantErr bool
+	}{
+		{name: "message", input: "message", want: FlagTypeMessage},
+		{name: "empty string defaults to message", input: "", want: FlagTypeMessage},
+		{name: "feed", input: "feed", want: FlagTypeFeed},
+		{name: "unknown", input: "unknown", want: FlagTypeUnknown},
+		{name: "case insensitive", input: "FEED", want: FlagTypeFeed},
+		{name: "with whitespace", input: " feed ", want: FlagTypeFeed},
+		{name: "invalid", input: "invalid_type", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseFlagType(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseFlagType(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseFlagType(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("parseFlagType(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseItemID(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantIT     ItemType
+		wantFT     FlagType
+		wantErr    bool
+		errContain string
+	}{
+		{name: "om prefix", input: "om_abc123", wantIT: ItemTypeDefault, wantFT: FlagTypeMessage},
+		{name: "omt prefix", input: "omt_xyz789", wantIT: ItemTypeThread, wantFT: FlagTypeFeed},
+		{name: "with whitespace", input: " om_abc123 ", wantIT: ItemTypeDefault, wantFT: FlagTypeMessage},
+		{name: "empty string", input: "", wantErr: true, errContain: "cannot be empty"},
+		{name: "unknown prefix", input: "oc_xxx", wantErr: true, errContain: "cannot infer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIT, gotFT, err := parseItemID(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseItemID(%q) expected error, got nil", tt.input)
+				}
+				if tt.errContain != "" && !strings.Contains(err.Error(), tt.errContain) {
+					t.Fatalf("parseItemID(%q) error = %q, want to contain %q", tt.input, err.Error(), tt.errContain)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseItemID(%q) unexpected error: %v", tt.input, err)
+			}
+			if gotIT != tt.wantIT {
+				t.Fatalf("parseItemID(%q) itemType = %v, want %v", tt.input, gotIT, tt.wantIT)
+			}
+			if gotFT != tt.wantFT {
+				t.Fatalf("parseItemID(%q) flagType = %v, want %v", tt.input, gotFT, tt.wantFT)
+			}
+		})
+	}
+}
+
+func TestIsValidCombo(t *testing.T) {
+	tests := []struct {
+		name string
+		it   ItemType
+		ft   FlagType
+		want bool
+	}{
+		{name: "default+message valid", it: ItemTypeDefault, ft: FlagTypeMessage, want: true},
+		{name: "thread+feed valid", it: ItemTypeThread, ft: FlagTypeFeed, want: true},
+		{name: "msg_thread+feed valid", it: ItemTypeMsgThread, ft: FlagTypeFeed, want: true},
+		{name: "default+feed invalid", it: ItemTypeDefault, ft: FlagTypeFeed, want: false},
+		{name: "thread+message invalid", it: ItemTypeThread, ft: FlagTypeMessage, want: false},
+		{name: "msg_thread+message invalid", it: ItemTypeMsgThread, ft: FlagTypeMessage, want: false},
+		{name: "unknown flag type", it: ItemTypeDefault, ft: FlagTypeUnknown, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidCombo(tt.it, tt.ft); got != tt.want {
+				t.Fatalf("isValidCombo(%v, %v) = %v, want %v", tt.it, tt.ft, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewFlagItem(t *testing.T) {
+	tests := []struct {
+		name     string
+		itemID   string
+		it       ItemType
+		ft       FlagType
+		wantJSON string
+	}{
+		{
+			name:     "default+message",
+			itemID:   "om_abc123",
+			it:       ItemTypeDefault,
+			ft:       FlagTypeMessage,
+			wantJSON: `{"item_id":"om_abc123","item_type":"0","flag_type":"2"}`,
+		},
+		{
+			name:     "thread+feed",
+			itemID:   "omt_xyz789",
+			it:       ItemTypeThread,
+			ft:       FlagTypeFeed,
+			wantJSON: `{"item_id":"omt_xyz789","item_type":"4","flag_type":"1"}`,
+		},
+		{
+			name:     "msg_thread+feed",
+			itemID:   "om_123",
+			it:       ItemTypeMsgThread,
+			ft:       FlagTypeFeed,
+			wantJSON: `{"item_id":"om_123","item_type":"11","flag_type":"1"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newFlagItem(tt.itemID, tt.it, tt.ft)
+			if got.ItemID != tt.itemID {
+				t.Fatalf("newFlagItem().ItemID = %q, want %q", got.ItemID, tt.itemID)
+			}
+			if got.ItemType != stringInt(int(tt.it)) {
+				t.Fatalf("newFlagItem().ItemType = %q, want %q", got.ItemType, stringInt(int(tt.it)))
+			}
+			if got.FlagType != stringInt(int(tt.ft)) {
+				t.Fatalf("newFlagItem().FlagType = %q, want %q", got.FlagType, stringInt(int(tt.ft)))
+			}
+		})
+	}
+}
+
+func TestAlternateFeedItemType(t *testing.T) {
+	tests := []struct {
+		name     string
+		items    []flagItem
+		wantNil  bool
+		wantItem flagItem // the swapped item, if any
+	}{
+		{
+			name: "swap thread to msg_thread",
+			items: []flagItem{
+				newFlagItem("omt_123", ItemTypeThread, FlagTypeFeed),
+			},
+			wantNil: false,
+			wantItem: flagItem{
+				ItemID:   "omt_123",
+				ItemType: "11", // ItemTypeMsgThread
+				FlagType: "1",  // FlagTypeFeed
+			},
+		},
+		{
+			name: "swap msg_thread to thread",
+			items: []flagItem{
+				newFlagItem("om_123", ItemTypeMsgThread, FlagTypeFeed),
+			},
+			wantNil: false,
+			wantItem: flagItem{
+				ItemID:   "om_123",
+				ItemType: "4", // ItemTypeThread
+				FlagType: "1", // FlagTypeFeed
+			},
+		},
+		{
+			name: "no feed item to swap",
+			items: []flagItem{
+				newFlagItem("om_123", ItemTypeDefault, FlagTypeMessage),
+			},
+			wantNil: true,
+		},
+		{
+			name: "multiple items with one swap",
+			items: []flagItem{
+				newFlagItem("om_123", ItemTypeDefault, FlagTypeMessage),
+				newFlagItem("omt_456", ItemTypeThread, FlagTypeFeed),
+			},
+			wantNil: false,
+			wantItem: flagItem{
+				ItemID:   "omt_456",
+				ItemType: "11", // ItemTypeMsgThread
+				FlagType: "1",
+			},
+		},
+		{
+			name:    "empty list",
+			items:   []flagItem{},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := alternateFeedItemType(tt.items)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("alternateFeedItemType() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("alternateFeedItemType() = nil, want non-nil")
+			}
+			// Find the swapped item
+			for _, item := range got {
+				if item.FlagType == "1" { // feed type
+					if item.ItemID != tt.wantItem.ItemID ||
+						item.ItemType != tt.wantItem.ItemType ||
+						item.FlagType != tt.wantItem.FlagType {
+						t.Fatalf("alternateFeedItemType() swapped item = %v, want %v", item, tt.wantItem)
+					}
+					return
+				}
+			}
+			t.Fatalf("alternateFeedItemType() no feed item found in result")
+		})
+	}
+}
+
+func TestParseItemTypeFromRaw(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  ItemType
+	}{
+		{name: "default", input: "0", want: ItemTypeDefault},
+		{name: "thread", input: "4", want: ItemTypeThread},
+		{name: "msg_thread", input: "11", want: ItemTypeMsgThread},
+		{name: "unknown defaults to default", input: "999", want: ItemTypeDefault},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseItemTypeFromRaw(tt.input); got != tt.want {
+				t.Fatalf("parseItemTypeFromRaw(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMustParseItemType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  ItemType
+	}{
+		{input: "0", want: ItemTypeDefault},
+		{input: "4", want: ItemTypeThread},
+		{input: "11", want: ItemTypeMsgThread},
+		{input: "999", want: ItemTypeDefault}, // unknown defaults to default
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := mustParseItemType(tt.input); got != tt.want {
+				t.Fatalf("mustParseItemType(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMustParseFlagType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  FlagType
+	}{
+		{input: "1", want: FlagTypeFeed},
+		{input: "2", want: FlagTypeMessage},
+		{input: "999", want: FlagTypeUnknown}, // unknown
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := mustParseFlagType(tt.input); got != tt.want {
+				t.Fatalf("mustParseFlagType(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// helper
+func stringInt(v int) string {
+	return strconv.Itoa(v)
+}
+
+func TestBuildCreateItem(t *testing.T) {
+	tests := []struct {
+		name       string
+		flags      map[string]string
+		wantItem   flagItem
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name: "message id defaults to message type",
+			flags: map[string]string{
+				"message-id": "om_abc123",
+			},
+			wantItem: newFlagItem("om_abc123", ItemTypeDefault, FlagTypeMessage),
+		},
+		{
+			name: "thread id defaults to message type",
+			flags: map[string]string{
+				"thread-id": "omt_xyz789",
+			},
+			wantItem: newFlagItem("omt_xyz789", ItemTypeDefault, FlagTypeMessage),
+		},
+		{
+			name: "explicit item-type and flag-type",
+			flags: map[string]string{
+				"message-id": "omt_xyz789",
+				"item-type":  "thread",
+				"flag-type":  "feed",
+			},
+			wantItem: newFlagItem("omt_xyz789", ItemTypeThread, FlagTypeFeed),
+		},
+		{
+			name: "explicit msg_thread type",
+			flags: map[string]string{
+				"message-id": "om_abc",
+				"item-type":  "msg_thread",
+				"flag-type":  "feed",
+			},
+			wantItem: newFlagItem("om_abc", ItemTypeMsgThread, FlagTypeFeed),
+		},
+		{
+			name: "missing message-id and thread-id",
+			flags: map[string]string{
+				"item-type": "default",
+			},
+			wantErr:    true,
+			errContain: "--message-id or --thread-id is required",
+		},
+		{
+			name: "only item-type without flag-type",
+			flags: map[string]string{
+				"message-id": "om_abc",
+				"item-type":  "thread",
+			},
+			wantErr:    true,
+			errContain: "--item-type and --flag-type must be provided together",
+		},
+		{
+			name: "only flag-type without item-type",
+			flags: map[string]string{
+				"message-id": "om_abc",
+				"flag-type":  "feed",
+			},
+			wantErr:    true,
+			errContain: "--item-type and --flag-type must be provided together",
+		},
+		{
+			name: "invalid item-type",
+			flags: map[string]string{
+				"message-id": "om_abc",
+				"item-type":  "invalid",
+				"flag-type":  "feed",
+			},
+			wantErr:    true,
+			errContain: "invalid --item-type",
+		},
+		{
+			name: "invalid flag-type",
+			flags: map[string]string{
+				"message-id": "om_abc",
+				"item-type":  "thread",
+				"flag-type":  "invalid",
+			},
+			wantErr:    true,
+			errContain: "invalid --flag-type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			for name := range tt.flags {
+				cmd.Flags().String(name, "", "")
+			}
+			if err := cmd.ParseFlags(nil); err != nil {
+				t.Fatalf("ParseFlags() error = %v", err)
+			}
+			for name, val := range tt.flags {
+				if err := cmd.Flags().Set(name, val); err != nil {
+					t.Fatalf("Flags().Set(%q) error = %v", name, err)
+				}
+			}
+			runtime := &common.RuntimeContext{Cmd: cmd}
+
+			got, err := buildCreateItem(runtime)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("buildCreateItem() expected error, got nil")
+				}
+				if tt.errContain != "" && !strings.Contains(err.Error(), tt.errContain) {
+					t.Fatalf("buildCreateItem() error = %q, want to contain %q", err.Error(), tt.errContain)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildCreateItem() unexpected error: %v", err)
+			}
+			if got.ItemID != tt.wantItem.ItemID {
+				t.Fatalf("buildCreateItem().ItemID = %q, want %q", got.ItemID, tt.wantItem.ItemID)
+			}
+			if got.ItemType != tt.wantItem.ItemType {
+				t.Fatalf("buildCreateItem().ItemType = %q, want %q", got.ItemType, tt.wantItem.ItemType)
+			}
+			if got.FlagType != tt.wantItem.FlagType {
+				t.Fatalf("buildCreateItem().FlagType = %q, want %q", got.FlagType, tt.wantItem.FlagType)
+			}
+		})
+	}
+}
+
+func TestBuildCancelItemsDryRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		flags      map[string]string
+		wantLen    int
+		wantDouble bool
+		wantErr    bool
+	}{
+		{
+			name:       "om prefix dry-run assumes double-cancel",
+			flags:      map[string]string{"message-id": "om_abc"},
+			wantLen:    2,
+			wantDouble: true,
+		},
+		{
+			name:       "omt prefix dry-run double-cancel",
+			flags:      map[string]string{"thread-id": "omt_xyz"},
+			wantLen:    2,
+			wantDouble: true,
+		},
+		{
+			name:       "explicit flag-type single cancel",
+			flags:      map[string]string{"message-id": "om_abc", "flag-type": "message"},
+			wantLen:    1,
+			wantDouble: false,
+		},
+		{
+			name:       "explicit item-type single cancel",
+			flags:      map[string]string{"message-id": "om_abc", "item-type": "default"},
+			wantLen:    1,
+			wantDouble: false,
+		},
+		{
+			name:    "missing id",
+			flags:   map[string]string{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{Use: "test"}
+			for name := range tt.flags {
+				cmd.Flags().String(name, "", "")
+			}
+			if err := cmd.ParseFlags(nil); err != nil {
+				t.Fatalf("ParseFlags() error = %v", err)
+			}
+			for name, val := range tt.flags {
+				if err := cmd.Flags().Set(name, val); err != nil {
+					t.Fatalf("Flags().Set(%q) error = %v", name, err)
+				}
+			}
+			runtime := &common.RuntimeContext{Cmd: cmd}
+
+			got, isDouble, err := buildCancelItemsDryRun(runtime)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("buildCancelItemsDryRun() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildCancelItemsDryRun() unexpected error: %v", err)
+			}
+			if len(got) != tt.wantLen {
+				t.Fatalf("buildCancelItemsDryRun() returned %d items, want %d", len(got), tt.wantLen)
+			}
+			if isDouble != tt.wantDouble {
+				t.Fatalf("buildCancelItemsDryRun() isDouble = %v, want %v", isDouble, tt.wantDouble)
+			}
+		})
+	}
+}
+
+func TestBuildSingleCancelItem(t *testing.T) {
+	tests := []struct {
+		name       string
+		id         string
+		itOverride string
+		ftOverride string
+		wantIT     ItemType
+		wantFT     FlagType
+		wantErr    bool
+	}{
+		{
+			name:   "om id infers default+message",
+			id:     "om_abc",
+			wantIT: ItemTypeDefault,
+			wantFT: FlagTypeMessage,
+		},
+		{
+			name:   "omt id infers thread+feed",
+			id:     "omt_xyz",
+			wantIT: ItemTypeThread,
+			wantFT: FlagTypeFeed,
+		},
+		{
+			name:       "explicit override",
+			id:         "omt_xyz",
+			itOverride: "msg_thread",
+			ftOverride: "feed",
+			wantIT:     ItemTypeMsgThread,
+			wantFT:     FlagTypeFeed,
+		},
+		{
+			name:       "only item-type override infers flag-type",
+			id:         "om_abc",
+			itOverride: "thread",
+			wantIT:     ItemTypeThread,
+			wantFT:     FlagTypeMessage, // inferred from om_ prefix
+		},
+		{
+			name:       "only flag-type override infers item-type",
+			id:         "omt_xyz",
+			ftOverride: "message",
+			wantIT:     ItemTypeThread, // inferred from omt_ prefix
+			wantFT:     FlagTypeMessage,
+		},
+		{
+			name:    "empty id",
+			id:      "",
+			wantErr: true,
+		},
+		{
+			name:       "invalid item-type override",
+			id:         "om_abc",
+			itOverride: "invalid",
+			wantErr:    true,
+		},
+		{
+			name:       "invalid flag-type override",
+			id:         "om_abc",
+			ftOverride: "invalid",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildSingleCancelItem(tt.id, tt.itOverride, tt.ftOverride)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("buildSingleCancelItem() expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("buildSingleCancelItem() unexpected error: %v", err)
+			}
+			if got.ItemID != tt.id {
+				t.Fatalf("buildSingleCancelItem().ItemID = %q, want %q", got.ItemID, tt.id)
+			}
+			if got.ItemType != stringInt(int(tt.wantIT)) {
+				t.Fatalf("buildSingleCancelItem().ItemType = %q, want %q", got.ItemType, stringInt(int(tt.wantIT)))
+			}
+			if got.FlagType != stringInt(int(tt.wantFT)) {
+				t.Fatalf("buildSingleCancelItem().FlagType = %q, want %q", got.FlagType, stringInt(int(tt.wantFT)))
+			}
+		})
+	}
+}
+
+func TestListQuery(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Int("page-size", 50, "")
+	cmd.Flags().String("page-token", "", "")
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+	if err := cmd.Flags().Set("page-size", "20"); err != nil {
+		t.Fatalf("Set page-size error = %v", err)
+	}
+	if err := cmd.Flags().Set("page-token", "next_token"); err != nil {
+		t.Fatalf("Set page-token error = %v", err)
+	}
+	runtime := &common.RuntimeContext{Cmd: cmd}
+
+	got := listQuery(runtime)
+	if got["page_size"][0] != "20" {
+		t.Fatalf("listQuery() page_size = %q, want %q", got["page_size"][0], "20")
+	}
+	if got["page_token"][0] != "next_token" {
+		t.Fatalf("listQuery() page_token = %q, want %q", got["page_token"][0], "next_token")
+	}
+}
+
+func TestAsString(t *testing.T) {
+	tests := []struct {
+		input any
+		want  string
+	}{
+		{input: "hello", want: "hello"},
+		{input: "", want: ""},
+		{input: 123, want: "123"},
+		{input: int(456), want: "456"},
+		{input: float64(78.9), want: "78.9"},
+		{input: nil, want: ""},
+		{input: []string{"a"}, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run("", func(t *testing.T) {
+			if got := asString(tt.input); got != tt.want {
+				t.Fatalf("asString(%v) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/shortcuts/im/shortcuts.go
+++ b/shortcuts/im/shortcuts.go
@@ -18,5 +18,8 @@ func Shortcuts() []common.Shortcut {
 		ImMessagesSearch,
 		ImMessagesSend,
 		ImThreadsMessagesList,
+		ImFlagCreate,
+		ImFlagCancel,
+		ImFlagList,
 	}
 }

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -18,6 +18,11 @@ metadata:
 - **Chat**: A group chat or P2P conversation, identified by `chat_id` (oc_xxx).
 - **Thread**: A reply thread under a message, identified by `thread_id` (om_xxx or omt_xxx).
 - **Reaction**: An emoji reaction on a message.
+- **Flag**: A bookmark (标记) on a message or thread. Supports two types:
+  - **Message-layer flag**: `(ItemTypeDefault, FlagTypeMessage)` — regular message bookmark
+  - **Feed-layer flag**: `(ItemTypeThread/ItemTypeMsgThread, FlagTypeFeed)` — thread as feed-layer bookmark
+  - **ItemTypeThread** (4) = thread in a topic-style chat (话题群)
+  - **ItemTypeMsgThread** (11) = thread in a regular chat (普通群)
 
 ## Resource Relationships
 
@@ -66,6 +71,9 @@ Shortcut 是对常用操作的高级封装（`lark-cli im +<verb> [flags]`）。
 | [`+messages-search`](references/lark-im-messages-search.md) | Search messages across chats (supports keyword, sender, time range filters) with user identity; user-only; filters by chat/sender/attachment/time, supports auto-pagination via `--page-all` / `--page-limit`, enriches results via batched mget and chats batch_query |
 | [`+messages-send`](references/lark-im-messages-send.md) | Send a message to a chat or direct message; user/bot; sends to chat-id or user-id with text/markdown/post/media, supports idempotency key |
 | [`+threads-messages-list`](references/lark-im-threads-messages-list.md) | List messages in a thread; user/bot; accepts om_/omt_ input, resolves message IDs to thread_id, supports sort/pagination |
+| [`+flag-create`](references/lark-im-flag-create.md) | Create a bookmark (标记) on a message or thread; user-only; defaults to message-layer flag; feed-layer flag requires explicit --item-type + --flag-type |
+| [`+flag-cancel`](references/lark-im-flag-cancel.md) | Cancel (remove) a bookmark; user-only; auto-detects chat_mode and double-cancels both message and feed layers when applicable |
+| [`+flag-list`](references/lark-im-flag-list.md) | List bookmarks; user-only; auto-enriches feed-type thread entries with message content; supports `--page-all` auto-pagination |
 
 ## API Resources
 
@@ -115,6 +123,12 @@ lark-cli im <resource> <method> [flags] # 调用 API
   - `delete` — 移除 Pin 消息。Identity: supports `user` and `bot`.
   - `list` — 获取群内 Pin 消息。Identity: supports `user` and `bot`.
 
+### flags
+
+  - `create` — 创建标记。Identity: `user` only (`user_access_token`).[Must-read](references/lark-im-flag-create.md)
+  - `cancel` — 取消标记。Identity: `user` only (`user_access_token`).[Must-read](references/lark-im-flag-cancel.md)
+  - `list` — 列出标记。Identity: `user` only (`user_access_token`).[Must-read](references/lark-im-flag-list.md)
+
 ## 权限表
 
 | 方法 | 所需 scope |
@@ -140,3 +154,6 @@ lark-cli im <resource> <method> [flags] # 调用 API
 | `pins.create` | `im:message.pins:write_only` |
 | `pins.delete` | `im:message.pins:write_only` |
 | `pins.list` | `im:message.pins:read` |
+| `flags.create` | `im:feed.flag:write` |
+| `flags.cancel` | `im:feed.flag:write` |
+| `flags.list` | `im:feed.flag:read`, `im:message:readonly` |

--- a/skills/lark-im/references/lark-im-flag-cancel.md
+++ b/skills/lark-im/references/lark-im-flag-cancel.md
@@ -1,0 +1,69 @@
+# im +flag-cancel（取消标记）
+
+> **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
+
+本 skill 对应 shortcut：`lark-cli im +flag-cancel`。底层 `POST /open-apis/im/v1/flags/cancel`。
+
+## 双删语义（重要）
+
+同一个 item 可能同时在两层存在标记：
+
+- 话题群（`chat_mode=topic`）中的话题：`(thread, feed)` + `(default, message)`
+- 普通群（`chat_mode=group`）中话题的根消息：`(default, message)` + `(msg_thread, feed)`
+
+**当用户没有从上下文（即 `--flag-type` / `--item-type`）指明要删哪一层时**，shortcut 会自动查询 chat API 的 `chat_mode` 来判断话题群/普通群，然后执行双删；服务端对不存在的标记取消请求幂等，所以多余那条是安全的 no-op。
+
+**chat_mode 判定流程**：
+1. 对于 `om_xxx`，先查询 `GET /open-apis/im/v1/messages/{id}` 获取 `chat_id`，判断是否为 thread root
+2. 如果是 thread root，再查询 `GET /open-apis/im/v1/chats/{chat_id}` 获取 `chat_mode`
+3. `chat_mode=topic` → feed 层用 `ItemTypeThread`；`chat_mode=group` → feed 层用 `ItemTypeMsgThread`
+4. 对于 `omt_xxx`，同样查询 chat API 获取 `chat_mode` 来决定 feed 层的 item_type
+
+> **注意**：`+messages-search` 返回的 `chat_type` 字段不可靠（已废弃），不能用来判断话题群/普通群，必须通过 chat API 的 `chat_mode` 字段判断。
+
+行为对照：
+
+- `--message-id om_xxx` 不带 `--flag-type` → 自动判定：话题根消息双删（feed 层 item_type 由 chat_mode 决定），普通消息单删 `(default, message)`
+- `--thread-id omt_xxx` 不带 `--flag-type` → 自动判定 chat_mode，双删对应的两层
+- 任意 id + `--flag-type message` → 单删 message 层
+- 任意 id + `--flag-type feed` → 单删 feed 层（item-type 由 id 推断或显式指定）
+
+## 命令
+
+```bash
+# 自动判定话题群/普通群：双删两层（推荐默认用法）
+lark-cli im +flag-cancel --as user --message-id om_xxx
+
+# 自动判定话题群/普通群：双删两层
+lark-cli im +flag-cancel --as user --thread-id omt_xxx
+
+# 已知只想清 message 层
+lark-cli im +flag-cancel --as user --message-id om_xxx --flag-type message
+
+# 已知只想清 feed 层 —— 普通群话题根消息
+lark-cli im +flag-cancel --as user --message-id om_xxx --item-type msg_thread --flag-type feed
+
+# 已知只想清 feed 层 —— 话题群中的话题
+lark-cli im +flag-cancel --as user --thread-id omt_xxx --item-type thread --flag-type feed
+
+# 预览请求
+lark-cli im +flag-cancel --as user --thread-id omt_xxx --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--message-id <om_xxx>` | 二选一 | 消息 ID（包括话题根消息） |
+| `--thread-id <omt_xxx>` | 二选一 | Thread ID |
+| `--item-type <name>` | 否 | 覆盖推断 |
+| `--flag-type <name>` | 否 | 覆盖推断；**未指定时自动判定 chat_mode 并双删** |
+| `--as user` | 必须 | 当前仅支持 user 身份 |
+
+## 幂等性
+
+服务端对"标记不存在"的取消请求不会返回错误，所以重复 `+cancel` 幂等。
+
+## 权限
+
+- Scope：`im:feed.flag:write`

--- a/skills/lark-im/references/lark-im-flag-create.md
+++ b/skills/lark-im/references/lark-im-flag-create.md
@@ -1,0 +1,56 @@
+# im +flag-create（创建标记）
+
+> **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
+
+本 skill 对应 shortcut：`lark-cli im +flag-create`。底层 `POST /open-apis/im/v1/flags`。
+
+**默认行为：走 `(default=0, message=2)` message 类型**。当用户没有明确说要标记 message 还是 feed 时，一律默认按 message 处理 —— 包括话题（`omt_xxx`）以及话题的根消息（同时可被 message 或 feed 标记，但默认 message）。要走 feed 层标记必须显式提供 `--item-type` + `--flag-type` 覆盖。
+
+- `--message-id om_xxx`（无覆盖） → `(default, message)`
+- `--thread-id omt_xxx`（无覆盖） → `(default, message)`（默认按消息层标记）
+- `--thread-id omt_xxx --item-type thread --flag-type feed` → `(thread, feed)` —— **话题群** 中的话题在 feed 层打标
+- `--thread-id omt_xxx --item-type msg_thread --flag-type feed` → `(msg_thread, feed)` —— **普通群** 中的话题在 feed 层打标
+
+## 命令
+
+```bash
+# 给一条消息打标（默认路径）
+lark-cli im +flag-create --as user --message-id om_x100xxx
+
+# 话题/话题根消息默认也是 message 层
+lark-cli im +flag-create --as user --thread-id omt_1a8xxx
+
+# 话题群中的话题：feed 层打标（须显式指定）
+lark-cli im +flag-create --as user --thread-id omt_1a8xxx --item-type thread --flag-type feed
+
+# 普通群中的话题：feed 层打标
+lark-cli im +flag-create --as user --thread-id omt_xxx --item-type msg_thread --flag-type feed
+
+# 预览请求（不发送）
+lark-cli im +flag-create --as user --message-id om_xxx --dry-run
+```
+
+## 参数
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `--message-id <om_xxx>` | 二选一 | 消息 ID |
+| `--thread-id <omt_xxx>` | 二选一 | Thread ID |
+| `--item-type <name>` | 否 | 覆盖推断：`default\|chat\|doc\|thread\|box\|open_app\|subscription\|msg_thread\|my_ai\|app_feed\|knowledge_ai` |
+| `--flag-type <name>` | 否 | 覆盖推断：`message\|feed` |
+| `--as user` | 必须 | 当前仅支持 user 身份 |
+
+## 合法组合约束
+
+Execute 前会校验 `(item_type, flag_type)` 组合；服务端目前只接受：
+
+- `(default, message)`
+- `(thread, feed)`
+- `(msg_thread, feed)`
+
+其他组合会在本地直接报 validation 错误。
+
+## 权限
+
+- Scope：`im:feed.flag:write`
+- 缺失时 CLI 会给出 `lark-cli auth login --scope "..."` 提示

--- a/skills/lark-im/references/lark-im-flag-list.md
+++ b/skills/lark-im/references/lark-im-flag-list.md
@@ -1,0 +1,97 @@
+# im +flag-list（列出标记）
+
+> **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
+
+本 skill 对应 shortcut：`lark-cli im +flag-list`。底层 `GET /open-apis/im/v1/flags`。
+
+## 排序规则（重要）
+
+API 返回的数据按 `update_time` **升序**排列，即**最旧的在最前面，最新的在最后面**。当 `has_more=true` 时，不能直接取第一页的条目作为最新标记，必须翻完所有页，取最后一页的最后一个条目才是最新的。
+
+推荐使用 `--page-all` 自动翻页获取完整列表，再用 `-q '.data.flag_items[-1]'` 取最新条目。
+
+## 命令
+
+```bash
+# 拉第一页（默认 page-size=50）
+lark-cli im +flag-list --as user
+
+# 自动翻页获取所有标记（推荐）
+lark-cli im +flag-list --as user --page-all
+
+# 自动翻页 + 取最新的一条标记
+lark-cli im +flag-list --as user --page-all -q '.data.flag_items[-1]'
+
+# 自动翻页 + 只要 item_id 列表
+lark-cli im +flag-list --as user --page-all -q '.data.flag_items[].item_id'
+
+# 指定页大小（上限 50）
+lark-cli im +flag-list --as user --page-size 30
+
+# 手动翻页
+lark-cli im +flag-list --as user --page-token <上一页返回的 page_token>
+
+# 关闭自动补消息内容（默认开启）
+lark-cli im +flag-list --as user --page-all --enrich-feed-thread=false
+
+# 限制最大翻页数（默认 20，上限 40）
+lark-cli im +flag-list --as user --page-all --page-limit 10
+```
+
+## 参数
+
+| 参数 | 默认 | 说明 |
+|------|------|------|
+| `--page-size <n>` | 50 | 范围 1-50（服务端上限 50） |
+| `--page-token <token>` | 空 | 上一页返回的翻页 token；空字符串也必须带 |
+| `--page-all` | false | 自动翻页获取所有页的数据并合并 |
+| `--page-limit <n>` | 20 | `--page-all` 模式下最大翻页数（上限 40） |
+| `--enrich-feed-thread` | true | 对 feed 层 thread 条目自动补消息内容（调 `im.messages.mget`） |
+
+## 返回结构
+
+返回以 `data` 为主体，字段说明如下：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `flag_items` | array | 当前仍然存在（未取消）的标记列表，按 `update_time` 升序 |
+| `delete_flag_items` | array | 曾经取消过的标记列表，按 `update_time` 升序 |
+| `messages` | array | 服务端对 `(default, message)` 的消息类型标记直接内联的消息内容 |
+| `has_more` | boolean | 是否还有下一页 |
+| `page_token` | string | 下一页的翻页 token |
+
+补充：`(thread, feed)` / `(msg_thread, feed)` 条目由 shortcut 自动调 `mget` 补齐，并写回到对应条目的 `message` 字段。
+
+## 返回样例（脱敏）
+
+```json
+{
+  "data": {
+    "delete_flag_items": [
+      {
+        "create_time": "xxx",
+        "flag_type": "xxx",
+        "item_id": "xxx",
+        "item_type": "xxx",
+        "update_time": "xxx"
+      }
+    ],
+    "flag_items": [
+      {
+        "create_time": "xxx",
+        "flag_type": "xxx",
+        "item_id": "xxx",
+        "item_type": "xxx",
+        "update_time": "xxx"
+      }
+    ],
+    "has_more": false,
+    "messages": [],
+    "page_token": "xxx"
+  }
+}
+```
+
+## 权限
+
+- Scope：`im:feed.flag:read`（列表）+ `im:message:readonly`（补消息内容）

--- a/tests/cli_e2e/im/flag_workflow_test.go
+++ b/tests/cli_e2e/im/flag_workflow_test.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestIM_FlagWorkflowAsUser(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	clie2e.SkipWithoutUserToken(t)
+
+	parentT := t
+	suffix := clie2e.GenerateSuffix()
+	chatName := "im-flag-" + suffix
+	messageText := "flag-test-msg-" + suffix
+	var chatID string
+	var messageID string
+
+	t.Run("create chat as user", func(t *testing.T) {
+		chatID = createChatAs(t, parentT, ctx, chatName, "user")
+	})
+
+	t.Run("send message as user", func(t *testing.T) {
+		messageID = sendMessageAs(t, ctx, chatID, messageText, "user")
+	})
+
+	t.Run("create flag as user", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-create",
+				"--message-id", messageID,
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+	})
+
+	t.Run("list flags as user", func(t *testing.T) {
+		result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-list",
+				"--page-size", "10",
+			},
+			DefaultAs: "user",
+		}, clie2e.RetryOptions{
+			ShouldRetry: func(result *clie2e.Result) bool {
+				if result == nil || result.ExitCode != 0 {
+					return true
+				}
+				// Check if our message is in the list
+				for _, item := range gjson.Get(result.Stdout, "data.flag_items").Array() {
+					if item.Get("item_id").String() == messageID {
+						return false
+					}
+				}
+				return true
+			},
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+
+		// Verify our flagged message is in the list
+		var found bool
+		for _, item := range gjson.Get(result.Stdout, "data.flag_items").Array() {
+			if item.Get("item_id").String() == messageID {
+				found = true
+				// Verify it's a message-type flag (flag_type=2)
+				require.Equal(t, "2", item.Get("flag_type").String(), "expected flag_type=2 (message)")
+				break
+			}
+		}
+		require.True(t, found, "expected message %s in flag list", messageID)
+	})
+
+	t.Run("cancel flag as user", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-cancel",
+				"--message-id", messageID,
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+	})
+
+	t.Run("verify flag removed", func(t *testing.T) {
+		result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-list",
+				"--page-size", "10",
+			},
+			DefaultAs: "user",
+		}, clie2e.RetryOptions{
+			ShouldRetry: func(result *clie2e.Result) bool {
+				if result == nil || result.ExitCode != 0 {
+					return true
+				}
+				// Check if our message is still in the list
+				for _, item := range gjson.Get(result.Stdout, "data.flag_items").Array() {
+					if item.Get("item_id").String() == messageID {
+						return true // Still there, retry
+					}
+				}
+				return false // Not found, success
+			},
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+
+		// Verify our message is NOT in the list
+		for _, item := range gjson.Get(result.Stdout, "data.flag_items").Array() {
+			require.NotEqual(t, messageID, item.Get("item_id").String(), "message should not be in flag list after cancel")
+		}
+	})
+}
+
+func TestIM_FlagCreateWithExplicitTypeAsUser(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	clie2e.SkipWithoutUserToken(t)
+
+	parentT := t
+	suffix := clie2e.GenerateSuffix()
+	chatName := "im-flag-explicit-" + suffix
+	messageText := "flag-explicit-msg-" + suffix
+	var chatID string
+	var messageID string
+
+	t.Run("create chat as user", func(t *testing.T) {
+		chatID = createChatAs(t, parentT, ctx, chatName, "user")
+	})
+
+	t.Run("send message as user", func(t *testing.T) {
+		messageID = sendMessageAs(t, ctx, chatID, messageText, "user")
+	})
+
+	t.Run("create flag with explicit types as user", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-create",
+				"--message-id", messageID,
+				"--item-type", "default",
+				"--flag-type", "message",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+	})
+
+	t.Run("cancel flag with explicit types as user", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-cancel",
+				"--message-id", messageID,
+				"--flag-type", "message",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+	})
+}
+
+func TestIM_FlagListPaginationAsUser(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	t.Cleanup(cancel)
+
+	clie2e.SkipWithoutUserToken(t)
+
+	t.Run("list flags with page-all as user", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-list",
+				"--page-size", "5",
+				"--page-all",
+				"--page-limit", "3",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, true)
+	})
+}
+
+func TestIM_FlagDryRun(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	clie2e.SkipWithoutUserToken(t)
+
+	t.Run("create flag dry-run", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-create",
+				"--message-id", "om_test_dry_run",
+				"--dry-run",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		require.Contains(t, result.Stdout, "POST")
+		require.Contains(t, result.Stdout, "/open-apis/im/v1/flags")
+	})
+
+	t.Run("cancel flag dry-run with om", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-cancel",
+				"--message-id", "om_test_dry_run",
+				"--dry-run",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		require.Contains(t, result.Stdout, "POST")
+		require.Contains(t, result.Stdout, "/open-apis/im/v1/flags/cancel")
+	})
+
+	t.Run("cancel flag dry-run with omt", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-cancel",
+				"--thread-id", "omt_test_dry_run",
+				"--dry-run",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		require.Contains(t, result.Stdout, "POST")
+		require.Contains(t, result.Stdout, "/open-apis/im/v1/flags/cancel")
+	})
+
+	t.Run("list flag dry-run", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"im", "+flag-list",
+				"--dry-run",
+			},
+			DefaultAs: "user",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		require.Contains(t, result.Stdout, "GET")
+		require.Contains(t, result.Stdout, "/open-apis/im/v1/flags")
+	})
+}


### PR DESCRIPTION
Change-Id: I8f87f0eadf83fb59b024a3b9fe67b23d363abe0a

## Summary
Add IM flag shortcut commands to lark-cli, enabling users to create, list, and cancel bookmarks on messages and threads via `+flag-create`, `+flag-list`, and `+flag-cancel`. 

## Changes
  - Add `+flag-create` shortcut: create a bookmark on a message or thread; defaults to message-layer flag; feed-layer flag requires explicit `--item-type` + `--flag-type`                                                              
  - Add `+flag-list` shortcut: list bookmarks with auto-enrichment of feed-type thread entries (fetches message content via mget); supports `--page-all` auto-pagination                                                                
  - Add `+flag-cancel` shortcut: cancel a bookmark; auto-detects chat_mode to determine correct feed-layer item_type (topic group→thread, regular group→msg_thread); double-cancels both message and feed layers when applicable                    
  - Add flag type enums (`FlagType`, `ItemType`) and helper functions in `shortcuts/im/helpers.go` for ID prefix inference, combo validation, and chat_mode resolution                                                                  
  - Update `skills/lark-im/SKILL.md` and add reference docs for the three new shortcuts                                                                                                                                                 
  - Update `internal/registry/service_descriptions.json` with flag API metadata                                                                                                                                                         
  - Add unit tests in `shortcuts/im/im_flag_test.go` and live E2E test in `tests/cli_e2e/im/flag_workflow_test.go`  

## Test Plan
  - [x] Unit tests pass (`shortcuts/im/im_flag_test.go` — 688 lines covering parse, build, combo validation, dry-run)                                                                                                                   
  - [x] Live E2E test verifies full create→list→cancel workflow as user (`tests/cli_e2e/im/flag_workflow_test.go`)                                                                                                                      
  - [x] `make unit-test` passes                                                                                                                                                                                                         
  - [x] Manual local verification confirms `lark im +flag-create`, `+flag-list`, `+flag-cancel` commands work as expected 

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added flag bookmarking system for messages and threads with three new commands: `+flag-create` (create bookmarks), `+flag-cancel` (remove bookmarks), and `+flag-list` (list bookmarks with pagination and optional enrichment capabilities).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->