### PR TITLE
fix(sheets): +batch-update sub-op CLI-side validation + cond-format / filter schema alignment

### DIFF
--- a/shortcuts/sheets/batch_op_contract_test.go
+++ b/shortcuts/sheets/batch_op_contract_test.go
@@ -6,6 +6,7 @@ package sheets
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/shortcuts/common"
@@ -312,6 +313,232 @@ func jsonRoundTrip(t *testing.T, m map[string]interface{}) map[string]interface{
 		t.Fatalf("unmarshal: %v", err)
 	}
 	return out
+}
+
+// TestBatchOp_ErrorEquivalence is the second half of the contract: for the
+// same bad input, the standalone shortcut Validate and the +batch-update
+// sub-op translator must emit the same friendly CLI error. Previously a
+// sub-op that omitted --sheet-id (or another required flag) slipped through
+// to the server and surfaced as "sheet undefined not found"; with the
+// validation pushed down into the xxxInput builders both paths now stop the
+// request before the API call.
+//
+// Scope: this test covers checks that cobra cannot enforce — XOR pairs
+// (sheet selector, image token/uri), range relationships, enum-bound rules,
+// pixel/size cross-flag coupling. cobra's own MarkFlagRequired catches the
+// single-required cases on the standalone path with its own
+// "required flag(s) \"X\" not set" wording; the batch path now catches the
+// same situations with our friendlier "--X is required" wording — those are
+// asserted by TestBatchOp_RejectsBadSubOpInput below.
+func TestBatchOp_ErrorEquivalence(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		// shortcut & standalone args. --url is supplied by the runner. Args
+		// satisfy every cobra-required flag so cobra doesn't short-circuit
+		// before our shared validator runs.
+		shortcut common.Shortcut
+		args     []string
+		// matching sub-op input; reach the same failing check.
+		subShortcut string
+		subInput    string
+		// substring expected in both errors. We assert *contains* rather than
+		// equality because the batch path wraps the inner error with
+		// "operations[i] (<name>): " context — the inner message must match.
+		wantContains string
+	}{
+		{
+			name:         "+cells-set missing sheet selector",
+			shortcut:     CellsSet,
+			args:         []string{"--range", "A1", "--cells", `[[{"value":"x"}]]`},
+			subShortcut:  "+cells-set",
+			subInput:     `{"range":"A1","cells":[[{"value":"x"}]]}`,
+			wantContains: "specify at least one of --sheet-id or --sheet-name",
+		},
+		{
+			name:         "+cells-set both sheet-id and sheet-name",
+			shortcut:     CellsSet,
+			args:         []string{"--sheet-id", "sh1", "--sheet-name", "Sheet1", "--range", "A1", "--cells", `[[{"value":"x"}]]`},
+			subShortcut:  "+cells-set",
+			subInput:     `{"sheet-id":"sh1","sheet-name":"Sheet1","range":"A1","cells":[[{"value":"x"}]]}`,
+			wantContains: "mutually exclusive",
+		},
+		{
+			name:         "+dim-insert missing sheet selector",
+			shortcut:     DimInsert,
+			args:         []string{"--dimension", "row", "--start", "0", "--end", "1"},
+			subShortcut:  "+dim-insert",
+			subInput:     `{"dimension":"row","start":0,"end":1}`,
+			wantContains: "specify at least one of --sheet-id or --sheet-name",
+		},
+		{
+			name:         "+dim-insert --end <= --start",
+			shortcut:     DimInsert,
+			args:         []string{"--sheet-id", "sh1", "--dimension", "row", "--start", "5", "--end", "3"},
+			subShortcut:  "+dim-insert",
+			subInput:     `{"sheet-id":"sh1","dimension":"row","start":5,"end":3}`,
+			wantContains: "must be greater than --start",
+		},
+		{
+			name:         "+rows-resize --type pixel without --size",
+			shortcut:     RowsResize,
+			args:         []string{"--sheet-id", "sh1", "--start", "0", "--end", "1", "--type", "pixel"},
+			subShortcut:  "+rows-resize",
+			subInput:     `{"sheet-id":"sh1","start":0,"end":1,"type":"pixel"}`,
+			wantContains: "--type pixel requires --size",
+		},
+		{
+			name:         "+sheet-delete missing sheet selector",
+			shortcut:     SheetDelete,
+			args:         []string{},
+			subShortcut:  "+sheet-delete",
+			subInput:     `{}`,
+			wantContains: "specify at least one of --sheet-id or --sheet-name",
+		},
+		{
+			name:         "+float-image-create both image-token and image-uri",
+			shortcut:     FloatImageCreate,
+			args:         []string{"--sheet-id", "sh1", "--image-name", "x.png", "--image-token", "t", "--image-uri", "u", "--position-row", "0", "--position-col", "A", "--size-width", "100", "--size-height", "50"},
+			subShortcut:  "+float-image-create",
+			subInput:     `{"sheet-id":"sh1","image-name":"x.png","image-token":"t","image-uri":"u","position-row":0,"position-col":"A","size-width":100,"size-height":50}`,
+			wantContains: "mutually exclusive",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Standalone path: run the shortcut with --dry-run + bad args.
+			// Validate runs before DryRun, so we expect it to fail there.
+			_, _, standaloneErr := runShortcutCapturingErr(
+				t, tc.shortcut,
+				append([]string{"--url", testURL, "--dry-run"}, tc.args...),
+			)
+			if standaloneErr == nil {
+				t.Fatalf("standalone Validate accepted bad input — expected error containing %q", tc.wantContains)
+			}
+			if !strings.Contains(standaloneErr.Error(), tc.wantContains) {
+				t.Errorf("standalone error = %q, want substring %q", standaloneErr.Error(), tc.wantContains)
+			}
+
+			// Batch path: translate the matching sub-op. The translator wraps
+			// the inner error with "operations[i] (<shortcut>): " — assert the
+			// inner message survives the wrap.
+			var subInput map[string]interface{}
+			if err := json.Unmarshal([]byte(tc.subInput), &subInput); err != nil {
+				t.Fatalf("bad subInput JSON: %v", err)
+			}
+			rawOp := map[string]interface{}{
+				"shortcut": tc.subShortcut,
+				"input":    subInput,
+			}
+			_, batchErr := translateBatchOp(rawOp, testToken, 0)
+			if batchErr == nil {
+				t.Fatalf("batch translator accepted bad input — expected error containing %q", tc.wantContains)
+			}
+			if !strings.Contains(batchErr.Error(), tc.wantContains) {
+				t.Errorf("batch error = %q, want substring %q (operations[i] prefix is fine)", batchErr.Error(), tc.wantContains)
+			}
+			// And the wrap context must include the sub-op index + shortcut
+			// name so error reports stay actionable in multi-op batches.
+			wrapHint := "operations[0] (" + tc.subShortcut + "):"
+			if !strings.Contains(batchErr.Error(), wrapHint) {
+				t.Errorf("batch error %q missing context prefix %q", batchErr.Error(), wrapHint)
+			}
+		})
+	}
+}
+
+// TestBatchOp_RejectsBadSubOpInput pins down the secondary guard: for
+// inputs that cobra's MarkFlagRequired catches on the standalone path,
+// the +batch-update sub-op (which has no cobra layer) must still reject
+// CLI-side with its own friendly error before issuing any API call. This
+// closes the original bug — a sub-op missing --sheet-id used to slip
+// through and surface as "sheet undefined not found" only after a
+// network round-trip.
+func TestBatchOp_RejectsBadSubOpInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		subShortcut  string
+		subInput     string
+		wantContains string
+	}{
+		{
+			"+cells-set missing --range",
+			"+cells-set",
+			`{"sheet-id":"sh1","cells":[[{"value":"x"}]]}`,
+			"--range is required",
+		},
+		{
+			"+dim-insert missing --dimension",
+			"+dim-insert",
+			`{"sheet-id":"sh1","start":0,"end":1}`,
+			"--dimension is required",
+		},
+		{
+			"+rows-resize missing --type",
+			"+rows-resize",
+			`{"sheet-id":"sh1","start":0,"end":0}`,
+			"--type is required",
+		},
+		{
+			"+range-copy missing --target-range",
+			"+range-copy",
+			`{"sheet-id":"sh1","source-range":"A1:B2"}`,
+			"--target-range is required",
+		},
+		{
+			"+sheet-rename missing --title",
+			"+sheet-rename",
+			`{"sheet-id":"sh1"}`,
+			"--title is required",
+		},
+		{
+			"+chart-update missing --chart-id",
+			"+chart-update",
+			`{"sheet-id":"sh1","properties":{"title":"T"}}`,
+			"--chart-id is required",
+		},
+		{
+			"+filter-create missing --range",
+			"+filter-create",
+			`{"sheet-id":"sh1"}`,
+			"--range is required",
+		},
+		{
+			"+float-image-update missing --float-image-id",
+			"+float-image-update",
+			`{"sheet-id":"sh1","image-name":"x.png","image-token":"t","position-row":0,"position-col":"A","size-width":100,"size-height":50}`,
+			"--float-image-id is required",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var subInput map[string]interface{}
+			if err := json.Unmarshal([]byte(tc.subInput), &subInput); err != nil {
+				t.Fatalf("bad subInput JSON: %v", err)
+			}
+			rawOp := map[string]interface{}{
+				"shortcut": tc.subShortcut,
+				"input":    subInput,
+			}
+			_, err := translateBatchOp(rawOp, testToken, 0)
+			if err == nil {
+				t.Fatalf("translator accepted bad input — expected error containing %q", tc.wantContains)
+			}
+			if !strings.Contains(err.Error(), tc.wantContains) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.wantContains)
+			}
+		})
+	}
 }
 
 // TestBatchOp_DispatchCoversReportedBugs is a focused guard for the two

--- a/shortcuts/sheets/batch_op_contract_test.go
+++ b/shortcuts/sheets/batch_op_contract_test.go
@@ -210,8 +210,8 @@ func TestBatchOp_BodyMatchesStandalone(t *testing.T) {
 		{
 			shortcut: "+cond-format-create",
 			sc:       CondFormatCreate,
-			args:     []string{"--sheet-id", "sh1", "--properties", `{"style":{}}`, "--rule-type", "duplicate", "--ranges", `["A1:A100"]`},
-			subInput: `{"sheet-id":"sh1","properties":{"style":{}},"rule-type":"duplicate","ranges":["A1:A100"]}`,
+			args:     []string{"--sheet-id", "sh1", "--properties", `{"style":{}}`, "--rule-type", "duplicateValues", "--ranges", `["A1:A100"]`},
+			subInput: `{"sheet-id":"sh1","properties":{"style":{}},"rule-type":"duplicateValues","ranges":["A1:A100"]}`,
 		},
 		{
 			shortcut: "+filter-create",
@@ -515,6 +515,21 @@ func TestBatchOp_RejectsBadSubOpInput(t *testing.T) {
 			"+float-image-update",
 			`{"sheet-id":"sh1","image-name":"x.png","image-token":"t","position-row":0,"position-col":"A","size-width":100,"size-height":50}`,
 			"--float-image-id is required",
+		},
+		// +filter-{update,delete} need sheet-id (not sheet-name) because
+		// server contract: filter_id === sheet_id, and we can't resolve
+		// sheet-name → sheet-id mid-batch.
+		{
+			"+filter-update with --sheet-name only (filter_id must equal sheet_id)",
+			"+filter-update",
+			`{"sheet-name":"Sheet1","range":"A1:F1000","properties":{"rules":[]}}`,
+			"+filter-update requires --sheet-id",
+		},
+		{
+			"+filter-delete with --sheet-name only (filter_id must equal sheet_id)",
+			"+filter-delete",
+			`{"sheet-name":"Sheet1"}`,
+			"+filter-delete requires --sheet-id",
 		},
 	}
 

--- a/shortcuts/sheets/batch_op_dispatch.go
+++ b/shortcuts/sheets/batch_op_dispatch.go
@@ -43,13 +43,6 @@ type batchOpMapping struct {
 	translate batchTranslateFn
 }
 
-// noErrTranslate adapts a builder that cannot fail into a batchTranslateFn.
-func noErrTranslate(f func(fv flagView, token, sheetID, sheetName string) map[string]interface{}) batchTranslateFn {
-	return func(fv flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
-		return f(fv, token, sheetID, sheetName), nil
-	}
-}
-
 // objCreateTranslate / objUpdateTranslate / objDeleteTranslate bind an object
 // CRUD spec to the shared object_crud builders.
 func objCreateTranslate(spec objectCRUDSpec) batchTranslateFn {
@@ -66,80 +59,84 @@ func objUpdateTranslate(spec objectCRUDSpec) batchTranslateFn {
 
 func objDeleteTranslate(spec objectCRUDSpec) batchTranslateFn {
 	return func(fv flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
-		return objectDeleteInput(fv, token, sheetID, sheetName, spec), nil
+		return objectDeleteInput(fv, token, sheetID, sheetName, spec)
 	}
 }
 
 // batchOpDispatch covers every write shortcut that can join an atomic batch.
+// Each entry plugs the shortcut's standalone xxxInput builder into the
+// batch translator path — so the body is byte-identical to the standalone
+// invocation (locked by TestBatchOp_BodyMatchesStandalone) and the missing-
+// flag error is identical too (locked by TestBatchOp_ErrorEquivalence).
 var batchOpDispatch = map[string]batchOpMapping{
 	// ─── 单元格内容 ──────────────────────────────────────────────────
 	"+cells-set":       {"set_cell_range", cellsSetInput},
 	"+cells-set-style": {"set_cell_range", cellsSetStyleInput},
-	"+cells-clear":     {"clear_cell_range", noErrTranslate(cellsClearInput)},
-	"+cells-replace":   {"replace_data", noErrTranslate(replaceInput)},
-	"+csv-put":         {"set_range_from_csv", noErrTranslate(csvPutInput)},
+	"+cells-clear":     {"clear_cell_range", cellsClearInput},
+	"+cells-replace":   {"replace_data", replaceInput},
+	"+csv-put":         {"set_range_from_csv", csvPutInput},
 	"+dropdown-set":    {"set_cell_range", dropdownSetInput},
 
 	// ─── 单元格合并 (merge_cells, operation 区分) ────────────────────
 	"+cells-merge": {"merge_cells", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		return mergeInput(fv, token, sid, sname, "merge", true), nil
+		return mergeInput(fv, token, sid, sname, "merge", true)
 	}},
 	"+cells-unmerge": {"merge_cells", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		return mergeInput(fv, token, sid, sname, "unmerge", false), nil
+		return mergeInput(fv, token, sid, sname, "unmerge", false)
 	}},
 
 	// ─── 行列结构 (modify_sheet_structure, operation 区分) ──────────
-	"+dim-insert": {"modify_sheet_structure", noErrTranslate(dimInsertInput)},
+	"+dim-insert": {"modify_sheet_structure", dimInsertInput},
 	"+dim-delete": {"modify_sheet_structure", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		return dimRangeOpInput(fv, token, sid, sname, "delete"), nil
+		return dimRangeOpInput(fv, token, sid, sname, "delete")
 	}},
 	"+dim-hide": {"modify_sheet_structure", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		return dimRangeOpInput(fv, token, sid, sname, "hide"), nil
+		return dimRangeOpInput(fv, token, sid, sname, "hide")
 	}},
 	"+dim-unhide": {"modify_sheet_structure", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		return dimRangeOpInput(fv, token, sid, sname, "unhide"), nil
+		return dimRangeOpInput(fv, token, sid, sname, "unhide")
 	}},
-	"+dim-freeze": {"modify_sheet_structure", noErrTranslate(dimFreezeInput)},
+	"+dim-freeze": {"modify_sheet_structure", dimFreezeInput},
 	"+dim-group": {"modify_sheet_structure", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		return dimGroupInput(fv, token, sid, sname, "group"), nil
+		return dimGroupInput(fv, token, sid, sname, "group")
 	}},
 	"+dim-ungroup": {"modify_sheet_structure", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		return dimGroupInput(fv, token, sid, sname, "ungroup"), nil
+		return dimGroupInput(fv, token, sid, sname, "ungroup")
 	}},
 
 	// ─── 行高列宽 (resize_range, 无 operation 字段) ─────────────────
 	"+rows-resize": {"resize_range", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		return resizeInput(fv, token, sid, sname, "row"), nil
+		return resizeInput(fv, token, sid, sname, "row")
 	}},
 	"+cols-resize": {"resize_range", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		return resizeInput(fv, token, sid, sname, "column"), nil
+		return resizeInput(fv, token, sid, sname, "column")
 	}},
 
 	// ─── 区域操作 (transform_range, operation 区分) ─────────────────
 	"+range-move": {"transform_range", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		return transformMoveCopyInput(fv, token, sid, sname, "move", false), nil
+		return transformMoveCopyInput(fv, token, sid, sname, "move", false)
 	}},
 	"+range-copy": {"transform_range", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		return transformMoveCopyInput(fv, token, sid, sname, "copy", true), nil
+		return transformMoveCopyInput(fv, token, sid, sname, "copy", true)
 	}},
-	"+range-fill": {"transform_range", noErrTranslate(rangeFillInput)},
+	"+range-fill": {"transform_range", rangeFillInput},
 	"+range-sort": {"transform_range", rangeSortInput},
 
 	// ─── 工作簿 / 子表 (modify_workbook_structure, operation 区分) ──
 	"+sheet-create": {"modify_workbook_structure", func(fv flagView, token, _, _ string) (map[string]interface{}, error) {
-		return sheetCreateInput(fv, token), nil
+		return sheetCreateInput(fv, token)
 	}},
-	"+sheet-delete": {"modify_workbook_structure", noErrTranslate(sheetDeleteInput)},
-	"+sheet-rename": {"modify_workbook_structure", noErrTranslate(sheetRenameInput)},
+	"+sheet-delete": {"modify_workbook_structure", sheetDeleteInput},
+	"+sheet-rename": {"modify_workbook_structure", sheetRenameInput},
 	"+sheet-move":   {"modify_workbook_structure", sheetMoveBatchInput},
-	"+sheet-copy":   {"modify_workbook_structure", noErrTranslate(sheetCopyInput)},
-	"+sheet-hide": {"modify_workbook_structure", noErrTranslate(func(fv flagView, t, sid, sn string) map[string]interface{} {
+	"+sheet-copy":   {"modify_workbook_structure", sheetCopyInput},
+	"+sheet-hide": {"modify_workbook_structure", func(fv flagView, t, sid, sn string) (map[string]interface{}, error) {
 		return sheetVisibilityInput(fv, t, sid, sn, "hide")
-	})},
-	"+sheet-unhide": {"modify_workbook_structure", noErrTranslate(func(fv flagView, t, sid, sn string) map[string]interface{} {
+	}},
+	"+sheet-unhide": {"modify_workbook_structure", func(fv flagView, t, sid, sn string) (map[string]interface{}, error) {
 		return sheetVisibilityInput(fv, t, sid, sn, "unhide")
-	})},
-	"+sheet-set-tab-color": {"modify_workbook_structure", noErrTranslate(sheetSetTabColorInput)},
+	}},
+	"+sheet-set-tab-color": {"modify_workbook_structure", sheetSetTabColorInput},
 
 	// ─── 对象族 CRUD (manage_*_object, operation 区分) ─────────────
 	"+chart-create": {"manage_chart_object", objCreateTranslate(chartSpec)},
@@ -156,11 +153,7 @@ var batchOpDispatch = map[string]batchOpMapping{
 
 	"+filter-create": {"manage_filter_object", filterCreateInput},
 	"+filter-update": {"manage_filter_object", filterUpdateInput},
-	"+filter-delete": {"manage_filter_object", func(fv flagView, token, sid, sname string) (map[string]interface{}, error) {
-		input := map[string]interface{}{"excel_id": token, "operation": "delete"}
-		sheetSelectorForToolInput(input, sid, sname)
-		return input, nil
-	}},
+	"+filter-delete": {"manage_filter_object", filterDeleteInput},
 
 	"+filter-view-create": {"manage_filter_view_object", objCreateTranslate(filterViewSpec)},
 	"+filter-view-update": {"manage_filter_view_object", objUpdateTranslate(filterViewSpec)},

--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -773,14 +773,14 @@
         "kind": "own",
         "type": "int",
         "required": "required",
-        "desc": "Start position (0-based, inclusive)"
+        "desc": "Start position (0-based)"
       },
       {
         "name": "end",
         "kind": "own",
         "type": "int",
         "required": "required",
-        "desc": "End position (0-based, inclusive)"
+        "desc": "End position (exclusive)"
       },
       {
         "name": "dry-run",
@@ -838,14 +838,14 @@
         "kind": "own",
         "type": "int",
         "required": "required",
-        "desc": "Start position (0-based, inclusive)"
+        "desc": "Start position (0-based)"
       },
       {
         "name": "end",
         "kind": "own",
         "type": "int",
         "required": "required",
-        "desc": "End position (0-based, inclusive)"
+        "desc": "End position (exclusive)"
       },
       {
         "name": "dry-run",
@@ -961,14 +961,14 @@
         "kind": "own",
         "type": "int",
         "required": "required",
-        "desc": "Start position (0-based, inclusive)"
+        "desc": "Start position (0-based)"
       },
       {
         "name": "end",
         "kind": "own",
         "type": "int",
         "required": "required",
-        "desc": "End position (0-based, inclusive)"
+        "desc": "End position (exclusive)"
       },
       {
         "name": "depth",
@@ -1046,14 +1046,14 @@
         "kind": "own",
         "type": "int",
         "required": "required",
-        "desc": "Start position (0-based, inclusive)"
+        "desc": "Start position (0-based)"
       },
       {
         "name": "end",
         "kind": "own",
         "type": "int",
         "required": "required",
-        "desc": "End position (0-based, inclusive)"
+        "desc": "End position (exclusive)"
       },
       {
         "name": "depth",
@@ -3184,7 +3184,7 @@
         "kind": "own",
         "type": "string",
         "required": "required",
-        "desc": "JSON: `{\"data_range\":\"Sheet1!A1:F1000\",\"rows\":[...],\"columns\":[...],\"values\":[...],\"filters\":[...],\"show_row_grand_total\":true,\"show_col_grand_total\":true}`",
+        "desc": "JSON: {\"rows\":[...],\"columns\":[...],\"values\":[...],\"filters\":[...],\"show_row_grand_total\":true,\"show_col_grand_total\":true} (data source goes through --source; do not put data_range here)",
         "input": [
           "file",
           "stdin"
@@ -3436,19 +3436,19 @@
         "required": "required",
         "desc": "Conditional format rule type; takes precedence over the same-named field inside `--properties`",
         "enum": [
-          "cellValue",
-          "formula",
-          "duplicate",
-          "unique",
-          "topBottom",
-          "aboveBelowAverage",
+          "duplicateValues",
+          "uniqueValues",
+          "cellIs",
+          "containsText",
+          "timePeriod",
+          "containsBlanks",
+          "notContainsBlanks",
           "dataBar",
           "colorScale",
-          "iconSet",
-          "textContains",
-          "dateOccurring",
-          "blankCell",
-          "errorCell"
+          "rank",
+          "aboveAverage",
+          "expression",
+          "iconSet"
         ]
       },
       {
@@ -3527,19 +3527,19 @@
         "required": "required",
         "desc": "Conditional format rule type; takes precedence over the same-named field inside `--properties`",
         "enum": [
-          "cellValue",
-          "formula",
-          "duplicate",
-          "unique",
-          "topBottom",
-          "aboveBelowAverage",
+          "duplicateValues",
+          "uniqueValues",
+          "cellIs",
+          "containsText",
+          "timePeriod",
+          "containsBlanks",
+          "notContainsBlanks",
           "dataBar",
           "colorScale",
-          "iconSet",
-          "textContains",
-          "dateOccurring",
-          "blankCell",
-          "errorCell"
+          "rank",
+          "aboveAverage",
+          "expression",
+          "iconSet"
         ]
       },
       {

--- a/shortcuts/sheets/execute_paths_test.go
+++ b/shortcuts/sheets/execute_paths_test.go
@@ -242,7 +242,7 @@ func TestExecute_BatchUpdate_Translated(t *testing.T) {
 	stub := toolOutputStub(testToken, "write", `{"results":[{"ok":true}]}`)
 	_, err := runShortcutWithStubs(t, BatchUpdate, []string{
 		"--url", testURL,
-		"--operations", `[{"shortcut":"+cells-set","input":{"range":"A1","cells":[[{"value":1}]]}}]`,
+		"--operations", `[{"shortcut":"+cells-set","input":{"sheet-id":"sh1","range":"A1","cells":[[{"value":1}]]}}]`,
 		"--continue-on-error",
 		"--yes",
 	}, stub)

--- a/shortcuts/sheets/helpers.go
+++ b/shortcuts/sheets/helpers.go
@@ -8,6 +8,7 @@
 package sheets
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 
@@ -77,6 +78,59 @@ func resolveSheetSelector(runtime *common.RuntimeContext) (sheetID, sheetName st
 		return "", "", common.FlagErrorf("%v", err)
 	}
 	return "", name, nil
+}
+
+// validateViaInput shrinks a shortcut's Validate to the minimal
+// "token + ask the xxxInput builder if everything else is OK" pattern.
+// The builder owns the sheet selector and shortcut-specific checks
+// (--range required, --start >= 0, ...), so Validate no longer duplicates
+// them — the same error fires whether the shortcut runs standalone or as a
+// +batch-update sub-op. Use the inline form when the builder needs extra
+// arguments (operation enum, withMergeType bool, ...).
+func validateViaInput(
+	build func(fv flagView, token, sheetID, sheetName string) (map[string]interface{}, error),
+) func(ctx context.Context, runtime *common.RuntimeContext) error {
+	return func(ctx context.Context, runtime *common.RuntimeContext) error {
+		token, err := resolveSpreadsheetToken(runtime)
+		if err != nil {
+			return err
+		}
+		sheetID := strings.TrimSpace(runtime.Str("sheet-id"))
+		sheetName := strings.TrimSpace(runtime.Str("sheet-name"))
+		_, err = build(runtime, token, sheetID, sheetName)
+		return err
+	}
+}
+
+// requireSheetSelector is the flagView-agnostic counterpart of
+// resolveSheetSelector: given the already-extracted (sheetID, sheetName) pair,
+// it enforces the same XOR and control-char rules.
+//
+// Every batchable xxxInput builder calls this at the top so the same friendly
+// error fires whether the shortcut runs standalone (Validate sees the error
+// through the builder) or as a +batch-update sub-op (translator sees it
+// directly, prefixed by operations[i]). Without this, batch sub-ops
+// missing --sheet-id would slip through CLI validation and only fail on the
+// server with an opaque "sheet undefined not found".
+func requireSheetSelector(sheetID, sheetName string) error {
+	sheetID = strings.TrimSpace(sheetID)
+	sheetName = strings.TrimSpace(sheetName)
+	if sheetID == "" && sheetName == "" {
+		return common.FlagErrorf("specify at least one of --sheet-id or --sheet-name")
+	}
+	if sheetID != "" && sheetName != "" {
+		return common.FlagErrorf("--sheet-id and --sheet-name are mutually exclusive")
+	}
+	if sheetID != "" {
+		if err := validate.RejectControlChars(sheetID, "sheet-id"); err != nil {
+			return common.FlagErrorf("%v", err)
+		}
+	} else {
+		if err := validate.RejectControlChars(sheetName, "sheet-name"); err != nil {
+			return common.FlagErrorf("%v", err)
+		}
+	}
+	return nil
 }
 
 // sheetSelectorForToolInput packs --sheet-id / --sheet-name into the tool
@@ -206,7 +260,7 @@ func borderStylesFromFlag(runtime flagView) (map[string]interface{}, error) {
 
 // requireAnyStyleFlag ensures at least one style-defining flag (style or
 // border) is set — otherwise the request would do nothing.
-func requireAnyStyleFlag(runtime *common.RuntimeContext) error {
+func requireAnyStyleFlag(runtime flagView) error {
 	if len(buildCellStyleFromFlags(runtime)) > 0 {
 		return nil
 	}

--- a/shortcuts/sheets/lark_sheet_object_crud.go
+++ b/shortcuts/sheets/lark_sheet_object_crud.go
@@ -306,18 +306,21 @@ var PivotDelete = newObjectDeleteShortcut(pivotSpec)
 // conditional format — CLI surface uses --rule-id (short), wired to the
 // tool's conditional_format_id on the wire. --rule-type and --ranges are
 // hoisted out of properties (both required, set on every CRUD write).
+//
+// Wire shape matches manage_conditional_format_object.properties — the
+// enum value lives at properties.rule_type (flat string, NOT nested under
+// a `rule` object), and ranges is a sibling array. Earlier CLI builds
+// wrote properties.rule.type which the server silently dropped — both
+// path and enum vocabulary are now aligned with the server schema (see
+// sheet-skill-spec/canonical-spec/tool-schemas/mcp-tools.json line
+// 3305-3324).
 var condFormatEnhance = func(rt flagView, input map[string]interface{}) {
 	props, _ := input["properties"].(map[string]interface{})
 	if props == nil {
 		return
 	}
 	if ruleType := strings.TrimSpace(rt.Str("rule-type")); ruleType != "" {
-		rule, _ := props["rule"].(map[string]interface{})
-		if rule == nil {
-			rule = map[string]interface{}{}
-		}
-		rule["type"] = ruleType
-		props["rule"] = rule
+		props["rule_type"] = ruleType
 	}
 	if rt.Str("ranges") != "" {
 		if arr, err := requireJSONArray(rt, "ranges"); err == nil {
@@ -648,6 +651,9 @@ func filterUpdateInput(runtime flagView, token, sheetID, sheetName string) (map[
 	if err := requireSheetSelector(sheetID, sheetName); err != nil {
 		return nil, err
 	}
+	if sheetID == "" {
+		return nil, common.FlagErrorf("+filter-update requires --sheet-id (filter_id must equal sheet_id; --sheet-name needs a network lookup unavailable here — call +workbook-info first or pass --sheet-id directly)")
+	}
 	if strings.TrimSpace(runtime.Str("range")) == "" {
 		return nil, common.FlagErrorf("--range is required")
 	}
@@ -660,6 +666,7 @@ func filterUpdateInput(runtime flagView, token, sheetID, sheetName string) (map[
 	input := map[string]interface{}{
 		"excel_id":   token,
 		"operation":  "update",
+		"filter_id":  sheetID, // server contract: filter_id === sheet_id for sheet-scoped filters
 		"properties": props,
 	}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
@@ -706,12 +713,23 @@ var FilterDelete = common.Shortcut{
 }
 
 // filterDeleteInput mirrors the standalone +filter-delete body for batch
-// sub-op reuse. filter_id is implicit (sheet-scoped), so no extra id flag.
+// sub-op reuse. Server contract: filter_id === sheet_id, and update/delete
+// must populate filter_id (per manage_filter_object schema). The CLI has no
+// separate --filter-id flag because the value is fully derived from sheet_id;
+// only --sheet-id is accepted (not --sheet-name, since there's no mid-call
+// network lookup to resolve it).
 func filterDeleteInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
 	if err := requireSheetSelector(sheetID, sheetName); err != nil {
 		return nil, err
 	}
-	input := map[string]interface{}{"excel_id": token, "operation": "delete"}
+	if sheetID == "" {
+		return nil, common.FlagErrorf("+filter-delete requires --sheet-id (filter_id must equal sheet_id; --sheet-name needs a network lookup unavailable here — call +workbook-info first or pass --sheet-id directly)")
+	}
+	input := map[string]interface{}{
+		"excel_id":  token,
+		"operation": "delete",
+		"filter_id": sheetID, // server contract: filter_id === sheet_id
+	}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
 	return input, nil
 }

--- a/shortcuts/sheets/lark_sheet_object_crud.go
+++ b/shortcuts/sheets/lark_sheet_object_crud.go
@@ -58,13 +58,13 @@ func newObjectCreateShortcut(spec objectCRUDSpec) common.Shortcut {
 		HasFormat:   true,
 		Flags:       flags,
 		Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			if _, err := resolveSpreadsheetToken(runtime); err != nil {
+			token, err := resolveSpreadsheetToken(runtime)
+			if err != nil {
 				return err
 			}
-			if _, _, err := resolveSheetSelector(runtime); err != nil {
-				return err
-			}
-			_, err := requireJSONObject(runtime, "properties")
+			sheetID := strings.TrimSpace(runtime.Str("sheet-id"))
+			sheetName := strings.TrimSpace(runtime.Str("sheet-name"))
+			_, err = objectCreateInput(runtime, token, sheetID, sheetName, spec)
 			return err
 		},
 		DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
@@ -97,6 +97,9 @@ func newObjectCreateShortcut(spec objectCRUDSpec) common.Shortcut {
 }
 
 func objectCreateInput(runtime flagView, token, sheetID, sheetName string, spec objectCRUDSpec) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
 	props, err := requireJSONObject(runtime, "properties")
 	if err != nil {
 		return nil, err
@@ -125,16 +128,13 @@ func newObjectUpdateShortcut(spec objectCRUDSpec) common.Shortcut {
 		HasFormat:   true,
 		Flags:       flags,
 		Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			if _, err := resolveSpreadsheetToken(runtime); err != nil {
+			token, err := resolveSpreadsheetToken(runtime)
+			if err != nil {
 				return err
 			}
-			if _, _, err := resolveSheetSelector(runtime); err != nil {
-				return err
-			}
-			if spec.idFlag != "" && strings.TrimSpace(runtime.Str(spec.idFlag)) == "" {
-				return common.FlagErrorf("--%s is required", spec.idFlag)
-			}
-			_, err := requireJSONObject(runtime, "properties")
+			sheetID := strings.TrimSpace(runtime.Str("sheet-id"))
+			sheetName := strings.TrimSpace(runtime.Str("sheet-name"))
+			_, err = objectUpdateInput(runtime, token, sheetID, sheetName, spec)
 			return err
 		},
 		DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
@@ -167,6 +167,12 @@ func newObjectUpdateShortcut(spec objectCRUDSpec) common.Shortcut {
 }
 
 func objectUpdateInput(runtime flagView, token, sheetID, sheetName string, spec objectCRUDSpec) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if spec.idFlag != "" && strings.TrimSpace(runtime.Str(spec.idFlag)) == "" {
+		return nil, common.FlagErrorf("--%s is required", spec.idFlag)
+	}
 	props, err := requireJSONObject(runtime, "properties")
 	if err != nil {
 		return nil, err
@@ -198,21 +204,20 @@ func newObjectDeleteShortcut(spec objectCRUDSpec) common.Shortcut {
 		HasFormat:   true,
 		Flags:       flags,
 		Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			if _, err := resolveSpreadsheetToken(runtime); err != nil {
+			token, err := resolveSpreadsheetToken(runtime)
+			if err != nil {
 				return err
 			}
-			if _, _, err := resolveSheetSelector(runtime); err != nil {
-				return err
-			}
-			if spec.idFlag != "" && strings.TrimSpace(runtime.Str(spec.idFlag)) == "" {
-				return common.FlagErrorf("--%s is required", spec.idFlag)
-			}
-			return nil
+			sheetID := strings.TrimSpace(runtime.Str("sheet-id"))
+			sheetName := strings.TrimSpace(runtime.Str("sheet-name"))
+			_, err = objectDeleteInput(runtime, token, sheetID, sheetName, spec)
+			return err
 		},
 		DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 			token, _ := resolveSpreadsheetToken(runtime)
 			sheetID, sheetName, _ := resolveSheetSelector(runtime)
-			return invokeToolDryRun(token, ToolKindWrite, spec.toolName, objectDeleteInput(runtime, token, sheetID, sheetName, spec))
+			input, _ := objectDeleteInput(runtime, token, sheetID, sheetName, spec)
+			return invokeToolDryRun(token, ToolKindWrite, spec.toolName, input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 			token, err := resolveSpreadsheetToken(runtime)
@@ -223,7 +228,11 @@ func newObjectDeleteShortcut(spec objectCRUDSpec) common.Shortcut {
 			if err != nil {
 				return err
 			}
-			out, err := callTool(ctx, runtime, token, ToolKindWrite, spec.toolName, objectDeleteInput(runtime, token, sheetID, sheetName, spec))
+			input, err := objectDeleteInput(runtime, token, sheetID, sheetName, spec)
+			if err != nil {
+				return err
+			}
+			out, err := callTool(ctx, runtime, token, ToolKindWrite, spec.toolName, input)
 			if err != nil {
 				return err
 			}
@@ -233,7 +242,13 @@ func newObjectDeleteShortcut(spec objectCRUDSpec) common.Shortcut {
 	}
 }
 
-func objectDeleteInput(runtime flagView, token, sheetID, sheetName string, spec objectCRUDSpec) map[string]interface{} {
+func objectDeleteInput(runtime flagView, token, sheetID, sheetName string, spec objectCRUDSpec) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if spec.idFlag != "" && strings.TrimSpace(runtime.Str(spec.idFlag)) == "" {
+		return nil, common.FlagErrorf("--%s is required", spec.idFlag)
+	}
 	input := map[string]interface{}{
 		"excel_id":  token,
 		"operation": "delete",
@@ -242,7 +257,7 @@ func objectDeleteInput(runtime flagView, token, sheetID, sheetName string, spec 
 	if spec.idFlag != "" {
 		input[spec.idField] = strings.TrimSpace(runtime.Str(spec.idFlag))
 	}
-	return input
+	return input, nil
 }
 
 // ─── per-object instantiations ────────────────────────────────────────
@@ -399,16 +414,13 @@ func newFloatImageWriteShortcut(command, description, op string, withIDFlag, isH
 		HasFormat:   true,
 		Flags:       flags,
 		Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			if _, err := resolveSpreadsheetToken(runtime); err != nil {
+			token, err := resolveSpreadsheetToken(runtime)
+			if err != nil {
 				return err
 			}
-			if _, _, err := resolveSheetSelector(runtime); err != nil {
-				return err
-			}
-			if withIDFlag && strings.TrimSpace(runtime.Str("float-image-id")) == "" {
-				return common.FlagErrorf("--float-image-id is required")
-			}
-			_, err := floatImageProperties(runtime)
+			sheetID := strings.TrimSpace(runtime.Str("sheet-id"))
+			sheetName := strings.TrimSpace(runtime.Str("sheet-name"))
+			_, err = floatImageWriteInput(runtime, token, sheetID, sheetName, op, withIDFlag)
 			return err
 		},
 		DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
@@ -441,6 +453,12 @@ func newFloatImageWriteShortcut(command, description, op string, withIDFlag, isH
 }
 
 func floatImageWriteInput(runtime flagView, token, sheetID, sheetName, op string, withIDFlag bool) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if withIDFlag && strings.TrimSpace(runtime.Str("float-image-id")) == "" {
+		return nil, common.FlagErrorf("--float-image-id is required")
+	}
 	props, err := floatImageProperties(runtime)
 	if err != nil {
 		return nil, err
@@ -525,23 +543,7 @@ var FilterCreate = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+filter-create"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if strings.TrimSpace(runtime.Str("range")) == "" {
-			return common.FlagErrorf("--range is required")
-		}
-		if runtime.Str("properties") != "" {
-			if _, err := requireJSONObject(runtime, "properties"); err != nil {
-				return err
-			}
-		}
-		return nil
-	},
+	Validate:    validateViaInput(filterCreateInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
@@ -571,6 +573,12 @@ var FilterCreate = common.Shortcut{
 }
 
 func filterCreateInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(runtime.Str("range")) == "" {
+		return nil, common.FlagErrorf("--range is required")
+	}
 	props := map[string]interface{}{
 		"range": strings.TrimSpace(runtime.Str("range")),
 	}
@@ -607,19 +615,7 @@ var FilterUpdate = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+filter-update"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if strings.TrimSpace(runtime.Str("range")) == "" {
-			return common.FlagErrorf("--range is required")
-		}
-		_, err := requireJSONObject(runtime, "properties")
-		return err
-	},
+	Validate:    validateViaInput(filterUpdateInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
@@ -649,6 +645,12 @@ var FilterUpdate = common.Shortcut{
 }
 
 func filterUpdateInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(runtime.Str("range")) == "" {
+		return nil, common.FlagErrorf("--range is required")
+	}
 	props, err := requireJSONObject(runtime, "properties")
 	if err != nil {
 		return nil, err
@@ -674,18 +676,11 @@ var FilterDelete = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+filter-delete"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		_, _, err := resolveSheetSelector(runtime)
-		return err
-	},
+	Validate:    validateViaInput(filterDeleteInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		input := map[string]interface{}{"excel_id": token, "operation": "delete"}
-		sheetSelectorForToolInput(input, sheetID, sheetName)
+		input, _ := filterDeleteInput(runtime, token, sheetID, sheetName)
 		return invokeToolDryRun(token, ToolKindWrite, "manage_filter_object", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
@@ -697,8 +692,10 @@ var FilterDelete = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		input := map[string]interface{}{"excel_id": token, "operation": "delete"}
-		sheetSelectorForToolInput(input, sheetID, sheetName)
+		input, err := filterDeleteInput(runtime, token, sheetID, sheetName)
+		if err != nil {
+			return err
+		}
 		out, err := callTool(ctx, runtime, token, ToolKindWrite, "manage_filter_object", input)
 		if err != nil {
 			return err
@@ -706,4 +703,15 @@ var FilterDelete = common.Shortcut{
 		runtime.Out(out, nil)
 		return nil
 	},
+}
+
+// filterDeleteInput mirrors the standalone +filter-delete body for batch
+// sub-op reuse. filter_id is implicit (sheet-scoped), so no extra id flag.
+func filterDeleteInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	input := map[string]interface{}{"excel_id": token, "operation": "delete"}
+	sheetSelectorForToolInput(input, sheetID, sheetName)
+	return input, nil
 }

--- a/shortcuts/sheets/lark_sheet_object_crud_test.go
+++ b/shortcuts/sheets/lark_sheet_object_crud_test.go
@@ -89,15 +89,19 @@ func TestObjectCRUDShortcuts_DryRun(t *testing.T) {
 				"pivot_table_id": "ptA",
 			},
 		},
-		// cond-format — --rule-id rename + --rule-type / --ranges hoist
+		// cond-format — --rule-id rename + --rule-type / --ranges hoist.
+		// rule_type lives at properties.rule_type (flat string), not nested
+		// under a `rule` object; enum vocabulary matches server schema
+		// (cellIs / duplicateValues / ... — see mcp-tools.json
+		// manage_conditional_format_object.properties.rule_type).
 		{
 			name: "+cond-format-update id rename + rule-type/ranges",
 			sc:   CondFormatUpdate,
 			args: []string{
 				"--url", testURL, "--sheet-id", testSheetID,
 				"--rule-id", "ruleA",
-				"--properties", `{"rule":{"operator":"greater_than","value":100}}`,
-				"--rule-type", "cellValue",
+				"--properties", `{"attrs":[{"operator":"greaterThan","value":"100"}],"style":{"back_color":"#FFD7D7"}}`,
+				"--rule-type", "cellIs",
 				"--ranges", `["A1:A100"]`,
 			},
 			toolName: "manage_conditional_format_object",
@@ -107,8 +111,10 @@ func TestObjectCRUDShortcuts_DryRun(t *testing.T) {
 				"operation":             "update",
 				"conditional_format_id": "ruleA",
 				"properties": map[string]interface{}{
-					"rule":   map[string]interface{}{"operator": "greater_than", "value": float64(100), "type": "cellValue"},
-					"ranges": []interface{}{"A1:A100"},
+					"rule_type": "cellIs",
+					"attrs":     []interface{}{map[string]interface{}{"operator": "greaterThan", "value": "100"}},
+					"style":     map[string]interface{}{"back_color": "#FFD7D7"},
+					"ranges":    []interface{}{"A1:A100"},
 				},
 			},
 		},
@@ -138,14 +144,41 @@ func TestObjectCRUDShortcuts_DryRun(t *testing.T) {
 			},
 		},
 		{
-			name:     "+filter-delete (no id flag, sheet-scoped)",
+			// +filter-delete has no separate --filter-id flag because the
+			// server contract sets filter_id === sheet_id; the translator
+			// auto-injects filter_id from --sheet-id. update/delete fail
+			// hard when only --sheet-name is given (no mid-call lookup).
+			name:     "+filter-delete (sheet-scoped, auto-injects filter_id=sheet_id)",
 			sc:       FilterDelete,
 			args:     []string{"--url", testURL, "--sheet-id", testSheetID},
 			toolName: "manage_filter_object",
 			wantInput: map[string]interface{}{
 				"excel_id":  testToken,
 				"sheet_id":  testSheetID,
+				"filter_id": testSheetID,
 				"operation": "delete",
+			},
+		},
+		{
+			// +filter-update auto-injects filter_id from sheet_id, hoists
+			// --range out of properties, and merges properties.rules.
+			name: "+filter-update auto-injects filter_id, hoists --range",
+			sc:   FilterUpdate,
+			args: []string{
+				"--url", testURL, "--sheet-id", testSheetID,
+				"--range", "A1:F1000",
+				"--properties", `{"rules":[{"col":"B"}]}`,
+			},
+			toolName: "manage_filter_object",
+			wantInput: map[string]interface{}{
+				"excel_id":  testToken,
+				"sheet_id":  testSheetID,
+				"filter_id": testSheetID,
+				"operation": "update",
+				"properties": map[string]interface{}{
+					"range": "A1:F1000",
+					"rules": []interface{}{map[string]interface{}{"col": "B"}},
+				},
 			},
 		},
 		// filter-view CRUD (cli-only via callTool)

--- a/shortcuts/sheets/lark_sheet_range_operations.go
+++ b/shortcuts/sheets/lark_sheet_range_operations.go
@@ -36,22 +36,12 @@ var CellsClear = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+cells-clear"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if strings.TrimSpace(runtime.Str("range")) == "" {
-			return common.FlagErrorf("--range is required")
-		}
-		return nil
-	},
+	Validate:    validateViaInput(cellsClearInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "clear_cell_range", cellsClearInput(runtime, token, sheetID, sheetName))
+		input, _ := cellsClearInput(runtime, token, sheetID, sheetName)
+		return invokeToolDryRun(token, ToolKindWrite, "clear_cell_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -62,7 +52,11 @@ var CellsClear = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "clear_cell_range", cellsClearInput(runtime, token, sheetID, sheetName))
+		input, err := cellsClearInput(runtime, token, sheetID, sheetName)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "clear_cell_range", input)
 		if err != nil {
 			return err
 		}
@@ -74,7 +68,13 @@ var CellsClear = common.Shortcut{
 	},
 }
 
-func cellsClearInput(runtime flagView, token, sheetID, sheetName string) map[string]interface{} {
+func cellsClearInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(runtime.Str("range")) == "" {
+		return nil, common.FlagErrorf("--range is required")
+	}
 	scope := runtime.Str("scope")
 	clearType := "contents"
 	switch scope {
@@ -89,7 +89,7 @@ func cellsClearInput(runtime flagView, token, sheetID, sheetName string) map[str
 		"clear_type": clearType,
 	}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
-	return input
+	return input, nil
 }
 
 // CellsMerge / CellsUnmerge share the merge_cells tool, dispatched by the
@@ -114,21 +114,20 @@ func newMergeShortcut(command, desc, op string, withMergeType bool) common.Short
 		HasFormat:   true,
 		Flags:       flags,
 		Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			if _, err := resolveSpreadsheetToken(runtime); err != nil {
+			token, err := resolveSpreadsheetToken(runtime)
+			if err != nil {
 				return err
 			}
-			if _, _, err := resolveSheetSelector(runtime); err != nil {
-				return err
-			}
-			if strings.TrimSpace(runtime.Str("range")) == "" {
-				return common.FlagErrorf("--range is required")
-			}
-			return nil
+			sheetID := strings.TrimSpace(runtime.Str("sheet-id"))
+			sheetName := strings.TrimSpace(runtime.Str("sheet-name"))
+			_, err = mergeInput(runtime, token, sheetID, sheetName, op, withMergeType)
+			return err
 		},
 		DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 			token, _ := resolveSpreadsheetToken(runtime)
 			sheetID, sheetName, _ := resolveSheetSelector(runtime)
-			return invokeToolDryRun(token, ToolKindWrite, "merge_cells", mergeInput(runtime, token, sheetID, sheetName, op, withMergeType))
+			input, _ := mergeInput(runtime, token, sheetID, sheetName, op, withMergeType)
+			return invokeToolDryRun(token, ToolKindWrite, "merge_cells", input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 			token, err := resolveSpreadsheetToken(runtime)
@@ -139,7 +138,11 @@ func newMergeShortcut(command, desc, op string, withMergeType bool) common.Short
 			if err != nil {
 				return err
 			}
-			out, err := callTool(ctx, runtime, token, ToolKindWrite, "merge_cells", mergeInput(runtime, token, sheetID, sheetName, op, withMergeType))
+			input, err := mergeInput(runtime, token, sheetID, sheetName, op, withMergeType)
+			if err != nil {
+				return err
+			}
+			out, err := callTool(ctx, runtime, token, ToolKindWrite, "merge_cells", input)
 			if err != nil {
 				return err
 			}
@@ -149,7 +152,13 @@ func newMergeShortcut(command, desc, op string, withMergeType bool) common.Short
 	}
 }
 
-func mergeInput(runtime flagView, token, sheetID, sheetName, op string, withMergeType bool) map[string]interface{} {
+func mergeInput(runtime flagView, token, sheetID, sheetName, op string, withMergeType bool) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(runtime.Str("range")) == "" {
+		return nil, common.FlagErrorf("--range is required")
+	}
 	input := map[string]interface{}{
 		"excel_id":  token,
 		"range":     strings.TrimSpace(runtime.Str("range")),
@@ -163,7 +172,7 @@ func mergeInput(runtime flagView, token, sheetID, sheetName, op string, withMerg
 			input["merge_type"] = "all"
 		}
 	}
-	return input
+	return input, nil
 }
 
 // resize_range now exposes two CLI shortcuts:
@@ -190,11 +199,12 @@ var RowsResize = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+rows-resize"),
-	Validate:    validateResize("row"),
+	Validate:    validateViaResize("row"),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "resize_range", resizeInput(runtime, token, sheetID, sheetName, "row"))
+		input, _ := resizeInput(runtime, token, sheetID, sheetName, "row")
+		return invokeToolDryRun(token, ToolKindWrite, "resize_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -205,7 +215,11 @@ var RowsResize = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "resize_range", resizeInput(runtime, token, sheetID, sheetName, "row"))
+		input, err := resizeInput(runtime, token, sheetID, sheetName, "row")
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "resize_range", input)
 		if err != nil {
 			return err
 		}
@@ -225,11 +239,12 @@ var ColsResize = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+cols-resize"),
-	Validate:    validateResize("column"),
+	Validate:    validateViaResize("column"),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "resize_range", resizeInput(runtime, token, sheetID, sheetName, "column"))
+		input, _ := resizeInput(runtime, token, sheetID, sheetName, "column")
+		return invokeToolDryRun(token, ToolKindWrite, "resize_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -240,7 +255,11 @@ var ColsResize = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "resize_range", resizeInput(runtime, token, sheetID, sheetName, "column"))
+		input, err := resizeInput(runtime, token, sheetID, sheetName, "column")
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "resize_range", input)
 		if err != nil {
 			return err
 		}
@@ -249,38 +268,19 @@ var ColsResize = common.Shortcut{
 	},
 }
 
-// validateResize returns a Validate closure shared by both rows/cols shortcuts.
-// dimension is either "row" or "column"; the closure rejects --type auto on
-// columns (column widths do not support auto-fit).
-func validateResize(dimension string) func(ctx context.Context, runtime *common.RuntimeContext) error {
+// validateViaResize wires the standalone Validate to resizeInput so both
+// paths (standalone + batch sub-op) emit the same error for missing --type,
+// out-of-range --start/--end, or --type auto on columns.
+func validateViaResize(dimension string) func(ctx context.Context, runtime *common.RuntimeContext) error {
 	return func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
+		token, err := resolveSpreadsheetToken(runtime)
+		if err != nil {
 			return err
 		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if !runtime.Changed("start") || !runtime.Changed("end") {
-			return common.FlagErrorf("--start and --end are required")
-		}
-		if runtime.Int("start") < 0 || runtime.Int("end") < runtime.Int("start") {
-			return common.FlagErrorf("invalid range: --start (%d) must be >= 0 and --end (%d) must be >= --start", runtime.Int("start"), runtime.Int("end"))
-		}
-		typ := strings.TrimSpace(runtime.Str("type"))
-		if typ == "" {
-			return common.FlagErrorf("--type is required (pixel / standard%s)", autoSuffix(dimension))
-		}
-		if dimension == "column" && typ == "auto" {
-			return common.FlagErrorf("--type auto is rows-only (column widths do not support auto-fit); use +rows-resize")
-		}
-		hasSize := runtime.Changed("size") && runtime.Int("size") > 0
-		if typ == "pixel" && !hasSize {
-			return common.FlagErrorf("--type pixel requires --size <px>")
-		}
-		if typ != "pixel" && hasSize {
-			return common.FlagErrorf("--size is only valid with --type pixel")
-		}
-		return nil
+		sheetID := strings.TrimSpace(runtime.Str("sheet-id"))
+		sheetName := strings.TrimSpace(runtime.Str("sheet-name"))
+		_, err = resizeInput(runtime, token, sheetID, sheetName, dimension)
+		return err
 	}
 }
 
@@ -297,14 +297,36 @@ func autoSuffix(dimension string) string {
 // exclusive end, so it is bumped by one here. dimRangeFull (not dimRange) is
 // used so a single row/column still emits "N:N" — resize_range rejects a bare
 // "N".
-func resizeInput(runtime flagView, token, sheetID, sheetName, dimension string) map[string]interface{} {
+func resizeInput(runtime flagView, token, sheetID, sheetName, dimension string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if !runtime.Changed("start") || !runtime.Changed("end") {
+		return nil, common.FlagErrorf("--start and --end are required")
+	}
+	if runtime.Int("start") < 0 || runtime.Int("end") < runtime.Int("start") {
+		return nil, common.FlagErrorf("invalid range: --start (%d) must be >= 0 and --end (%d) must be >= --start", runtime.Int("start"), runtime.Int("end"))
+	}
+	typ := strings.TrimSpace(runtime.Str("type"))
+	if typ == "" {
+		return nil, common.FlagErrorf("--type is required (pixel / standard%s)", autoSuffix(dimension))
+	}
+	if dimension == "column" && typ == "auto" {
+		return nil, common.FlagErrorf("--type auto is rows-only (column widths do not support auto-fit); use +rows-resize")
+	}
+	hasSize := runtime.Changed("size") && runtime.Int("size") > 0
+	if typ == "pixel" && !hasSize {
+		return nil, common.FlagErrorf("--type pixel requires --size <px>")
+	}
+	if typ != "pixel" && hasSize {
+		return nil, common.FlagErrorf("--size is only valid with --type pixel")
+	}
 	rangeStr := dimRangeFull(dimension, runtime.Int("start"), runtime.Int("end")+1)
 	input := map[string]interface{}{
 		"excel_id": token,
 		"range":    rangeStr,
 	}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
-	typ := strings.TrimSpace(runtime.Str("type"))
 	sizeBlock := map[string]interface{}{"type": typ}
 	if typ == "pixel" {
 		sizeBlock["value"] = runtime.Int("size")
@@ -314,7 +336,7 @@ func resizeInput(runtime flagView, token, sheetID, sheetName, dimension string) 
 	} else {
 		input["resize_width"] = sizeBlock
 	}
-	return input
+	return input, nil
 }
 
 // ─── transform_range (4 shortcuts) ────────────────────────────────────
@@ -334,7 +356,7 @@ var RangeMove = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+range-move"),
-	Validate:    validateRangeMoveOrCopy,
+	Validate:    validateRangeMoveOrCopy("move", false),
 	DryRun:      transformDryRunFn("move", false, false),
 	Execute:     transformExecuteFn("move", false, false),
 }
@@ -350,7 +372,7 @@ var RangeCopy = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+range-copy"),
-	Validate:    validateRangeMoveOrCopy,
+	Validate:    validateRangeMoveOrCopy("copy", true),
 	DryRun:      transformDryRunFn("copy", true, false),
 	Execute:     transformExecuteFn("copy", true, false),
 }
@@ -368,25 +390,12 @@ var RangeFill = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+range-fill"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if strings.TrimSpace(runtime.Str("source-range")) == "" {
-			return common.FlagErrorf("--source-range is required")
-		}
-		if strings.TrimSpace(runtime.Str("target-range")) == "" {
-			return common.FlagErrorf("--target-range is required")
-		}
-		return nil
-	},
+	Validate:    validateViaInput(rangeFillInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "transform_range", rangeFillInput(runtime, token, sheetID, sheetName))
+		input, _ := rangeFillInput(runtime, token, sheetID, sheetName)
+		return invokeToolDryRun(token, ToolKindWrite, "transform_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -397,7 +406,11 @@ var RangeFill = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "transform_range", rangeFillInput(runtime, token, sheetID, sheetName))
+		input, err := rangeFillInput(runtime, token, sheetID, sheetName)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "transform_range", input)
 		if err != nil {
 			return err
 		}
@@ -416,21 +429,7 @@ var RangeSort = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+range-sort"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if strings.TrimSpace(runtime.Str("range")) == "" {
-			return common.FlagErrorf("--range is required")
-		}
-		if _, err := requireJSONArray(runtime, "sort-keys"); err != nil {
-			return err
-		}
-		return nil
-	},
+	Validate:    validateViaInput(rangeSortInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
@@ -461,28 +460,28 @@ var RangeSort = common.Shortcut{
 
 // ─── transform_range helpers ──────────────────────────────────────────
 
-func validateRangeMoveOrCopy(ctx context.Context, runtime *common.RuntimeContext) error {
-	if _, err := resolveSpreadsheetToken(runtime); err != nil {
+// validateRangeMoveOrCopy wires the standalone Validate to transformMoveCopyInput
+// so missing --source-range / --target-range fire the same friendly error on
+// the batch sub-op path.
+func validateRangeMoveOrCopy(op string, withPasteType bool) func(ctx context.Context, runtime *common.RuntimeContext) error {
+	return func(ctx context.Context, runtime *common.RuntimeContext) error {
+		token, err := resolveSpreadsheetToken(runtime)
+		if err != nil {
+			return err
+		}
+		sheetID := strings.TrimSpace(runtime.Str("sheet-id"))
+		sheetName := strings.TrimSpace(runtime.Str("sheet-name"))
+		_, err = transformMoveCopyInput(runtime, token, sheetID, sheetName, op, withPasteType)
 		return err
 	}
-	if _, _, err := resolveSheetSelector(runtime); err != nil {
-		return err
-	}
-	if strings.TrimSpace(runtime.Str("source-range")) == "" {
-		return common.FlagErrorf("--source-range is required")
-	}
-	if strings.TrimSpace(runtime.Str("target-range")) == "" {
-		return common.FlagErrorf("--target-range is required")
-	}
-	return nil
 }
 
 func transformDryRunFn(op string, withPasteType, _ bool) func(context.Context, *common.RuntimeContext) *common.DryRunAPI {
 	return func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "transform_range",
-			transformMoveCopyInput(runtime, token, sheetID, sheetName, op, withPasteType))
+		input, _ := transformMoveCopyInput(runtime, token, sheetID, sheetName, op, withPasteType)
+		return invokeToolDryRun(token, ToolKindWrite, "transform_range", input)
 	}
 }
 
@@ -496,8 +495,11 @@ func transformExecuteFn(op string, withPasteType, _ bool) func(context.Context, 
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "transform_range",
-			transformMoveCopyInput(runtime, token, sheetID, sheetName, op, withPasteType))
+		input, err := transformMoveCopyInput(runtime, token, sheetID, sheetName, op, withPasteType)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "transform_range", input)
 		if err != nil {
 			return err
 		}
@@ -506,7 +508,16 @@ func transformExecuteFn(op string, withPasteType, _ bool) func(context.Context, 
 	}
 }
 
-func transformMoveCopyInput(runtime flagView, token, sheetID, sheetName, op string, withPasteType bool) map[string]interface{} {
+func transformMoveCopyInput(runtime flagView, token, sheetID, sheetName, op string, withPasteType bool) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(runtime.Str("source-range")) == "" {
+		return nil, common.FlagErrorf("--source-range is required")
+	}
+	if strings.TrimSpace(runtime.Str("target-range")) == "" {
+		return nil, common.FlagErrorf("--target-range is required")
+	}
 	input := map[string]interface{}{
 		"excel_id":          token,
 		"operation":         op,
@@ -522,7 +533,7 @@ func transformMoveCopyInput(runtime flagView, token, sheetID, sheetName, op stri
 			input["paste_type"] = pasteTypeToTool(pt)
 		}
 	}
-	return input
+	return input, nil
 }
 
 // pasteTypeToTool maps the CLI vocabulary (values / formulas / formats / all)
@@ -539,7 +550,16 @@ func pasteTypeToTool(pt string) string {
 	return "all"
 }
 
-func rangeFillInput(runtime flagView, token, sheetID, sheetName string) map[string]interface{} {
+func rangeFillInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(runtime.Str("source-range")) == "" {
+		return nil, common.FlagErrorf("--source-range is required")
+	}
+	if strings.TrimSpace(runtime.Str("target-range")) == "" {
+		return nil, common.FlagErrorf("--target-range is required")
+	}
 	input := map[string]interface{}{
 		"excel_id":          token,
 		"operation":         "fill",
@@ -548,7 +568,7 @@ func rangeFillInput(runtime flagView, token, sheetID, sheetName string) map[stri
 		"fill_type":         fillSeriesToToolType(runtime.Str("series-type")),
 	}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
-	return input
+	return input, nil
 }
 
 // fillSeriesToToolType maps the CLI series vocabulary to the tool's fill_type.
@@ -563,6 +583,12 @@ func fillSeriesToToolType(seriesType string) string {
 }
 
 func rangeSortInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(runtime.Str("range")) == "" {
+		return nil, common.FlagErrorf("--range is required")
+	}
 	keys, err := requireJSONArray(runtime, "sort-keys")
 	if err != nil {
 		return nil, err

--- a/shortcuts/sheets/lark_sheet_search_replace.go
+++ b/shortcuts/sheets/lark_sheet_search_replace.go
@@ -114,25 +114,12 @@ var CellsReplace = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+cells-replace"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if strings.TrimSpace(runtime.Str("find")) == "" {
-			return common.FlagErrorf("--find is required")
-		}
-		if !runtime.Changed("replacement") {
-			return common.FlagErrorf("--replacement is required (pass an empty string to delete matches)")
-		}
-		return nil
-	},
+	Validate:    validateViaInput(replaceInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "replace_data", replaceInput(runtime, token, sheetID, sheetName))
+		input, _ := replaceInput(runtime, token, sheetID, sheetName)
+		return invokeToolDryRun(token, ToolKindWrite, "replace_data", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -143,7 +130,11 @@ var CellsReplace = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "replace_data", replaceInput(runtime, token, sheetID, sheetName))
+		input, err := replaceInput(runtime, token, sheetID, sheetName)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "replace_data", input)
 		if err != nil {
 			return err
 		}
@@ -155,7 +146,16 @@ var CellsReplace = common.Shortcut{
 	},
 }
 
-func replaceInput(runtime flagView, token, sheetID, sheetName string) map[string]interface{} {
+func replaceInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(runtime.Str("find")) == "" {
+		return nil, common.FlagErrorf("--find is required")
+	}
+	if !runtime.Changed("replacement") {
+		return nil, common.FlagErrorf("--replacement is required (pass an empty string to delete matches)")
+	}
 	input := map[string]interface{}{
 		"excel_id":     token,
 		"search_term":  runtime.Str("find"),
@@ -168,5 +168,5 @@ func replaceInput(runtime flagView, token, sheetID, sheetName string) map[string
 	if opts := searchReplaceOptions(runtime); len(opts) > 0 {
 		input["options"] = opts
 	}
-	return input
+	return input, nil
 }

--- a/shortcuts/sheets/lark_sheet_sheet_structure.go
+++ b/shortcuts/sheets/lark_sheet_sheet_structure.go
@@ -124,11 +124,12 @@ var DimInsert = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+dim-insert"),
-	Validate:    validateDimRange,
+	Validate:    validateViaInput(dimInsertInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", dimInsertInput(runtime, token, sheetID, sheetName))
+		input, _ := dimInsertInput(runtime, token, sheetID, sheetName)
+		return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -139,7 +140,11 @@ var DimInsert = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_sheet_structure", dimInsertInput(runtime, token, sheetID, sheetName))
+		input, err := dimInsertInput(runtime, token, sheetID, sheetName)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_sheet_structure", input)
 		if err != nil {
 			return err
 		}
@@ -148,7 +153,13 @@ var DimInsert = common.Shortcut{
 	},
 }
 
-func dimInsertInput(runtime flagView, token, sheetID, sheetName string) map[string]interface{} {
+func dimInsertInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if err := requireDimRange(runtime); err != nil {
+		return nil, err
+	}
 	dim := runtime.Str("dimension")
 	start := runtime.Int("start")
 	end := runtime.Int("end")
@@ -165,7 +176,7 @@ func dimInsertInput(runtime flagView, token, sheetID, sheetName string) map[stri
 	case "after":
 		input["side"] = "after"
 	}
-	return input
+	return input, nil
 }
 
 // DimDelete deletes rows / columns — irreversible, high-risk-write.
@@ -178,11 +189,12 @@ var DimDelete = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+dim-delete"),
-	Validate:    validateDimRange,
+	Validate:    validateDimRangeOp("delete"),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", dimRangeOpInput(runtime, token, sheetID, sheetName, "delete"))
+		input, _ := dimRangeOpInput(runtime, token, sheetID, sheetName, "delete")
+		return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -193,7 +205,11 @@ var DimDelete = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_sheet_structure", dimRangeOpInput(runtime, token, sheetID, sheetName, "delete"))
+		input, err := dimRangeOpInput(runtime, token, sheetID, sheetName, "delete")
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_sheet_structure", input)
 		if err != nil {
 			return err
 		}
@@ -203,6 +219,36 @@ var DimDelete = common.Shortcut{
 	Tips: []string{
 		"Row/column deletion is irreversible. Always preview with --dry-run first.",
 	},
+}
+
+// validateDimRangeOp returns a Validate closure that delegates to
+// dimRangeOpInput for shortcuts (delete/hide/unhide) whose builder takes an
+// extra `op` argument. Token check happens here; the rest is the builder.
+func validateDimRangeOp(op string) func(ctx context.Context, runtime *common.RuntimeContext) error {
+	return func(ctx context.Context, runtime *common.RuntimeContext) error {
+		token, err := resolveSpreadsheetToken(runtime)
+		if err != nil {
+			return err
+		}
+		sheetID := strings.TrimSpace(runtime.Str("sheet-id"))
+		sheetName := strings.TrimSpace(runtime.Str("sheet-name"))
+		_, err = dimRangeOpInput(runtime, token, sheetID, sheetName, op)
+		return err
+	}
+}
+
+// validateDimGroupOp is the group/ungroup counterpart of validateDimRangeOp.
+func validateDimGroupOp(op string) func(ctx context.Context, runtime *common.RuntimeContext) error {
+	return func(ctx context.Context, runtime *common.RuntimeContext) error {
+		token, err := resolveSpreadsheetToken(runtime)
+		if err != nil {
+			return err
+		}
+		sheetID := strings.TrimSpace(runtime.Str("sheet-id"))
+		sheetName := strings.TrimSpace(runtime.Str("sheet-name"))
+		_, err = dimGroupInput(runtime, token, sheetID, sheetName, op)
+		return err
+	}
 }
 
 // DimHide / DimUnhide toggle visibility on a row/column range.
@@ -232,28 +278,12 @@ var DimFreeze = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+dim-freeze"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if !runtime.Changed("dimension") {
-			return common.FlagErrorf("--dimension is required")
-		}
-		if !runtime.Changed("count") {
-			return common.FlagErrorf("--count is required (0 unfreezes)")
-		}
-		if runtime.Int("count") < 0 {
-			return common.FlagErrorf("--count must be >= 0")
-		}
-		return nil
-	},
+	Validate:    validateViaInput(dimFreezeInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", dimFreezeInput(runtime, token, sheetID, sheetName))
+		input, _ := dimFreezeInput(runtime, token, sheetID, sheetName)
+		return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -264,7 +294,11 @@ var DimFreeze = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_sheet_structure", dimFreezeInput(runtime, token, sheetID, sheetName))
+		input, err := dimFreezeInput(runtime, token, sheetID, sheetName)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_sheet_structure", input)
 		if err != nil {
 			return err
 		}
@@ -273,7 +307,19 @@ var DimFreeze = common.Shortcut{
 	},
 }
 
-func dimFreezeInput(runtime flagView, token, sheetID, sheetName string) map[string]interface{} {
+func dimFreezeInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if !runtime.Changed("dimension") {
+		return nil, common.FlagErrorf("--dimension is required")
+	}
+	if !runtime.Changed("count") {
+		return nil, common.FlagErrorf("--count is required (0 unfreezes)")
+	}
+	if runtime.Int("count") < 0 {
+		return nil, common.FlagErrorf("--count must be >= 0")
+	}
 	dim := runtime.Str("dimension")
 	count := runtime.Int("count")
 	op := "freeze"
@@ -289,18 +335,13 @@ func dimFreezeInput(runtime flagView, token, sheetID, sheetName string) map[stri
 			input["freeze_columns"] = count
 		}
 	}
-	return input
+	return input, nil
 }
 
-// validateDimRange validates the public XOR pair and dimension/start/end
-// triple shared by insert/delete/hide/unhide/group/ungroup.
-func validateDimRange(ctx context.Context, runtime *common.RuntimeContext) error {
-	if _, err := resolveSpreadsheetToken(runtime); err != nil {
-		return err
-	}
-	if _, _, err := resolveSheetSelector(runtime); err != nil {
-		return err
-	}
+// requireDimRange validates the dimension/start/end triple shared by
+// insert/delete/hide/unhide/group/ungroup. Pure flag-level checks — the sheet
+// selector and token live in their own helpers.
+func requireDimRange(runtime flagView) error {
 	if !runtime.Changed("dimension") {
 		return common.FlagErrorf("--dimension is required")
 	}
@@ -320,14 +361,20 @@ func validateDimRange(ctx context.Context, runtime *common.RuntimeContext) error
 
 // dimRangeOpInput builds the tool input for delete/hide/unhide which all
 // take a `range` field. dimRange handles 0-based exclusive → 1-based inclusive.
-func dimRangeOpInput(runtime flagView, token, sheetID, sheetName, op string) map[string]interface{} {
+func dimRangeOpInput(runtime flagView, token, sheetID, sheetName, op string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if err := requireDimRange(runtime); err != nil {
+		return nil, err
+	}
 	input := map[string]interface{}{
 		"excel_id":  token,
 		"operation": op,
 		"range":     dimRange(runtime.Str("dimension"), runtime.Int("start"), runtime.Int("end")),
 	}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
-	return input
+	return input, nil
 }
 
 // newDimRangeOpShortcut builds the shared shape for hide / unhide.
@@ -341,11 +388,12 @@ func newDimRangeOpShortcut(command, desc, op, risk string) common.Shortcut {
 		AuthTypes:   []string{"user", "bot"},
 		HasFormat:   true,
 		Flags:       flagsFor(command),
-		Validate:    validateDimRange,
+		Validate:    validateDimRangeOp(op),
 		DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 			token, _ := resolveSpreadsheetToken(runtime)
 			sheetID, sheetName, _ := resolveSheetSelector(runtime)
-			return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", dimRangeOpInput(runtime, token, sheetID, sheetName, op))
+			input, _ := dimRangeOpInput(runtime, token, sheetID, sheetName, op)
+			return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 			token, err := resolveSpreadsheetToken(runtime)
@@ -356,7 +404,11 @@ func newDimRangeOpShortcut(command, desc, op, risk string) common.Shortcut {
 			if err != nil {
 				return err
 			}
-			out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_sheet_structure", dimRangeOpInput(runtime, token, sheetID, sheetName, op))
+			input, err := dimRangeOpInput(runtime, token, sheetID, sheetName, op)
+			if err != nil {
+				return err
+			}
+			out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_sheet_structure", input)
 			if err != nil {
 				return err
 			}
@@ -380,11 +432,12 @@ func newDimGroupShortcut(command, desc, op string) common.Shortcut {
 		AuthTypes:   []string{"user", "bot"},
 		HasFormat:   true,
 		Flags:       flags,
-		Validate:    validateDimRange,
+		Validate:    validateDimGroupOp(op),
 		DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 			token, _ := resolveSpreadsheetToken(runtime)
 			sheetID, sheetName, _ := resolveSheetSelector(runtime)
-			return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", dimGroupInput(runtime, token, sheetID, sheetName, op))
+			input, _ := dimGroupInput(runtime, token, sheetID, sheetName, op)
+			return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 			token, err := resolveSpreadsheetToken(runtime)
@@ -395,7 +448,11 @@ func newDimGroupShortcut(command, desc, op string) common.Shortcut {
 			if err != nil {
 				return err
 			}
-			out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_sheet_structure", dimGroupInput(runtime, token, sheetID, sheetName, op))
+			input, err := dimGroupInput(runtime, token, sheetID, sheetName, op)
+			if err != nil {
+				return err
+			}
+			out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_sheet_structure", input)
 			if err != nil {
 				return err
 			}
@@ -405,14 +462,17 @@ func newDimGroupShortcut(command, desc, op string) common.Shortcut {
 	}
 }
 
-func dimGroupInput(runtime flagView, token, sheetID, sheetName, op string) map[string]interface{} {
-	input := dimRangeOpInput(runtime, token, sheetID, sheetName, op)
+func dimGroupInput(runtime flagView, token, sheetID, sheetName, op string) (map[string]interface{}, error) {
+	input, err := dimRangeOpInput(runtime, token, sheetID, sheetName, op)
+	if err != nil {
+		return nil, err
+	}
 	if op == "group" {
 		if gs := runtime.Str("group-state"); gs != "" {
 			input["group_state"] = gs
 		}
 	}
-	return input
+	return input, nil
 }
 
 // ─── dimension formatting helpers ─────────────────────────────────────

--- a/shortcuts/sheets/lark_sheet_workbook.go
+++ b/shortcuts/sheets/lark_sheet_workbook.go
@@ -90,30 +90,28 @@ var SheetCreate = common.Shortcut{
 	HasFormat:   true,
 	Flags:       flagsFor("+sheet-create"),
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
+		token, err := resolveSpreadsheetToken(runtime)
+		if err != nil {
 			return err
 		}
-		if strings.TrimSpace(runtime.Str("title")) == "" {
-			return common.FlagErrorf("--title is required")
-		}
-		if n := runtime.Int("row-count"); n < 0 || n > 50000 {
-			return common.FlagErrorf("--row-count must be between 0 and 50000")
-		}
-		if n := runtime.Int("col-count"); n < 0 || n > 200 {
-			return common.FlagErrorf("--col-count must be between 0 and 200")
-		}
-		return nil
+		_, err = sheetCreateInput(runtime, token)
+		return err
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", sheetCreateInput(runtime, token))
+		input, _ := sheetCreateInput(runtime, token)
+		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", sheetCreateInput(runtime, token))
+		input, err := sheetCreateInput(runtime, token)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", input)
 		if err != nil {
 			return err
 		}
@@ -122,7 +120,16 @@ var SheetCreate = common.Shortcut{
 	},
 }
 
-func sheetCreateInput(runtime flagView, token string) map[string]interface{} {
+func sheetCreateInput(runtime flagView, token string) (map[string]interface{}, error) {
+	if strings.TrimSpace(runtime.Str("title")) == "" {
+		return nil, common.FlagErrorf("--title is required")
+	}
+	if n := runtime.Int("row-count"); n < 0 || n > 50000 {
+		return nil, common.FlagErrorf("--row-count must be between 0 and 50000")
+	}
+	if n := runtime.Int("col-count"); n < 0 || n > 200 {
+		return nil, common.FlagErrorf("--col-count must be between 0 and 200")
+	}
 	input := map[string]interface{}{
 		"excel_id":   token,
 		"operation":  "create",
@@ -137,43 +144,63 @@ func sheetCreateInput(runtime flagView, token string) map[string]interface{} {
 	if n := runtime.Int("col-count"); n > 0 {
 		input["columns"] = n
 	}
-	return input
+	return input, nil
 }
 
 // sheetDeleteInput / sheetRenameInput / sheetVisibilityInput /
 // sheetSetTabColorInput build the modify_workbook_structure body for the
 // matching shortcut. Shared by standalone DryRun/Execute and by the
-// +batch-update sub-op dispatch so both paths emit an identical body.
-func sheetDeleteInput(runtime flagView, token, sheetID, sheetName string) map[string]interface{} {
+// +batch-update sub-op dispatch so both paths emit an identical body and the
+// same friendly error when --sheet-id/--sheet-name (or the shortcut's own
+// required flags) are missing.
+func sheetDeleteInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
 	input := map[string]interface{}{"excel_id": token, "operation": "delete"}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
-	return input
+	return input, nil
 }
 
-func sheetRenameInput(runtime flagView, token, sheetID, sheetName string) map[string]interface{} {
+func sheetRenameInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(runtime.Str("title")) == "" {
+		return nil, common.FlagErrorf("--title is required")
+	}
 	input := map[string]interface{}{
 		"excel_id":  token,
 		"operation": "rename",
 		"new_name":  strings.TrimSpace(runtime.Str("title")),
 	}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
-	return input
+	return input, nil
 }
 
-func sheetVisibilityInput(runtime flagView, token, sheetID, sheetName, op string) map[string]interface{} {
+func sheetVisibilityInput(runtime flagView, token, sheetID, sheetName, op string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
 	input := map[string]interface{}{"excel_id": token, "operation": op}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
-	return input
+	return input, nil
 }
 
-func sheetSetTabColorInput(runtime flagView, token, sheetID, sheetName string) map[string]interface{} {
+func sheetSetTabColorInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if !runtime.Changed("color") {
+		return nil, common.FlagErrorf("--color is required (empty string clears)")
+	}
 	input := map[string]interface{}{
 		"excel_id":  token,
 		"operation": "set_tab_color",
 		"tab_color": runtime.Str("color"),
 	}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
-	return input
+	return input, nil
 }
 
 // SheetDelete deletes a sub-sheet. high-risk-write — framework rejects
@@ -187,17 +214,12 @@ var SheetDelete = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+sheet-delete"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		_, _, err := resolveSheetSelector(runtime)
-		return err
-	},
+	Validate:    validateViaInput(sheetDeleteInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", sheetDeleteInput(runtime, token, sheetID, sheetName))
+		input, _ := sheetDeleteInput(runtime, token, sheetID, sheetName)
+		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -208,7 +230,11 @@ var SheetDelete = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", sheetDeleteInput(runtime, token, sheetID, sheetName))
+		input, err := sheetDeleteInput(runtime, token, sheetID, sheetName)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", input)
 		if err != nil {
 			return err
 		}
@@ -230,22 +256,12 @@ var SheetRename = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+sheet-rename"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if strings.TrimSpace(runtime.Str("title")) == "" {
-			return common.FlagErrorf("--title is required")
-		}
-		return nil
-	},
+	Validate:    validateViaInput(sheetRenameInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", sheetRenameInput(runtime, token, sheetID, sheetName))
+		input, _ := sheetRenameInput(runtime, token, sheetID, sheetName)
+		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -256,7 +272,11 @@ var SheetRename = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", sheetRenameInput(runtime, token, sheetID, sheetName))
+		input, err := sheetRenameInput(runtime, token, sheetID, sheetName)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", input)
 		if err != nil {
 			return err
 		}
@@ -378,17 +398,12 @@ var SheetCopy = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+sheet-copy"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		_, _, err := resolveSheetSelector(runtime)
-		return err
-	},
+	Validate:    validateViaInput(sheetCopyInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", sheetCopyInput(runtime, token, sheetID, sheetName))
+		input, _ := sheetCopyInput(runtime, token, sheetID, sheetName)
+		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -399,7 +414,11 @@ var SheetCopy = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", sheetCopyInput(runtime, token, sheetID, sheetName))
+		input, err := sheetCopyInput(runtime, token, sheetID, sheetName)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", input)
 		if err != nil {
 			return err
 		}
@@ -408,7 +427,10 @@ var SheetCopy = common.Shortcut{
 	},
 }
 
-func sheetCopyInput(runtime flagView, token, sheetID, sheetName string) map[string]interface{} {
+func sheetCopyInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
 	input := map[string]interface{}{"excel_id": token, "operation": "duplicate"}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
 	if t := strings.TrimSpace(runtime.Str("title")); t != "" {
@@ -417,7 +439,7 @@ func sheetCopyInput(runtime flagView, token, sheetID, sheetName string) map[stri
 	if runtime.Changed("index") {
 		input["target_index"] = runtime.Int("index")
 	}
-	return input
+	return input, nil
 }
 
 // SheetHide / SheetUnhide toggle visibility. Visible bool semantics live in
@@ -441,16 +463,20 @@ func newSheetVisibilityShortcut(command, desc, op string) common.Shortcut {
 		HasFormat:   true,
 		Flags:       flagsFor(command),
 		Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			if _, err := resolveSpreadsheetToken(runtime); err != nil {
+			token, err := resolveSpreadsheetToken(runtime)
+			if err != nil {
 				return err
 			}
-			_, _, err := resolveSheetSelector(runtime)
+			sheetID := strings.TrimSpace(runtime.Str("sheet-id"))
+			sheetName := strings.TrimSpace(runtime.Str("sheet-name"))
+			_, err = sheetVisibilityInput(runtime, token, sheetID, sheetName, op)
 			return err
 		},
 		DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 			token, _ := resolveSpreadsheetToken(runtime)
 			sheetID, sheetName, _ := resolveSheetSelector(runtime)
-			return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", sheetVisibilityInput(runtime, token, sheetID, sheetName, op))
+			input, _ := sheetVisibilityInput(runtime, token, sheetID, sheetName, op)
+			return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 			token, err := resolveSpreadsheetToken(runtime)
@@ -461,7 +487,11 @@ func newSheetVisibilityShortcut(command, desc, op string) common.Shortcut {
 			if err != nil {
 				return err
 			}
-			out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", sheetVisibilityInput(runtime, token, sheetID, sheetName, op))
+			input, err := sheetVisibilityInput(runtime, token, sheetID, sheetName, op)
+			if err != nil {
+				return err
+			}
+			out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", input)
 			if err != nil {
 				return err
 			}
@@ -481,22 +511,12 @@ var SheetSetTabColor = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+sheet-set-tab-color"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if !runtime.Changed("color") {
-			return common.FlagErrorf("--color is required (empty string clears)")
-		}
-		return nil
-	},
+	Validate:    validateViaInput(sheetSetTabColorInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", sheetSetTabColorInput(runtime, token, sheetID, sheetName))
+		input, _ := sheetSetTabColorInput(runtime, token, sheetID, sheetName)
+		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -507,7 +527,11 @@ var SheetSetTabColor = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", sheetSetTabColorInput(runtime, token, sheetID, sheetName))
+		input, err := sheetSetTabColorInput(runtime, token, sheetID, sheetName)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "modify_workbook_structure", input)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/sheets/lark_sheet_write_cells.go
+++ b/shortcuts/sheets/lark_sheet_write_cells.go
@@ -43,21 +43,7 @@ var CellsSet = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+cells-set"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if strings.TrimSpace(runtime.Str("range")) == "" {
-			return common.FlagErrorf("--range is required")
-		}
-		if _, err := requireJSONArray(runtime, "cells"); err != nil {
-			return err
-		}
-		return nil
-	},
+	Validate:    validateViaInput(cellsSetInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
@@ -87,6 +73,12 @@ var CellsSet = common.Shortcut{
 }
 
 func cellsSetInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(runtime.Str("range")) == "" {
+		return nil, common.FlagErrorf("--range is required")
+	}
 	cells, err := requireJSONArray(runtime, "cells")
 	if err != nil {
 		return nil, err
@@ -118,28 +110,7 @@ var CellsSetStyle = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+cells-set-style"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		r := strings.TrimSpace(runtime.Str("range"))
-		if r == "" {
-			return common.FlagErrorf("--range is required")
-		}
-		if _, _, err := rangeDimensions(r); err != nil {
-			return common.FlagErrorf("--range %q: %v", r, err)
-		}
-		if err := requireAnyStyleFlag(runtime); err != nil {
-			return err
-		}
-		if _, err := borderStylesFromFlag(runtime); err != nil {
-			return err
-		}
-		return nil
-	},
+	Validate:    validateViaInput(cellsSetStyleInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
@@ -169,10 +140,19 @@ var CellsSetStyle = common.Shortcut{
 }
 
 func cellsSetStyleInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
 	rangeStr := strings.TrimSpace(runtime.Str("range"))
+	if rangeStr == "" {
+		return nil, common.FlagErrorf("--range is required")
+	}
 	rows, cols, err := rangeDimensions(rangeStr)
 	if err != nil {
 		return nil, common.FlagErrorf("--range %q: %v", rangeStr, err)
+	}
+	if err := requireAnyStyleFlag(runtime); err != nil {
+		return nil, err
 	}
 	cellStyle := buildCellStyleFromFlags(runtime)
 	borderStyles, err := borderStylesFromFlag(runtime)
@@ -214,29 +194,12 @@ var CsvPut = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+csv-put"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		if strings.TrimSpace(runtime.Str("csv")) == "" {
-			return common.FlagErrorf("--csv is required")
-		}
-		anchor := strings.TrimSpace(runtime.Str("start-cell"))
-		if anchor == "" {
-			return common.FlagErrorf("--start-cell is required")
-		}
-		if _, _, ok := splitCellRef(anchor); !ok {
-			return common.FlagErrorf("--start-cell %q must be a single cell ref (e.g. A1)", anchor)
-		}
-		return nil
-	},
+	Validate:    validateViaInput(csvPutInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
-		return invokeToolDryRun(token, ToolKindWrite, "set_range_from_csv", csvPutInput(runtime, token, sheetID, sheetName))
+		input, _ := csvPutInput(runtime, token, sheetID, sheetName)
+		return invokeToolDryRun(token, ToolKindWrite, "set_range_from_csv", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetToken(runtime)
@@ -247,7 +210,11 @@ var CsvPut = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindWrite, "set_range_from_csv", csvPutInput(runtime, token, sheetID, sheetName))
+		input, err := csvPutInput(runtime, token, sheetID, sheetName)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "set_range_from_csv", input)
 		if err != nil {
 			return err
 		}
@@ -256,17 +223,30 @@ var CsvPut = common.Shortcut{
 	},
 }
 
-func csvPutInput(runtime flagView, token, sheetID, sheetName string) map[string]interface{} {
+func csvPutInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(runtime.Str("csv")) == "" {
+		return nil, common.FlagErrorf("--csv is required")
+	}
+	anchor := strings.TrimSpace(runtime.Str("start-cell"))
+	if anchor == "" {
+		return nil, common.FlagErrorf("--start-cell is required")
+	}
+	if _, _, ok := splitCellRef(anchor); !ok {
+		return nil, common.FlagErrorf("--start-cell %q must be a single cell ref (e.g. A1)", anchor)
+	}
 	input := map[string]interface{}{
 		"excel_id":   token,
 		"csv":        runtime.Str("csv"),
-		"start_cell": strings.TrimSpace(runtime.Str("start-cell")),
+		"start_cell": anchor,
 	}
 	sheetSelectorForToolInput(input, sheetID, sheetName)
 	if !runtime.Bool("allow-overwrite") {
 		input["allow_overwrite"] = false
 	}
-	return input
+	return input, nil
 }
 
 // ─── +dropdown-* (set_cell_range via data_validation) ─────────────────
@@ -285,25 +265,7 @@ var DropdownSet = common.Shortcut{
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+dropdown-set"),
-	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		if _, err := resolveSpreadsheetToken(runtime); err != nil {
-			return err
-		}
-		if _, _, err := resolveSheetSelector(runtime); err != nil {
-			return err
-		}
-		r := strings.TrimSpace(runtime.Str("range"))
-		if r == "" {
-			return common.FlagErrorf("--range is required")
-		}
-		if _, _, err := rangeDimensions(r); err != nil {
-			return common.FlagErrorf("--range %q: %v", r, err)
-		}
-		if _, err := validateDropdownOptionsColors(runtime); err != nil {
-			return err
-		}
-		return nil
-	},
+	Validate:    validateViaInput(dropdownSetInput),
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
 		sheetID, sheetName, _ := resolveSheetSelector(runtime)
@@ -333,14 +295,20 @@ var DropdownSet = common.Shortcut{
 }
 
 func dropdownSetInput(runtime flagView, token, sheetID, sheetName string) (map[string]interface{}, error) {
-	validation, err := buildDropdownValidation(runtime)
-	if err != nil {
+	if err := requireSheetSelector(sheetID, sheetName); err != nil {
 		return nil, err
 	}
 	rangeStr := strings.TrimSpace(runtime.Str("range"))
+	if rangeStr == "" {
+		return nil, common.FlagErrorf("--range is required")
+	}
 	rows, cols, err := rangeDimensions(rangeStr)
 	if err != nil {
 		return nil, common.FlagErrorf("--range %q: %v", rangeStr, err)
+	}
+	validation, err := buildDropdownValidation(runtime)
+	if err != nil {
+		return nil, err
 	}
 	cells := fillCellsMatrix(rows, cols, map[string]interface{}{"data_validation": validation})
 	input := map[string]interface{}{
@@ -390,8 +358,8 @@ func buildDropdownValidation(runtime flagView) (map[string]interface{}, error) {
 }
 
 // validateDropdownOptionsColors validates --options is a JSON array and that
-// --colors (when set) has matching length. Used by +dropdown-set Validate.
-func validateDropdownOptionsColors(runtime *common.RuntimeContext) (int, error) {
+// --colors (when set) has matching length. Used by +dropdown-update Validate.
+func validateDropdownOptionsColors(runtime flagView) (int, error) {
 	options, err := requireJSONArray(runtime, "options")
 	if err != nil {
 		return 0, err

--- a/skills/lark-sheets/references/lark-sheets-conditional-format.md
+++ b/skills/lark-sheets/references/lark-sheets-conditional-format.md
@@ -96,7 +96,7 @@ _公共四件套 · 系统：`--dry-run`_
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `--properties` | string + File + Stdin（复合 JSON） | required | 规则配置 JSON，含 `style`（命中样式，必填）和 `attrs?`（规则参数列表，因 `rule_type` 不同结构而异）/ `has_ref?`。`rule_type` 和 `ranges` 已拎为独立 flag |
-| `--rule-type` | string | required | 条件格式规则类型；优先级高于 `--properties` 中同名字段（可选值：`cellValue` / `formula` / `duplicate` / `unique` / `topBottom` / `aboveBelowAverage` / `dataBar` / `colorScale` / `iconSet` / `textContains` / `dateOccurring` / `blankCell` / `errorCell`） |
+| `--rule-type` | string | required | 条件格式规则类型；优先级高于 `--properties` 中同名字段（可选值：`duplicateValues` / `uniqueValues` / `cellIs` / `containsText` / `timePeriod` / `containsBlanks` / `notContainsBlanks` / `dataBar` / `colorScale` / `rank` / `aboveAverage` / `expression` / `iconSet`） |
 | `--ranges` | string + File + Stdin（简单 JSON） | required | 应用条件格式的 A1 范围 JSON 数组（如 `["A1:A100","C2:C50"]`）；优先级高于 `--properties` 中同名字段 |
 
 ### `+cond-format-update`
@@ -107,7 +107,7 @@ _公共四件套 · 系统：`--dry-run`_
 | --- | --- | --- | --- |
 | `--rule-id` | string | required | 目标规则 id |
 | `--properties` | string + File + Stdin（复合 JSON） | required | 规则配置 JSON，结构同 `+cond-format-create` 的 `--properties`；update 是整组覆盖式 |
-| `--rule-type` | string | required | 条件格式规则类型；优先级高于 `--properties` 中同名字段（可选值：`cellValue` / `formula` / `duplicate` / `unique` / `topBottom` / `aboveBelowAverage` / `dataBar` / `colorScale` / `iconSet` / `textContains` / `dateOccurring` / `blankCell` / `errorCell`） |
+| `--rule-type` | string | required | 条件格式规则类型；优先级高于 `--properties` 中同名字段（可选值：`duplicateValues` / `uniqueValues` / `cellIs` / `containsText` / `timePeriod` / `containsBlanks` / `notContainsBlanks` / `dataBar` / `colorScale` / `rank` / `aboveAverage` / `expression` / `iconSet`） |
 | `--ranges` | string + File + Stdin（简单 JSON） | required | 应用条件格式的 A1 范围 JSON 数组（如 `["A1:A100","C2:C50"]`）；优先级高于 `--properties` 中同名字段 |
 
 ### `+cond-format-delete`

--- a/skills/lark-sheets/references/lark-sheets-pivot-table.md
+++ b/skills/lark-sheets/references/lark-sheets-pivot-table.md
@@ -61,7 +61,7 @@ _公共四件套 · 系统：`--dry-run`_
 
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
-| `--properties` | string + File + Stdin（复合 JSON） | required | JSON：`{"data_range":"Sheet1!A1:F1000","rows":[...],"columns":[...],"values":[...],"filters":[...],"show_row_grand_total":true,"show_col_grand_total":true}` |
+| `--properties` | string + File + Stdin（复合 JSON） | required | JSON：{"rows":[...],"columns":[...],"values":[...],"filters":[...],"show_row_grand_total":true,"show_col_grand_total":true}（数据源走 --source，不要再放进 properties.data_range） |
 | `--target-sheet-id` | string | optional | 透视表落点子表 id；省略时自动新建子表（推荐） |
 | `--target-position` | string | optional | 落点起始 cell（A1 格式，如 `A1`），默认 `A1` |
 | `--source` | string | required | 透视表源数据区域（A1 表示法，格式 `SheetName!StartCell:EndCell`，如 `Sheet1!A1:D100`） |

--- a/skills/lark-sheets/references/lark-sheets-sheet-structure.md
+++ b/skills/lark-sheets/references/lark-sheets-sheet-structure.md
@@ -88,8 +88,8 @@ _公共四件套 · 系统：`--dry-run`_
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `--dimension` | string | required | 维度方向（行或列）（可选值：`row` / `column`） |
-| `--start` | int | required | 起始位置（0-based, inclusive） |
-| `--end` | int | required | 结束位置（0-based, inclusive） |
+| `--start` | int | required | 起始位置（0-based） |
+| `--end` | int | required | 结束位置（exclusive） |
 
 ### `+dim-unhide`
 
@@ -98,8 +98,8 @@ _公共四件套 · 系统：`--dry-run`_
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `--dimension` | string | required | 维度方向（行或列）（可选值：`row` / `column`） |
-| `--start` | int | required | 起始位置（0-based, inclusive） |
-| `--end` | int | required | 结束位置（0-based, inclusive） |
+| `--start` | int | required | 起始位置（0-based） |
+| `--end` | int | required | 结束位置（exclusive） |
 
 ### `+dim-freeze`
 
@@ -117,8 +117,8 @@ _公共四件套 · 系统：`--dry-run`_
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `--dimension` | string | required | 维度方向（行或列）（可选值：`row` / `column`） |
-| `--start` | int | required | 起始位置（0-based, inclusive） |
-| `--end` | int | required | 结束位置（0-based, inclusive） |
+| `--start` | int | required | 起始位置（0-based） |
+| `--end` | int | required | 结束位置（exclusive） |
 | `--depth` | int | optional | 嵌套层级（`+dim-group` 用），默认 1 |
 | `--group-state` | string | optional | 分组初始展开状态（可选值：`expand` / `fold`） |
 
@@ -129,8 +129,8 @@ _公共四件套 · 系统：`--dry-run`_
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `--dimension` | string | required | 维度方向（行或列）（可选值：`row` / `column`） |
-| `--start` | int | required | 起始位置（0-based, inclusive） |
-| `--end` | int | required | 结束位置（0-based, inclusive） |
+| `--start` | int | required | 起始位置（0-based） |
+| `--end` | int | required | 结束位置（exclusive） |
 | `--depth` | int | optional | 嵌套层级（`+dim-group` 用），默认 1 |
 
 ### `+dim-move`

--- a/skills/lark-sheets/references/lark-sheets-workbook.md
+++ b/skills/lark-sheets/references/lark-sheets-workbook.md
@@ -161,6 +161,10 @@ lark-cli sheets +sheet-create --url "https://example.feishu.cn/sheets/shtXXX" \
 
 ### `+sheet-move`
 
+standalone 路径在缺 `--source-index` / 只给 `--sheet-name` 时会自动发起一次 `+workbook-info` 读把它们解出来。
+
+> ⚠️ **在 `+batch-update` 内调用 `+sheet-move`**：必须同时显式传 `--sheet-id` 和 `--source-index`。batch 中途无法发起结构查询，所以 batch translator 强制要求两者都显式。
+
 ### `+sheet-copy`
 
 ### `+sheet-hide` / `+sheet-unhide`


### PR DESCRIPTION
## Summary

Two adjacent fixes around `+batch-update` and related write shortcuts, both surfaced by BOE smoke testing of multi-op batches.

- **8d0fefd `fix(sheets): push +batch-update sub-op validation down into xxxInput builders`** — sub-ops that omit `--sheet-id` (or any other required flag) used to slip past CLI validation and surface as opaque server errors like `sheet undefined not found` after a network round-trip. Every batchable `xxxInput` builder now returns `(map, error)` and owns its own sheet-selector + required-field checks via the new `requireSheetSelector` helper. Standalone `Validate` shrinks to `validateViaInput(xxxInput)`, so identical bad input now fires identical CLI errors from both standalone and batch paths (wrapped as `operations[N] (+shortcut): ...` in the batch case). `sheetMoveBatchInput`'s explicit-`source-index` constraint is preserved.

- **4e44e66 `fix(sheets): align +cond-format / +filter with server schema (#4 + #5)`**
  - `+cond-format`: `condFormatEnhance` was writing `properties.rule.type` (nested), but the server schema (`manage_conditional_format_object`) wants flat `properties.rule_type`. The CLI enum (`cellValue / formula / duplicate / ...`) was also a CLI-invented vocabulary none of whose values the server accepts. **Breaking**: enum aligned with server (`cellIs / duplicateValues / containsText / timePeriod / containsBlanks / notContainsBlanks / dataBar / colorScale / rank / aboveAverage / expression / iconSet`); scripts using old names now hit cobra `invalid value ..., allowed: ...`. No alias layer.
  - `+filter-{update,delete}`: server contract is `filter_id === sheet_id` and both ops MUST carry `filter_id` — the CLI translator never set it, so every call failed server-side. Translator now auto-injects `filter_id` from `sheet_id`. Because `filter_id` must equal `sheet_id` (not `sheet_name`), update/delete reject `--sheet-name`-only with a friendly error pointing at `+workbook-info`.
  - Doc artifacts that got regenerated alongside (sync from sheet-skill-spec):
    - `+dim-{hide,unhide,group,ungroup}` `--start/--end` desc changed from `(0-based, inclusive)` to `(0-based)` / `(exclusive)` to match the half-open range semantics the code has always implemented.
    - `+sheet-move` reference gains a batch-internal warning about explicit `--sheet-id` + `--source-index`.
    - `+pivot-create --properties` example drops the stale `data_range` field (data source goes through `--source`).

## Test plan

- [x] `go vet ./shortcuts/sheets/...`
- [x] `go build ./...`
- [x] `go test ./shortcuts/sheets/...` — all green, including
  - `TestBatchOp_BodyMatchesStandalone` (~40 cases): batch sub-op bodies stay byte-identical to standalone bodies.
  - `TestBatchOp_ErrorEquivalence` (7 cases): XOR / logical-constraint errors fire identically standalone vs batch.
  - `TestBatchOp_RejectsBadSubOpInput` (10 cases): cobra-required flags + filter sheet-name-only now rejected CLI-side in batch.
  - `TestObjectCRUDShortcuts_DryRun`: cond-format body uses flat `properties.rule_type`; filter update/delete auto-inject `filter_id = sheet_id`.
- [x] BOE smoke (spreadsheet `ICFwstkUGheyfptGWS2bB7RgcDf`):
  - Missing `--sheet-id` in a batch sub-op now returns `operations[0] (+dim-insert): specify at least one of --sheet-id or --sheet-name` before any network call.
  - `+cond-format-create --rule-type cellIs` writes `properties.rule_type: "cellIs"` flat; old enum `cellValue` rejected by cobra with the new enum listed.
  - `+filter-update --sheet-id X` auto-populates `filter_id: X`; `--sheet-name` only gets the friendly error.

## Notes / follow-ups

- **Breaking change** for `+cond-format-{create,update} --rule-type`: any script passing the old vocabulary needs to migrate to server enum (`cellValue → cellIs`, `duplicate → duplicateValues`, etc.). Per offline discussion no alias layer is added — earlier alignment is better than carrying two vocabularies.
- `+sparkline-update` still requires user to hand-fill `properties.sparklines[].sparkline_id`; auto list-then-update is a separate change of its own (architecture limit, not in this PR).
- This PR sits on top of the upstream `0ea7c14` / `1e05e7b` flagView abstraction; no overlap with those commits.