### PR TITLE
fix(sheets): add missing JSON unmarshal error handling in dry-run mode

### DIFF
--- a/shortcuts/sheets/lark_sheets_cell_style_and_merge.go
+++ b/shortcuts/sheets/lark_sheets_cell_style_and_merge.go
@@ -95,7 +95,7 @@ var SheetSetStyle = common.Shortcut{
 		}
 		r := normalizePointRange(runtime.Str("sheet-id"), runtime.Str("range"))
 		var style interface{}
-		json.Unmarshal([]byte(runtime.Str("style")), &style)
+		_ = json.Unmarshal([]byte(runtime.Str("style")), &style) // Validate already parses and validates this JSON.
 		return common.NewDryRunAPI().
 			PUT("/open-apis/sheets/v2/spreadsheets/:token/style").
 			Body(map[string]interface{}{
@@ -164,7 +164,7 @@ var SheetBatchSetStyle = common.Shortcut{
 			token = extractSpreadsheetToken(runtime.Str("url"))
 		}
 		var data interface{}
-		json.Unmarshal([]byte(runtime.Str("data")), &data)
+		_ = json.Unmarshal([]byte(runtime.Str("data")), &data) // Validate already parses and validates this JSON via validateBatchStyleData().
 		normalizeBatchStyleRanges(data)
 		return common.NewDryRunAPI().
 			PUT("/open-apis/sheets/v2/spreadsheets/:token/styles_batch_update").


### PR DESCRIPTION
## Summary

Two DryRun functions in the sheets shortcuts called `json.Unmarshal` without checking the return value. This looks like a bug, but `Validate` already parses and validates the same `--style` / `--data` JSON before `DryRun` runs, so the error is structurally impossible at this point.

Use `_ =` assignment + comment to silence the unchecked-error lint warning and make the safety invariant explicit to future readers.

## Changes

- `SheetSetStyle.DryRun`: document why `json.Unmarshal` of `--style` can be safely ignored
- `SheetBatchSetStyle.DryRun`: document why `json.Unmarshal` of `--data` can be safely ignored (via `validateBatchStyleData()`)

## Note

The initial attempt added `if err != nil { return common.FlagErrorf(...) }` inside `DryRun`, but `DryRun` must return `*common.DryRunAPI` (not `error`), so that would not compile. The correct fix is to acknowledge the already-validated invariant instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Internal code cleanup to improve maintainability in sheet functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->