### PR TITLE
test(update): isolate stamp writes from real ~/.lark-cli/skills.stamp

### DIFF
--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -168,6 +168,11 @@ func TestUpdateManual_Human(t *testing.T) {
 }
 
 func TestUpdateNpm_JSON(t *testing.T) {
+	// Isolate config dir: this test mocks fetchLatest="2.0.0" and lets
+	// runSkillsAndStamp → WriteStamp succeed, which without isolation would
+	// clobber the real ~/.lark-cli/skills.stamp with "2.0.0".
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
 	f, stdout, _ := newTestFactory(t)
 	cmd := NewCmdUpdate(f)
 	cmd.SetArgs([]string{"--json"})
@@ -195,6 +200,9 @@ func TestUpdateNpm_JSON(t *testing.T) {
 }
 
 func TestUpdateNpm_Human(t *testing.T) {
+	// Same isolation as TestUpdateNpm_JSON — see comment there.
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
 	f, _, stderr := newTestFactory(t)
 	cmd := NewCmdUpdate(f)
 	cmd.SetArgs([]string{})
@@ -222,6 +230,9 @@ func TestUpdateNpm_Human(t *testing.T) {
 }
 
 func TestUpdateForce_JSON(t *testing.T) {
+	// Same stamp-isolation rationale as TestUpdateNpm_JSON.
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
 	f, stdout, _ := newTestFactory(t)
 	cmd := NewCmdUpdate(f)
 	cmd.SetArgs([]string{"--force", "--json"})
@@ -312,6 +323,9 @@ func TestUpdateInvalidVersion_JSON(t *testing.T) {
 }
 
 func TestUpdateDevVersion_JSON(t *testing.T) {
+	// Same stamp-isolation rationale as TestUpdateNpm_JSON.
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
 	f, stdout, _ := newTestFactory(t)
 	cmd := NewCmdUpdate(f)
 	cmd.SetArgs([]string{"--json"})
@@ -629,6 +643,9 @@ func TestPermissionHint(t *testing.T) {
 
 func TestUpdateWindows_NpmSuccess_JSON(t *testing.T) {
 	// With the rename trick, Windows npm installs can now auto-update.
+	// Same stamp-isolation rationale as TestUpdateNpm_JSON.
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
 	f, stdout, _ := newTestFactory(t)
 	cmd := NewCmdUpdate(f)
 	cmd.SetArgs([]string{"--json"})


### PR DESCRIPTION
## Summary
- Five tests in `cmd/update/update_test.go` mocked `SkillsUpdateOverride` to return success and let `runSkillsAndStamp` call `WriteStamp`, but did **not** isolate `LARKSUITE_CLI_CONFIG_DIR`. Each run clobbered the real `~/.lark-cli/skills.stamp` with the mocked version (\`"2.0.0"\` or \`"1.0.0"\`), causing `skillscheck.Init` to fire a misleading drift notice (\`lark-cli skills X out of sync with binary Y\`) on every subsequent invocation.
- Patch: add \`t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())\` at the top of:
  - \`TestUpdateNpm_JSON\` (writes \`"2.0.0"\`)
  - \`TestUpdateNpm_Human\` (writes \`"2.0.0"\`)
  - \`TestUpdateForce_JSON\` (writes \`"1.0.0"\`)
  - \`TestUpdateDevVersion_JSON\` (writes \`"1.0.0"\`)
  - \`TestUpdateWindows_NpmSuccess_JSON\` (writes \`"2.0.0"\`)
- Scope intentionally limited to tests that mock \`SkillsUpdateOverride\` to success. Tests that invoke real \`npx\` are pre-existing slow/network behavior, out of scope here.

## Test plan
- [x] \`go test ./cmd/update/ -run '^(TestUpdateNpm_JSON|TestUpdateNpm_Human|TestUpdateForce_JSON|TestUpdateDevVersion_JSON|TestUpdateWindows_NpmSuccess_JSON)\$' -v\` — all 5 pass in <10ms each
- [x] Verified \`~/.lark-cli/skills.stamp\` not mutated after run
- [x] \`go vet ./cmd/update/...\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by configuring temporary directories for configuration storage, preventing tests from affecting real user configuration files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/858)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->