### PR TITLE
fix(sheets): use FileIO for write-image input

### DIFF
--- a/shortcuts/sheets/lark_sheets_cell_images.go
+++ b/shortcuts/sheets/lark_sheets_cell_images.go
@@ -5,13 +5,15 @@ package sheets
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"io/fs"
+	"io"
+	"os"
 	"path/filepath"
 
+	"github.com/larksuite/cli/extension/fileio"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
-	"github.com/larksuite/cli/internal/vfs"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -42,10 +44,6 @@ var SheetWriteImage = common.Shortcut{
 			return err
 		}
 		if err := validateSingleCellRange(runtime.Str("range")); err != nil {
-			return err
-		}
-		_, _, err := validateSheetWriteImageFile(runtime.Str("image"))
-		if err != nil {
 			return err
 		}
 		return nil
@@ -79,12 +77,19 @@ var SheetWriteImage = common.Shortcut{
 		pointRange := normalizePointRange(runtime.Str("sheet-id"), runtime.Str("range"))
 
 		imagePath := runtime.Str("image")
-		safePath, stat, err := validateSheetWriteImageFile(imagePath)
+		fio := runtime.FileIO()
+		stat, err := validateSheetWriteImageFile(fio, imagePath)
 		if err != nil {
 			return err
 		}
 
-		imageBytes, err := vfs.ReadFile(safePath)
+		imageFile, err := fio.Open(imagePath)
+		if err != nil {
+			return wrapSheetWriteImageOpenError(err)
+		}
+		defer imageFile.Close()
+
+		imageBytes, err := io.ReadAll(imageFile)
 		if err != nil {
 			return output.ErrValidation("cannot read image file: %s", err)
 		}
@@ -109,21 +114,37 @@ var SheetWriteImage = common.Shortcut{
 	},
 }
 
-func validateSheetWriteImageFile(imagePath string) (string, fs.FileInfo, error) {
-	safePath, err := validate.SafeInputPath(imagePath)
-	if err != nil {
-		return "", nil, output.ErrValidation("unsafe image path: %s", err)
+func validateSheetWriteImageFile(fio fileio.FileIO, imagePath string) (fileio.FileInfo, error) {
+	if fio == nil {
+		return nil, output.ErrValidation("no file I/O provider registered")
 	}
-	stat, err := vfs.Stat(safePath)
+	stat, err := fio.Stat(imagePath)
 	if err != nil {
-		return "", nil, output.ErrValidation("image file not found: %s", imagePath)
+		return nil, wrapSheetWriteImageStatError(err, imagePath)
 	}
-	if !stat.Mode().IsRegular() {
-		return "", nil, output.ErrValidation("image must be a regular file: %s", imagePath)
+	if stat.IsDir() || !stat.Mode().IsRegular() {
+		return nil, output.ErrValidation("image must be a regular file: %s", imagePath)
 	}
 	const maxImageSize int64 = 20 * 1024 * 1024
 	if stat.Size() > maxImageSize {
-		return "", nil, output.ErrValidation("image %.1fMB exceeds 20MB limit", float64(stat.Size())/1024/1024)
+		return nil, output.ErrValidation("image %.1fMB exceeds 20MB limit", float64(stat.Size())/1024/1024)
 	}
-	return safePath, stat, nil
+	return stat, nil
+}
+
+func wrapSheetWriteImageStatError(err error, imagePath string) error {
+	if errors.Is(err, fileio.ErrPathValidation) {
+		return output.ErrValidation("unsafe image path: %s", err)
+	}
+	if os.IsNotExist(err) {
+		return output.ErrValidation("image file not found: %s", imagePath)
+	}
+	return output.ErrValidation("cannot stat image file: %s", err)
+}
+
+func wrapSheetWriteImageOpenError(err error) error {
+	if errors.Is(err, fileio.ErrPathValidation) {
+		return output.ErrValidation("unsafe image path: %s", err)
+	}
+	return output.ErrValidation("cannot read image file: %s", err)
 }

--- a/shortcuts/sheets/lark_sheets_sheet_write_image_test.go
+++ b/shortcuts/sheets/lark_sheets_sheet_write_image_test.go
@@ -7,12 +7,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
+	"io/fs"
 	"os"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 
+	"github.com/larksuite/cli/extension/fileio"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
@@ -37,6 +40,56 @@ func mountAndRunSheets(t *testing.T, s common.Shortcut, args []string, f *cmduti
 	}
 	return parent.Execute()
 }
+
+type sheetWriteImageStaticFileIOProvider struct {
+	fio fileio.FileIO
+}
+
+func (p *sheetWriteImageStaticFileIOProvider) Name() string { return "sheet-write-image-static" }
+
+func (p *sheetWriteImageStaticFileIOProvider) ResolveFileIO(context.Context) fileio.FileIO {
+	return p.fio
+}
+
+type sheetWriteImageMemoryFileIO struct {
+	files map[string][]byte
+}
+
+func (f *sheetWriteImageMemoryFileIO) Open(name string) (fileio.File, error) {
+	data, ok := f.files[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return sheetWriteImageMemoryFile{Reader: bytes.NewReader(data)}, nil
+}
+
+func (f *sheetWriteImageMemoryFileIO) Stat(name string) (fileio.FileInfo, error) {
+	data, ok := f.files[name]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return sheetWriteImageFileInfo{size: int64(len(data))}, nil
+}
+
+func (f *sheetWriteImageMemoryFileIO) ResolvePath(path string) (string, error) { return path, nil }
+
+func (f *sheetWriteImageMemoryFileIO) Save(string, fileio.SaveOptions, io.Reader) (fileio.SaveResult, error) {
+	return nil, nil
+}
+
+type sheetWriteImageMemoryFile struct {
+	*bytes.Reader
+}
+
+func (sheetWriteImageMemoryFile) Close() error { return nil }
+
+type sheetWriteImageFileInfo struct {
+	size int64
+}
+
+func (i sheetWriteImageFileInfo) Size() int64       { return i.size }
+func (i sheetWriteImageFileInfo) IsDir() bool       { return false }
+func (i sheetWriteImageFileInfo) Mode() fs.FileMode { return 0 }
 
 const existingWriteImageTestFile = "./lark_sheets_cell_images.go"
 
@@ -221,80 +274,20 @@ func TestSheetWriteImageDryRunWithSheetID(t *testing.T) {
 	}
 }
 
-func TestSheetWriteImageDryRunRejectsMissingFile(t *testing.T) {
+func TestSheetWriteImageDryRunDoesNotValidateImageFile(t *testing.T) {
 	f, stdout, _, _ := cmdutil.TestFactory(t, sheetsTestConfig())
 	err := mountAndRunSheets(t, SheetWriteImage, []string{
 		"+write-image",
 		"--spreadsheet-token", "shtTOKEN",
 		"--range", "sheet1!A1:A1",
-		"--image", "./missing.png",
+		"--image", "/__bridge_url__/qKrk1wSAtS",
 		"--dry-run", "--as", "user",
 	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "image file not found") {
-		t.Fatalf("expected file-not-found error before dry-run planning, got: %v", err)
-	}
-}
-
-func TestSheetWriteImageDryRunRejectsDirectory(t *testing.T) {
-	tmpDir := t.TempDir()
-	cmdutil.TestChdir(t, tmpDir)
-	if err := os.Mkdir("imgdir", 0o755); err != nil {
-		t.Fatalf("Mkdir() error: %v", err)
-	}
-
-	f, stdout, _, _ := cmdutil.TestFactory(t, sheetsTestConfig())
-	err := mountAndRunSheets(t, SheetWriteImage, []string{
-		"+write-image",
-		"--spreadsheet-token", "shtTOKEN",
-		"--range", "sheet1!A1:A1",
-		"--image", "./imgdir",
-		"--dry-run", "--as", "user",
-	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "regular file") {
-		t.Fatalf("expected regular-file error before dry-run planning, got: %v", err)
-	}
-}
-
-func TestSheetWriteImageDryRunRejectsAbsolutePath(t *testing.T) {
-	f, stdout, _, _ := cmdutil.TestFactory(t, sheetsTestConfig())
-	err := mountAndRunSheets(t, SheetWriteImage, []string{
-		"+write-image",
-		"--spreadsheet-token", "shtTOKEN",
-		"--range", "sheet1!A1:A1",
-		"--image", "/etc/passwd",
-		"--dry-run", "--as", "user",
-	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "unsafe image path") {
-		t.Fatalf("expected unsafe-path error before dry-run planning, got: %v", err)
-	}
-}
-
-func TestSheetWriteImageDryRunRejectsOversizedFile(t *testing.T) {
-	tmpDir := t.TempDir()
-	cmdutil.TestChdir(t, tmpDir)
-
-	fh, err := os.Create("huge.png")
 	if err != nil {
-		t.Fatalf("Create() error: %v", err)
+		t.Fatalf("dry-run should not stat or open image files, got: %v", err)
 	}
-	if err := fh.Truncate(20*1024*1024 + 1); err != nil {
-		fh.Close()
-		t.Fatalf("Truncate() error: %v", err)
-	}
-	if err := fh.Close(); err != nil {
-		t.Fatalf("Close() error: %v", err)
-	}
-
-	f, stdout, _, _ := cmdutil.TestFactory(t, sheetsTestConfig())
-	err = mountAndRunSheets(t, SheetWriteImage, []string{
-		"+write-image",
-		"--spreadsheet-token", "shtTOKEN",
-		"--range", "sheet1!A1:A1",
-		"--image", "./huge.png",
-		"--dry-run", "--as", "user",
-	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "exceeds 20MB limit") {
-		t.Fatalf("expected size error before dry-run planning, got: %v", err)
+	if !strings.Contains(stdout.String(), "/__bridge_url__/qKrk1wSAtS") {
+		t.Fatalf("dry-run output should preserve image path: %s", stdout.String())
 	}
 }
 
@@ -365,6 +358,55 @@ func TestSheetWriteImageExecuteSendsJSON(t *testing.T) {
 	// Verify output contains expected fields.
 	if !strings.Contains(stdout.String(), "spreadsheetToken") {
 		t.Fatalf("stdout missing spreadsheetToken: %s", stdout.String())
+	}
+}
+
+func TestSheetWriteImageExecuteUsesFileIOForBridgeSentinelPath(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, sheetsTestConfig())
+	imagePath := "/__bridge_url__/qKrk1wSAtS"
+	imageData := []byte{0x89, 0x50, 0x4E, 0x47}
+	f.FileIOProvider = &sheetWriteImageStaticFileIOProvider{
+		fio: &sheetWriteImageMemoryFileIO{
+			files: map[string][]byte{imagePath: imageData},
+		},
+	}
+
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/sheets/v2/spreadsheets/shtTOKEN/values_image",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"spreadsheetToken": "shtTOKEN",
+				"revision":         float64(5),
+				"updateRange":      "sheet1!A1:A1",
+			},
+		},
+	}
+	reg.Register(stub)
+
+	err := mountAndRunSheets(t, SheetWriteImage, []string{
+		"+write-image",
+		"--spreadsheet-token", "shtTOKEN",
+		"--range", "sheet1!A1:A1",
+		"--image", imagePath,
+		"--name", "bridge.png",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+		t.Fatalf("request body is not valid JSON: %v", err)
+	}
+	if body["name"] != "bridge.png" {
+		t.Fatalf("body name = %v, want bridge.png", body["name"])
+	}
+	if body["image"] == nil {
+		t.Fatal("body image field is nil")
 	}
 }
 


### PR DESCRIPTION
## Summary
  Fix `sheets +write-image` to read image inputs through the FileIO abstraction instead of direct local filesystem access. This allows cli-server bridge injected paths such as `/
  __bridge_url__/...` to work correctly while preserving local file validation during execution.

  ## Changes
  - Remove image file stat/read checks from `Validate`, so dry-run and bridge-injected sentinel paths are not rejected before execution.
  - Replace direct `validate.SafeInputPath`, `vfs.Stat`, and `vfs.ReadFile` usage with `runtime.FileIO().Stat/Open`.
  - Preserve execution-time validation for missing files, unsafe paths, non-regular files, oversized images, and read failures.
  - Update `+write-image` tests and add regression coverage for bridge sentinel paths backed by a fake FileIO provider.

  ## Test Plan
  - [x] Unit tests pass
    - `go test ./shortcuts/sheets -run SheetWriteImage -count=1`
    - `go test ./shortcuts/sheets -count=1`

  ## Related Issues
  - None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced error messages for image validation in sheet operations
  * Added 20MB maximum file size limit for sheet images
  * Preview mode now skips image file validation checks for improved performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->