### PR TITLE
fix(output): classify wiki lock-contention error (131009) with retry hint

### DIFF
--- a/internal/output/lark_errors.go
+++ b/internal/output/lark_errors.go
@@ -39,6 +39,10 @@ const (
 	LarkErrDriveCrossTenantUnit    = 1064510 // cross tenant and unit not support
 	LarkErrDriveCrossBrand         = 1064511 // cross brand not support
 
+	// Wiki write-path lock contention (e.g. concurrent wiki +node-create under the
+	// same parent). Server-side write lock; transient, safe to retry with backoff.
+	LarkErrWikiLockContention = 131009
+
 	// Sheets float image: width/height/offset out of range or invalid.
 	LarkErrSheetsFloatImageInvalidDims = 1310246
 
@@ -83,6 +87,8 @@ func ClassifyLarkError(code int, msg string) (int, string, string) {
 	// drive-specific constraints that benefit from actionable hints
 	case LarkErrDriveResourceContention:
 		return ExitAPI, "conflict", "please retry later and avoid concurrent duplicate requests"
+	case LarkErrWikiLockContention:
+		return ExitAPI, "conflict", "wiki write lock contention on this parent node; retry with exponential backoff or serialize sibling-node writes"
 	case LarkErrDriveCrossTenantUnit:
 		return ExitAPI, "cross_tenant_unit", "operate on source and target within the same tenant and region/unit"
 	case LarkErrDriveCrossBrand:

--- a/internal/output/lark_errors_test.go
+++ b/internal/output/lark_errors_test.go
@@ -90,3 +90,24 @@ func TestClassifyLarkError_DriveCreateShortcutConstraints(t *testing.T) {
 		})
 	}
 }
+
+// TestClassifyLarkError_WikiLockContention verifies the wiki write-lock
+// contention error (131009) maps to an actionable retry hint instead of
+// a generic "api_error". Surfaces during concurrent wiki +node-create
+// against the same parent (see larksuite/cli#1012).
+func TestClassifyLarkError_WikiLockContention(t *testing.T) {
+	t.Parallel()
+	gotExitCode, gotType, gotHint := ClassifyLarkError(LarkErrWikiLockContention, "raw msg")
+	if gotExitCode != ExitAPI {
+		t.Fatalf("exitCode=%d, want %d", gotExitCode, ExitAPI)
+	}
+	if gotType != "conflict" {
+		t.Fatalf("type=%q, want %q", gotType, "conflict")
+	}
+	if !strings.Contains(gotHint, "wiki write lock") {
+		t.Fatalf("hint=%q, want substring %q", gotHint, "wiki write lock")
+	}
+	if !strings.Contains(gotHint, "backoff") {
+		t.Fatalf("hint=%q, want substring %q", gotHint, "backoff")
+	}
+}


### PR DESCRIPTION
## Summary

Wiki write-path operations (most commonly `wiki +node-create` against the same parent) surface code **131009 "lock contention"** under concurrent calls. Currently this falls through to the generic `"api_error"` classification, giving users no hint that it is transient and safe to retry.

This PR mirrors the existing `LarkErrDriveResourceContention` (1061045) treatment: add a named constant, classify as `"conflict"`, and emit a hint that points the caller toward exponential backoff or serializing sibling-node writes.

## Changes

- Add `LarkErrWikiLockContention = 131009` constant in `internal/output/lark_errors.go`
- Classify it as `(ExitAPI, "conflict", <retry hint>)` alongside the existing Drive contention case
- Add `TestClassifyLarkError_WikiLockContention` covering exit code / type / hint substring

## Test Plan

- [x] `gofmt -l ./internal/output/` — clean
- [x] `go vet ./internal/output/...` — clean
- [x] `go test ./internal/output/... -run "WikiLock" -v` — pass
- [x] `make unit-test` — pass

## Scope note

This PR only adds **classification** + hint, matching the existing Drive contention precedent. It does **not** add client-side retry — that's left as a separate design decision (see issue #1012 for context). Downstream tools can already detect the `"conflict"` errType and retry on their side; this PR removes the need for downstream tools to hardcode `131009` themselves.

## Related Issues

- Refs #1012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for wiki write operations that encounter lock contention, now classifying conflicts more clearly and providing explicit retry/backoff guidance to help automatic recovery.
* **Tests**
  * Added a unit test to verify the conflict classification and that retry/backoff guidance is included for wiki lock contention scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1014?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->