### PR TITLE
test: drop stale e2e yes flags

### DIFF
--- a/tests/cli_e2e/calendar/calendar_create_event_test.go
+++ b/tests/cli_e2e/calendar/calendar_create_event_test.go
@@ -66,7 +66,6 @@ func TestCalendar_CreateEvent(t *testing.T) {
 					"calendar_id": calendarID,
 					"event_id":    eventID,
 				},
-				Yes: true,
 			})
 			clie2e.ReportCleanupFailure(parentT, "delete event "+eventID, deleteResult, deleteErr)
 		})

--- a/tests/cli_e2e/calendar/calendar_personal_event_workflow_test.go
+++ b/tests/cli_e2e/calendar/calendar_personal_event_workflow_test.go
@@ -77,7 +77,6 @@ func TestCalendar_PersonalEventWorkflowAsUser(t *testing.T) {
 					"calendar_id": calendarID,
 					"event_id":    eventID,
 				},
-				Yes: true,
 			})
 			clie2e.ReportCleanupFailure(parentT, "delete event "+eventID, deleteResult, deleteErr)
 		})

--- a/tests/cli_e2e/calendar/calendar_rsvp_workflow_test.go
+++ b/tests/cli_e2e/calendar/calendar_rsvp_workflow_test.go
@@ -99,7 +99,6 @@ func TestCalendar_RSVPWorkflowAsUser(t *testing.T) {
 					"calendar_id": calendarID,
 					"event_id":    eventID,
 				},
-				Yes: true,
 			})
 			clie2e.ReportCleanupFailure(parentT, "delete event "+eventID, deleteResult, deleteErr)
 		})

--- a/tests/cli_e2e/calendar/calendar_update_event_test.go
+++ b/tests/cli_e2e/calendar/calendar_update_event_test.go
@@ -68,7 +68,6 @@ func TestCalendar_UpdateEventWorkflow(t *testing.T) {
 					"calendar_id": calendarID,
 					"event_id":    eventID,
 				},
-				Yes: true,
 			})
 			clie2e.ReportCleanupFailure(parentT, "delete event "+eventID, deleteResult, deleteErr)
 		})
@@ -126,7 +125,6 @@ func TestCalendar_UpdateEventWorkflow(t *testing.T) {
 				"calendar_id": calendarID,
 				"event_id":    eventID,
 			},
-			Yes: true,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)

--- a/tests/cli_e2e/sheets/sheets_crud_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_crud_workflow_test.go
@@ -240,7 +240,6 @@ func TestSheets_SpreadsheetsResource(t *testing.T) {
 			DefaultAs: "bot",
 			Params:    map[string]any{"spreadsheet_token": spreadsheetToken},
 			Data:      map[string]any{"title": updatedTitle},
-			Yes:       true,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)

--- a/tests/cli_e2e/sheets/sheets_filter_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_filter_workflow_test.go
@@ -141,7 +141,6 @@ func TestSheets_FilterWorkflow(t *testing.T) {
 				"sheet_id":          sheetID,
 			},
 			Data: filterData,
-			Yes:  true,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)


### PR DESCRIPTION
## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test cases for calendar event management operations including event creation, updates, and RSVP workflows to reflect current CLI command behavior and expectations.
  * Updated end-to-end test cases for spreadsheet operations including resource CRUD tasks, spreadsheet patching, and filter management to align with current CLI specifications and requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/920)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->