### PR TITLE
fix(wiki): surface real node url for +node-create / +node-copy

### DIFF
--- a/shortcuts/wiki/wiki_helpers.go
+++ b/shortcuts/wiki/wiki_helpers.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package wiki
+
+import (
+	"strings"
+
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// wikiNodeURL returns the user-facing link for a wiki node. The create/copy
+// OpenAPI responses carry a real `url` (undocumented in the server-docs schema
+// but present in practice); prefer it so the CLI surfaces the canonical link.
+// Fall back to BuildResourceURL synthesis only when the response omits it.
+//
+// Shared by +node-create and +node-copy, hence kept here rather than in either
+// command's file.
+func wikiNodeURL(brand core.LarkBrand, node *wikiNodeRecord) string {
+	if node == nil {
+		return ""
+	}
+	if u := strings.TrimSpace(node.URL); u != "" {
+		return u
+	}
+	return common.BuildResourceURL(brand, "wiki", node.NodeToken)
+}

--- a/shortcuts/wiki/wiki_list_copy_test.go
+++ b/shortcuts/wiki/wiki_list_copy_test.go
@@ -415,6 +415,7 @@ func TestWikiNodeCopyCopiesNodeToTargetSpace(t *testing.T) {
 					"node_type":         "origin",
 					"title":             "Architecture (Copy)",
 					"has_child":         false,
+					"url":               "https://abc.feishu.cn/wiki/wik_copied_real",
 				},
 			},
 			"msg": "success",
@@ -450,6 +451,9 @@ func TestWikiNodeCopyCopiesNodeToTargetSpace(t *testing.T) {
 	}
 	if envelope.Data["space_id"] != "space_dst" {
 		t.Fatalf("space_id = %v, want %q", envelope.Data["space_id"], "space_dst")
+	}
+	if got, want := envelope.Data["url"], "https://abc.feishu.cn/wiki/wik_copied_real"; got != want {
+		t.Fatalf("url = %#v, want %q (copy must surface the response url)", got, want)
 	}
 
 	var captured map[string]interface{}

--- a/shortcuts/wiki/wiki_node_copy.go
+++ b/shortcuts/wiki/wiki_node_copy.go
@@ -89,6 +89,9 @@ var WikiNodeCopy = common.Shortcut{
 		fmt.Fprintf(runtime.IO().ErrOut, "Copied to node %s in space %s\n",
 			common.MaskToken(node.NodeToken), common.MaskToken(node.SpaceID))
 		out := wikiNodeCopyOutput(node)
+		if u := wikiNodeURL(runtime.Config.Brand, node); u != "" {
+			out["url"] = u
+		}
 		runtime.OutFormat(out, nil, func(w io.Writer) {
 			renderWikiNodeCopyPretty(w, out)
 		})
@@ -105,6 +108,9 @@ func renderWikiNodeCopyPretty(w io.Writer, out map[string]interface{}) {
 	fmt.Fprintf(w, "  obj_token:         %s\n", valueOrDash(out["obj_token"]))
 	if parent, _ := out["parent_node_token"].(string); parent != "" {
 		fmt.Fprintf(w, "  parent_node_token: %s\n", parent)
+	}
+	if url, _ := out["url"].(string); url != "" {
+		fmt.Fprintf(w, "  url:               %s\n", url)
 	}
 }
 

--- a/shortcuts/wiki/wiki_node_create.go
+++ b/shortcuts/wiki/wiki_node_create.go
@@ -461,20 +461,6 @@ func parseWikiNodeRecord(node map[string]interface{}) (*wikiNodeRecord, error) {
 	}, nil
 }
 
-// wikiNodeURL returns the user-facing link for a wiki node. The create/copy
-// OpenAPI responses carry a real `url` (undocumented in the server-docs schema
-// but present in practice); prefer it so the CLI surfaces the canonical link.
-// Fall back to BuildResourceURL synthesis only when the response omits it.
-func wikiNodeURL(brand core.LarkBrand, node *wikiNodeRecord) string {
-	if node == nil {
-		return ""
-	}
-	if u := strings.TrimSpace(node.URL); u != "" {
-		return u
-	}
-	return common.BuildResourceURL(brand, "wiki", node.NodeToken)
-}
-
 func parseWikiSpaceRecord(space map[string]interface{}) (*wikiSpaceRecord, error) {
 	if space == nil {
 		return nil, output.Errorf(output.ExitAPI, "api_error", "wiki space response missing space")

--- a/shortcuts/wiki/wiki_node_create.go
+++ b/shortcuts/wiki/wiki_node_create.go
@@ -118,6 +118,7 @@ type wikiNodeRecord struct {
 	OriginNodeToken string
 	Title           string
 	HasChild        bool
+	URL             string
 }
 
 // wikiSpaceRecord contains the response fields used when resolving spaces.
@@ -456,7 +457,22 @@ func parseWikiNodeRecord(node map[string]interface{}) (*wikiNodeRecord, error) {
 		OriginNodeToken: common.GetString(node, "origin_node_token"),
 		Title:           common.GetString(node, "title"),
 		HasChild:        common.GetBool(node, "has_child"),
+		URL:             common.GetString(node, "url"),
 	}, nil
+}
+
+// wikiNodeURL returns the user-facing link for a wiki node. The create/copy
+// OpenAPI responses carry a real `url` (undocumented in the server-docs schema
+// but present in practice); prefer it so the CLI surfaces the canonical link.
+// Fall back to BuildResourceURL synthesis only when the response omits it.
+func wikiNodeURL(brand core.LarkBrand, node *wikiNodeRecord) string {
+	if node == nil {
+		return ""
+	}
+	if u := strings.TrimSpace(node.URL); u != "" {
+		return u
+	}
+	return common.BuildResourceURL(brand, "wiki", node.NodeToken)
 }
 
 func parseWikiSpaceRecord(space map[string]interface{}) (*wikiSpaceRecord, error) {
@@ -498,7 +514,7 @@ func augmentWikiNodeCreateOutput(runtime *common.RuntimeContext, execution *wiki
 	if grant := common.AutoGrantCurrentUserDrivePermission(runtime, execution.Node.NodeToken, "wiki"); grant != nil {
 		out["permission_grant"] = grant
 	}
-	if u := common.BuildResourceURL(runtime.Config.Brand, "wiki", execution.Node.NodeToken); u != "" {
+	if u := wikiNodeURL(runtime.Config.Brand, execution.Node); u != "" {
 		out["url"] = u
 	}
 	return out

--- a/shortcuts/wiki/wiki_node_create_test.go
+++ b/shortcuts/wiki/wiki_node_create_test.go
@@ -451,6 +451,7 @@ func TestWikiNodeCreateMountedExecuteWithExplicitSpaceID(t *testing.T) {
 					"origin_node_token": "",
 					"title":             "Wiki Node",
 					"has_child":         false,
+					"url":               "https://abc.feishu.cn/wiki/wik_created_real",
 				},
 			},
 			"msg": "success",
@@ -484,8 +485,8 @@ func TestWikiNodeCreateMountedExecuteWithExplicitSpaceID(t *testing.T) {
 	if envelope.Data["node_token"] != "wik_created" {
 		t.Fatalf("node_token = %#v, want %q", envelope.Data["node_token"], "wik_created")
 	}
-	if got, want := envelope.Data["url"], "https://www.feishu.cn/wiki/wik_created"; got != want {
-		t.Fatalf("url = %#v, want %q", got, want)
+	if got, want := envelope.Data["url"], "https://abc.feishu.cn/wiki/wik_created_real"; got != want {
+		t.Fatalf("url = %#v, want %q (response url must win over synthesized fallback)", got, want)
 	}
 
 	var captured map[string]interface{}
@@ -626,5 +627,49 @@ func TestAugmentWikiNodeCreateOutputReturnsEmptyMapForNilInput(t *testing.T) {
 
 	if got := augmentWikiNodeCreateOutput(nil, &wikiNodeCreateExecution{}); len(got) != 0 {
 		t.Fatalf("augmentWikiNodeCreateOutput(nil, empty execution) = %#v, want empty map", got)
+	}
+}
+
+func TestWikiNodeURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		node *wikiNodeRecord
+		want string
+	}{
+		{
+			name: "prefers response url over synthesized fallback",
+			node: &wikiNodeRecord{NodeToken: "wik_token", URL: "https://abc.feishu.cn/wiki/wik_real"},
+			want: "https://abc.feishu.cn/wiki/wik_real",
+		},
+		{
+			name: "falls back to synthesized url when response omits it",
+			node: &wikiNodeRecord{NodeToken: "wik_token"},
+			want: "https://www.feishu.cn/wiki/wik_token",
+		},
+		{
+			name: "blank response url is treated as absent",
+			node: &wikiNodeRecord{NodeToken: "wik_token", URL: "   "},
+			want: "https://www.feishu.cn/wiki/wik_token",
+		},
+		{
+			name: "nil node yields empty string",
+			node: nil,
+			want: "",
+		},
+		{
+			name: "no token and no url yields empty string",
+			node: &wikiNodeRecord{},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := wikiNodeURL(core.BrandFeishu, tc.node); got != tc.want {
+				t.Fatalf("wikiNodeURL() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

The create-node and copy-node OpenAPI responses carry a real `url` field (present in practice, even though it is not in Feishu's documented node schema). Both shortcuts ignored it:

- `+node-create` synthesized a link via `BuildResourceURL` (host + `/wiki/` + token).
- `+node-copy` emitted no URL at all.

This change makes both shortcuts prefer the canonical URL returned by the API:

- Parse `url` into the shared `wikiNodeRecord`.
- Add a `wikiNodeURL(brand, node)` helper that returns the response `url` when present and falls back to `BuildResourceURL` synthesis only when it is blank/absent.
- Wire `augmentWikiNodeCreateOutput` (+node-create) and `+node-copy` output/pretty rendering to the helper.

`+node-get` / `+space-create` are intentionally untouched — they build their own output maps and deliberately omit URL, so the new struct field does not leak into them.

## Test plan

- [x] `go test ./shortcuts/wiki/...` passes
- [x] `gofmt` clean, `go vet ./shortcuts/...` clean
- [x] `./build.sh` succeeds
- [x] Updated existing `+node-create` e2e test: mock returns a real `url`; asserts it wins over synthesized fallback
- [x] Updated existing `+node-copy` e2e test: mock returns a real `url`; asserts copy surfaces it
- [x] Added `TestWikiNodeURL` covering prefer-response / fallback / blank / nil / no-token
- [ ] `golangci-lint` not run locally (not installed); relying on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki node create and copy outputs now include a user-facing URL when available; if the API omits it, a synthesized URL is used as a fallback. The pretty output shows the URL only when present.

* **Tests**
  * Tests updated and added to verify URL selection, precedence (API URL preferred), fallback behavior, and output formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->