### PR TITLE
improve e2e resource cleanup

### DIFF
--- a/tests/cli_e2e/base/helpers_test.go
+++ b/tests/cli_e2e/base/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/larksuite/cli/tests/cli_e2e/drive"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -83,9 +84,11 @@ func isCleanupSuppressedResult(result *clie2e.Result) bool {
 func createBaseWithRetry(t *testing.T, ctx context.Context, name string) string {
 	t.Helper()
 
+	const defaultAs = "bot"
+
 	result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
 		Args:      []string{"base", "+base-create", "--name", name, "--time-zone", "Asia/Shanghai"},
-		DefaultAs: "bot",
+		DefaultAs: defaultAs,
 	}, clie2e.RetryOptions{})
 	require.NoError(t, err)
 	result.AssertExitCode(t, 0)
@@ -96,6 +99,13 @@ func createBaseWithRetry(t *testing.T, ctx context.Context, name string) string 
 		baseToken = gjson.Get(result.Stdout, "data.base.base_token").String()
 	}
 	require.NotEmpty(t, baseToken, "stdout:\n%s", result.Stdout)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := clie2e.CleanupContext()
+		defer cancel()
+
+		deleteResult, deleteErr := drive.DeleteDriveResourceAndVerify(cleanupCtx, baseToken, "bitable", defaultAs)
+		clie2e.ReportCleanupFailure(t, "delete base "+baseToken, deleteResult, deleteErr)
+	})
 	return baseToken
 }
 

--- a/tests/cli_e2e/docs/docs_create_fetch_test.go
+++ b/tests/cli_e2e/docs/docs_create_fetch_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
-	drivee2e "github.com/larksuite/cli/tests/cli_e2e/drive"
+	"github.com/larksuite/cli/tests/cli_e2e/drive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -26,11 +26,12 @@ func TestDocs_CreateAndFetchWorkflowAsBot(t *testing.T) {
 	docTitle := "lark-cli-e2e-docs-" + suffix
 	docContent := "# Test Document\n\nThis document was created by lark-cli e2e test."
 
-	folderToken := drivee2e.CreateDriveFolder(t, parentT, ctx, folderName, "bot", "")
+	const defaultAs = "bot"
+	folderToken := drive.CreateDriveFolder(t, parentT, ctx, folderName, defaultAs, "")
 	var docToken string
 
 	t.Run("create", func(t *testing.T) {
-		docToken = createDocWithRetry(t, parentT, ctx, folderToken, docTitle, docContent, "bot")
+		docToken = createDocWithRetry(t, parentT, ctx, folderToken, docTitle, docContent, defaultAs)
 	})
 
 	t.Run("fetch", func(t *testing.T) {
@@ -61,10 +62,11 @@ func TestDocs_CreateAndFetchWorkflowAsUser(t *testing.T) {
 	docTitle := "lark-cli-e2e-user-docs-" + suffix
 	docContent := "# User Test Document\n\nCreated with user access token."
 	var docToken string
-	folderToken := drivee2e.CreateDriveFolder(t, parentT, ctx, folderName, "user", "")
+	const defaultAs = "user"
+	folderToken := drive.CreateDriveFolder(t, parentT, ctx, folderName, defaultAs, "")
 
 	t.Run("create as user", func(t *testing.T) {
-		docToken = createDocWithRetry(t, parentT, ctx, folderToken, docTitle, docContent, "user")
+		docToken = createDocWithRetry(t, parentT, ctx, folderToken, docTitle, docContent, defaultAs)
 	})
 
 	t.Run("fetch as user", func(t *testing.T) {
@@ -72,7 +74,7 @@ func TestDocs_CreateAndFetchWorkflowAsUser(t *testing.T) {
 
 		result, err := clie2e.RunCmd(ctx, clie2e.Request{
 			Args:      []string{"docs", "+fetch", "--doc", docToken},
-			DefaultAs: "user",
+			DefaultAs: defaultAs,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)

--- a/tests/cli_e2e/docs/docs_update_test.go
+++ b/tests/cli_e2e/docs/docs_update_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
-	drivee2e "github.com/larksuite/cli/tests/cli_e2e/drive"
+	"github.com/larksuite/cli/tests/cli_e2e/drive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -27,12 +27,13 @@ func TestDocs_UpdateWorkflow(t *testing.T) {
 	updatedTitle := "lark-cli-e2e-update-updated-" + suffix
 	originalContent := "# Original\n\nThis is the original content."
 	updatedContent := "# Updated\n\nThis is the updated content."
+	const defaultAs = "bot"
 
-	folderToken := drivee2e.CreateDriveFolder(t, parentT, ctx, folderName, "bot", "")
+	folderToken := drive.CreateDriveFolder(t, parentT, ctx, folderName, defaultAs, "")
 	var docToken string
 
 	t.Run("create as bot", func(t *testing.T) {
-		docToken = createDocWithRetry(t, parentT, ctx, folderToken, originalTitle, originalContent, "bot")
+		docToken = createDocWithRetry(t, parentT, ctx, folderToken, originalTitle, originalContent, defaultAs)
 	})
 
 	t.Run("update-title-and-content as bot", func(t *testing.T) {
@@ -46,7 +47,7 @@ func TestDocs_UpdateWorkflow(t *testing.T) {
 				"--markdown", updatedContent,
 				"--new-title", updatedTitle,
 			},
-			DefaultAs: "bot",
+			DefaultAs: defaultAs,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)
@@ -61,7 +62,7 @@ func TestDocs_UpdateWorkflow(t *testing.T) {
 				"docs", "+fetch",
 				"--doc", docToken,
 			},
-			DefaultAs: "bot",
+			DefaultAs: defaultAs,
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)

--- a/tests/cli_e2e/docs/helpers_test.go
+++ b/tests/cli_e2e/docs/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/larksuite/cli/tests/cli_e2e/drive"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -37,15 +38,7 @@ func createDocWithRetry(t *testing.T, parentT *testing.T, ctx context.Context, f
 		cleanupCtx, cancel := clie2e.CleanupContext()
 		defer cancel()
 
-		deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
-			Args: []string{
-				"drive", "+delete",
-				"--file-token", docToken,
-				"--type", "docx",
-				"--yes",
-			},
-			DefaultAs: defaultAs,
-		})
+		deleteResult, deleteErr := drive.DeleteDriveResourceAndVerify(cleanupCtx, docToken, "docx", defaultAs)
 		clie2e.ReportCleanupFailure(parentT, "delete doc "+docToken, deleteResult, deleteErr)
 	})
 

--- a/tests/cli_e2e/drive/helpers.go
+++ b/tests/cli_e2e/drive/helpers.go
@@ -5,7 +5,10 @@ package drive
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
 	"github.com/tidwall/gjson"
@@ -44,12 +47,124 @@ func CreateDriveFolder(t *testing.T, parentT *testing.T, ctx context.Context, na
 		cleanupCtx, cancel := clie2e.CleanupContext()
 		defer cancel()
 
-		deleteResult, deleteErr := clie2e.RunCmdWithRetry(cleanupCtx, clie2e.Request{
-			Args:      []string{"drive", "+delete", "--file-token", folderToken, "--type", "folder", "--yes"},
-			DefaultAs: defaultAs,
-		}, clie2e.RetryOptions{})
+		deleteResult, deleteErr := DeleteDriveResourceAndVerify(cleanupCtx, folderToken, "folder", defaultAs)
 		clie2e.ReportCleanupFailure(parentT, "delete drive folder "+folderToken, deleteResult, deleteErr)
 	})
 
 	return folderToken
+}
+
+// DeleteDriveResourceAndVerify deletes a Drive-backed resource, then polls
+// drive meta until the token is either gone or no longer has an accessible URL.
+// This prevents cleanup from looking successful when the delete command
+// returned a suppressed not_found or partial API error but the resource still
+// exists.
+func DeleteDriveResourceAndVerify(ctx context.Context, token, docType, defaultAs string) (*clie2e.Result, error) {
+	if defaultAs == "" {
+		defaultAs = "bot"
+	}
+
+	deleteResult, deleteErr := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+		Args:      []string{"drive", "+delete", "--file-token", token, "--type", docType, "--yes"},
+		DefaultAs: defaultAs,
+	}, clie2e.RetryOptions{})
+	if deleteErr != nil || deleteResult == nil {
+		return deleteResult, deleteErr
+	}
+	if deleteResult.ExitCode != 0 {
+		deleted, verifyErr := IsDriveResourceDeleted(ctx, token, docType, defaultAs)
+		if verifyErr != nil {
+			return deleteResult, verifyErr
+		}
+		if deleted {
+			deleteResult.ExitCode = 0
+			return deleteResult, nil
+		}
+		return deleteResult, fmt.Errorf("drive resource %s/%s still exists after delete failed: exit=%d stdout=%s stderr=%s", docType, token, deleteResult.ExitCode, deleteResult.Stdout, deleteResult.Stderr)
+	}
+	if err := WaitDriveResourceDeleted(ctx, token, docType, defaultAs); err != nil {
+		return deleteResult, err
+	}
+	return deleteResult, nil
+}
+
+func WaitDriveResourceDeleted(ctx context.Context, token, docType, defaultAs string) error {
+	deadline := time.NewTimer(20 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		deleted, err := IsDriveResourceDeleted(ctx, token, docType, defaultAs)
+		if err != nil {
+			return err
+		}
+		if deleted {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("drive resource %s/%s still exists after delete", docType, token)
+		case <-ticker.C:
+		}
+	}
+}
+
+func IsDriveResourceDeleted(ctx context.Context, token, docType, defaultAs string) (bool, error) {
+	if defaultAs == "" {
+		defaultAs = "bot"
+	}
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args:      []string{"api", "post", "/open-apis/drive/v1/metas/batch_query"},
+		DefaultAs: defaultAs,
+		Data: map[string]any{
+			"request_docs": []map[string]any{{
+				"doc_token": token,
+				"doc_type":  docType,
+			}},
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	if result.ExitCode != 0 {
+		combined := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+		if strings.Contains(combined, "not found") || strings.Contains(combined, "404") {
+			return true, nil
+		}
+		return false, fmt.Errorf("verify drive resource %s/%s after delete: exit=%d stdout=%s stderr=%s", docType, token, result.ExitCode, result.Stdout, result.Stderr)
+	}
+	if !isDriveMetaQuerySuccessful(result.Stdout) {
+		return false, fmt.Errorf("verify drive resource %s/%s after delete returned unsuccessful envelope: stdout=%s stderr=%s", docType, token, result.Stdout, result.Stderr)
+	}
+	metas := gjson.Get(result.Stdout, "data.metas").Array()
+	if len(metas) == 0 {
+		return true, nil
+	}
+	if docType != "folder" {
+		allURLsCleared := true
+		for _, meta := range metas {
+			if meta.Get("url").String() != "" {
+				allURLsCleared = false
+				break
+			}
+		}
+		if allURLsCleared {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isDriveMetaQuerySuccessful(stdout string) bool {
+	if ok := gjson.Get(stdout, "ok"); ok.Exists() {
+		return ok.Bool()
+	}
+	if code := gjson.Get(stdout, "code"); code.Exists() {
+		return code.Int() == 0
+	}
+	return false
 }

--- a/tests/cli_e2e/sheets/helpers_test.go
+++ b/tests/cli_e2e/sheets/helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
-	drivee2e "github.com/larksuite/cli/tests/cli_e2e/drive"
+	"github.com/larksuite/cli/tests/cli_e2e/drive"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -16,7 +16,7 @@ import (
 func createSpreadsheet(t *testing.T, parentT *testing.T, ctx context.Context, title string, defaultAs string) string {
 	t.Helper()
 
-	folderToken := drivee2e.CreateDriveFolder(t, parentT, ctx, title+"-folder", defaultAs, "")
+	folderToken := drive.CreateDriveFolder(t, parentT, ctx, title+"-folder", defaultAs, "")
 
 	result, err := clie2e.RunCmd(ctx, clie2e.Request{
 		Args: []string{
@@ -37,15 +37,7 @@ func createSpreadsheet(t *testing.T, parentT *testing.T, ctx context.Context, ti
 		cleanupCtx, cancel := clie2e.CleanupContext()
 		defer cancel()
 
-		deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
-			Args: []string{
-				"drive", "+delete",
-				"--file-token", spreadsheetToken,
-				"--type", "sheet",
-				"--yes",
-			},
-			DefaultAs: defaultAs,
-		})
+		deleteResult, deleteErr := drive.DeleteDriveResourceAndVerify(cleanupCtx, spreadsheetToken, "sheet", defaultAs)
 		clie2e.ReportCleanupFailure(parentT, "delete spreadsheet "+spreadsheetToken, deleteResult, deleteErr)
 	})
 

--- a/tests/cli_e2e/sheets/sheets_crud_workflow_test.go
+++ b/tests/cli_e2e/sheets/sheets_crud_workflow_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
-	drivee2e "github.com/larksuite/cli/tests/cli_e2e/drive"
+	"github.com/larksuite/cli/tests/cli_e2e/drive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -180,12 +180,13 @@ func TestSheets_SpreadsheetsResource(t *testing.T) {
 
 	suffix := clie2e.GenerateSuffix()
 	spreadsheetToken := ""
+	const defaultAs = "bot"
 
 	t.Run("create spreadsheet with spreadsheets create as bot", func(t *testing.T) {
-		folderToken := drivee2e.CreateDriveFolder(t, parentT, ctx, "lark-cli-e2e-sheets-resource-folder-"+suffix, "bot", "")
+		folderToken := drive.CreateDriveFolder(t, parentT, ctx, "lark-cli-e2e-sheets-resource-folder-"+suffix, defaultAs, "")
 		result, err := clie2e.RunCmd(ctx, clie2e.Request{
 			Args:      []string{"sheets", "spreadsheets", "create"},
-			DefaultAs: "bot",
+			DefaultAs: defaultAs,
 			Data: map[string]any{
 				"title":        "lark-cli-e2e-sheets-resource-" + suffix,
 				"folder_token": folderToken,
@@ -202,15 +203,7 @@ func TestSheets_SpreadsheetsResource(t *testing.T) {
 			cleanupCtx, cancel := clie2e.CleanupContext()
 			defer cancel()
 
-			deleteResult, deleteErr := clie2e.RunCmd(cleanupCtx, clie2e.Request{
-				Args: []string{
-					"drive", "+delete",
-					"--file-token", spreadsheetToken,
-					"--type", "sheet",
-					"--yes",
-				},
-				DefaultAs: "bot",
-			})
+			deleteResult, deleteErr := drive.DeleteDriveResourceAndVerify(cleanupCtx, spreadsheetToken, "sheet", defaultAs)
 			clie2e.ReportCleanupFailure(parentT, "delete spreadsheet "+spreadsheetToken, deleteResult, deleteErr)
 		})
 	})

--- a/tests/cli_e2e/wiki/helpers_test.go
+++ b/tests/cli_e2e/wiki/helpers_test.go
@@ -5,14 +5,17 @@ package wiki
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	clie2e "github.com/larksuite/cli/tests/cli_e2e"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
-func createWikiNode(t *testing.T, parentT *testing.T, ctx context.Context, spaceID string, data map[string]any) gjson.Result {
+func createWikiNode(t *testing.T, parentT *testing.T, ctx context.Context, spaceID string, data map[string]any) (gjson.Result, *clie2e.Result, error) {
 	t.Helper()
 
 	result, err := clie2e.RunCmd(ctx, clie2e.Request{
@@ -20,9 +23,9 @@ func createWikiNode(t *testing.T, parentT *testing.T, ctx context.Context, space
 		DefaultAs: "bot",
 		Data:      data,
 	})
-	require.NoError(t, err)
-	result.AssertExitCode(t, 0)
-	result.AssertStdoutStatus(t, 0)
+	if err != nil || result.ExitCode != 0 {
+		return gjson.Result{}, result, err
+	}
 
 	node := gjson.Get(result.Stdout, "data.node")
 	require.True(t, node.Exists(), "stdout:\n%s", result.Stdout)
@@ -34,11 +37,118 @@ func createWikiNode(t *testing.T, parentT *testing.T, ctx context.Context, space
 		cleanupCtx, cancel := clie2e.CleanupContext()
 		defer cancel()
 
-		deleteResult, deleteErr := deleteWikiNode(cleanupCtx, spaceID, nodeToken, objType)
+		deleteResult, deleteErr := deleteWikiNodeAndVerify(cleanupCtx, spaceID, nodeToken, objType)
 		clie2e.ReportCleanupFailure(parentT, "delete wiki node "+nodeToken, deleteResult, deleteErr)
 	})
 
-	return node
+	return node, result, nil
+}
+
+// createWikiNodeUnderAnyHost creates an isolated parent under an existing
+// my_library root node. It avoids adding test nodes directly at the root level,
+// whose single-layer limit is easy to exhaust when cleanup regresses. If the
+// library is empty, it creates one reusable root host and keeps it for future
+// test runs.
+func createWikiNodeUnderAnyHost(t *testing.T, parentT *testing.T, ctx context.Context, title string) (gjson.Result, gjson.Result) {
+	t.Helper()
+
+	hosts := listWikiRootHosts(t, ctx)
+	if len(hosts) == 0 {
+		hosts = append(hosts, createWikiRootHost(t, ctx))
+	}
+
+	var layerLimitResults []string
+	for _, host := range hosts {
+		spaceID := host.Get("space_id").String()
+		hostNodeToken := host.Get("node_token").String()
+		if spaceID == "" || hostNodeToken == "" {
+			continue
+		}
+		node, result, err := createWikiNode(t, parentT, ctx, spaceID, map[string]any{
+			"node_type":         "origin",
+			"obj_type":          "docx",
+			"title":             title,
+			"parent_node_token": hostNodeToken,
+		})
+		if err == nil && result.ExitCode == 0 {
+			return host, node
+		}
+		if isWikiLayerLimitResult(result) {
+			layerLimitResults = append(layerLimitResults, fmt.Sprintf("host=%s stdout=%s stderr=%s", hostNodeToken, result.Stdout, result.Stderr))
+			continue
+		}
+		require.NoError(t, err)
+		require.Failf(t, "create wiki node under host failed", "host=%s exit=%d stdout=%s stderr=%s", hostNodeToken, result.ExitCode, result.Stdout, result.Stderr)
+	}
+	require.Failf(t, "create wiki node under host failed", "all candidate hosts hit the single-layer node limit:\n%s", strings.Join(layerLimitResults, "\n"))
+	return gjson.Result{}, gjson.Result{}
+}
+
+func createWikiRootHost(t *testing.T, ctx context.Context) gjson.Result {
+	t.Helper()
+
+	result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+		Args:      []string{"api", "post", "/open-apis/wiki/v2/spaces/my_library/nodes"},
+		DefaultAs: "bot",
+		Data: map[string]any{
+			"node_type": "origin",
+			"obj_type":  "docx",
+			"title":     "lark-cli-e2e-wiki-host",
+		},
+	}, clie2e.RetryOptions{})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	result.AssertStdoutStatus(t, 0)
+
+	host := gjson.Get(result.Stdout, "data.node")
+	require.True(t, host.Exists(), "stdout:\n%s", result.Stdout)
+	require.NotEmpty(t, host.Get("space_id").String(), "stdout:\n%s", result.Stdout)
+	require.NotEmpty(t, host.Get("node_token").String(), "stdout:\n%s", result.Stdout)
+	return host
+}
+
+func listWikiRootHosts(t *testing.T, ctx context.Context) []gjson.Result {
+	t.Helper()
+
+	var hosts []gjson.Result
+	pageToken := ""
+	seenPageTokens := map[string]struct{}{}
+	for {
+		params := map[string]any{"page_size": 50}
+		if pageToken != "" {
+			if _, exists := seenPageTokens[pageToken]; exists {
+				t.Fatalf("wiki root host pagination loop detected for page_token %q", pageToken)
+			}
+			seenPageTokens[pageToken] = struct{}{}
+			params["page_token"] = pageToken
+		}
+
+		listResult, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+			Args:      []string{"api", "get", "/open-apis/wiki/v2/spaces/my_library/nodes"},
+			DefaultAs: "bot",
+			Params:    params,
+		}, clie2e.RetryOptions{})
+		require.NoError(t, err)
+		listResult.AssertExitCode(t, 0)
+		listResult.AssertStdoutStatus(t, 0)
+
+		parsed := gjson.Parse(listResult.Stdout)
+		hosts = append(hosts, parsed.Get("data.items").Array()...)
+
+		pageToken = parsed.Get("data.page_token").String()
+		if pageToken == "" || !parsed.Get("data.has_more").Bool() {
+			return hosts
+		}
+	}
+}
+
+func isWikiLayerLimitResult(result *clie2e.Result) bool {
+	if result == nil {
+		return false
+	}
+	combined := result.Stdout + "\n" + result.Stderr
+	return strings.Contains(combined, "131003") ||
+		strings.Contains(strings.ToLower(combined), "single-layer nodes")
 }
 
 func getWikiNode(t *testing.T, ctx context.Context, nodeToken string) gjson.Result {
@@ -88,19 +198,213 @@ func listWikiSpaces(t *testing.T, ctx context.Context, pageSize int) gjson.Resul
 	return gjson.Parse(result.Stdout)
 }
 
-// deleteWikiNode removes a wiki space node. The DELETE endpoint requires
-// obj_type as a body field (validation error 99992402 if omitted), so
-// pass it via --data rather than --params even though DELETE bodies are
-// uncommon.
-func deleteWikiNode(ctx context.Context, spaceID, nodeToken, objType string) (*clie2e.Result, error) {
-	return clie2e.RunCmd(ctx, clie2e.Request{
-		Args:      []string{"api", "delete", "/open-apis/wiki/v2/spaces/" + spaceID + "/nodes/" + nodeToken},
-		DefaultAs: "bot",
-		Data:      map[string]any{"obj_type": objType},
-	})
+type wikiNodeInfo struct {
+	NodeToken string
+	ObjType   string
 }
 
-func findWikiNodeByToken(t *testing.T, ctx context.Context, spaceID string, nodeToken string) gjson.Result {
+// deleteWikiNodeAndVerify removes a wiki node, then polls get_node until the
+// original node token is gone. Wiki cleanup cannot use drive +delete because
+// wiki origin nodes need the backing obj_token and parent nodes must delete
+// children first.
+func deleteWikiNodeAndVerify(ctx context.Context, spaceID, nodeToken, objType string) (*clie2e.Result, error) {
+	getResult, getErr := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+		Args:      []string{"api", "get", "/open-apis/wiki/v2/spaces/get_node"},
+		DefaultAs: "bot",
+		Params:    map[string]any{"token": nodeToken},
+	}, clie2e.RetryOptions{})
+	if getErr != nil {
+		return getResult, getErr
+	}
+	if getResult == nil {
+		return nil, fmt.Errorf("get wiki node %s before delete returned nil result", nodeToken)
+	}
+	if getResult.ExitCode != 0 || !wikiAPISuccess(getResult.Stdout) {
+		if isWikiNodeDeletedResult(getResult) {
+			getResult.ExitCode = 0
+			getResult.RunErr = nil
+			return getResult, nil
+		}
+		return getResult, fmt.Errorf("get wiki node %s before delete failed: exit=%d stdout=%s stderr=%s", nodeToken, getResult.ExitCode, getResult.Stdout, getResult.Stderr)
+	}
+
+	node := gjson.Get(getResult.Stdout, "data.node")
+	originalNodeToken := nodeToken
+	if resolvedSpaceID := node.Get("space_id").String(); resolvedSpaceID != "" {
+		spaceID = resolvedSpaceID
+	}
+	if resolvedObjType := node.Get("obj_type").String(); resolvedObjType != "" {
+		objType = resolvedObjType
+	}
+	if objType == "" {
+		objType = "docx"
+	}
+
+	children, childListResult, childListErr := listWikiNodeChildren(ctx, spaceID, originalNodeToken)
+	if childListErr != nil || childListResult == nil || childListResult.ExitCode != 0 {
+		return childListResult, childListErr
+	}
+	for _, child := range children {
+		childDeleteResult, childDeleteErr := deleteWikiNodeAndVerify(ctx, spaceID, child.NodeToken, child.ObjType)
+		if childDeleteErr != nil || childDeleteResult == nil || (childDeleteResult.ExitCode != 0 && !isWikiNodeDeletedResult(childDeleteResult)) {
+			return childDeleteResult, childDeleteErr
+		}
+	}
+
+	deleteToken := originalNodeToken
+	if node.Get("node_type").String() == "origin" {
+		if objToken := node.Get("obj_token").String(); objToken != "" {
+			deleteToken = objToken
+		}
+	}
+
+	deleteResult, deleteErr := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+		Args:      []string{"api", "delete", "/open-apis/wiki/v2/spaces/" + spaceID + "/nodes/" + deleteToken},
+		DefaultAs: "bot",
+		Data:      map[string]any{"obj_type": objType},
+	}, clie2e.RetryOptions{})
+	if deleteErr != nil || deleteResult == nil {
+		return deleteResult, deleteErr
+	}
+	if deleteResult.ExitCode != 0 || !wikiAPISuccess(deleteResult.Stdout) {
+		deleted, verifyErr := isWikiNodeDeleted(ctx, originalNodeToken)
+		if verifyErr != nil {
+			return deleteResult, verifyErr
+		}
+		if deleted {
+			deleteResult.ExitCode = 0
+			return deleteResult, nil
+		}
+		return deleteResult, fmt.Errorf("wiki node %s still exists after delete failed: exit=%d stdout=%s stderr=%s", originalNodeToken, deleteResult.ExitCode, deleteResult.Stdout, deleteResult.Stderr)
+	}
+	if err := waitWikiNodeDeleted(ctx, originalNodeToken); err != nil {
+		return deleteResult, err
+	}
+	return deleteResult, nil
+}
+
+func listWikiNodeChildren(ctx context.Context, spaceID, parentNodeToken string) ([]wikiNodeInfo, *clie2e.Result, error) {
+	var children []wikiNodeInfo
+	pageToken := ""
+	seenPageTokens := map[string]struct{}{}
+	for {
+		params := map[string]any{
+			"page_size":         50,
+			"parent_node_token": parentNodeToken,
+		}
+		if pageToken != "" {
+			if _, exists := seenPageTokens[pageToken]; exists {
+				return children, nil, fmt.Errorf("wiki children pagination loop detected for parent %s page_token %q", parentNodeToken, pageToken)
+			}
+			seenPageTokens[pageToken] = struct{}{}
+			params["page_token"] = pageToken
+		}
+
+		result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+			Args:      []string{"api", "get", "/open-apis/wiki/v2/spaces/" + spaceID + "/nodes"},
+			DefaultAs: "bot",
+			Params:    params,
+		}, clie2e.RetryOptions{})
+		if err != nil || result == nil || result.ExitCode != 0 {
+			return children, result, err
+		}
+		if !wikiAPISuccess(result.Stdout) {
+			return children, result, fmt.Errorf("list wiki node children for parent %s failed: stdout=%s stderr=%s", parentNodeToken, result.Stdout, result.Stderr)
+		}
+
+		parsed := gjson.Parse(result.Stdout)
+		for _, item := range parsed.Get("data.items").Array() {
+			nodeToken := item.Get("node_token").String()
+			if nodeToken == "" {
+				continue
+			}
+			objType := item.Get("obj_type").String()
+			if objType == "" {
+				objType = "docx"
+			}
+			children = append(children, wikiNodeInfo{NodeToken: nodeToken, ObjType: objType})
+		}
+
+		pageToken = parsed.Get("data.page_token").String()
+		if pageToken == "" || !parsed.Get("data.has_more").Bool() {
+			return children, result, nil
+		}
+	}
+}
+
+func waitWikiNodeDeleted(ctx context.Context, nodeToken string) error {
+	deadline := time.NewTimer(20 * time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	for {
+		deleted, err := isWikiNodeDeleted(ctx, nodeToken)
+		if err != nil {
+			return err
+		}
+		if deleted {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("wiki node %s still exists after delete", nodeToken)
+		case <-ticker.C:
+		}
+	}
+}
+
+func isWikiNodeDeleted(ctx context.Context, nodeToken string) (bool, error) {
+	result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
+		Args:      []string{"api", "get", "/open-apis/wiki/v2/spaces/get_node"},
+		DefaultAs: "bot",
+		Params:    map[string]any{"token": nodeToken},
+	}, clie2e.RetryOptions{})
+	if err != nil {
+		return false, err
+	}
+	if result == nil {
+		return false, fmt.Errorf("verify wiki node %s after delete returned nil result", nodeToken)
+	}
+	if result.ExitCode == 0 && wikiAPISuccess(result.Stdout) {
+		return false, nil
+	}
+	if isWikiNodeDeletedResult(result) {
+		return true, nil
+	}
+	return false, fmt.Errorf("verify wiki node %s after delete: exit=%d stdout=%s stderr=%s", nodeToken, result.ExitCode, result.Stdout, result.Stderr)
+}
+
+func wikiAPISuccess(stdout string) bool {
+	if ok := gjson.Get(stdout, "ok"); ok.Exists() {
+		return ok.Bool()
+	}
+	if code := gjson.Get(stdout, "code"); code.Exists() {
+		return code.Int() == 0
+	}
+	return false
+}
+
+func isWikiNodeDeletedResult(result *clie2e.Result) bool {
+	if result == nil {
+		return false
+	}
+	if code := gjson.Get(result.Stdout, "error.code"); code.Exists() && code.Int() == 131005 {
+		return true
+	}
+	if code := gjson.Get(result.Stdout, "code"); code.Exists() && code.Int() == 131005 {
+		return true
+	}
+	combined := strings.ToLower(result.Stdout + "\n" + result.Stderr)
+	return strings.Contains(combined, "131005") ||
+		strings.Contains(combined, "node not found") ||
+		strings.Contains(combined, "not found")
+}
+
+func findWikiNodeByToken(t *testing.T, ctx context.Context, spaceID string, nodeToken string, parentNodeTokens ...string) gjson.Result {
 	t.Helper()
 
 	pageToken := ""
@@ -108,6 +412,9 @@ func findWikiNodeByToken(t *testing.T, ctx context.Context, spaceID string, node
 	seenPageTokens := map[string]struct{}{}
 	for {
 		params := map[string]any{"page_size": 50}
+		if len(parentNodeTokens) > 0 && parentNodeTokens[0] != "" {
+			params["parent_node_token"] = parentNodeTokens[0]
+		}
 		if pageToken != "" {
 			if _, exists := seenPageTokens[pageToken]; exists {
 				t.Fatalf("wiki list pagination loop detected for page_token %q, last stdout:\n%s", pageToken, lastStdout)

--- a/tests/cli_e2e/wiki/wiki_shortcut_workflow_test.go
+++ b/tests/cli_e2e/wiki/wiki_shortcut_workflow_test.go
@@ -31,7 +31,7 @@ func TestWiki_ShortcutWorkflow(t *testing.T) {
 	childTitle := "lark-cli-e2e-wiki-sc-child-" + suffix
 	copyTitle := "lark-cli-e2e-wiki-sc-copy-" + suffix
 
-	var spaceID, parentNodeToken, childNodeToken, childObjType string
+	var spaceID, parentNodeToken, childNodeToken, childObjType, copiedNodeToken string
 
 	// Setup: reuse an existing first-layer node in my_library as the host so
 	// we never bump the top-layer node count (the bot's my_library top layer
@@ -46,44 +46,22 @@ func TestWiki_ShortcutWorkflow(t *testing.T) {
 	// parent always has exactly the children this test creates, so the
 	// pagination scan never has to dig through historical cruft.
 	t.Run("setup: locate my_library host node + create isolated parent + create test child", func(t *testing.T) {
-		listResult, err := clie2e.RunCmd(ctx, clie2e.Request{
-			Args:      []string{"api", "get", "/open-apis/wiki/v2/spaces/my_library/nodes"},
-			DefaultAs: "bot",
-			Params:    map[string]any{"page_size": 50},
-		})
-		require.NoError(t, err)
-		listResult.AssertExitCode(t, 0)
-		listResult.AssertStdoutStatus(t, 0)
-
-		items := gjson.Get(listResult.Stdout, "data.items").Array()
-		if len(items) == 0 {
-			t.Skip("skipped: my_library has no existing top-level nodes to host the test structure")
-		}
-		host := items[0]
+		host, isolatedParent := createWikiNodeUnderAnyHost(t, parentT, ctx, parentTitle)
 		spaceID = host.Get("space_id").String()
-		hostNodeToken := host.Get("node_token").String()
 		require.NotEmpty(t, spaceID, "host space_id must be present in listing")
-		require.NotEmpty(t, hostNodeToken, "host node_token must be present in listing")
-
-		// Create a fresh intermediate parent under the host. The helper
-		// auto-registers a t.Cleanup callback that deletes this parent
-		// (and, by API cascade, anything still under it) after the test.
-		isolatedParent := createWikiNode(t, parentT, ctx, spaceID, map[string]any{
-			"node_type":         "origin",
-			"obj_type":          "docx",
-			"title":             parentTitle,
-			"parent_node_token": hostNodeToken,
-		})
 		parentNodeToken = isolatedParent.Get("node_token").String()
 		require.NotEmpty(t, parentNodeToken, "isolated parent node_token must be present after create")
 
 		// Create the test child UNDER the freshly-isolated parent.
-		child := createWikiNode(t, parentT, ctx, spaceID, map[string]any{
+		child, result, err := createWikiNode(t, parentT, ctx, spaceID, map[string]any{
 			"node_type":         "origin",
 			"obj_type":          "docx",
 			"title":             childTitle,
 			"parent_node_token": parentNodeToken,
 		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, 0)
 		childNodeToken = child.Get("node_token").String()
 		childObjType = child.Get("obj_type").String()
 		require.NotEmpty(t, childNodeToken)
@@ -184,7 +162,7 @@ func TestWiki_ShortcutWorkflow(t *testing.T) {
 		require.NotEmpty(t, parentNodeToken)
 		require.NotEmpty(t, childNodeToken)
 
-		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
 			Args: []string{
 				"wiki", "+node-copy",
 				"--space-id", spaceID,
@@ -197,13 +175,13 @@ func TestWiki_ShortcutWorkflow(t *testing.T) {
 			// explicit confirmation before issuing the request.
 			Yes:       true,
 			DefaultAs: "bot",
-		})
+		}, clie2e.RetryOptions{})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)
 
 		out := gjson.Parse(result.Stdout)
 		require.True(t, out.Get("ok").Bool(), "stdout:\n%s", result.Stdout)
-		copiedNodeToken := out.Get("data.node_token").String()
+		copiedNodeToken = out.Get("data.node_token").String()
 		copiedSpaceID := out.Get("data.space_id").String()
 		copiedObjType := out.Get("data.obj_type").String()
 		require.NotEmpty(t, copiedNodeToken, "stdout:\n%s", result.Stdout)
@@ -213,7 +191,7 @@ func TestWiki_ShortcutWorkflow(t *testing.T) {
 		parentT.Cleanup(func() {
 			cleanupCtx, cancel := clie2e.CleanupContext()
 			defer cancel()
-			deleteResult, deleteErr := deleteWikiNode(cleanupCtx, copiedSpaceID, copiedNodeToken, copiedObjType)
+			deleteResult, deleteErr := deleteWikiNodeAndVerify(cleanupCtx, copiedSpaceID, copiedNodeToken, copiedObjType)
 			clie2e.ReportCleanupFailure(parentT, "delete copied wiki node "+copiedNodeToken, deleteResult, deleteErr)
 		})
 

--- a/tests/cli_e2e/wiki/wiki_workflow_test.go
+++ b/tests/cli_e2e/wiki/wiki_workflow_test.go
@@ -25,21 +25,20 @@ func TestWiki_NodeWorkflow(t *testing.T) {
 	copiedTitle := "lark-cli-e2e-wiki-copy-" + suffix
 
 	var spaceID string
+	var hostNodeToken string
 	var parentNodeToken string
 	var createdNodeToken string
 	var createdObjToken string
 	var copiedNodeToken string
 	var copiedSpaceID string
 
-	t.Run("create isolated parent node as bot", func(t *testing.T) {
-		parentNode := createWikiNode(t, parentT, ctx, "my_library", map[string]any{
-			"node_type": "origin",
-			"obj_type":  "docx",
-			"title":     parentTitle,
-		})
+	t.Run("create isolated parent node under host as bot", func(t *testing.T) {
+		host, parentNode := createWikiNodeUnderAnyHost(t, parentT, ctx, parentTitle)
 		spaceID = parentNode.Get("space_id").String()
+		hostNodeToken = host.Get("node_token").String()
 		parentNodeToken = parentNode.Get("node_token").String()
 		require.NotEmpty(t, spaceID)
+		require.NotEmpty(t, hostNodeToken)
 		require.NotEmpty(t, parentNodeToken)
 		assert.Equal(t, parentTitle, parentNode.Get("title").String())
 	})
@@ -47,12 +46,15 @@ func TestWiki_NodeWorkflow(t *testing.T) {
 	t.Run("create node as bot", func(t *testing.T) {
 		require.NotEmpty(t, parentNodeToken, "parent node token should be created before child node")
 
-		node := createWikiNode(t, parentT, ctx, spaceID, map[string]any{
+		node, result, err := createWikiNode(t, parentT, ctx, spaceID, map[string]any{
 			"node_type":         "origin",
 			"obj_type":          "docx",
 			"title":             createdTitle,
 			"parent_node_token": parentNodeToken,
 		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+		result.AssertStdoutStatus(t, 0)
 
 		createdNodeToken = node.Get("node_token").String()
 		createdObjToken = node.Get("obj_token").String()
@@ -94,9 +96,10 @@ func TestWiki_NodeWorkflow(t *testing.T) {
 
 	t.Run("list nodes and find isolated parent node as bot", func(t *testing.T) {
 		require.NotEmpty(t, spaceID, "space ID should be available before list")
+		require.NotEmpty(t, hostNodeToken, "host node token should be available before list")
 		require.NotEmpty(t, parentNodeToken, "parent node token should be available before list")
 
-		nodeItem := findWikiNodeByToken(t, ctx, spaceID, parentNodeToken)
+		nodeItem := findWikiNodeByToken(t, ctx, spaceID, parentNodeToken, hostNodeToken)
 		assert.Equal(t, parentTitle, nodeItem.Get("title").String())
 	})
 
@@ -104,14 +107,15 @@ func TestWiki_NodeWorkflow(t *testing.T) {
 		require.NotEmpty(t, spaceID, "space ID should be available before copy")
 		require.NotEmpty(t, createdNodeToken, "node token should be available before copy")
 
-		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		result, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
 			Args:      []string{"api", "post", "/open-apis/wiki/v2/spaces/" + spaceID + "/nodes/" + createdNodeToken + "/copy"},
 			DefaultAs: "bot",
 			Data: map[string]any{
-				"target_space_id": spaceID,
-				"title":           copiedTitle,
+				"target_space_id":     spaceID,
+				"target_parent_token": parentNodeToken,
+				"title":               copiedTitle,
 			},
-		})
+		}, clie2e.RetryOptions{})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)
 		result.AssertStdoutStatus(t, 0)
@@ -125,7 +129,7 @@ func TestWiki_NodeWorkflow(t *testing.T) {
 			cleanupCtx, cancel := clie2e.CleanupContext()
 			defer cancel()
 
-			deleteResult, deleteErr := deleteWikiNode(cleanupCtx, copiedSpaceID, copiedNodeToken, copiedObjType)
+			deleteResult, deleteErr := deleteWikiNodeAndVerify(cleanupCtx, copiedSpaceID, copiedNodeToken, copiedObjType)
 			clie2e.ReportCleanupFailure(parentT, "delete copied wiki node "+copiedNodeToken, deleteResult, deleteErr)
 		})
 	})


### PR DESCRIPTION
Change-Id: I3e04a82f622853549f11ac49cbd6fefa194c7c56

## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cleanup reliability across CLI e2E suites with verified deletion, polling and retry logic for drive, docs, sheets, and wiki resources.
  * Enhanced wiki workflows: recursive cleanup, better host selection, handling of layer-limit cases, and more robust copy/create assertions.
  * Consolidated identity handling (bot/user) to remove hard-coded values and standardized helper/import usage and retry behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->