### PR TITLE
feat: add task +get shortcut for single task detail retrieval

### DIFF
--- a/shortcuts/task/shortcuts.go
+++ b/shortcuts/task/shortcuts.go
@@ -248,6 +248,7 @@ var CreateTask = common.Shortcut{
 func Shortcuts() []common.Shortcut {
 	return []common.Shortcut{
 		CreateTask,
+		GetTask,
 		UpdateTask,
 		SetAncestorTask,
 		CommentTask,

--- a/shortcuts/task/task_get.go
+++ b/shortcuts/task/task_get.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package task
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var GetTask = common.Shortcut{
+	Service:     "task",
+	Command:     "+get",
+	Description: "get a single task by id",
+	Risk:        "read",
+	Scopes:      []string{"task:task:read"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+
+	Flags: []common.Flag{
+		{Name: "task-id", Desc: "task id (guid or applink URL)", Required: true},
+	},
+
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		taskId := url.PathEscape(extractTaskGuid(runtime.Str("task-id")))
+		return common.NewDryRunAPI().
+			GET("/open-apis/task/v2/tasks/" + taskId).
+			Params(map[string]interface{}{"user_id_type": "open_id"})
+	},
+
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		taskId := extractTaskGuid(runtime.Str("task-id"))
+
+		task, err := getTaskDetail(runtime, taskId)
+		if err != nil {
+			return err
+		}
+
+		guid, _ := task["guid"].(string)
+		summary, _ := task["summary"].(string)
+		urlVal, _ := task["url"].(string)
+		urlVal = truncateTaskURL(urlVal)
+
+		outData := map[string]interface{}{
+			"guid":    guid,
+			"summary": summary,
+			"url":     urlVal,
+		}
+		if description, ok := task["description"].(string); ok {
+			outData["description"] = description
+		}
+		if dueObj, ok := task["due"].(map[string]interface{}); ok {
+			if tsStr, ok := dueObj["timestamp"].(string); ok {
+				if ts, pErr := strconv.ParseInt(tsStr, 10, 64); pErr == nil {
+					outData["due_at"] = time.UnixMilli(ts).Local().Format(time.RFC3339)
+				}
+			}
+		}
+		if createdAtStr, ok := task["created_at"].(string); ok {
+			if ts, pErr := strconv.ParseInt(createdAtStr, 10, 64); pErr == nil {
+				outData["created_at"] = time.UnixMilli(ts).Local().Format(time.RFC3339)
+			}
+		}
+		if status, ok := task["status"].(string); ok {
+			outData["status"] = status
+		}
+
+		runtime.OutFormat(outData, nil, func(w io.Writer) {
+			fmt.Fprintf(w, "📋 Task Detail\n")
+			if guid != "" {
+				fmt.Fprintf(w, "  ID: %s\n", guid)
+			}
+			if summary != "" {
+				fmt.Fprintf(w, "  Summary: %s\n", summary)
+			}
+			if desc, ok := task["description"].(string); ok && desc != "" {
+				fmt.Fprintf(w, "  Description: %s\n", desc)
+			}
+			if status, ok := task["status"].(string); ok && status != "" {
+				fmt.Fprintf(w, "  Status: %s\n", status)
+			}
+			if dueAt, ok := outData["due_at"].(string); ok {
+				fmt.Fprintf(w, "  Due: %s\n", dueAt)
+			}
+			if createdAt, ok := outData["created_at"].(string); ok {
+				fmt.Fprintf(w, "  Created: %s\n", createdAt)
+			}
+			if urlVal != "" {
+				fmt.Fprintf(w, "  URL: %s\n", urlVal)
+			}
+		})
+		return nil
+	},
+}

--- a/shortcuts/task/task_get_test.go
+++ b/shortcuts/task/task_get_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package task
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestGetTask(t *testing.T) {
+	tests := []struct {
+		name           string
+		taskId         string
+		formatFlag     string
+		expectedOutput []string
+	}{
+		{
+			name:       "pretty format",
+			taskId:     "task-123",
+			formatFlag: "pretty",
+			expectedOutput: []string{
+				"📋 Task Detail",
+				"task-123",
+				"Buy groceries",
+			},
+		},
+		{
+			name:       "json format",
+			taskId:     "task-456",
+			formatFlag: "json",
+			expectedOutput: []string{
+				`"guid": "task-456"`,
+				`"summary": "Review PR"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, stdout, _, reg := taskShortcutTestFactory(t)
+			warmTenantToken(t, f, reg)
+
+			reg.Register(&httpmock.Stub{
+				Method: "GET",
+				URL:    "/open-apis/task/v2/tasks/" + tt.taskId,
+				Body: map[string]interface{}{
+					"code": 0, "msg": "success",
+					"data": map[string]interface{}{
+						"task": map[string]interface{}{
+							"guid":        tt.taskId,
+							"summary":     map[string]string{"task-123": "Buy groceries", "task-456": "Review PR"}[tt.taskId],
+							"description": "task description here",
+							"status":      "in_progress",
+							"created_at":  "1775174400000",
+							"due": map[string]interface{}{
+								"timestamp": "1775347200000",
+							},
+							"url": "https://example.com/" + tt.taskId,
+						},
+					},
+				},
+			})
+
+			err := runMountedTaskShortcut(t, GetTask, []string{"+get", "--task-id", tt.taskId, "--format", tt.formatFlag, "--as", "bot"}, f, stdout)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+
+			out := stdout.String()
+			outNorm := strings.ReplaceAll(out, `":"`, `": "`)
+
+			for _, expected := range tt.expectedOutput {
+				if !strings.Contains(outNorm, expected) && !strings.Contains(out, expected) {
+					t.Errorf("output missing expected string (%s), got: %s", expected, out)
+				}
+			}
+		})
+	}
+}

--- a/tests/cli_e2e/task/task_get_dryrun_test.go
+++ b/tests/cli_e2e/task/task_get_dryrun_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package task
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestTask_GetDryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "task_dryrun_test")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "task_dryrun_secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantMethod string
+		wantURL    string
+		wantTaskID string
+	}{
+		{
+			name: "get task by guid",
+			args: []string{
+				"task", "+get",
+				"--task-id", "task-guid-123",
+				"--dry-run",
+			},
+			wantMethod: "GET",
+			wantURL:    "/open-apis/task/v2/tasks/task-guid-123",
+			wantTaskID: "task-guid-123",
+		},
+		{
+			name: "get task by applink URL resolves to guid",
+			args: []string{
+				"task", "+get",
+				"--task-id", "https://applink.feishu.cn/client/todo/task?guid=task-from-url",
+				"--dry-run",
+			},
+			wantMethod: "GET",
+			wantURL:    "/open-apis/task/v2/tasks/task-from-url",
+			wantTaskID: "task-from-url",
+		},
+	}
+
+	for _, temp := range tests {
+		tt := temp
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			t.Cleanup(cancel)
+
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args:      tt.args,
+				DefaultAs: "bot",
+			})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 0)
+
+			out := result.Stdout
+			if count := gjson.Get(out, "api.#").Int(); count != 1 {
+				t.Fatalf("expected 1 API call, got %d\nstdout:\n%s", count, out)
+			}
+			if method := gjson.Get(out, "api.0.method").String(); method != tt.wantMethod {
+				t.Fatalf("api[0].method = %q, want %q\nstdout:\n%s", method, tt.wantMethod, out)
+			}
+			if url := gjson.Get(out, "api.0.url").String(); url != tt.wantURL {
+				t.Fatalf("api[0].url = %q, want %q\nstdout:\n%s", url, tt.wantURL, out)
+			}
+			if got := gjson.Get(out, "api.0.params.user_id_type").String(); got != "open_id" {
+				t.Fatalf("api[0].params.user_id_type = %q, want open_id\nstdout:\n%s", got, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

task 模块有 create、update、complete、search 这些命令，但唯独没有按 ID 查单个任务详情的功能。`getTaskDetail` 这个 helper 其实已经在 `+complete` 和 `+search` 里用了，只是没暴露成独立命令。这个 PR 就是把它补上。

The task module has shortcuts for creating, updating, completing, and searching tasks, but no way to fetch a single task by ID. The `getTaskDetail` helper already exists internally (used by `+complete` and `+search`), so this PR just exposes it as a standalone `task +get` command.

## Changes

- 新增 `task +get` 命令，支持 `--task-id`（GUID 或 applink URL）、`--format`、`--jq`、`--dry-run`
- 在 `Shortcuts()` 里注册 `GetTask`
- 补了单元测试（pretty/json 输出）和 dry-run E2E 测试（GUID 输入 + applink URL 解析）

- Added `task +get` shortcut with `--task-id` (GUID or applink URL), `--format`, `--jq`, `--dry-run`
- Registered `GetTask` in `Shortcuts()`
- Added unit tests (pretty/json output) and dry-run E2E test (GUID input + applink URL resolution)

## Test Plan

- [x] `go test ./shortcuts/task/... -race` 通过
- [x] `go vet` / `gofmt` / `go mod tidy` / `golangci-lint` 均无问题
- [x] dry-run E2E 测试通过
- [x] 单元测试覆盖 pretty 和 json 两种输出格式
- [x] 本地 `lark-cli task +get --task-id xxx` 验证命令正常工作

- [x] `go test ./shortcuts/task/... -race` passes
- [x] `go vet` / `gofmt` / `go mod tidy` / `golangci-lint` all clean
- [x] Dry-run E2E test passes
- [x] Unit tests cover both pretty and json output formats
- [x] Manual `lark-cli task +get --task-id xxx` verification

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `task +get` shortcut to retrieve and display individual task details by ID, including summary, description, creation and due dates, status, and URL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->