### PR TITLE
chore(lint): exclude bidichk from test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,6 +45,7 @@ linters:
       - path: _test\.go$
         linters:
           - bodyclose
+          - bidichk
           - gocritic
           - depguard
           - forbidigo


### PR DESCRIPTION
## Summary
- Test files (e.g. `internal/vfs/localfileio/path_test.go`) need to construct strings with dangerous Unicode codepoints (RLO, ZWSP, BOM, LSEP, LRI) to verify path validation rejects them.
- `bidichk` decodes `‮`-style escape literals and flags them as Trojan Source attack risks — a false positive for intentional test data.
- Excluding `bidichk` for `_test\.go$` keeps the production-code protection intact while unblocking lint on PRs that add such tests (e.g. #955).

## Test plan
- [x] `golangci-lint run ./internal/vfs/localfileio/...` passes locally (`0 issues`)
- [ ] CI lint job goes green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality checks in the test suite to detect additional types of issues, improving code consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->