### PR TITLE
fix(drive): clarify wiki-owned delete failures

### DIFF
--- a/shortcuts/drive/drive_delete.go
+++ b/shortcuts/drive/drive_delete.go
@@ -5,6 +5,7 @@ package drive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -88,7 +89,7 @@ var DriveDelete = common.Shortcut{
 			nil,
 		)
 		if err != nil {
-			return err
+			return enrichDriveDeleteError(err)
 		}
 
 		if spec.FileType == "folder" {
@@ -138,11 +139,42 @@ func validateDriveDeleteSpec(spec driveDeleteSpec) error {
 	if err := validate.ResourceName(spec.FileToken, "--file-token"); err != nil {
 		return output.ErrValidation("%s", err)
 	}
+	if looksLikeWikiNodeToken(spec.FileToken) {
+		return output.ErrValidation("unsupported wiki node token for drive +delete: wiki-owned nodes cannot be deleted through the Drive files API. Move the node to an archive location with wiki +move, or delete it from Feishu Web/Desktop UI")
+	}
 	if spec.FileType == "wiki" {
-		return output.ErrValidation("unsupported file type: wiki. This shortcut only supports Drive files and folders; wiki documents are not supported")
+		return output.ErrValidation("unsupported file type: wiki. This shortcut only supports Drive files and folders; wiki-owned nodes cannot be deleted through the Drive files API. Move the node to an archive location with wiki +move, or delete it from Feishu Web/Desktop UI")
 	}
 	if !driveDeleteAllowedTypes[spec.FileType] {
 		return output.ErrValidation("unsupported file type: %s. Supported types: file, docx, bitable, doc, sheet, mindnote, folder, shortcut, slides", spec.FileType)
 	}
 	return nil
+}
+
+func looksLikeWikiNodeToken(token string) bool {
+	token = strings.ToLower(strings.TrimSpace(token))
+	return strings.HasPrefix(token, "wikcn") || strings.HasPrefix(token, "wiki")
+}
+
+func enrichDriveDeleteError(err error) error {
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+		return err
+	}
+	if exitErr.Detail.Code != 1061004 {
+		return err
+	}
+
+	hint := "Drive delete returned 1061004 forbidden. If this target is a wiki-owned node, it cannot be deleted through drive +delete or the Drive files API. Move it to an archive location with wiki +move when possible, or delete it from Feishu Web/Desktop UI. If it is not wiki-owned, verify the caller has delete permission and the space:document:delete scope."
+	return &output.ExitError{
+		Code: exitErr.Code,
+		Detail: &output.ErrDetail{
+			Type:    exitErr.Detail.Type,
+			Code:    exitErr.Detail.Code,
+			Message: exitErr.Detail.Message,
+			Hint:    hint,
+			Detail:  exitErr.Detail.Detail,
+		},
+		Err: err,
+	}
 }

--- a/shortcuts/drive/drive_delete_test.go
+++ b/shortcuts/drive/drive_delete_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -27,7 +29,22 @@ func TestValidateDriveDeleteSpecRejectsWiki(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected wiki type error, got nil")
 	}
-	if !strings.Contains(err.Error(), "wiki documents are not supported") {
+	if !strings.Contains(err.Error(), "wiki-owned nodes cannot be deleted") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateDriveDeleteSpecRejectsWikiNodeToken(t *testing.T) {
+	t.Parallel()
+
+	err := validateDriveDeleteSpec(driveDeleteSpec{
+		FileToken: "wikcn_test_node",
+		FileType:  "docx",
+	})
+	if err == nil {
+		t.Fatal("expected wiki token error, got nil")
+	}
+	if !strings.Contains(err.Error(), "wiki-owned nodes cannot be deleted") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -122,6 +139,42 @@ func TestDriveDeleteFileSuccess(t *testing.T) {
 	}
 	if !bytes.Contains(stdout.Bytes(), []byte(`"file_token": "file_token_test"`)) {
 		t.Fatalf("stdout missing file token: %s", stdout.String())
+	}
+}
+
+func TestDriveDeleteForbiddenAddsWikiOwnedHint(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/open-apis/drive/v1/files/docx_token_test",
+		Body: map[string]interface{}{
+			"code": 1061004,
+			"msg":  "forbidden",
+		},
+	})
+
+	err := mountAndRunDrive(t, DriveDelete, []string{
+		"+delete",
+		"--file-token", "docx_token_test",
+		"--type", "docx",
+		"--yes",
+		"--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected forbidden error, got nil")
+	}
+
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+		t.Fatalf("expected structured exit error, got %T: %v", err, err)
+	}
+	if exitErr.Detail.Code != 1061004 {
+		t.Fatalf("error code = %d, want 1061004", exitErr.Detail.Code)
+	}
+	for _, needle := range []string{"wiki-owned node", "Drive files API", "wiki +move", "Feishu Web/Desktop UI"} {
+		if !strings.Contains(exitErr.Detail.Hint, needle) {
+			t.Fatalf("hint missing %q: %s", needle, exitErr.Detail.Hint)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- reject wiki node tokens early in `drive +delete` validation with a more specific explanation
- add guidance to `1061004 forbidden` delete failures for wiki-owned nodes, including the expected alternatives
- cover the validation and enriched error message paths with tests

## Validation

- `go test -count=1 ./shortcuts/drive`
- `go test -race -gcflags="all=-N -l" -count=1 ./shortcuts/drive`
- `go vet ./shortcuts/drive`
- `make build`

Refs #566


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `drive +delete` now displays clearer error messages when attempting to delete wiki-owned nodes, including guidance on alternative deletion methods.
  * Added input validation to prevent deletion attempts on wiki-owned nodes with an explanatory error message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/953?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->