### PR TITLE
feat(doc): warn before overwrite when document contains whiteboard or file blocks

### DIFF
--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -224,9 +224,6 @@ func warnOverwriteResourceBlocks(runtime *common.RuntimeContext) string {
 		return ""
 	}
 	md, _ := result["markdown"].(string)
-	if md == "" {
-		return ""
-	}
 	return checkOverwriteResourceBlocks(md)
 }
 

--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -160,6 +160,16 @@ func executeUpdateV1(_ context.Context, runtime *common.RuntimeContext) error {
 		fmt.Fprintf(runtime.IO().ErrOut, "warning: %s\n", w)
 	}
 
+	// Overwrite replaces the entire document, silently discarding any
+	// whiteboard or file-attachment blocks that cannot be re-created from
+	// Markdown. Pre-fetch the current content and warn when such blocks
+	// are present so the caller can take a backup before proceeding.
+	if runtime.Str("mode") == "overwrite" {
+		if w := warnOverwriteResourceBlocks(runtime); w != "" {
+			fmt.Fprintf(runtime.IO().ErrOut, "warning: %s\n", w)
+		}
+	}
+
 	// Surface callout type= hint so users know to switch to background-color/
 	// border-color when they want a colored callout. Non-blocking, advisory.
 	if md := runtime.Str("markdown"); md != "" {
@@ -196,4 +206,56 @@ func buildUpdateArgsV1(runtime *common.RuntimeContext) map[string]interface{} {
 		args["new_title"] = v
 	}
 	return args
+}
+
+// warnOverwriteResourceBlocks pre-fetches the current document and returns a
+// non-empty warning string when the document contains whiteboard or file
+// attachment blocks that would be permanently deleted by an overwrite. Returns
+// an empty string (no warning) when the document is clean or the fetch fails
+// (we never block the overwrite on a best-effort check).
+func warnOverwriteResourceBlocks(runtime *common.RuntimeContext) string {
+	args := map[string]interface{}{
+		"doc_id":           runtime.Str("doc"),
+		"skip_task_detail": true,
+	}
+	result, err := common.CallMCPTool(runtime, "fetch-doc", args)
+	if err != nil {
+		// Fetch failed — silently skip the guard rather than blocking overwrite.
+		return ""
+	}
+	md, _ := result["markdown"].(string)
+	if md == "" {
+		return ""
+	}
+	return checkOverwriteResourceBlocks(md)
+}
+
+// checkOverwriteResourceBlocks scans Markdown for resource block tags that
+// cannot survive an overwrite: <whiteboard …> and <file …>. Returns a
+// warning string listing the counts if any are found, empty string otherwise.
+func checkOverwriteResourceBlocks(markdown string) string {
+	var found []string
+	if n := strings.Count(markdown, "<whiteboard"); n > 0 {
+		if n == 1 {
+			found = append(found, "1 whiteboard block")
+		} else {
+			found = append(found, fmt.Sprintf("%d whiteboard blocks", n))
+		}
+	}
+	if n := strings.Count(markdown, "<file"); n > 0 {
+		if n == 1 {
+			found = append(found, "1 file attachment block")
+		} else {
+			found = append(found, fmt.Sprintf("%d file attachment blocks", n))
+		}
+	}
+	if len(found) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"the document contains %s that cannot be reconstructed from Markdown; "+
+			"overwrite will permanently delete them. "+
+			"Consider fetching a backup with `docs +fetch` before overwriting.",
+		strings.Join(found, " and "),
+	)
 }

--- a/shortcuts/doc/docs_update.go
+++ b/shortcuts/doc/docs_update.go
@@ -6,6 +6,7 @@ package doc
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -208,14 +209,30 @@ func buildUpdateArgsV1(runtime *common.RuntimeContext) map[string]interface{} {
 	return args
 }
 
+// resourceBlockRe matches the opening of a <whiteboard …> or <file …> tag
+// (followed by whitespace, > or /) to avoid false positives on tag names like
+// <file-view> or prose that merely mentions the word "whiteboard".
+var resourceBlockRe = regexp.MustCompile(`<(whiteboard|file)[\s/>]`)
+
 // warnOverwriteResourceBlocks pre-fetches the current document and returns a
 // non-empty warning string when the document contains whiteboard or file
 // attachment blocks that would be permanently deleted by an overwrite. Returns
 // an empty string (no warning) when the document is clean or the fetch fails
 // (we never block the overwrite on a best-effort check).
+//
+// This function is not unit-tested because it depends on an external MCP call
+// (fetch-doc). The pure detection logic lives in checkOverwriteResourceBlocks,
+// which has full table-driven coverage.
+//
+// Performance: this adds one extra fetch-doc round-trip to every --mode overwrite
+// call, even when the document has no resource blocks. The cost is intentional:
+// the guard is best-effort and silent on failure, so the latency is bounded and
+// the trade-off is acceptable to avoid silent data loss.
 func warnOverwriteResourceBlocks(runtime *common.RuntimeContext) string {
 	args := map[string]interface{}{
-		"doc_id":           runtime.Str("doc"),
+		"doc_id": runtime.Str("doc"),
+		// skip_task_detail reduces response payload by omitting per-block task
+		// metadata, making the pre-fetch faster and cheaper.
 		"skip_task_detail": true,
 	}
 	result, err := common.CallMCPTool(runtime, "fetch-doc", args)
@@ -231,20 +248,26 @@ func warnOverwriteResourceBlocks(runtime *common.RuntimeContext) string {
 // cannot survive an overwrite: <whiteboard …> and <file …>. Returns a
 // warning string listing the counts if any are found, empty string otherwise.
 func checkOverwriteResourceBlocks(markdown string) string {
-	var found []string
-	if n := strings.Count(markdown, "<whiteboard"); n > 0 {
-		if n == 1 {
-			found = append(found, "1 whiteboard block")
-		} else {
-			found = append(found, fmt.Sprintf("%d whiteboard blocks", n))
+	matches := resourceBlockRe.FindAllStringSubmatch(markdown, -1)
+	whiteboards, files := 0, 0
+	for _, m := range matches {
+		switch m[1] {
+		case "whiteboard":
+			whiteboards++
+		case "file":
+			files++
 		}
 	}
-	if n := strings.Count(markdown, "<file"); n > 0 {
-		if n == 1 {
-			found = append(found, "1 file attachment block")
-		} else {
-			found = append(found, fmt.Sprintf("%d file attachment blocks", n))
-		}
+	var found []string
+	if whiteboards == 1 {
+		found = append(found, "1 whiteboard block")
+	} else if whiteboards > 1 {
+		found = append(found, fmt.Sprintf("%d whiteboard blocks", whiteboards))
+	}
+	if files == 1 {
+		found = append(found, "1 file attachment block")
+	} else if files > 1 {
+		found = append(found, fmt.Sprintf("%d file attachment blocks", files))
 	}
 	if len(found) == 0 {
 		return ""

--- a/shortcuts/doc/docs_update_test.go
+++ b/shortcuts/doc/docs_update_test.go
@@ -168,3 +168,35 @@ func TestNormalizeWhiteboardResult(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateSelectionByTitleV1(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		title   string
+		wantErr bool
+		errSub  string
+	}{
+		{name: "empty title is valid", title: "", wantErr: false},
+		{name: "single heading is valid", title: "## Section", wantErr: false},
+		{name: "h1 heading is valid", title: "# Top", wantErr: false},
+		{name: "deep heading is valid", title: "### Sub-section", wantErr: false},
+		{name: "missing hash prefix is invalid", title: "No hash", wantErr: true, errSub: "'#'"},
+		{name: "multiline title is invalid", title: "## First\n## Second", wantErr: true, errSub: "single"},
+		{name: "title with embedded carriage return is invalid", title: "## Title\r## Next", wantErr: true, errSub: "single"},
+		{name: "leading-space heading is valid after trim", title: "  ## Section", wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateSelectionByTitleV1(tt.title)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateSelectionByTitleV1(%q) error = %v, wantErr = %v", tt.title, err, tt.wantErr)
+			}
+			if tt.wantErr && tt.errSub != "" && !strings.Contains(err.Error(), tt.errSub) {
+				t.Errorf("expected error to contain %q, got: %v", tt.errSub, err)
+			}
+		})
+	}
+}

--- a/shortcuts/doc/docs_update_test.go
+++ b/shortcuts/doc/docs_update_test.go
@@ -4,6 +4,7 @@ package doc
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -53,6 +54,72 @@ func TestIsWhiteboardCreateMarkdown(t *testing.T) {
 			t.Fatalf("did not expect plain markdown to be treated as whiteboard creation")
 		}
 	})
+}
+
+func TestCheckOverwriteResourceBlocks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		markdown string
+		wantWarn bool
+		wantSubs []string
+	}{
+		{
+			name:     "empty markdown is clean",
+			markdown: "",
+			wantWarn: false,
+		},
+		{
+			name:     "plain prose is clean",
+			markdown: "## Heading\n\nsome text",
+			wantWarn: false,
+		},
+		{
+			name:     "single whiteboard triggers warning",
+			markdown: `<whiteboard token="abc123"/>`,
+			wantWarn: true,
+			wantSubs: []string{"1 whiteboard block", "overwrite"},
+		},
+		{
+			name:     "multiple whiteboards counted",
+			markdown: "<whiteboard token=\"a\"/>\n<whiteboard token=\"b\"/>",
+			wantWarn: true,
+			wantSubs: []string{"2 whiteboard blocks"},
+		},
+		{
+			name:     "single file attachment triggers warning",
+			markdown: `<file token="tok" name="report.pdf"/>`,
+			wantWarn: true,
+			wantSubs: []string{"1 file attachment block"},
+		},
+		{
+			name:     "multiple file attachments counted",
+			markdown: "<file token=\"a\"/>\n<file token=\"b\"/>\n<file token=\"c\"/>",
+			wantWarn: true,
+			wantSubs: []string{"3 file attachment blocks"},
+		},
+		{
+			name:     "whiteboard and file together both counted",
+			markdown: "<whiteboard token=\"wb\"/>\n<file token=\"f\"/>",
+			wantWarn: true,
+			wantSubs: []string{"1 whiteboard block", "1 file attachment block"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := checkOverwriteResourceBlocks(tt.markdown)
+			if (got != "") != tt.wantWarn {
+				t.Fatalf("checkOverwriteResourceBlocks(%q) = %q, wantWarn=%v", tt.markdown, got, tt.wantWarn)
+			}
+			for _, sub := range tt.wantSubs {
+				if !strings.Contains(got, sub) {
+					t.Errorf("expected warning to contain %q, got: %s", sub, got)
+				}
+			}
+		})
+	}
 }
 
 func TestNormalizeWhiteboardResult(t *testing.T) {


### PR DESCRIPTION
## Summary

Add a best-effort pre-flight guard for the v1 `overwrite` mode that warns the user when the current document contains whiteboard or file attachment blocks that cannot be reconstructed from Markdown.

## Changes

- **`shortcuts/doc/docs_update.go`**: In `executeUpdateV1`, pre-fetch the document when `--mode overwrite` and call `warnOverwriteResourceBlocks` / `checkOverwriteResourceBlocks` to detect resource blocks
- **`shortcuts/doc/docs_update_test.go`**: Add `TestCheckOverwriteResourceBlocks` with table-driven cases covering single/multiple whiteboard blocks, file attachments, and combined cases

## Behaviour

When `--mode overwrite` is used and the current document contains `<whiteboard>` or `<file>` blocks:

```
warning: the document contains 2 whiteboard blocks and 1 file attachment block that cannot be
reconstructed from Markdown; overwrite will permanently delete them.
Consider fetching a backup with `docs +fetch` before overwriting.
```

The guard is **best-effort**: if the pre-fetch fails (network error, permission, etc.) the warning is silently skipped and the overwrite proceeds normally. The overwrite is never blocked — this is a warning only.

## Test Plan

- [x] `go test ./shortcuts/doc/...` — all pass
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a best-effort pre-check that prints a non-blocking overwrite warning when overwriting documents that contain embedded whiteboards or file attachments; the check is skipped silently if the pre-fetch fails.

* **Tests**
  * Added automated tests covering the overwrite-warning behavior and selection-title validation to ensure correct warnings and error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/825)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->