### PR TITLE
docs: clarify contributor guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@
 ## Test Plan
 <!-- Describe how this change was verified. -->
 - [ ] Unit tests pass
-- [ ] Manual local verification confirms the `lark xxx` command works as expected
+- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected
 
 ## Related Issues
 <!-- Link related issues. Use Closes/Fixes to close them automatically. -->

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ Community contributions are welcome! If you find a bug or have feature suggestio
 
 For major changes, we recommend discussing with us first via an Issue.
 
+Before opening a PR, see [AGENTS.md](./AGENTS.md) for the local build, test, and PR checklist used by contributors and AI agents.
+
 ## License
 
 This project is licensed under the **MIT License**.

--- a/README.zh.md
+++ b/README.zh.md
@@ -279,6 +279,8 @@ lark-cli schema im.messages.delete
 
 对于较大的改动，建议先通过 Issue 与我们讨论。
 
+提交 PR 前，请先阅读 [AGENTS.md](./AGENTS.md)，其中列出了贡献者和 AI Agent 使用的本地构建、测试和 PR 检查清单。
+
 ## 许可证
 
 本项目基于 **MIT 许可证** 开源。


### PR DESCRIPTION
## Summary
Clarify contributor-facing guidance by linking the README contribution sections to `AGENTS.md`, where the repository already keeps the local build, test, and PR checklist. Also update the PR template example command from the old `lark xxx` placeholder to the actual `lark-cli <domain> <command>` form.

## Changes
- Link the English and Chinese Contributing sections to `AGENTS.md`
- Update the PR template manual verification checklist item to use `lark-cli <domain> <command>`

## Test Plan
- [x] `git diff --check`
- [x] `make fmt-check`
- [x] `node scripts/skill-format-check/index.js`
- [ ] Unit tests pass — not run; docs/template-only change
- [ ] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected — not applicable; no CLI behavior change

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template to reflect the current command-line workflow syntax and contribution checklist.
  * Added a pre‑PR notice in English and Chinese README content directing contributors to consult the supplementary local build, test, and pre-submission checklist documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->