### PR TITLE
fix(sheets): replace unreal :read scope with :readonly in shortcuts

### DIFF
--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -237,8 +237,8 @@ func TestLoadAutoApproveSet(t *testing.T) {
 	}
 
 	// Verify allow list entries are present
-	if !aaSet["sheets:spreadsheet:read"] {
-		t.Error("expected sheets:spreadsheet:read in auto-approve set (from allow list)")
+	if !aaSet["sheets:spreadsheet:readonly"] {
+		t.Error("expected sheets:spreadsheet:readonly in auto-approve set (from allow list)")
 	}
 
 	t.Logf("Auto-approve set has %d scopes", len(aaSet))
@@ -292,7 +292,7 @@ func TestFilterAutoApproveScopes(t *testing.T) {
 	scopes := []string{
 		"calendar:calendar.event:create", // auto-approve (in allow list)
 		"zzz:unknown:scope",              // not in auto-approve
-		"sheets:spreadsheet:read",        // auto-approve (in allow list)
+		"sheets:spreadsheet:readonly",    // auto-approve (in allow list)
 	}
 
 	result := FilterAutoApproveScopes(scopes)

--- a/shortcuts/sheets/lark_sheets_cell_data.go
+++ b/shortcuts/sheets/lark_sheets_cell_data.go
@@ -28,7 +28,7 @@ var SheetRead = common.Shortcut{
 	Command:     "+read",
 	Description: "Read spreadsheet cell values",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -99,7 +99,7 @@ var SheetWrite = common.Shortcut{
 	Command:     "+write",
 	Description: "Write to spreadsheet cells (overwrite mode)",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -175,7 +175,7 @@ var SheetAppend = common.Shortcut{
 	Command:     "+append",
 	Description: "Append rows to a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -251,7 +251,7 @@ var SheetFind = common.Shortcut{
 	Command:     "+find",
 	Description: "Find cells in a spreadsheet",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -335,7 +335,7 @@ var SheetReplace = common.Shortcut{
 	Command:     "+replace",
 	Description: "Find and replace cell values in a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_cell_images.go
+++ b/shortcuts/sheets/lark_sheets_cell_images.go
@@ -20,7 +20,7 @@ var SheetWriteImage = common.Shortcut{
 	Command:     "+write-image",
 	Description: "Write an image into a spreadsheet cell",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_cell_style_and_merge.go
+++ b/shortcuts/sheets/lark_sheets_cell_style_and_merge.go
@@ -59,7 +59,7 @@ var SheetSetStyle = common.Shortcut{
 	Command:     "+set-style",
 	Description: "Set cell style for a range",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -141,7 +141,7 @@ var SheetBatchSetStyle = common.Shortcut{
 	Command:     "+batch-set-style",
 	Description: "Batch set cell styles for multiple ranges",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -227,7 +227,7 @@ var SheetMergeCells = common.Shortcut{
 	Command:     "+merge-cells",
 	Description: "Merge cells in a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -292,7 +292,7 @@ var SheetUnmergeCells = common.Shortcut{
 	Command:     "+unmerge-cells",
 	Description: "Unmerge (split) cells in a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_dropdown.go
+++ b/shortcuts/sheets/lark_sheets_dropdown.go
@@ -107,7 +107,7 @@ var SheetSetDropdown = common.Shortcut{
 	Command:     "+set-dropdown",
 	Description: "Set dropdown list on a cell range",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -168,7 +168,7 @@ var SheetUpdateDropdown = common.Shortcut{
 	Command:     "+update-dropdown",
 	Description: "Update dropdown list settings",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -235,7 +235,7 @@ var SheetGetDropdown = common.Shortcut{
 	Command:     "+get-dropdown",
 	Description: "Get dropdown list settings for a range",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -279,7 +279,7 @@ var SheetDeleteDropdown = common.Shortcut{
 	Command:     "+delete-dropdown",
 	Description: "Delete dropdown list from cell ranges",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_filter_views.go
+++ b/shortcuts/sheets/lark_sheets_filter_views.go
@@ -43,7 +43,7 @@ var SheetCreateFilterView = common.Shortcut{
 	Command:     "+create-filter-view",
 	Description: "Create a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -98,7 +98,7 @@ var SheetUpdateFilterView = common.Shortcut{
 	Command:     "+update-filter-view",
 	Description: "Update a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -154,7 +154,7 @@ var SheetListFilterViews = common.Shortcut{
 	Command:     "+list-filter-views",
 	Description: "List all filter views in a sheet",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -187,7 +187,7 @@ var SheetGetFilterView = common.Shortcut{
 	Command:     "+get-filter-view",
 	Description: "Get a filter view by ID",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -221,7 +221,7 @@ var SheetDeleteFilterView = common.Shortcut{
 	Command:     "+delete-filter-view",
 	Description: "Delete a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -255,7 +255,7 @@ var SheetCreateFilterViewCondition = common.Shortcut{
 	Command:     "+create-filter-view-condition",
 	Description: "Create a filter condition on a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -297,7 +297,7 @@ var SheetUpdateFilterViewCondition = common.Shortcut{
 	Command:     "+update-filter-view-condition",
 	Description: "Update a filter condition on a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -350,7 +350,7 @@ var SheetListFilterViewConditions = common.Shortcut{
 	Command:     "+list-filter-view-conditions",
 	Description: "List all filter conditions of a filter view",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -386,7 +386,7 @@ var SheetGetFilterViewCondition = common.Shortcut{
 	Command:     "+get-filter-view-condition",
 	Description: "Get a filter condition by column",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -424,7 +424,7 @@ var SheetDeleteFilterViewCondition = common.Shortcut{
 	Command:     "+delete-filter-view-condition",
 	Description: "Delete a filter condition from a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},

--- a/shortcuts/sheets/lark_sheets_float_images.go
+++ b/shortcuts/sheets/lark_sheets_float_images.go
@@ -367,7 +367,7 @@ var SheetGetFloatImage = common.Shortcut{
 	Command:     "+get-float-image",
 	Description: "Get a floating image by ID",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -401,7 +401,7 @@ var SheetListFloatImages = common.Shortcut{
 	Command:     "+list-float-images",
 	Description: "List all floating images in a sheet",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_row_column_management.go
+++ b/shortcuts/sheets/lark_sheets_row_column_management.go
@@ -16,7 +16,7 @@ var SheetAddDimension = common.Shortcut{
 	Command:     "+add-dimension",
 	Description: "Add rows or columns at the end of a sheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -75,7 +75,7 @@ var SheetInsertDimension = common.Shortcut{
 	Command:     "+insert-dimension",
 	Description: "Insert rows or columns at a specified position",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -148,7 +148,7 @@ var SheetUpdateDimension = common.Shortcut{
 	Command:     "+update-dimension",
 	Description: "Update row or column properties (visibility, size)",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -237,7 +237,7 @@ var SheetMoveDimension = common.Shortcut{
 	Command:     "+move-dimension",
 	Description: "Move rows or columns to a new position",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -309,7 +309,7 @@ var SheetDeleteDimension = common.Shortcut{
 	Command:     "+delete-dimension",
 	Description: "Delete rows or columns",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_sheet_management.go
+++ b/shortcuts/sheets/lark_sheets_sheet_management.go
@@ -497,7 +497,7 @@ var SheetCreateSheet = common.Shortcut{
 	Command:     "+create-sheet",
 	Description: "Create a sheet in an existing spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -548,7 +548,7 @@ var SheetCopySheet = common.Shortcut{
 	Command:     "+copy-sheet",
 	Description: "Copy a sheet within a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -622,7 +622,7 @@ var SheetDeleteSheet = common.Shortcut{
 	Command:     "+delete-sheet",
 	Description: "Delete a sheet from a spreadsheet",
 	Risk:        "high-risk-write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -662,7 +662,7 @@ var SheetUpdateSheet = common.Shortcut{
 	Command:     "+update-sheet",
 	Description: "Update sheet properties",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_spreadsheet_management.go
+++ b/shortcuts/sheets/lark_sheets_spreadsheet_management.go
@@ -24,7 +24,7 @@ var SheetInfo = common.Shortcut{
 	Command:     "+info",
 	Description: "View spreadsheet and sheet information",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/shortcuts_test.go
+++ b/shortcuts/sheets/shortcuts_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/internal/auth"
+)
+
+func TestShortcuts_NoUnrealReadScope(t *testing.T) {
+	for _, s := range Shortcuts() {
+		for _, scope := range s.Scopes {
+			if scope == "sheets:spreadsheet:read" {
+				t.Errorf("shortcut %s declares unreal scope %q; Feishu Open Platform uses sheets:spreadsheet:readonly", s.Command, scope)
+			}
+		}
+	}
+}
+
+func TestShortcuts_PrecheckAcceptsFeishuSheetsScopes(t *testing.T) {
+	granted := "sheets:spreadsheet:create sheets:spreadsheet:readonly sheets:spreadsheet:write_only"
+	for _, s := range Shortcuts() {
+		sheetsOnly := true
+		for _, scope := range s.Scopes {
+			if len(scope) < 7 || scope[:7] != "sheets:" {
+				sheetsOnly = false
+				break
+			}
+		}
+		if !sheetsOnly || len(s.Scopes) == 0 {
+			continue
+		}
+		if missing := auth.MissingScopes(granted, s.Scopes); len(missing) > 0 {
+			t.Errorf("shortcut %s rejects a token granted real Feishu sheets scopes; missing=%v required=%v", s.Command, missing, s.Scopes)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

All `lark-cli sheets` shortcuts declared `sheets:spreadsheet:read` as a required scope, but that scope name does not exist on the Feishu Open Platform — the real name is `sheets:spreadsheet:readonly`. Because the framework's preflight (`internal/auth/scope.go` MissingScopes) does exact-string scope matching, tokens that carried the correct `:readonly` / `:write_only` / `:create` scopes were rejected with a misleading `missing required scope(s): sheets:spreadsheet:read` hint, and the entire sheets shortcut layer was unusable.

## Changes

- Replace `sheets:spreadsheet:read` with `sheets:spreadsheet:readonly` in every sheets shortcut declaration (35 occurrences across 9 files under `shortcuts/sheets/`).
- Update the two affected scope strings in `internal/registry/registry_test.go` so the auto-approve-set test reflects the real scope name.
- Add two regression tests in `shortcuts/sheets/shortcuts_test.go`:
  - `TestShortcuts_NoUnrealReadScope` — walks every registered sheets shortcut and fails if any re-declares the unreal `:read` form.
  - `TestShortcuts_PrecheckAcceptsFeishuSheetsScopes` — feeds a token granted the documented Feishu sheets scopes (`:create` / `:readonly` / `:write_only`) through `auth.MissingScopes` against every sheets-only shortcut's `Scopes`, and fails if any shortcut is rejected. This pins the precheck behaviour the issue reported.

## Test Plan

- [x] `go test ./shortcuts/sheets/...` passes (both new tests included).
- [x] `go test ./internal/registry/...` passes.
- [x] `TestShortcuts_PrecheckAcceptsFeishuSheetsScopes` hermetically verifies that `lark-cli sheets +read` / `+write` / `+append` / `+find` (and every other sheets-only shortcut) no longer reject tokens holding `sheets:spreadsheet:readonly` / `:write_only` / `:create`.

## Related Issues

- Fixes #838


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OAuth permission scopes for Sheets operations to use the `sheets:spreadsheet:readonly` variant instead of the deprecated `sheets:spreadsheet:read` scope across read, write, styling, filtering, and management shortcuts.
  * Added validation tests to ensure all Sheets shortcuts declare correct permission scopes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/909)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->