### PR TITLE
docs(lark-search): improve search workflow from eval run base-b1m-selected2-20260521

### DIFF
--- a/shortcuts/drive/drive_search.go
+++ b/shortcuts/drive/drive_search.go
@@ -34,6 +34,8 @@ const (
 	driveSearchMaxOpenedSpanDays = 365 // hard cap: reject --opened-* spans beyond ~1 year
 )
 
+const driveSearchEvidenceTopResultsLimit = 5
+
 var driveSearchSortValues = []string{
 	"default",
 	"edit_time",
@@ -46,6 +48,8 @@ var driveSearchDocTypeSet = map[string]struct{}{
 	"DOC": {}, "SHEET": {}, "BITABLE": {}, "MINDNOTE": {}, "FILE": {},
 	"WIKI": {}, "DOCX": {}, "FOLDER": {}, "CATALOG": {}, "SLIDES": {}, "SHORTCUT": {},
 }
+
+var driveSearchHighlightTagRe = regexp.MustCompile(`</?hb?>`)
 
 // driveSearchHourAggregatedFields lists filter keys the server aggregates at
 // hour granularity. We pre-snap start/end and emit a stderr notice so callers
@@ -142,10 +146,11 @@ var DriveSearch = common.Shortcut{
 		normalizedItems := addDriveSearchIsoTimeFields(items)
 
 		resultData := map[string]interface{}{
-			"total":      data["total"],
-			"has_more":   data["has_more"],
-			"page_token": data["page_token"],
-			"results":    normalizedItems,
+			"total":                data["total"],
+			"has_more":             data["has_more"],
+			"page_token":           data["page_token"],
+			"results":              normalizedItems,
+			"evidence_top_results": buildDriveSearchEvidenceTopResults(normalizedItems),
 		}
 
 		runtime.OutFormat(resultData, &output.Meta{Count: len(normalizedItems)}, func(w io.Writer) {
@@ -663,7 +668,6 @@ func renderDriveSearchTable(w io.Writer, data map[string]interface{}, items []in
 		return
 	}
 
-	htmlTagRe := regexp.MustCompile(`</?hb?>`)
 	var rows []map[string]interface{}
 	for _, item := range items {
 		u, _ := item.(map[string]interface{})
@@ -676,7 +680,7 @@ func renderDriveSearchTable(w io.Writer, data map[string]interface{}, items []in
 		} else if s, ok := u["title"].(string); ok {
 			rawTitle = s
 		}
-		title := common.TruncateStr(htmlTagRe.ReplaceAllString(rawTitle, ""), 50)
+		title := common.TruncateStr(cleanDriveSearchText(rawTitle), 50)
 
 		resultMeta, _ := u["result_meta"].(map[string]interface{})
 		docTypes := ""
@@ -717,6 +721,132 @@ func renderDriveSearchTable(w io.Writer, data map[string]interface{}, items []in
 		moreHint = " (more available, use --format json to get page_token, then --page-token to paginate)"
 	}
 	fmt.Fprintf(w, "\n%d result(s)%s\n", len(rows), moreHint)
+}
+
+func buildDriveSearchEvidenceTopResults(items []interface{}) []map[string]interface{} {
+	out := make([]map[string]interface{}, 0, min(len(items), driveSearchEvidenceTopResultsLimit))
+	for _, item := range items {
+		if len(out) >= driveSearchEvidenceTopResultsLimit {
+			break
+		}
+		u, _ := item.(map[string]interface{})
+		if u == nil {
+			continue
+		}
+		out = append(out, buildDriveSearchEvidenceResult(len(out)+1, u))
+	}
+	return out
+}
+
+func buildDriveSearchEvidenceResult(rank int, item map[string]interface{}) map[string]interface{} {
+	resultMeta, _ := item["result_meta"].(map[string]interface{})
+	itemFirst := []map[string]interface{}{item, resultMeta}
+	metaFirst := []map[string]interface{}{resultMeta, item}
+
+	url := driveSearchFirstString(metaFirst, "url", "app_link", "link")
+	token := driveSearchFirstString(metaFirst,
+		"token",
+		"doc_token",
+		"wiki_token",
+		"obj_token",
+		"file_token",
+		"sheet_token",
+		"bitable_token",
+		"node_token",
+		"resource_token",
+	)
+	resultType := driveSearchFirstString(metaFirst, "doc_types", "doc_type", "type")
+	if resultType == "" {
+		resultType = driveSearchFirstString(itemFirst, "entity_type")
+	}
+	if ref, ok := common.ParseResourceURL(url); ok {
+		if token == "" {
+			token = ref.Token
+		}
+		if resultType == "" {
+			resultType = ref.Type
+		}
+	}
+
+	id := driveSearchFirstString(metaFirst, "id", "doc_id", "object_id", "entity_id", "resource_id")
+	if id == "" {
+		id = token
+	}
+
+	return map[string]interface{}{
+		"rank":            rank,
+		"title":           cleanDriveSearchText(driveSearchFirstString(itemFirst, "title", "title_highlighted", "name")),
+		"id":              id,
+		"token":           token,
+		"type":            resultType,
+		"url":             url,
+		"create_time_iso": driveSearchFirstString(metaFirst, "create_time_iso", "created_time_iso"),
+		"update_time_iso": driveSearchFirstString(metaFirst, "update_time_iso", "edit_time_iso", "modified_time_iso"),
+		"open_time_iso":   driveSearchFirstString(metaFirst, "open_time_iso"),
+		"summary":         cleanDriveSearchText(driveSearchFirstString(itemFirst, "summary", "summary_highlighted", "snippet")),
+	}
+}
+
+func cleanDriveSearchText(s string) string {
+	s = driveSearchHighlightTagRe.ReplaceAllString(s, "")
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func driveSearchFirstString(maps []map[string]interface{}, keys ...string) string {
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for _, key := range keys {
+			if s := driveSearchStringValue(m[key]); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func driveSearchStringValue(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return strings.TrimSpace(val)
+	case json.Number:
+		return strings.TrimSpace(val.String())
+	case int:
+		return strconv.Itoa(val)
+	case int64:
+		return strconv.FormatInt(val, 10)
+	case float64:
+		if math.IsInf(val, 0) || math.IsNaN(val) {
+			return ""
+		}
+		if val == math.Trunc(val) {
+			return strconv.FormatInt(int64(val), 10)
+		}
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	case []string:
+		return strings.Join(nonEmptyDriveSearchStrings(val), ",")
+	case []interface{}:
+		parts := make([]string, 0, len(val))
+		for _, item := range val {
+			if s := driveSearchStringValue(item); s != "" {
+				parts = append(parts, s)
+			}
+		}
+		return strings.Join(parts, ",")
+	default:
+		return ""
+	}
+}
+
+func nonEmptyDriveSearchStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if s := strings.TrimSpace(value); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // addDriveSearchIsoTimeFields recursively annotates every `*_time` numeric

--- a/shortcuts/drive/drive_search_test.go
+++ b/shortcuts/drive/drive_search_test.go
@@ -960,3 +960,78 @@ func TestRenderDriveSearchTable(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildDriveSearchEvidenceTopResults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("projects stable fields for evidence use", func(t *testing.T) {
+		t.Parallel()
+		items := addDriveSearchIsoTimeFields([]interface{}{
+			map[string]interface{}{
+				"title_highlighted":   "<h>Automation</h> Doc",
+				"summary_highlighted": "contains <hb>key</hb>\ncontent",
+				"entity_type":         "DOC",
+				"result_meta": map[string]interface{}{
+					"url":         "https://example.feishu.cn/docx/doxcnABC",
+					"update_time": int64(1745193600),
+					"create_time": json.Number("1745107200"),
+					"doc_types":   []interface{}{"DOCX"},
+				},
+			},
+		})
+
+		got := buildDriveSearchEvidenceTopResults(items)
+		if len(got) != 1 {
+			t.Fatalf("len(got)=%d, want 1", len(got))
+		}
+		row := got[0]
+		if row["rank"] != 1 {
+			t.Fatalf("rank=%v, want 1", row["rank"])
+		}
+		if row["title"] != "Automation Doc" {
+			t.Fatalf("title=%q", row["title"])
+		}
+		if row["summary"] != "contains key content" {
+			t.Fatalf("summary=%q", row["summary"])
+		}
+		if row["token"] != "doxcnABC" || row["id"] != "doxcnABC" {
+			t.Fatalf("token/id not derived from url: %#v", row)
+		}
+		if row["type"] != "DOCX" {
+			t.Fatalf("type=%v, want DOCX", row["type"])
+		}
+		if row["url"] != "https://example.feishu.cn/docx/doxcnABC" {
+			t.Fatalf("url=%v", row["url"])
+		}
+		if row["update_time_iso"] == "" || row["create_time_iso"] == "" {
+			t.Fatalf("iso times should be projected, got %#v", row)
+		}
+	})
+
+	t.Run("caps to top five valid results with sequential ranks", func(t *testing.T) {
+		t.Parallel()
+		items := []interface{}{"skip-me"}
+		for i := 0; i < driveSearchEvidenceTopResultsLimit+1; i++ {
+			items = append(items, map[string]interface{}{"title": "doc"})
+		}
+
+		got := buildDriveSearchEvidenceTopResults(items)
+		if len(got) != driveSearchEvidenceTopResultsLimit {
+			t.Fatalf("len(got)=%d, want %d", len(got), driveSearchEvidenceTopResultsLimit)
+		}
+		if got[0]["rank"] != 1 || got[len(got)-1]["rank"] != driveSearchEvidenceTopResultsLimit {
+			t.Fatalf("ranks should be sequential after skipping invalid items: %#v", got)
+		}
+	})
+
+	t.Run("empty output remains an array", func(t *testing.T) {
+		t.Parallel()
+		got := buildDriveSearchEvidenceTopResults(nil)
+		if got == nil {
+			t.Fatal("empty evidence output should be a non-nil slice so JSON renders []")
+		}
+		if len(got) != 0 {
+			t.Fatalf("len(got)=%d, want 0", len(got))
+		}
+	})
+}

--- a/skills/lark-drive/references/lark-drive-search.md
+++ b/skills/lark-drive/references/lark-drive-search.md
@@ -156,7 +156,9 @@ stdout 的 JSON 输出不受影响。`open_time` / `create_time` 不做 snap。
 
 ## 输出
 
-- `--format json`（默认）：`{ total, has_more, page_token, results: [...] }`；所有 `*_time` 字段递归补 `*_time_iso`
+- `--format json`（默认）：`{ total, has_more, page_token, results: [...], evidence_top_results: [...] }`；所有 `*_time` 字段递归补 `*_time_iso`
+- `evidence_top_results`：第一页前 5 个结果的稳定摘要，包含 `rank`、`title`、`id`、`token`、`type`、`url`、`create_time_iso`、`update_time_iso`、`open_time_iso`、`summary`；标题和摘要已剥离 `<h>` / `<hb>` 高亮标签，适合快速判断候选是否值得继续 `drive +inspect` / 业务域读取
+- `results`：完整原始结果结构，保留服务端返回的高亮、嵌套 `result_meta` 和其他字段；需要排查字段缺失或做深度解析时看这里
 - `--format pretty`：4 列 table —— `type | title | edit_time | url`
 - `title_highlighted` / `summary_highlighted` 可能包含 `<h>` / `<hb>` 高亮标签，客户端对比前需先剥离
 


### PR DESCRIPTION
<!-- Generated by /eval-search propose-pr run-id: base-b1m-selected2-20260521 -->

## Eval Summary

- Run: base-b1m-selected2-20260521
- Dataset size: 2
- Scored: 2
- Total: 2/30 (6.7%)
- Primary bottleneck: search_strategy

## Findings

- F-002 [medium] tool_capability/drive -> shortcuts/drive: 没有可用 evidence_top_results；drive search shortcut 需要返回更稳定的标题、id/token、时间和摘要字段。 (cases: case_002)
- F-001 [low] search_strategy/drive -> skills/lark-drive/references/lark-drive-search.md: recall=1；应在 drive 搜索中优先使用 query 的时间/人员/状态过滤，并用非污染 evidence_top_results 验证目标资源。 (cases: case_001)
- F-003 [low] search_strategy/drive -> skills/lark-drive/references/lark-drive-search.md: recall=0；应在 drive 搜索中优先使用 query 的时间/人员/状态过滤，并用非污染 evidence_top_results 验证目标资源。 (cases: case_002)

## Review Notes

This PR was generated from eval-search findings. Reviewers should check that
changes are domain-specific, generic, and not tailored to one case's exact gold
answer.
