### PR TITLE
feat(common): add FlagHints + did-you-mean unknown-flag error enhancemen

### DIFF
--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -734,6 +734,13 @@ func (s Shortcut) mountDeclarative(ctx context.Context, parent *cobra.Command, f
 	registerShortcutFlagsWithContext(ctx, cmd, f, &shortcut)
 	cmdutil.SetTips(cmd, shortcut.Tips)
 	cmdutil.SetRisk(cmd, shortcut.Risk)
+	if shortcut.FlagHints != nil {
+		b, _ := json.Marshal(shortcut.FlagHints)
+		if cmd.Annotations == nil {
+			cmd.Annotations = make(map[string]string)
+		}
+		cmd.Annotations["flag_hints"] = string(b)
+	}
 	parent.AddCommand(cmd)
 	if shortcut.PostMount != nil {
 		shortcut.PostMount(cmd)

--- a/shortcuts/common/types.go
+++ b/shortcuts/common/types.go
@@ -51,7 +51,14 @@ type Shortcut struct {
 	Flags     []Flag   // flag definitions; --dry-run is auto-injected
 	HasFormat bool     // auto-inject --format flag (json|pretty|table|ndjson|csv)
 	Tips      []string // optional tips shown in --help output
-	Hidden    bool     // hide from --help / tab completion (still executable); use when deprecating a command in favor of a replacement
+	// FlagHints maps a misused flag name (without "--") to the correct flag name
+	// (without "--"). The framework generates "did you mean: --<value>?" for exact
+	// matches, keeping the same format as edit-distance suggestions.
+	// Key contract: no "--" prefix; value must be a valid registered flag name.
+	// Leave nil when no domain-specific mapping is needed — edit-distance fallback
+	// still applies.
+	FlagHints map[string]string
+	Hidden    bool // hide from --help / tab completion (still executable); use when deprecating a command in favor of a replacement
 
 	// Business logic hooks.
 	DryRun   func(ctx context.Context, runtime *RuntimeContext) *DryRunAPI // optional: framework prints & returns when --dry-run is set

--- a/shortcuts/mail/flag_suggest.go
+++ b/shortcuts/mail/flag_suggest.go
@@ -4,6 +4,7 @@
 package mail
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -32,8 +33,9 @@ type Candidate struct {
 	// Distance is the Levenshtein edit distance to the unknown token.
 	// Zero indicates a bidirectional prefix hit (Reason == "prefix").
 	Distance int `json:"distance"`
-	// Reason explains how the candidate was matched: "prefix" for
-	// bidirectional prefix hits, "edit_distance" for fuzzy matches.
+	// Reason explains how the candidate was matched: "hint" for
+	// FlagHints exact matches, "prefix" for bidirectional prefix hits,
+	// "edit_distance" for fuzzy matches.
 	Reason string `json:"reason"`
 }
 
@@ -74,11 +76,29 @@ func flagSuggestErrorFunc(c *cobra.Command, err error) error {
 	if isShorthand {
 		matches = suggestShorthand(token, names)
 	} else {
-		matches = suggest(token, names)
+		// Priority 0: per-command FlagHints exact match (registered via Annotations).
+		var hintTarget string
+		if hints := readFlagHints(c); len(hints) > 0 {
+			hintTarget = hints[token]
+		}
+		if hintTarget != "" {
+			var shorthand string
+			if f := c.Flags().Lookup(hintTarget); f != nil {
+				shorthand = f.Shorthand
+			}
+			matches = append(matches, Candidate{Flag: "--" + hintTarget, Shorthand: shorthand, Distance: 0, Reason: "hint"})
+		}
+		// Priority 1+2: prefix + Levenshtein, deduplicating the hint target.
+		for _, cand := range suggest(token, names) {
+			if hintTarget != "" && cand.Flag == "--"+hintTarget {
+				continue
+			}
+			matches = append(matches, cand)
+		}
+		if len(matches) > maxCandidates {
+			matches = matches[:maxCandidates]
+		}
 	}
-	// Normalise to a non-nil slice so the JSON envelope always emits
-	// `candidates: []` instead of `null`, keeping the wire shape stable
-	// for downstream parsers regardless of command-state.
 	if matches == nil {
 		matches = []Candidate{}
 	}
@@ -256,6 +276,24 @@ func levThreshold(s string) int {
 		return 4
 	}
 	return t
+}
+
+// readFlagHints retrieves the FlagHints map stored in cmd.Annotations by
+// shortcuts/common/runner.go during command registration. Returns nil when
+// no hints are configured for this subcommand.
+func readFlagHints(cmd *cobra.Command) map[string]string {
+	if cmd.Annotations == nil {
+		return nil
+	}
+	raw, ok := cmd.Annotations["flag_hints"]
+	if !ok {
+		return nil
+	}
+	var hints map[string]string
+	if err := json.Unmarshal([]byte(raw), &hints); err != nil {
+		return nil
+	}
+	return hints
 }
 
 // levenshtein computes the standard Levenshtein edit distance between

--- a/shortcuts/mail/flag_suggest_test.go
+++ b/shortcuts/mail/flag_suggest_test.go
@@ -4,6 +4,7 @@
 package mail
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -349,4 +350,141 @@ func TestLevenshtein_EmptyAndIdentical(t *testing.T) {
 	assert.Equal(t, 3, levenshtein("abc", ""))
 	assert.Equal(t, 0, levenshtein("abc", "abc"))
 	assert.Equal(t, 1, levenshtein("abc", "abd"))
+}
+
+// --- readFlagHints ---
+
+func TestReadFlagHints_Normal(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Annotations = map[string]string{
+		"flag_hints": `{"set-body":"patch-file","recipient":"to"}`,
+	}
+	hints := readFlagHints(cmd)
+	require.NotNil(t, hints)
+	assert.Equal(t, "patch-file", hints["set-body"])
+	assert.Equal(t, "to", hints["recipient"])
+}
+
+func TestReadFlagHints_NilAnnotations(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	assert.Nil(t, readFlagHints(cmd))
+}
+
+func TestReadFlagHints_KeyAbsent(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Annotations = map[string]string{"other_key": "value"}
+	assert.Nil(t, readFlagHints(cmd))
+}
+
+func TestReadFlagHints_InvalidJSON(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Annotations = map[string]string{"flag_hints": `{not valid json`}
+	assert.Nil(t, readFlagHints(cmd), "malformed JSON must return nil without panicking")
+}
+
+// --- flagSuggestErrorFunc FlagHints priority 0 ---
+
+// newFakeMailCmdWithHints returns a command with flags registered and
+// FlagHints stored in Annotations, mirroring what runner.go does at
+// mount time.
+func newFakeMailCmdWithHints(flags map[string]string, hints map[string]string) *cobra.Command {
+	cmd := &cobra.Command{Use: "mail-sub"}
+	for name, usage := range flags {
+		cmd.Flags().String(name, "", usage)
+	}
+	if hints != nil {
+		b, _ := json.Marshal(hints)
+		cmd.Annotations = map[string]string{"flag_hints": string(b)}
+	}
+	return cmd
+}
+
+func TestFlagSuggestErrorFunc_FlagHints_Hit(t *testing.T) {
+	cmd := newFakeMailCmdWithHints(
+		map[string]string{"patch-file": "patch body from file"},
+		map[string]string{"set-body": "patch-file"},
+	)
+	got := flagSuggestErrorFunc(cmd, errors.New("unknown flag: --set-body"))
+	var exitErr *output.ExitError
+	require.True(t, errors.As(got, &exitErr))
+	assert.Equal(t, "unknown_flag", exitErr.Detail.Type)
+
+	cands := exitErr.Detail.Detail.(map[string]any)["candidates"].([]Candidate)
+	require.NotEmpty(t, cands)
+	assert.Equal(t, "--patch-file", cands[0].Flag)
+	assert.Equal(t, 0, cands[0].Distance)
+	assert.Equal(t, "hint", cands[0].Reason, "FlagHints match must carry reason=hint")
+}
+
+func TestFlagSuggestErrorFunc_FlagHints_TopPriority(t *testing.T) {
+	// Even when edit-distance would also find a candidate, the hint must
+	// appear first and carry reason=hint.
+	cmd := newFakeMailCmdWithHints(
+		map[string]string{"patch-file": "", "patch-fil": ""},
+		map[string]string{"set-body": "patch-file"},
+	)
+	got := flagSuggestErrorFunc(cmd, errors.New("unknown flag: --set-body"))
+	var exitErr *output.ExitError
+	require.True(t, errors.As(got, &exitErr))
+
+	cands := exitErr.Detail.Detail.(map[string]any)["candidates"].([]Candidate)
+	require.NotEmpty(t, cands)
+	assert.Equal(t, "--patch-file", cands[0].Flag)
+	assert.Equal(t, "hint", cands[0].Reason)
+}
+
+func TestFlagSuggestErrorFunc_FlagHints_Dedup(t *testing.T) {
+	// The hint target must not appear twice in candidates even when
+	// suggest() would also match it via prefix/edit-distance.
+	cmd := newFakeMailCmdWithHints(
+		map[string]string{"patch-file": ""},
+		map[string]string{"patch-fil": "patch-file"}, // "patch-fil" typo → "patch-file"
+	)
+	got := flagSuggestErrorFunc(cmd, errors.New("unknown flag: --patch-fil"))
+	var exitErr *output.ExitError
+	require.True(t, errors.As(got, &exitErr))
+
+	cands := exitErr.Detail.Detail.(map[string]any)["candidates"].([]Candidate)
+	count := 0
+	for _, c := range cands {
+		if c.Flag == "--patch-file" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "--patch-file must appear exactly once (no dedup violation)")
+}
+
+func TestFlagSuggestErrorFunc_FlagHints_Miss_FallsBackToLevenshtein(t *testing.T) {
+	// FlagHints has no entry for the unknown token; normal suggest must
+	// still fire.
+	cmd := newFakeMailCmdWithHints(
+		map[string]string{"patch-file": ""},
+		map[string]string{"set-body": "patch-file"}, // unrelated hint
+	)
+	got := flagSuggestErrorFunc(cmd, errors.New("unknown flag: --patch-fil"))
+	var exitErr *output.ExitError
+	require.True(t, errors.As(got, &exitErr))
+
+	cands := exitErr.Detail.Detail.(map[string]any)["candidates"].([]Candidate)
+	require.NotEmpty(t, cands)
+	assert.NotEqual(t, "hint", cands[0].Reason, "must fall back to prefix/edit_distance when hint misses")
+}
+
+func TestFlagSuggestErrorFunc_FlagHints_ShorthandUnaffected(t *testing.T) {
+	// FlagHints must not interfere with shorthand errors.
+	cmd := newFakeMailCmdWithHints(
+		map[string]string{"to": ""},
+		map[string]string{"t": "to"}, // hypothetical hint key that looks like a shorthand
+	)
+	cmd.Flags().StringP("body", "b", "", "")
+	got := flagSuggestErrorFunc(cmd, errors.New("unknown shorthand flag: 'b' in -bXY"))
+	var exitErr *output.ExitError
+	require.True(t, errors.As(got, &exitErr))
+
+	cands := exitErr.Detail.Detail.(map[string]any)["candidates"].([]Candidate)
+	require.NotEmpty(t, cands)
+	// All shorthand candidates must not carry reason=hint.
+	for _, c := range cands {
+		assert.NotEqual(t, "hint", c.Reason)
+	}
 }

--- a/shortcuts/mail/mail_draft_edit.go
+++ b/shortcuts/mail/mail_draft_edit.go
@@ -27,6 +27,17 @@ var MailDraftEdit = common.Shortcut{
 	Scopes:      []string{"mail:user_mailbox.message:modify", "mail:user_mailbox.message:readonly", "mail:user_mailbox:readonly"},
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
+	FlagHints: map[string]string{
+		"set-body":     "patch-file",
+		"body":         "patch-file",
+		"content":      "patch-file",
+		"message-body": "patch-file",
+		"to":           "set-to",
+		"recipient":    "set-to",
+		"recipients":   "set-to",
+		"id":           "draft-id",
+		"mail-id":      "draft-id",
+	},
 	Flags: []common.Flag{
 		{Name: "from", Default: "me", Desc: "Mailbox email address containing the draft (default: me). Prefer --mailbox for clarity; --from is kept for backward compatibility."},
 		{Name: "mailbox", Desc: "Mailbox email address that owns the draft (default: falls back to --from, then me). Takes priority over --from when both are set."},

--- a/shortcuts/mail/mail_message.go
+++ b/shortcuts/mail/mail_message.go
@@ -20,6 +20,10 @@ var MailMessage = common.Shortcut{
 	Scopes:      []string{"mail:user_mailbox.message:readonly", "mail:user_mailbox.message.address:read", "mail:user_mailbox.message.subject:read", "mail:user_mailbox.message.body:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
+	FlagHints: map[string]string{
+		"id":      "message-id",
+		"mail-id": "message-id",
+	},
 	Flags: []common.Flag{
 		{Name: "mailbox", Default: "me", Desc: "email address (default: me)"},
 		{Name: "message-id", Desc: "Required. Email message ID", Required: true},

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -23,6 +23,12 @@ var MailSend = common.Shortcut{
 	Risk:        "write",
 	Scopes:      []string{"mail:user_mailbox.message:send", "mail:user_mailbox.message:modify", "mail:user_mailbox:readonly"},
 	AuthTypes:   []string{"user"},
+	FlagHints: map[string]string{
+		"recipient":    "to",
+		"recipients":   "to",
+		"message-body": "body",
+		"content":      "body",
+	},
 	Flags: []common.Flag{
 		{Name: "to", Desc: "Recipient email address(es), comma-separated"},
 		{Name: "subject", Desc: "Email subject. Required unless --template-id supplies a non-empty subject."},

--- a/shortcuts/mail/mail_thread.go
+++ b/shortcuts/mail/mail_thread.go
@@ -51,6 +51,11 @@ var MailThread = common.Shortcut{
 	Scopes:      []string{"mail:user_mailbox.message:readonly", "mail:user_mailbox.message.address:read", "mail:user_mailbox.message.subject:read", "mail:user_mailbox.message.body:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
+	FlagHints: map[string]string{
+		"thread":       "thread-id",
+		"conversation": "thread-id",
+		"tid":          "thread-id",
+	},
 	Flags: []common.Flag{
 		{Name: "mailbox", Default: "me", Desc: "email address (default: me)"},
 		{Name: "thread-id", Desc: "Required. Email thread ID", Required: true},

--- a/shortcuts/mail/mail_triage.go
+++ b/shortcuts/mail/mail_triage.go
@@ -53,6 +53,12 @@ var MailTriage = common.Shortcut{
 	Risk:        "read",
 	Scopes:      []string{"mail:user_mailbox.message:readonly", "mail:user_mailbox.message.address:read", "mail:user_mailbox.message.subject:read", "mail:user_mailbox.message.body:read"},
 	AuthTypes:   []string{"user", "bot"},
+	FlagHints: map[string]string{
+		"search":  "query",
+		"keyword": "query",
+		"limit":   "max",
+		"count":   "max",
+	},
 	Flags: []common.Flag{
 		{Name: "format", Default: "table", Desc: "output format: table | json | data (json/data output object with pagination fields)"},
 		{Name: "max", Type: "int", Default: "20", Desc: "maximum number of messages to fetch (1-400; auto-paginates internally)"},


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/8f59c0d
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Synthesize transport contract for larksuite/cli | passed | — |
| S2 | Implement Shortcut unknown-flag error enhancement (FlagHints + Did-You-Mean) | passed | 8061341 |

## Source specs

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “did you mean” suggestions for mistyped flag names using improved distance-based matching and dynamic thresholding.
  * Added per-shortcut flag alias hints so common aliases map to canonical flags, improving suggestions for mail shortcuts.

* **Bug Fixes**
  * Suppressed automatic usage output on flag-parse errors for cleaner, focused error messages and hints.

* **Tests**
  * Added comprehensive unit tests and a benchmark covering suggestion logic, thresholding, hinting, and error wrapping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->