### PR TITLE
fix: address Base attachment review follow-ups

### DIFF
--- a/shortcuts/base/base_execute_test.go
+++ b/shortcuts/base/base_execute_test.go
@@ -1909,7 +1909,7 @@ func TestBaseRecordExecuteReadCreateDelete(t *testing.T) {
 		}
 	})
 
-	t.Run("download attachment uses extra info", func(t *testing.T) {
+	t.Run("download attachment includes extra query parameter", func(t *testing.T) {
 		factory, stdout, reg := newExecuteFactory(t)
 
 		extra := `{"bitablePerm":{"tableId":"tbl_x","attachments":{"fld_att":{"rec_x":["box_a"]}}}}`

--- a/shortcuts/base/record_upload_attachment.go
+++ b/shortcuts/base/record_upload_attachment.go
@@ -499,7 +499,7 @@ func uploadAttachmentToBase(runtime *common.RuntimeContext, filePath, fileName, 
 	if width, height, ok := detectAttachmentImageDimensions(runtime.FileIO(), filePath, mimeType); ok {
 		attachment["image_width"] = width
 		attachment["image_height"] = height
-	} else if strings.HasPrefix(mimeType, "image/") {
+	} else if attachmentImageDimensionsWarningEnabled(mimeType) {
 		fmt.Fprintf(runtime.IO().ErrOut, "Warning: image dimensions unavailable for %s; attachment may display as square\n", fileName)
 	}
 	return attachment, nil
@@ -572,6 +572,15 @@ func detectAttachmentImageDimensions(fio fileio.FileIO, filePath string, mimeTyp
 		return 0, 0, false
 	}
 	return cfg.Width, cfg.Height, true
+}
+
+func attachmentImageDimensionsWarningEnabled(mimeType string) bool {
+	switch mimeType {
+	case "image/gif", "image/jpeg", "image/png":
+		return true
+	default:
+		return false
+	}
 }
 
 type baseAttachmentDownloadItem struct {

--- a/shortcuts/base/record_upload_attachment_test.go
+++ b/shortcuts/base/record_upload_attachment_test.go
@@ -100,6 +100,27 @@ func TestDetectAttachmentImageDimensions(t *testing.T) {
 	}
 }
 
+func TestAttachmentImageDimensionsWarningEnabled(t *testing.T) {
+	tests := []struct {
+		mimeType string
+		want     bool
+	}{
+		{mimeType: "image/gif", want: true},
+		{mimeType: "image/jpeg", want: true},
+		{mimeType: "image/png", want: true},
+		{mimeType: "image/webp", want: false},
+		{mimeType: "application/pdf", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mimeType, func(t *testing.T) {
+			if got := attachmentImageDimensionsWarningEnabled(tt.mimeType); got != tt.want {
+				t.Fatalf("attachmentImageDimensionsWarningEnabled(%q) = %v, want %v", tt.mimeType, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDetectAttachmentMIMETypeWrapsOpenError(t *testing.T) {
 	fio := attachmentTestFileIO{openErr: os.ErrNotExist}
 


### PR DESCRIPTION
## Summary
Address the two remaining review follow-ups from the Base attachment API work. This narrows the image-dimension warning so unsupported image MIME types like WebP do not emit a misleading message, and renames a download test to match the behavior it actually verifies.

## Changes
- Restrict the "image dimensions unavailable" warning to MIME types whose dimensions are currently decoded (`image/gif`, `image/jpeg`, `image/png`)
- Add unit coverage for the warning eligibility helper, including the `image/webp` case
- Rename the download execute test to reflect that it validates the outgoing `extra` query parameter rather than a response field

## Test Plan
- [x] Unit tests pass
- [ ] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
- Related to [larksuite/cli#887](https://github.com/larksuite/cli/pull/887)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the "image dimensions unavailable" warning during attachment uploads to display only for GIF, JPEG, and PNG formats, reducing unnecessary warnings for other image types.

* **Tests**
  * Added test coverage for the image dimension warning behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->