### PR TITLE
chore(release): v1.0.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.34] - 2026-05-19
+
+### Features
+
+- **drive**: Switch markdown export to V2 `docs_ai` fetch API (#948)
+- **drive**: Add `+inspect` shortcut for document URL inspection with wiki unwrapping (#947)
+- **wiki**: Add `+node-get` / `+node-delete` / `+space-create` shortcuts (#904)
+- **base**: Support Base attachment APIs (#887)
+- **mail**: Validate `bot` + `mailbox=me` and add dynamic `--as` help tests (#895)
+- **mail**: Expose draft priority in `--inspect` projection and document `--set-priority` (#779)
+
+### Bug Fixes
+
+- **identitydiag**: Harden verify path and tighten status semantics (#961)
+- **wiki**: Surface real node URL for `+node-create` / `+node-copy` (#960)
+- **auth**: Split bot and user identity diagnostics (#957)
+- **base**: Address Base attachment review follow-ups (#958)
+- **docs**: Clarify `replace_all` selection errors (#954)
+
+### Documentation
+
+- **drive**: Clarify add comment constraints (#967)
+- **lark-im**: Clarify message activity search (#865)
+
+### Tests
+
+- Verify e2e resource cleanup (#949)
+- **lint**: Exclude `bidichk` from test files (#959)
+
 ## [v1.0.33] - 2026-05-18
 
 ### Features
@@ -745,6 +774,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.34]: https://github.com/larksuite/cli/releases/tag/v1.0.34
 [v1.0.33]: https://github.com/larksuite/cli/releases/tag/v1.0.33
 [v1.0.32]: https://github.com/larksuite/cli/releases/tag/v1.0.32
 [v1.0.31]: https://github.com/larksuite/cli/releases/tag/v1.0.31

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.33",
+  "version": "1.0.34",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

Release v1.0.34 — patch bump rolling up 15 commits since v1.0.33.

### Features
- **drive**: V2 `docs_ai` markdown export (#948); `+inspect` shortcut for document URL inspection with wiki unwrapping (#947)
- **wiki**: `+node-get` / `+node-delete` / `+space-create` shortcuts (#904)
- **base**: Base attachment APIs (#887)
- **mail**: `bot` + `mailbox=me` validation and dynamic `--as` help tests (#895); draft priority in `--inspect` and `--set-priority` docs (#779)

### Bug Fixes
- **identitydiag**: harden verify path and tighten status semantics (#961)
- **wiki**: surface real node URL for `+node-create` / `+node-copy` (#960)
- **auth**: split bot and user identity diagnostics (#957)
- **base**: address attachment review follow-ups (#958)
- **docs**: clarify `replace_all` selection errors (#954)

### Docs & Tests
- docs(drive) #967, docs(lark-im) #865, test e2e cleanup #949, chore(lint) bidichk #959

## Test plan

- [ ] CI green on `release/v1.0.34`
- [ ] After merge: tag `v1.0.34` and publish to npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release v1.0.34**
  * New version released with new features, bug fixes, documentation improvements, and test enhancements now available. Users can review the changelog for complete details on all changes included in this release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/972?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->