### PR TITLE
test: drop stale yes flags from e2e

### DIFF
--- a/tests/cli_e2e/calendar/calendar_create_event_test.go
+++ b/tests/cli_e2e/calendar/calendar_create_event_test.go
@@ -100,7 +100,6 @@ func TestCalendar_CreateEvent(t *testing.T) {
 				"calendar_id": calendarID,
 				"event_id":    eventID,
 			},
-			Yes: true,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)

--- a/tests/cli_e2e/sheets/sheets_filter_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_filter_workflow_test.go
@@ -94,7 +94,6 @@ func TestSheets_FilterWorkflow(t *testing.T) {
 				"sheet_id":          sheetID,
 			},
 			Data: filterData,
-			Yes:  true,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)


### PR DESCRIPTION
## Summary
- remove stale `Yes: true` from `calendar events delete` e2e after the command stopped registering `--yes`
- remove stale `Yes: true` from `sheets spreadsheet.sheet.filters create` e2e after the command stopped registering `--yes`

## Verification
- `go test ./tests/cli_e2e/calendar ./tests/cli_e2e/sheets -run '^$'`

Note: local full pre-commit Go test is blocked by unrelated local-only failures in `internal/auth/token_store_test.go` and an `internal/binding` exec-provider timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated calendar and sheets E2E test workflows to adjust confirmation handling for event deletion and filter creation operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/815)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->