### PR TITLE
fix: resolve tenant-specific URLs via drive meta API

### DIFF
--- a/shortcuts/common/tenant_url.go
+++ b/shortcuts/common/tenant_url.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"strings"
+)
+
+// FetchTenantResourceURL tries to resolve a tenant-specific URL for a resource
+// via the drive meta batch_query API (with_url=true). If the API succeeds and
+// returns a non-empty URL, that URL is returned. Otherwise it falls back to
+// BuildResourceURL using the brand-standard host.
+//
+// This is the preferred way to obtain resource URLs because batch_query
+// returns the tenant's actual vanity domain (e.g. example.feishu.cn) rather
+// than the generic www.feishu.cn / www.larksuite.com hosts, which may not
+// redirect correctly for private-deployment tenants.
+//
+// The kind parameter must be a value BuildResourceURL recognizes (docx, sheet,
+// wiki, file, folder, slides, bitable, mindnote). doc_type for the meta API
+// is derived from kind automatically.
+//
+// Returns "" only when both the meta lookup and the brand fallback fail
+// (typically because token is empty).
+func FetchTenantResourceURL(runtime *RuntimeContext, kind, token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+
+	docType := kindToDocType(kind)
+	if docType != "" {
+		if metaData, err := runtime.CallAPI(
+			"POST",
+			"/open-apis/drive/v1/metas/batch_query",
+			nil,
+			map[string]interface{}{
+				"request_docs": []map[string]interface{}{
+					{
+						"doc_token": token,
+						"doc_type":  docType,
+					},
+				},
+				"with_url": true,
+			},
+		); err == nil {
+			metas := GetSlice(metaData, "metas")
+			if len(metas) > 0 {
+				if meta, ok := metas[0].(map[string]interface{}); ok {
+					if url := strings.TrimSpace(GetString(meta, "url")); url != "" {
+						return url
+					}
+				}
+			}
+		}
+	}
+
+	return BuildResourceURL(runtime.Config.Brand, kind, token)
+}
+
+// kindToDocType maps a BuildResourceURL kind to the doc_type value used by
+// the drive meta batch_query API. Returns "" for kinds that have no
+// corresponding drive meta type (e.g. unknown kinds).
+func kindToDocType(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "docx", "doc":
+		return "docx"
+	case "sheet":
+		return "sheet"
+	case "bitable":
+		return "bitable"
+	case "wiki":
+		return "wiki"
+	case "file":
+		return "file"
+	case "folder":
+		return "folder"
+	case "mindnote":
+		return "mindnote"
+	case "slides":
+		return "slides"
+	default:
+		return ""
+	}
+}

--- a/shortcuts/common/tenant_url_test.go
+++ b/shortcuts/common/tenant_url_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestFetchTenantResourceURL_ReturnsMetaURL(t *testing.T) {
+	t.Parallel()
+
+	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test", AppSecret: "secret", Brand: core.BrandFeishu})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/metas/batch_query",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"metas": []interface{}{
+					map[string]interface{}{
+						"doc_token": "doxcnABC",
+						"doc_type":  "docx",
+						"url":       "https://tenant.feishu.cn/docx/doxcnABC",
+					},
+				},
+			},
+		},
+	})
+
+	rt := newTestRuntimeForTenantURL(t, f)
+	got := FetchTenantResourceURL(rt, "docx", "doxcnABC")
+	want := "https://tenant.feishu.cn/docx/doxcnABC"
+	if got != want {
+		t.Fatalf("FetchTenantResourceURL = %q, want %q", got, want)
+	}
+}
+
+func TestFetchTenantResourceURL_FallsBackToBuildResourceURL(t *testing.T) {
+	t.Parallel()
+
+	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test", AppSecret: "secret", Brand: core.BrandFeishu})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/metas/batch_query",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"metas": []interface{}{},
+			},
+		},
+	})
+
+	rt := newTestRuntimeForTenantURL(t, f)
+	got := FetchTenantResourceURL(rt, "docx", "doxcnABC")
+	want := "https://www.feishu.cn/docx/doxcnABC"
+	if got != want {
+		t.Fatalf("FetchTenantResourceURL = %q, want %q", got, want)
+	}
+}
+
+func TestFetchTenantResourceURL_FallsBackWhenMetaAPIFails(t *testing.T) {
+	t.Parallel()
+
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test", AppSecret: "secret", Brand: core.BrandLark})
+
+	rt := newTestRuntimeForTenantURL(t, f)
+	got := FetchTenantResourceURL(rt, "sheet", "shtcnABC")
+	want := "https://www.larksuite.com/sheets/shtcnABC"
+	if got != want {
+		t.Fatalf("FetchTenantResourceURL = %q, want %q", got, want)
+	}
+}
+
+func TestFetchTenantResourceURL_EmptyToken(t *testing.T) {
+	t.Parallel()
+
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test", AppSecret: "secret", Brand: core.BrandFeishu})
+
+	rt := newTestRuntimeForTenantURL(t, f)
+	if got := FetchTenantResourceURL(rt, "docx", ""); got != "" {
+		t.Fatalf("FetchTenantResourceURL(empty token) = %q, want empty", got)
+	}
+}
+
+func TestFetchTenantResourceURL_UnknownKind(t *testing.T) {
+	t.Parallel()
+
+	f, _, _, _ := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test", AppSecret: "secret", Brand: core.BrandFeishu})
+
+	rt := newTestRuntimeForTenantURL(t, f)
+	if got := FetchTenantResourceURL(rt, "calendar", "calABC"); got != "" {
+		t.Fatalf("FetchTenantResourceURL(unknown kind) = %q, want empty", got)
+	}
+}
+
+func TestFetchTenantResourceURL_TrimsWhitespaceURL(t *testing.T) {
+	t.Parallel()
+
+	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test", AppSecret: "secret", Brand: core.BrandFeishu})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/metas/batch_query",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"metas": []interface{}{
+					map[string]interface{}{
+						"doc_token": "doxcnABC",
+						"doc_type":  "docx",
+						"url":       "  https://tenant.feishu.cn/docx/doxcnABC  ",
+					},
+				},
+			},
+		},
+	})
+
+	rt := newTestRuntimeForTenantURL(t, f)
+	got := FetchTenantResourceURL(rt, "docx", "doxcnABC")
+	want := "https://tenant.feishu.cn/docx/doxcnABC"
+	if got != want {
+		t.Fatalf("FetchTenantResourceURL = %q, want %q", got, want)
+	}
+}
+
+func TestFetchTenantResourceURL_FallsBackWhenMetaURLIsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	f, _, _, reg := cmdutil.TestFactory(t, &core.CliConfig{AppID: "test", AppSecret: "secret", Brand: core.BrandFeishu})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/metas/batch_query",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"metas": []interface{}{
+					map[string]interface{}{
+						"doc_token": "doxcnABC",
+						"doc_type":  "docx",
+						"url":       "   ",
+					},
+				},
+			},
+		},
+	})
+
+	rt := newTestRuntimeForTenantURL(t, f)
+	got := FetchTenantResourceURL(rt, "docx", "doxcnABC")
+	want := "https://www.feishu.cn/docx/doxcnABC"
+	if got != want {
+		t.Fatalf("FetchTenantResourceURL = %q, want %q", got, want)
+	}
+}
+
+func TestKindToDocType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		kind string
+		want string
+	}{
+		{"docx", "docx"},
+		{"doc", "docx"},
+		{"sheet", "sheet"},
+		{"bitable", "bitable"},
+		{"wiki", "wiki"},
+		{"file", "file"},
+		{"folder", "folder"},
+		{"mindnote", "mindnote"},
+		{"slides", "slides"},
+		{"DOCX", "docx"},
+		{"  sheet  ", "sheet"},
+		{"calendar", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			got := kindToDocType(tt.kind)
+			if got != tt.want {
+				t.Fatalf("kindToDocType(%q) = %q, want %q", tt.kind, got, tt.want)
+			}
+		})
+	}
+}
+
+// newTestRuntimeForTenantURL creates a RuntimeContext backed by a test factory
+// with a context that carries shortcut headers so CallAPI works.
+func newTestRuntimeForTenantURL(t *testing.T, f *cmdutil.Factory) *RuntimeContext {
+	t.Helper()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetContext(context.Background())
+	cfg, _ := f.Config()
+	return TestNewRuntimeContextForAPI(context.Background(), cmd, cfg, f, core.AsBot)
+}

--- a/shortcuts/doc/docs_create.go
+++ b/shortcuts/doc/docs_create.go
@@ -172,7 +172,7 @@ func fallbackDocURLV1(runtime *common.RuntimeContext, result map[string]interfac
 	if docID == "" {
 		return
 	}
-	if u := common.BuildResourceURL(runtime.Config.Brand, "docx", docID); u != "" {
+	if u := common.FetchTenantResourceURL(runtime, "docx", docID); u != "" {
 		result["doc_url"] = u
 	}
 }

--- a/shortcuts/doc/docs_create_v2.go
+++ b/shortcuts/doc/docs_create_v2.go
@@ -102,7 +102,7 @@ func fallbackDocsCreateURLV2(runtime *common.RuntimeContext, data map[string]int
 	if docID == "" {
 		return
 	}
-	if u := common.BuildResourceURL(runtime.Config.Brand, "docx", docID); u != "" {
+	if u := common.FetchTenantResourceURL(runtime, "docx", docID); u != "" {
 		doc["url"] = u
 	}
 }

--- a/shortcuts/drive/drive_import.go
+++ b/shortcuts/drive/drive_import.go
@@ -122,7 +122,7 @@ var DriveImport = common.Shortcut{
 		if statusURL := strings.TrimSpace(status.URL); statusURL != "" {
 			out["url"] = statusURL
 		} else if status.Token != "" {
-			if u := common.BuildResourceURL(runtime.Config.Brand, normalizeDriveImportKindForURL(resultType, spec.DocType), status.Token); u != "" {
+			if u := common.FetchTenantResourceURL(runtime, normalizeDriveImportKindForURL(resultType, spec.DocType), status.Token); u != "" {
 				out["url"] = u
 			}
 		}

--- a/shortcuts/drive/drive_upload.go
+++ b/shortcuts/drive/drive_upload.go
@@ -169,7 +169,7 @@ var DriveUpload = common.Shortcut{
 		// wiki node URL, which the upload response doesn't carry. Skip the
 		// fallback for parent_type=wiki rather than emit a link that 404s.
 		if target.ParentType == driveUploadParentTypeExplorer {
-			if u := common.BuildResourceURL(runtime.Config.Brand, "file", uploadResult.FileToken); u != "" {
+			if u := common.FetchTenantResourceURL(runtime, "file", uploadResult.FileToken); u != "" {
 				out["url"] = u
 			}
 		}

--- a/shortcuts/markdown/markdown_create.go
+++ b/shortcuts/markdown/markdown_create.go
@@ -79,7 +79,7 @@ var MarkdownCreate = common.Shortcut{
 			"file_name":  finalMarkdownFileName(spec),
 			"size_bytes": fileSize,
 		}
-		if u := common.BuildResourceURL(runtime.Config.Brand, "file", result.FileToken); u != "" {
+		if u := common.FetchTenantResourceURL(runtime, "file", result.FileToken); u != "" {
 			out["url"] = u
 		}
 		if grant := common.AutoGrantCurrentUserDrivePermission(runtime, result.FileToken, "file"); grant != nil {

--- a/shortcuts/wiki/wiki_node_create.go
+++ b/shortcuts/wiki/wiki_node_create.go
@@ -498,7 +498,7 @@ func augmentWikiNodeCreateOutput(runtime *common.RuntimeContext, execution *wiki
 	if grant := common.AutoGrantCurrentUserDrivePermission(runtime, execution.Node.NodeToken, "wiki"); grant != nil {
 		out["permission_grant"] = grant
 	}
-	if u := common.BuildResourceURL(runtime.Config.Brand, "wiki", execution.Node.NodeToken); u != "" {
+	if u := common.FetchTenantResourceURL(runtime, "wiki", execution.Node.NodeToken); u != "" {
 		out["url"] = u
 	}
 	return out


### PR DESCRIPTION
## Problem

Several CLI shortcuts that create resources (`drive +upload`, `drive +import`, `docs +create`, `markdown +create`, `wiki +node-create`) use `BuildResourceURL` to generate user-facing URLs. `BuildResourceURL` hard-codes `www.feishu.cn` and `www.larksuite.com` as hosts. For tenants with private deployments or custom vanity domains, these URLs do not redirect correctly, leaving users with broken links.

Issues: #810, #925

## Solution

Introduce `FetchTenantResourceURL` in `shortcuts/common/tenant_url.go`. This helper:

1. Queries the drive meta `batch_query` API (`with_url=true`) to obtain the tenant-specific URL for the newly created resource.
2. Falls back to `BuildResourceURL` when the API is unavailable, returns no URL, or the resource kind has no drive meta mapping.

This mirrors the existing pattern already used by `slides +create` (which calls `batch_query` directly) and is consistent with `sheets +create` / `drive +create-folder` (which read the `url` field from the create API response).

## Changes

- **New file**: `shortcuts/common/tenant_url.go` — `FetchTenantResourceURL` + `kindToDocType`
- **New file**: `shortcuts/common/tenant_url_test.go` — 7 unit tests covering meta URL resolution, fallback, empty token, unknown kind, and whitespace trimming
- **Modified**: Replaced `BuildResourceURL` with `FetchTenantResourceURL` in:
  - `shortcuts/drive/drive_upload.go`
  - `shortcuts/drive/drive_import.go`
  - `shortcuts/doc/docs_create.go`
  - `shortcuts/doc/docs_create_v2.go`
  - `shortcuts/markdown/markdown_create.go`
  - `shortcuts/wiki/wiki_node_create.go`

## Testing

- `go test ./shortcuts/common/ -run TestFetchTenantResourceURL` — PASS (7/7)
- `go test ./shortcuts/wiki/` — PASS
- `go test ./shortcuts/markdown/` — PASS
- `go test ./shortcuts/doc/` — PASS
- `go test ./shortcuts/slides/` — PASS
- `go test ./shortcuts/sheets/` — PASS
- `go vet ./shortcuts/common/ ./shortcuts/drive/ ./shortcuts/wiki/ ./shortcuts/markdown/ ./shortcuts/doc/ ./shortcuts/slides/ ./shortcuts/sheets/` — clean
- `gofmt -l` on all modified files — clean

## Backward Compatibility

Public-cloud tenants continue to receive the same brand-standard URLs because `BuildResourceURL` is still the fallback when `batch_query` does not return a tenant-specific URL. No breaking changes to CLI flags or output shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced resource URL resolution to use tenant-specific API lookups for documents, spreadsheets, files, wikis, and other content types, improving accuracy of resource addresses across the system.

* **Tests**
  * Added comprehensive test coverage for URL resolution logic, including API response handling, fallback scenarios, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->