### PR TITLE
fix(im): clarify messages-send dry-run chat membership

### DIFF
--- a/shortcuts/im/builders_test.go
+++ b/shortcuts/im/builders_test.go
@@ -729,6 +729,18 @@ func TestShortcutDryRunShapes(t *testing.T) {
 		}
 	})
 
+	t.Run("ImMessagesSend dry run warns chat membership is not verified", func(t *testing.T) {
+		runtime := newTestRuntimeContext(t, map[string]string{
+			"chat-id": "oc_123",
+			"text":    "hello",
+		}, nil)
+		got := mustMarshalDryRun(t, ImMessagesSend.DryRun(context.Background(), runtime))
+		if !strings.Contains(got, "does not verify that the selected bot/user is a member of the target chat") ||
+			!strings.Contains(got, "Bot/User can NOT be out of the chat") {
+			t.Fatalf("ImMessagesSend.DryRun() missing membership warning: %s", got)
+		}
+	})
+
 	t.Run("ImMessagesSend dry run uses placeholder media key for url input", func(t *testing.T) {
 		runtime := newTestRuntimeContext(t, map[string]string{
 			"chat-id": "oc_123",

--- a/shortcuts/im/im_messages_send.go
+++ b/shortcuts/im/im_messages_send.go
@@ -81,10 +81,14 @@ var ImMessagesSend = common.Shortcut{
 		if desc != "" {
 			d.Desc(desc)
 		}
-		return d.
+		d.
 			POST("/open-apis/im/v1/messages").
 			Params(map[string]interface{}{"receive_id_type": receiveIdType}).
 			Body(body)
+		if chatFlag != "" {
+			d.Desc("Dry-run validates request shape only. It does not verify that the selected bot/user is a member of the target chat. A real send can still fail with `Bot/User can NOT be out of the chat`.")
+		}
+		return d
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		chatFlag := runtime.Str("chat-id")


### PR DESCRIPTION
## Summary
Clarify that `im +messages-send --dry-run` validates request shape only and does not prove the selected bot/user can send to the target chat.

## Changes
- Add a dry-run warning on chat-id sends explaining that chat membership is not verified.
- Preserve existing dry-run descriptions such as media placeholder notes.
- Add a dry-run shape regression test for the membership warning.

## Test Plan
- [x] Targeted regression: `go test ./shortcuts/im -run 'TestShortcutDryRunShapes/ImMessagesSend_dry_run_warns_chat_membership_is_not_verified' -count=1`
- [x] Related dry-run shape tests: `go test ./shortcuts/im -run 'TestShortcutDryRunShapes' -count=1`
- [x] Related IM send tests: `go test ./shortcuts/im -run 'TestImMessagesSend|TestShortcutDryRunShapes' -count=1`
- [x] Format check: `gofmt -l shortcuts/im/im_messages_send.go shortcuts/im/builders_test.go`
- [x] Diff check: `git diff --check -- shortcuts/im/im_messages_send.go shortcuts/im/builders_test.go`
- [ ] Full package test: `go test ./shortcuts/im -count=1` was run locally on Windows but is blocked by existing media/path tests unrelated to this change (`TestParseMediaDurationSuccess`, `TestNormalizeDownloadOutputPath`, `TestResolveIMResourceDownloadPath`, `TestValidateMediaFlagPath`).

## Related Issues
- Closes #915

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dry-run for sending messages now displays a warning clarifying that bot/user chat membership is not verified during validation, though actual sends may still fail due to membership issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->