### PR TITLE
fix: remove misleading default value from --as flag help text

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ EXAMPLES:
 FLAGS:
     --params <json>       URL/query parameters JSON
     --data <json>         request body JSON (POST/PATCH/PUT/DELETE)
-    --as <type>           identity type: user | bot | auto (default: auto)
+    --as <type>           identity type: user | bot
     --format <fmt>        output format: json (default) | ndjson | table | csv | pretty
     --page-all            automatically paginate through all pages
     --page-size <N>       page size (0 = use API default)

--- a/internal/cmdutil/identity_flag.go
+++ b/internal/cmdutil/identity_flag.go
@@ -14,8 +14,8 @@ import (
 // AddAPIIdentityFlag registers the standard --as flag shape used by api/service commands.
 func AddAPIIdentityFlag(ctx context.Context, cmd *cobra.Command, f *Factory, target *string) {
 	addIdentityFlag(ctx, cmd, f, target, identityFlagConfig{
-		defaultValue:     "auto",
-		usage:            "identity type: user | bot | auto (default)",
+		defaultValue:     "",
+		usage:            "identity type: user | bot",
 		completionValues: []string{"user", "bot"},
 	})
 }
@@ -26,7 +26,7 @@ func AddShortcutIdentityFlag(ctx context.Context, cmd *cobra.Command, f *Factory
 		authTypes = []string{"user"}
 	}
 	addIdentityFlag(ctx, cmd, f, nil, identityFlagConfig{
-		defaultValue:     authTypes[0],
+		defaultValue:     "",
 		usage:            "identity type: " + strings.Join(authTypes, " | "),
 		completionValues: authTypes,
 	})

--- a/internal/cmdutil/identity_flag_test.go
+++ b/internal/cmdutil/identity_flag_test.go
@@ -24,8 +24,8 @@ func TestAddAPIIdentityFlag_NonStrictMode(t *testing.T) {
 	if flag.Hidden {
 		t.Fatal("expected --as flag to be visible outside strict mode")
 	}
-	if got := flag.DefValue; got != "auto" {
-		t.Fatalf("default value = %q, want %q", got, "auto")
+	if got := flag.DefValue; got != "" {
+		t.Fatalf("default value = %q, want empty string", got)
 	}
 }
 
@@ -49,7 +49,7 @@ func TestAddAPIIdentityFlag_StrictModeHidesFlagAndLocksDefault(t *testing.T) {
 	}
 }
 
-func TestAddShortcutIdentityFlag_UsesAuthTypes(t *testing.T) {
+func TestAddShortcutIdentityFlag_NoDefault(t *testing.T) {
 	f, _, _, _ := TestFactory(t, &core.CliConfig{AppID: "a", AppSecret: "s"})
 	cmd := &cobra.Command{Use: "test"}
 
@@ -62,7 +62,7 @@ func TestAddShortcutIdentityFlag_UsesAuthTypes(t *testing.T) {
 	if flag.Hidden {
 		t.Fatal("expected --as flag to be visible outside strict mode")
 	}
-	if got := flag.DefValue; got != "bot" {
-		t.Fatalf("default value = %q, want %q", got, "bot")
+	if got := flag.DefValue; got != "" {
+		t.Fatalf("default value = %q, want empty string", got)
 	}
 }


### PR DESCRIPTION
## Summary

The `--as` flag help text displayed misleading default values (e.g. `(default "bot")`, `(default "auto")`) that did not reflect the actual runtime identity resolution logic. `ResolveAs()` never uses the cobra default — it resolves identity via credential config and auto-detection. This fix removes the misleading defaults and the meaningless `auto` option from help text.

## Changes

- Set cobra default value to empty string in `AddShortcutIdentityFlag` and `AddAPIIdentityFlag` (`internal/cmdutil/identity_flag.go`)
- Remove `auto` from API/service `--as` usage text and completions (`internal/cmdutil/identity_flag.go`)
- Update root help template to match (`cmd/root.go`)
- Update `DefValue` test assertions (`internal/cmdutil/identity_flag_test.go`)

## Test Plan

- [x] `make unit-test` passed
- [x] `make validate` passed (via validate.sh)
- [x] local-eval passed — skipped (lite mode, no shortcut/skill changes)
- [x] acceptance-reviewer passed (2/2 cases)
- [x] manual verification: `lark-cli im +chat-create -h`, `lark-cli docs +create -h`, `lark-cli api -h` — all show `--as` without default suffix

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `--as` flag default has been modified. Users must now explicitly specify the identity type as "user" or "bot" instead of relying on an automatic default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->