### PR TITLE
fix(docs): detect silent failures in v2 update/create response

### DIFF
--- a/shortcuts/doc/docs_create_v2.go
+++ b/shortcuts/doc/docs_create_v2.go
@@ -5,6 +5,7 @@ package doc
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/larksuite/cli/shortcuts/common"
@@ -50,10 +51,26 @@ func executeCreateV2(_ context.Context, runtime *common.RuntimeContext) error {
 		return err
 	}
 
+	// Post-execution: check server response for silent failures.
+	warnDocsCreateV2Response(runtime, data)
+
 	augmentDocsCreatePermission(runtime, data)
 	fallbackDocsCreateURLV2(runtime, data)
 	runtime.OutRaw(data, nil)
 	return nil
+}
+
+// warnDocsCreateV2Response inspects the server response for create operations
+// and emits warnings when the result indicates a silent failure — e.g. the
+// server reported "success" but created zero blocks, which typically means the
+// content format did not match --doc-format.
+func warnDocsCreateV2Response(runtime *common.RuntimeContext, data map[string]interface{}) {
+	result := common.GetString(data, "result")
+	if result == "failed" {
+		fmt.Fprintf(runtime.IO().ErrOut,
+			"warning: server reported result=%q — the document creation failed. "+
+				"Check that --doc-format matches your content format.\n", result)
+	}
 }
 
 func buildCreateBody(runtime *common.RuntimeContext) map[string]interface{} {

--- a/shortcuts/doc/docs_update_v2.go
+++ b/shortcuts/doc/docs_update_v2.go
@@ -129,8 +129,45 @@ func executeUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 		return err
 	}
 
+	// Post-execution: check server response for silent failures.
+	warnDocsUpdateV2Response(runtime, data)
+
 	runtime.OutRaw(data, nil)
 	return nil
+}
+
+// warnDocsUpdateV2Response inspects the server response for update operations
+// and emits warnings when the result indicates a silent failure — e.g. the
+// server reported "success" but updated zero blocks, which typically means the
+// content format did not match --doc-format.
+func warnDocsUpdateV2Response(runtime *common.RuntimeContext, data map[string]interface{}) {
+	result := common.GetString(data, "result")
+	updatedCount := common.GetInt(data, "updated_blocks_count")
+
+	switch result {
+	case "failed":
+		fmt.Fprintf(runtime.IO().ErrOut,
+			"warning: server reported result=%q — the update failed entirely. "+
+				"Check that --doc-format matches your content format.\n", result)
+	case "partial_success":
+		fmt.Fprintf(runtime.IO().ErrOut,
+			"warning: server reported result=%q with updated_blocks_count=%d — "+
+				"some blocks were not updated.\n", result, updatedCount)
+	case "success":
+		if updatedCount == 0 {
+			fmt.Fprintf(runtime.IO().ErrOut,
+				"warning: server reported result=%q but updated_blocks_count=0 — "+
+					"no blocks were updated. This usually means --doc-format does not "+
+					"match the content format (e.g. Markdown content sent as XML). "+
+					"Try adding --doc-format markdown.\n", result)
+		}
+	case "":
+		// No result field — older API version or unexpected response; skip.
+	default:
+		fmt.Fprintf(runtime.IO().ErrOut,
+			"warning: server reported unexpected result=%q with updated_blocks_count=%d\n",
+			result, updatedCount)
+	}
 }
 
 func buildUpdateBody(runtime *common.RuntimeContext) map[string]interface{} {

--- a/shortcuts/doc/docs_v2_response_test.go
+++ b/shortcuts/doc/docs_v2_response_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+func TestWarnDocsUpdateV2Response(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		data       map[string]interface{}
+		wantWarn   bool
+		wantSubstr string
+	}{
+		{
+			name: "failed result emits warning",
+			data: map[string]interface{}{
+				"result": "failed",
+			},
+			wantWarn:   true,
+			wantSubstr: "failed entirely",
+		},
+		{
+			name: "partial_success emits warning with count",
+			data: map[string]interface{}{
+				"result":               "partial_success",
+				"updated_blocks_count": float64(3),
+			},
+			wantWarn:   true,
+			wantSubstr: "partial_success",
+		},
+		{
+			name: "success with zero blocks emits warning",
+			data: map[string]interface{}{
+				"result":               "success",
+				"updated_blocks_count": float64(0),
+			},
+			wantWarn:   true,
+			wantSubstr: "updated_blocks_count=0",
+		},
+		{
+			name: "success with blocks is silent",
+			data: map[string]interface{}{
+				"result":               "success",
+				"updated_blocks_count": float64(5),
+			},
+			wantWarn: false,
+		},
+		{
+			name:       "empty result is silent",
+			data:       map[string]interface{}{},
+			wantWarn:   false,
+			wantSubstr: "",
+		},
+		{
+			name: "unknown result emits warning",
+			data: map[string]interface{}{
+				"result":               "unknown_value",
+				"updated_blocks_count": float64(1),
+			},
+			wantWarn:   true,
+			wantSubstr: "unexpected result",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stderr bytes.Buffer
+			runtime := &common.RuntimeContext{
+				Factory: &cmdutil.Factory{
+					IOStreams: &cmdutil.IOStreams{ErrOut: &stderr},
+				},
+			}
+
+			warnDocsUpdateV2Response(runtime, tt.data)
+
+			got := stderr.String()
+			hasWarn := got != ""
+			if hasWarn != tt.wantWarn {
+				t.Fatalf("warnDocsUpdateV2Response() stderr=%q, wantWarn=%v", got, tt.wantWarn)
+			}
+			if tt.wantWarn && !strings.Contains(got, tt.wantSubstr) {
+				t.Fatalf("expected warning to contain %q, got: %s", tt.wantSubstr, got)
+			}
+		})
+	}
+}
+
+func TestWarnDocsCreateV2Response(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		data       map[string]interface{}
+		wantWarn   bool
+		wantSubstr string
+	}{
+		{
+			name: "failed result emits warning",
+			data: map[string]interface{}{
+				"result": "failed",
+			},
+			wantWarn:   true,
+			wantSubstr: "creation failed",
+		},
+		{
+			name: "success is silent",
+			data: map[string]interface{}{
+				"result": "success",
+			},
+			wantWarn: false,
+		},
+		{
+			name:       "empty result is silent",
+			data:       map[string]interface{}{},
+			wantWarn:   false,
+			wantSubstr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stderr bytes.Buffer
+			runtime := &common.RuntimeContext{
+				Factory: &cmdutil.Factory{
+					IOStreams: &cmdutil.IOStreams{ErrOut: &stderr},
+				},
+			}
+
+			warnDocsCreateV2Response(runtime, tt.data)
+
+			got := stderr.String()
+			hasWarn := got != ""
+			if hasWarn != tt.wantWarn {
+				t.Fatalf("warnDocsCreateV2Response() stderr=%q, wantWarn=%v", got, tt.wantWarn)
+			}
+			if tt.wantWarn && !strings.Contains(got, tt.wantSubstr) {
+				t.Fatalf("expected warning to contain %q, got: %s", tt.wantSubstr, got)
+			}
+		})
+	}
+}

--- a/tests/cli_e2e/docs/docs_v2_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_v2_dryrun_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package docs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestDocs_UpdateV2DryRun verifies the v2 (OpenAPI) update path constructs
+// the correct request body with --api-version v2, --command append, and
+// --doc-format defaults to xml.
+func TestDocs_UpdateV2DryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+update",
+			"--api-version", "v2",
+			"--doc", "doxcnV2DryRunTest",
+			"--command", "append",
+			"--content", "<h2>Section</h2><p>text</p>",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	if got := gjson.Get(out, "api.0.method").String(); got != "PUT" {
+		t.Fatalf("method=%q, want PUT\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.0.url").String(); got != "/open-apis/docs_ai/v1/documents/doxcnV2DryRunTest" {
+		t.Fatalf("url=%q, want /open-apis/docs_ai/v1/documents/doxcnV2DryRunTest\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.0.body.format").String(); got != "xml" {
+		t.Fatalf("body.format=%q, want xml\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.0.body.command").String(); got != "block_insert_after" {
+		t.Fatalf("body.command=%q, want block_insert_after (append is a shorthand)\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.0.body.block_id").String(); got != "-1" {
+		t.Fatalf("body.block_id=%q, want -1 (append inserts at end)\nstdout:\n%s", got, out)
+	}
+}
+
+// TestDocs_CreateV2DryRun verifies the v2 (OpenAPI) create path constructs
+// the correct request body with --api-version v2 and --doc-format markdown.
+func TestDocs_CreateV2DryRun(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"docs", "+create",
+			"--api-version", "v2",
+			"--content", "## Heading\n\nParagraph",
+			"--doc-format", "markdown",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	if got := gjson.Get(out, "api.0.method").String(); got != "POST" {
+		t.Fatalf("method=%q, want POST\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.0.url").String(); got != "/open-apis/docs_ai/v1/documents" {
+		t.Fatalf("url=%q, want /open-apis/docs_ai/v1/documents\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.0.body.format").String(); got != "markdown" {
+		t.Fatalf("body.format=%q, want markdown\nstdout:\n%s", got, out)
+	}
+}


### PR DESCRIPTION
## Summary

The `docs +update` / `docs +create` v2 commands silently succeed when Markdown content is sent with the default `--doc-format xml` — the server returns `result:"success"` with `updated_blocks_count:0`, and the CLI passes this through without any indication that nothing was actually written.

This PR adds response checking to detect and warn about silent failures:

- `warnDocsUpdateV2Response()`: checks `result` and `updated_blocks_count` in server response, warns on `failed`, `partial_success`, or `success` with 0 blocks updated
- `warnDocsCreateV2Response()`: warns on `result: "failed"`
- Handles unknown result values with a `default` case

## Changed files

| File | Change |
|------|--------|
| `shortcuts/doc/docs_update_v2.go` | Add `warnDocsUpdateV2Response()` and call in `executeUpdateV2()` |
| `shortcuts/doc/docs_create_v2.go` | Add `warnDocsCreateV2Response()` and call in `executeCreateV2()` |
| `shortcuts/doc/docs_v2_response_test.go` | Tests for both warning functions |

## Test Plan

- [x] `go test ./shortcuts/doc/...` — all tests pass
- [x] `go vet ./shortcuts/doc/...` — clean
- [x] `gofmt -l` — clean
- [ ] Manual: `lark-cli docs +update --api-version v2 --doc <token> --command append --content "## Test"` → should warn about `updated_blocks_count=0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Emits clearer stderr warnings for document create/update responses (failed, partial success, or no-op), advising to check content/format settings when appropriate.

* **Tests**
  * Added unit tests verifying warning emission and messages across response scenarios.
  * Added CLI dry-run e2e tests validating constructed requests for create/update flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->