### PR TITLE
feat(im): support file input for message content

### DIFF
--- a/shortcuts/im/im_messages_send.go
+++ b/shortcuts/im/im_messages_send.go
@@ -29,7 +29,7 @@ var ImMessagesSend = common.Shortcut{
 		{Name: "chat-id", Desc: "(required, mutually exclusive with --user-id) chat ID (oc_xxx)"},
 		{Name: "user-id", Desc: "(required, mutually exclusive with --chat-id) user open_id (ou_xxx)"},
 		{Name: "msg-type", Default: "text", Desc: "message type for --content JSON; when using --text/--markdown/--image/--file/--video/--audio, the effective type is inferred automatically", Enum: []string{"text", "post", "image", "file", "audio", "media", "interactive", "share_chat", "share_user"}},
-		{Name: "content", Desc: "(one of --content/--text/--markdown/--image/--file/--video/--audio required) message content JSON"},
+		{Name: "content", Desc: "(one of --content/--text/--markdown/--image/--file/--video/--audio required) message content JSON; supports @file and - for stdin", Input: []string{common.File, common.Stdin}},
 		{Name: "text", Desc: "plain text message (auto-wrapped as JSON)"},
 		{Name: "markdown", Desc: "markdown text (auto-wrapped as post format with style optimization; image URLs auto-resolved)"},
 		{Name: "idempotency-key", Desc: "idempotency key (prevents duplicate sends)"},

--- a/tests/cli_e2e/im/messages_send_content_input_test.go
+++ b/tests/cli_e2e/im/messages_send_content_input_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIMMessagesSendContentFileAndStdinDryRun(t *testing.T) {
+	setDryRunConfigEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	cardJSON := `{"type":"template","data":{"template_id":"tpl_123"}}`
+
+	t.Run("content from file", func(t *testing.T) {
+		dir := t.TempDir()
+		cardPath := filepath.Join(dir, "card.json")
+		require.NoError(t, os.WriteFile(cardPath, []byte(cardJSON), 0644))
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{"im", "+messages-send",
+				"--as", "bot",
+				"--chat-id", "oc_dryrun_chat",
+				"--msg-type", "interactive",
+				"--content", "@" + cardPath,
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		require.Contains(t, result.Stdout, "/open-apis/im/v1/messages")
+		require.Contains(t, result.Stdout, "interactive")
+		require.Contains(t, result.Stdout, "tpl_123")
+		require.NotContains(t, result.Stdout, "@"+cardPath)
+	})
+
+	t.Run("content from stdin", func(t *testing.T) {
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{"im", "+messages-send",
+				"--as", "bot",
+				"--chat-id", "oc_dryrun_chat",
+				"--msg-type", "interactive",
+				"--content", "-",
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+			Stdin:     []byte(cardJSON),
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		require.Contains(t, result.Stdout, "/open-apis/im/v1/messages")
+		require.Contains(t, result.Stdout, "interactive")
+		require.Contains(t, result.Stdout, "tpl_123")
+		require.NotContains(t, strings.TrimSpace(result.Stdout), `"content":"-"`)
+	})
+}
+
+func setDryRunConfigEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("LARKSUITE_CLI_APP_ID", "cli_dryrun_test")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret_dryrun_test")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+}


### PR DESCRIPTION
## Summary
Support file and stdin input for `im +messages-send --content`, making scripted interactive-card sends safer and less brittle than passing large JSON through one shell argument.

## Changes
- Mark `--content` as a file/stdin-capable input flag, enabling `--content @card.json` and `--content -`
- Update `--content` help text to document the new input modes
- Add a dry-run E2E test covering both file-backed and stdin-backed interactive content

## Test Plan
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark xxx` command works as expected
- Not run locally: Go toolchain is not installed in this WSL environment (`gofmt: command not found`)

## Related Issues
- Fixes #916


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--content` flag for sending instant messages now supports reading message content from local files and standard input.

* **Tests**
  * Added end-to-end tests verifying file and stdin input support for message content delivery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/917)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->