### PR TITLE
feat(drive): add +inspect shortcut for document URL inspection with wiki unwrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ app.log
 /sidecar-server-demo
 /server-demo
 .tmp/
+cover*.out

--- a/shortcuts/common/drive_meta.go
+++ b/shortcuts/common/drive_meta.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+// FetchDriveMetaTitle looks up the document title via the drive metas batch_query API.
+func FetchDriveMetaTitle(runtime *RuntimeContext, token, docType string) (string, error) {
+	data, err := runtime.CallAPI(
+		"POST",
+		"/open-apis/drive/v1/metas/batch_query",
+		nil,
+		map[string]interface{}{
+			"request_docs": []map[string]interface{}{
+				{
+					"doc_token": token,
+					"doc_type":  docType,
+				},
+			},
+		},
+	)
+	if err != nil {
+		return "", err
+	}
+
+	metas := GetSlice(data, "metas")
+	if len(metas) == 0 {
+		return "", nil
+	}
+	meta, _ := metas[0].(map[string]interface{})
+	return GetString(meta, "title"), nil
+}

--- a/shortcuts/common/drive_meta_test.go
+++ b/shortcuts/common/drive_meta_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+var driveMetaTestSeq atomic.Int64
+
+func TestFetchDriveMetaTitle(t *testing.T) {
+	t.Run("returns title from batch_query response", func(t *testing.T) {
+		runtime, reg := newDriveMetaTestRuntime(t)
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "/open-apis/drive/v1/metas/batch_query",
+			Body: map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"metas": []map[string]interface{}{
+						{"doc_token": "doxcnABC", "doc_type": "docx", "title": "My Document"},
+					},
+				},
+			},
+		})
+
+		title, err := FetchDriveMetaTitle(runtime, "doxcnABC", "docx")
+		if err != nil {
+			t.Fatalf("FetchDriveMetaTitle() error: %v", err)
+		}
+		if title != "My Document" {
+			t.Errorf("title = %q, want %q", title, "My Document")
+		}
+	})
+
+	t.Run("returns empty string when metas is empty", func(t *testing.T) {
+		runtime, reg := newDriveMetaTestRuntime(t)
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "/open-apis/drive/v1/metas/batch_query",
+			Body: map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"metas": []map[string]interface{}{},
+				},
+			},
+		})
+
+		title, err := FetchDriveMetaTitle(runtime, "doxcnABC", "docx")
+		if err != nil {
+			t.Fatalf("FetchDriveMetaTitle() error: %v", err)
+		}
+		if title != "" {
+			t.Errorf("title = %q, want empty string", title)
+		}
+	})
+
+	t.Run("returns empty string when meta has no title", func(t *testing.T) {
+		runtime, reg := newDriveMetaTestRuntime(t)
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "/open-apis/drive/v1/metas/batch_query",
+			Body: map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"metas": []map[string]interface{}{
+						{"doc_token": "doxcnABC", "doc_type": "docx"},
+					},
+				},
+			},
+		})
+
+		title, err := FetchDriveMetaTitle(runtime, "doxcnABC", "docx")
+		if err != nil {
+			t.Fatalf("FetchDriveMetaTitle() error: %v", err)
+		}
+		if title != "" {
+			t.Errorf("title = %q, want empty string", title)
+		}
+	})
+
+	t.Run("propagates API error", func(t *testing.T) {
+		runtime, reg := newDriveMetaTestRuntime(t)
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "/open-apis/drive/v1/metas/batch_query",
+			Body: map[string]interface{}{
+				"code": 99991668,
+				"msg":  "permission denied",
+			},
+		})
+
+		_, err := FetchDriveMetaTitle(runtime, "doxcnABC", "docx")
+		if err == nil {
+			t.Fatal("FetchDriveMetaTitle() expected error, got nil")
+		}
+	})
+}
+
+func newDriveMetaTestRuntime(t *testing.T) (*RuntimeContext, *httpmock.Registry) {
+	t.Helper()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	cfg := &core.CliConfig{
+		AppID: fmt.Sprintf("drive-meta-test-%d", driveMetaTestSeq.Add(1)), AppSecret: "test-secret", Brand: core.BrandFeishu,
+	}
+	f, _, _, reg := cmdutil.TestFactory(t, cfg)
+	runtime := &RuntimeContext{
+		ctx:        context.Background(),
+		Config:     cfg,
+		Factory:    f,
+		resolvedAs: core.AsBot,
+	}
+	return runtime, reg
+}

--- a/shortcuts/common/resource_url.go
+++ b/shortcuts/common/resource_url.go
@@ -84,26 +84,6 @@ var urlPathToType = []struct {
 	{"/slides/", "slides"},
 }
 
-// larkHostSuffixes are the known Lark/Feishu host suffixes.
-// A URL whose host ends with one of these is considered a valid
-// Lark document URL; anything else is rejected to prevent
-// third-party sites from being misinterpreted.
-var larkHostSuffixes = []string{
-	".feishu.cn",
-	".larksuite.com",
-}
-
-// isLarkHost returns true if the host belongs to a known Lark/Feishu domain.
-func isLarkHost(host string) bool {
-	host = strings.ToLower(host)
-	for _, suffix := range larkHostSuffixes {
-		if strings.HasSuffix(host, suffix) {
-			return true
-		}
-	}
-	return false
-}
-
 // ParseResourceURL parses a Lark/Feishu URL and extracts the resource type
 // and token from the URL path. It is the inverse of BuildResourceURL.
 //
@@ -128,12 +108,6 @@ func ParseResourceURL(rawURL string) (ResourceRef, bool) {
 
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return ResourceRef{}, false
-	}
-
-	// Reject URLs whose host is not a known Lark/Feishu domain.
-	// This prevents https://google.com/docx/xxx from being accepted.
-	if u.Host != "" && !isLarkHost(u.Host) {
 		return ResourceRef{}, false
 	}
 

--- a/shortcuts/common/resource_url.go
+++ b/shortcuts/common/resource_url.go
@@ -4,6 +4,7 @@
 package common
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/larksuite/cli/internal/core"
@@ -54,4 +55,106 @@ func BuildResourceURL(brand core.LarkBrand, kind, token string) string {
 	default:
 		return ""
 	}
+}
+
+// ResourceRef holds the parsed type and token from a Lark resource URL.
+type ResourceRef struct {
+	Type  string // e.g. "docx", "bitable", "wiki", "sheet", etc.
+	Token string // the token extracted from the URL path
+}
+
+// urlPathToType maps URL path prefixes to resource types.
+// Longer prefixes must come first to avoid false matches
+// (e.g. "/drive/folder/" before a hypothetical "/drive/").
+// Aliases (e.g. "/bitable/" → "bitable") must come after the
+// canonical prefix to keep the list deterministic.
+var urlPathToType = []struct {
+	Prefix string
+	Type   string
+}{
+	{"/drive/folder/", "folder"},
+	{"/docx/", "docx"},
+	{"/doc/", "doc"},
+	{"/sheets/", "sheet"},
+	{"/base/", "bitable"},
+	{"/bitable/", "bitable"},
+	{"/wiki/", "wiki"},
+	{"/file/", "file"},
+	{"/mindnote/", "mindnote"},
+	{"/slides/", "slides"},
+}
+
+// larkHostSuffixes are the known Lark/Feishu host suffixes.
+// A URL whose host ends with one of these is considered a valid
+// Lark document URL; anything else is rejected to prevent
+// third-party sites from being misinterpreted.
+var larkHostSuffixes = []string{
+	".feishu.cn",
+	".larksuite.com",
+}
+
+// isLarkHost returns true if the host belongs to a known Lark/Feishu domain.
+func isLarkHost(host string) bool {
+	host = strings.ToLower(host)
+	for _, suffix := range larkHostSuffixes {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseResourceURL parses a Lark/Feishu URL and extracts the resource type
+// and token from the URL path. It is the inverse of BuildResourceURL.
+//
+// Supported path patterns:
+//
+//	/docx/TOKEN      -> {Type: "docx", Token: TOKEN}
+//	/doc/TOKEN       -> {Type: "doc",  Token: TOKEN}
+//	/sheets/TOKEN    -> {Type: "sheet", Token: TOKEN}
+//	/base/TOKEN      -> {Type: "bitable", Token: TOKEN}
+//	/wiki/TOKEN      -> {Type: "wiki", Token: TOKEN}
+//	/file/TOKEN      -> {Type: "file", Token: TOKEN}
+//	/drive/folder/TOKEN -> {Type: "folder", Token: TOKEN}
+//	/mindnote/TOKEN  -> {Type: "mindnote", Token: TOKEN}
+//	/slides/TOKEN    -> {Type: "slides", Token: TOKEN}
+//
+// Returns (ResourceRef{}, false) when the URL does not match any known pattern.
+func ParseResourceURL(rawURL string) (ResourceRef, bool) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return ResourceRef{}, false
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ResourceRef{}, false
+	}
+
+	// Reject URLs whose host is not a known Lark/Feishu domain.
+	// This prevents https://google.com/docx/xxx from being accepted.
+	if u.Host != "" && !isLarkHost(u.Host) {
+		return ResourceRef{}, false
+	}
+
+	path := u.Path
+
+	for _, mapping := range urlPathToType {
+		if !strings.HasPrefix(path, mapping.Prefix) {
+			continue
+		}
+		token := path[len(mapping.Prefix):]
+		// Trim trailing slashes and stop at the next path segment boundary.
+		token = strings.TrimRight(token, "/")
+		if idx := strings.IndexByte(token, '/'); idx >= 0 {
+			token = token[:idx]
+		}
+		token = strings.TrimSpace(token)
+		if token == "" {
+			return ResourceRef{}, false
+		}
+		return ResourceRef{Type: mapping.Type, Token: token}, true
+	}
+
+	return ResourceRef{}, false
 }

--- a/shortcuts/common/resource_url_test.go
+++ b/shortcuts/common/resource_url_test.go
@@ -45,10 +45,12 @@ func TestParseResourceURL(t *testing.T) {
 		// With extra path segments after token
 		{"extra path", "https://xxx.feishu.cn/docx/doxcnABC/edit", "docx", "doxcnABC", true},
 
+		// Non-Lark host with Lark-like path (host validation is the caller's responsibility)
+		{"non-lark host with lark path", "https://google.com/docx/doxcnABC", "docx", "doxcnABC", true},
+
 		// Negative cases
 		{"unrecognized path", "https://xxx.feishu.cn/calendar/calABC", "", "", false},
-		{"non-lark host with lark-like path", "https://google.com/docx/doxcnABC", "", "", false},
-		{"non-lark host", "https://example.com/page", "", "", false},
+		{"non-lark host unrecognized path", "https://example.com/page", "", "", false},
 		{"empty input", "", "", "", false},
 		{"bare token", "doxcnABC", "", "", false},
 		{"invalid url parse", "://not-a-valid-url", "", "", false},

--- a/shortcuts/common/resource_url_test.go
+++ b/shortcuts/common/resource_url_test.go
@@ -9,6 +9,100 @@ import (
 	"github.com/larksuite/cli/internal/core"
 )
 
+func TestParseResourceURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		rawURL    string
+		wantType  string
+		wantToken string
+		wantOK    bool
+	}{
+		// All 9 supported types
+		{"docx", "https://xxx.feishu.cn/docx/doxcnABC", "docx", "doxcnABC", true},
+		{"doc", "https://xxx.feishu.cn/doc/doccnABC", "doc", "doccnABC", true},
+		{"sheet", "https://xxx.feishu.cn/sheets/shtcnABC", "sheet", "shtcnABC", true},
+		{"bitable via /base/", "https://xxx.feishu.cn/base/bascnABC", "bitable", "bascnABC", true},
+		{"bitable via /bitable/", "https://xxx.feishu.cn/bitable/bascnABC", "bitable", "bascnABC", true},
+		{"wiki", "https://xxx.feishu.cn/wiki/wikcnABC", "wiki", "wikcnABC", true},
+		{"file", "https://xxx.feishu.cn/file/boxcnABC", "file", "boxcnABC", true},
+		{"folder", "https://xxx.feishu.cn/drive/folder/fldcnABC", "folder", "fldcnABC", true},
+		{"mindnote", "https://xxx.feishu.cn/mindnote/mncnABC", "mindnote", "mncnABC", true},
+		{"slides", "https://xxx.feishu.cn/slides/slkcnABC", "slides", "slkcnABC", true},
+
+		// Lark domain
+		{"lark docx", "https://xxx.larksuite.com/docx/doxcnABC", "docx", "doxcnABC", true},
+		{"lark wiki", "https://xxx.larksuite.com/wiki/wikcnABC", "wiki", "wikcnABC", true},
+
+		// With query parameters
+		{"with query", "https://xxx.feishu.cn/docx/doxcnABC?from=wiki", "docx", "doxcnABC", true},
+		{"with fragment", "https://xxx.feishu.cn/docx/doxcnABC#section", "docx", "doxcnABC", true},
+
+		// With trailing slash
+		{"trailing slash", "https://xxx.feishu.cn/docx/doxcnABC/", "docx", "doxcnABC", true},
+
+		// With extra path segments after token
+		{"extra path", "https://xxx.feishu.cn/docx/doxcnABC/edit", "docx", "doxcnABC", true},
+
+		// Negative cases
+		{"unrecognized path", "https://xxx.feishu.cn/calendar/calABC", "", "", false},
+		{"non-lark host with lark-like path", "https://google.com/docx/doxcnABC", "", "", false},
+		{"non-lark host", "https://example.com/page", "", "", false},
+		{"empty input", "", "", "", false},
+		{"bare token", "doxcnABC", "", "", false},
+		{"invalid url parse", "://not-a-valid-url", "", "", false},
+		{"matching prefix but empty token", "https://xxx.feishu.cn/docx/", "", "", false},
+		{"matching prefix but whitespace-only token", "https://xxx.feishu.cn/docx/   ", "", "", false},
+		{"whitespace-only input", "   ", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ref, ok := ParseResourceURL(tt.rawURL)
+			if ok != tt.wantOK {
+				t.Errorf("ParseResourceURL(%q) ok = %v, want %v", tt.rawURL, ok, tt.wantOK)
+			}
+			if ok {
+				if ref.Type != tt.wantType {
+					t.Errorf("ParseResourceURL(%q) Type = %q, want %q", tt.rawURL, ref.Type, tt.wantType)
+				}
+				if ref.Token != tt.wantToken {
+					t.Errorf("ParseResourceURL(%q) Token = %q, want %q", tt.rawURL, ref.Token, tt.wantToken)
+				}
+			}
+		})
+	}
+}
+
+// TestParseResourceURL_RoundTrip verifies that ParseResourceURL is the inverse
+// of BuildResourceURL for all supported types.
+func TestParseResourceURL_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	types := []string{"docx", "doc", "sheet", "bitable", "wiki", "file", "folder", "mindnote", "slides"}
+	token := "testTOKEN123"
+
+	for _, kind := range types {
+		t.Run(kind, func(t *testing.T) {
+			built := BuildResourceURL(core.BrandFeishu, kind, token)
+			if built == "" {
+				t.Fatalf("BuildResourceURL returned empty for kind %q", kind)
+			}
+			ref, ok := ParseResourceURL(built)
+			if !ok {
+				t.Fatalf("ParseResourceURL(%q) returned ok=false", built)
+			}
+			if ref.Type != kind {
+				t.Errorf("round-trip type mismatch: got %q, want %q", ref.Type, kind)
+			}
+			if ref.Token != token {
+				t.Errorf("round-trip token mismatch: got %q, want %q", ref.Token, token)
+			}
+		})
+	}
+}
+
 func TestBuildResourceURL(t *testing.T) {
 	t.Parallel()
 

--- a/shortcuts/drive/drive_export.go
+++ b/shortcuts/drive/drive_export.go
@@ -122,7 +122,7 @@ var DriveExport = common.Shortcut{
 			if fileName == "" {
 				// Prefer the remote title for the exported file name, but still fall
 				// back to the token if metadata is empty.
-				title, err := fetchDriveMetaTitle(runtime, spec.Token, spec.DocType)
+				title, err := common.FetchDriveMetaTitle(runtime, spec.Token, spec.DocType)
 				if err != nil {
 					fmt.Fprintf(runtime.IO().ErrOut, "Title lookup failed, using token as filename: %v\n", err)
 					title = spec.Token

--- a/shortcuts/drive/drive_export_common.go
+++ b/shortcuts/drive/drive_export_common.go
@@ -228,34 +228,6 @@ func parseDriveExportStatus(ticket string, data map[string]interface{}) driveExp
 	return status
 }
 
-// fetchDriveMetaTitle looks up the document title so exported files can use a
-// human-readable default name when possible.
-func fetchDriveMetaTitle(runtime *common.RuntimeContext, token, docType string) (string, error) {
-	data, err := runtime.CallAPI(
-		"POST",
-		"/open-apis/drive/v1/metas/batch_query",
-		nil,
-		map[string]interface{}{
-			"request_docs": []map[string]interface{}{
-				{
-					"doc_token": token,
-					"doc_type":  docType,
-				},
-			},
-		},
-	)
-	if err != nil {
-		return "", err
-	}
-
-	metas := common.GetSlice(data, "metas")
-	if len(metas) == 0 {
-		return "", nil
-	}
-	meta, _ := metas[0].(map[string]interface{})
-	return common.GetString(meta, "title"), nil
-}
-
 // saveContentToOutputDir validates the target path, enforces overwrite policy,
 // and writes the payload atomically via FileIO.Save.
 func saveContentToOutputDir(fio fileio.FileIO, outputDir, fileName string, payload []byte, overwrite bool) (string, error) {

--- a/shortcuts/drive/drive_inspect.go
+++ b/shortcuts/drive/drive_inspect.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var DriveInspect = common.Shortcut{
+	Service:           "drive",
+	Command:           "+inspect",
+	Description:       "Inspect a Lark document URL to get its type, title, and canonical token (with wiki unwrapping)",
+	Risk:              "read",
+	Scopes:            []string{"drive:drive.metadata:readonly"},
+	ConditionalScopes: []string{"wiki:node:retrieve"},
+	AuthTypes:         []string{"user", "bot"},
+	HasFormat:         true,
+	Flags: []common.Flag{
+		{
+			Name:     "url",
+			Desc:     "Lark/Feishu document URL (docx, doc, sheet, bitable, wiki, file, folder, mindnote, slides)",
+			Required: true,
+		},
+		{
+			Name: "type",
+			Desc: "document type (required when --url is a bare token; auto-detected for URLs)",
+			Enum: []string{"doc", "docx", "sheet", "bitable", "wiki", "file", "folder", "mindnote", "slides"},
+		},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		raw := strings.TrimSpace(runtime.Str("url"))
+		if raw == "" {
+			return output.ErrValidation("--url cannot be empty")
+		}
+
+		_, ok := common.ParseResourceURL(raw)
+		if !ok {
+			// Not a recognized URL pattern.
+			if strings.Contains(raw, "://") {
+				return output.ErrValidation("unsupported --url %q: use a recognized Lark document URL or a bare token with --type", raw)
+			}
+			// Bare token: --type is required.
+			if strings.TrimSpace(runtime.Str("type")) == "" {
+				return output.ErrValidation("--type is required when --url is a bare token (allowed: doc, docx, sheet, bitable, wiki, file, folder, mindnote, slides)")
+			}
+		}
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		raw := strings.TrimSpace(runtime.Str("url"))
+		ref, ok := common.ParseResourceURL(raw)
+		if !ok {
+			ref = common.ResourceRef{
+				Type:  strings.TrimSpace(runtime.Str("type")),
+				Token: raw,
+			}
+		}
+
+		dry := common.NewDryRunAPI()
+
+		if ref.Type == "wiki" {
+			dry.Desc("2-step: inspect wiki node, then batch query metadata")
+			dry.GET("/open-apis/wiki/v2/spaces/get_node").
+				Desc("[1] Inspect wiki node to get underlying document").
+				Params(map[string]interface{}{"token": ref.Token})
+			dry.POST("/open-apis/drive/v1/metas/batch_query").
+				Desc("[2] Batch query document metadata (title)").
+				Body(map[string]interface{}{
+					"request_docs": []map[string]interface{}{
+						{"doc_token": "<obj_token from step 1>", "doc_type": "<obj_type from step 1>"},
+					},
+				})
+			return dry
+		}
+
+		dry.Desc("1-step: batch query document metadata")
+		dry.POST("/open-apis/drive/v1/metas/batch_query").
+			Body(map[string]interface{}{
+				"request_docs": []map[string]interface{}{
+					{"doc_token": ref.Token, "doc_type": ref.Type},
+				},
+			})
+		return dry
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		raw := strings.TrimSpace(runtime.Str("url"))
+
+		// Step 1: Parse URL to extract {type, token}.
+		ref, ok := common.ParseResourceURL(raw)
+		if !ok {
+			// Bare token: use --type.
+			ref = common.ResourceRef{
+				Type:  strings.TrimSpace(runtime.Str("type")),
+				Token: raw,
+			}
+		}
+
+		inputURL := raw
+		docType := ref.Type
+		docToken := ref.Token
+
+		var wikiNode map[string]interface{}
+
+		// Step 2: If type is "wiki", unwrap via get_node API.
+		if docType == "wiki" {
+			fmt.Fprintf(runtime.IO().ErrOut, "Inspecting wiki node: %s\n", common.MaskToken(docToken))
+			data, err := runtime.CallAPI(
+				"GET",
+				"/open-apis/wiki/v2/spaces/get_node",
+				map[string]interface{}{"token": docToken},
+				nil,
+			)
+			if err != nil {
+				return err
+			}
+
+			node := common.GetMap(data, "node")
+			objType := common.GetString(node, "obj_type")
+			objToken := common.GetString(node, "obj_token")
+			spaceID := common.GetString(node, "space_id")
+			nodeToken := common.GetString(node, "node_token")
+
+			if objType == "" || objToken == "" {
+				return output.Errorf(output.ExitAPI, "api_error", "wiki get_node returned incomplete node data (obj_type=%q, obj_token=%q)", objType, objToken)
+			}
+
+			wikiNode = map[string]interface{}{
+				"space_id":   spaceID,
+				"node_token": nodeToken,
+				"obj_token":  objToken,
+				"obj_type":   objType,
+			}
+
+			docType = objType
+			docToken = objToken
+
+			fmt.Fprintf(runtime.IO().ErrOut, "Wiki unwrapped to %s: %s\n", docType, common.MaskToken(docToken))
+		}
+
+		// Step 3: Call batch_query to verify and get title.
+		title, err := common.FetchDriveMetaTitle(runtime, docToken, docType)
+		if err != nil {
+			return err
+		}
+
+		// Step 4: Build the resolved URL.
+		resolvedURL := common.BuildResourceURL(runtime.Config.Brand, docType, docToken)
+
+		// Step 5: Build output.
+		result := map[string]interface{}{
+			"input_url": inputURL,
+			"type":      docType,
+			"title":     title,
+			"token":     docToken,
+			"url":       resolvedURL,
+		}
+		if wikiNode != nil {
+			result["wiki_node"] = wikiNode
+		}
+
+		runtime.OutFormat(result, nil, func(w io.Writer) {
+			fmt.Fprintf(w, "Type:  %s\n", docType)
+			if title != "" {
+				fmt.Fprintf(w, "Title: %s\n", title)
+			}
+			fmt.Fprintf(w, "Token: %s\n", docToken)
+			if resolvedURL != "" {
+				fmt.Fprintf(w, "URL:   %s\n", resolvedURL)
+			}
+			if wikiNode != nil {
+				fmt.Fprintf(w, "Wiki:  space_id=%s, node_token=%s\n", wikiNode["space_id"], wikiNode["node_token"])
+			}
+		})
+		return nil
+	},
+}

--- a/shortcuts/drive/drive_inspect.go
+++ b/shortcuts/drive/drive_inspect.go
@@ -7,11 +7,32 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
+
+// larkHostSuffixes are the known Lark/Feishu host suffixes used by +inspect
+// to reject URLs from unrelated domains (e.g. google.com/docx/TOKEN).
+// This list lives here rather than in ParseResourceURL because host validation
+// is a business decision of the +inspect command; a general-purpose URL parser
+// should not hardcode domain lists that may expand over time.
+var larkHostSuffixes = []string{
+	".feishu.cn",
+	".larksuite.com",
+}
+
+func isLarkHost(host string) bool {
+	host = strings.ToLower(host)
+	for _, suffix := range larkHostSuffixes {
+		if strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
+}
 
 var DriveInspect = common.Shortcut{
 	Service:           "drive",
@@ -41,7 +62,12 @@ var DriveInspect = common.Shortcut{
 		}
 
 		_, ok := common.ParseResourceURL(raw)
-		if !ok {
+		if ok {
+			// Parsed successfully — verify the host is a known Lark/Feishu domain.
+			if u, err := url.Parse(raw); err == nil && !isLarkHost(u.Host) {
+				return output.ErrValidation("unsupported --url %q: host %q is not a recognized Lark/Feishu domain", raw, u.Host)
+			}
+		} else {
 			// Not a recognized URL pattern.
 			if strings.Contains(raw, "://") {
 				return output.ErrValidation("unsupported --url %q: use a recognized Lark document URL or a bare token with --type", raw)

--- a/shortcuts/drive/drive_inspect.go
+++ b/shortcuts/drive/drive_inspect.go
@@ -7,32 +7,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/url"
 	"strings"
 
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
-
-// larkHostSuffixes are the known Lark/Feishu host suffixes used by +inspect
-// to reject URLs from unrelated domains (e.g. google.com/docx/TOKEN).
-// This list lives here rather than in ParseResourceURL because host validation
-// is a business decision of the +inspect command; a general-purpose URL parser
-// should not hardcode domain lists that may expand over time.
-var larkHostSuffixes = []string{
-	".feishu.cn",
-	".larksuite.com",
-}
-
-func isLarkHost(host string) bool {
-	host = strings.ToLower(host)
-	for _, suffix := range larkHostSuffixes {
-		if strings.HasSuffix(host, suffix) {
-			return true
-		}
-	}
-	return false
-}
 
 var DriveInspect = common.Shortcut{
 	Service:           "drive",
@@ -62,12 +41,7 @@ var DriveInspect = common.Shortcut{
 		}
 
 		_, ok := common.ParseResourceURL(raw)
-		if ok {
-			// Parsed successfully — verify the host is a known Lark/Feishu domain.
-			if u, err := url.Parse(raw); err == nil && !isLarkHost(u.Host) {
-				return output.ErrValidation("unsupported --url %q: host %q is not a recognized Lark/Feishu domain", raw, u.Host)
-			}
-		} else {
+		if !ok {
 			// Not a recognized URL pattern.
 			if strings.Contains(raw, "://") {
 				return output.ErrValidation("unsupported --url %q: use a recognized Lark document URL or a bare token with --type", raw)

--- a/shortcuts/drive/drive_inspect_test.go
+++ b/shortcuts/drive/drive_inspect_test.go
@@ -51,8 +51,8 @@ func TestDriveInspectValidate_NonLarkHostWithLarkPath(t *testing.T) {
 
 	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
 	err := DriveInspect.Validate(context.Background(), runtime)
-	if err == nil {
-		t.Fatal("expected error for non-Lark host with Lark-like path, got nil")
+	if err != nil {
+		t.Fatalf("expected no error for non-Lark host with Lark-like path (host validation removed), got %v", err)
 	}
 }
 

--- a/shortcuts/drive/drive_inspect_test.go
+++ b/shortcuts/drive/drive_inspect_test.go
@@ -1,0 +1,466 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// --- Validate tests ---
+
+func TestDriveInspectValidate_EmptyURL(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	err := DriveInspect.Validate(context.Background(), runtime)
+	if err == nil {
+		t.Fatal("expected error for empty --url, got nil")
+	}
+}
+
+func TestDriveInspectValidate_UnsupportedURL(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "https://google.com/some/page")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	err := DriveInspect.Validate(context.Background(), runtime)
+	if err == nil {
+		t.Fatal("expected error for unsupported URL, got nil")
+	}
+}
+
+func TestDriveInspectValidate_NonLarkHostWithLarkPath(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "https://google.com/docx/doxcnLooksValid")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	err := DriveInspect.Validate(context.Background(), runtime)
+	if err == nil {
+		t.Fatal("expected error for non-Lark host with Lark-like path, got nil")
+	}
+}
+
+func TestDriveInspectValidate_BareTokenWithoutType(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "doxcnBareToken")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	err := DriveInspect.Validate(context.Background(), runtime)
+	if err == nil {
+		t.Fatal("expected error for bare token without --type, got nil")
+	}
+}
+
+func TestDriveInspectValidate_BareTokenWithType(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "doxcnBareToken")
+	_ = cmd.Flags().Set("type", "docx")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	err := DriveInspect.Validate(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestDriveInspectValidate_ValidDocxURL(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "https://xxx.feishu.cn/docx/doxcnABC")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	err := DriveInspect.Validate(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestDriveInspectValidate_ValidWikiURL(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "https://xxx.feishu.cn/wiki/wikcnABC")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	err := DriveInspect.Validate(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+// --- DryRun tests ---
+
+func TestDriveInspectDryRun_DocxURL(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "https://xxx.feishu.cn/docx/doxcnABC")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	dry := DriveInspect.DryRun(context.Background(), runtime)
+	if dry == nil {
+		t.Fatal("DryRun returned nil")
+	}
+
+	data, err := json.Marshal(dry)
+	if err != nil {
+		t.Fatalf("marshal dry run: %v", err)
+	}
+
+	var got struct {
+		API []struct {
+			URL    string                 `json:"url"`
+			Method string                 `json:"method"`
+			Body   map[string]interface{} `json:"body"`
+		} `json:"api"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal dry run: %v", err)
+	}
+	if len(got.API) != 1 {
+		t.Fatalf("expected 1 API step, got %d", len(got.API))
+	}
+	if got.API[0].URL != "/open-apis/drive/v1/metas/batch_query" {
+		t.Errorf("API URL = %q, want /open-apis/drive/v1/metas/batch_query", got.API[0].URL)
+	}
+	// Verify body contains request_docs with the correct token and type.
+	reqDocs, ok := got.API[0].Body["request_docs"].([]interface{})
+	if !ok || len(reqDocs) != 1 {
+		t.Fatalf("expected request_docs with 1 entry, got %v", got.API[0].Body["request_docs"])
+	}
+	doc, _ := reqDocs[0].(map[string]interface{})
+	if doc["doc_token"] != "doxcnABC" {
+		t.Errorf("doc_token = %v, want doxcnABC", doc["doc_token"])
+	}
+	if doc["doc_type"] != "docx" {
+		t.Errorf("doc_type = %v, want docx", doc["doc_type"])
+	}
+}
+
+func TestDriveInspectDryRun_WikiURL(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "https://xxx.feishu.cn/wiki/wikcnABC")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	dry := DriveInspect.DryRun(context.Background(), runtime)
+	if dry == nil {
+		t.Fatal("DryRun returned nil")
+	}
+
+	data, err := json.Marshal(dry)
+	if err != nil {
+		t.Fatalf("marshal dry run: %v", err)
+	}
+
+	var got struct {
+		API []struct {
+			URL    string                 `json:"url"`
+			Params map[string]interface{} `json:"params"`
+			Body   map[string]interface{} `json:"body"`
+		} `json:"api"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal dry run: %v", err)
+	}
+	if len(got.API) != 2 {
+		t.Fatalf("expected 2 API steps, got %d", len(got.API))
+	}
+	if got.API[0].URL != "/open-apis/wiki/v2/spaces/get_node" {
+		t.Errorf("step 1 URL = %q, want /open-apis/wiki/v2/spaces/get_node", got.API[0].URL)
+	}
+	// Verify step 1 params contain the wiki token.
+	if got.API[0].Params["token"] != "wikcnABC" {
+		t.Errorf("step 1 params.token = %v, want wikcnABC", got.API[0].Params["token"])
+	}
+	if got.API[1].URL != "/open-apis/drive/v1/metas/batch_query" {
+		t.Errorf("step 2 URL = %q, want /open-apis/drive/v1/metas/batch_query", got.API[1].URL)
+	}
+	// Verify step 2 body contains request_docs placeholder.
+	if got.API[1].Body["request_docs"] == nil {
+		t.Error("step 2 body should contain request_docs")
+	}
+}
+
+func TestDriveInspectDryRun_BareTokenWithType(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "doxcnBareToken")
+	_ = cmd.Flags().Set("type", "docx")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	dry := DriveInspect.DryRun(context.Background(), runtime)
+	if dry == nil {
+		t.Fatal("DryRun returned nil")
+	}
+
+	data, err := json.Marshal(dry)
+	if err != nil {
+		t.Fatalf("marshal dry run: %v", err)
+	}
+
+	var got struct {
+		API []struct {
+			URL string `json:"url"`
+		} `json:"api"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal dry run: %v", err)
+	}
+	if len(got.API) != 1 {
+		t.Fatalf("expected 1 API step, got %d", len(got.API))
+	}
+}
+
+// --- Execute tests ---
+
+func TestDriveInspectExecute_DocxURL(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	cfg := driveTestConfig()
+	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/metas/batch_query",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"metas": []map[string]interface{}{
+					{"doc_token": "doxcnABC", "doc_type": "docx", "title": "Test Doc"},
+				},
+			},
+		},
+	})
+
+	err := mountAndRunDrive(t, DriveInspect, []string{
+		"+inspect",
+		"--url", "https://xxx.feishu.cn/docx/doxcnABC",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeDriveEnvelope(t, stdout)
+	if data["type"] != "docx" {
+		t.Errorf("type = %v, want docx", data["type"])
+	}
+	if data["token"] != "doxcnABC" {
+		t.Errorf("token = %v, want doxcnABC", data["token"])
+	}
+	if data["title"] != "Test Doc" {
+		t.Errorf("title = %v, want Test Doc", data["title"])
+	}
+	if _, ok := data["wiki_node"]; ok {
+		t.Error("wiki_node should not be present for non-wiki URL")
+	}
+}
+
+func TestDriveInspectExecute_WikiURL(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	cfg := driveTestConfig()
+	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":   "docx",
+					"obj_token":  "doxcnUnwrapped",
+					"space_id":   "space123",
+					"node_token": "wikcnNodeToken",
+					"title":      "Wiki Doc",
+					"node_type":  "origin",
+				},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/metas/batch_query",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"metas": []map[string]interface{}{
+					{"doc_token": "doxcnUnwrapped", "doc_type": "docx", "title": "Wiki Doc"},
+				},
+			},
+		},
+	})
+
+	err := mountAndRunDrive(t, DriveInspect, []string{
+		"+inspect",
+		"--url", "https://xxx.feishu.cn/wiki/wikcnABC",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeDriveEnvelope(t, stdout)
+	if data["type"] != "docx" {
+		t.Errorf("type = %v, want docx (unwrapped from wiki)", data["type"])
+	}
+	if data["token"] != "doxcnUnwrapped" {
+		t.Errorf("token = %v, want doxcnUnwrapped", data["token"])
+	}
+	if data["title"] != "Wiki Doc" {
+		t.Errorf("title = %v, want Wiki Doc", data["title"])
+	}
+	wikiNode, ok := data["wiki_node"].(map[string]interface{})
+	if !ok {
+		t.Fatal("wiki_node should be present for wiki URL")
+	}
+	if wikiNode["space_id"] != "space123" {
+		t.Errorf("wiki_node.space_id = %v, want space123", wikiNode["space_id"])
+	}
+}
+
+func TestDriveInspectExecute_WikiGetNodeIncompleteData(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	cfg := driveTestConfig()
+	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":  "",
+					"obj_token": "",
+				},
+			},
+		},
+	})
+
+	err := mountAndRunDrive(t, DriveInspect, []string{
+		"+inspect",
+		"--url", "https://xxx.feishu.cn/wiki/wikcnABC",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected error for incomplete wiki node data, got nil")
+	}
+}
+
+func TestDriveInspectExecute_BareTokenWithType(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	cfg := driveTestConfig()
+	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/metas/batch_query",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"metas": []map[string]interface{}{
+					{"doc_token": "doxcnBare", "doc_type": "docx", "title": "Bare Doc"},
+				},
+			},
+		},
+	})
+
+	err := mountAndRunDrive(t, DriveInspect, []string{
+		"+inspect",
+		"--url", "doxcnBare",
+		"--type", "docx",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeDriveEnvelope(t, stdout)
+	if data["type"] != "docx" {
+		t.Errorf("type = %v, want docx", data["type"])
+	}
+	if data["token"] != "doxcnBare" {
+		t.Errorf("token = %v, want doxcnBare", data["token"])
+	}
+}
+
+func TestDriveInspectExecute_BatchQueryError(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	cfg := driveTestConfig()
+	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/metas/batch_query",
+		Body: map[string]interface{}{
+			"code": 99991668,
+			"msg":  "permission denied",
+		},
+	})
+
+	err := mountAndRunDrive(t, DriveInspect, []string{
+		"+inspect",
+		"--url", "https://xxx.feishu.cn/docx/doxcnABC",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected error for batch_query failure, got nil")
+	}
+}
+
+func TestDriveInspectExecute_PrettyFormat(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	cfg := driveTestConfig()
+	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/metas/batch_query",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"metas": []map[string]interface{}{
+					{"doc_token": "doxcnABC", "doc_type": "docx", "title": "Test Doc"},
+				},
+			},
+		},
+	})
+
+	err := mountAndRunDrive(t, DriveInspect, []string{
+		"+inspect",
+		"--url", "https://xxx.feishu.cn/docx/doxcnABC",
+		"--format", "pretty",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Pretty format outputs to stdout as text, not JSON envelope.
+	// Just verify it didn't error.
+	_ = stdout
+}

--- a/shortcuts/drive/shortcuts.go
+++ b/shortcuts/drive/shortcuts.go
@@ -29,5 +29,6 @@ func Shortcuts() []common.Shortcut {
 		DriveTaskResult,
 		DriveApplyPermission,
 		DriveSearch,
+		DriveInspect,
 	}
 }

--- a/shortcuts/drive/shortcuts_test.go
+++ b/shortcuts/drive/shortcuts_test.go
@@ -32,6 +32,7 @@ func TestShortcutsIncludesExpectedCommands(t *testing.T) {
 		"+task_result",
 		"+apply-permission",
 		"+search",
+		"+inspect",
 	}
 
 	if len(got) != len(want) {

--- a/skill-template/domains/drive.md
+++ b/skill-template/domains/drive.md
@@ -34,6 +34,16 @@
 
 #### 处理流程
 
+**推荐方式：使用 `drive +inspect` 自动解包**
+
+```bash
+lark-cli drive +inspect --url 'https://xxx.feishu.cn/wiki/wikcnXXX'
+```
+
+返回结果包含 `type`（底层文档类型）、`token`（真实 file_token）、`title`、`url` 等字段，直接用于后续操作。
+
+**手动方式：使用 `wiki.spaces.get_node` 查询节点信息**
+
 1. **使用 `wiki.spaces.get_node` 查询节点信息**
    ```bash
    lark-cli wiki spaces get_node --params '{"token":"wiki_token"}'

--- a/skills/lark-drive/SKILL.md
+++ b/skills/lark-drive/SKILL.md
@@ -51,6 +51,16 @@ metadata:
 
 #### 处理流程
 
+**推荐方式：使用 `drive +inspect` 自动解包**
+
+```bash
+lark-cli drive +inspect --url 'https://xxx.feishu.cn/wiki/wikcnXXX'
+```
+
+返回结果包含 `type`（底层文档类型）、`token`（真实 file_token）、`title`、`url` 等字段，直接用于后续操作。
+
+**手动方式：使用 `wiki.spaces.get_node` 查询节点信息**
+
 1. **使用 `wiki.spaces.get_node` 查询节点信息**
    ```bash
    lark-cli wiki spaces get_node --params '{"token":"wiki_token"}'
@@ -259,6 +269,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli drive +<verb> [flags]`）
 | [`+delete`](references/lark-drive-delete.md) | Delete a Drive file or folder with limited polling for folder deletes |
 | [`+push`](references/lark-drive-push.md) | File-level local → Drive mirror. Duplicate remote `rel_path` conflicts fail by default; `newest` / `oldest` only apply to duplicate files when you explicitly want to target one remote file. `--if-exists` supports `skip` / `smart` / `overwrite` (`smart` skips files whose remote `modified_time` is already up to date, but falls through to the same overwrite path when the remote is older, so it inherits overwrite's rollout caveat). `--delete-remote` requires `--yes`. `--local-dir` must stay inside cwd. |
 | [`+task_result`](references/lark-drive-task-result.md) | Poll async task result for import, export, move, or delete operations |
+| [`+inspect`](references/lark-drive-inspect.md) | Inspect a Lark document URL to get its type, title, and canonical token; auto-unwraps wiki URLs to the underlying document |
 | [`+apply-permission`](references/lark-drive-apply-permission.md) | Apply to the document owner for view/edit access (user-only; 5/day per document) |
 
 ## API Resources

--- a/skills/lark-drive/references/lark-drive-inspect.md
+++ b/skills/lark-drive/references/lark-drive-inspect.md
@@ -1,0 +1,50 @@
+
+# drive +inspect（文档 URL 检视：类型、标题、Token 解析）
+
+> **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
+
+给定一个飞书文档 URL 或 bare token，返回其类型、标题和 canonical token。对 wiki URL 自动解包到底层文档。
+
+## 命令
+
+```bash
+# 检视一个 docx URL
+lark-cli drive +inspect --url 'https://xxx.feishu.cn/docx/doxcnXXX'
+
+# 检视一个 wiki URL（自动解包到底层文档）
+lark-cli drive +inspect --url 'https://xxx.feishu.cn/wiki/wikcnXXX'
+
+# bare token 需要指定 --type
+lark-cli drive +inspect --url doxcnXXX --type docx
+
+# 格式化输出
+lark-cli drive +inspect --url 'https://xxx.feishu.cn/base/bascnXXX' --format pretty
+```
+
+## 输出
+
+JSON 输出包含以下字段：
+
+| 字段 | 说明 |
+|------|------|
+| `input_url` | 原始输入 URL |
+| `type` | 文档类型（docx, doc, sheet, bitable, wiki, file, folder, mindnote, slides） |
+| `title` | 文档标题 |
+| `token` | canonical file token |
+| `url` | 重建的 canonical URL |
+| `wiki_node` | 仅 wiki URL：包含 `space_id`, `node_token`, `obj_token`, `obj_type` |
+
+## 典型场景
+
+| 场景 | 命令 |
+|------|------|
+| 用户给了一个 URL，想知道它是什么类型的文档 | `lark-cli drive +inspect --url '<url>'` |
+| wiki 链接需要拿到底层文档的 token 来做后续操作 | `lark-cli drive +inspect --url '<wiki_url>'`，取输出中的 `token` |
+| 只有 token 没有 URL | `lark-cli drive +inspect --url <token> --type <type>` |
+
+## 注意事项
+
+- `--url` 为必填参数
+- 当 `--url` 是 bare token（非完整 URL）时，`--type` 也是必填的
+- wiki URL 会自动调用 `get_node` API 解包，输出中 `type` 和 `token` 是底层文档的类型和 token
+- 支持 `--dry-run` 查看将调用的 API 步骤

--- a/tests/cli_e2e/drive/drive_inspect_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_inspect_dryrun_test.go
@@ -1,0 +1,237 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// --- Happy path: all supported URL types ---
+
+func TestDriveInspectDryRun_DocxURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+	result := runInspectDryRun(t, "https://xxx.feishu.cn/docx/doxcnDryRunE2E")
+	assertOneStepBatchQuery(t, result)
+}
+
+func TestDriveInspectDryRun_DocURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+	result := runInspectDryRun(t, "https://xxx.feishu.cn/doc/doccnDryRunE2E")
+	assertOneStepBatchQuery(t, result)
+}
+
+func TestDriveInspectDryRun_SheetURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+	result := runInspectDryRun(t, "https://xxx.feishu.cn/sheets/shtcnDryRunE2E")
+	assertOneStepBatchQuery(t, result)
+}
+
+func TestDriveInspectDryRun_BitableURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+	result := runInspectDryRun(t, "https://xxx.feishu.cn/base/bascnDryRunE2E")
+	assertOneStepBatchQuery(t, result)
+}
+
+func TestDriveInspectDryRun_FileURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+	result := runInspectDryRun(t, "https://xxx.feishu.cn/file/boxcnDryRunE2E")
+	assertOneStepBatchQuery(t, result)
+}
+
+func TestDriveInspectDryRun_FolderURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+	result := runInspectDryRun(t, "https://xxx.feishu.cn/drive/folder/fldcnDryRunE2E")
+	assertOneStepBatchQuery(t, result)
+}
+
+func TestDriveInspectDryRun_MindnoteURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+	result := runInspectDryRun(t, "https://xxx.feishu.cn/mindnote/mncnDryRunE2E")
+	assertOneStepBatchQuery(t, result)
+}
+
+func TestDriveInspectDryRun_SlidesURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+	result := runInspectDryRun(t, "https://xxx.feishu.cn/slides/slkcnDryRunE2E")
+	assertOneStepBatchQuery(t, result)
+}
+
+// --- Wiki URL: two-step flow ---
+
+func TestDriveInspectDryRun_WikiURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+inspect",
+			"--url", "https://xxx.feishu.cn/wiki/wikcnDryRunE2E",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	require.Equal(t, int64(2), gjson.Get(result.Stdout, "api.#").Int(),
+		"expected exactly 2 dry-run API steps for wiki URL, stdout:\n%s", result.Stdout)
+	require.Equal(t, "/open-apis/wiki/v2/spaces/get_node",
+		gjson.Get(result.Stdout, "api.0.url").String(),
+		"expected get_node as first step, stdout:\n%s", result.Stdout)
+	require.Equal(t, "/open-apis/drive/v1/metas/batch_query",
+		gjson.Get(result.Stdout, "api.1.url").String(),
+		"expected batch_query as second step, stdout:\n%s", result.Stdout)
+}
+
+// --- Bare token with --type ---
+
+func TestDriveInspectDryRun_BareTokenWithType(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+inspect",
+			"--url", "doxcnBareToken",
+			"--type", "docx",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	assertOneStepBatchQuery(t, result)
+}
+
+// --- Validation errors ---
+
+func TestDriveInspectValidation_EmptyURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+inspect",
+			"--url", "",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Contains(t, result.Stderr, "--url cannot be empty",
+		"expected empty URL validation error, stderr:\n%s", result.Stderr)
+}
+
+func TestDriveInspectValidation_UnsupportedURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+inspect",
+			"--url", "https://google.com/some/page",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Contains(t, result.Stderr, "unsupported --url",
+		"expected unsupported URL validation error, stderr:\n%s", result.Stderr)
+}
+
+func TestDriveInspectValidation_BareTokenWithoutType(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+inspect",
+			"--url", "doxcnBareToken",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Contains(t, result.Stderr, "--type is required when --url is a bare token",
+		"expected bare-token-without-type validation error, stderr:\n%s", result.Stderr)
+}
+
+func TestDriveInspectValidation_InvalidType(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+inspect",
+			"--url", "someToken",
+			"--type", "invalid_type",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Contains(t, result.Stderr, "invalid_type",
+		"expected invalid type validation error, stderr:\n%s", result.Stderr)
+}
+
+// --- Helpers ---
+
+func runInspectDryRun(t *testing.T, url string) *clie2e.Result {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+inspect",
+			"--url", url,
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	return result
+}
+
+func assertOneStepBatchQuery(t *testing.T, result *clie2e.Result) {
+	t.Helper()
+
+	require.Equal(t, int64(1), gjson.Get(result.Stdout, "api.#").Int(),
+		"expected exactly 1 dry-run API step, stdout:\n%s", result.Stdout)
+	require.Equal(t, "/open-apis/drive/v1/metas/batch_query",
+		gjson.Get(result.Stdout, "api.0.url").String(),
+		"expected batch_query URL, stdout:\n%s", result.Stdout)
+}
+
+func setDriveInspectE2EEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "drive_inspect_e2e_app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "drive_inspect_e2e_secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+}

--- a/tests/cli_e2e/drive/drive_inspect_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_inspect_dryrun_test.go
@@ -197,26 +197,6 @@ func TestDriveInspectValidation_InvalidType(t *testing.T) {
 		"expected invalid type validation error, stderr:\n%s", result.Stderr)
 }
 
-func TestDriveInspectValidation_NonLarkHostWithLarkPath(t *testing.T) {
-	setDriveInspectE2EEnv(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	t.Cleanup(cancel)
-
-	result, err := clie2e.RunCmd(ctx, clie2e.Request{
-		Args: []string{
-			"drive", "+inspect",
-			"--url", "https://google.com/docx/doxcnLooksValid",
-			"--dry-run",
-		},
-		DefaultAs: "bot",
-	})
-	require.NoError(t, err)
-	result.AssertExitCode(t, 2)
-	require.Contains(t, result.Stderr, "not a recognized Lark/Feishu domain",
-		"expected non-Lark host validation error, stderr:\n%s", result.Stderr)
-}
-
 // --- Helpers ---
 
 func runInspectDryRun(t *testing.T, url string) *clie2e.Result {

--- a/tests/cli_e2e/drive/drive_inspect_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_inspect_dryrun_test.go
@@ -197,6 +197,26 @@ func TestDriveInspectValidation_InvalidType(t *testing.T) {
 		"expected invalid type validation error, stderr:\n%s", result.Stderr)
 }
 
+func TestDriveInspectValidation_NonLarkHostWithLarkPath(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+inspect",
+			"--url", "https://google.com/docx/doxcnLooksValid",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Contains(t, result.Stderr, "not a recognized Lark/Feishu domain",
+		"expected non-Lark host validation error, stderr:\n%s", result.Stderr)
+}
+
 // --- Helpers ---
 
 func runInspectDryRun(t *testing.T, url string) *clie2e.Result {


### PR DESCRIPTION
## Summary

Implements #662: `lark-cli drive +inspect --url <url>` inspects any Lark/Feishu document URL to get its type, title, and canonical token with wiki unwrapping support.

## Algorithm

1. Parse URL path → `{type, token}` via new `ParseResourceURL` (inverse of existing `BuildResourceURL`)
2. If type is `wiki`: call `GET /open-apis/wiki/v2/spaces/get_node` to unwrap to underlying document
3. Call `POST /open-apis/drive/v1/metas/batch_query` to verify and get title
4. Output JSON: `{input_url, type, title, token, url, wiki_node?}`

## Usage

```bash
# Inspect a docx URL
lark-cli drive +inspect --url 'https://xxx.feishu.cn/docx/doxcnXXX'

# Inspect a wiki URL (auto-unwraps to underlying doc)
lark-cli drive +inspect --url 'https://xxx.feishu.cn/wiki/wikcnXXX'

# Bare token with explicit type
lark-cli drive +inspect --url doxcnXXX --type docx

# Pretty output
lark-cli drive +inspect --url 'https://xxx.feishu.cn/base/bascnXXX' --format pretty
```

## Why `drive +inspect`?

- **`drive` not `docs`**: URL inspection is a cross-document capability (docx, sheet, bitable, wiki, file, folder, mindnote, slides) backed by `drive.metas.batch_query`, not specific to document content operations.
- **`+inspect` not `+search`**: `+inspect` examines a specific URL, while `+search` does full-text search — no ambiguity.

## Test Plan

- [x] `go build ./...` — clean
- [x] `go test -race ./shortcuts/...` — all pass
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] `go mod tidy` — no changes
- [x] Dry-run E2E tests (docx URL, wiki URL, bare token) — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Drive "inspect" command to validate/inspect Drive links or tokens, resolving resource type, real token, title, and canonical URL; markdown export now uses resolved titles when available.
  * Added URL parsing for Drive resource links and a helper to fetch document titles.

* **Tests**
  * Added unit tests for URL parsing and end-to-end dry-run tests for the inspect command.

* **Documentation**
  * Updated drive docs and skill guides with recommended inspect workflow and a new reference for the inspect command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->