### PR TITLE
fix: clean base error detail output

### DIFF
--- a/shortcuts/base/base_errors.go
+++ b/shortcuts/base/base_errors.go
@@ -4,7 +4,6 @@
 package base
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/internal/output"
@@ -20,6 +19,9 @@ func handleBaseAPIResult(result interface{}, err error, action string) (map[stri
 	return dataMap, nil
 }
 
+// handleBaseAPIResultAny normalizes the Base v3 {code,msg,data} envelope used
+// by shortcut APIs. Success returns data as-is; API failures become the CLI's
+// structured ErrAPI, with server-provided message/hint promoted to the top level.
 func handleBaseAPIResultAny(result interface{}, err error, action string) (interface{}, error) {
 	if err != nil {
 		return nil, output.Errorf(output.ExitAPI, "api_error", "%s: %s", action, err)
@@ -37,15 +39,32 @@ func handleBaseAPIResultAny(result interface{}, err error, action string) (inter
 		msg, _ = resultMap["msg"].(string)
 	}
 
-	fullMsg := fmt.Sprintf("%s: [%d] %s", action, larkCode, msg)
 	detail := extractErrorDetail(resultMap)
-	apiErr := output.ErrAPI(larkCode, fullMsg, detail)
-	if apiErr.Detail != nil && apiErr.Detail.Hint == "" {
-		if hint := extractErrorHint(resultMap); hint != "" {
-			apiErr.Detail.Hint = hint
-		}
+	apiErr := output.ErrAPI(larkCode, msg, detail)
+	hint := extractErrorHint(resultMap)
+	if apiErr.Detail != nil && apiErr.Detail.Hint == "" && hint != "" {
+		apiErr.Detail.Hint = hint
+	}
+	if apiErr.Detail != nil {
+		apiErr.Detail.Detail = cleanEmptyBaseErrorDetail(detail)
 	}
 	return nil, apiErr
+}
+
+func cleanEmptyBaseErrorDetail(detail interface{}) interface{} {
+	detailMap, ok := detail.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	for key, value := range detailMap {
+		if value == nil {
+			delete(detailMap, key)
+		}
+	}
+	if len(detailMap) == 0 {
+		return nil
+	}
+	return detailMap
 }
 
 func extractErrorDetail(resultMap map[string]interface{}) interface{} {
@@ -77,13 +96,13 @@ func nonNilMapValue(src map[string]interface{}, key string) (interface{}, bool) 
 
 func extractErrorHint(resultMap map[string]interface{}) string {
 	if detail, ok := resultMap["error"].(map[string]interface{}); ok {
-		if hint, _ := detail["hint"].(string); strings.TrimSpace(hint) != "" {
+		if hint := consumeStringField(detail, "hint"); hint != "" {
 			return hint
 		}
 	}
 	data, _ := resultMap["data"].(map[string]interface{})
 	if detail, ok := data["error"].(map[string]interface{}); ok {
-		if hint, _ := detail["hint"].(string); strings.TrimSpace(hint) != "" {
+		if hint := consumeStringField(detail, "hint"); hint != "" {
 			return hint
 		}
 	}
@@ -93,9 +112,17 @@ func extractErrorHint(resultMap map[string]interface{}) string {
 func extractDataErrorMessage(resultMap map[string]interface{}) string {
 	data, _ := resultMap["data"].(map[string]interface{})
 	if detail, ok := data["error"].(map[string]interface{}); ok {
-		if message, _ := detail["message"].(string); strings.TrimSpace(message) != "" {
+		if message := consumeStringField(detail, "message"); message != "" {
 			return message
 		}
 	}
 	return ""
+}
+
+func consumeStringField(src map[string]interface{}, key string) string {
+	value, _ := src[key].(string)
+	if _, exists := src[key]; exists {
+		delete(src, key)
+	}
+	return strings.TrimSpace(value)
 }

--- a/shortcuts/base/base_errors_test.go
+++ b/shortcuts/base/base_errors_test.go
@@ -4,8 +4,11 @@
 package base
 
 import (
+	"errors"
 	"strings"
 	"testing"
+
+	"github.com/larksuite/cli/internal/output"
 )
 
 func TestErrorDetailHelpers(t *testing.T) {
@@ -47,11 +50,130 @@ func TestHandleBaseAPIResultErrorPaths(t *testing.T) {
 			"error": map[string]interface{}{"message": "invalid filter", "hint": "check field name"},
 		},
 	}
-	if _, err := handleBaseAPIResultAny(result, nil, "set filter"); err == nil || !strings.Contains(err.Error(), "invalid filter") || !strings.Contains(err.Error(), "190001") {
+	if _, err := handleBaseAPIResultAny(result, nil, "set filter"); err == nil || !strings.Contains(err.Error(), "invalid filter") {
 		t.Fatalf("err=%v", err)
+	} else {
+		var exitErr *output.ExitError
+		if !errors.As(err, &exitErr) || exitErr.Detail == nil || exitErr.Detail.Code != 190001 {
+			t.Fatalf("expected structured code 190001, got %v", err)
+		}
 	}
 	if _, err := handleBaseAPIResult(result, nil, "set filter"); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestHandleBaseAPIResultCleansBaseErrorDetail(t *testing.T) {
+	result := map[string]interface{}{
+		"code": 800010407,
+		"msg":  "cell value invalid",
+		"data": map[string]interface{}{
+			"error": map[string]interface{}{
+				"docs_url":       nil,
+				"hint":           "Provide a number value.",
+				"level":          "error",
+				"logid":          "20260508160000000000000000000000",
+				"message":        "The cell value does not match the expected input shape.",
+				"path":           "Amount",
+				"retry_after_ms": nil,
+				"retryable":      false,
+				"extra_context":  "future detail field",
+				"table":          map[string]interface{}{"id": "tbl_1", "name": "Orders"},
+				"type":           "invalid_request",
+				"upstream_code":  nil,
+				"value":          "abc",
+			},
+		},
+	}
+
+	_, err := handleBaseAPIResultAny(result, nil, "API call failed")
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+		t.Fatalf("expected structured exit error, got %v", err)
+	}
+
+	errDetail := exitErr.Detail
+	if errDetail.Code != 800010407 {
+		t.Fatalf("code=%d", errDetail.Code)
+	}
+	if errDetail.Hint != "Provide a number value." {
+		t.Fatalf("hint=%q", errDetail.Hint)
+	}
+	detail, _ := errDetail.Detail.(map[string]interface{})
+	if detail == nil {
+		t.Fatalf("expected cleaned detail, got %#v", errDetail.Detail)
+	}
+	if _, exists := detail["message"]; exists {
+		t.Fatalf("detail should not repeat message: %#v", detail)
+	}
+	if _, exists := detail["hint"]; exists {
+		t.Fatalf("detail should not repeat hint: %#v", detail)
+	}
+	if _, exists := detail["docs_url"]; exists {
+		t.Fatalf("detail should omit nil docs_url: %#v", detail)
+	}
+	if detail["level"] != "error" {
+		t.Fatalf("detail should preserve non-duplicate fields: %#v", detail)
+	}
+	if detail["extra_context"] != "future detail field" {
+		t.Fatalf("detail should pass through unknown non-nil fields: %#v", detail)
+	}
+	if detail["path"] != "Amount" || detail["value"] != "abc" {
+		t.Fatalf("cleaned detail mismatch: %#v", detail)
+	}
+	if detail["logid"] != "20260508160000000000000000000000" {
+		t.Fatalf("logid=%q", detail["logid"])
+	}
+	if retryable, ok := detail["retryable"].(bool); !ok || retryable {
+		t.Fatalf("retryable=%v", detail["retryable"])
+	}
+	table, _ := detail["table"].(map[string]interface{})
+	if table["id"] != "tbl_1" || table["name"] != "Orders" {
+		t.Fatalf("table=%#v", detail["table"])
+	}
+}
+
+func TestHandleBaseAPIResultAlwaysRemovesMessageAndHintFromDetail(t *testing.T) {
+	result := map[string]interface{}{
+		"code": output.LarkErrTokenNoPermission,
+		"msg":  "permission denied",
+		"data": map[string]interface{}{
+			"error": map[string]interface{}{
+				"hint":    "Grant base:record:read to the app.",
+				"message": "Missing required scope base:record:read.",
+			},
+		},
+	}
+
+	_, err := handleBaseAPIResultAny(result, nil, "API call failed")
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+		t.Fatalf("expected structured exit error, got %v", err)
+	}
+	if exitErr.Detail.Message != "Permission denied [99991676]" {
+		t.Fatalf("message=%q", exitErr.Detail.Message)
+	}
+	if exitErr.Detail.Detail != nil {
+		t.Fatalf("detail should be empty after removing message and hint: %#v", exitErr.Detail.Detail)
+	}
+}
+
+func TestAttachBaseResponseLogIDFromHeader(t *testing.T) {
+	result := map[string]interface{}{
+		"code": 91402,
+		"msg":  "NOTEXIST",
+		"data": map[string]interface{}{},
+	}
+	attachBaseErrorLogID(result, "20260508170000000000000000000000")
+
+	_, err := handleBaseAPIResultAny(result, nil, "API call failed")
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+		t.Fatalf("expected structured exit error, got %v", err)
+	}
+	detail, _ := exitErr.Detail.Detail.(map[string]interface{})
+	if detail["logid"] != "20260508170000000000000000000000" {
+		t.Fatalf("logid=%q", detail["logid"])
 	}
 }
 

--- a/shortcuts/base/helpers.go
+++ b/shortcuts/base/helpers.go
@@ -412,6 +412,11 @@ func baseV3Raw(runtime *common.RuntimeContext, method, path string, params map[s
 	if err != nil {
 		return nil, err
 	}
+	result, parseErr := decodeBaseV3Response(resp.RawBody)
+	if parseErr == nil && baseV3ResultCode(result) != 0 {
+		attachBaseErrorLogID(result, baseResponseLogID(resp))
+		return result, nil
+	}
 	if resp.StatusCode >= http.StatusBadRequest {
 		body := strings.TrimSpace(string(resp.RawBody))
 		if body == "" {
@@ -419,13 +424,60 @@ func baseV3Raw(runtime *common.RuntimeContext, method, path string, params map[s
 		}
 		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
 	}
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	return result, nil
+}
+
+func decodeBaseV3Response(body []byte) (map[string]interface{}, error) {
 	var result map[string]interface{}
-	dec := json.NewDecoder(bytes.NewReader(resp.RawBody))
+	dec := json.NewDecoder(bytes.NewReader(body))
 	dec.UseNumber()
 	if err := dec.Decode(&result); err != nil {
 		return nil, fmt.Errorf("response parse error: %w", err)
 	}
 	return result, nil
+}
+
+func baseV3ResultCode(result map[string]interface{}) int {
+	if result == nil {
+		return 0
+	}
+	return toInt(result["code"])
+}
+
+func attachBaseErrorLogID(result map[string]interface{}, logID string) {
+	if result == nil || strings.TrimSpace(logID) == "" {
+		return
+	}
+	logID = strings.TrimSpace(logID)
+	if detail, ok := result["error"].(map[string]interface{}); ok {
+		if _, exists := detail["logid"]; !exists {
+			detail["logid"] = logID
+		}
+		return
+	}
+	data, _ := result["data"].(map[string]interface{})
+	if data == nil {
+		data = map[string]interface{}{}
+		result["data"] = data
+	}
+	detail, _ := data["error"].(map[string]interface{})
+	if detail == nil {
+		detail = map[string]interface{}{}
+		data["error"] = detail
+	}
+	if _, exists := detail["logid"]; !exists {
+		detail["logid"] = logID
+	}
+}
+
+func baseResponseLogID(resp *larkcore.ApiResp) string {
+	if resp == nil {
+		return ""
+	}
+	return strings.TrimSpace(resp.Header.Get("x-tt-logid"))
 }
 
 func baseV3Call(runtime *common.RuntimeContext, method, path string, params map[string]interface{}, data interface{}) (map[string]interface{}, error) {


### PR DESCRIPTION
## Summary
Clean up `lark-cli base` structured API errors so agents can read the actionable message, hint, and diagnostics without duplicated envelope fields.

## Changes
- Promote Base structured `data.error.message` / `hint` to top-level CLI error fields while removing them from `detail`.
- Drop null fields from Base error `detail` and add response-header `x-tt-logid` as `detail.logid` for Base v3 business errors.
- Keep Base transport errors contextual while simplifying Base business error messages to the service-provided message.

## Test Plan
- [x] Unit tests pass: `go test ./shortcuts/base ./internal/output`
- [x] Manual local verification confirms the `lark xxx` command works as expected: `make build`; `./lark-cli base +record-upsert ...` cell-format error; `./lark-cli base +table-list --base-token app_invalid_token`; dashboard/workflow/role/advperm invalid-token checks

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Base API error response normalization with structured error details.
  * Error details now properly cleaned to remove unnecessary entries.
  * Error tracking information now properly captured from API responses.

* **Tests**
  * Comprehensive test coverage for error detail handling and cleanup.
  * Tests added for error parsing and tracking information attachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->