### PR TITLE
chore(release): v1.0.36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.36] - 2026-05-21
+
+### Features
+
+- **drive/markdown**: Return real tenant URLs for `drive +upload` and `markdown +create` (#992)
+
+### Bug Fixes
+
+- **auth**: Return validation error when `--scope` is empty in `auth check` (#999)
+
+### Documentation
+
+- **lark-drive**: Improve search evidence guidance (#864)
+
 ## [v1.0.35] - 2026-05-20
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

- Bump version to 1.0.36
- Update CHANGELOG.md with changes since v1.0.35

### Highlights

- feat(drive/markdown): Return real tenant URLs for `drive +upload` and `markdown +create` (#992)
- fix(auth): Return validation error when `--scope` is empty in `auth check` (#999)
- docs(lark-drive): Improve search evidence guidance (#864)

## Test plan

- [ ] CI passes
- [ ] Verify version bump in `package.json`
- [ ] Verify CHANGELOG.md entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved drive and markdown tenant URL handling

* **Bug Fixes**
  * Fixed auth scope validation for the check command

* **Documentation**
  * Added guidance for lark-drive search evidence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1011?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->