### PR TITLE
fix(registry): wait for background meta refresh before test reset

### DIFF
--- a/internal/registry/remote.go
+++ b/internal/registry/remote.go
@@ -270,13 +270,6 @@ func triggerBackgroundRefresh() {
 	})
 }
 
-// waitBackgroundRefresh blocks until any in-flight background refresh started by
-// triggerBackgroundRefresh has finished. Tests use this via resetInit to avoid
-// races with package-level globals (configuredBrand, testMetaURL, etc.).
-func waitBackgroundRefresh() {
-	bgRefreshInFlight.Wait()
-}
-
 func doBackgroundRefresh() {
 	defer func() { _ = recover() }()
 	meta, _ := loadCacheMeta()

--- a/internal/registry/remote.go
+++ b/internal/registry/remote.go
@@ -255,12 +255,26 @@ func doSyncFetch() {
 
 // --- background refresh ---
 
-var refreshOnce sync.Once
+var (
+	refreshOnce       sync.Once
+	bgRefreshInFlight sync.WaitGroup // tracks doBackgroundRefresh goroutines for test teardown (resetInit)
+)
 
 func triggerBackgroundRefresh() {
 	refreshOnce.Do(func() {
-		go doBackgroundRefresh()
+		bgRefreshInFlight.Add(1)
+		go func() {
+			defer bgRefreshInFlight.Done()
+			doBackgroundRefresh()
+		}()
 	})
+}
+
+// waitBackgroundRefresh blocks until any in-flight background refresh started by
+// triggerBackgroundRefresh has finished. Tests use this via resetInit to avoid
+// races with package-level globals (configuredBrand, testMetaURL, etc.).
+func waitBackgroundRefresh() {
+	bgRefreshInFlight.Wait()
 }
 
 func doBackgroundRefresh() {

--- a/internal/registry/remote_test.go
+++ b/internal/registry/remote_test.go
@@ -17,6 +17,13 @@ import (
 	"github.com/larksuite/cli/internal/core"
 )
 
+// waitBackgroundRefresh blocks until any in-flight background refresh started by
+// triggerBackgroundRefresh has finished. Lives in this _test file so production
+// binaries cannot call it and accidentally block on test teardown state.
+func waitBackgroundRefresh() {
+	bgRefreshInFlight.Wait()
+}
+
 // resetInit resets the package-level state so each test starts fresh.
 func resetInit() {
 	// Must wait: a prior test's Init() may have started doBackgroundRefresh which

--- a/internal/registry/remote_test.go
+++ b/internal/registry/remote_test.go
@@ -19,6 +19,9 @@ import (
 
 // resetInit resets the package-level state so each test starts fresh.
 func resetInit() {
+	// Must wait: a prior test's Init() may have started doBackgroundRefresh which
+	// reads globals this function mutates (see CI race: TestComputeMinimumScopeSet → Tenant).
+	waitBackgroundRefresh()
 	initOnce = sync.Once{}
 	mergedServices = make(map[string]map[string]interface{})
 	mergedProjectList = nil


### PR DESCRIPTION
## Summary
Fixes a **data race** in `internal/registry` tests that caused **`go test -race`** (coverage CI job) to fail intermittently.

## Root cause
- `TestComputeMinimumScopeSet` calls `Init()` → `triggerBackgroundRefresh()`, which starts `doBackgroundRefresh` in a goroutine.
- The next test, `TestComputeMinimumScopeSet_Tenant`, calls `resetInit()` while that goroutine can still be running `fetchRemoteMerged` / `remoteMetaURL` and **reading** package-level globals that `resetInit()` **writes** → race under `-race`.

This is unrelated to doc-only PRs (e.g. #891); it is test-isolation / lifecycle hygiene.

## Change
- Wrap the background refresh goroutine in `sync.WaitGroup` (`bgRefreshInFlight`).
- At the start of test helper `resetInit()`, call `waitBackgroundRefresh()` before mutating globals.

## Verification
```bash
go test -race -count=3 ./internal/registry/... -run 'TestComputeMinimumScopeSet'
go test -race ./internal/registry/...
```

## Review
Per team thread: **@Codex** code owner review; cross-check welcome on test/race narrative.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background refresh initialization to reliably track in-flight work and avoid race conditions during reinitialization.

* **Tests**
  * Added test synchronization to wait for background refresh completion before resetting state, improving test stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/894)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->