### PR TITLE
fix: silence misleading "skills not installed" startup notice

### DIFF
--- a/cmd/root_integration_test.go
+++ b/cmd/root_integration_test.go
@@ -504,10 +504,12 @@ func TestIntegration_Shortcut_BusinessError_OutputsEnvelope(t *testing.T) {
 	})
 }
 
-// TestSetupNotices_ColdStart verifies that when no skills stamp exists,
-// the composed PendingNotice provider includes a "skills" key with an
-// empty Current and the cold-start message.
-func TestSetupNotices_ColdStart(t *testing.T) {
+// TestSetupNotices_ColdStart_NoNotice verifies that a missing stamp
+// produces no skills key in the composed notice. Users who installed
+// skills via `npx skills add` (no stamp) must not see the misleading
+// "not installed" notice — only `lark-cli update` users opt into the
+// drift tracker.
+func TestSetupNotices_ColdStart_NoNotice(t *testing.T) {
 	clearNoticeEnv(t)
 	dir := t.TempDir()
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", dir)
@@ -530,17 +532,10 @@ func TestSetupNotices_ColdStart(t *testing.T) {
 
 	notice := output.GetNotice()
 	if notice == nil {
-		t.Fatal("GetNotice() = nil, want non-nil for cold start")
+		return // expected — no pending notices at all
 	}
-	skills, ok := notice["skills"].(map[string]interface{})
-	if !ok {
-		t.Fatalf("notice.skills missing, got %+v", notice)
-	}
-	if skills["current"] != "" || skills["target"] != "1.0.21" {
-		t.Errorf("notice.skills = %+v, want {current:\"\", target:\"1.0.21\"}", skills)
-	}
-	if msg, _ := skills["message"].(string); msg != "lark-cli skills not installed, run: lark-cli update" {
-		t.Errorf("notice.skills.message = %q, want cold-start message", msg)
+	if _, ok := notice["skills"]; ok {
+		t.Errorf("notice.skills present in cold-start state, want absent: %+v", notice)
 	}
 }
 

--- a/internal/skillscheck/check.go
+++ b/internal/skillscheck/check.go
@@ -4,9 +4,9 @@
 package skillscheck
 
 // Init runs the synchronous skills version check. Stores a StaleNotice
-// when the local stamp does not match currentVersion. Safe to call
-// from cmd/root.go before rootCmd.Execute(); zero network, zero
-// subprocess — only a local stamp file read.
+// when the local stamp records a version that does not match
+// currentVersion. Safe to call from cmd/root.go before rootCmd.Execute();
+// zero network, zero subprocess — only a local stamp file read.
 //
 // Skip rules: see shouldSkip (CI envs, DEV builds, non-release semver,
 // LARKSUITE_CLI_NO_SKILLS_NOTIFIER opt-out).
@@ -15,10 +15,12 @@ package skillscheck
 //   - shouldSkip rule met
 //   - ReadStamp returns an I/O error other than ENOENT
 //   - Stamp matches currentVersion (in-sync)
+//   - Stamp is missing (cold start) — only users who ran `lark-cli update`
+//     opt into drift tracking; npx-only installs are intentionally silent.
 func Init(currentVersion string) {
 	// Clear any stale notice from a prior call so early returns below
-	// (skip rules / read errors / in-sync) leave pending == nil instead
-	// of preserving a stale value from a previous Init invocation.
+	// (skip rules / read errors / cold start / in-sync) leave pending == nil
+	// instead of preserving a stale value from a previous Init invocation.
 	SetPending(nil)
 	if shouldSkip(currentVersion) {
 		return
@@ -28,11 +30,19 @@ func Init(currentVersion string) {
 		// Fail closed — don't nag for a transient FS problem.
 		return
 	}
+	if stamp == "" {
+		// Cold start: the stamp is written exclusively by `lark-cli update`
+		// (runSkillsAndStamp). Users who installed skills via
+		// `npx skills add larksuite/cli -g` have no stamp yet — they must
+		// not be nagged with "skills not installed", since the on-disk
+		// skills directory may already be fully populated.
+		return
+	}
 	if stamp == currentVersion {
 		return
 	}
 	SetPending(&StaleNotice{
-		Current: stamp, // "" when never synced
+		Current: stamp, // guaranteed non-empty under the new contract
 		Target:  currentVersion,
 	})
 }

--- a/internal/skillscheck/check_test.go
+++ b/internal/skillscheck/check_test.go
@@ -29,17 +29,13 @@ func TestInit_InSync_NoNotice(t *testing.T) {
 	}
 }
 
-func TestInit_ColdStart_NoticeWithEmptyCurrent(t *testing.T) {
+func TestInit_ColdStart_NoNotice(t *testing.T) {
 	clearSkillsSkipEnv(t)
 	resetPending(t)
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	Init("1.0.21")
-	got := GetPending()
-	if got == nil {
-		t.Fatal("GetPending() = nil, want non-nil for cold start")
-	}
-	if got.Current != "" || got.Target != "1.0.21" {
-		t.Errorf("notice = %+v, want {Current:\"\", Target:\"1.0.21\"}", got)
+	if got := GetPending(); got != nil {
+		t.Errorf("GetPending() = %+v, want nil (cold start is silent)", got)
 	}
 }
 

--- a/internal/skillscheck/notice.go
+++ b/internal/skillscheck/notice.go
@@ -15,20 +15,20 @@ import (
 
 // StaleNotice signals that the locally synced skills version does not
 // match the running binary. Current is the last successfully synced
-// version (or "" when never synced); Target is the running binary
-// version. Mirrors internal/update.UpdateInfo's pending-notice pattern.
+// version (always non-empty — Init no longer emits a notice on cold
+// start). Target is the running binary version. Mirrors
+// internal/update.UpdateInfo's pending-notice pattern.
 type StaleNotice struct {
 	Current string `json:"current"`
 	Target  string `json:"target"`
 }
 
 // Message returns a single-line, AI-agent-parseable description of the
-// gap plus the canonical fix command. Mirrors internal/update.UpdateInfo.Message
-// in style ("..., run: lark-cli update" suffix).
+// drift plus the canonical fix command. Mirrors internal/update.UpdateInfo.Message
+// in style ("..., run: lark-cli update" suffix). Current is guaranteed
+// non-empty because Init only emits a StaleNotice for the drift case
+// (stamp present and != binary version).
 func (s *StaleNotice) Message() string {
-	if s.Current == "" {
-		return "lark-cli skills not installed, run: lark-cli update"
-	}
 	return fmt.Sprintf(
 		"lark-cli skills %s out of sync with binary %s, run: lark-cli update",
 		s.Current, s.Target,

--- a/internal/skillscheck/notice_test.go
+++ b/internal/skillscheck/notice_test.go
@@ -15,11 +15,6 @@ func TestStaleNotice_Message(t *testing.T) {
 		want string
 	}{
 		{
-			"cold_start",
-			StaleNotice{Current: "", Target: "1.0.21"},
-			"lark-cli skills not installed, run: lark-cli update",
-		},
-		{
 			"drift",
 			StaleNotice{Current: "1.0.20", Target: "1.0.21"},
 			"lark-cli skills 1.0.20 out of sync with binary 1.0.21, run: lark-cli update",


### PR DESCRIPTION
## Summary

Remove the cold-start `_notice.skills` ("skills not installed, run: lark-cli update") that fires whenever `~/.lark-cli/skills.stamp` is missing. The stamp is written exclusively by `lark-cli update`, so users who installed skills via `npx skills add larksuite/cli -g` (the documented path) saw the misleading notice on every CLI run despite a fully populated `~/.agents/skills/`.

The version-drift notice (stamp version != binary version) is preserved unchanged for users who opted into tracking by running `lark-cli update`.

## Changes

- `internal/skillscheck/check.go` - `Init` returns silently when the stamp file is missing; documents cold-start as an explicit failure mode.
- `internal/skillscheck/notice.go` - `StaleNotice.Message` drops the dead cold-start branch; `Current` is now guaranteed non-empty.
- `internal/skillscheck/check_test.go` - replace `TestInit_ColdStart_NoticeWithEmptyCurrent` with `TestInit_ColdStart_NoNotice` asserting silence.
- `internal/skillscheck/notice_test.go` - drop the `cold_start` row from `TestStaleNotice_Message`.
- `cmd/root_integration_test.go` - rename `TestSetupNotices_ColdStart` to `TestSetupNotices_ColdStart_NoNotice` and assert the `skills` key is absent.
- No new files, no env vars, no schema changes. JSON output for `_notice.skills` keeps the same `{current, target, message}` shape - only the cold-start message string is no longer possible.

## Test Plan

- [x] `make unit-test` passed
- [x] validate passed (build / vet / unit / integration / convention / security all green)
- [ ] local-eval passed: skipped - sandbox `auth-login` pre-flight failed on the test account's scope grant for 7 unrelated scopes (`approval` / `attendance` / `im:message.send_as_user` / `mail:user_mailbox.message:send`), so the sandbox exited before invoking E2E. Cross-validated via the Phase 3 dev-e2e-testcase-writer agent: 5/5 E2E cases (`tests_e2e/skillscheck/...`) pass against the patched code.
- [x] acceptance-reviewer passed (9/9 cases on a real lark-cli binary, including the npx-only sim with 128 lark-* skills on disk + no stamp)
- [x] manual verification: cold-start tmpdir -> no notice; `echo 1.0.27 > skills.stamp` (in-sync) -> no notice; `echo 1.0.20 > skills.stamp` + binary 1.0.27 -> expected "out of sync" notice; `LARKSUITE_CLI_NO_SKILLS_NOTIFIER=1` -> silent in every state.

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cold-start runs no longer emit a spurious skills-status notice, improving first-run behavior.

* **Behavior**
  * Notices about installed skills always include a non-empty current version when present; cold-starts are treated as "no notice."

* **Tests**
  * Tests updated to expect no notice on cold-start and removed prior empty-current test cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/801)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->