### PR TITLE
fix(auth): return validation error when --scope is empty in auth check

### DIFF
--- a/cmd/auth/check.go
+++ b/cmd/auth/check.go
@@ -47,8 +47,7 @@ func authCheckRun(opts *CheckOptions) error {
 
 	required := strings.Fields(opts.Scope)
 	if len(required) == 0 {
-		output.PrintJson(f.IOStreams.Out, map[string]interface{}{"ok": true, "granted": []string{}, "missing": []string{}})
-		return nil
+		return output.ErrValidation("--scope cannot be empty")
 	}
 
 	config, err := f.Config()


### PR DESCRIPTION
## Summary
`auth check --scope ""` returned `ok: true` instead of a validation error. `strings.Fields("")` produces an empty slice, which matches `len(required) == 0`, causing the command to report success without checking any scopes.

## Fix
Replace the false-positive success path with `output.ErrValidation("--scope cannot be empty")`, consistent with error handling patterns elsewhere in the auth package.

## Changes
- `cmd/auth/check.go`: 1 insertion, 2 deletions

## Verification
- `go build ./...` — clean
- `go test ./cmd/auth/...` — all pass (1 pre-existing Windows file-cleanup failure unrelated)

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `auth check --scope` validation to properly reject empty scope values with an error instead of returning a success response.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->