### PR TITLE
docs: clarify task member id types in references

### DIFF
--- a/skills/lark-task/references/lark-task-assign.md
+++ b/skills/lark-task/references/lark-task-assign.md
@@ -10,6 +10,9 @@ Assign or remove members (assignees) from a task.
 # Add an assignee
 lark-cli task +assign --task-id "<task_guid>" --add "ou_aaa"
 
+# Add an app assignee
+lark-cli task +assign --task-id "<task_guid>" --add "cli_xxx"
+
 # Transfer an assignee (remove old, add new)
 lark-cli task +assign --task-id "<task_guid>" --remove "ou_old" --add "ou_new"
 
@@ -22,8 +25,8 @@ lark-cli task +assign --task-id "<task_guid>" --add "ou_aaa,ou_bbb"
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `--task-id <guid>` | Yes | The task GUID to modify. For Feishu task applinks, use the `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
-| `--add <ids>` | No | Comma-separated list of user `open_id`s to add as assignees. |
-| `--remove <ids>` | No | Comma-separated list of user `open_id`s to remove from assignees. |
+| `--add <ids>` | No | Comma-separated assignee IDs. Use user `open_id`s like `ou_xxx` for people, or app IDs like `cli_xxx` for apps. |
+| `--remove <ids>` | No | Comma-separated assignee IDs. Use user `open_id`s like `ou_xxx` for people, or app IDs like `cli_xxx` for apps. |
 
 ## Workflow
 

--- a/skills/lark-task/references/lark-task-create.md
+++ b/skills/lark-task/references/lark-task-create.md
@@ -15,6 +15,11 @@ lark-cli task +create \
   --due "2026-03-25" \
   --tasklist-id "https://applink.larkoffice.com/client/todo/task_list?guid=a4b00000-000-000-000-00000000036c"
 
+# Create a task assigned to an app
+lark-cli task +create \
+  --summary "Nightly Sync" \
+  --assignee "cli_xxx"
+
 # Create a simple task
 lark-cli task +create \
   --summary "Buy milk"
@@ -29,7 +34,8 @@ lark-cli task +create --summary "Test Task" --dry-run
 |-----------|----------|-------------|
 | `--summary <text>` | Yes | The title or summary of the task |
 | `--description <text>` | No | Detailed description of the task |
-| `--assignee <id>` | No | The `open_id` of the user to assign the task to (e.g., `ou_xxx`) |
+| `--assignee <id>` | No | Assignee ID. Use user `open_id` like `ou_xxx` for people, or app ID like `cli_xxx` for apps. |
+| `--follower <id>` | No | Follower ID. Use user `open_id` like `ou_xxx` for people, or app ID like `cli_xxx` for apps. |
 | `--due <time>` | No | Due date. Supports ISO 8601, `YYYY-MM-DD`, relative time (e.g., `+2d`), or ms timestamp. `YYYY-MM-DD` and relative time will automatically set it as an all-day task. |
 | `--tasklist-id <id>` | No | The GUID of the tasklist, or a full AppLink URL (the CLI will automatically extract the `guid` parameter from the URL). |
 | `--idempotency-key <key>` | No | Client token to ensure idempotency of the request. |

--- a/skills/lark-task/references/lark-task-followers.md
+++ b/skills/lark-task/references/lark-task-followers.md
@@ -10,6 +10,9 @@ Manage task followers. Add or remove followers from an existing task.
 # Add a follower
 lark-cli task +followers --task-id "<task_guid>" --add "ou_aaa"
 
+# Add an app follower
+lark-cli task +followers --task-id "<task_guid>" --add "cli_xxx"
+
 # Remove a follower
 lark-cli task +followers --task-id "<task_guid>" --remove "ou_aaa"
 ```
@@ -19,8 +22,8 @@ lark-cli task +followers --task-id "<task_guid>" --remove "ou_aaa"
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `--task-id <guid>` | Yes | The task GUID to modify. For Feishu task applinks, use the `guid` query parameter, not the `suite_entity_num` / display task ID like `t104121`. |
-| `--add <ids>` | No | Comma-separated list of user `open_id`s to add as followers. |
-| `--remove <ids>` | No | Comma-separated list of user `open_id`s to remove from followers. |
+| `--add <ids>` | No | Comma-separated follower IDs. Use user `open_id`s like `ou_xxx` for people, or app IDs like `cli_xxx` for apps. |
+| `--remove <ids>` | No | Comma-separated follower IDs. Use user `open_id`s like `ou_xxx` for people, or app IDs like `cli_xxx` for apps. |
 
 ## Workflow
 


### PR DESCRIPTION
Change-Id: Icaf012238cd93eeb784014d807c12168faf0a202

## Summary
- clarify that task assignee/follower reference docs support both user open_id and app id
- add app-based examples for assign, create, and followers commands

## Testing
- docs only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that task assignments now support both users and applications
  * Enhanced task creation guide with examples for assigning tasks to applications
  * Expanded follower management documentation to support adding applications as followers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->