### PR TITLE
docs: add svg whiteboard support to doc v2 skill

### DIFF
--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: lark-doc
-version: 2.0.0
-description: "飞书云文档 / Docx / 知识库 Wiki 文档（v2）：创建、打开、读取、获取、查看、总结、整理、改写、翻译、审阅和编辑飞书文档内容。当用户给出飞书文档 URL/token，或说查看/读取/打开某个文档、提取文档内容、总结文档、生成/创建文档、追加/替换/删除/移动内容、调整排版、插入或下载文档图片/附件/素材/画板缩略图时使用。文档内容中出现嵌入电子表格、多维表格、画板、引用或同步块时，也先用本 skill 读取和提取 token，再切到对应 skill 下钻。使用本 skill 时，docs +create、docs +fetch、docs +update 必须携带 --api-version v2；默认使用 DocxXML，也支持 Markdown。"
+description: "飞书云文档 / Docx / 知识库 Wiki 文档（v2）：创建、打开、读取、获取、查看、总结、整理、改写、翻译、审阅和编辑飞书文档内容。当用户给出飞书文档 URL/token，或说查看/读取/打开某个文档、提取文档内容、总结文档、生成/创建文档、追加/替换/删除/移动内容、调整排版、插入或下载文档图片/附件/素材/画板缩略图时使用。文档内容中出现嵌入电子表格、多维表格、需要将重要信息可视化为画板（含 SVG 画板）、引用或同步块时，也先用本 skill 读取和提取 token，再切到对应 skill 下钻。使用本 skill 时，docs +create、docs +fetch、docs +update 必须携带 --api-version v2；默认使用 DocxXML，也支持 Markdown。"
 metadata:
   requires:
     bins: ["lark-cli"]
@@ -34,6 +33,8 @@ lark-cli docs +update --api-version v2 --doc "文档URL或token" --command appen
 
 ## 快速决策
 - 用户需要在文档内**创建、复制或移动**资源块（画板、电子表格、多维表格等）时，必须先读取 [`lark-doc-xml.md`](references/lark-doc-xml.md) 的「三、资源块」章节
+- 写文档时，重要信息（核心流程、架构、对比、风险、路线图、关键指标、因果关系）优先规划为画板，不要只用文字或表格承载
+- 新增画板必须隔离到 SubAgent：简单图由 SubAgent 直接插入 `<whiteboard type="svg">完整 SVG</whiteboard>`，不读 `lark-whiteboard`；复杂图才由主 Agent 先建 `<whiteboard type="blank"></whiteboard>`，再启动 SubAgent 读取 `lark-whiteboard` 写入
 - 用户说"看一下文档里的图片/附件/素材""预览素材" → 用 `lark-cli docs +media-preview`
 - 用户明确说"下载素材" → 用 `lark-cli docs +media-download`
 - 如果目标是画板/whiteboard/画板缩略图 → 只能用 `lark-cli docs +media-download --type whiteboard`（不要用 `+media-preview`）

--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -221,7 +221,7 @@ lark-cli docs +update --api-version v2 --doc "<doc_id>" --command str_replace \
 
 ## 画板处理
 
-> **`docs +update` 不能直接编辑已有画板的内容。** 本命令只能**新增**画板块；要修改已有画板，先用 `docs +fetch --api-version v2` 取到 `<whiteboard token="...">`，再切到 [`lark-whiteboard`](../../lark-whiteboard/SKILL.md) 用 `whiteboard +update` 写入。
+> **`docs +update` 不能直接编辑已有画板的内容。** 本命令只能**新增**画板块；要修改已有画板，先用 `docs +fetch --api-version v2` 取到 `<whiteboard token="...">`，再按 [`lark-doc-whiteboard.md`](lark-doc-whiteboard.md) 启动 SubAgent 读取 [`lark-whiteboard`](../../lark-whiteboard/SKILL.md) 并写入。
 
 画板的语法选型与插入示例见 [`lark-doc-style.md`](style/lark-doc-style.md) 的「画板语法与插入」章节。
 

--- a/skills/lark-doc/references/lark-doc-whiteboard.md
+++ b/skills/lark-doc/references/lark-doc-whiteboard.md
@@ -6,46 +6,79 @@
 
 | Skill | 核心职责 | 约束 |
 |------|------|------|
-| `lark-doc` | 文档内容读取/更新、插入空白画板占位、获取 board_token | 不能直接编辑画板内容；`docs +update` 的画板能力仅限插入空白占位 |
-| `lark-whiteboard` | 查询/导出画板（+query）；图表内容生成（Mermaid/DSL/SVG 路由、场景选型、渲染验证）；写入画板（+update） | 图表内容生成由此 skill 完整执行，不依赖外部调度 |
+| `lark-doc` | 识别画板机会、判断简单/复杂、调度 SubAgent、插入简单 SVG 画板或复杂空白画板 | 主 Agent 不直接创作画板内容；简单图不需要读取 `lark-whiteboard` |
+| `lark-whiteboard` | 查询/导出已有画板；复杂图表生成（Mermaid/DSL/SVG 路由、场景选型、渲染验证）；写入已有/空白画板 | 仅复杂图或已有画板更新时由独立 SubAgent 读取 |
+
+## 画板优先规则
+
+写文档时，重要信息优先画板化。遇到核心流程、系统架构、方案对比、风险链路、里程碑、指标趋势、因果归因、组织关系、能力分层等内容，不要只用段落或表格承载；除非内容只是一次性补充说明，否则应规划为画板。
+
+同一篇文档可以有多个画板。优先多个聚焦画板，而不是把所有信息塞进一张大图。
 
 ## 文档与画板协同流程
 
-### 步骤 1：判断场景
+### 步骤 1：识别画板机会
 
 | 场景 | 入口 |
 |------|------|
-| 文档中需要插入新画板 | 继续步骤 2 |
-| 已有画板需要更新内容 | 先 `docs +fetch --api-version v2` 获取 `board_token`，跳至步骤 3 |
+| 文档中需要插入简单新画板 | 走步骤 2A |
+| 文档中需要插入复杂新画板 | 走步骤 2B |
+| 已有画板需要更新内容 | 先 `docs +fetch --api-version v2` 获取 `board_token`，跳至步骤 3B |
 | 只查看 / 下载已有画板 | 切换至 `lark-whiteboard`，不走本流程 |
 
-### 步骤 2：在文档中创建空白画板
+简单图判定：节点少、静态、布局可控、适合一个完整自包含 SVG 表达，例如小型流程、2-3 方对比、小型状态机、简单时间线或小型示意图。
 
-- 创建场景：`docs +create`；编辑场景：`docs +update`
-- markdown 中使用 `<whiteboard type="blank"></whiteboard>`（不要转义）
-- 多个画板时，在相应的地方插入各自的 whiteboard 标签
-- 从响应的 `data.board_tokens` 中读取 token 列表
+复杂图判定：节点多、跨泳道/跨系统、需要自动布局或精细排版、包含数据图表、组织架构、复杂架构、复杂依赖、已有画板更新，或需要 `lark-whiteboard` 的渲染验证。
 
-### 步骤 3：生成并写入画板内容
+### 步骤 2A：简单图 — SubAgent 直接插入 SVG 画板
 
-读取 [`../../lark-whiteboard/SKILL.md`](../../lark-whiteboard/SKILL.md)，跳至"渲染 & 写入画板"章节，按其完整流程为每个 board_token 生成并写入图表内容。
+主 Agent 启动 SubAgent，让它用 `docs +create --api-version v2` / `docs +update --api-version v2` 插入：
 
-多个画板时依次处理，每个画板完成后再处理下一个。
+```xml
+<whiteboard type="svg"><svg ...>...</svg></whiteboard>
+```
+
+简单图 SubAgent 的最小上下文：
+- doc token、插入位置（标题 / block_id / command）
+- 图表目标、受众、源段落或数据
+- 要求读取 `lark-doc-xml.md`；不需要读取 `lark-whiteboard`
+- SVG 必须完整自包含：包含 `<svg>` 根节点和 `viewBox`，不引用外部图片、脚本、远程资源
+
+### 步骤 2B：复杂图 — 先创建空白画板
+
+- 主 Agent 使用 `docs +create --api-version v2` / `docs +update --api-version v2` 插入 `<whiteboard type="blank"></whiteboard>`。
+- 从 v2 响应的 `data.document.new_blocks[]` 中读取 `block_type == "whiteboard"` 的 `block_token` 作为 board_token。
+
+### 步骤 3B：复杂图或已有画板 — 启动 lark-whiteboard SubAgent
+
+复杂图和已有画板更新必须启动 SubAgent。主 Agent 只传最小上下文，不直接执行 `lark-whiteboard` 的渲染和写入流程。
+
+复杂图 SubAgent 的最小上下文：
+- board_token
+- 图表目标、推荐画板类型、受众
+- 与图表直接相关的源段落或数据
+- 要求读取 [`../../lark-whiteboard/SKILL.md`](../../lark-whiteboard/SKILL.md)，按其完整流程写入该 board_token
+
+多个画板互不依赖时，可并行启动多个 SubAgent；每个 SubAgent 只负责一个画板或一个 SVG 插入点，不要互相复用上下文。
 
 ### 步骤 4：完成校验
 
-- 确认每个 token 对应的画板都已填充真实内容
-- 不保留空白占位画板；只有空白画板而无内容视为任务未完成
+- 简单 SVG：确认插入的是 `<whiteboard type="svg">`，且内容是完整 `<svg ...>...</svg>`
+- 复杂画板：确认每个 token 对应的画板都已填充真实内容
+- 不保留空白占位画板；复杂路径只有空白画板而无内容视为任务未完成
 
 ---
 
 ## 语义与画板类型映射
 
+下表用于帮助主 Agent 判断简单/复杂路径，并给 SubAgent 指定推荐画板类型。
+
 | 语义 | 画板类型 |
 |------|------|
-| 架构/分层/技术方案/模块依赖/调用关系 | 架构图 |
-| 流程/审批/部署/业务流转/状态机 | 流程图 |
-| 跨角色流程/跨系统交互/端到端链路 | 泳道图 |
+| 小型流程/状态机/简单时间线/小型对比/小型示意图 | SVG 画板（简单路径） |
+| 架构/分层/技术方案/模块依赖/调用关系 | 架构图（复杂路径） |
+| 流程/审批/部署/业务流转/状态机 | 流程图（按复杂度分流） |
+| 跨角色流程/跨系统交互/端到端链路 | 泳道图（复杂路径） |
 | 组织/层级/汇报关系 | 组织架构图 |
 | 时间线/里程碑/版本规划 | 里程碑图 |
 | 因果/复盘/根因分析 | 鱼骨图 |
@@ -56,6 +89,7 @@
 | 转化漏斗/销售漏斗 | 漏斗图 |
 | 分类梳理/知识体系/思维导图/时序图/类图 | Mermaid |
 | 数据分布/占比/饼图 | Mermaid |
+| 简单自定义图形/小型 SVG 示意图 | SVG 画板（简单路径） |
 | 柱状图/条形图/数据对比 | 柱状图 |
 | 折线图/趋势图/时序数据 | 折线图 |
 

--- a/skills/lark-doc/references/lark-doc-xml.md
+++ b/skills/lark-doc/references/lark-doc-xml.md
@@ -15,7 +15,7 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
 |-|-|-|
 | `<callout>` | 高亮框，子块仅支持文本、标题、列表、待办、引用 | `emoji`(默认 bulb), `background-color`, `border-color`, `text-color` |
 | `<grid>` + `<column>` | 分栏布局，各列 width-ratio 之和为 1 | `width-ratio` |
-| `<whiteboard>` | 嵌入画板 | `type`: `mermaid` \| `plantuml` \| `blank` |
+| `<whiteboard>` | 嵌入画板 | `type`: `blank` \| `mermaid` \| `plantuml` \| `svg` |
 | `<pre>` | （代码块，内含 `code`）| `lang`, `caption` |
 | `<figure>` | 视图容器 | `view-type` |
 | `<bookmark>` | 书签链接 | `<bookmark name="标题" href="https://..."></bookmark>`，必传 name 和 href |
@@ -41,7 +41,7 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
 文档中可嵌入外部资源块（属于容器标签的特殊形式），需要额外语法创建：
 
 - `<img>` — `<img href="https://..."/>` 上传网络图片
-- `<whiteboard>` — `<whiteboard type="blank"></whiteboard>` 空白；`<whiteboard type="mermaid|plantuml">内容</whiteboard>` 带内容；
+- `<whiteboard>` — 简单图由 SubAgent 直接插入 `<whiteboard type="svg">完整自包含 SVG</whiteboard>`；复杂图使用 `<whiteboard type="blank"></whiteboard>` 先创建空白画板，再按 [`lark-doc-whiteboard.md`](lark-doc-whiteboard.md) 启动 SubAgent 调用 `lark-whiteboard` 写入；
 - `<sheet>` — `<sheet type="blank"></sheet>` 空白；`<sheet sheet-id="SID" token="TOKEN"></sheet>` 复制已有
 - `<task>` — `<task task-id="GUID"></task>`，必传 task-id（任务 guid）
 - `<chat_card>` — `<chat_card chat-id="CHAT_ID"></chat_card>`，必传 chat-id

--- a/skills/lark-doc/references/style/lark-doc-create-workflow.md
+++ b/skills/lark-doc/references/style/lark-doc-create-workflow.md
@@ -19,7 +19,7 @@
 ### 第一波 — 规划与骨架（串行）
 
 1. 分析用户需求：受众、目的、范围
-2. 设计大纲——每个 h1/h2 章节至少规划 1 个非文本 block
+2. 设计大纲——每个 h1/h2 章节至少规划 1 个非文本 block；承载重要信息的章节优先规划画板
 3. `docs +create --api-version v2` **只建骨架**：标题 + 开头 `<callout>` + 各级标题 + 每节一句占位摘要
    - ⚠️ **不要**一次性把完整章节内容塞进 `--content`。超长 `--content` 容易触发字符/参数限制。
    - 完整内容留到第二波，由各 Agent 用 `docs +update --command append` 或 `block_insert_after` 分段写入。
@@ -35,11 +35,13 @@
 
 5. `docs +fetch --api-version v2 --detail with-ids` 获取文档，审查整体效果
 6. 评估样式达标（富 block 密度、元素多样性、连续 `<p>` 数量）
-7. **画板意图识别**：逐章节扫描，按 `lark-doc-style.md`「画板意图识别」表判断是否有段落适合用图表达。记录需要插图的章节及推荐的画板类型
+7. **画板意图识别**：逐章节扫描，按 `lark-doc-style.md`「画板意图识别」表判断是否有段落适合用图表达。重要信息优先画板化，记录需要插图的章节、推荐画板类型、简单/复杂路径和用于画图的源内容
 
-### 第四波 — 润色与图表（并行 Agent）
-8. Spawn Agent 定向改进：（结合 `lark-doc-style.md` 润色）
-   - **优先处理第三波识别出的画板需求**：简单图直接 `<whiteboard type="mermaid|plantuml">`，复杂图 spawn Agent 使用 **lark-whiteboard** skill
+### 第四波 — 画板与润色（并行 Agent）
+8. **优先处理第三波识别出的画板需求**：
+   - 简单图：启动 SVG SubAgent，直接插入 `<whiteboard type="svg">完整 SVG</whiteboard>`；不读取 **lark-whiteboard**
+   - 复杂图：主 Agent 先插入 `<whiteboard type="blank"></whiteboard>` 并提取 `block_token`，再为每个 `block_token` 启动 SubAgent 使用 **lark-whiteboard** skill 写入画板
+9. Spawn 内容改写 Agent 定向润色：
    - 文字密集章节转为 `<table>`/`<grid>`/`<callout>`
    - 主要章节间补充 `<hr/>`
    - 本地图片使用 `docs +media-insert` 插入
@@ -47,4 +49,8 @@
 
 ## Agent 子任务要求
 
-Spawn Agent 时必须提供：文档 token、章节范围（标题/block ID）、`lark-doc-xml.md` 和 `lark-doc-style.md` 路径、具体的 `docs +update` command 和 `--block-id`。
+内容改写 Agent 必须收到：文档 token、章节范围（标题/block ID）、`lark-doc-xml.md` 和 `lark-doc-style.md` 路径、具体的 `docs +update` command 和 `--block-id`。
+
+SVG SubAgent 必须收到：文档 token、插入位置（标题/block ID）、图表目标、源内容片段、`lark-doc-xml.md` 路径。它只负责插入一个 `<whiteboard type="svg">...</whiteboard>`，不改其他正文，也不读取 `lark-whiteboard`。
+
+复杂画板 SubAgent 必须收到：board_token、图表目标、推荐画板类型、源内容片段、[`../../../lark-whiteboard/SKILL.md`](../../../lark-whiteboard/SKILL.md) 路径。它只负责写入画板，不改文档正文。

--- a/skills/lark-doc/references/style/lark-doc-style.md
+++ b/skills/lark-doc/references/style/lark-doc-style.md
@@ -8,26 +8,29 @@
 2. **Front-load 结论**：文档以 `<callout>` 开头概括核心结论；每章节首段点明要旨
 3. **视觉节奏**：连续纯文本不超过 3 段；不同主题章节间用 `<hr/>` 分隔
 4. **最少惊讶**：同类信息使用同类元素，全篇风格统一
+5. **重要信息画板化**：核心流程、架构、对比、风险、路线图、指标趋势等重要信息优先使用画板表达
 
 ## 二、元素选择指南
 
-涉及图表需求时，简单图用 `<whiteboard type="mermaid/plantuml">` 内嵌，复杂图使用 **lark-whiteboard** skill。
+涉及图表需求时，先判定简单/复杂：简单图启动 SubAgent 直接插入 `<whiteboard type="svg">完整 SVG</whiteboard>`，不读取 **lark-whiteboard**；复杂图才使用空白画板 + **lark-whiteboard** SubAgent。
 
-| 场景 | 推荐方案 |
-|-|-|
-| 核心结论 / 摘要 / 注意事项 | `<callout>` + emoji + 背景色 |
-| 方案对比 / 优劣势 / Before vs After | `<grid>` 2 列分栏 |
-| 3+ 属性的结构化数据 / 指标表 | `<table>` + 表头背景色 |
-| 任务清单 / 检查项 | `<checkbox>` |
-| 代码片段 | `<pre lang="x" caption="说明">` |
-| 引用 / 公式 | `<blockquote>` / `<latex>` |
-| 操作入口 / 跳转链接 | `<button>` / `<a type="url-preview">` |
-| 简单流程图 / 时序图 / 状态机 / 甘特图 | `<whiteboard type="mermaid/plantuml">` |
-| 复杂架构图 / 数据图 / 思维导图 / 组织架构 | **lark-whiteboard** skill |
+| 场景 | 推荐方案                                                          |
+|-|---------------------------------------------------------------|
+| 核心结论 / 摘要 / 注意事项 | `<callout>` + emoji + 背景色                                     |
+| 重要方案对比 / 优劣势 / Before vs After | `<grid>` 2 列分栏；简单 SVG SubAgent；复杂矩阵用 lark-whiteboard SubAgent |
+| 简短低风险对比 | `<grid>` 2 列分栏                                                |
+| 3+ 属性的结构化数据 / 指标表 | `<table>` + 表头背景色                                             |
+| 任务清单 / 检查项 | `<checkbox>`                                                  |
+| 代码片段 | `<pre lang="x" caption="说明">`                                 |
+| 引用 / 公式 | `<blockquote>` / `<latex>`                                    |
+| 操作入口 / 跳转链接 | `<button>` / `<a type="url-preview">`                         |
+| 简单流程图 / 小型状态机 / 小型时间线 | 简单 SVG SubAgent                                               |
+| 简单自定义图形 / 小型 SVG 示意图 | 简单 SVG SubAgent                                               |
+| 复杂架构图 / 数据图 / 思维导图 / 组织架构 | 空白画板 + lark-whiteboard SubAgent                               |
 
 ### 画板意图识别
 
-撰写或审查每个段落/章节时，**必须判断该内容是否适合用图表达**。满足以下任一特征时，应使用画板而非纯文本：
+撰写或审查每个段落/章节时，**必须判断该内容是否适合用图表达**。满足以下任一特征时，应使用画板而非纯文本；如果该内容承载章节核心结论、关键决策或主要论据，即使结构较简单也优先画板化：
 
 | 内容特征 | 信号词 / 模式 | 推荐画板类型 |
 |-|-|-|
@@ -45,21 +48,27 @@
 | 占比分布 | "占比"、"份额"、"分布"、百分比加总 ≈100% | 饼图 / 树状图 |
 
 **判断规则：**
-- 简单图（节点 ≤ 10、无需精细排版）→ `<whiteboard type="mermaid/plantuml">` 内嵌
-- 复杂图（节点 > 10、需自定义布局/样式、数据图表）→ spawn Agent 使用 **lark-whiteboard** skill
+- 重要信息能图示就图示；不要为了省步骤把关键流程、架构、对比、风险链路写成纯文本
+- 简单图由 SubAgent 直接插入 `<whiteboard type="svg">完整 SVG</whiteboard>`，不读取 **lark-whiteboard**
+- 复杂图或已有画板更新才先插入 `<whiteboard type="blank"></whiteboard>`，再启动 SubAgent 使用 **lark-whiteboard** skill 写入内容
+- 低重要度、局部辅助信息才用 `<table>` / `<grid>` / `<callout>` 承载
 
 ### 画板语法与插入
 
-> **提醒：** `docs +update` 不能编辑已有画板内容；下面的语法都是**新增**画板块。修改已有画板需切到 [`lark-whiteboard`](../../../lark-whiteboard/SKILL.md)。
+> **提醒：** `docs +update` 不能编辑已有画板内容；下面的语法都是**新增**画板块。修改已有画板需启动 SubAgent 读取 [`lark-whiteboard`](../../../lark-whiteboard/SKILL.md)。
 
-#### 内嵌 Mermaid / PlantUML（首选）
-简单图直接用 `<whiteboard type="mermaid|plantuml">语法</whiteboard>`，作为 block 嵌入文档。
+#### 简单 SVG 画板（SubAgent 插入）
 
-#### DSL 画板（Mermaid / PlantUML 不够用时）
-需要架构图、对比图、组织架构等复杂结构时：
-1. 用 `<whiteboard type="blank"></whiteboard>` 通过 `docs +create` / `docs +update` 插入空白画板
-2. 从响应 `data.document.new_blocks` 中提取画板 `block_token`
-3. 切到 [`lark-whiteboard`](../../../lark-whiteboard/SKILL.md) skill 设计并上传 DSL
+1. 主 Agent 启动 SubAgent，传入 doc token、插入位置、图表目标和源内容
+2. SubAgent 使用 `<whiteboard type="svg">完整自包含 SVG</whiteboard>` 通过 `docs +create --api-version v2` / `docs +update --api-version v2` 插入
+3. SVG 必须包含 `<svg>` 根节点和 `viewBox`，不要引用外部图片、脚本或远程资源
+
+#### 复杂画板（空白画板 + lark-whiteboard SubAgent）
+
+1. 用 `<whiteboard type="blank"></whiteboard>` 通过 `docs +create --api-version v2` / `docs +update --api-version v2` 插入空白画板
+2. 从 v2 响应 `data.document.new_blocks` 中提取画板 `block_token`
+3. 必须启动 SubAgent，把 `block_token`、图表目标、推荐画板类型和源内容交给它
+4. SubAgent 读取 [`lark-whiteboard`](../../../lark-whiteboard/SKILL.md) skill 并写入该画板；主 Agent 不直接调用画板渲染流程
 
 更完整的协同流程见 [`lark-doc-whiteboard.md`](../lark-doc-whiteboard.md)。
 

--- a/skills/lark-doc/references/style/lark-doc-update-workflow.md
+++ b/skills/lark-doc/references/style/lark-doc-update-workflow.md
@@ -25,24 +25,30 @@
    - 用户明确要改整篇 → `docs +fetch --api-version v2 --detail with-ids`
    - 详见 [`lark-doc-fetch.md`](../lark-doc-fetch.md) "意图引导：选择正确的 --scope"
 2. 系统性评估：结构清晰度、富 block 密度（≥40%）、元素多样性（≥3种）、连续 `<p>` 是否超过 3 段、是否有开头 callout 和章节 `<hr/>`
-3. **画板意图识别**：逐章节扫描，按 `lark-doc-style.md`「画板意图识别」表判断哪些段落的信息适合用图表达。记录需要插图的章节（block ID）及推荐的画板类型
+3. **画板意图识别**：逐章节扫描，按 `lark-doc-style.md`「画板意图识别」表判断哪些段落的信息适合用图表达。重要信息优先画板化，记录需要插图的章节（block ID）、推荐画板类型、简单/复杂路径和源内容片段
 4. 向用户简要说明改进计划（包含识别出的画板机会）
 
 ### 第二波 — 定向改写（并行 Agent）
 
-5. Spawn Agent 在不重叠的章节上并行改进，各 Agent 收到文档 token 和特定 block ID：（见 `lark-doc-style.md`）
+5. **优先处理第一波识别出的画板候选段落**：
+   - 简单图：启动 SVG SubAgent，直接插入 `<whiteboard type="svg">完整 SVG</whiteboard>`；不读取 **lark-whiteboard**
+   - 复杂图：主 Agent 先插入 `<whiteboard type="blank"></whiteboard>` 并提取 `block_token`，再为每个 `block_token` 启动 SubAgent 使用 **lark-whiteboard** skill 写入画板
+6. Spawn 内容改写 Agent 在不重叠的章节上并行改进，各 Agent 收到文档 token 和特定 block ID：（见 `lark-doc-style.md`）
    - 开头适当添加 `<callout>`、重组引言
-   - 纯文本转为 `<grid>`/`<table>`/`<whiteboard>`
-   - **对第一波识别出的画板候选段落**：简单图直接 `<whiteboard type="mermaid|plantuml">`，复杂图 spawn Agent 使用 **lark-whiteboard** skill
-   - 添加流程图、对比分栏等富 block
+   - 纯文本转为 `<grid>`/`<table>`/`<callout>`
+   - 添加低重要度对比分栏、关键提示等富 block；画板类需求只走第 5 步
 
 ### 第三波 — 验证（串行）
 
-5. 获取更新后文档局部内容，重新检查样式指标
-6. 未达标则定向修正，向用户呈现结果
+7. 获取更新后文档局部内容，重新检查样式指标
+8. 未达标则定向修正，向用户呈现结果
 
 ## Agent 子任务要求
 
-Spawn Agent 时必须提供：文档 token、章节范围（标题/block ID）、`lark-doc-xml.md` 和 `lark-doc-style.md` 路径、具体的 `docs +update` command 和 `--block-id`。
+内容改写 Agent 必须收到：文档 token、章节范围（标题/block ID）、`lark-doc-xml.md` 和 `lark-doc-style.md` 路径、具体的 `docs +update` command 和 `--block-id`。
+
+SVG SubAgent 必须收到：文档 token、插入位置（标题/block ID）、图表目标、源内容片段、`lark-doc-xml.md` 路径。它只负责插入一个 `<whiteboard type="svg">...</whiteboard>`，不改其他正文，也不读取 `lark-whiteboard`。
+
+复杂画板 SubAgent 必须收到：board_token、图表目标、推荐画板类型、源内容片段、[`../../../lark-whiteboard/SKILL.md`](../../../lark-whiteboard/SKILL.md) 路径。它只负责写入画板，不改文档正文。
 
 **上下文节省提示**：Agent 如需在自己负责的章节内重新读取内容，优先用 `docs +fetch --api-version v2 --scope section --start-block-id <章节标题id>`（自动覆盖整节），或 `--scope range --start-block-id xxx --end-block-id yyy` 精确区间，只拉自己的章节，不要重复拉全文。


### PR DESCRIPTION
Change-Id: Icada6fb894aaf9a00187fa68c132d3ade8223b99

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on whiteboard usage, distinguishing between simple SVG diagrams and complex visualizations
  * Refined workflow recommendations for creating and updating documents with visual elements
  * Expanded best practices for planning and implementing diagrams in document creation processes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/901)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced whiteboard support for Lark docs with clearer guidance on using SVG whiteboards for simple diagrams and a streamlined process for complex visualizations.
  * Updated workflow documentation to clarify how to incorporate whiteboards when creating and updating documents.
  * Revised style guides emphasizing whiteboard usage for visualizing important information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/901)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->