### PR TITLE
fix(base): default attachment file_types to all for form-questions-update

### DIFF
--- a/shortcuts/base/base_form_questions_update.go
+++ b/shortcuts/base/base_form_questions_update.go
@@ -25,14 +25,18 @@ var BaseFormQuestionsUpdate = common.Shortcut{
 		{Name: "base-token", Desc: "Base token (base_token)", Required: true},
 		{Name: "table-id", Desc: "table ID", Required: true},
 		{Name: "form-id", Desc: "form ID", Required: true},
-		{Name: "questions", Desc: `questions JSON array, max 10 items, each item must include "id". Supported fields: "id"(required),"title","description"(plain text or markdown link like [text](https://example.com)),"required","option_display_mode"(0=dropdown,1=vertical,2=horizontal,select only). E.g. '[{"id":"q_001","title":"Updated?","required":true}]'`, Required: true},
+		{Name: "questions", Desc: `questions JSON array, max 10 items, each item must include "id". Supported fields: "id"(required),"title","description"(plain text or markdown link like [text](https://example.com)),"required","option_display_mode"(0=dropdown,1=vertical,2=horizontal,select only),"attachment"({"file_types":["all"]},attachment only). E.g. '[{"id":"q_001","title":"Updated?","required":true}]'`, Required: true},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
-		return common.NewDryRunAPI().
+		dr := common.NewDryRunAPI().
 			PATCH("/open-apis/base/v3/bases/:base_token/tables/:table_id/forms/:form_id/questions").
 			Set("base_token", runtime.Str("base-token")).
 			Set("table_id", runtime.Str("table-id")).
 			Set("form_id", runtime.Str("form-id"))
+		if questions, err := parseUpdateFormQuestions(runtime.Str("questions")); err == nil {
+			dr.Body(map[string]interface{}{"questions": questions})
+		}
+		return dr
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		baseToken := runtime.Str("base-token")
@@ -40,8 +44,8 @@ var BaseFormQuestionsUpdate = common.Shortcut{
 		formId := runtime.Str("form-id")
 		questionsJSON := runtime.Str("questions")
 
-		var questions []interface{}
-		if err := json.Unmarshal([]byte(questionsJSON), &questions); err != nil {
+		questions, err := parseUpdateFormQuestions(questionsJSON)
+		if err != nil {
 			return output.Errorf(output.ExitValidation, "invalid_json", "--questions must be a valid JSON array: %s", err)
 		}
 
@@ -73,4 +77,30 @@ var BaseFormQuestionsUpdate = common.Shortcut{
 		})
 		return nil
 	},
+}
+
+func parseUpdateFormQuestions(questionsJSON string) ([]interface{}, error) {
+	var questions []interface{}
+	if err := json.Unmarshal([]byte(questionsJSON), &questions); err != nil {
+		return nil, err
+	}
+	normalizeUpdateFormQuestionAttachments(questions)
+	return questions, nil
+}
+
+func normalizeUpdateFormQuestionAttachments(questions []interface{}) {
+	for _, question := range questions {
+		q, ok := question.(map[string]interface{})
+		if !ok || q["type"] != "attachment" {
+			continue
+		}
+		attachment, ok := q["attachment"].(map[string]interface{})
+		if !ok {
+			q["attachment"] = map[string]interface{}{"file_types": []interface{}{"all"}}
+			continue
+		}
+		if fileTypes, ok := attachment["file_types"]; !ok || fileTypes == nil {
+			attachment["file_types"] = []interface{}{"all"}
+		}
+	}
 }

--- a/shortcuts/base/base_form_questions_update_test.go
+++ b/shortcuts/base/base_form_questions_update_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeUpdateFormQuestionAttachments(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantJSON string
+	}{
+		{
+			name:     "attachment without attachment config defaults to all",
+			input:    `[{"type":"attachment","title":"Upload"}]`,
+			wantJSON: `[{"attachment":{"file_types":["all"]},"title":"Upload","type":"attachment"}]`,
+		},
+		{
+			name:     "attachment with explicit file_types preserved",
+			input:    `[{"type":"attachment","title":"Upload","attachment":{"file_types":["image","pdf"]}}]`,
+			wantJSON: `[{"attachment":{"file_types":["image","pdf"]},"title":"Upload","type":"attachment"}]`,
+		},
+		{
+			name:     "attachment with null file_types defaults to all",
+			input:    `[{"type":"attachment","title":"Upload","attachment":{"file_types":null}}]`,
+			wantJSON: `[{"attachment":{"file_types":["all"]},"title":"Upload","type":"attachment"}]`,
+		},
+		{
+			name:     "non-attachment type unchanged",
+			input:    `[{"type":"text","title":"Name"}]`,
+			wantJSON: `[{"title":"Name","type":"text"}]`,
+		},
+		{
+			name:     "mixed types only normalizes attachment",
+			input:    `[{"type":"text","title":"Name"},{"type":"attachment","title":"Upload"}]`,
+			wantJSON: `[{"title":"Name","type":"text"},{"attachment":{"file_types":["all"]},"title":"Upload","type":"attachment"}]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseUpdateFormQuestions(tt.input)
+			if err != nil {
+				t.Fatalf("parseUpdateFormQuestions error: %v", err)
+			}
+			gotBytes, _ := json.Marshal(got)
+			var gotMap, wantMap []map[string]interface{}
+			_ = json.Unmarshal(gotBytes, &gotMap)
+			_ = json.Unmarshal([]byte(tt.wantJSON), &wantMap)
+			gotBytes2, _ := json.Marshal(gotMap)
+			wantBytes2, _ := json.Marshal(wantMap)
+			if string(gotBytes2) != string(wantBytes2) {
+				t.Errorf("got %s, want %s", gotBytes2, wantBytes2)
+			}
+		})
+	}
+}
+
+func TestParseUpdateFormQuestionsInvalidJSON(t *testing.T) {
+	_, err := parseUpdateFormQuestions(`not-json`)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}


### PR DESCRIPTION
# Fix `base +form-questions-update` attachment file_types default

## Summary

PR #931 fixed the same issue for `+form-questions-create`, but `+form-questions-update` still silently restricts attachment questions to images only when the user omits the `attachment.file_types` field.

This change mirrors the create fix: when the `--questions` JSON contains an attachment type question without explicit `file_types`, normalize the payload so it defaults to `["all"]`, matching Feishu UI behavior.

## Changes

- **Execute**: Parse and normalize questions JSON, defaulting missing/null `attachment.file_types` to `["all"]` for attachment type questions.
- **DryRun**: Include the normalized request body in dry-run output so users can see the effective payload.
- **Flag description**: Document the `attachment` configuration field (`{"file_types":["all"]}`) in the `--questions` help text.
- **Tests**: Add unit tests for the normalization logic (missing config, explicit config, null config, non-attachment types, mixed types).

## Related

- Relates to #929 (this is a follow-up to PR #931 which only fixed the create path).

## Checklist

- [x] gofmt passes
- [x] Unit tests added
- [ ] Full integration test (blocked by local resource constraints — OOM during dependency download)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced form questions configuration with automatic defaults for attachment file types.
  * Improved dry-run functionality to include questions in preview requests.

* **Documentation**
  * Expanded guidance for attachment field usage in form questions configuration.

* **Tests**
  * Added validation tests for form question parsing and normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->