### PR TITLE
docs(lark-im): clarify message activity search

### DIFF
--- a/skills/lark-im/references/lark-im-chat-messages-list.md
+++ b/skills/lark-im/references/lark-im-chat-messages-list.md
@@ -135,6 +135,12 @@ lark-cli api GET /open-apis/im/v1/messages \
 4. **For time ranges:** both ISO 8601 and date-only inputs are supported. Date-only is usually simpler.
 5. **For full content:** table output truncates content. Use `--format json` when you need the complete message body.
 6. **For sender info:** the command already resolves sender names, so you do not need a separate lookup.
+7. **Application/bot identity + named group history:** If the user says "使用应用身份/以 bot 身份" and asks to list or read historical messages for a named group, use bot identity for both steps:
+   ```bash
+   lark-cli im +chat-search --as bot --query "<chat name keyword>" --format json
+   lark-cli im +chat-messages-list --as bot --chat-id <chat_id> --page-size 50 --format json
+   ```
+   Do not use `im +messages-search --as bot`; `+messages-search` is user-only. Continue with `--page-token` if `has_more=true`.
 
 ## References
 

--- a/skills/lark-im/references/lark-im-messages-search.md
+++ b/skills/lark-im/references/lark-im-messages-search.md
@@ -156,6 +156,19 @@ Use `im +messages-resources-download` if you need to fetch the underlying image 
 
 ## AI Usage Guidance
 
+### Query boundary for activity review
+
+Use `--query` only for real message keywords. If the user asks for activity review such as "最近一周我和哪些 Bot 有过交互" or "整理我和某人的聊天记录", and the useful constraints are sender type, chat, person, or time range, keep `--query ""` and rely on those filters. Do not put generic instruction words such as "看看", "总结", "交互内容", or "聊天记录" into `--query`; those words often over-constrain message search and hide the relevant messages.
+
+```bash
+# Review recent bot interactions without forcing a keyword
+lark-cli im +messages-search --query "" --sender-type bot --start "<YYYY-MM-DDT00:00:00+08:00>" --end "<YYYY-MM-DDT23:59:59+08:00>" --page-all --format json
+```
+
+Replace the time placeholders at execution time. For example, "最近一周" means computing the start date and end date from the current day before running the command; do not copy date literals from this reference into answers for relative requests.
+
+For activity summaries, validate evidence by message IDs and chat context. The final answer should cite or retain the `message_id`, sender, chat, and create time for each important item. If the row's source data contains concrete `om_...` message IDs or `ou_...` user IDs, treat those IDs as strong recall targets during verification; do not rely only on a high-level keyword match.
+
 ### Resolving chat_id from a chat name
 
 When the user refers to a chat by name and you need its `chat_id` for the `--chat-id` filter, use [`+chat-search`](lark-im-chat-search.md) first:

--- a/skills/lark-im/references/lark-im-messages-search.md
+++ b/skills/lark-im/references/lark-im-messages-search.md
@@ -160,6 +160,8 @@ Use `im +messages-resources-download` if you need to fetch the underlying image 
 
 Use `--query` only for real message keywords. If the user asks for activity review such as "最近一周我和哪些 Bot 有过交互" or "整理我和某人的聊天记录", and the useful constraints are sender type, chat, person, or time range, keep `--query ""` and rely on those filters. Do not put generic instruction words such as "看看", "总结", "交互内容", or "聊天记录" into `--query`; those words often over-constrain message search and hide the relevant messages.
 
+This guidance applies only when using user identity. `im +messages-search` is user-only; if the user explicitly asks for application/bot identity, do not try `--as bot`. For bot identity with a named group and history/listing intent, resolve the group with `im +chat-search --as bot`, then list messages with `im +chat-messages-list --as bot --chat-id <chat_id>`.
+
 ```bash
 # Review recent bot interactions without forcing a keyword
 lark-cli im +messages-search --query "" --sender-type bot --start "<YYYY-MM-DDT00:00:00+08:00>" --end "<YYYY-MM-DDT23:59:59+08:00>" --page-all --format json


### PR DESCRIPTION
## Summary

- Clarify that message activity review should keep `--query ""` and rely on sender/chat/time filters.
- Replace fixed relative-date examples with runtime placeholders.
- Add message_id, sender, chat, and create-time evidence validation guidance.
- Keep this PR scoped to `skills/lark-im/**` only.

## Eval Signal

Runs:

- `tests/eval-search/runs/2026-05-12T06-14Z-multientity-sandbox-a970`
- `tests/eval-search/runs/2026-05-13Tfull-critical-info-sandbox`

Observed:

- The IM bot-interaction case needs empty-query activity review plus message_id/chat-context evidence validation.
- Source data may contain concrete `om_...` message IDs or `ou_...` user IDs; those should be treated as strong recall targets.

## Validation

- `git diff --check`
- PR diff is scoped to `skills/lark-im/**`.

Docs-only change; no unit tests were run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using bot identity when listing historical messages in group chats, including pagination instructions.
  * Added best practices for activity review searches with filter recommendations and identity constraint clarifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->