### PR TITLE
fix: add default timeout to bare http.Client instances

### DIFF
--- a/cmd/config/init_interactive.go
+++ b/cmd/config/init_interactive.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/charmbracelet/huh"
 	"github.com/larksuite/cli/internal/build"
@@ -168,7 +169,7 @@ func runCreateAppFlow(ctx context.Context, f *cmdutil.Factory, brandOverride cor
 	}
 
 	// Step 1: Request app registration (begin)
-	httpClient := &http.Client{}
+	httpClient := &http.Client{Timeout: 30 * time.Second}
 	authResp, err := larkauth.RequestAppRegistration(httpClient, larkBrand, f.IOStreams.ErrOut)
 	if err != nil {
 		return nil, output.ErrAuth("app registration failed: %v", err)

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -179,7 +179,7 @@ func networkChecks(ctx context.Context, opts *DoctorOptions, ep core.Endpoints) 
 		}
 	}
 
-	httpClient := &http.Client{}
+	httpClient := &http.Client{Timeout: 10 * time.Second}
 	mcpURL := ep.MCP + "/mcp"
 
 	type probeResult struct {

--- a/internal/validate/url.go
+++ b/internal/validate/url.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 const (
@@ -108,7 +109,7 @@ func ValidateDownloadSourceURL(ctx context.Context, rawURL string) error {
 // and connection rules for untrusted URLs.
 func NewDownloadHTTPClient(base *http.Client, opts DownloadHTTPClientOptions) *http.Client {
 	if base == nil {
-		base = &http.Client{}
+		base = &http.Client{Timeout: 30 * time.Second}
 	}
 	if opts.MaxRedirects <= 0 {
 		opts.MaxRedirects = defaultDownloadMaxRedirects


### PR DESCRIPTION
## Summary

- Three call-sites created `&http.Client{}` without any `Timeout`, which can hang indefinitely when a remote server is unresponsive
- `cmd/config/init_interactive.go` (app registration flow) had **zero** timeout protection — neither client-level nor per-request context
- `cmd/doctor/doctor.go` (endpoint probes) had a per-request `context.WithTimeout` but no client-level safety net
- `internal/validate/url.go` (`NewDownloadHTTPClient` nil-fallback) created a bare client as defensive default

This PR adds explicit `Timeout` values to all three sites:
| File | Timeout | Rationale |
|---|---|---|
| `cmd/doctor/doctor.go` | 10s | Matches existing per-request context timeout |
| `cmd/config/init_interactive.go` | 30s | Matches `cachedHttpClientFunc` factory default |
| `internal/validate/url.go` | 30s | Matches factory default for defensive fallback |

## Test plan
- [x] `go build ./...` passes
- [x] Existing tests in `cmd/doctor`, `internal/validate` still pass
- [ ] Manual: `lark-cli doctor` still probes endpoints correctly
- [ ] Manual: `lark-cli config init` interactive flow still completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added request timeouts to HTTP operations, including app registration, network diagnostics, and downloads. This prevents the application from hanging indefinitely when network requests don't receive timely responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->