### PR TITLE
docs(im): name --query/--member-ids in +chat-search shortcut row

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -58,7 +58,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli im +<verb> [flags]`）。
 |----------|------|
 | [`+chat-create`](references/lark-im-chat-create.md) | Create a group chat; user/bot; creates private/public chats, invites users/bots, optionally sets bot manager |
 | [`+chat-messages-list`](references/lark-im-chat-messages-list.md) | List messages in a chat or P2P conversation; user/bot; accepts --chat-id or --user-id, resolves P2P chat_id, supports time range/sort/pagination |
-| [`+chat-search`](references/lark-im-chat-search.md) | Search visible group chats by keyword and/or member open_ids (e.g. look up chat_id by group name); user/bot; supports member/type filters, sorting, and pagination |
+| [`+chat-search`](references/lark-im-chat-search.md) | Search visible group chats by `--query` keyword and/or `--member-ids`; user/bot; e.g. look up chat_id by group name; supports type filters, sorting, and pagination |
 | [`+chat-update`](references/lark-im-chat-update.md) | Update group chat name or description; user/bot; updates a chat's name or description |
 | [`+messages-mget`](references/lark-im-messages-mget.md) | Batch get messages by IDs; user/bot; fetches up to 50 om_ message IDs, formats sender names, expands thread replies |
 | [`+messages-reply`](references/lark-im-messages-reply.md) | Reply to a message (supports thread replies); user/bot; supports text/markdown/post/media replies, reply-in-thread, idempotency key |


### PR DESCRIPTION
## Summary
- Replace the natural-language phrase "by keyword and/or member open_ids" with the actual flag names `--query` / `--member-ids` in the `+chat-search` row of `skills/lark-im/SKILL.md`.
- LLM agents reading only the shortcut table were inferring a non-existent `--keyword` flag from the prose. Naming the real flags inline matches the style already used by `+chat-messages-list` and removes the wrong-guess path.

## Test plan
- [x] `git diff main` shows the intended single-line change in `skills/lark-im/SKILL.md`.
- [ ] In a fresh Claude Code session with the updated skill installed, asking "搜群 X" causes the agent to call `lark-cli im +chat-search --query "X"` directly, without first guessing `--keyword`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated chat search shortcut documentation to improve clarity regarding member filtering parameters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/812)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->