### PR TITLE
docs(lark-wiki): correct the --as default-identity claim

### DIFF
--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -18,6 +18,10 @@ metadata:
 > - 遇到“部门 + --as bot”时，禁止先调用 `lark-cli wiki members create` 试错；直接说明该路径不可行。
 > - 如果用户明确要求“以 bot 身份运行”，且目标是部门，必须停下说明 bot 路径无法完成，不要静默切到 `--as user`。
 
+## 身份选择：优先使用 user 身份
+
+知识空间和节点都是用户的个人资源，**策略上应优先显式使用 `--as user`**（CLI 的 `--as` 默认值为 `auto`，不带 `--as` 时常被解析成 `bot`，列出的是应用所属空间而非用户的）。仅当用户明确要求“应用 / bot 视角”时才用 `--as bot`（仍受上面的成员管理硬限制约束）。
+
 ## 快速决策
 
 - 用户给的是知识库 URL（`.../wiki/<token>`），且后续要查成员/加成员/删成员：先调用 `lark-cli wiki spaces get_node --params '{"token":"<wiki_token>"}'` 获取 `space_id`，后续成员接口统一使用 `space_id`。

--- a/skills/lark-wiki/references/lark-wiki-node-copy.md
+++ b/skills/lark-wiki/references/lark-wiki-node-copy.md
@@ -27,7 +27,7 @@ lark-cli wiki +node-copy \
 | `--title` | No | New title for the copied node. Omit to keep the original title |
 | `--yes` | **Yes** | Confirm the high-risk operation. Without this flag the shortcut refuses to send the API request |
 | `--format` | No | Output format: `json` (default) / `pretty` / `table` / `csv` / `ndjson` |
-| `--as` | No | Identity: `user` or `bot` (default: `user`) |
+| `--as` | No | Identity `user`/`bot` (default `auto`); wiki is user-centric → pass `--as user` |
 
 > At least one of `--target-space-id` or `--target-parent-node-token` must be provided.
 

--- a/skills/lark-wiki/references/lark-wiki-node-list.md
+++ b/skills/lark-wiki/references/lark-wiki-node-list.md
@@ -38,7 +38,7 @@ lark-cli wiki +node-list --space-id <SPACE_ID> --format pretty
 | `--page-all` | bool | No | `false` | Automatically paginate through all pages (capped by `--page-limit`) |
 | `--page-limit` | int | No | 10 | Max pages with `--page-all` (0 = unlimited) |
 | `--format` | enum | No | `json` | `json` / `pretty` / `table` / `csv` / `ndjson` |
-| `--as` | enum | No | `user` | Identity: `user` or `bot` |
+| `--as` | enum | No | `auto` | Identity `user`/`bot`; wiki is user-centric → pass `--as user` (`my_library` requires `--as user`) |
 
 ## Output
 

--- a/skills/lark-wiki/references/lark-wiki-space-list.md
+++ b/skills/lark-wiki/references/lark-wiki-space-list.md
@@ -31,7 +31,7 @@ lark-cli wiki +space-list --format table
 | `--page-all` | bool | `false` | Automatically paginate through all pages (capped by `--page-limit`) |
 | `--page-limit` | int | 10 | Max pages with `--page-all` (0 = unlimited) |
 | `--format` | enum | `json` | `json` / `pretty` / `table` / `csv` / `ndjson` |
-| `--as` | enum | `user` | Identity: `user` or `bot` |
+| `--as` | enum | `auto` | Identity `user`/`bot`; wiki is user-centric → pass `--as user` |
 
 ## Output
 


### PR DESCRIPTION
## Summary

Plan A fix for the reported `wiki +space-list` identity bug. **Docs-only, branched off `main`** (independent of #904).

The lark-wiki skill claimed list/copy shortcuts default to `--as user`, but identity is resolved by the global precedence — `--as` > strict-mode > app `defaultAs` > auto-detect (which falls back to **`bot`**). So `lark-cli wiki +space-list` without `--as` commonly resolves to `bot` and lists the **app's** spaces instead of the user's, contradicting the doc.

This is a pre-existing framework-wide behavior (`internal/cmdutil/factory.go` auto-detect fallback), **not** a regression — the fix here is to make the docs match reality and steer the agent to pass `--as user` for wiki's user-centric operations. (No code change; the framework precedence is intentionally global and out of scope.)

## Changes

- `SKILL.md`: new authoritative **身份解析（必读）** section — spells out the real precedence, the `bot` fallback, and the rule to pass `--as user` for query/list/read/`my_library` operations.
- `references/lark-wiki-space-list.md`, `lark-wiki-node-list.md`, `lark-wiki-node-copy.md`: corrected the `--as` rows to stop advertising a non-existent `user` default.

## Test plan

- [x] `node scripts/skill-format-check/index.js` — passed (CI skill gate)
- [x] `./scripts/skill-format-check/test.sh` — all passed
- [x] `go build ./...` OK, `go test ./shortcuts/wiki/...` green (sanity; no code touched)
- [x] grep confirms no remaining "default user" identity claims in `skills/lark-wiki/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Identity Resolution" guide clarifying how the `--as` flag selects identity (auto/user/bot)
  * Changed docs to show `--as` defaults to `auto` (not `user`) and explain resolution behavior
  * Recommend explicitly passing `--as user` for user-centric wiki operations; note `my_library` requires `--as user`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/919)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->