### PR TITLE
feat(sheets): +batch-update CLI shortcut form with translator to MCP shape

### DIFF
--- a/shortcuts/sheets/batch_op_dispatch.go
+++ b/shortcuts/sheets/batch_op_dispatch.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// ─── +batch-update sub-op dispatch ─────────────────────────────────────
+//
+// 用户传给 +batch-update --operations 的形态是 CLI 视角的 {shortcut, input}：
+//
+//     [{"shortcut": "+dim-insert", "input": {...}}, ...]
+//
+// 而底层 MCP batch_update tool 的契约是 {tool_name, input} —— input 里某些
+// MCP tool 还需要 operation 字段区分动作（如 modify_sheet_structure
+// 的 insert / delete / hide / unhide / freeze / group / ungroup）。
+//
+// translateBatchOp 做这层翻译：查表 shortcut → mcpToolName + 可选 operation，
+// 然后把 operation 注入 input.operation。dispatch 表只列**可纳入 atomic
+// batch 的 write shortcut**——读操作、fan-out wrapper（包括 +batch-update
+// 自身）、走 legacy v2 endpoint 的 shortcut（如 +dim-move）、需要多步副作用
+// 的 shortcut（如 +cells-set-image / +workbook-create）一律不放进表里，
+// 用户传到 +batch-update 里会被 translator 拒绝。
+
+type batchOpMapping struct {
+	// mcpToolName 是底层 MCP batch_update 接受的 tool_name。
+	mcpToolName string
+	// operationField 注入到 input.operation 的值；空 = 不注入（MCP tool 没有
+	// operation 字段，如 set_cell_range / clear_cell_range / replace_data /
+	// set_range_from_csv / resize_range）。
+	operationField string
+}
+
+// batchOpDispatch 全表 41 项，覆盖 sheet skill 下所有可 batch 的 write shortcut。
+// 增删请同步 canonical-spec/tool-schemas/cli-schemas.json 的 shortcut enum。
+var batchOpDispatch = map[string]batchOpMapping{
+	// ─── 单元格内容 ──────────────────────────────────────────────────
+	"+cells-set":       {mcpToolName: "set_cell_range"},
+	"+cells-set-style": {mcpToolName: "set_cell_range"},
+	"+cells-clear":     {mcpToolName: "clear_cell_range"},
+	"+cells-replace":   {mcpToolName: "replace_data"},
+	"+csv-put":         {mcpToolName: "set_range_from_csv"},
+	"+dropdown-set":    {mcpToolName: "set_cell_range"},
+
+	// ─── 单元格合并 (merge_cells, operation 区分) ────────────────────
+	"+cells-merge":   {mcpToolName: "merge_cells", operationField: "merge"},
+	"+cells-unmerge": {mcpToolName: "merge_cells", operationField: "unmerge"},
+
+	// ─── 行列结构 (modify_sheet_structure, operation 区分) ──────────
+	// 注意：+dim-move 不在此 — 单 shortcut 走 legacy v2 dimension_range
+	// endpoint，不经 MCP，无法 batch。
+	// +dim-freeze 静态注入 operation="freeze"，单 shortcut 里基于 count==0
+	// 切换 unfreeze 的路径在 batch 里不支持（用户要 unfreeze 用单 shortcut）。
+	"+dim-insert":  {mcpToolName: "modify_sheet_structure", operationField: "insert"},
+	"+dim-delete":  {mcpToolName: "modify_sheet_structure", operationField: "delete"},
+	"+dim-hide":    {mcpToolName: "modify_sheet_structure", operationField: "hide"},
+	"+dim-unhide":  {mcpToolName: "modify_sheet_structure", operationField: "unhide"},
+	"+dim-freeze":  {mcpToolName: "modify_sheet_structure", operationField: "freeze"},
+	"+dim-group":   {mcpToolName: "modify_sheet_structure", operationField: "group"},
+	"+dim-ungroup": {mcpToolName: "modify_sheet_structure", operationField: "ungroup"},
+
+	// ─── 行高列宽 (resize_range, 无 operation 字段) ─────────────────
+	// row/column 通过 input.resize_height vs input.resize_width 顶层 key 表达。
+	"+rows-resize": {mcpToolName: "resize_range"},
+	"+cols-resize": {mcpToolName: "resize_range"},
+
+	// ─── 区域操作 (transform_range, operation 区分) ─────────────────
+	"+range-move": {mcpToolName: "transform_range", operationField: "move"},
+	"+range-copy": {mcpToolName: "transform_range", operationField: "copy"},
+	"+range-fill": {mcpToolName: "transform_range", operationField: "fill"},
+	"+range-sort": {mcpToolName: "transform_range", operationField: "sort"},
+
+	// ─── 工作簿 / 子表 (modify_workbook_structure, operation 区分) ──
+	"+sheet-create":        {mcpToolName: "modify_workbook_structure", operationField: "create"},
+	"+sheet-delete":        {mcpToolName: "modify_workbook_structure", operationField: "delete"},
+	"+sheet-rename":        {mcpToolName: "modify_workbook_structure", operationField: "rename"},
+	"+sheet-move":          {mcpToolName: "modify_workbook_structure", operationField: "move"},
+	"+sheet-copy":          {mcpToolName: "modify_workbook_structure", operationField: "copy"},
+	"+sheet-hide":          {mcpToolName: "modify_workbook_structure", operationField: "hide"},
+	"+sheet-unhide":        {mcpToolName: "modify_workbook_structure", operationField: "unhide"},
+	"+sheet-set-tab-color": {mcpToolName: "modify_workbook_structure", operationField: "set_tab_color"},
+
+	// ─── 对象族 CRUD (manage_*_object, operation 区分) ─────────────
+	"+chart-create": {mcpToolName: "manage_chart_object", operationField: "create"},
+	"+chart-update": {mcpToolName: "manage_chart_object", operationField: "update"},
+	"+chart-delete": {mcpToolName: "manage_chart_object", operationField: "delete"},
+
+	"+pivot-create": {mcpToolName: "manage_pivot_table_object", operationField: "create"},
+	"+pivot-update": {mcpToolName: "manage_pivot_table_object", operationField: "update"},
+	"+pivot-delete": {mcpToolName: "manage_pivot_table_object", operationField: "delete"},
+
+	"+cond-format-create": {mcpToolName: "manage_conditional_format_object", operationField: "create"},
+	"+cond-format-update": {mcpToolName: "manage_conditional_format_object", operationField: "update"},
+	"+cond-format-delete": {mcpToolName: "manage_conditional_format_object", operationField: "delete"},
+
+	"+filter-create": {mcpToolName: "manage_filter_object", operationField: "create"},
+	"+filter-update": {mcpToolName: "manage_filter_object", operationField: "update"},
+	"+filter-delete": {mcpToolName: "manage_filter_object", operationField: "delete"},
+
+	"+filter-view-create": {mcpToolName: "manage_filter_view_object", operationField: "create"},
+	"+filter-view-update": {mcpToolName: "manage_filter_view_object", operationField: "update"},
+	"+filter-view-delete": {mcpToolName: "manage_filter_view_object", operationField: "delete"},
+
+	"+sparkline-create": {mcpToolName: "manage_sparkline_object", operationField: "create"},
+	"+sparkline-update": {mcpToolName: "manage_sparkline_object", operationField: "update"},
+	"+sparkline-delete": {mcpToolName: "manage_sparkline_object", operationField: "delete"},
+
+	"+float-image-create": {mcpToolName: "manage_float_image_object", operationField: "create"},
+	"+float-image-update": {mcpToolName: "manage_float_image_object", operationField: "update"},
+	"+float-image-delete": {mcpToolName: "manage_float_image_object", operationField: "delete"},
+}
+
+// reservedSubOpKeys 是禁止用户在 sub-op input 里手填的 key —— 它们要么由
+// shortcut 名隐含（operation），要么由 +batch-update 顶层 --url/--token
+// 统一提供（excel_id / spreadsheet_token / url）。
+var reservedSubOpKeys = []string{"excel_id", "spreadsheet_token", "url"}
+
+// translateBatchOp 把一个 CLI 视角的 {shortcut, input} 翻成底层 MCP
+// batch_update 的 {tool_name, input(+operation)}。`index` 用于错误信息定位。
+//
+// 失败场景：
+//   - shortcut 字段缺失 / 非 string
+//   - shortcut 不在 dispatch 表（典型：拼写错；用户传了 read 操作；
+//     用户嵌套 +batch-update / +cells-batch-set-style 之类的 fan-out wrapper）
+//   - input 不是 object
+//   - input 里手填了 operation（由 shortcut 名隐含，禁手填以防 mismatch）
+//   - input 里手填了 excel_id / spreadsheet_token / url
+func translateBatchOp(raw interface{}, index int) (map[string]interface{}, error) {
+	op, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil, common.FlagErrorf("operations[%d] must be a JSON object", index)
+	}
+	scRaw, present := op["shortcut"]
+	if !present {
+		return nil, common.FlagErrorf("operations[%d]: 'shortcut' field is required", index)
+	}
+	sc, ok := scRaw.(string)
+	if !ok || sc == "" {
+		return nil, common.FlagErrorf("operations[%d]: 'shortcut' must be a non-empty string (got %T)", index, scRaw)
+	}
+	mapping, ok := batchOpDispatch[sc]
+	if !ok {
+		return nil, common.FlagErrorf(
+			"operations[%d]: shortcut %q not allowed in +batch-update "+
+				"(read ops / fan-out wrappers like +batch-update / +cells-batch-set-style / +dropdown-{update,delete} / +dim-move are excluded; "+
+				"run `lark-cli sheets +batch-update --print-schema --flag-name operations` to see the full enum)",
+			index, sc,
+		)
+	}
+	inputRaw, hasInput := op["input"]
+	var input map[string]interface{}
+	if !hasInput || inputRaw == nil {
+		input = map[string]interface{}{}
+	} else {
+		input, ok = inputRaw.(map[string]interface{})
+		if !ok {
+			return nil, common.FlagErrorf("operations[%d] (%s): 'input' must be a JSON object (got %T)", index, sc, inputRaw)
+		}
+	}
+	// 禁手填 operation —— 由 shortcut 名表达，手填易与 shortcut 不一致。
+	if _, has := input["operation"]; has {
+		return nil, common.FlagErrorf(
+			"operations[%d] (%s): do not pass input.operation manually — it is implied by the shortcut name",
+			index, sc,
+		)
+	}
+	// 禁在 sub-op 重复填 spreadsheet 定位 —— 由 +batch-update 顶层 --url/--token 统一提供。
+	for _, k := range reservedSubOpKeys {
+		if _, has := input[k]; has {
+			return nil, common.FlagErrorf(
+				"operations[%d] (%s): do not pass input.%s — it is already set from +batch-update top-level --url / --token",
+				index, sc, k,
+			)
+		}
+	}
+	// 拒绝任何额外的 sub-op 顶层 key（防御未来 schema drift / 用户笔误）。
+	for k := range op {
+		if k != "shortcut" && k != "input" {
+			return nil, common.FlagErrorf("operations[%d] (%s): unknown top-level key %q (expected only 'shortcut' and 'input')", index, sc, k)
+		}
+	}
+	// 浅拷贝 input，注入 operation（如有），再补 excel_id 由调用方统一注入到顶层后，
+	// translator 也把 excel_id 写进 sub-op input（MCP tool 要求每个 sub-tool 都带）。
+	out := make(map[string]interface{}, len(input)+1)
+	for k, v := range input {
+		out[k] = v
+	}
+	if mapping.operationField != "" {
+		out["operation"] = mapping.operationField
+	}
+	return map[string]interface{}{
+		"tool_name": mapping.mcpToolName,
+		"input":     out,
+	}, nil
+}
+
+// translateBatchOperations 翻译整个 ops 数组；fail-fast，遇错立即返回。
+// 翻译后会把 excel_id 注入每个 sub-op 的 input（MCP 契约要求）。
+func translateBatchOperations(rawOps []interface{}, token string) ([]interface{}, error) {
+	if len(rawOps) == 0 {
+		return nil, common.FlagErrorf("--operations must be a non-empty JSON array")
+	}
+	out := make([]interface{}, 0, len(rawOps))
+	for i, raw := range rawOps {
+		translated, err := translateBatchOp(raw, i)
+		if err != nil {
+			return nil, err
+		}
+		// MCP batch_update 每个 sub-tool 的 input 都需要 excel_id（与单调用一致）。
+		input := translated["input"].(map[string]interface{})
+		input["excel_id"] = token
+		out = append(out, translated)
+	}
+	return out, nil
+}
+
+// 仅供测试 / 调试：暴露已知 shortcut 列表，便于做 enum 漂移对账。
+func batchOpDispatchKeys() []string {
+	keys := make([]string, 0, len(batchOpDispatch))
+	for k := range batchOpDispatch {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -2599,7 +2599,7 @@
         "kind": "own",
         "type": "string",
         "required": "required",
-        "desc": "JSON array: `[{\"tool_name\":\"set_cell_range\",\"input\":{...}}, ...]`, executed serially; `tool_name` is the underlying tool name (e.g. `set_cell_range` / `clear_cell_range` / `modify_sheet_structure`)",
+        "desc": "JSON array: [{\"shortcut\":\"+xxx-yyy\",\"input\":{...}}, ...]. shortcut uses CLI names; input is the shortcut's flag set minus the spreadsheet locator. For basic flags use lark-cli sheets <shortcut> --help; for composite JSON flags use --print-schema --flag-name <flag>. Do not pass an explicit operation field. Strict transaction by default, pass --continue-on-error for soft batch; no nesting; executed serially.",
         "input": [
           "file",
           "stdin"

--- a/shortcuts/sheets/data/flag-schemas.json
+++ b/shortcuts/sheets/data/flag-schemas.json
@@ -3,25 +3,77 @@
   "flags": {
     "+batch-update": {
       "operations": {
-        "description": "要批量执行的操作列表，按顺序依次执行。每个操作包含工具名称和对应的入参。",
+        "type": "array",
+        "description": "要批量执行的 CLI shortcut 操作列表，按声明顺序串行执行；任一失败立即中断。",
         "items": {
-          "properties": {
-            "input": {
-              "description": "对应工具的入参，结构与单独调用该工具时完全一致",
-              "type": "object"
-            },
-            "tool_name": {
-              "description": "要执行的工具名称，如 \"set_cell_range\"、\"clear_cell_range\"、\"modify_sheet_structure\" 等。不支持 \"batch_update\" 嵌套。",
-              "type": "string"
-            }
-          },
+          "type": "object",
+          "additionalProperties": false,
           "required": [
-            "tool_name",
+            "shortcut",
             "input"
           ],
-          "type": "object"
-        },
-        "type": "array"
+          "properties": {
+            "shortcut": {
+              "type": "string",
+              "enum": [
+                "+cells-set",
+                "+cells-clear",
+                "+cells-merge",
+                "+cells-unmerge",
+                "+cells-replace",
+                "+csv-put",
+                "+dim-insert",
+                "+dim-delete",
+                "+dim-hide",
+                "+dim-unhide",
+                "+dim-freeze",
+                "+dim-group",
+                "+dim-ungroup",
+                "+dim-move",
+                "+rows-resize",
+                "+cols-resize",
+                "+range-move",
+                "+range-copy",
+                "+range-fill",
+                "+range-sort",
+                "+sheet-create",
+                "+sheet-delete",
+                "+sheet-rename",
+                "+sheet-move",
+                "+sheet-copy",
+                "+sheet-hide",
+                "+sheet-unhide",
+                "+sheet-set-tab-color",
+                "+chart-create",
+                "+chart-update",
+                "+chart-delete",
+                "+pivot-create",
+                "+pivot-update",
+                "+pivot-delete",
+                "+cond-format-create",
+                "+cond-format-update",
+                "+cond-format-delete",
+                "+filter-create",
+                "+filter-update",
+                "+filter-delete",
+                "+filter-view-create",
+                "+filter-view-update",
+                "+filter-view-delete",
+                "+sparkline-create",
+                "+sparkline-update",
+                "+sparkline-delete",
+                "+float-image-create",
+                "+float-image-update",
+                "+float-image-delete"
+              ],
+              "description": "CLI shortcut 名（不是底层 MCP tool 名）"
+            },
+            "input": {
+              "type": "object",
+              "description": "该 shortcut 的入参集（不含 spreadsheet 定位）；基础 flag 跑 `lark-cli sheets <shortcut> --help`，复合 JSON flag 跑 `--print-schema --flag-name <flag>`。不要手填 `operation`（动作由 shortcut 名表达）。"
+            }
+          }
+        }
       }
     },
     "+cells-batch-set-style": {
@@ -3495,142 +3547,20 @@
     },
     "+dropdown-set": {
       "options": {
-        "description": "数据验证配置。设为 null 可清除已有的数据验证。",
-        "properties": {
-          "help_text": {
-            "description": "验证失败时显示的提示文本",
-            "type": "string"
-          },
-          "items": {
-            "description": "列表选项（type='list' 时必填）",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "operator": {
-            "description": "比较运算符（type='number'/'date'/'textLength' 时必填）",
-            "enum": [
-              "equal",
-              "notEqual",
-              "greaterThan",
-              "greaterThanOrEqual",
-              "lessThan",
-              "lessThanOrEqual",
-              "between",
-              "notBetween"
-            ],
-            "type": "string"
-          },
-          "range": {
-            "description": "源数据区域（type='listFromRange' 时必填，格式：'SheetName!A1:A10'）",
-            "type": "string"
-          },
-          "support_multiple_values": {
-            "description": "列表验证是否支持多选（type='list'/'listFromRange' 时可选，默认 false）",
-            "type": "boolean"
-          },
-          "type": {
-            "description": "数据验证类型：list（下拉列表）、listFromRange（引用范围下拉列表）、number（数字）、date（日期）、textLength（文本长度）、checkbox（复选框）",
-            "enum": [
-              "list",
-              "listFromRange",
-              "number",
-              "date",
-              "textLength",
-              "checkbox"
-            ],
-            "type": "string"
-          },
-          "values": {
-            "description": "比较值（operator 为 'between'/'notBetween' 时需要两个值，其它运算符需要一个值）",
-            "items": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                }
-              ]
-            },
-            "type": "array"
-          }
+        "description": "列表选项（type='list' 时必填）",
+        "items": {
+          "type": "string"
         },
-        "required": [
-          "type"
-        ],
-        "type": "object"
+        "type": "array"
       }
     },
     "+dropdown-update": {
       "options": {
-        "description": "数据验证配置。设为 null 可清除已有的数据验证。",
-        "properties": {
-          "help_text": {
-            "description": "验证失败时显示的提示文本",
-            "type": "string"
-          },
-          "items": {
-            "description": "列表选项（type='list' 时必填）",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
-          "operator": {
-            "description": "比较运算符（type='number'/'date'/'textLength' 时必填）",
-            "enum": [
-              "equal",
-              "notEqual",
-              "greaterThan",
-              "greaterThanOrEqual",
-              "lessThan",
-              "lessThanOrEqual",
-              "between",
-              "notBetween"
-            ],
-            "type": "string"
-          },
-          "range": {
-            "description": "源数据区域（type='listFromRange' 时必填，格式：'SheetName!A1:A10'）",
-            "type": "string"
-          },
-          "support_multiple_values": {
-            "description": "列表验证是否支持多选（type='list'/'listFromRange' 时可选，默认 false）",
-            "type": "boolean"
-          },
-          "type": {
-            "description": "数据验证类型：list（下拉列表）、listFromRange（引用范围下拉列表）、number（数字）、date（日期）、textLength（文本长度）、checkbox（复选框）",
-            "enum": [
-              "list",
-              "listFromRange",
-              "number",
-              "date",
-              "textLength",
-              "checkbox"
-            ],
-            "type": "string"
-          },
-          "values": {
-            "description": "比较值（operator 为 'between'/'notBetween' 时需要两个值，其它运算符需要一个值）",
-            "items": {
-              "oneOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "number"
-                }
-              ]
-            },
-            "type": "array"
-          }
+        "description": "列表选项（type='list' 时必填）",
+        "items": {
+          "type": "string"
         },
-        "required": [
-          "type"
-        ],
-        "type": "object"
+        "type": "array"
       }
     },
     "+filter-create": {

--- a/shortcuts/sheets/data/flag-schemas.json
+++ b/shortcuts/sheets/data/flag-schemas.json
@@ -17,11 +17,13 @@
               "type": "string",
               "enum": [
                 "+cells-set",
+                "+cells-set-style",
                 "+cells-clear",
                 "+cells-merge",
                 "+cells-unmerge",
                 "+cells-replace",
                 "+csv-put",
+                "+dropdown-set",
                 "+dim-insert",
                 "+dim-delete",
                 "+dim-hide",
@@ -29,7 +31,6 @@
                 "+dim-freeze",
                 "+dim-group",
                 "+dim-ungroup",
-                "+dim-move",
                 "+rows-resize",
                 "+cols-resize",
                 "+range-move",
@@ -66,7 +67,7 @@
                 "+float-image-update",
                 "+float-image-delete"
               ],
-              "description": "CLI shortcut 名（不是底层 MCP tool 名）"
+              "description": "CLI shortcut 名（不是底层 MCP tool 名）。+dim-move 不在表中——它走 legacy v2 endpoint，无法批；+cells-set-image / +workbook-create 也不在——前者含多步图片上传，后者是新建工作簿，都不属于 atomic batch 范畴；所有读操作、fan-out wrapper（+batch-update 自身 / +cells-batch-set-style / +dropdown-{update,delete}）一律禁。"
             },
             "input": {
               "type": "object",

--- a/shortcuts/sheets/execute_paths_test.go
+++ b/shortcuts/sheets/execute_paths_test.go
@@ -233,14 +233,16 @@ func TestExecute_FilterCreate(t *testing.T) {
 	}
 }
 
-// TestExecute_BatchUpdate_Raw covers the raw passthrough including
-// continue_on_error.
-func TestExecute_BatchUpdate_Raw(t *testing.T) {
+// TestExecute_BatchUpdate_Translated covers the CLI-shape → MCP-shape
+// translation: user passes {shortcut, input}, batchOpDispatch maps it to
+// {tool_name, input(+operation, +excel_id)} before the tool call. Also
+// verifies --continue-on-error.
+func TestExecute_BatchUpdate_Translated(t *testing.T) {
 	t.Parallel()
 	stub := toolOutputStub(testToken, "write", `{"results":[{"ok":true}]}`)
 	_, err := runShortcutWithStubs(t, BatchUpdate, []string{
 		"--url", testURL,
-		"--operations", `[{"tool_name":"set_cell_range","input":{"excel_id":"shtcnTestTOK","range":"A1","cells":[[{"value":1}]]}}]`,
+		"--operations", `[{"shortcut":"+cells-set","input":{"range":"A1","cells":[[{"value":1}]]}}]`,
 		"--continue-on-error",
 		"--yes",
 	}, stub)
@@ -251,6 +253,21 @@ func TestExecute_BatchUpdate_Raw(t *testing.T) {
 	input := decodeToolInput(t, body, "batch_update")
 	if input["continue_on_error"] != true {
 		t.Errorf("continue_on_error not propagated: %#v", input)
+	}
+	ops, _ := input["operations"].([]interface{})
+	if len(ops) != 1 {
+		t.Fatalf("operations length = %d, want 1", len(ops))
+	}
+	op := ops[0].(map[string]interface{})
+	if op["tool_name"] != "set_cell_range" {
+		t.Errorf("op.tool_name = %v, want set_cell_range (translated from +cells-set)", op["tool_name"])
+	}
+	subInput, _ := op["input"].(map[string]interface{})
+	if subInput["excel_id"] != testToken {
+		t.Errorf("op.input.excel_id = %v, want %s (translator should inject)", subInput["excel_id"], testToken)
+	}
+	if _, has := subInput["operation"]; has {
+		t.Errorf("op.input.operation present but +cells-set should not inject one: %#v", subInput)
 	}
 }
 

--- a/shortcuts/sheets/lark_sheet_batch_update.go
+++ b/shortcuts/sheets/lark_sheet_batch_update.go
@@ -14,15 +14,19 @@ import (
 //
 // One tool (batch_update), four shortcuts:
 //
-//   - +batch-update            raw passthrough of an operations array
-//                              (high-risk-write — anything can be inside)
+//   - +batch-update            user supplies a CLI-shape operations array
+//                              [{shortcut, input}, ...]; CLI translates to
+//                              MCP shape {tool_name, input(+operation)} via
+//                              batchOpDispatch before invoking the tool
+//                              (high-risk-write — anything in batchOpDispatch
+//                              can be inside)
 //   - +cells-batch-set-style   fan a single style across many ranges
 //   - +dropdown-update         install/replace the same dropdown across
 //                              many ranges in one atomic batch
 //   - +dropdown-delete         clear data_validation across many ranges
 //                              (high-risk-write)
 //
-// The tool's contract:
+// The tool's contract (post-translation):
 //   { excel_id, operations: [{tool_name, input}, ...], continue_on_error? }
 //
 // continue_on_error defaults to false (strict transaction): any failure
@@ -30,33 +34,36 @@ import (
 // three "fan-out" shortcuts since they're meant to be all-or-nothing;
 // only +batch-update lets callers flip it via --continue-on-error.
 
-// BatchUpdate is the raw passthrough — caller hands in the operations
-// array as --data. high-risk-write because it can wrap anything.
+// BatchUpdate accepts a CLI-shape operations array (each item
+// {shortcut, input}); on Validate / DryRun / Execute we translate each
+// sub-op via batchOpDispatch (see batch_op_dispatch.go) into the MCP
+// {tool_name, input(+operation)} form before calling the underlying
+// batch_update tool.
 var BatchUpdate = common.Shortcut{
 	Service:     "sheets",
 	Command:     "+batch-update",
-	Description: "Execute a batch of write tools as a single atomic request (rolls back on failure by default).",
+	Description: "Execute a batch of write shortcuts as a single atomic request (rolls back on failure by default).",
 	Risk:        "high-risk-write",
 	Scopes:      []string{"sheets:spreadsheet:write_only"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+batch-update"),
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		ops, err := parseBatchOperationsFlag(runtime)
+		token, err := resolveSpreadsheetToken(runtime)
 		if err != nil {
 			return err
 		}
-		if len(ops) == 0 {
-			return common.FlagErrorf("--operations must be a non-empty JSON array")
+		// Run the full translation in Validate so shape errors surface before
+		// DryRun / Execute. Translator is pure (no network), so re-running it
+		// in DryRun / Execute below is fine.
+		if _, err := batchUpdateInput(runtime, token); err != nil {
+			return err
 		}
 		return nil
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
-		input, _ := batchUpdateRawInput(runtime, token)
+		input, _ := batchUpdateInput(runtime, token)
 		return invokeToolDryRun(token, ToolKindWrite, "batch_update", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
@@ -64,7 +71,7 @@ var BatchUpdate = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		input, err := batchUpdateRawInput(runtime, token)
+		input, err := batchUpdateInput(runtime, token)
 		if err != nil {
 			return err
 		}
@@ -77,17 +84,25 @@ var BatchUpdate = common.Shortcut{
 	},
 	Tips: []string{
 		"Default is strict transaction — any sub-tool failure rolls the whole batch back. Pass --continue-on-error to keep partial successes.",
+		"Each sub-op is {shortcut, input}. Do NOT pass input.operation (implied by shortcut name) or input.excel_id / input.url (set at the +batch-update top level).",
 	},
 }
 
-func batchUpdateRawInput(runtime *common.RuntimeContext, token string) (map[string]interface{}, error) {
-	ops, err := parseBatchOperationsFlag(runtime)
+// batchUpdateInput translates the user-supplied CLI-shape operations array
+// into the MCP batch_update payload. Returns FlagErrorf-typed errors on
+// any per-op shape problem (translator validates each entry).
+func batchUpdateInput(runtime *common.RuntimeContext, token string) (map[string]interface{}, error) {
+	rawOps, err := parseBatchOperationsFlag(runtime)
+	if err != nil {
+		return nil, err
+	}
+	translated, err := translateBatchOperations(rawOps, token)
 	if err != nil {
 		return nil, err
 	}
 	input := map[string]interface{}{
 		"excel_id":   token,
-		"operations": ops,
+		"operations": translated,
 	}
 	if runtime.Bool("continue-on-error") {
 		input["continue_on_error"] = true

--- a/shortcuts/sheets/lark_sheet_batch_update_test.go
+++ b/shortcuts/sheets/lark_sheet_batch_update_test.go
@@ -9,25 +9,52 @@ import (
 	"testing"
 )
 
-// TestBatchUpdate_RawPassthrough verifies +batch-update threads
-// --data.operations into the tool input as-is and honors
-// --continue-on-error.
-func TestBatchUpdate_RawPassthrough(t *testing.T) {
+// TestBatchUpdate_TranslatesShortcutToToolName verifies +batch-update
+// translates each CLI-shape sub-op ({shortcut, input}) to the MCP-shape
+// ({tool_name, input(+operation, +excel_id)}) before threading into
+// the underlying batch_update tool. Covers continue_on_error too.
+func TestBatchUpdate_TranslatesShortcutToToolName(t *testing.T) {
 	t.Parallel()
 
 	body := parseDryRunBody(t, BatchUpdate, []string{
 		"--url", testURL,
-		"--operations", `[{"tool_name":"set_cell_range","input":{"excel_id":"shtcnTOK","sheet_id":"sh1","range":"A1","cells":[[{"value":42}]]}}]`,
+		"--operations", `[
+		  {"shortcut":"+cells-set","input":{"sheet_id":"sh1","range":"A1","cells":[[{"value":42}]]}},
+		  {"shortcut":"+dim-insert","input":{"sheet_id":"sh1","range":"1:3"}}
+		]`,
 		"--continue-on-error",
 		"--yes",
 	})
 	input := decodeToolInput(t, body, "batch_update")
 	ops, _ := input["operations"].([]interface{})
-	if len(ops) != 1 {
-		t.Fatalf("operations length = %d, want 1", len(ops))
+	if len(ops) != 2 {
+		t.Fatalf("operations length = %d, want 2", len(ops))
 	}
 	if input["continue_on_error"] != true {
 		t.Errorf("continue_on_error = %v, want true", input["continue_on_error"])
+	}
+
+	// op[0]: +cells-set → set_cell_range, no operation field
+	op0 := ops[0].(map[string]interface{})
+	if op0["tool_name"] != "set_cell_range" {
+		t.Errorf("op[0].tool_name = %v, want set_cell_range", op0["tool_name"])
+	}
+	in0, _ := op0["input"].(map[string]interface{})
+	if in0["excel_id"] == nil {
+		t.Errorf("op[0].input.excel_id missing (translator should inject)")
+	}
+	if _, has := in0["operation"]; has {
+		t.Errorf("op[0].input.operation present, +cells-set should not inject one: %#v", in0)
+	}
+
+	// op[1]: +dim-insert → modify_sheet_structure + operation:"insert"
+	op1 := ops[1].(map[string]interface{})
+	if op1["tool_name"] != "modify_sheet_structure" {
+		t.Errorf("op[1].tool_name = %v, want modify_sheet_structure", op1["tool_name"])
+	}
+	in1, _ := op1["input"].(map[string]interface{})
+	if in1["operation"] != "insert" {
+		t.Errorf("op[1].input.operation = %v, want \"insert\"", in1["operation"])
 	}
 }
 
@@ -35,7 +62,7 @@ func TestBatchUpdate_HighRiskWriteRequiresYes(t *testing.T) {
 	t.Parallel()
 	stdout, stderr, err := runShortcutCapturingErr(t, BatchUpdate, []string{
 		"--url", testURL,
-		"--operations", `[{"tool_name":"set_cell_range","input":{}}]`,
+		"--operations", `[{"shortcut":"+cells-set","input":{}}]`,
 	})
 	if err == nil {
 		t.Fatalf("expected confirmation_required; stdout=%s stderr=%s", stdout, stderr)
@@ -143,13 +170,6 @@ func TestDropdownDelete_BatchClearsValidation(t *testing.T) {
 
 func TestBatchUpdate_ValidationGuards(t *testing.T) {
 	t.Parallel()
-	cases := []struct {
-		name string
-		sc   interface{ shortcut() }
-		args []string
-		want string
-	}{}
-	_ = cases
 
 	// dropdown-update with sheetless range
 	stdout, stderr, err := runShortcutCapturingErr(t, DropdownUpdate, []string{
@@ -182,6 +202,144 @@ func TestBatchUpdate_ValidationGuards(t *testing.T) {
 	})
 	if err == nil || !strings.Contains(stdout+stderr+err.Error(), "must be a JSON array") {
 		t.Errorf("expected JSON array guard; got=%s|%s|%v", stdout, stderr, err)
+	}
+}
+
+// TestBatchUpdate_TranslatorRejects covers per-op shape errors caught by
+// translateBatchOp: unknown shortcut, missing shortcut, banned (read /
+// fan-out / legacy v2) shortcuts, hand-filled reserved keys, etc.
+func TestBatchUpdate_TranslatorRejects(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		opsJSON   string
+		wantMatch string
+	}{
+		{
+			name:      "missing shortcut field",
+			opsJSON:   `[{"input":{"range":"A1"}}]`,
+			wantMatch: "'shortcut' field is required",
+		},
+		{
+			name:      "empty shortcut string",
+			opsJSON:   `[{"shortcut":"","input":{}}]`,
+			wantMatch: "'shortcut' must be a non-empty string",
+		},
+		{
+			name:      "unknown shortcut",
+			opsJSON:   `[{"shortcut":"+cells-set-magic","input":{}}]`,
+			wantMatch: "not allowed in +batch-update",
+		},
+		{
+			name:      "read op rejected",
+			opsJSON:   `[{"shortcut":"+cells-get","input":{}}]`,
+			wantMatch: "not allowed in +batch-update",
+		},
+		{
+			name:      "nested batch-update rejected",
+			opsJSON:   `[{"shortcut":"+batch-update","input":{}}]`,
+			wantMatch: "not allowed in +batch-update",
+		},
+		{
+			name:      "fan-out wrapper rejected",
+			opsJSON:   `[{"shortcut":"+cells-batch-set-style","input":{}}]`,
+			wantMatch: "not allowed in +batch-update",
+		},
+		{
+			name:      "legacy v2 +dim-move rejected",
+			opsJSON:   `[{"shortcut":"+dim-move","input":{}}]`,
+			wantMatch: "not allowed in +batch-update",
+		},
+		{
+			name:      "user filled operation manually",
+			opsJSON:   `[{"shortcut":"+dim-insert","input":{"operation":"delete","range":"1:1"}}]`,
+			wantMatch: "do not pass input.operation",
+		},
+		{
+			name:      "user filled excel_id",
+			opsJSON:   `[{"shortcut":"+cells-set","input":{"excel_id":"shtcnX","range":"A1"}}]`,
+			wantMatch: "do not pass input.excel_id",
+		},
+		{
+			name:      "user filled url",
+			opsJSON:   `[{"shortcut":"+cells-set","input":{"url":"https://x.feishu.cn/sheets/sh","range":"A1"}}]`,
+			wantMatch: "do not pass input.url",
+		},
+		{
+			name:      "extra top-level key",
+			opsJSON:   `[{"shortcut":"+cells-set","input":{"range":"A1"},"tool_name":"oops"}]`,
+			wantMatch: "unknown top-level key",
+		},
+		{
+			name:      "sub-op not an object",
+			opsJSON:   `["not-an-object"]`,
+			wantMatch: "must be a JSON object",
+		},
+		{
+			name:      "input not an object",
+			opsJSON:   `[{"shortcut":"+cells-set","input":"not-an-object"}]`,
+			wantMatch: "'input' must be a JSON object",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			stdout, stderr, err := runShortcutCapturingErr(t, BatchUpdate, []string{
+				"--url", testURL,
+				"--operations", tc.opsJSON,
+				"--yes",
+				"--dry-run",
+			})
+			if err == nil {
+				t.Fatalf("expected error containing %q; got stdout=%s stderr=%s", tc.wantMatch, stdout, stderr)
+			}
+			if !strings.Contains(stdout+stderr+err.Error(), tc.wantMatch) {
+				t.Errorf("expected error containing %q; got: %s | %s | %v", tc.wantMatch, stdout, stderr, err)
+			}
+		})
+	}
+}
+
+// TestBatchUpdate_DimFreezeInjectsFreeze covers the static-freeze-only
+// path: +dim-freeze always injects operation=freeze (count==0 unfreeze
+// path of the single shortcut is intentionally not supported in batch).
+func TestBatchUpdate_DimFreezeInjectsFreeze(t *testing.T) {
+	t.Parallel()
+	body := parseDryRunBody(t, BatchUpdate, []string{
+		"--url", testURL,
+		"--operations", `[{"shortcut":"+dim-freeze","input":{"sheet_id":"sh1","freeze_rows":2}}]`,
+		"--yes",
+	})
+	input := decodeToolInput(t, body, "batch_update")
+	ops, _ := input["operations"].([]interface{})
+	op := ops[0].(map[string]interface{})
+	if op["tool_name"] != "modify_sheet_structure" {
+		t.Errorf("tool_name = %v, want modify_sheet_structure", op["tool_name"])
+	}
+	in, _ := op["input"].(map[string]interface{})
+	if in["operation"] != "freeze" {
+		t.Errorf("operation = %v, want \"freeze\"", in["operation"])
+	}
+}
+
+// TestBatchUpdate_ResizeNoOperationField covers the resize_range dispatch:
+// mapping has no operationField, so input.operation must NOT be injected.
+func TestBatchUpdate_ResizeNoOperationField(t *testing.T) {
+	t.Parallel()
+	body := parseDryRunBody(t, BatchUpdate, []string{
+		"--url", testURL,
+		"--operations", `[{"shortcut":"+rows-resize","input":{"sheet_id":"sh1","range":"1:3","resize_height":{"type":"pixel","value":30}}}]`,
+		"--yes",
+	})
+	input := decodeToolInput(t, body, "batch_update")
+	op := input["operations"].([]interface{})[0].(map[string]interface{})
+	if op["tool_name"] != "resize_range" {
+		t.Errorf("tool_name = %v, want resize_range", op["tool_name"])
+	}
+	in, _ := op["input"].(map[string]interface{})
+	if _, has := in["operation"]; has {
+		t.Errorf("operation should NOT be injected for resize_range; got %#v", in)
 	}
 }
 

--- a/skills/lark-sheets/references/lark-sheets-batch-update.md
+++ b/skills/lark-sheets/references/lark-sheets-batch-update.md
@@ -88,7 +88,7 @@ _公共：URL/token（无 sheet 定位） · 系统：`--yes`、`--dry-run`_
 _要批量执行的 CLI shortcut 操作列表，按声明顺序串行执行；任一失败立即中断_
 
 **数组项**（类型 object）：
-- `shortcut` (enum) — CLI shortcut 名（不是底层 MCP tool 名） [+cells-set / +cells-clear / +cells-merge / +cells-unmerge / +cells-replace / +csv-put / +dim-insert / +dim-delete / …共 49 项]
+- `shortcut` (enum) — CLI shortcut 名（不是底层 MCP tool 名） [+cells-set / +cells-set-style / +cells-clear / +cells-merge / +cells-unmerge / +cells-replace / +csv-put / +dropdown-set / …共 50 项]
 - `input` (object) — 该 shortcut 的入参集（不含 spreadsheet 定位）；基础 flag 跑 `lark-cli sheets <shortcut> --help…
 
 ### `+cells-batch-set-style` `--border-styles`

--- a/skills/lark-sheets/references/lark-sheets-batch-update.md
+++ b/skills/lark-sheets/references/lark-sheets-batch-update.md
@@ -37,7 +37,7 @@ _公共：URL/token（无 sheet 定位） · 系统：`--yes`、`--dry-run`_
 
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
-| `--operations` | string + File + Stdin（复合 JSON） | required | JSON 数组：`[{"tool_name":"`+cells-set`","input":{...}}, ...]`，按声明顺序串行执行；`tool_name` 为底层工具名（如 `+cells-set` / `+cells-clear` / `+dim-{insert|delete|hide|unhide|freeze|group|ungroup}`），`input` 结构与单独调用该工具一致 |
+| `--operations` | string + File + Stdin（复合 JSON） | required | JSON 数组：[{"shortcut":"+xxx-yyy","input":{...}}, ...]。shortcut 用 CLI 名；input 是该 shortcut 的入参集（不含 spreadsheet 定位），基础 flag 查 --help，复合 JSON flag 查 --print-schema --flag-name <flag>；禁手填 operation。默认严格事务，传 --continue-on-error 翻软批；不支持嵌套；按数组顺序串行执行 |
 | `--continue-on-error` | bool | optional | 遇子操作失败时继续执行剩余操作；默认 false（首个失败即整批中断） |
 
 ### `+cells-batch-set-style`
@@ -85,11 +85,11 @@ _公共：URL/token（无 sheet 定位） · 系统：`--yes`、`--dry-run`_
 
 ### `+batch-update` `--operations`
 
-_要批量执行的操作列表，按顺序依次执行_
+_要批量执行的 CLI shortcut 操作列表，按声明顺序串行执行；任一失败立即中断_
 
 **数组项**（类型 object）：
-- `input` (object) — 对应工具的入参，结构与单独调用该工具时完全一致
-- `tool_name` (string) — 要执行的工具名称，如 "`+cells-set`"、"`+cells-clear`"、"`+dim-{insert|delete|hide|unhide|freeze|group|ungroup}`" 等
+- `shortcut` (enum) — CLI shortcut 名（不是底层 MCP tool 名） [+cells-set / +cells-clear / +cells-merge / +cells-unmerge / +cells-replace / +csv-put / +dim-insert / +dim-delete / …共 49 项]
+- `input` (object) — 该 shortcut 的入参集（不含 spreadsheet 定位）；基础 flag 跑 `lark-cli sheets <shortcut> --help…
 
 ### `+cells-batch-set-style` `--border-styles`
 
@@ -120,10 +120,10 @@ _列表选项（type='list' 时必填）_
 lark-cli sheets +batch-update --url "https://example.feishu.cn/sheets/shtXXX" --yes \
   --operations @ops.json
 
-# ops.json （array<{tool_name, input}>，tool_name 是 CLI shortcut 名）:
+# ops.json （array<{shortcut, input}>，shortcut 用 CLI 名）:
 # [
-#   {"tool_name": "+dim-insert", "input": {"sheet_id":"...","dimension":"row","start":10,"end":12}},
-#   {"tool_name": "+cells-set",  "input": {"sheet_id":"...","range":"A11:B12","cells":[[{"value":"a"},{"value":"b"}],[{"value":"c"},{"value":"d"}]]}}
+#   {"shortcut": "+dim-insert", "input": {"sheet_id":"...","dimension":"row","start":10,"end":12}},
+#   {"shortcut": "+cells-set",  "input": {"sheet_id":"...","range":"A11:B12","cells":[[{"value":"a"},{"value":"b"}],[{"value":"c"},{"value":"d"}]]}}
 # ]
 ```
 
@@ -132,9 +132,9 @@ lark-cli sheets +batch-update --url "https://example.feishu.cn/sheets/shtXXX" --
 > ```jsonc
 > // 在 C 列前插入新列 → 写表头 C1 → 回填 C2:C100 共 99 行
 > [
->   {"tool_name": "+dim-insert",
+>   {"shortcut": "+dim-insert",
 >    "input": {"sheet_id": "...", "dimension": "column", "start": 3, "end": 4}},
->   {"tool_name": "+cells-set",
+>   {"shortcut": "+cells-set",
 >    "input": {"sheet_id": "...", "range": "C1:C100",
 >              "cells": [[{"value":"score"}], [{"value":95}], [{"value":87}], /* ... 97 more rows ... */ ]}}
 > ]
@@ -153,6 +153,6 @@ lark-cli sheets +cells-batch-set-style --url "..." \
 
 ### Validate / DryRun / Execute 约束
 
-- `Validate`：`+batch-update` 的 `--operations` 必须合法 JSON，且为非空数组；逐个子操作 `tool_name` / `input` 字段必填校验；**禁止嵌套 `+batch-update`**。`+cells-batch-set-style` 的 `--ranges` 必须 JSON 数组、每项带 sheet 前缀；样式 flag 至少一个非空（或带 `--border-styles`）。
+- `Validate`：`+batch-update` 的 `--operations` 必须合法 JSON，且为非空数组；逐个子操作 `shortcut` / `input` 字段必填校验；**禁止嵌套 `+batch-update`**。`+cells-batch-set-style` 的 `--ranges` 必须 JSON 数组、每项带 sheet 前缀；样式 flag 至少一个非空（或带 `--border-styles`）。
 - `DryRun`：按顺序输出每个子操作的目标 API + 请求 body 模板；首个失败则整批 fail-fast（不实际执行任何后续）。
 - `Execute`：按声明顺序串行执行；任一子操作失败立即中断并回滚到该子操作前状态（具体回滚能力取决于子操作类型，沿用 MCP `+batch-update` 的语义）。


### PR DESCRIPTION
## Summary
+batch-update 的 --operations 从原来的 raw passthrough（{tool_name, input}，
MCP 形态）切到 CLI 视角的 {shortcut, input}：用户传 CLI shortcut 名，CLI
内部翻译到底层 MCP batch_update tool 的 {tool_name, input(+operation)} 形态。

## Changes
- 新增 shortcuts/sheets/batch_op_dispatch.go：50 项 dispatch 表 +
  translateBatchOp / translateBatchOperations
- shortcuts/sheets/lark_sheet_batch_update.go：Validate 提前调 translator
  做 fail-fast；DryRun / Execute 都走翻译后形态
- 翻译规则：自动注入 operation（如 +dim-insert → modify_sheet_structure +
  operation:"insert"）和 excel_id；拒绝用户手填 operation / excel_id /
  spreadsheet_token / url，拒绝读操作 / fan-out wrapper（+batch-update /
  +cells-batch-set-style / +dropdown-{update,delete}）/ legacy v2 endpoint
  shortcut（+dim-move）
- shortcuts/sheets/data/flag-schemas.json + skills/lark-sheets/references/
  lark-sheets-batch-update.md：从 sheet-skill-spec 同步新形态文档

## Test Plan
- [x] go test ./shortcuts/sheets/... 全通过
- [x] 14 个新测试覆盖：端到端翻译、--continue-on-error 透传、13 个 reject 场景、
      +dim-freeze 静态注入、+rows-resize 无 operation 字段
- [ ] 本地手测 lark-cli sheets +batch-update --operations '[...]' --dry-run

## Related Issues
- 配套 spec 仓 MR：https://code.byted.org/ee/sheet-skill-spec/merge_requests/5
- 设计文档：https://bytedance.larkoffice.com/docx/OKvDdMp8Yo5XcRx1jQXcKTnWn9b