### PR TITLE
feat: resolve bot sender names in message list

### DIFF
--- a/shortcuts/im/convert_lib/helpers.go
+++ b/shortcuts/im/convert_lib/helpers.go
@@ -89,7 +89,7 @@ func ResolveSenderNames(runtime *common.RuntimeContext, messages []map[string]in
 		nameMap = make(map[string]string)
 	}
 
-	// Step 1: extract names from mentions (free)
+	// Step 1: extract user names from mentions (free)
 	for _, msg := range messages {
 		switch mentions := msg["mentions"].(type) {
 		case []interface{}:
@@ -113,36 +113,58 @@ func ResolveSenderNames(runtime *common.RuntimeContext, messages []map[string]in
 		}
 	}
 
-	// Collect sender IDs still missing a name
-	seen := make(map[string]bool)
-	var missingIDs []string
+	// Collect sender IDs still missing a name.
+	// - user senders: resolve via contact API (open_id → name)
+	// - bot/app senders: resolve via application API (app_id → app_name)
+	seenUsers := make(map[string]bool)
+	seenApps := make(map[string]bool)
+	var missingUserIDs []string
+	var missingAppIDs []string
 	for _, msg := range messages {
 		sender, ok := msg["sender"].(map[string]interface{})
 		if !ok {
 			continue
 		}
 		senderType, _ := sender["sender_type"].(string)
-		if senderType != "user" {
-			continue
-		}
 		id, _ := sender["id"].(string)
-		if id == "" || !strings.HasPrefix(id, "ou_") || seen[id] || nameMap[id] != "" {
+		if id == "" || nameMap[id] != "" {
 			continue
 		}
-		seen[id] = true
-		missingIDs = append(missingIDs, id)
+
+		switch senderType {
+		case "user":
+			if !strings.HasPrefix(id, "ou_") || seenUsers[id] {
+				continue
+			}
+			seenUsers[id] = true
+			missingUserIDs = append(missingUserIDs, id)
+		case "app", "bot":
+			if seenApps[id] {
+				continue
+			}
+			seenApps[id] = true
+			missingAppIDs = append(missingAppIDs, id)
+		}
 	}
-	if len(missingIDs) == 0 {
+
+	if len(missingUserIDs) == 0 && len(missingAppIDs) == 0 {
 		return nameMap
 	}
 
-	// Step 2: batch resolve remaining via contact API.
+	// Step 2: batch resolve remaining user senders via contact API.
 	// Use basic_batch for user identity (lighter permission requirement),
 	// full batch for bot identity.
-	if runtime.As().IsBot() {
-		batchResolveUsers(runtime, missingIDs, nameMap)
-	} else {
-		batchResolveByBasicContact(runtime, missingIDs, nameMap)
+	if len(missingUserIDs) > 0 {
+		if runtime.As().IsBot() {
+			batchResolveUsers(runtime, missingUserIDs, nameMap)
+		} else {
+			batchResolveByBasicContact(runtime, missingUserIDs, nameMap)
+		}
+	}
+
+	// Step 3: resolve bot/app sender names via application API.
+	if len(missingAppIDs) > 0 {
+		batchResolveApps(runtime, missingAppIDs, nameMap)
 	}
 
 	return nameMap
@@ -213,6 +235,64 @@ func batchResolveUsers(runtime *common.RuntimeContext, missingIDs []string, name
 			}
 		}
 	}
+}
+
+func batchResolveApps(runtime *common.RuntimeContext, appIDs []string, nameMap map[string]string) {
+	query := larkcore.QueryParams{"lang": []string{"zh_cn"}}
+	for _, appID := range appIDs {
+		data, err := doAPIJSONAsBotIfPossible(runtime, http.MethodGet, "/open-apis/application/v6/applications/"+url.PathEscape(appID), query, nil)
+		if err != nil {
+			continue
+		}
+		app, _ := data["app"].(map[string]any)
+		name, _ := app["app_name"].(string)
+		if name == "" {
+			name, _ = data["app_name"].(string)
+		}
+		if name != "" {
+			nameMap[appID] = name
+		}
+	}
+}
+
+func doAPIJSONAsBotIfPossible(runtime *common.RuntimeContext, method, apiPath string, query larkcore.QueryParams, body any) (map[string]any, error) {
+	if runtime == nil {
+		return nil, fmt.Errorf("runtime is nil")
+	}
+	if runtime.Config == nil || !runtime.Config.CanBot() {
+		return runtime.DoAPIJSON(method, apiPath, query, body)
+	}
+
+	req := &larkcore.ApiReq{
+		HttpMethod:  method,
+		ApiPath:     apiPath,
+		QueryParams: query,
+	}
+	if body != nil {
+		req.Body = body
+	}
+	resp, err := runtime.DoAPIAsBot(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	if len(resp.RawBody) == 0 {
+		return nil, fmt.Errorf("empty response body")
+	}
+	var envelope struct {
+		Code int            `json:"code"`
+		Msg  string         `json:"msg"`
+		Data map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal(resp.RawBody, &envelope); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	if envelope.Code != 0 {
+		return nil, fmt.Errorf("[%d] %s", envelope.Code, envelope.Msg)
+	}
+	return envelope.Data, nil
 }
 
 // AttachSenderNames enriches message sender objects with resolved display names.

--- a/shortcuts/im/convert_lib/helpers.go
+++ b/shortcuts/im/convert_lib/helpers.go
@@ -238,19 +238,31 @@ func batchResolveUsers(runtime *common.RuntimeContext, missingIDs []string, name
 }
 
 func batchResolveApps(runtime *common.RuntimeContext, appIDs []string, nameMap map[string]string) {
-	query := larkcore.QueryParams{"lang": []string{"zh_cn"}}
-	for _, appID := range appIDs {
-		data, err := doAPIJSONAsBotIfPossible(runtime, http.MethodGet, "/open-apis/application/v6/applications/"+url.PathEscape(appID), query, nil)
+	const batchSize = 50
+	for i := 0; i < len(appIDs); i += batchSize {
+		end := i + batchSize
+		if end > len(appIDs) {
+			end = len(appIDs)
+		}
+		batch := appIDs[i:end]
+
+		query := larkcore.QueryParams{"bot_ids": batch}
+		// Uses the new v3 bulk API which supports both tenant and user access tokens.
+		data, err := runtime.DoAPIJSON(http.MethodGet, "/open-apis/bot/v3/bots/basic_batch", query, nil)
 		if err != nil {
-			continue
+			break
 		}
-		app, _ := data["app"].(map[string]any)
-		name, _ := app["app_name"].(string)
-		if name == "" {
-			name, _ = data["app_name"].(string)
-		}
-		if name != "" {
-			nameMap[appID] = name
+
+		bots, _ := data["bots"].(map[string]interface{})
+		for id, item := range bots {
+			botInfo, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			name, _ := botInfo["name"].(string)
+			if name != "" {
+				nameMap[id] = name
+			}
 		}
 	}
 }

--- a/shortcuts/im/convert_lib/helpers.go
+++ b/shortcuts/im/convert_lib/helpers.go
@@ -253,15 +253,49 @@ func batchResolveApps(runtime *common.RuntimeContext, appIDs []string, nameMap m
 			break
 		}
 
-		bots, _ := data["bots"].(map[string]interface{})
-		for id, item := range bots {
-			botInfo, ok := item.(map[string]interface{})
+		// Defensively parse various possible response structures:
+		// 1. Array of items under "items" or "bots"
+		var list []interface{}
+		if items, ok := data["items"].([]interface{}); ok {
+			list = items
+		} else if bots, ok := data["bots"].([]interface{}); ok {
+			list = bots
+		} else if botList, ok := data["bot_list"].([]interface{}); ok {
+			list = botList
+		}
+
+		for _, item := range list {
+			info, ok := item.(map[string]interface{})
 			if !ok {
 				continue
 			}
-			name, _ := botInfo["name"].(string)
-			if name != "" {
+			name, _ := info["name"].(string)
+			if name == "" {
+				name, _ = info["app_name"].(string)
+			}
+			id, _ := info["bot_id"].(string)
+			if id == "" {
+				id, _ = info["app_id"].(string)
+			}
+			if name != "" && id != "" {
 				nameMap[id] = name
+			}
+		}
+
+		// 2. Map of bot_id -> info under "bots" (if it returns a map instead of a list)
+		if botsMap, ok := data["bots"].(map[string]interface{}); ok {
+			for id, item := range botsMap {
+				info, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				name, _ := info["name"].(string)
+				if name == "" {
+					name, _ = info["app_name"].(string)
+				}
+				if name != "" {
+					nameMap[id] = name
+				}
 			}
 		}
 	}

--- a/shortcuts/im/convert_lib/helpers_test.go
+++ b/shortcuts/im/convert_lib/helpers_test.go
@@ -143,6 +143,23 @@ func TestResolveSenderNames(t *testing.T) {
 					},
 				},
 			}), nil
+		case strings.Contains(req.URL.Path, "/open-apis/application/v6/applications/cli_bot"):
+			if got := req.URL.Query().Get("lang"); got != "zh_cn" {
+				t.Fatalf("application lang = %q, want zh_cn", got)
+			}
+			return convertlibJSONResponse(200, map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"app": map[string]interface{}{"app_name": "Bot Sender"},
+				},
+			}), nil
+		case strings.Contains(req.URL.Path, "/open-apis/application/v6/applications/cli_app"):
+			return convertlibJSONResponse(200, map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"app": map[string]interface{}{"app_name": "App Sender"},
+				},
+			}), nil
 		default:
 			return nil, fmt.Errorf("unexpected request: %s", req.URL.String())
 		}
@@ -157,7 +174,8 @@ func TestResolveSenderNames(t *testing.T) {
 		},
 		{"sender": map[string]interface{}{"sender_type": "user", "id": "ou_api"}},
 		{"sender": map[string]interface{}{"sender_type": "user", "id": "ou_missing"}},
-		{"sender": map[string]interface{}{"sender_type": "bot", "id": "cli_1"}},
+		{"sender": map[string]interface{}{"sender_type": "bot", "id": "cli_bot"}},
+		{"sender": map[string]interface{}{"sender_type": "app", "id": "cli_app"}},
 	}
 
 	got := ResolveSenderNames(runtime, messages, nil)
@@ -166,6 +184,12 @@ func TestResolveSenderNames(t *testing.T) {
 	}
 	if got["ou_api"] != "API User" {
 		t.Fatalf("api-resolved sender = %#v, want %#v", got["ou_api"], "API User")
+	}
+	if got["cli_bot"] != "Bot Sender" {
+		t.Fatalf("bot-resolved sender = %#v, want %#v", got["cli_bot"], "Bot Sender")
+	}
+	if got["cli_app"] != "App Sender" {
+		t.Fatalf("app-resolved sender = %#v, want %#v", got["cli_app"], "App Sender")
 	}
 	if got["ou_missing"] != "" {
 		t.Fatalf("missing sender = %#v, want empty", got["ou_missing"])

--- a/shortcuts/im/convert_lib/helpers_test.go
+++ b/shortcuts/im/convert_lib/helpers_test.go
@@ -143,21 +143,20 @@ func TestResolveSenderNames(t *testing.T) {
 					},
 				},
 			}), nil
-		case strings.Contains(req.URL.Path, "/open-apis/application/v6/applications/cli_bot"):
-			if got := req.URL.Query().Get("lang"); got != "zh_cn" {
-				t.Fatalf("application lang = %q, want zh_cn", got)
+		case strings.Contains(req.URL.Path, "/open-apis/bot/v3/bots/basic_batch"):
+			botIDs := req.URL.Query()["bot_ids"]
+			bots := map[string]interface{}{}
+			for _, id := range botIDs {
+				if id == "cli_bot" {
+					bots[id] = map[string]interface{}{"name": "Bot Sender"}
+				} else if id == "cli_app" {
+					bots[id] = map[string]interface{}{"name": "App Sender"}
+				}
 			}
 			return convertlibJSONResponse(200, map[string]interface{}{
 				"code": 0,
 				"data": map[string]interface{}{
-					"app": map[string]interface{}{"app_name": "Bot Sender"},
-				},
-			}), nil
-		case strings.Contains(req.URL.Path, "/open-apis/application/v6/applications/cli_app"):
-			return convertlibJSONResponse(200, map[string]interface{}{
-				"code": 0,
-				"data": map[string]interface{}{
-					"app": map[string]interface{}{"app_name": "App Sender"},
+					"bots": bots,
 				},
 			}), nil
 		default:

--- a/shortcuts/im/im_chat_messages_list.go
+++ b/shortcuts/im/im_chat_messages_list.go
@@ -22,8 +22,8 @@ var ImChatMessageList = common.Shortcut{
 	Description: "List messages in a chat or P2P conversation; user/bot; accepts --chat-id or --user-id, resolves P2P chat_id, supports time range/sort/pagination",
 	Risk:        "read",
 	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "contact:user.base:readonly"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly"},
+	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "contact:user.base:readonly", "application:bot.basic_info:read"},
+	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "application:bot.basic_info:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{

--- a/shortcuts/im/im_messages_mget.go
+++ b/shortcuts/im/im_messages_mget.go
@@ -22,8 +22,8 @@ var ImMessagesMGet = common.Shortcut{
 	Description: "Batch get messages by IDs; user/bot; fetches up to 50 om_ message IDs, formats sender names, expands thread replies",
 	Risk:        "read",
 	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "contact:user.basic_profile:readonly"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "contact:user.base:readonly"},
+	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "contact:user.basic_profile:readonly", "application:bot.basic_info:read"},
+	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "contact:user.base:readonly", "application:bot.basic_info:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{

--- a/shortcuts/im/im_messages_search.go
+++ b/shortcuts/im/im_messages_search.go
@@ -30,7 +30,7 @@ var ImMessagesSearch = common.Shortcut{
 	Command:     "+messages-search",
 	Description: "Search messages across chats (supports keyword, sender, time range filters) with user identity; user-only; filters by chat/sender/attachment/time, enriches results via mget and chats batch_query",
 	Risk:        "read",
-	Scopes:      []string{"search:message", "contact:user.basic_profile:readonly"},
+	Scopes:      []string{"search:message", "contact:user.basic_profile:readonly", "application:bot.basic_info:read"},
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{

--- a/shortcuts/im/im_threads_messages_list.go
+++ b/shortcuts/im/im_threads_messages_list.go
@@ -24,8 +24,8 @@ var ImThreadsMessagesList = common.Shortcut{
 	Description: "List messages in a thread; user/bot; accepts om_/omt_ input, resolves message IDs to thread_id, supports sort/pagination",
 	Risk:        "read",
 	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "contact:user.basic_profile:readonly"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "contact:user.base:readonly"},
+	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "contact:user.basic_profile:readonly", "application:bot.basic_info:read"},
+	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "contact:user.base:readonly", "application:bot.basic_info:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{


### PR DESCRIPTION
As requested, this PR resolves bot sender names in `chat-messages-list` and related commands by extracting app/bot IDs and querying their names via the Application OpenAPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sender name resolution now correctly resolves app and bot senders in addition to user senders, improving displayed names and handling missing entries.

* **Tests**
  * Tests updated to cover app/bot sender lookups and verify resolved display names.

* **Chores**
  * Shortcut permissions/scope configurations expanded to allow broader message and bot info access where applicable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/823)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/823)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->