### PR TITLE
feat(cmdutil): add did-you-mean suggestions for unknown flags

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -105,6 +105,11 @@ func buildInternal(ctx context.Context, inv cmdutil.InvocationContext, opts ...B
 
 	installTipsHelpFunc(rootCmd)
 	rootCmd.SilenceErrors = true
+	// Install structured "did you mean" handler for unknown flags. cobra's
+	// FlagErrorFunc lookup walks up to the root, so a single install on the
+	// root applies to every subcommand. Other flag-error types (required
+	// flag missing, type mismatch, etc.) pass through unchanged.
+	rootCmd.SetFlagErrorFunc(cmdutil.UnknownFlagHandler)
 
 	RegisterGlobalFlags(rootCmd.PersistentFlags(), &cfg.globals)
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {

--- a/internal/cmdutil/flag_suggest.go
+++ b/internal/cmdutil/flag_suggest.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmdutil
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// commonSynonyms maps wrong flag names that come from other CLIs' conventions
+// to the canonical lark-cli name. It is consulted before edit-distance
+// matching because the names are far apart in Levenshtein distance (e.g.
+// "limit" vs "max" is distance 4) but semantically interchangeable in agent
+// prompts. A synonym is only suggested when the canonical target flag is
+// actually registered on the invoked command.
+var commonSynonyms = map[string]synonymHint{
+	"limit":   {target: "max"},
+	"count":   {target: "max"},
+	"size":    {target: "page-size"},
+	"folder":  {target: "filter", extra: `pass folder via --filter '{"folder":"..."}'`},
+	"mailbox": {target: "filter", extra: `pass mailbox via --filter '{"folder":"..."}'`},
+	"subject": {target: "filter", extra: `pass subject via --filter '{"subject":"..."}'`},
+}
+
+type synonymHint struct {
+	target string
+	extra  string
+}
+
+// UnknownFlagHandler is wired via rootCmd.SetFlagErrorFunc. cobra walks up to
+// the root when a child command has not set its own FlagErrorFunc, so a
+// single install on the root command applies CLI-wide.
+//
+// It only acts on "unknown flag" parse errors. Every other flag-error type
+// (required flag missing, value type mismatch, ambiguous flag, etc.) is
+// returned unchanged so cobra's default semantics apply.
+//
+// On a hit, it returns an *output.ExitError with type=validation. The root
+// error handler in cmd/root.go routes ExitError through
+// output.WriteErrorEnvelope, producing the structured stderr JSON that
+// AGENTS.md mandates for AI-agent consumption.
+func UnknownFlagHandler(cmd *cobra.Command, err error) error {
+	if err == nil {
+		return nil
+	}
+	badName, isShort, ok := parseUnknownFlagName(err.Error())
+	if !ok {
+		return err
+	}
+	dashes := "--"
+	if isShort {
+		dashes = "-"
+	}
+	exit := output.ErrValidation("unknown flag: %s%s", dashes, badName)
+	// Skip suggestions for short (single-char) flags: pflag's short-flag
+	// namespace is completely separate from long flags, and 1-char inputs
+	// would Levenshtein-match almost anything within the default threshold.
+	if isShort {
+		return exit
+	}
+	if suggestion, hint, found := SuggestFlag(cmd, badName); found {
+		if hint == "" {
+			hint = fmt.Sprintf("did you mean --%s?", suggestion)
+		}
+		exit.Detail.Hint = hint
+	}
+	return exit
+}
+
+// parseUnknownFlagName extracts the bad flag name from a pflag error message.
+// pflag emits "unknown flag: --foo" for long flags and
+// "unknown shorthand flag: 'x' in -x" for short flags. The second return
+// value reports whether it was a shorthand. ok=false signals the caller to
+// pass the error through untouched.
+func parseUnknownFlagName(msg string) (name string, isShort bool, ok bool) {
+	const longPrefix = "unknown flag: --"
+	const shortPrefix = "unknown shorthand flag: '"
+	switch {
+	case strings.HasPrefix(msg, longPrefix):
+		n := strings.TrimPrefix(msg, longPrefix)
+		if i := strings.IndexAny(n, " \t\n"); i >= 0 {
+			n = n[:i]
+		}
+		return n, false, n != ""
+	case strings.HasPrefix(msg, shortPrefix):
+		rest := strings.TrimPrefix(msg, shortPrefix)
+		if end := strings.Index(rest, "'"); end >= 0 {
+			n := rest[:end]
+			return n, true, n != ""
+		}
+	}
+	return "", false, false
+}
+
+// SuggestFlag returns the closest flag name on cmd to badName.
+//
+// Layer A (synonyms): consults commonSynonyms first. The synonym is only
+// returned when the target flag is registered (and not hidden) on cmd, so we
+// don't mislead users on commands that don't define it.
+//
+// Layer B (edit distance): Levenshtein with threshold max(2, len(badName)/3).
+// Hidden flags are excluded.
+func SuggestFlag(cmd *cobra.Command, badName string) (suggestion string, hint string, ok bool) {
+	if cmd == nil || badName == "" {
+		return "", "", false
+	}
+	flags := cmd.Flags()
+
+	if syn, found := commonSynonyms[badName]; found {
+		if f := flags.Lookup(syn.target); f != nil && !f.Hidden {
+			hintMsg := fmt.Sprintf("did you mean --%s?", syn.target)
+			if syn.extra != "" {
+				hintMsg = hintMsg + " " + syn.extra
+			}
+			return syn.target, hintMsg, true
+		}
+	}
+
+	threshold := len(badName) / 3
+	if threshold < 2 {
+		threshold = 2
+	}
+	type cand struct {
+		name string
+		d    int
+	}
+	var cands []cand
+	flags.VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		d := levenshtein(badName, f.Name)
+		if d <= threshold {
+			cands = append(cands, cand{f.Name, d})
+		}
+	})
+	if len(cands) == 0 {
+		return "", "", false
+	}
+	sort.Slice(cands, func(i, j int) bool {
+		if cands[i].d != cands[j].d {
+			return cands[i].d < cands[j].d
+		}
+		return cands[i].name < cands[j].name
+	})
+	return cands[0].name, "", true
+}
+
+// levenshtein returns the edit distance between a and b using a single-row
+// DP. Inlined to avoid pulling a third-party dependency for ~25 lines.
+func levenshtein(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a == "" {
+		return len(b)
+	}
+	if b == "" {
+		return len(a)
+	}
+	ar := []rune(a)
+	br := []rune(b)
+	prev := make([]int, len(br)+1)
+	curr := make([]int, len(br)+1)
+	for j := 0; j <= len(br); j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ar); i++ {
+		curr[0] = i
+		for j := 1; j <= len(br); j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			m := del
+			if ins < m {
+				m = ins
+			}
+			if sub < m {
+				m = sub
+			}
+			curr[j] = m
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(br)]
+}
+
+// Compile-time guard: signature must match cobra's FlagErrorFunc.
+var _ func(*cobra.Command, error) error = UnknownFlagHandler

--- a/internal/cmdutil/flag_suggest_test.go
+++ b/internal/cmdutil/flag_suggest_test.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmdutil
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// newTriageLikeCmd builds a minimal cobra command whose flag surface mirrors
+// `mail +triage` closely enough for suggestion tests: the canonical names
+// (--max, --filter, --page-size) plus an inherited persistent flag and a
+// hidden flag we want excluded from suggestions.
+func newTriageLikeCmd() *cobra.Command {
+	root := &cobra.Command{Use: "lark-cli"}
+	root.PersistentFlags().String("format", "json", "")
+
+	leaf := &cobra.Command{Use: "+triage", RunE: func(*cobra.Command, []string) error { return nil }}
+	leaf.Flags().Int("max", 0, "")
+	leaf.Flags().String("filter", "", "")
+	leaf.Flags().Int("page-size", 0, "")
+	leaf.Flags().String("internal", "", "hidden internal flag")
+	_ = leaf.Flags().MarkHidden("internal")
+	root.AddCommand(leaf)
+	return leaf
+}
+
+func TestSuggestFlag_SynonymHit(t *testing.T) {
+	cmd := newTriageLikeCmd()
+	tests := []struct {
+		bad      string
+		want     string
+		hintHas  string
+		wantHint bool
+	}{
+		{"limit", "max", "did you mean --max?", true},
+		{"count", "max", "did you mean --max?", true},
+		{"size", "page-size", "did you mean --page-size?", true},
+		{"folder", "filter", `--filter '{"folder":"..."}'`, true},
+		{"mailbox", "filter", `--filter '{"folder":"..."}'`, true},
+		{"subject", "filter", `--filter '{"subject":"..."}'`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.bad, func(t *testing.T) {
+			got, hint, ok := SuggestFlag(cmd, tt.bad)
+			if !ok {
+				t.Fatalf("expected suggestion for %q, got none", tt.bad)
+			}
+			if got != tt.want {
+				t.Errorf("suggestion = %q, want %q", got, tt.want)
+			}
+			if tt.wantHint && !strings.Contains(hint, tt.hintHas) {
+				t.Errorf("hint = %q, want substring %q", hint, tt.hintHas)
+			}
+		})
+	}
+}
+
+func TestSuggestFlag_SynonymTargetMissingFallsThrough(t *testing.T) {
+	// A command without --max: synonym lookup must not blindly return "max".
+	root := &cobra.Command{Use: "lark-cli"}
+	leaf := &cobra.Command{Use: "+other"}
+	leaf.Flags().String("filter", "", "")
+	root.AddCommand(leaf)
+
+	if _, _, ok := SuggestFlag(leaf, "limit"); ok {
+		t.Error("expected no suggestion when synonym target --max is not registered, got one")
+	}
+}
+
+func TestSuggestFlag_EditDistanceTypo(t *testing.T) {
+	cmd := newTriageLikeCmd()
+	cases := map[string]string{
+		"filtr":     "filter",
+		"fileter":   "filter",
+		"page-siez": "page-size", // transposition
+	}
+	for bad, want := range cases {
+		t.Run(bad, func(t *testing.T) {
+			got, _, ok := SuggestFlag(cmd, bad)
+			if !ok {
+				t.Fatalf("expected suggestion for %q, got none", bad)
+			}
+			if got != want {
+				t.Errorf("suggestion for %q = %q, want %q", bad, got, want)
+			}
+		})
+	}
+}
+
+func TestSuggestFlag_NoSuggestionWhenFar(t *testing.T) {
+	cmd := newTriageLikeCmd()
+	if got, _, ok := SuggestFlag(cmd, "xyzabcd"); ok {
+		t.Errorf("expected no suggestion for far-distance %q, got %q", "xyzabcd", got)
+	}
+}
+
+func TestSuggestFlag_HiddenFlagsExcluded(t *testing.T) {
+	cmd := newTriageLikeCmd()
+	// "internal" is hidden; an obvious typo of it must not be suggested.
+	if got, _, ok := SuggestFlag(cmd, "internl"); ok {
+		t.Errorf("hidden flag should be excluded from suggestions, got %q", got)
+	}
+}
+
+func TestSuggestFlag_TiebreakAlphabetical(t *testing.T) {
+	// Both "abc" and "abd" are at edit distance 1 from "abe"; tie-breaks
+	// alphabetically -> "abc".
+	root := &cobra.Command{Use: "lark-cli"}
+	leaf := &cobra.Command{Use: "+x"}
+	leaf.Flags().String("abc", "", "")
+	leaf.Flags().String("abd", "", "")
+	root.AddCommand(leaf)
+	got, _, ok := SuggestFlag(leaf, "abe")
+	if !ok {
+		t.Fatal("expected a suggestion")
+	}
+	if got != "abc" {
+		t.Errorf("tie-break = %q, want abc", got)
+	}
+}
+
+func TestSuggestFlag_NilOrEmpty(t *testing.T) {
+	if _, _, ok := SuggestFlag(nil, "anything"); ok {
+		t.Error("nil cmd should yield no suggestion")
+	}
+	cmd := newTriageLikeCmd()
+	if _, _, ok := SuggestFlag(cmd, ""); ok {
+		t.Error("empty badName should yield no suggestion")
+	}
+}
+
+func TestParseUnknownFlagName(t *testing.T) {
+	cases := []struct {
+		msg       string
+		want      string
+		wantShort bool
+		wantOK    bool
+		comment   string
+	}{
+		{"unknown flag: --limit", "limit", false, true, "long flag"},
+		{"unknown flag: --page-size", "page-size", false, true, "long flag with hyphen"},
+		{"unknown shorthand flag: 'x' in -x", "x", true, true, "short flag"},
+		{"flag needs an argument: --foo", "", false, false, "different error"},
+		{"required flag(s) \"q\" not set", "", false, false, "required flag missing"},
+		{"", "", false, false, "empty"},
+		{"unknown flag: --", "", false, false, "empty flag name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.comment, func(t *testing.T) {
+			got, isShort, ok := parseUnknownFlagName(tc.msg)
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v (msg=%q)", ok, tc.wantOK, tc.msg)
+			}
+			if got != tc.want {
+				t.Errorf("name = %q, want %q (msg=%q)", got, tc.want, tc.msg)
+			}
+			if isShort != tc.wantShort {
+				t.Errorf("isShort = %v, want %v (msg=%q)", isShort, tc.wantShort, tc.msg)
+			}
+		})
+	}
+}
+
+func TestUnknownFlagHandler_PassesThroughOtherErrors(t *testing.T) {
+	cmd := newTriageLikeCmd()
+	original := errors.New("flag needs an argument: --max")
+	got := UnknownFlagHandler(cmd, original)
+	if got != original {
+		t.Errorf("expected pass-through of non-unknown-flag error, got %v", got)
+	}
+}
+
+func TestUnknownFlagHandler_SynonymProducesEnvelope(t *testing.T) {
+	cmd := newTriageLikeCmd()
+	got := UnknownFlagHandler(cmd, fmt.Errorf("unknown flag: --limit"))
+	var exit *output.ExitError
+	if !errors.As(got, &exit) {
+		t.Fatalf("expected *output.ExitError, got %T", got)
+	}
+	if exit.Code != output.ExitValidation {
+		t.Errorf("Code = %d, want %d", exit.Code, output.ExitValidation)
+	}
+	if exit.Detail == nil {
+		t.Fatal("Detail is nil")
+	}
+	if exit.Detail.Type != "validation" {
+		t.Errorf("Type = %q, want validation", exit.Detail.Type)
+	}
+	if exit.Detail.Message != "unknown flag: --limit" {
+		t.Errorf("Message = %q, want exact 'unknown flag: --limit'", exit.Detail.Message)
+	}
+	if exit.Detail.Hint != "did you mean --max?" {
+		t.Errorf("Hint = %q, want 'did you mean --max?'", exit.Detail.Hint)
+	}
+}
+
+func TestUnknownFlagHandler_TypoProducesEnvelope(t *testing.T) {
+	cmd := newTriageLikeCmd()
+	got := UnknownFlagHandler(cmd, fmt.Errorf("unknown flag: --filtr"))
+	var exit *output.ExitError
+	if !errors.As(got, &exit) {
+		t.Fatalf("expected *output.ExitError, got %T", got)
+	}
+	if exit.Detail.Hint != "did you mean --filter?" {
+		t.Errorf("Hint = %q, want 'did you mean --filter?'", exit.Detail.Hint)
+	}
+}
+
+func TestUnknownFlagHandler_NoMatchOmitsHint(t *testing.T) {
+	cmd := newTriageLikeCmd()
+	got := UnknownFlagHandler(cmd, fmt.Errorf("unknown flag: --xyzabcd"))
+	var exit *output.ExitError
+	if !errors.As(got, &exit) {
+		t.Fatalf("expected *output.ExitError, got %T", got)
+	}
+	if exit.Detail.Hint != "" {
+		t.Errorf("Hint = %q, want empty when no suggestion found", exit.Detail.Hint)
+	}
+	if !strings.Contains(exit.Detail.Message, "--xyzabcd") {
+		t.Errorf("Message = %q, want it to include the bad flag name", exit.Detail.Message)
+	}
+}
+
+func TestUnknownFlagHandler_ShortFlagSkipsSuggestion(t *testing.T) {
+	// Short (1-char) flags share no namespace with long flags, so the
+	// handler must not Levenshtein-match a single char against long flag
+	// names. It should produce a "-X" message and an empty hint.
+	cmd := newTriageLikeCmd()
+	got := UnknownFlagHandler(cmd, fmt.Errorf("unknown shorthand flag: 'Z' in -Z"))
+	var exit *output.ExitError
+	if !errors.As(got, &exit) {
+		t.Fatalf("expected *output.ExitError, got %T", got)
+	}
+	if exit.Detail.Message != "unknown flag: -Z" {
+		t.Errorf("Message = %q, want 'unknown flag: -Z' (single dash)", exit.Detail.Message)
+	}
+	if exit.Detail.Hint != "" {
+		t.Errorf("Hint = %q, want empty for short flag", exit.Detail.Hint)
+	}
+}
+
+func TestLevenshtein(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "abc", 0},
+		{"", "abc", 3},
+		{"abc", "", 3},
+		{"kitten", "sitting", 3},
+		{"filtr", "filter", 1},
+		{"page-siez", "page-size", 2},
+		{"limit", "max", 4},
+	}
+	for _, c := range cases {
+		t.Run(c.a+"_"+c.b, func(t *testing.T) {
+			if got := levenshtein(c.a, c.b); got != c.want {
+				t.Errorf("levenshtein(%q,%q) = %d, want %d", c.a, c.b, got, c.want)
+			}
+		})
+	}
+}

--- a/tests/cli_e2e/flag_suggest_regression_test.go
+++ b/tests/cli_e2e/flag_suggest_regression_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package clie2e
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFlagSuggest_Regression locks in the structured "did you mean" envelope
+// shipped via cmdutil.UnknownFlagHandler. The unit tests in
+// internal/cmdutil/flag_suggest_test.go prove the handler logic in isolation;
+// this E2E asserts the wiring in cmd/build.go reaches every shortcut and the
+// error envelope actually lands on stderr in the contract shape AGENTS.md
+// requires (so AI agents can pattern-match `error.hint`).
+func TestFlagSuggest_Regression(t *testing.T) {
+	setDryRunConfigEnv(t)
+
+	tests := []struct {
+		name        string
+		args        []string
+		wantMessage string
+		wantHint    string // empty means: hint must be absent or empty
+	}{
+		{
+			name:        "synonym limit suggests max",
+			args:        []string{"mail", "+triage", "--limit", "5", "--dry-run"},
+			wantMessage: "unknown flag: --limit",
+			wantHint:    "did you mean --max?",
+		},
+		{
+			name:        "synonym folder suggests filter with example",
+			args:        []string{"mail", "+triage", "--folder", "Inbox", "--dry-run"},
+			wantMessage: "unknown flag: --folder",
+			wantHint:    `did you mean --filter? pass folder via --filter '{"folder":"..."}'`,
+		},
+		{
+			name:        "typo filtr suggests filter",
+			args:        []string{"mail", "+triage", "--filtr", "{}", "--dry-run"},
+			wantMessage: "unknown flag: --filtr",
+			wantHint:    "did you mean --filter?",
+		},
+		{
+			name:        "far-distance unknown flag has no hint",
+			args:        []string{"mail", "+triage", "--xyzqqq=1", "--dry-run"},
+			wantMessage: "unknown flag: --xyzqqq",
+			wantHint:    "",
+		},
+		{
+			name:        "synonym not suggested on commands without target flag",
+			args:        []string{"auth", "status", "--limit", "1"},
+			wantMessage: "unknown flag: --limit",
+			wantHint:    "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			t.Cleanup(cancel)
+
+			result, err := RunCmd(ctx, Request{Args: tc.args})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 2) // ExitValidation
+
+			var env map[string]any
+			require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(result.Stderr)), &env),
+				"stderr must be valid JSON; got:\n%s", result.Stderr)
+			assert.Equal(t, false, env["ok"], "ok should be false")
+
+			errObj, ok := env["error"].(map[string]any)
+			require.True(t, ok, "error must be object: %#v", env)
+			assert.Equal(t, "validation", errObj["type"])
+			assert.Equal(t, tc.wantMessage, errObj["message"])
+
+			hint, _ := errObj["hint"].(string)
+			assert.Equal(t, tc.wantHint, hint)
+		})
+	}
+}
+
+// TestFlagSuggest_RegressionPassThrough proves the handler does NOT swallow
+// other flag-error types (required flag missing, value type mismatch). They
+// must reach cobra's default plain-text "Error: ..." path so we don't change
+// existing semantics for non-unknown-flag errors.
+func TestFlagSuggest_RegressionPassThrough(t *testing.T) {
+	setDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := RunCmd(ctx, Request{
+		Args: []string{"mail", "+triage", "--max", "not-a-number", "--dry-run"},
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 1)
+	combined := result.Stdout + result.Stderr
+	assert.Contains(t, combined, "invalid argument", "type-mismatch error must reach the user")
+	// And it must NOT be wrapped in our did-you-mean envelope.
+	assert.NotContains(t, combined, `"hint":"did you mean`)
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                            
                                                                  
  Wire `cmdutil.UnknownFlagHandler` onto the root command via                                                                                                                                                           
  `SetFlagErrorFunc` so that unknown CLI flags produce the structured
  `ExitError` envelope with an optional `hint` field (e.g.                                                                                                                                                              
  `"did you mean --max?"`). AI agents that consume lark-cli output via                                                                                                                                                  
  AGENTS.md pattern-match `error.hint` to recover from typos; today an                                                                                                                                                  
  unknown flag yields a generic message and the agent has no signal for                                                                                                                                                 
  what to retry with. cobra walks up to the root for `FlagErrorFunc`, so                                                                                                                                                
  a single install on `rootCmd` applies CLI-wide.                                                                                                                                                                       
                                                                                                                                                                                                                        
  ## Changes                                                      
                                                                                                                                                                                                                        
  - Add `internal/cmdutil/flag_suggest.go` with `UnknownFlagHandler` and                                                                                                                                                
    `SuggestFlag`. Two-layer matching: a curated synonym map (other-CLI
    conventions agents commonly reach for, e.g. `--limit -> --max`,                                                                                                                                                     
    `--folder -> --filter`) followed by a Levenshtein fallback with                                                                                                                                                     
    threshold `max(2, len/3)`. Hidden flags excluded; ties broken                                                                                                                                                       
    alphabetically.                                                                                                                                                                                                     
  - Synonym layer only fires when the canonical target flag is registered                                                                                                                                               
    on the invoked command, so we don't mislead users on commands that                                                                                                                                                  
    don't define it.                                                                                                                                                                                                    
  - Short flags get a plain "unknown flag" message — pflag's short-flag                                                                                                                                                 
    namespace is separate from long flags and 1-char Levenshtein matches                                                                                                                                                
    would be near-meaningless.                                                                                                                                                                                          
  - Other flag-error types (required missing, type mismatch, etc.) pass                                                                                                                                                 
    through unchanged so cobra's default semantics apply.                                                                                                                                                               
  - Wire the handler in `cmd/build.go` via `rootCmd.SetFlagErrorFunc`.                                                                                                                                                  
                                                                                                                                                                                                                        
  ### Behavior reference                                                                                                                                                                                                
                                                                                                                                                                                                                        
  | Input | Output hint |                                                                                                                                                                                               
  |---|---|
  | `--limit 5` | `did you mean --max?` |                                                                                                                                                                               
  | `--folder INBOX` | `did you mean --filter? pass folder via --filter '{"folder":"..."}'` |
  | `--maxx 5` | `did you mean --max?` |                                                                                                                                                                                
  | `--halp` | `did you mean --help?` |
  | `-Z` | (no hint — short-flag namespace is separate) |                                                                                                                                                               
  | `--totally-bogus-xyz` | (no hint — beyond threshold) |                                                                                                                                                              
                                                                                                                                                                                                                        
  ## Test Plan                                                                                                                                                                                                          
                                                                                                                                                                                                                        
  - [x] Unit tests pass: `go test ./internal/cmdutil/...` covers                                                                                                                                                        
        `flag_suggest_test.go` (14 funcs incl. synonym hit/fallthrough,
        edit-distance, hidden-flag exclusion, tiebreaker, nil-defense,                                                                                                                                                  
        pflag message parsing, handler pass-through).                                                                                                                                                                   
  - [x] E2E regression: `go test ./tests/cli_e2e/...` runs                                                                                                                                                              
        `flag_suggest_regression_test.go` (5 hit cases + pass-through).                                                                                                                                                 
  - [x] Manual smoke confirms `lark-cli mail +triage --limit 5 --dry-run`                                                                                                                                               
        and equivalents across `calendar`, `drive`, `im`, `okr`                                                                                                                                                         
        subcommands all return the structured envelope with the expected                                                                                                                                                
        `hint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent flag suggestions for unrecognized command-line flags, including "did you mean?" hints for typos and suggestions based on common flag name synonyms to improve CLI usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->