### PR TITLE
fix: Fix installation errors when PowerShell is disabled by Group Pol…

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -146,12 +146,17 @@ function extractZipWindows(archivePath, destDir) {
         "$ErrorActionPreference='Stop';" +
         "Expand-Archive -LiteralPath $env:LARK_CLI_ARCHIVE -DestinationPath $env:LARK_CLI_DEST -Force";
       execFileSync("powershell.exe", [...psOpts, cmdlet], { stdio: psStdio, env: psEnv });
-    } catch (fallbackErr) {
-      throw new Error(
-        `Failed to extract ${archivePath}. ` +
-        `.NET ZipFile attempt: ${primaryErr.message}. ` +
-        `Expand-Archive fallback: ${fallbackErr.message}`
-      );
+    } catch (secondErr) {
+      try {
+        execFileSync("tar", ["-xf", archivePath, "-C", destDir], { stdio: psStdio });
+      } catch (fallbackErr) {
+        throw new Error(
+          `Failed to extract ${archivePath}. ` +
+          `.NET ZipFile attempt: ${primaryErr.message}. ` +
+          `Expand-Archive fallback: ${secondErr.message}. ` +
+          `tar fallback: ${fallbackErr.message}`
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
…icy.

## Summary
Fix installation errors when PowerShell is disabled by Group Policy.

## Changes
- Add extraction using the tar command as a fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ZIP extraction reliability on Windows by implementing multiple fallback extraction methods, ensuring the installation process succeeds even if the primary method encounters issues.
  * Improved error messaging to provide more detailed information when extraction fails, helping diagnose installation problems more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->