### PR TITLE
fix: accept absolute paths in file flags; add dry-run chat membership warning

### DIFF
--- a/cmd/event/consume.go
+++ b/cmd/event/consume.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -309,10 +310,14 @@ func preflightEventTypes(pf *preflightCtx) error {
 	)
 }
 
-// sanitizeOutputDir rejects absolute/parent-escaping paths and ~ (SafeOutputPath treats it as a literal dir name).
+// sanitizeOutputDir rejects absolute/parent-escaping paths and ~ so that
+// event output stays within the working directory.
 func sanitizeOutputDir(dir string) (string, error) {
 	if strings.HasPrefix(dir, "~") {
 		return "", output.ErrValidation("%s; use a relative path like ./output instead", errOutputDirTilde)
+	}
+	if filepath.IsAbs(dir) {
+		return "", output.ErrValidation("%s %q: absolute paths are not permitted for --output-dir; use a relative path", errOutputDirUnsafe, dir)
 	}
 	safe, err := validate.SafeOutputPath(dir)
 	if err != nil {

--- a/internal/client/response_test.go
+++ b/internal/client/response_test.go
@@ -400,11 +400,18 @@ func TestSaveResponse_RejectsPathTraversal(t *testing.T) {
 	}
 }
 
-func TestSaveResponse_RejectsAbsolutePath(t *testing.T) {
+func TestSaveResponse_AcceptsAbsolutePath(t *testing.T) {
+	f, err := os.CreateTemp("", "save-abs-*.bin")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	f.Close()
+	t.Cleanup(func() { os.Remove(f.Name()) })
+
 	resp := newApiResp([]byte("data"), map[string]string{"Content-Type": "application/octet-stream"})
-	_, err := SaveResponse(&localfileio.LocalFileIO{}, resp, "/tmp/evil.txt")
-	if err == nil {
-		t.Fatal("expected error for absolute path")
+	_, err = SaveResponse(&localfileio.LocalFileIO{}, resp, f.Name())
+	if err != nil {
+		t.Fatalf("SaveResponse to absolute path should succeed: %v", err)
 	}
 }
 

--- a/internal/cmdutil/resolve_test.go
+++ b/internal/cmdutil/resolve_test.go
@@ -157,11 +157,10 @@ func TestResolveInput_AtFile_PathValidation(t *testing.T) {
 	fio := &localfileio.LocalFileIO{}
 	dir := t.TempDir()
 	TestChdir(t, dir)
-	// Absolute paths are rejected by SafeInputPath; the error must surface
-	// as an invalid-path message, not a generic read failure.
-	_, err := ResolveInput("@/etc/passwd", nil, fio)
+	// Path traversal must surface as an invalid-path message, not a generic read failure.
+	_, err := ResolveInput("@../../etc/passwd", nil, fio)
 	if err == nil || !strings.Contains(err.Error(), "invalid file path") {
-		t.Errorf("expected path-validation error, got: %v", err)
+		t.Errorf("expected path-validation error for traversal, got: %v", err)
 	}
 }
 

--- a/internal/validate/path_test.go
+++ b/internal/validate/path_test.go
@@ -31,9 +31,9 @@ func TestSafeOutputPath_RejectsPathTraversalAndDangerousInput(t *testing.T) {
 		{"dot-dot mid path", "subdir/../../etc/passwd", true},
 		{"triple dot-dot", "../../../etc/shadow", true},
 
-		// ── GIVEN: absolute paths → THEN: rejected ──
-		{"absolute path unix", "/etc/passwd", true},
-		{"absolute path root", "/tmp/evil", true},
+		// ── GIVEN: absolute paths → THEN: allowed (OS enforces access) ──
+		{"absolute path unix", "/etc/passwd", false},
+		{"absolute path tmp", "/tmp/output.xlsx", false},
 
 		// ── GIVEN: control characters in path → THEN: rejected ──
 		{"null byte", "file\x00.txt", true},
@@ -187,7 +187,7 @@ func TestSafeLocalFlagPath(t *testing.T) {
 		{"https URL passes through", "--image", "https://example.com/a.jpg", "https://example.com/a.jpg", ""},
 		{"relative path accepted, returned unchanged", "--file", "photo.jpg", "photo.jpg", ""},
 		{"path traversal rejected", "--file", "../escape.txt", "", "--file"},
-		{"absolute path rejected", "--image", "/etc/passwd", "", "--image"},
+		{"absolute path accepted", "--image", "/etc/passwd", "/etc/passwd", ""},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := SafeLocalFlagPath(tt.flag, tt.value)
@@ -207,7 +207,7 @@ func TestSafeLocalFlagPath(t *testing.T) {
 	}
 }
 
-func TestSafeUploadPath_AllowsTempFileAbsolutePath(t *testing.T) {
+func TestSafeInputPath_AllowsAbsoluteTempPath(t *testing.T) {
 	// GIVEN: a real temp file (absolute path under os.TempDir())
 	f, err := os.CreateTemp("", "upload-test-*.bin")
 	if err != nil {
@@ -216,22 +216,17 @@ func TestSafeUploadPath_AllowsTempFileAbsolutePath(t *testing.T) {
 	tmpPath := f.Name()
 	f.Close()
 	t.Cleanup(func() { os.Remove(tmpPath) })
+	tmpPath, _ = filepath.EvalSymlinks(tmpPath)
 
-	// WHEN: SafeUploadPath validates the absolute temp path
-	_, err = SafeInputPath(tmpPath)
+	// WHEN: SafeInputPath validates the absolute temp path
+	got, err := SafeInputPath(tmpPath)
 
-	// THEN: absolute paths are rejected even in temp dir
-	if err == nil {
-		t.Fatal("expected error for absolute temp path, got nil")
+	// THEN: absolute paths are accepted; OS permissions apply on actual read
+	if err != nil {
+		t.Fatalf("unexpected error for absolute temp path: %v", err)
 	}
-}
-
-func TestSafeUploadPath_RejectsNonTempAbsolutePath(t *testing.T) {
-	// GIVEN: an absolute path outside the temp directory
-	// WHEN / THEN: SafeUploadPath rejects it
-	_, err := SafeInputPath("/etc/passwd")
-	if err == nil {
-		t.Error("expected error for absolute non-temp path, got nil")
+	if got != tmpPath {
+		t.Errorf("got %q, want %q", got, tmpPath)
 	}
 }
 
@@ -258,26 +253,25 @@ func TestSafeUploadPath_AcceptsRelativePath(t *testing.T) {
 	}
 }
 
-func TestSafeInputPath_ErrorMessageContainsCorrectFlagName(t *testing.T) {
-	// GIVEN: an absolute path
-
+func TestSafeInputPath_ErrorMessageContainsFlagName(t *testing.T) {
+	// GIVEN: a relative path that escapes CWD via ..
 	// WHEN: SafeInputPath rejects it
-	_, err := SafeInputPath("/etc/passwd")
+	_, err := SafeInputPath("../../etc/passwd")
 
-	// THEN: error message mentions --file (not --output)
+	// THEN: error message mentions --file
 	if err == nil {
-		t.Fatal("expected error for absolute path")
+		t.Fatal("expected error for path-traversal input")
 	}
 	if !strings.Contains(err.Error(), "--file") {
 		t.Errorf("error should mention --file, got: %s", err.Error())
 	}
 
 	// WHEN: SafeOutputPath rejects it
-	_, err = SafeOutputPath("/etc/passwd")
+	_, err = SafeOutputPath("../../etc/passwd")
 
-	// THEN: error message mentions --output (not --file)
+	// THEN: error message mentions --output
 	if err == nil {
-		t.Fatal("expected error for absolute path")
+		t.Fatal("expected error for path-traversal output")
 	}
 	if !strings.Contains(err.Error(), "--output") {
 		t.Errorf("error should mention --output, got: %s", err.Error())

--- a/internal/vfs/localfileio/localfileio_test.go
+++ b/internal/vfs/localfileio/localfileio_test.go
@@ -83,15 +83,21 @@ func TestLocalFileIO_Open_RejectsTraversal(t *testing.T) {
 	}
 }
 
-func TestLocalFileIO_Open_RejectsAbsolutePath(t *testing.T) {
+func TestLocalFileIO_Open_AcceptsAbsolutePath(t *testing.T) {
+	f, err := os.CreateTemp("", "open-abs-*.txt")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	f.WriteString("hello")
+	f.Close()
+	t.Cleanup(func() { os.Remove(f.Name()) })
+
 	fio := &LocalFileIO{}
-	_, err := fio.Open("/etc/passwd")
-	if err == nil {
-		t.Error("expected error for absolute path")
+	r, err := fio.Open(f.Name())
+	if err != nil {
+		t.Fatalf("Open absolute path should succeed: %v", err)
 	}
-	if err != nil && !strings.Contains(err.Error(), "relative path") {
-		t.Errorf("error should mention relative path, got: %v", err)
-	}
+	r.Close()
 }
 
 func TestLocalFileIO_Open_NonexistentFile(t *testing.T) {
@@ -204,11 +210,18 @@ func TestLocalFileIO_Save_RejectsTraversal(t *testing.T) {
 	}
 }
 
-func TestLocalFileIO_Save_RejectsAbsolutePath(t *testing.T) {
+func TestLocalFileIO_Save_AcceptsAbsolutePath(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "save-abs-*.txt")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	tmpFile.Close()
+	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
+
 	fio := &LocalFileIO{}
-	_, err := fio.Save("/tmp/evil.txt", fileio.SaveOptions{}, strings.NewReader("bad"))
-	if err == nil {
-		t.Error("expected error for absolute path in Save")
+	_, err = fio.Save(tmpFile.Name(), fileio.SaveOptions{}, strings.NewReader("content"))
+	if err != nil {
+		t.Errorf("Save to absolute path should succeed: %v", err)
 	}
 }
 
@@ -242,11 +255,14 @@ func TestLocalFileIO_ResolvePath_RejectsTraversal(t *testing.T) {
 	}
 }
 
-func TestLocalFileIO_ResolvePath_RejectsAbsolute(t *testing.T) {
+func TestLocalFileIO_ResolvePath_AcceptsAbsolute(t *testing.T) {
 	fio := &LocalFileIO{}
-	_, err := fio.ResolvePath("/etc/passwd")
-	if err == nil {
-		t.Error("expected error for absolute path in ResolvePath")
+	got, err := fio.ResolvePath("/etc/passwd")
+	if err != nil {
+		t.Fatalf("ResolvePath absolute path should succeed: %v", err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("expected absolute path result, got %q", got)
 	}
 }
 
@@ -259,25 +275,25 @@ func TestLocalFileIO_ErrorMessages_ContainCorrectFlagName(t *testing.T) {
 	fio := &LocalFileIO{}
 
 	// Open/Stat use SafeInputPath → errors should mention "--file"
-	_, err := fio.Open("/absolute/path")
+	_, err := fio.Open("../../traversal/path")
 	if err == nil || !strings.Contains(err.Error(), "--file") {
-		t.Errorf("Open absolute path error should mention --file, got: %v", err)
+		t.Errorf("Open traversal path error should mention --file, got: %v", err)
 	}
 
-	_, err = fio.Stat("/absolute/path")
+	_, err = fio.Stat("../../traversal/path")
 	if err == nil || !strings.Contains(err.Error(), "--file") {
-		t.Errorf("Stat absolute path error should mention --file, got: %v", err)
+		t.Errorf("Stat traversal path error should mention --file, got: %v", err)
 	}
 
 	// Save/ResolvePath use SafeOutputPath → errors should mention "--output"
-	_, err = fio.Save("/absolute/path", fileio.SaveOptions{}, strings.NewReader(""))
+	_, err = fio.Save("../../traversal/path", fileio.SaveOptions{}, strings.NewReader(""))
 	if err == nil || !strings.Contains(err.Error(), "--output") {
-		t.Errorf("Save absolute path error should mention --output, got: %v", err)
+		t.Errorf("Save traversal path error should mention --output, got: %v", err)
 	}
 
-	_, err = fio.ResolvePath("/absolute/path")
+	_, err = fio.ResolvePath("../../traversal/path")
 	if err == nil || !strings.Contains(err.Error(), "--output") {
-		t.Errorf("ResolvePath absolute path error should mention --output, got: %v", err)
+		t.Errorf("ResolvePath traversal path error should mention --output, got: %v", err)
 	}
 }
 

--- a/internal/vfs/localfileio/path.go
+++ b/internal/vfs/localfileio/path.go
@@ -63,7 +63,14 @@ func safePath(raw, flagName string) (string, error) {
 	path := filepath.Clean(raw)
 
 	if filepath.IsAbs(path) {
-		return "", fmt.Errorf("%s must be a relative path within the current directory, got %q (hint: cd to the target directory first, or use a relative path like ./filename)", flagName, raw)
+		// Absolute paths are accepted without cwd restriction, matching
+		// common CLI conventions (gh, gcloud, kubectl cp). OS permissions
+		// still enforce access when the file is actually read or written.
+		resolved, err := resolveNearestAncestor(path)
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve symlinks: %w", err)
+		}
+		return resolved, nil
 	}
 
 	cwd, err := vfs.Getwd()

--- a/internal/vfs/localfileio/path_test.go
+++ b/internal/vfs/localfileio/path_test.go
@@ -41,11 +41,11 @@ func TestSafeOutputPath_RejectsPathTraversalAndDangerousInput(t *testing.T) {
 		{"bell char", "file\x07.txt", true},
 
 		// ── GIVEN: dangerous Unicode in path → THEN: rejected ──
-		{"bidi RLO", "file‮name.txt", true},
-		{"zero width space", "file​name.txt", true},
+		{"bidi RLO", "file\u202Ename.txt", true},
+		{"zero width space", "file\u200Bname.txt", true},
 		{"BOM char", "file\uFEFFname.txt", true},
-		{"line separator", "file name.txt", true},
-		{"bidi LRI", "file⁦name.txt", true},
+		{"line separator", "file\u2028name.txt", true},
+		{"bidi LRI", "file\u2066name.txt", true},
 
 		// ── GIVEN: looks dangerous but is actually safe → THEN: allowed ──
 		{"literal percent 2e", "%2e%2e/etc/passwd", false},

--- a/internal/vfs/localfileio/path_test.go
+++ b/internal/vfs/localfileio/path_test.go
@@ -23,7 +23,7 @@ func TestSafeOutputPath_RejectsPathTraversalAndDangerousInput(t *testing.T) {
 		{"nested subdir", "a/b/c/file.txt", false},
 		{"dot in name", "my.report.v2.xlsx", false},
 		{"space in name", "my file.txt", false},
-		{"unicode normal", "报告.xlsx", false},
+		{"unicode normal", "\xe5\xa0\xb1\xe5\x91\x8a.xlsx", false}, // 报告.xlsx
 		{"dot-dot resolves to cwd", "subdir/..", false},
 
 		// ── GIVEN: path traversal via .. → THEN: rejected ──
@@ -31,9 +31,9 @@ func TestSafeOutputPath_RejectsPathTraversalAndDangerousInput(t *testing.T) {
 		{"dot-dot mid path", "subdir/../../etc/passwd", true},
 		{"triple dot-dot", "../../../etc/shadow", true},
 
-		// ── GIVEN: absolute paths → THEN: rejected ──
-		{"absolute path unix", "/etc/passwd", true},
-		{"absolute path root", "/tmp/evil", true},
+		// ── GIVEN: absolute paths → THEN: allowed (OS enforces access) ──
+		{"absolute path unix", "/etc/passwd", false},
+		{"absolute path tmp", "/tmp/output.xlsx", false},
 
 		// ── GIVEN: control characters in path → THEN: rejected ──
 		{"null byte", "file\x00.txt", true},
@@ -41,11 +41,11 @@ func TestSafeOutputPath_RejectsPathTraversalAndDangerousInput(t *testing.T) {
 		{"bell char", "file\x07.txt", true},
 
 		// ── GIVEN: dangerous Unicode in path → THEN: rejected ──
-		{"bidi RLO", "file\u202Ename.txt", true},
-		{"zero width space", "file\u200Bname.txt", true},
+		{"bidi RLO", "file‮name.txt", true},
+		{"zero width space", "file​name.txt", true},
 		{"BOM char", "file\uFEFFname.txt", true},
-		{"line separator", "file\u2028name.txt", true},
-		{"bidi LRI", "file\u2066name.txt", true},
+		{"line separator", "file name.txt", true},
+		{"bidi LRI", "file⁦name.txt", true},
 
 		// ── GIVEN: looks dangerous but is actually safe → THEN: allowed ──
 		{"literal percent 2e", "%2e%2e/etc/passwd", false},
@@ -81,6 +81,29 @@ func TestSafeOutputPath_ReturnsCanonicalAbsolutePath(t *testing.T) {
 	want := filepath.Join(dir, "output", "file.txt")
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSafeOutputPath_ReturnsAbsolutePathUnchanged(t *testing.T) {
+	// GIVEN: an absolute path to a file in /tmp
+	f, err := os.CreateTemp("", "safe-output-*.txt")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	tmpPath := f.Name()
+	f.Close()
+	t.Cleanup(func() { os.Remove(tmpPath) })
+	tmpPath, _ = filepath.EvalSymlinks(tmpPath)
+
+	// WHEN: SafeOutputPath validates the absolute path
+	got, err := SafeOutputPath(tmpPath)
+
+	// THEN: accepted and returned as the resolved absolute path
+	if err != nil {
+		t.Fatalf("unexpected error for absolute path: %v", err)
+	}
+	if got != tmpPath {
+		t.Errorf("got %q, want %q", got, tmpPath)
 	}
 }
 
@@ -167,7 +190,7 @@ func TestSafeOutputPath_DeepNonExistentPathStaysInCWD(t *testing.T) {
 	}
 }
 
-func TestSafeUploadPath_AllowsTempFileAbsolutePath(t *testing.T) {
+func TestSafeInputPath_AllowsAbsoluteTempPath(t *testing.T) {
 	// GIVEN: a real temp file (absolute path under os.TempDir())
 	f, err := os.CreateTemp("", "upload-test-*.bin")
 	if err != nil {
@@ -176,22 +199,17 @@ func TestSafeUploadPath_AllowsTempFileAbsolutePath(t *testing.T) {
 	tmpPath := f.Name()
 	f.Close()
 	t.Cleanup(func() { os.Remove(tmpPath) })
+	tmpPath, _ = filepath.EvalSymlinks(tmpPath)
 
-	// WHEN: SafeUploadPath validates the absolute temp path
-	_, err = SafeInputPath(tmpPath)
+	// WHEN: SafeInputPath validates the absolute temp path
+	got, err := SafeInputPath(tmpPath)
 
-	// THEN: absolute paths are rejected even in temp dir
-	if err == nil {
-		t.Fatal("expected error for absolute temp path, got nil")
+	// THEN: absolute paths are accepted; OS permissions apply on actual read
+	if err != nil {
+		t.Fatalf("unexpected error for absolute temp path: %v", err)
 	}
-}
-
-func TestSafeUploadPath_RejectsNonTempAbsolutePath(t *testing.T) {
-	// GIVEN: an absolute path outside the temp directory
-	// WHEN / THEN: SafeUploadPath rejects it
-	_, err := SafeInputPath("/etc/passwd")
-	if err == nil {
-		t.Error("expected error for absolute non-temp path, got nil")
+	if got != tmpPath {
+		t.Errorf("got %q, want %q", got, tmpPath)
 	}
 }
 
@@ -218,26 +236,25 @@ func TestSafeUploadPath_AcceptsRelativePath(t *testing.T) {
 	}
 }
 
-func Test_SafeInputPath_ErrorMessageContainsCorrectFlagName(t *testing.T) {
-	// GIVEN: an absolute path
-
+func Test_SafeInputPath_ErrorMessageContainsFlagName(t *testing.T) {
+	// GIVEN: a relative path that escapes CWD via ..
 	// WHEN: SafeInputPath rejects it
-	_, err := SafeInputPath("/etc/passwd")
+	_, err := SafeInputPath("../../etc/passwd")
 
-	// THEN: error message mentions --file (not --output)
+	// THEN: error message mentions --file
 	if err == nil {
-		t.Fatal("expected error for absolute path")
+		t.Fatal("expected error for path-traversal input")
 	}
 	if !strings.Contains(err.Error(), "--file") {
 		t.Errorf("error should mention --file, got: %s", err.Error())
 	}
 
 	// WHEN: SafeOutputPath rejects it
-	_, err = SafeOutputPath("/etc/passwd")
+	_, err = SafeOutputPath("../../etc/passwd")
 
-	// THEN: error message mentions --output (not --file)
+	// THEN: error message mentions --output
 	if err == nil {
-		t.Fatal("expected error for absolute path")
+		t.Fatal("expected error for path-traversal output")
 	}
 	if !strings.Contains(err.Error(), "--output") {
 		t.Errorf("error should mention --output, got: %s", err.Error())

--- a/shortcuts/drive/drive_pull_test.go
+++ b/shortcuts/drive/drive_pull_test.go
@@ -1285,25 +1285,32 @@ func TestDrivePullDownloadDoesNotEscapeViaSymlinkParentRef(t *testing.T) {
 	mustReadFile(t, filepath.Join(escapeDir, "preexisting.txt"), "DO-NOT-TOUCH")
 }
 
-// TestDrivePullRejectsAbsoluteLocalDir confirms SafeLocalFlagPath surfaces
-// the proper flag name in the error message.
-func TestDrivePullRejectsAbsoluteLocalDir(t *testing.T) {
-	f, _, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+// TestDrivePullAcceptsAbsoluteLocalDir confirms absolute paths are accepted
+// for --local-dir, matching common CLI conventions (gh, gcloud, kubectl cp).
+func TestDrivePullAcceptsAbsoluteLocalDir(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 
 	tmpDir := t.TempDir()
 	withDriveWorkingDir(t, tmpDir)
+	absDir := t.TempDir()
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"files": []interface{}{}, "has_more": false},
+		},
+	})
 
 	err := mountAndRunDrive(t, DrivePull, []string{
 		"+pull",
-		"--local-dir", "/etc",
+		"--local-dir", absDir,
 		"--folder-token", "folder_root",
 		"--as", "bot",
 	}, f, nil)
-	if err == nil {
-		t.Fatal("expected validation error for absolute --local-dir, got nil")
-	}
-	if !strings.Contains(err.Error(), "--local-dir") {
-		t.Fatalf("error must reference --local-dir, got: %v", err)
+	if err != nil {
+		t.Fatalf("absolute --local-dir should be accepted, got: %v", err)
 	}
 }
 

--- a/shortcuts/drive/drive_push_test.go
+++ b/shortcuts/drive/drive_push_test.go
@@ -770,25 +770,33 @@ func TestDrivePushDeleteRemoteDeletesEntireDuplicateGroupWithoutLocalCounterpart
 	reg.Verify(t)
 }
 
-// TestDrivePushRejectsAbsoluteLocalDir confirms SafeLocalFlagPath surfaces
-// the proper flag name in the error message.
-func TestDrivePushRejectsAbsoluteLocalDir(t *testing.T) {
-	f, _, _, _ := cmdutil.TestFactory(t, driveTestConfig())
+// TestDrivePushAcceptsAbsoluteLocalDir confirms absolute paths are accepted
+// for --local-dir, matching common CLI conventions (gh, gcloud, kubectl cp).
+func TestDrivePushAcceptsAbsoluteLocalDir(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
 
 	tmpDir := t.TempDir()
 	withDriveWorkingDir(t, tmpDir)
+	absDir := t.TempDir()
+
+	// Push from an empty directory → no files to upload, returns immediately.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "folder_token=folder_root",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{"files": []interface{}{}, "has_more": false},
+		},
+	})
 
 	err := mountAndRunDrive(t, DrivePush, []string{
 		"+push",
-		"--local-dir", "/etc",
+		"--local-dir", absDir,
 		"--folder-token", "folder_root",
 		"--as", "bot",
 	}, f, nil)
-	if err == nil {
-		t.Fatal("expected validation error for absolute --local-dir, got nil")
-	}
-	if !strings.Contains(err.Error(), "--local-dir") {
-		t.Fatalf("error must reference --local-dir, got: %v", err)
+	if err != nil {
+		t.Fatalf("absolute --local-dir should be accepted, got: %v", err)
 	}
 }
 

--- a/shortcuts/drive/drive_sync_test.go
+++ b/shortcuts/drive/drive_sync_test.go
@@ -1097,11 +1097,12 @@ func TestDriveSyncValidateRejectsInvalidInputs(t *testing.T) {
 		}
 	})
 
-	t.Run("absolute local-dir", func(t *testing.T) {
-		runtime, _ := newDriveSyncRuntime(t, "/etc", "folder_root")
+	t.Run("absolute local-dir is accepted", func(t *testing.T) {
+		absDir := t.TempDir()
+		runtime, _ := newDriveSyncRuntime(t, absDir, "folder_root")
 		err := DriveSync.Validate(context.Background(), runtime)
-		if err == nil || !strings.Contains(err.Error(), "--local-dir") {
-			t.Fatalf("Validate() error = %v, want invalid local-dir error", err)
+		if err != nil {
+			t.Fatalf("Validate() should accept absolute --local-dir, got: %v", err)
 		}
 	})
 
@@ -1145,11 +1146,13 @@ func TestDriveSyncDryRunUsesFolderToken(t *testing.T) {
 	}
 }
 
-func TestDriveSyncExecuteRejectsUnsafeLocalDir(t *testing.T) {
-	runtime, _ := newDriveSyncRuntime(t, "/etc", "folder_root")
+func TestDriveSyncExecuteRejectsTraversalLocalDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	runtime, _ := newDriveSyncRuntime(t, "../../etc", "folder_root")
 	err := DriveSync.Execute(context.Background(), runtime)
 	if err == nil || !strings.Contains(err.Error(), "--local-dir") {
-		t.Fatalf("Execute() error = %v, want unsafe local-dir validation error", err)
+		t.Fatalf("Execute() error = %v, want path-traversal validation error mentioning --local-dir", err)
 	}
 }
 

--- a/shortcuts/event/processor_test.go
+++ b/shortcuts/event/processor_test.go
@@ -634,10 +634,14 @@ func TestParseRoutes_EmptyPath(t *testing.T) {
 	}
 }
 
-func TestParseRoutes_RejectsAbsolutePath(t *testing.T) {
-	_, err := ParseRoutes([]string{`^test=dir:/tmp/evil`})
-	if err == nil {
-		t.Error("expected error for absolute path in route")
+func TestParseRoutes_AcceptsAbsolutePath(t *testing.T) {
+	absDir := t.TempDir()
+	routes, err := ParseRoutes([]string{"^test=dir:" + absDir})
+	if err != nil {
+		t.Fatalf("unexpected error for absolute path in route: %v", err)
+	}
+	if routes == nil {
+		t.Fatal("expected non-nil routes")
 	}
 }
 

--- a/shortcuts/im/im_messages_send.go
+++ b/shortcuts/im/im_messages_send.go
@@ -81,10 +81,14 @@ var ImMessagesSend = common.Shortcut{
 		if desc != "" {
 			d.Desc(desc)
 		}
-		return d.
+		chain := d.
 			POST("/open-apis/im/v1/messages").
 			Params(map[string]interface{}{"receive_id_type": receiveIdType}).
 			Body(body)
+		if receiveIdType == "chat_id" {
+			chain.Desc("NOTE: dry-run validates request shape only. Bot/user chat membership is NOT verified; the real send may fail with \"Bot/User can NOT be out of the chat\". Use `lark-cli im +chat-messages-list --chat-id <id> --page-size 1` to check reachability first.")
+		}
+		return chain
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		chatFlag := runtime.Str("chat-id")

--- a/shortcuts/im/validate_media_test.go
+++ b/shortcuts/im/validate_media_test.go
@@ -34,7 +34,7 @@ func TestValidateMediaFlagPath(t *testing.T) {
 		{"valid local file", "--image", "photo.jpg", false},
 		{"nonexistent file allowed", "--file", "missing.txt", false},
 		{"path traversal rejected", "--image", "../../etc/passwd", true},
-		{"absolute path rejected", "--file", "/etc/passwd", true},
+		{"absolute path accepted", "--file", "/etc/passwd", false},
 	}
 
 	for _, tt := range tests {

--- a/shortcuts/sheets/lark_sheets_sheet_write_image_test.go
+++ b/shortcuts/sheets/lark_sheets_sheet_write_image_test.go
@@ -255,17 +255,24 @@ func TestSheetWriteImageDryRunRejectsDirectory(t *testing.T) {
 	}
 }
 
-func TestSheetWriteImageDryRunRejectsAbsolutePath(t *testing.T) {
+func TestSheetWriteImageDryRunAcceptsAbsolutePath(t *testing.T) {
+	fh, err := os.CreateTemp("", "dry-run-img-*.png")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	fh.Close()
+	t.Cleanup(func() { os.Remove(fh.Name()) })
+
 	f, stdout, _, _ := cmdutil.TestFactory(t, sheetsTestConfig())
-	err := mountAndRunSheets(t, SheetWriteImage, []string{
+	err = mountAndRunSheets(t, SheetWriteImage, []string{
 		"+write-image",
 		"--spreadsheet-token", "shtTOKEN",
 		"--range", "sheet1!A1:A1",
-		"--image", "/etc/passwd",
+		"--image", fh.Name(),
 		"--dry-run", "--as", "user",
 	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "unsafe image path") {
-		t.Fatalf("expected unsafe-path error before dry-run planning, got: %v", err)
+	if err != nil {
+		t.Fatalf("absolute path should be accepted in dry-run, got: %v", err)
 	}
 }
 
@@ -564,27 +571,26 @@ func TestSheetWriteImageExecuteRejectsOversizedFile(t *testing.T) {
 	}
 }
 
-func TestSheetWriteImageExecuteRejectsAbsolutePath(t *testing.T) {
-	f, _, _, _ := cmdutil.TestFactory(t, sheetsTestConfig())
-
-	tmpDir := t.TempDir()
-	cmdutil.TestChdir(t, tmpDir)
-
-	if err := os.WriteFile("abs.png", []byte{0x89, 0x50}, 0644); err != nil {
-		t.Fatalf("WriteFile() error: %v", err)
+func TestSheetWriteImageExecuteAcceptsAbsolutePath(t *testing.T) {
+	fh, err := os.CreateTemp("", "exec-img-*.png")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
 	}
+	fh.Write([]byte{0x89, 0x50}) // minimal PNG header bytes
+	fh.Close()
+	t.Cleanup(func() { os.Remove(fh.Name()) })
 
-	err := mountAndRunSheets(t, SheetWriteImage, []string{
+	f, _, _, _ := cmdutil.TestFactory(t, sheetsTestConfig())
+	err = mountAndRunSheets(t, SheetWriteImage, []string{
 		"+write-image",
 		"--spreadsheet-token", "shtTOKEN",
 		"--range", "sheet1!A1:A1",
-		"--image", "/etc/passwd",
+		"--image", fh.Name(),
 		"--as", "user",
 	}, f, nil)
-	if err == nil {
-		t.Fatal("expected error for absolute path, got nil")
-	}
-	if !strings.Contains(err.Error(), "unsafe image path") {
-		t.Fatalf("unexpected error: %v", err)
+	// No "unsafe image path" error — path validation passes; API call fails
+	// because no HTTP stub is registered, but that's expected here.
+	if err != nil && strings.Contains(err.Error(), "unsafe image path") {
+		t.Fatalf("absolute path should not produce unsafe-image-path error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- **fix #872**: `--image`, `--file`, `--video`, `--audio`, `--local-dir` flags rejected absolute paths with a misleading error. Common CLI tools (`gh`, `gcloud`, `aws s3 cp`, `kubectl cp`) all accept absolute paths; OS permissions already enforce access. Now absolute paths pass validation while `../` traversal protection is preserved.

- **fix #915**: `im +messages-send --dry-run` succeeded for syntactically valid payloads but gave no indication that bot/user chat membership is *not* verified. A `--chat-id` send now prints a NOTE in dry-run output warning the real send may fail with `Bot/User can NOT be out of the chat`.

**Exception**: `event consume --output-dir` retains its absolute-path restriction — event output files should remain within the working directory.

## Changes

- `internal/vfs/localfileio/path.go`: `safePath()` now accepts absolute paths (resolves symlinks, skips cwd restriction); relative path `../` guard unchanged
- `cmd/event/consume.go`: explicit `filepath.IsAbs` guard added to `sanitizeOutputDir` to maintain its documented restriction
- `shortcuts/im/im_messages_send.go`: chat-id dry-run output includes membership warning
- All tests updated to reflect new behavior

## Test plan

- [ ] `go test ./...` (excluding e2e) passes with no failures
- [ ] `lark-cli im +messages-send --chat-id oc_xxx --text hello --dry-run` shows NOTE about membership
- [ ] `lark-cli im +messages-reply --message-id om_xxx --image /tmp/photo.png --dry-run` no longer errors on absolute path
- [ ] `lark-cli drive +pull --local-dir /home/user/docs --folder-token xxx --dry-run` works with absolute path

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Absolute file and directory paths are now accepted across file operations and CLI directory flags.
  - Dry-run for IM sends adds a descriptive warning when targeting chats.

* **Bug Fixes**
  - Path validation now focuses on traversal patterns and reports the relevant flag names in errors.
  - Improved symlink resolution for absolute paths and safer handling of resolved paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/955?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->