### PR TITLE
feat: add info command for version and environment info

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -13,6 +13,7 @@ import (
 	cmdconfig "github.com/larksuite/cli/cmd/config"
 	"github.com/larksuite/cli/cmd/doctor"
 	cmdevent "github.com/larksuite/cli/cmd/event"
+	cmdinfo "github.com/larksuite/cli/cmd/info"
 	"github.com/larksuite/cli/cmd/profile"
 	"github.com/larksuite/cli/cmd/schema"
 	"github.com/larksuite/cli/cmd/service"
@@ -116,6 +117,7 @@ func buildInternal(ctx context.Context, inv cmdutil.InvocationContext, opts ...B
 	rootCmd.AddCommand(auth.NewCmdAuth(f))
 	rootCmd.AddCommand(profile.NewCmdProfile(f))
 	rootCmd.AddCommand(doctor.NewCmdDoctor(f))
+	rootCmd.AddCommand(cmdinfo.NewCmdInfo(f))
 	rootCmd.AddCommand(api.NewCmdApiWithContext(ctx, f, nil))
 	rootCmd.AddCommand(schema.NewCmdSchema(f, nil))
 	rootCmd.AddCommand(completion.NewCmdCompletion(f))

--- a/cmd/info/info.go
+++ b/cmd/info/info.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package info
+
+import (
+	"runtime"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/build"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/output"
+)
+
+// InfoOptions holds inputs for the info command.
+type InfoOptions struct {
+	Factory *cmdutil.Factory
+}
+
+// NewCmdInfo creates the info command.
+func NewCmdInfo(f *cmdutil.Factory) *cobra.Command {
+	opts := &InfoOptions{Factory: f}
+
+	cmd := &cobra.Command{
+		Use:   "info",
+		Short: "Show CLI version and environment info",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return infoRun(opts)
+		},
+	}
+
+	cmdutil.DisableAuthCheck(cmd)
+	return cmd
+}
+
+func infoRun(opts *InfoOptions) error {
+	output.PrintJson(opts.Factory.IOStreams.Out, map[string]interface{}{
+		"ok":      true,
+		"version": build.Version,
+		"os":      runtime.GOOS,
+		"arch":    runtime.GOARCH,
+		"go":      runtime.Version(),
+	})
+	return nil
+}

--- a/cmd/info/info_test.go
+++ b/cmd/info/info_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package info
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+)
+
+func TestInfoRun_Success(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+
+	opts := &InfoOptions{Factory: f}
+	err := infoRun(opts)
+	if err != nil {
+		t.Fatalf("infoRun returned error: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("failed to parse JSON: %v", err)
+	}
+
+	if ok, _ := result["ok"].(bool); !ok {
+		t.Error("expected ok=true")
+	}
+	if _, ok := result["version"]; !ok {
+		t.Error("expected version field")
+	}
+	if _, ok := result["os"]; !ok {
+		t.Error("expected os field")
+	}
+	if _, ok := result["arch"]; !ok {
+		t.Error("expected arch field")
+	}
+	if _, ok := result["go"]; !ok {
+		t.Error("expected go field")
+	}
+}


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/becd860
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Synthesize transport contract for larksuite/cli | passed | — |
| S2 | Add info command for version and environment info | passed | 114bbc2c |

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `info` command that provides system and application details including version, operating system, processor architecture, and Go runtime version. The command returns data in JSON format without requiring authentication.

* **Tests**
  * Added unit tests to validate the new `info` command's functionality and output format.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/831)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->