### PR TITLE
fix: use ErrValidation instead of fmt.Errorf in Validate paths

### DIFF
--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -2331,15 +2331,15 @@ func validateSendTime(runtime *common.RuntimeContext) error {
 		return nil
 	}
 	if !runtime.Bool("confirm-send") {
-		return fmt.Errorf("--send-time requires --confirm-send to be set")
+		return output.ErrValidation("--send-time requires --confirm-send to be set")
 	}
 	ts, err := strconv.ParseInt(sendTime, 10, 64)
 	if err != nil {
-		return fmt.Errorf("--send-time must be a valid Unix timestamp in seconds, got %q", sendTime)
+		return output.ErrValidation("--send-time must be a valid Unix timestamp in seconds, got %q", sendTime)
 	}
 	minTime := time.Now().Unix() + 5*60
 	if ts < minTime {
-		return fmt.Errorf("--send-time must be at least 5 minutes in the future (minimum: %d, got: %d)", minTime, ts)
+		return output.ErrValidation("--send-time must be at least 5 minutes in the future (minimum: %d, got: %d)", minTime, ts)
 	}
 	return nil
 }
@@ -2444,10 +2444,10 @@ func validateRecipientCount(to, cc, bcc string) error {
 func validateComposeInlineAndAttachments(fio fileio.FileIO, attachFlag, inlineFlag string, plainText bool, body string) error {
 	if strings.TrimSpace(inlineFlag) != "" {
 		if plainText {
-			return fmt.Errorf("--inline is not supported with --plain-text (inline images require HTML body)")
+			return output.ErrValidation("--inline is not supported with --plain-text (inline images require HTML body)")
 		}
 		if body != "" && !bodyIsHTML(body) {
-			return fmt.Errorf("--inline requires an HTML body (the provided body appears to be plain text; add HTML tags or remove --inline)")
+			return output.ErrValidation("--inline requires an HTML body (the provided body appears to be plain text; add HTML tags or remove --inline)")
 		}
 	}
 	inlineSpecs, err := parseInlineSpecs(inlineFlag)
@@ -2529,7 +2529,7 @@ func validateEventFlags(runtime *common.RuntimeContext) error {
 	hasAll := summary != "" && start != "" && end != ""
 
 	if hasAny && !hasAll {
-		return fmt.Errorf("--event-summary, --event-start, and --event-end must all be provided together")
+		return output.ErrValidation("--event-summary, --event-start, and --event-end must all be provided together")
 	}
 	if summary == "" {
 		return nil

--- a/shortcuts/mail/signature_compose.go
+++ b/shortcuts/mail/signature_compose.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
 	"github.com/larksuite/cli/shortcuts/mail/emlbuilder"
@@ -241,7 +242,7 @@ func signatureCIDs(sig *signatureResult) []string {
 // validateSignatureWithPlainText returns an error if both --plain-text and --signature-id are set.
 func validateSignatureWithPlainText(plainText bool, signatureID string) error {
 	if plainText && signatureID != "" {
-		return fmt.Errorf("--plain-text and --signature-id are mutually exclusive: signatures require HTML mode")
+		return output.ErrValidation("--plain-text and --signature-id are mutually exclusive: signatures require HTML mode")
 	}
 	return nil
 }

--- a/shortcuts/sheets/lark_sheets_filter_views.go
+++ b/shortcuts/sheets/lark_sheets_filter_views.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -463,7 +464,7 @@ func validateExpectedFlag(s string) error {
 	}
 	var arr []interface{}
 	if err := json.Unmarshal([]byte(s), &arr); err != nil {
-		return fmt.Errorf("--expected must be a JSON array (e.g. [\"6\"]), got: %s", s)
+		return output.ErrValidation("--expected must be a JSON array (e.g. [\"6\"]), got: %s", s)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
8 bare `fmt.Errorf` calls in Validate paths (across 3 files) returned unstructured errors without the standard `type: validation` JSON envelope and exit code 2. Replaced with `output.ErrValidation` for consistency with the rest of the codebase.

## Changes
| File | Function | Changes |
|------|----------|---------|
| `shortcuts/sheets/lark_sheets_filter_views.go` | `validateExpectedFlag` | 1 `fmt.Errorf` → `ErrValidation` + import |
| `shortcuts/mail/helpers.go` | `validateSendTime`, `validateComposeInlineAndAttachments`, `validateEventFlags` | 6 `fmt.Errorf` → `ErrValidation` |
| `shortcuts/mail/signature_compose.go` | `validateSignatureWithPlainText` | 1 `fmt.Errorf` → `ErrValidation` + import |

## Verification
- `go build ./...` — clean
- `go test ./shortcuts/sheets/... ./shortcuts/mail/...` — pre-existing failures only (Windows CRLF golden files, sheets image paths), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized validation error handling across mail and sheets commands for flag and format checks.

* **Bug Fixes**
  * Validation now consistently surfaces user-facing errors for send-time checks, inline vs plain-text conflicts, incomplete event flag sets, signature/plain-text exclusivity, and invalid expected-JSON parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->