### PR TITLE
feat: recommend lark-cli update over npm install for AI agents

### DIFF
--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -252,7 +252,7 @@ func checkCLIUpdate() []checkResult {
 	if update.IsNewer(latest, current) {
 		return []checkResult{warn("cli_update",
 			fmt.Sprintf("%s → %s available", current, latest),
-			"run: lark-cli update (or: npm install -g @larksuite/cli)")}
+			"run: lark-cli update")}
 	}
 	return []checkResult{pass("cli_update", latest+" (up to date)")}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -140,6 +140,7 @@ func setupNotices() {
 				"current": info.Current,
 				"latest":  info.Latest,
 				"message": info.Message(),
+				"command": "lark-cli update",
 			}
 		}
 		if stale := skillscheck.GetPending(); stale != nil {
@@ -147,6 +148,7 @@ func setupNotices() {
 				"current": stale.Current,
 				"target":  stale.Target,
 				"message": stale.Message(),
+				"command": "lark-cli update",
 			}
 		}
 		if len(notice) == 0 {

--- a/cmd/root_integration_test.go
+++ b/cmd/root_integration_test.go
@@ -661,11 +661,17 @@ func TestSetupNotices_BothUpdateAndSkills(t *testing.T) {
 	if _, ok := notice["skills"].(map[string]interface{}); !ok {
 		t.Errorf("missing 'skills' key: %+v", notice)
 	}
-	upd := notice["update"].(map[string]interface{})
+	upd, ok := notice["update"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("notice.update missing or wrong type: %+v", notice)
+	}
 	if cmd, _ := upd["command"].(string); cmd != "lark-cli update" {
 		t.Errorf("notice.update.command = %q, want %q", cmd, "lark-cli update")
 	}
-	sk := notice["skills"].(map[string]interface{})
+	sk, ok := notice["skills"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("notice.skills missing or wrong type: %+v", notice)
+	}
 	if cmd, _ := sk["command"].(string); cmd != "lark-cli update" {
 		t.Errorf("notice.skills.command = %q, want %q", cmd, "lark-cli update")
 	}

--- a/cmd/root_integration_test.go
+++ b/cmd/root_integration_test.go
@@ -612,6 +612,9 @@ func TestSetupNotices_Drift(t *testing.T) {
 	if msg, _ := skills["message"].(string); msg != want {
 		t.Errorf("notice.skills.message = %q, want %q", msg, want)
 	}
+	if cmd, _ := skills["command"].(string); cmd != "lark-cli update" {
+		t.Errorf("notice.skills.command = %q, want %q", cmd, "lark-cli update")
+	}
 }
 
 // TestSetupNotices_BothUpdateAndSkills verifies the composed envelope
@@ -657,6 +660,14 @@ func TestSetupNotices_BothUpdateAndSkills(t *testing.T) {
 	}
 	if _, ok := notice["skills"].(map[string]interface{}); !ok {
 		t.Errorf("missing 'skills' key: %+v", notice)
+	}
+	upd := notice["update"].(map[string]interface{})
+	if cmd, _ := upd["command"].(string); cmd != "lark-cli update" {
+		t.Errorf("notice.update.command = %q, want %q", cmd, "lark-cli update")
+	}
+	sk := notice["skills"].(map[string]interface{})
+	if cmd, _ := sk["command"].(string); cmd != "lark-cli update" {
+		t.Errorf("notice.skills.command = %q, want %q", cmd, "lark-cli update")
 	}
 }
 

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -227,7 +227,7 @@ func doManualUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest stri
 	fmt.Fprintf(io.ErrOut, "To update manually, download the latest release:\n")
 	fmt.Fprintf(io.ErrOut, "  Release:   %s\n", releaseURL(latest))
 	fmt.Fprintf(io.ErrOut, "  Changelog: %s\n", changelogURL())
-	fmt.Fprintf(io.ErrOut, "\nOr install via npm:\n  npm install -g %s@%s\n", selfupdate.NpmPackage, latest)
+	fmt.Fprintf(io.ErrOut, "\nOr install via npm (note: skills will not be synced):\n  npm install -g %s@%s\n", selfupdate.NpmPackage, latest)
 	emitSkillsTextHints(io, skillsResult)
 	return nil
 }
@@ -324,7 +324,7 @@ func verificationFailureHint(updater *selfupdate.Updater, latest string) string 
 	if updater.CanRestorePreviousVersion() {
 		return "the previous version has been restored"
 	}
-	return fmt.Sprintf("automatic rollback is unavailable on this platform; reinstall manually: npm install -g %s@%s, or download %s", selfupdate.NpmPackage, latest, releaseURL(latest))
+	return fmt.Sprintf("automatic rollback is unavailable on this platform; reinstall manually (skills will not be synced): npm install -g %s@%s, or download %s; to sync skills afterward, run: lark-cli update", selfupdate.NpmPackage, latest, releaseURL(latest))
 }
 
 // runSkillsAndStamp triggers updater.RunSkillsUpdate and persists the

--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -227,7 +227,7 @@ func doManualUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest stri
 	fmt.Fprintf(io.ErrOut, "To update manually, download the latest release:\n")
 	fmt.Fprintf(io.ErrOut, "  Release:   %s\n", releaseURL(latest))
 	fmt.Fprintf(io.ErrOut, "  Changelog: %s\n", changelogURL())
-	fmt.Fprintf(io.ErrOut, "\nOr install via npm (note: skills will not be synced):\n  npm install -g %s@%s\n", selfupdate.NpmPackage, latest)
+	fmt.Fprintf(io.ErrOut, "\nOr install via npm (note: skills will not be synced):\n  npm install -g %s@%s\n  npx skills add larksuite/cli -y -g   # sync skills separately\n", selfupdate.NpmPackage, latest)
 	emitSkillsTextHints(io, skillsResult)
 	return nil
 }
@@ -324,7 +324,7 @@ func verificationFailureHint(updater *selfupdate.Updater, latest string) string 
 	if updater.CanRestorePreviousVersion() {
 		return "the previous version has been restored"
 	}
-	return fmt.Sprintf("automatic rollback is unavailable on this platform; reinstall manually (skills will not be synced): npm install -g %s@%s, or download %s; to sync skills afterward, run: lark-cli update", selfupdate.NpmPackage, latest, releaseURL(latest))
+	return fmt.Sprintf("automatic rollback is unavailable on this platform; reinstall manually (skills will not be synced): npm install -g %s@%s && npx skills add larksuite/cli -y -g, or download %s", selfupdate.NpmPackage, latest, releaseURL(latest))
 }
 
 // runSkillsAndStamp triggers updater.RunSkillsUpdate and persists the

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -484,8 +484,8 @@ func TestUpdateNpmVerifyFail_JSON_NoRestoreHintWhenBackupUnavailable(t *testing.
 	if !strings.Contains(out, "skills will not be synced") {
 		t.Errorf("expected skills-not-synced warning in rollback hint, got: %s", out)
 	}
-	if !strings.Contains(out, "lark-cli update") {
-		t.Errorf("expected lark-cli update hint for skills sync, got: %s", out)
+	if !strings.Contains(out, "npx skills add larksuite/cli -y -g") {
+		t.Errorf("expected npx skills add hint for skills sync, got: %s", out)
 	}
 }
 

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -481,6 +481,12 @@ func TestUpdateNpmVerifyFail_JSON_NoRestoreHintWhenBackupUnavailable(t *testing.
 	if !strings.Contains(out, "npm install -g @larksuite/cli@2.0.0") {
 		t.Errorf("expected manual reinstall command in hint, got: %s", out)
 	}
+	if !strings.Contains(out, "skills will not be synced") {
+		t.Errorf("expected skills-not-synced warning in rollback hint, got: %s", out)
+	}
+	if !strings.Contains(out, "lark-cli update") {
+		t.Errorf("expected lark-cli update hint for skills sync, got: %s", out)
+	}
 }
 
 func TestUpdateCheck_JSON_Npm(t *testing.T) {

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -86,13 +86,9 @@ lark-cli 命令执行后，如果检测到新版本，JSON 输出中会包含 `_
    ```bash
    lark-cli update
    ```
-3. 如果 `lark-cli update` 失败，再尝试 npm fallback（注意：skills 不会同步）：
-   ```bash
-   npm install -g @larksuite/cli && npx skills add larksuite/cli -g -y
-   ```
-4. 更新完成后提醒用户：**退出并重新打开 AI Agent** 以加载最新 Skills
+3. 更新完成后提醒用户：**退出并重新打开 AI Agent** 以加载最新 Skills
 
-**重要**：不要直接使用 `npm install` 更新，它不会同步 AI Skills。始终优先使用 `lark-cli update`。
+**重要**：始终使用 `lark-cli update` 更新，它会同时更新 CLI 和 AI Skills。
 
 **规则**：不要静默忽略更新提示。即使当前任务与更新无关，也应在完成用户请求后补充告知。
 

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-shared
 version: 1.0.0
-description: "飞书/Lark CLI 共享基础：应用配置初始化、认证登录（auth login）、身份切换（--as user/bot）、权限与 scope 管理、Permission denied 错误处理、安全规则。当用户需要第一次配置(`lark-cli config init`)、使用登录授权(`lark-cli auth login`)、遇到权限不足、切换 user/bot 身份、配置 scope、或首次使用 lark-cli 时触发。"
+description: "Use when first setting up lark-cli, running auth login, switching user/bot identity (--as), handling permission denied or scope errors, needing to update lark-cli, or seeing _notice in JSON output."
 ---
 
 # lark-cli 共享规则
@@ -82,11 +82,17 @@ lark-cli 命令执行后，如果检测到新版本，JSON 输出中会包含 `_
 **当你在输出中看到 `_notice.update` 时，完成用户当前请求后，主动提议帮用户更新**：
 
 1. 告知用户当前版本和最新版本号
-2. 提议执行更新（CLI 和 Skills 需要同时更新）：
+2. 提议执行更新（同时更新 CLI 和 Skills）：
    ```bash
-   npm update -g @larksuite/cli && npx skills add larksuite/cli -g -y
+   lark-cli update
    ```
-3. 更新完成后提醒用户：**退出并重新打开 AI Agent**以加载最新 Skills
+3. 如果 `lark-cli update` 失败，再尝试 npm fallback（注意：skills 不会同步）：
+   ```bash
+   npm install -g @larksuite/cli && npx skills add larksuite/cli -g -y
+   ```
+4. 更新完成后提醒用户：**退出并重新打开 AI Agent** 以加载最新 Skills
+
+**重要**：不要直接使用 `npm install` 更新，它不会同步 AI Skills。始终优先使用 `lark-cli update`。
 
 **规则**：不要静默忽略更新提示。即使当前任务与更新无关，也应在完成用户请求后补充告知。
 


### PR DESCRIPTION
## Summary

AI agents seeing update notices would run `npm install -g @larksuite/cli` directly, which doesn't sync skills. This PR makes `lark-cli update` the sole recommended update command across all user/AI-facing outputs, demoting `npm install` to an explicit fallback with a "skills will not be synced" warning.

## Changes

- Rewrite `skills/lark-shared/SKILL.md` frontmatter description to pure trigger conditions (skill writing best practices) and update section to recommend `lark-cli update` first, npm as fallback
- Add `"command": "lark-cli update"` field to `_notice.update` and `_notice.skills` JSON in `cmd/root.go`
- Remove npm alternative from doctor hint in `cmd/doctor/doctor.go`
- Add "skills will not be synced" warning to manual update and rollback hint paths in `cmd/update/update.go`

## Test Plan

- [x] `make unit-test` passed
- [x] validate passed (build + vet + unit + integration + convention guard)
- [x] skipped: local-eval E2E (lite mode, no existing E2E for update/doctor domain)
- [x] acceptance-reviewer passed (2/2 cases: _notice command field verification + SKILL.md AI readability)
- [x] manual verification: built binary with simulated update+skills drift, confirmed `_notice.update.command == "lark-cli update"` and `_notice.skills.command == "lark-cli update"` in JSON output; confirmed `lark-cli doctor` shows `"run: lark-cli update"` without npm mention

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified CLI update guidance to recommend `lark-cli update` only
  * Clarified that npm-based installation does not synchronize skills
  * Enhanced error messages with explicit skills synchronization instructions
  * Update notices now include an explicit `lark-cli update` command hint in their payloads

* **Documentation**
  * Updated setup guide with clearer update workflow, restart reminder, and npm limitations

* **Tests**
  * Expanded tests to cover update and skills synchronization notices and payload contents

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/884)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->