### PR TITLE
feat(doc): add v2 XML content guards for bare ampersands and deprecated tags

### DIFF
--- a/shortcuts/doc/docs_create_v2.go
+++ b/shortcuts/doc/docs_create_v2.go
@@ -28,7 +28,7 @@ func validateCreateV2(_ context.Context, runtime *common.RuntimeContext) error {
 	if runtime.Str("parent-token") != "" && runtime.Str("parent-position") != "" {
 		return common.FlagErrorf("--parent-token and --parent-position are mutually exclusive")
 	}
-	if runtime.Str("doc-format") != "markdown" && runtime.Str("content") != "" {
+	if runtime.Str("doc-format") != "markdown" {
 		if msg := CheckV2XMLBareAmpersand(runtime.Str("content")); msg != "" {
 			return common.FlagErrorf("%s", msg)
 		}

--- a/shortcuts/doc/docs_create_v2.go
+++ b/shortcuts/doc/docs_create_v2.go
@@ -5,6 +5,7 @@ package doc
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/shortcuts/common"
@@ -27,6 +28,11 @@ func validateCreateV2(_ context.Context, runtime *common.RuntimeContext) error {
 	if runtime.Str("parent-token") != "" && runtime.Str("parent-position") != "" {
 		return common.FlagErrorf("--parent-token and --parent-position are mutually exclusive")
 	}
+	if runtime.Str("doc-format") != "markdown" {
+		if msg := CheckV2XMLBareAmpersand(runtime.Str("content")); msg != "" {
+			return common.FlagErrorf("%s", msg)
+		}
+	}
 	return nil
 }
 
@@ -44,6 +50,12 @@ func dryRunCreateV2(_ context.Context, runtime *common.RuntimeContext) *common.D
 
 func executeCreateV2(_ context.Context, runtime *common.RuntimeContext) error {
 	body := buildCreateBody(runtime)
+
+	if runtime.Str("doc-format") != "markdown" {
+		for _, w := range CheckV2XMLWarnings(runtime.Str("content")) {
+			fmt.Fprintf(runtime.IO().ErrOut, "warning: %s\n", w)
+		}
+	}
 
 	data, err := doDocAPI(runtime, "POST", "/open-apis/docs_ai/v1/documents", body)
 	if err != nil {

--- a/shortcuts/doc/docs_create_v2.go
+++ b/shortcuts/doc/docs_create_v2.go
@@ -28,7 +28,7 @@ func validateCreateV2(_ context.Context, runtime *common.RuntimeContext) error {
 	if runtime.Str("parent-token") != "" && runtime.Str("parent-position") != "" {
 		return common.FlagErrorf("--parent-token and --parent-position are mutually exclusive")
 	}
-	if runtime.Str("doc-format") != "markdown" {
+	if runtime.Str("doc-format") != "markdown" && runtime.Str("content") != "" {
 		if msg := CheckV2XMLBareAmpersand(runtime.Str("content")); msg != "" {
 			return common.FlagErrorf("%s", msg)
 		}

--- a/shortcuts/doc/docs_update_check.go
+++ b/shortcuts/doc/docs_update_check.go
@@ -317,13 +317,20 @@ func CheckV2XMLBareAmpersand(content string) string {
 // hypothetical attributes or element names that start with "quote-container".
 var quoteContainerTagRe = regexp.MustCompile(`<quote-container(?:\s|>|/)`)
 
-// columnIntWidthRe matches a <column … width="N" …> attribute where N is a
-// plain integer (not a float). The pattern requires:
-//   - whitespace before "width" to exclude attributes like data-width
-//   - the value to be enclosed in quotes with digits immediately before the
-//     closing quote, so width="0.5" does NOT match (the dot prevents \d+
-//     from consuming the full value up to the quote).
-var columnIntWidthRe = regexp.MustCompile(`<column\b[^>]*\swidth\s*=\s*["']\d+["']`)
+// columnWidthAttrRe matches a <column … width="…" …> attribute, capturing the
+// opening quote, the numeric value, and the closing quote. Go's RE2 does not
+// support backreferences, so we verify opening == closing quote in Go code.
+var columnWidthAttrRe = regexp.MustCompile(`<column\b[^>]*\swidth\s*=\s*(['"])([0-9.]+)(['"])`)
+
+// isIntWidth reports whether s is a plain integer with no decimal point.
+func isIntWidth(s string) bool {
+	for _, c := range s {
+		if c == '.' {
+			return false
+		}
+	}
+	return true
+}
 
 // CheckV2XMLWarnings returns a list of non-fatal warnings for v2 XML content.
 // These describe constructs that are silently dropped or ignored by the v2 API
@@ -347,10 +354,13 @@ func CheckV2XMLWarnings(content string) []string {
 			"<quote-container> is not supported in v2 XML and will be silently dropped; "+
 				"use <blockquote> instead.")
 	}
-	if columnIntWidthRe.MatchString(content) {
-		warnings = append(warnings,
-			"<column width=\"N\"> with an integer value has no effect in v2 XML; "+
-				"use width-ratio=\"0.5\" (float 0–1) to set column width.")
+	for _, m := range columnWidthAttrRe.FindAllStringSubmatch(content, -1) {
+		if m[1] == m[3] && isIntWidth(m[2]) {
+			warnings = append(warnings,
+				`<column width="N"> with an integer value has no effect in v2 XML; `+
+					`use width-ratio="0.5" (float 0–1) to set column width.`)
+			break
+		}
 	}
 	return warnings
 }

--- a/shortcuts/doc/docs_update_check.go
+++ b/shortcuts/doc/docs_update_check.go
@@ -310,10 +310,19 @@ func CheckV2XMLBareAmpersand(content string) string {
 		"Escape it as &amp; (and < as &lt;, > as &gt; where needed)."
 }
 
+// quoteContainerTagRe matches the opening of a <quote-container> element
+// (tag name followed by whitespace, >, or />) to avoid false positives on
+// hypothetical attributes or element names that start with "quote-container".
+var quoteContainerTagRe = regexp.MustCompile(`<quote-container(?:\s|>|/)`)
+
 // columnIntWidthRe matches a <column … width="N" …> attribute where N is a
-// plain integer. In v2 XML the valid attribute is width-ratio (a float 0–1),
-// not width. An integer width silently has no effect on column sizing.
-var columnIntWidthRe = regexp.MustCompile(`<column\b[^>]*\bwidth="(\d+)"`)
+// plain integer. The pattern requires whitespace before "width" to avoid
+// matching unrelated attributes such as data-width, and accepts optional
+// whitespace around "=" and either single or double quotes, so forms like
+// width='50' or width = "50" are also detected. Go's RE2 engine does not
+// support backreferences, so mismatched quote pairs (e.g. width="50') are
+// also matched — that is acceptable for a non-blocking warning.
+var columnIntWidthRe = regexp.MustCompile(`<column\b[^>]*\swidth\s*=\s*['"]?\d+['"]?`)
 
 // CheckV2XMLWarnings returns a list of non-fatal warnings for v2 XML content.
 // These describe constructs that are silently dropped or ignored by the v2 API
@@ -332,7 +341,7 @@ func CheckV2XMLWarnings(content string) []string {
 		return nil
 	}
 	var warnings []string
-	if strings.Contains(content, "<quote-container") {
+	if quoteContainerTagRe.MatchString(content) {
 		warnings = append(warnings,
 			"<quote-container> is not supported in v2 XML and will be silently dropped; "+
 				"use <blockquote> instead.")

--- a/shortcuts/doc/docs_update_check.go
+++ b/shortcuts/doc/docs_update_check.go
@@ -322,8 +322,11 @@ var quoteContainerTagRe = regexp.MustCompile(`<quote-container(?:\s|>|/)`)
 // support backreferences, so we verify opening == closing quote in Go code.
 var columnWidthAttrRe = regexp.MustCompile(`<column\b[^>]*\swidth\s*=\s*(['"])([0-9.]+)(['"])`)
 
-// isIntWidth reports whether s is a plain integer with no decimal point.
+// isIntWidth reports whether s is a non-empty string of digits with no decimal point.
 func isIntWidth(s string) bool {
+	if s == "" {
+		return false
+	}
 	for _, c := range s {
 		if c == '.' {
 			return false

--- a/shortcuts/doc/docs_update_check.go
+++ b/shortcuts/doc/docs_update_check.go
@@ -279,3 +279,68 @@ func leadingRun(s string, c byte) string {
 	}
 	return s[:i]
 }
+
+// ── v2 XML content guards ──────────────────────────────────────────────────
+
+// xmlEntityRe matches a valid XML entity reference: &amp; &lt; &gt; &apos;
+// &quot; &#N; or &#xH;. Used to skip over valid references when scanning for
+// bare ampersands.
+var xmlEntityRe = regexp.MustCompile(`&(amp|lt|gt|apos|quot|#\d+|#x[0-9a-fA-F]+);`)
+
+// CheckV2XMLBareAmpersand returns a non-empty error message when content
+// contains a bare & that would cause the v2 XML parser to reject the request.
+// Only runs when --doc-format xml (the default). Callers in Validate should
+// return this as a hard error.
+//
+// Go's regexp package does not support lookahead, so we detect bare ampersands
+// by replacing all valid entity references with a placeholder and then
+// checking whether any & remains.
+func CheckV2XMLBareAmpersand(content string) string {
+	if content == "" || !strings.Contains(content, "&") {
+		return ""
+	}
+	// Replace every valid entity with its same-length placeholder so positional
+	// byte offsets are preserved (not required here, but avoids false positives).
+	stripped := xmlEntityRe.ReplaceAllString(content, "ENTITY")
+	if !strings.Contains(stripped, "&") {
+		return ""
+	}
+	return "content contains a bare & character that is not a valid XML entity reference; " +
+		"the v2 XML parser will reject the request. " +
+		"Escape it as &amp; (and < as &lt;, > as &gt; where needed)."
+}
+
+// columnIntWidthRe matches a <column … width="N" …> attribute where N is a
+// plain integer. In v2 XML the valid attribute is width-ratio (a float 0–1),
+// not width. An integer width silently has no effect on column sizing.
+var columnIntWidthRe = regexp.MustCompile(`<column\b[^>]*\bwidth="(\d+)"`)
+
+// CheckV2XMLWarnings returns a list of non-fatal warnings for v2 XML content.
+// These describe constructs that are silently dropped or ignored by the v2 API
+// but do not cause the request to fail. Callers should print these to stderr
+// before executing the API call.
+//
+// Warnings emitted:
+//
+//  1. <quote-container> is not recognised by the v2 XML parser; the block is
+//     silently dropped. Use <blockquote> instead.
+//
+//  2. <column width="N"> with an integer value has no effect in v2. The
+//     correct attribute is width-ratio="0.N" (e.g. width-ratio="0.5").
+func CheckV2XMLWarnings(content string) []string {
+	if content == "" {
+		return nil
+	}
+	var warnings []string
+	if strings.Contains(content, "<quote-container") {
+		warnings = append(warnings,
+			"<quote-container> is not supported in v2 XML and will be silently dropped; "+
+				"use <blockquote> instead.")
+	}
+	if columnIntWidthRe.MatchString(content) {
+		warnings = append(warnings,
+			"<column width=\"N\"> with an integer value has no effect in v2 XML; "+
+				"use width-ratio=\"0.5\" (float 0–1) to set column width.")
+	}
+	return warnings
+}

--- a/shortcuts/doc/docs_update_check.go
+++ b/shortcuts/doc/docs_update_check.go
@@ -299,8 +299,10 @@ func CheckV2XMLBareAmpersand(content string) string {
 	if content == "" || !strings.Contains(content, "&") {
 		return ""
 	}
-	// Replace every valid entity with its same-length placeholder so positional
-	// byte offsets are preserved (not required here, but avoids false positives).
+	// Replace every valid entity reference with a fixed placeholder so that
+	// the subsequent Contains check only fires on truly bare ampersands.
+	// ("ENTITY" is not the same length as each entity; byte offsets are not
+	// preserved, but that is fine — we only need a yes/no bare-& answer.)
 	stripped := xmlEntityRe.ReplaceAllString(content, "ENTITY")
 	if !strings.Contains(stripped, "&") {
 		return ""
@@ -316,13 +318,12 @@ func CheckV2XMLBareAmpersand(content string) string {
 var quoteContainerTagRe = regexp.MustCompile(`<quote-container(?:\s|>|/)`)
 
 // columnIntWidthRe matches a <column … width="N" …> attribute where N is a
-// plain integer. The pattern requires whitespace before "width" to avoid
-// matching unrelated attributes such as data-width, and accepts optional
-// whitespace around "=" and either single or double quotes, so forms like
-// width='50' or width = "50" are also detected. Go's RE2 engine does not
-// support backreferences, so mismatched quote pairs (e.g. width="50') are
-// also matched — that is acceptable for a non-blocking warning.
-var columnIntWidthRe = regexp.MustCompile(`<column\b[^>]*\swidth\s*=\s*['"]?\d+['"]?`)
+// plain integer (not a float). The pattern requires:
+//   - whitespace before "width" to exclude attributes like data-width
+//   - the value to be enclosed in quotes with digits immediately before the
+//     closing quote, so width="0.5" does NOT match (the dot prevents \d+
+//     from consuming the full value up to the quote).
+var columnIntWidthRe = regexp.MustCompile(`<column\b[^>]*\swidth\s*=\s*["']\d+["']`)
 
 // CheckV2XMLWarnings returns a list of non-fatal warnings for v2 XML content.
 // These describe constructs that are silently dropped or ignored by the v2 API

--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -374,6 +374,28 @@ func TestDocsUpdateWarningsEmpty(t *testing.T) {
 	}
 }
 
+func TestIsIntWidth(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"50", true},
+		{"0", true},
+		{"0.5", false},
+		{"1.0", false},
+		{"", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			if got := isIntWidth(tt.input); got != tt.want {
+				t.Errorf("isIntWidth(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckV2XMLBareAmpersand(t *testing.T) {
 	t.Parallel()
 
@@ -469,6 +491,12 @@ func TestCheckV2XMLWarnings(t *testing.T) {
 		{
 			name:    "column float width value is not flagged",
 			content: `<grid><column width="0.5"><p>A</p></column></grid>`,
+			wantLen: 0,
+		},
+		// mixed quotes (opening " and closing ') should NOT match — backreference check
+		{
+			name:    "column mixed-quote width is not flagged",
+			content: `<column width="50'/>`,
 			wantLen: 0,
 		},
 	}

--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -384,7 +384,7 @@ func TestIsIntWidth(t *testing.T) {
 		{"0", true},
 		{"0.5", false},
 		{"1.0", false},
-		{"", true},
+		{"", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -439,6 +439,30 @@ func TestCheckV2XMLWarnings(t *testing.T) {
 			content: `<quote-container/><grid><column width="30"/></grid>`,
 			wantLen: 2,
 		},
+		// false-positive guards: names that start with "quote-container" but aren't the tag
+		{
+			name:    "quote-containerized attribute prefix is not flagged",
+			content: `<block quote-containerized="true"/>`,
+			wantLen: 0,
+		},
+		// false-positive guard: data-width should not trigger column warning
+		{
+			name:    "data-width attribute is not flagged",
+			content: `<column data-width="50"/>`,
+			wantLen: 0,
+		},
+		// single-quoted width should be caught
+		{
+			name:    "column single-quoted integer width triggers warning",
+			content: `<grid><column width='30'/></grid>`,
+			wantLen: 1,
+		},
+		// width with spaces around = should be caught
+		{
+			name:    "column width with spaces around equals triggers warning",
+			content: `<grid><column width = "40"/></grid>`,
+			wantLen: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -373,3 +373,101 @@ func TestDocsUpdateWarningsEmpty(t *testing.T) {
 		t.Fatalf("expected no warnings, got: %v", warnings)
 	}
 }
+
+func TestCheckV2XMLBareAmpersand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{name: "empty is fine", content: "", wantErr: false},
+		{name: "no ampersand", content: "<text>hello world</text>", wantErr: false},
+		{name: "amp entity is fine", content: "<text>a &amp; b</text>", wantErr: false},
+		{name: "lt entity is fine", content: "&lt;tag&gt;", wantErr: false},
+		{name: "gt entity is fine", content: "a &gt; b", wantErr: false},
+		{name: "apos entity is fine", content: "&apos;", wantErr: false},
+		{name: "quot entity is fine", content: "&quot;", wantErr: false},
+		{name: "decimal numeric ref is fine", content: "&#65;", wantErr: false},
+		{name: "hex numeric ref is fine", content: "&#x41;", wantErr: false},
+		{name: "bare ampersand flagged", content: "a & b", wantErr: true},
+		{name: "bare ampersand in tag flagged", content: `<text color="blue">R&D</text>`, wantErr: true},
+		{name: "unknown entity flagged", content: "&nbsp;", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := CheckV2XMLBareAmpersand(tt.content)
+			if (got != "") != tt.wantErr {
+				t.Fatalf("CheckV2XMLBareAmpersand(%q) = %q, wantErr=%v", tt.content, got, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckV2XMLWarnings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		content      string
+		wantContains []string
+		wantLen      int
+	}{
+		{name: "empty returns nil", content: "", wantLen: 0},
+		{name: "clean XML no warnings", content: "<blockquote><p>text</p></blockquote>", wantLen: 0},
+		{
+			name:         "quote-container triggers warning",
+			content:      `<quote-container><p>text</p></quote-container>`,
+			wantContains: []string{"quote-container", "blockquote"},
+			wantLen:      1,
+		},
+		{
+			name:         "column integer width triggers warning",
+			content:      `<grid><column width="50"><p>A</p></column></grid>`,
+			wantContains: []string{"width-ratio"},
+			wantLen:      1,
+		},
+		{
+			name:    "column float width-ratio is fine",
+			content: `<grid><column width-ratio="0.5"><p>A</p></column></grid>`,
+			wantLen: 0,
+		},
+		{
+			name:    "both issues produce two warnings",
+			content: `<quote-container/><grid><column width="30"/></grid>`,
+			wantLen: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := CheckV2XMLWarnings(tt.content)
+			if len(got) != tt.wantLen {
+				t.Fatalf("CheckV2XMLWarnings(%q) returned %d warnings, want %d: %v", tt.content, len(got), tt.wantLen, got)
+			}
+			combined := ""
+			for _, w := range got {
+				combined += w
+			}
+			for _, sub := range tt.wantContains {
+				if !containsStr(combined, sub) {
+					t.Errorf("expected warning to contain %q, got: %s", sub, combined)
+				}
+			}
+		})
+	}
+}
+
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
+		func() bool {
+			for i := 0; i+len(sub) <= len(s); i++ {
+				if s[i:i+len(sub)] == sub {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/shortcuts/doc/docs_update_check_test.go
+++ b/shortcuts/doc/docs_update_check_test.go
@@ -394,6 +394,8 @@ func TestCheckV2XMLBareAmpersand(t *testing.T) {
 		{name: "bare ampersand flagged", content: "a & b", wantErr: true},
 		{name: "bare ampersand in tag flagged", content: `<text color="blue">R&D</text>`, wantErr: true},
 		{name: "unknown entity flagged", content: "&nbsp;", wantErr: true},
+		// mixed: valid entity alongside a bare & — the bare one must still be caught
+		{name: "valid entity mixed with bare ampersand flagged", content: "a &amp; b & c", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -463,6 +465,12 @@ func TestCheckV2XMLWarnings(t *testing.T) {
 			content: `<grid><column width = "40"/></grid>`,
 			wantLen: 1,
 		},
+		// float value must NOT trigger warning — width="0.5" is valid width-ratio syntax
+		{
+			name:    "column float width value is not flagged",
+			content: `<grid><column width="0.5"><p>A</p></column></grid>`,
+			wantLen: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -476,22 +484,10 @@ func TestCheckV2XMLWarnings(t *testing.T) {
 				combined += w
 			}
 			for _, sub := range tt.wantContains {
-				if !containsStr(combined, sub) {
+				if !strings.Contains(combined, sub) {
 					t.Errorf("expected warning to contain %q, got: %s", sub, combined)
 				}
 			}
 		})
 	}
-}
-
-func containsStr(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(sub) == 0 ||
-		func() bool {
-			for i := 0; i+len(sub) <= len(s); i++ {
-				if s[i:i+len(sub)] == sub {
-					return true
-				}
-			}
-			return false
-		}())
 }

--- a/shortcuts/doc/docs_update_v2.go
+++ b/shortcuts/doc/docs_update_v2.go
@@ -103,7 +103,7 @@ func validateUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 			return common.FlagErrorf("--command append requires --content")
 		}
 	}
-	if runtime.Str("doc-format") != "markdown" && content != "" {
+	if runtime.Str("doc-format") != "markdown" {
 		if msg := CheckV2XMLBareAmpersand(content); msg != "" {
 			return common.FlagErrorf("%s", msg)
 		}

--- a/shortcuts/doc/docs_update_v2.go
+++ b/shortcuts/doc/docs_update_v2.go
@@ -103,6 +103,11 @@ func validateUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 			return common.FlagErrorf("--command append requires --content")
 		}
 	}
+	if runtime.Str("doc-format") != "markdown" && content != "" {
+		if msg := CheckV2XMLBareAmpersand(content); msg != "" {
+			return common.FlagErrorf("%s", msg)
+		}
+	}
 	return nil
 }
 
@@ -123,6 +128,12 @@ func executeUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 
 	apiPath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s", ref.Token)
 	body := buildUpdateBody(runtime)
+
+	if runtime.Str("doc-format") != "markdown" {
+		for _, w := range CheckV2XMLWarnings(runtime.Str("content")) {
+			fmt.Fprintf(runtime.IO().ErrOut, "warning: %s\n", w)
+		}
+	}
 
 	data, err := doDocAPI(runtime, "PUT", apiPath, body)
 	if err != nil {

--- a/tests/cli_e2e/docs/docs_update_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_update_dryrun_test.go
@@ -11,6 +11,7 @@ import (
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 // TestDocs_UpdateDryRunSuppressesSemanticWarnings asserts the contract that
@@ -67,4 +68,105 @@ func TestDocs_UpdateDryRunSuppressesSemanticWarnings(t *testing.T) {
 				needle, result.Stdout, result.Stderr)
 		}
 	}
+}
+
+// TestDocs_V2CreateXMLGuardDryRun verifies the v2 XML content guards on the
+// docs +create dry-run path. A bare ampersand in XML content must cause a
+// validation error (exit 2), while clean XML must succeed.
+func TestDocs_V2CreateXMLGuardDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	t.Run("bare ampersand rejected", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"docs", "+create",
+				"--content", `<text>R&D</text>`,
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 2)
+
+		combined := result.Stdout + "\n" + result.Stderr
+		if !strings.Contains(combined, "bare &") {
+			t.Fatalf("expected bare-ampersand error, got:\nstdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+		}
+	})
+
+	t.Run("clean XML accepted", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"docs", "+create",
+				"--content", `<text>R&amp;D</text>`,
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+
+		method := gjson.Get(result.Stdout, "api.0.method").String()
+		require.Equal(t, "POST", method)
+	})
+}
+
+// TestDocs_V2UpdateXMLGuardDryRun verifies the v2 XML content guards on the
+// docs +update dry-run path. A bare ampersand must cause a validation error,
+// while clean XML with a <quote-container> (non-fatal warning) must still
+// succeed with exit 0 — warnings are only emitted on the execute path, not
+// dry-run.
+func TestDocs_V2UpdateXMLGuardDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	t.Run("bare ampersand rejected", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"docs", "+update",
+				"--doc", "doxcnDryRunE2E",
+				"--command", "overwrite",
+				"--content", `<text>R&D</text>`,
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 2)
+
+		combined := result.Stdout + "\n" + result.Stderr
+		if !strings.Contains(combined, "bare &") {
+			t.Fatalf("expected bare-ampersand error, got:\nstdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+		}
+	})
+
+	t.Run("warning-only content passes dry-run", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"docs", "+update",
+				"--doc", "doxcnDryRunE2E",
+				"--command", "overwrite",
+				"--content", `<quote-container><p>text</p></quote-container>`,
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+
+		// Warnings must NOT appear in dry-run output (only emitted on execute path).
+		combined := result.Stdout + "\n" + result.Stderr
+		if strings.Contains(combined, "warning:") {
+			t.Errorf("dry-run must not emit XML warnings; got:\nstdout: %s\nstderr: %s", result.Stdout, result.Stderr)
+		}
+	})
 }

--- a/tests/cli_e2e/docs/docs_update_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_update_dryrun_test.go
@@ -74,6 +74,7 @@ func TestDocs_UpdateDryRunSuppressesSemanticWarnings(t *testing.T) {
 // docs +create dry-run path. A bare ampersand in XML content must cause a
 // validation error (exit 2), while clean XML must succeed.
 func TestDocs_V2CreateXMLGuardDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
 	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
 	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
@@ -122,6 +123,7 @@ func TestDocs_V2CreateXMLGuardDryRun(t *testing.T) {
 // succeed with exit 0 — warnings are only emitted on the execute path, not
 // dry-run.
 func TestDocs_V2UpdateXMLGuardDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
 	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
 	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
@@ -162,6 +164,11 @@ func TestDocs_V2UpdateXMLGuardDryRun(t *testing.T) {
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)
+
+		// Assert dry-run request envelope shape.
+		method := gjson.Get(result.Stdout, "api.0.method").String()
+		require.Equal(t, "PUT", method)
+		require.Contains(t, gjson.Get(result.Stdout, "api.0.url").String(), "doxcnDryRunE2E")
 
 		// Warnings must NOT appear in dry-run output (only emitted on execute path).
 		combined := result.Stdout + "\n" + result.Stderr


### PR DESCRIPTION
## Summary

Add pre-flight static checks for the v2 XML document path to catch two categories of silent failures before the API call is made.

## Changes

- **`shortcuts/doc/docs_update_check.go`**: Add `CheckV2XMLBareAmpersand` (hard error) and `CheckV2XMLWarnings` (non-fatal warnings) with table-driven tests
- **`shortcuts/doc/docs_create_v2.go`**: Integrate bare-ampersand check in `validateCreateV2` and XML warnings in `executeCreateV2`
- **`shortcuts/doc/docs_update_v2.go`**: Same integration in `validateUpdateV2` / `executeUpdateV2`
- **`shortcuts/doc/docs_update_check_test.go`**: Add `TestCheckV2XMLBareAmpersand` and `TestCheckV2XMLWarnings`

## Checks

**`CheckV2XMLBareAmpersand`** — hard error (returned from Validate):
- Fires when content contains a `&` that is not a recognised XML entity (`&amp;`, `&lt;`, `&gt;`, `&apos;`, `&quot;`, `&#N;`, `&#xH;`).
- The v2 XML parser rejects such requests outright; catching this early gives a clear error instead of an opaque API failure.

**`CheckV2XMLWarnings`** — non-fatal warnings (printed to stderr before the API call):
1. `<quote-container>` — v2 silently drops the block; the correct tag is `<blockquote>`.
2. `<column width="N">` with an integer value — has no effect in v2; the correct attribute is `width-ratio="0.5"` (float 0–1).

Both checks only fire when `--doc-format` is `xml` (the default).

## Test Plan

- [x] `go test ./shortcuts/doc/...` — all pass, 66.4% coverage
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced v2 document validation: submissions (when not using markdown) are blocked for malformed bare ampersands.
  * Emits user-facing warnings to stderr for unsupported XML constructs (e.g., quote-container) and integer column-width attributes before processing.

* **Tests**
  * Added unit tests covering bare-ampersand detection and XML warning conditions.
  * Added CLI dry-run end-to-end tests verifying create/update guard and warning behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/822?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->