### PR TITLE
docs(im): warn against fabricating chat URLs from chat_id

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -51,6 +51,15 @@ When using bot identity (`--as bot`) to fetch messages (e.g. `+chat-messages-lis
 
 Card messages (`interactive` type) are not yet supported for compact conversion in event subscriptions. The raw event data will be returned instead, with a hint printed to stderr.
 
+### Sharing Chats / Generating Chat URLs
+
+Group share links must come from `chats.link`. **Never hand-construct `applink.feishu.cn/...?chatId=oc_xxx` style URLs from a `chat_id`** — they don't navigate. The API returns a tenant-specific join link (host varies); pass it through as-is.
+
+```bash
+lark-cli im chats link --params '{"chat_id":"oc_xxx"}'
+# default 7-day validity; pass --data '{"validity_period":"year"|"permanently"}' to extend
+```
+
 ### Flag Types
 
 Flags support two layers:

--- a/skills/lark-im/references/lark-im-chat-search.md
+++ b/skills/lark-im/references/lark-im-chat-search.md
@@ -87,6 +87,15 @@ CHAT_ID=$(lark-cli im +chat-search --query "daily report" --format json | jq -r 
 lark-cli im +messages-send --chat-id "$CHAT_ID" --text "Today's progress update"
 ```
 
+### Scenario 4: Search a chat and get its share link
+
+```bash
+CHAT_ID=$(lark-cli im +chat-search --query "alert group" --format json | jq -r '.data.chats[0].chat_id')
+lark-cli im chats link --params "{\"chat_id\":\"$CHAT_ID\"}"
+```
+
+Never hand-build `applink.feishu.cn/...?chatId=oc_xxx` URLs — see [SKILL.md](../SKILL.md#sharing-chats--generating-chat-urls).
+
 ## Common Errors and Troubleshooting
 
 | Symptom | Root Cause | Solution |


### PR DESCRIPTION
## Summary

- Add **Sharing Chats / Generating Chat URLs** note in `skills/lark-im/SKILL.md`: group share links must come from `chats.link`; never hand-build `applink.feishu.cn/...?chatId=oc_xxx` style URLs from a `chat_id` (they don't navigate).
- Add **Scenario 4** in `skills/lark-im/references/lark-im-chat-search.md` linking `+chat-search` -> `chats.link` and pointing back to the SKILL.md note.

Motivation: a recent postmortem ([Bytedance docx NwTcdGd...](https://bytedance.larkoffice.com/docx/NwTcdGd96oSxtIxWH0ecYuOcnSh)) captured an Agent fabricating `applink.feishu.cn/client/chat/chatter?chatId=oc_xxx` URLs for group sharing. The links looked plausible but did not navigate. There was nothing in the skill telling the model "go to `chats.link`, don't invent URLs" -- so the same trap was easy to walk back into. These two short additions close that gap. The `chats.link` host is tenant-specific, so it is not hard-coded in docs or examples.

## Test plan

- [ ] Render `skills/lark-im/SKILL.md` and confirm the new section sits between *Card Messages* and *Flag Types*.
- [ ] Render `skills/lark-im/references/lark-im-chat-search.md` and confirm Scenario 4 follows Scenario 3 with a working anchor link back to SKILL.md.
- [ ] No code changes -- existing tests unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Documentation**
  * Added guidance on correctly generating and sharing chat links using supported methods
  * Included warning against manually constructing chat URLs
  * Added example workflow for searching chats and retrieving their share links

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/861)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->