### PR TITLE
fix(sheets): correct scope name from "sheets:spreadsheet:read" to "sheets:spreadsheet:readonly"

### DIFF
--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -237,7 +237,7 @@ func TestLoadAutoApproveSet(t *testing.T) {
 	}
 
 	// Verify allow list entries are present
-	if !aaSet["sheets:spreadsheet:read"] {
+	if !aaSet["sheets:spreadsheet:readonly"] {
 		t.Error("expected sheets:spreadsheet:read in auto-approve set (from allow list)")
 	}
 
@@ -292,7 +292,7 @@ func TestFilterAutoApproveScopes(t *testing.T) {
 	scopes := []string{
 		"calendar:calendar.event:create", // auto-approve (in allow list)
 		"zzz:unknown:scope",              // not in auto-approve
-		"sheets:spreadsheet:read",        // auto-approve (in allow list)
+		"sheets:spreadsheet:readonly",        // auto-approve (in allow list)
 	}
 
 	result := FilterAutoApproveScopes(scopes)

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -238,7 +238,7 @@ func TestLoadAutoApproveSet(t *testing.T) {
 
 	// Verify allow list entries are present
 	if !aaSet["sheets:spreadsheet:readonly"] {
-		t.Error("expected sheets:spreadsheet:read in auto-approve set (from allow list)")
+		t.Error("expected sheets:spreadsheet:readonly in auto-approve set (from allow list)")
 	}
 
 	t.Logf("Auto-approve set has %d scopes", len(aaSet))

--- a/shortcuts/sheets/lark_sheets_cell_data.go
+++ b/shortcuts/sheets/lark_sheets_cell_data.go
@@ -28,7 +28,7 @@ var SheetRead = common.Shortcut{
 	Command:     "+read",
 	Description: "Read spreadsheet cell values",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -99,7 +99,7 @@ var SheetWrite = common.Shortcut{
 	Command:     "+write",
 	Description: "Write to spreadsheet cells (overwrite mode)",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -175,7 +175,7 @@ var SheetAppend = common.Shortcut{
 	Command:     "+append",
 	Description: "Append rows to a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -251,7 +251,7 @@ var SheetFind = common.Shortcut{
 	Command:     "+find",
 	Description: "Find cells in a spreadsheet",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -335,7 +335,7 @@ var SheetReplace = common.Shortcut{
 	Command:     "+replace",
 	Description: "Find and replace cell values in a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_cell_images.go
+++ b/shortcuts/sheets/lark_sheets_cell_images.go
@@ -20,7 +20,7 @@ var SheetWriteImage = common.Shortcut{
 	Command:     "+write-image",
 	Description: "Write an image into a spreadsheet cell",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_cell_style_and_merge.go
+++ b/shortcuts/sheets/lark_sheets_cell_style_and_merge.go
@@ -59,7 +59,7 @@ var SheetSetStyle = common.Shortcut{
 	Command:     "+set-style",
 	Description: "Set cell style for a range",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -141,7 +141,7 @@ var SheetBatchSetStyle = common.Shortcut{
 	Command:     "+batch-set-style",
 	Description: "Batch set cell styles for multiple ranges",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -227,7 +227,7 @@ var SheetMergeCells = common.Shortcut{
 	Command:     "+merge-cells",
 	Description: "Merge cells in a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -292,7 +292,7 @@ var SheetUnmergeCells = common.Shortcut{
 	Command:     "+unmerge-cells",
 	Description: "Unmerge (split) cells in a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_dropdown.go
+++ b/shortcuts/sheets/lark_sheets_dropdown.go
@@ -107,7 +107,7 @@ var SheetSetDropdown = common.Shortcut{
 	Command:     "+set-dropdown",
 	Description: "Set dropdown list on a cell range",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -168,7 +168,7 @@ var SheetUpdateDropdown = common.Shortcut{
 	Command:     "+update-dropdown",
 	Description: "Update dropdown list settings",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -235,7 +235,7 @@ var SheetGetDropdown = common.Shortcut{
 	Command:     "+get-dropdown",
 	Description: "Get dropdown list settings for a range",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -279,7 +279,7 @@ var SheetDeleteDropdown = common.Shortcut{
 	Command:     "+delete-dropdown",
 	Description: "Delete dropdown list from cell ranges",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_filter_views.go
+++ b/shortcuts/sheets/lark_sheets_filter_views.go
@@ -43,7 +43,7 @@ var SheetCreateFilterView = common.Shortcut{
 	Command:     "+create-filter-view",
 	Description: "Create a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -98,7 +98,7 @@ var SheetUpdateFilterView = common.Shortcut{
 	Command:     "+update-filter-view",
 	Description: "Update a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -154,7 +154,7 @@ var SheetListFilterViews = common.Shortcut{
 	Command:     "+list-filter-views",
 	Description: "List all filter views in a sheet",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -187,7 +187,7 @@ var SheetGetFilterView = common.Shortcut{
 	Command:     "+get-filter-view",
 	Description: "Get a filter view by ID",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -221,7 +221,7 @@ var SheetDeleteFilterView = common.Shortcut{
 	Command:     "+delete-filter-view",
 	Description: "Delete a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -255,7 +255,7 @@ var SheetCreateFilterViewCondition = common.Shortcut{
 	Command:     "+create-filter-view-condition",
 	Description: "Create a filter condition on a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -297,7 +297,7 @@ var SheetUpdateFilterViewCondition = common.Shortcut{
 	Command:     "+update-filter-view-condition",
 	Description: "Update a filter condition on a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -350,7 +350,7 @@ var SheetListFilterViewConditions = common.Shortcut{
 	Command:     "+list-filter-view-conditions",
 	Description: "List all filter conditions of a filter view",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -386,7 +386,7 @@ var SheetGetFilterViewCondition = common.Shortcut{
 	Command:     "+get-filter-view-condition",
 	Description: "Get a filter condition by column",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -424,7 +424,7 @@ var SheetDeleteFilterViewCondition = common.Shortcut{
 	Command:     "+delete-filter-view-condition",
 	Description: "Delete a filter condition from a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},

--- a/shortcuts/sheets/lark_sheets_float_images.go
+++ b/shortcuts/sheets/lark_sheets_float_images.go
@@ -367,7 +367,7 @@ var SheetGetFloatImage = common.Shortcut{
 	Command:     "+get-float-image",
 	Description: "Get a floating image by ID",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -401,7 +401,7 @@ var SheetListFloatImages = common.Shortcut{
 	Command:     "+list-float-images",
 	Description: "List all floating images in a sheet",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_row_column_management.go
+++ b/shortcuts/sheets/lark_sheets_row_column_management.go
@@ -16,7 +16,7 @@ var SheetAddDimension = common.Shortcut{
 	Command:     "+add-dimension",
 	Description: "Add rows or columns at the end of a sheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -75,7 +75,7 @@ var SheetInsertDimension = common.Shortcut{
 	Command:     "+insert-dimension",
 	Description: "Insert rows or columns at a specified position",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -148,7 +148,7 @@ var SheetUpdateDimension = common.Shortcut{
 	Command:     "+update-dimension",
 	Description: "Update row or column properties (visibility, size)",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -237,7 +237,7 @@ var SheetMoveDimension = common.Shortcut{
 	Command:     "+move-dimension",
 	Description: "Move rows or columns to a new position",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -309,7 +309,7 @@ var SheetDeleteDimension = common.Shortcut{
 	Command:     "+delete-dimension",
 	Description: "Delete rows or columns",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_sheet_management.go
+++ b/shortcuts/sheets/lark_sheets_sheet_management.go
@@ -497,7 +497,7 @@ var SheetCreateSheet = common.Shortcut{
 	Command:     "+create-sheet",
 	Description: "Create a sheet in an existing spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -548,7 +548,7 @@ var SheetCopySheet = common.Shortcut{
 	Command:     "+copy-sheet",
 	Description: "Copy a sheet within a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -622,7 +622,7 @@ var SheetDeleteSheet = common.Shortcut{
 	Command:     "+delete-sheet",
 	Description: "Delete a sheet from a spreadsheet",
 	Risk:        "high-risk-write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -662,7 +662,7 @@ var SheetUpdateSheet = common.Shortcut{
 	Command:     "+update-sheet",
 	Description: "Update sheet properties",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_spreadsheet_management.go
+++ b/shortcuts/sheets/lark_sheets_spreadsheet_management.go
@@ -24,7 +24,7 @@ var SheetInfo = common.Shortcut{
 	Command:     "+info",
 	Description: "View spreadsheet and sheet information",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/skills/lark-sheets/SKILL.md
+++ b/skills/lark-sheets/SKILL.md
@@ -335,11 +335,11 @@ lark-cli sheets <resource> <method> [flags] # 调用 API
 | `spreadsheets.patch` | `sheets:spreadsheet.meta:write_only` |
 | `spreadsheet.sheet.filters.create` | `sheets:spreadsheet:write_only` |
 | `spreadsheet.sheet.filters.delete` | `sheets:spreadsheet:write_only` |
-| `spreadsheet.sheet.filters.get` | `sheets:spreadsheet:read` |
+| `spreadsheet.sheet.filters.get` | `sheets:spreadsheet:readonly` |
 | `spreadsheet.sheet.filters.update` | `sheets:spreadsheet:write_only` |
-| `spreadsheet.sheets.find` | `sheets:spreadsheet:read` |
+| `spreadsheet.sheets.find` | `sheets:spreadsheet:readonly` |
 | `spreadsheet.sheet.float_images.create` | `sheets:spreadsheet:write_only` |
 | `spreadsheet.sheet.float_images.patch` | `sheets:spreadsheet:write_only` |
-| `spreadsheet.sheet.float_images.get` | `sheets:spreadsheet:read` |
-| `spreadsheet.sheet.float_images.query` | `sheets:spreadsheet:read` |
+| `spreadsheet.sheet.float_images.get` | `sheets:spreadsheet:readonly` |
+| `spreadsheet.sheet.float_images.query` | `sheets:spreadsheet:readonly` |
 | `spreadsheet.sheet.float_images.delete` | `sheets:spreadsheet:write_only` |


### PR DESCRIPTION
## Summary
Fixes #838
The Feishu Open Platform uses `sheets:spreadsheet:readonly` as the actual scope name for read access to spreadsheets. The incorrect scope `sheets:spreadsheet:read` was hardcoded in all sheets shortcut commands, causing the local precheck to reject tokens that had the correct scopes (`:readonly`, `:write_only`, `:create`).
## Changes
- Replaced all 36 occurrences of `"sheets:spreadsheet:read"` with `"sheets:spreadsheet:readonly"` across 9 sheets shortcut files
- Updated `internal/registry/registry_test.go` to use the correct scope name
- Updated `skills/lark-sheets/SKILL.md` documentation table
## Files modified
- `shortcuts/sheets/lark_sheets_cell_data.go`
- `shortcuts/sheets/lark_sheets_cell_images.go`
- `shortcuts/sheets/lark_sheets_cell_style_and_merge.go`
- `shortcuts/sheets/lark_sheets_dropdown.go`
- `shortcuts/sheets/lark_sheets_filter_views.go`
- `shortcuts/sheets/lark_sheets_float_images.go`
- `shortcuts/sheets/lark_sheets_row_column_management.go`
- `shortcuts/sheets/lark_sheets_sheet_management.go`
- `shortcuts/sheets/lark_sheets_spreadsheet_management.go`
- `internal/registry/registry_test.go`
- `skills/lark-sheets/SKILL.md`
## Testing
Verified that `scope_overrides.json` already contains `sheets:spreadsheet:readonly` in both the priority overrides and the recommend allow list, confirming this is the correct scope name.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
* **Chores**
  * Updated OAuth scope declarations for Sheets operations to use `sheets:spreadsheet:readonly` (and retain `sheets:spreadsheet:write_only` where applicable).
* **Tests**
  * Adjusted tests to expect the revised Sheets OAuth scopes.
* **Documentation**
  * Updated Sheets permission reference entries to reflect the new `readonly` scope.
<!-- review_stack_entry_start -->
[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/902)
<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- CLA recheck -->