### PR TITLE
fix(sheets): use correct scope sheets:spreadsheet:readonly instead of :read

### DIFF
--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -237,8 +237,8 @@ func TestLoadAutoApproveSet(t *testing.T) {
 	}
 
 	// Verify allow list entries are present
-	if !aaSet["sheets:spreadsheet:read"] {
-		t.Error("expected sheets:spreadsheet:read in auto-approve set (from allow list)")
+	if !aaSet["sheets:spreadsheet:readonly"] {
+		t.Error("expected sheets:spreadsheet:readonly in auto-approve set (from allow list)")
 	}
 
 	t.Logf("Auto-approve set has %d scopes", len(aaSet))
@@ -292,7 +292,7 @@ func TestFilterAutoApproveScopes(t *testing.T) {
 	scopes := []string{
 		"calendar:calendar.event:create", // auto-approve (in allow list)
 		"zzz:unknown:scope",              // not in auto-approve
-		"sheets:spreadsheet:read",        // auto-approve (in allow list)
+		"sheets:spreadsheet:readonly",        // auto-approve (in allow list)
 	}
 
 	result := FilterAutoApproveScopes(scopes)

--- a/internal/registry/scope_priorities.json
+++ b/internal/registry/scope_priorities.json
@@ -85,11 +85,6 @@
     "recommend": "true"
   },
   {
-    "scope_name": "sheets:spreadsheet:read",
-    "final_score": "65.0000",
-    "recommend": "true"
-  },
-  {
     "scope_name": "base:workflow:create",
     "final_score": "79.4755",
     "recommend": "true"

--- a/shortcuts/sheets/lark_sheets_cell_data.go
+++ b/shortcuts/sheets/lark_sheets_cell_data.go
@@ -28,7 +28,7 @@ var SheetRead = common.Shortcut{
 	Command:     "+read",
 	Description: "Read spreadsheet cell values",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -99,7 +99,7 @@ var SheetWrite = common.Shortcut{
 	Command:     "+write",
 	Description: "Write to spreadsheet cells (overwrite mode)",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -175,7 +175,7 @@ var SheetAppend = common.Shortcut{
 	Command:     "+append",
 	Description: "Append rows to a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -251,7 +251,7 @@ var SheetFind = common.Shortcut{
 	Command:     "+find",
 	Description: "Find cells in a spreadsheet",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -335,7 +335,7 @@ var SheetReplace = common.Shortcut{
 	Command:     "+replace",
 	Description: "Find and replace cell values in a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_cell_images.go
+++ b/shortcuts/sheets/lark_sheets_cell_images.go
@@ -20,7 +20,7 @@ var SheetWriteImage = common.Shortcut{
 	Command:     "+write-image",
 	Description: "Write an image into a spreadsheet cell",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_cell_style_and_merge.go
+++ b/shortcuts/sheets/lark_sheets_cell_style_and_merge.go
@@ -59,7 +59,7 @@ var SheetSetStyle = common.Shortcut{
 	Command:     "+set-style",
 	Description: "Set cell style for a range",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -141,7 +141,7 @@ var SheetBatchSetStyle = common.Shortcut{
 	Command:     "+batch-set-style",
 	Description: "Batch set cell styles for multiple ranges",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -227,7 +227,7 @@ var SheetMergeCells = common.Shortcut{
 	Command:     "+merge-cells",
 	Description: "Merge cells in a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -292,7 +292,7 @@ var SheetUnmergeCells = common.Shortcut{
 	Command:     "+unmerge-cells",
 	Description: "Unmerge (split) cells in a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_dropdown.go
+++ b/shortcuts/sheets/lark_sheets_dropdown.go
@@ -107,7 +107,7 @@ var SheetSetDropdown = common.Shortcut{
 	Command:     "+set-dropdown",
 	Description: "Set dropdown list on a cell range",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -168,7 +168,7 @@ var SheetUpdateDropdown = common.Shortcut{
 	Command:     "+update-dropdown",
 	Description: "Update dropdown list settings",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -235,7 +235,7 @@ var SheetGetDropdown = common.Shortcut{
 	Command:     "+get-dropdown",
 	Description: "Get dropdown list settings for a range",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -279,7 +279,7 @@ var SheetDeleteDropdown = common.Shortcut{
 	Command:     "+delete-dropdown",
 	Description: "Delete dropdown list from cell ranges",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_filter_views.go
+++ b/shortcuts/sheets/lark_sheets_filter_views.go
@@ -43,7 +43,7 @@ var SheetCreateFilterView = common.Shortcut{
 	Command:     "+create-filter-view",
 	Description: "Create a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -98,7 +98,7 @@ var SheetUpdateFilterView = common.Shortcut{
 	Command:     "+update-filter-view",
 	Description: "Update a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -154,7 +154,7 @@ var SheetListFilterViews = common.Shortcut{
 	Command:     "+list-filter-views",
 	Description: "List all filter views in a sheet",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -187,7 +187,7 @@ var SheetGetFilterView = common.Shortcut{
 	Command:     "+get-filter-view",
 	Description: "Get a filter view by ID",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -221,7 +221,7 @@ var SheetDeleteFilterView = common.Shortcut{
 	Command:     "+delete-filter-view",
 	Description: "Delete a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -255,7 +255,7 @@ var SheetCreateFilterViewCondition = common.Shortcut{
 	Command:     "+create-filter-view-condition",
 	Description: "Create a filter condition on a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -297,7 +297,7 @@ var SheetUpdateFilterViewCondition = common.Shortcut{
 	Command:     "+update-filter-view-condition",
 	Description: "Update a filter condition on a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -350,7 +350,7 @@ var SheetListFilterViewConditions = common.Shortcut{
 	Command:     "+list-filter-view-conditions",
 	Description: "List all filter conditions of a filter view",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -386,7 +386,7 @@ var SheetGetFilterViewCondition = common.Shortcut{
 	Command:     "+get-filter-view-condition",
 	Description: "Get a filter condition by column",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},
@@ -424,7 +424,7 @@ var SheetDeleteFilterViewCondition = common.Shortcut{
 	Command:     "+delete-filter-view-condition",
 	Description: "Delete a filter condition from a filter view",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL (required if --spreadsheet-token is not set)"},

--- a/shortcuts/sheets/lark_sheets_float_images.go
+++ b/shortcuts/sheets/lark_sheets_float_images.go
@@ -367,7 +367,7 @@ var SheetGetFloatImage = common.Shortcut{
 	Command:     "+get-float-image",
 	Description: "Get a floating image by ID",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -401,7 +401,7 @@ var SheetListFloatImages = common.Shortcut{
 	Command:     "+list-float-images",
 	Description: "List all floating images in a sheet",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_row_column_management.go
+++ b/shortcuts/sheets/lark_sheets_row_column_management.go
@@ -16,7 +16,7 @@ var SheetAddDimension = common.Shortcut{
 	Command:     "+add-dimension",
 	Description: "Add rows or columns at the end of a sheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -75,7 +75,7 @@ var SheetInsertDimension = common.Shortcut{
 	Command:     "+insert-dimension",
 	Description: "Insert rows or columns at a specified position",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -148,7 +148,7 @@ var SheetUpdateDimension = common.Shortcut{
 	Command:     "+update-dimension",
 	Description: "Update row or column properties (visibility, size)",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -237,7 +237,7 @@ var SheetMoveDimension = common.Shortcut{
 	Command:     "+move-dimension",
 	Description: "Move rows or columns to a new position",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -309,7 +309,7 @@ var SheetDeleteDimension = common.Shortcut{
 	Command:     "+delete-dimension",
 	Description: "Delete rows or columns",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_sheet_management.go
+++ b/shortcuts/sheets/lark_sheets_sheet_management.go
@@ -497,7 +497,7 @@ var SheetCreateSheet = common.Shortcut{
 	Command:     "+create-sheet",
 	Description: "Create a sheet in an existing spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -548,7 +548,7 @@ var SheetCopySheet = common.Shortcut{
 	Command:     "+copy-sheet",
 	Description: "Copy a sheet within a spreadsheet",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -622,7 +622,7 @@ var SheetDeleteSheet = common.Shortcut{
 	Command:     "+delete-sheet",
 	Description: "Delete a sheet from a spreadsheet",
 	Risk:        "high-risk-write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},
@@ -662,7 +662,7 @@ var SheetUpdateSheet = common.Shortcut{
 	Command:     "+update-sheet",
 	Description: "Update sheet properties",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:write_only", "sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/shortcuts/sheets/lark_sheets_spreadsheet_management.go
+++ b/shortcuts/sheets/lark_sheets_spreadsheet_management.go
@@ -24,7 +24,7 @@ var SheetInfo = common.Shortcut{
 	Command:     "+info",
 	Description: "View spreadsheet and sheet information",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	Scopes:      []string{"sheets:spreadsheet:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "url", Desc: "spreadsheet URL"},

--- a/skills/lark-sheets/SKILL.md
+++ b/skills/lark-sheets/SKILL.md
@@ -335,11 +335,11 @@ lark-cli sheets <resource> <method> [flags] # 调用 API
 | `spreadsheets.patch` | `sheets:spreadsheet.meta:write_only` |
 | `spreadsheet.sheet.filters.create` | `sheets:spreadsheet:write_only` |
 | `spreadsheet.sheet.filters.delete` | `sheets:spreadsheet:write_only` |
-| `spreadsheet.sheet.filters.get` | `sheets:spreadsheet:read` |
+| `spreadsheet.sheet.filters.get` | `sheets:spreadsheet:readonly` |
 | `spreadsheet.sheet.filters.update` | `sheets:spreadsheet:write_only` |
-| `spreadsheet.sheets.find` | `sheets:spreadsheet:read` |
+| `spreadsheet.sheets.find` | `sheets:spreadsheet:readonly` |
 | `spreadsheet.sheet.float_images.create` | `sheets:spreadsheet:write_only` |
 | `spreadsheet.sheet.float_images.patch` | `sheets:spreadsheet:write_only` |
-| `spreadsheet.sheet.float_images.get` | `sheets:spreadsheet:read` |
-| `spreadsheet.sheet.float_images.query` | `sheets:spreadsheet:read` |
+| `spreadsheet.sheet.float_images.get` | `sheets:spreadsheet:readonly` |
+| `spreadsheet.sheet.float_images.query` | `sheets:spreadsheet:readonly` |
 | `spreadsheet.sheet.float_images.delete` | `sheets:spreadsheet:write_only` |


### PR DESCRIPTION
## Summary

Fixes #838

All sheets shortcuts used the non-existent scope `sheets:spreadsheet:read` in their local precheck, causing **every** shortcut (`+read`, `+write`, `+append`, `+info`, etc.) to reject tokens that carry the real Feishu platform scope `sheets:spreadsheet:readonly`.

The issue reporter confirmed that `sheets:spreadsheet:read` does not exist on the Feishu Open Platform — the correct name is `sheets:spreadsheet:readonly`, consistent with every other domain (`docx:document:readonly`, `drive:drive.metadata:readonly`, etc.).

### Changes
- **9 shortcut files** in `shortcuts/sheets/` — replaced all 36 occurrences of `"sheets:spreadsheet:read"` → `"sheets:spreadsheet:readonly"`
- **`internal/registry/scope_priorities.json`** — removed the duplicate wrong entry (the correct `sheets:spreadsheet:readonly` entry already existed)
- **`internal/registry/registry_test.go`** — updated test assertions to use the correct scope name
- **`skills/lark-sheets/SKILL.md`** — fixed scope references in the API scope table

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./shortcuts/sheets/` passes
- [x] `go test ./internal/registry/` passes
- [ ] Manual: `lark-cli sheets +info --spreadsheet-token <token>` no longer rejects valid `sheets:spreadsheet:readonly` tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authorization scopes for Sheets operations to use `sheets:spreadsheet:readonly` instead of `sheets:spreadsheet:read` for read-only access.
  * Updated write operations to require `sheets:spreadsheet:write_only` alongside `sheets:spreadsheet:readonly` for proper authorization.
  * Changes apply across multiple sheet operations including cell data, images, styling, dropdowns, filters, and sheet management.

* **Tests**
  * Updated authorization scope tests to reflect new scope requirements.

* **Documentation**
  * Updated Sheets skill documentation to reflect new authorization scope names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->