### PR TITLE
feat(install): skip interactive prompts in non-TTY environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,7 @@ Choose **one** of the following methods:
 **Option 1 — From npm (recommended):**
 
 ```bash
-# Install CLI
-npm install -g @larksuite/cli
-
-# Install CLI SKILL (required)
-npx skills add larksuite/cli -y -g
+npx @larksuite/cli@latest install
 ```
 
 **Option 2 — From source:**
@@ -102,11 +98,7 @@ lark-cli calendar +agenda
 **Step 1 — Install**
 
 ```bash
-# Install CLI
-npm install -g @larksuite/cli
-
-# Install CLI SKILL (required)
-npx skills add larksuite/cli -y -g
+npx @larksuite/cli@latest install
 ```
 
 **Step 2 — Configure app credentials**

--- a/README.zh.md
+++ b/README.zh.md
@@ -62,11 +62,7 @@
 **方式一 — 从 npm 安装（推荐）：**
 
 ```bash
-# 安装 CLI
-npm install -g @larksuite/cli
-
-# 安装 CLI SKILL（必需）
-npx skills add larksuite/cli -y -g
+npx @larksuite/cli@latest install
 ```
 
 **方式二 — 从源码安装：**
@@ -102,11 +98,7 @@ lark-cli calendar +agenda
 **第 1 步 — 安装**
 
 ```bash
-# 安装 CLI
-npm install -g @larksuite/cli
-
-# 安装 CLI SKILL（必需）
-npx skills add larksuite/cli -y -g
+npx @larksuite/cli@latest install
 ```
 
 **第 2 步 — 配置应用凭证**

--- a/scripts/install-wizard.js
+++ b/scripts/install-wizard.js
@@ -44,6 +44,7 @@ const messages = {
     step4Fail:      "授权失败。运行以下命令重试: lark-cli auth login",
     done:           "安装完成！\n可以和你的 AI 工具（如 Claude Code、Trae等）说：\"飞书/Lark CLI 能帮我做什么？结合我的情况推荐一下从哪里开始\"",
     cancelled:      "安装已取消",
+    nonTtyHint:     "要完成配置，请在终端中运行：\n  lark-cli config init --new\n  lark-cli auth login",
   },
   en: {
     setup:          "Setting up Feishu/Lark CLI...",
@@ -72,6 +73,7 @@ const messages = {
     step4Fail:      "Failed to authorize. Run lark-cli auth login to retry",
     done:           "You are all set!\nNow try asking your AI tool (Claude Code, Trae, etc.): \"What can Feishu/Lark CLI help me with, and where should I start?\"",
     cancelled:      "Installation cancelled",
+    nonTtyHint:     "To complete setup, run interactively:\n  lark-cli config init --new\n  lark-cli auth login",
   },
 };
 
@@ -353,17 +355,23 @@ async function stepAuthLogin(msg) {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const lang = await stepSelectLang();
+  const isInteractive = !!process.stdin.isTTY;
+  const lang = isInteractive ? await stepSelectLang() : (parseLangArg() || "en");
   const msg = messages[lang];
 
-  p.intro(msg.setup);
-
-  await stepInstallGlobally(msg);
-  await stepInstallSkills(msg);
-  await stepConfigInit(msg, lang);
-  await stepAuthLogin(msg);
-
-  p.outro(msg.done);
+  if (isInteractive) {
+    p.intro(msg.setup);
+    await stepInstallGlobally(msg);
+    await stepInstallSkills(msg);
+    await stepConfigInit(msg, lang);
+    await stepAuthLogin(msg);
+    p.outro(msg.done);
+  } else {
+    console.log(msg.setup);
+    await stepInstallGlobally(msg);
+    await stepInstallSkills(msg);
+    console.log(msg.nonTtyHint);
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

When AI tools (Claude Code, Trae, etc.) run `npx @larksuite/cli install`, the interactive prompts block because stdin is not a TTY. This PR detects `process.stdin.isTTY` and skips interactive steps (language selection, config init, auth login) in non-TTY environments, running only the non-interactive install steps and printing hints for manual completion.

## Changes

- Add `nonTtyHint` i18n messages (zh/en) to `scripts/install-wizard.js`
- Rewrite `main()` in `scripts/install-wizard.js` to branch on `!!process.stdin.isTTY`: TTY path unchanged, non-TTY path skips interactive prompts and uses `console.log()` instead of `@clack/prompts`
- Simplify install instructions in `README.md` and `README.zh.md` to use `npx @larksuite/cli@latest install`

## Test Plan

- [x] `make unit-test` passed
- [x] validate passed
- [x] skipped: local-eval E2E (user instruction — JS script change, not Go CLI command)
- [x] acceptance-reviewer passed (5/5 cases: non-TTY default en, non-TTY --lang zh, invalid --lang fallback, --lang=value syntax, /dev/null redirect)
- [x] manual verification: `echo "" | node scripts/install-wizard.js` — non-interactive path taken, hints printed; `node scripts/install-wizard.js` — full interactive wizard runs

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions in English and Chinese documentation to use the simplified `npx @larksuite/cli@latest install` command

* **Chores**
  * Improved installation wizard to properly handle both interactive and non-interactive terminal environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/888)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->