### PR TITLE
docs(lark-search): improve search workflow from eval run base-b1m-selected2-v2-20260521

### DIFF
--- a/shortcuts/drive/drive_search.go
+++ b/shortcuts/drive/drive_search.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -32,6 +33,7 @@ const driveSearchErrUserNotVisible = 99992351
 const (
 	driveSearchSliceDays         = 90  // one slice = server-side 3-month cap
 	driveSearchMaxOpenedSpanDays = 365 // hard cap: reject --opened-* spans beyond ~1 year
+	driveSearchEvidenceTopLimit  = 5
 )
 
 var driveSearchSortValues = []string{
@@ -46,6 +48,8 @@ var driveSearchDocTypeSet = map[string]struct{}{
 	"DOC": {}, "SHEET": {}, "BITABLE": {}, "MINDNOTE": {}, "FILE": {},
 	"WIKI": {}, "DOCX": {}, "FOLDER": {}, "CATALOG": {}, "SLIDES": {}, "SHORTCUT": {},
 }
+
+var driveSearchHighlightTagRe = regexp.MustCompile(`</?hb?>`)
 
 // driveSearchHourAggregatedFields lists filter keys the server aggregates at
 // hour granularity. We pre-snap start/end and emit a stderr notice so callers
@@ -142,10 +146,11 @@ var DriveSearch = common.Shortcut{
 		normalizedItems := addDriveSearchIsoTimeFields(items)
 
 		resultData := map[string]interface{}{
-			"total":      data["total"],
-			"has_more":   data["has_more"],
-			"page_token": data["page_token"],
-			"results":    normalizedItems,
+			"total":                data["total"],
+			"has_more":             data["has_more"],
+			"page_token":           data["page_token"],
+			"results":              normalizedItems,
+			"evidence_top_results": buildDriveSearchEvidenceTopResults(normalizedItems),
 		}
 
 		runtime.OutFormat(resultData, &output.Meta{Count: len(normalizedItems)}, func(w io.Writer) {
@@ -655,6 +660,247 @@ func cloneDriveSearchFilter(src map[string]interface{}) map[string]interface{} {
 	return dst
 }
 
+// buildDriveSearchEvidenceTopResults exposes the first results in a compact,
+// stable shape for machine readers. The raw Search API response remains in
+// `results`; this list keeps the fields agents need to choose fetch targets.
+func buildDriveSearchEvidenceTopResults(items []interface{}) []map[string]interface{} {
+	if len(items) == 0 {
+		return []map[string]interface{}{}
+	}
+
+	limit := len(items)
+	if limit > driveSearchEvidenceTopLimit {
+		limit = driveSearchEvidenceTopLimit
+	}
+
+	out := make([]map[string]interface{}, 0, limit)
+	for _, item := range items {
+		if len(out) >= limit {
+			break
+		}
+		unit, _ := item.(map[string]interface{})
+		if unit == nil {
+			continue
+		}
+		resultMeta, _ := unit["result_meta"].(map[string]interface{})
+
+		row := map[string]interface{}{
+			"rank": len(out) + 1,
+		}
+		driveSearchPutString(row, "title", firstDriveSearchPlainString("title", unit, resultMeta))
+		driveSearchPutString(row, "entity_type", firstDriveSearchString("entity_type", unit, resultMeta))
+		if docTypes := firstDriveSearchStringSlice("doc_types", unit, resultMeta); len(docTypes) > 0 {
+			row["doc_types"] = docTypes
+			if len(docTypes) == 1 {
+				row["doc_type"] = docTypes[0]
+			}
+		}
+
+		resultURL := firstDriveSearchString("url", unit, resultMeta)
+		driveSearchPutString(row, "url", resultURL)
+		token := firstDriveSearchStringFromKeys(
+			[]string{"token", "doc_token", "docs_token", "document_token", "wiki_token", "node_token", "obj_token", "file_token", "folder_token", "sheet_token", "bitable_token", "app_token", "mindnote_token", "slide_token"},
+			unit,
+			resultMeta,
+		)
+		tokenType := firstDriveSearchStringFromKeys(
+			[]string{"token_type", "doc_type", "obj_type", "file_type"},
+			unit,
+			resultMeta,
+		)
+		if resultURL != "" && (token == "" || tokenType == "") {
+			urlToken, urlTokenType := driveSearchTokenFromURL(resultURL)
+			if token == "" {
+				token = urlToken
+			}
+			if tokenType == "" {
+				tokenType = urlTokenType
+			}
+		}
+		driveSearchPutString(row, "token", token)
+		driveSearchPutString(row, "token_type", tokenType)
+		driveSearchPutString(row, "id", firstDriveSearchStringFromKeys(
+			[]string{"id", "entity_id", "resource_id", "document_id", "docs_id", "file_id", "obj_id", "doc_id", "wiki_id"},
+			unit,
+			resultMeta,
+		))
+
+		timeKeys := []string{"update_time", "update_time_iso", "edit_time", "edit_time_iso", "modified_time", "modified_time_iso", "create_time", "create_time_iso", "open_time", "open_time_iso"}
+		for _, key := range timeKeys {
+			if value, ok := firstDriveSearchValue(key, unit, resultMeta); ok {
+				row[key] = value
+			}
+		}
+		driveSearchPutString(row, "time_iso", firstDriveSearchStringFromKeys(
+			[]string{"update_time_iso", "edit_time_iso", "modified_time_iso", "open_time_iso", "create_time_iso"},
+			unit,
+			resultMeta,
+		))
+		if value, ok := firstDriveSearchValueFromKeys(
+			[]string{"update_time", "edit_time", "modified_time", "open_time", "create_time"},
+			unit,
+			resultMeta,
+		); ok {
+			row["time"] = value
+		}
+
+		driveSearchPutString(row, "summary", common.TruncateStr(firstDriveSearchPlainString("summary", unit, resultMeta), 500))
+		out = append(out, row)
+	}
+
+	return out
+}
+
+func firstDriveSearchPlainString(baseKey string, maps ...map[string]interface{}) string {
+	if s := firstDriveSearchString(baseKey, maps...); s != "" {
+		return driveSearchPlainText(s)
+	}
+	if s := firstDriveSearchString(baseKey+"_highlighted", maps...); s != "" {
+		return driveSearchPlainText(s)
+	}
+	return ""
+}
+
+func driveSearchPlainText(s string) string {
+	return strings.TrimSpace(driveSearchHighlightTagRe.ReplaceAllString(s, ""))
+}
+
+func firstDriveSearchString(key string, maps ...map[string]interface{}) string {
+	return firstDriveSearchStringFromKeys([]string{key}, maps...)
+}
+
+func firstDriveSearchStringFromKeys(keys []string, maps ...map[string]interface{}) string {
+	if value, ok := firstDriveSearchValueFromKeys(keys, maps...); ok {
+		return driveSearchStringValue(value)
+	}
+	return ""
+}
+
+func firstDriveSearchStringSlice(key string, maps ...map[string]interface{}) []string {
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		if values := driveSearchStringSliceValue(m[key]); len(values) > 0 {
+			return values
+		}
+	}
+	return nil
+}
+
+func firstDriveSearchValue(key string, maps ...map[string]interface{}) (interface{}, bool) {
+	return firstDriveSearchValueFromKeys([]string{key}, maps...)
+}
+
+func firstDriveSearchValueFromKeys(keys []string, maps ...map[string]interface{}) (interface{}, bool) {
+	for _, m := range maps {
+		if m == nil {
+			continue
+		}
+		for _, key := range keys {
+			value, ok := m[key]
+			if !ok || value == nil {
+				continue
+			}
+			if s, ok := value.(string); ok && strings.TrimSpace(s) == "" {
+				continue
+			}
+			return value, true
+		}
+	}
+	return nil, false
+}
+
+func driveSearchPutString(row map[string]interface{}, key, value string) {
+	if value != "" {
+		row[key] = value
+	}
+}
+
+func driveSearchStringValue(value interface{}) string {
+	switch v := value.(type) {
+	case string:
+		return strings.TrimSpace(v)
+	case json.Number:
+		return v.String()
+	case fmt.Stringer:
+		return strings.TrimSpace(v.String())
+	case int:
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case float64:
+		if math.Trunc(v) == v {
+			return strconv.FormatInt(int64(v), 10)
+		}
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		return ""
+	}
+}
+
+func driveSearchStringSliceValue(value interface{}) []string {
+	switch v := value.(type) {
+	case []string:
+		return compactDriveSearchStrings(v)
+	case []interface{}:
+		values := make([]string, 0, len(v))
+		for _, item := range v {
+			if s := driveSearchStringValue(item); s != "" {
+				values = append(values, s)
+			}
+		}
+		return values
+	default:
+		if s := driveSearchStringValue(value); s != "" {
+			return []string{s}
+		}
+		return nil
+	}
+}
+
+func compactDriveSearchStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if s := strings.TrimSpace(value); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func driveSearchTokenFromURL(rawURL string) (string, string) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", ""
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	tokenAfter := map[string]string{
+		"base":      "base",
+		"bitable":   "base",
+		"doc":       "doc",
+		"docs":      "doc",
+		"docx":      "docx",
+		"file":      "file",
+		"folder":    "folder",
+		"mindnote":  "mindnote",
+		"mindnotes": "mindnote",
+		"sheets":    "sheet",
+		"slides":    "slides",
+		"wiki":      "wiki",
+	}
+	for i, part := range parts {
+		tokenType, ok := tokenAfter[strings.ToLower(part)]
+		if !ok || i+1 >= len(parts) {
+			continue
+		}
+		if token := strings.TrimSpace(parts[i+1]); token != "" {
+			return token, tokenType
+		}
+	}
+	return "", ""
+}
+
 // renderDriveSearchTable mirrors the column layout of doc +search so the pretty
 // output is consistent for users switching between the two.
 func renderDriveSearchTable(w io.Writer, data map[string]interface{}, items []interface{}) {
@@ -663,7 +909,6 @@ func renderDriveSearchTable(w io.Writer, data map[string]interface{}, items []in
 		return
 	}
 
-	htmlTagRe := regexp.MustCompile(`</?hb?>`)
 	var rows []map[string]interface{}
 	for _, item := range items {
 		u, _ := item.(map[string]interface{})
@@ -676,7 +921,7 @@ func renderDriveSearchTable(w io.Writer, data map[string]interface{}, items []in
 		} else if s, ok := u["title"].(string); ok {
 			rawTitle = s
 		}
-		title := common.TruncateStr(htmlTagRe.ReplaceAllString(rawTitle, ""), 50)
+		title := common.TruncateStr(driveSearchPlainText(rawTitle), 50)
 
 		resultMeta, _ := u["result_meta"].(map[string]interface{})
 		docTypes := ""

--- a/shortcuts/drive/drive_search_test.go
+++ b/shortcuts/drive/drive_search_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"math"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -612,6 +613,113 @@ func TestAddDriveSearchIsoTimeFields(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestBuildDriveSearchEvidenceTopResults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("normalizes stable evidence fields", func(t *testing.T) {
+		t.Parallel()
+		items := addDriveSearchIsoTimeFields([]interface{}{
+			map[string]interface{}{
+				"title_highlighted":   "<h>Auto</h> plan",
+				"summary_highlighted": "Owner transfer <hb>notes</hb>",
+				"entity_type":         "DOC",
+				"result_meta": map[string]interface{}{
+					"doc_types":   []interface{}{"DOCX"},
+					"url":         "https://example.feishu.cn/docx/doxcnEvidence123",
+					"update_time": json.Number("1745193600"),
+				},
+			},
+		})
+
+		got := buildDriveSearchEvidenceTopResults(items)
+		if len(got) != 1 {
+			t.Fatalf("len=%d, want 1", len(got))
+		}
+		row := got[0]
+		if row["rank"] != 1 {
+			t.Fatalf("rank=%v, want 1", row["rank"])
+		}
+		if row["title"] != "Auto plan" {
+			t.Fatalf("title=%v, want stripped title", row["title"])
+		}
+		if row["summary"] != "Owner transfer notes" {
+			t.Fatalf("summary=%v, want stripped summary", row["summary"])
+		}
+		if row["token"] != "doxcnEvidence123" || row["token_type"] != "docx" {
+			t.Fatalf("token fields = (%v, %v), want parsed docx token", row["token"], row["token_type"])
+		}
+		if row["time_iso"] == "" || row["update_time_iso"] == "" {
+			t.Fatalf("expected ISO time aliases, got: %v", row)
+		}
+		docTypes, ok := row["doc_types"].([]string)
+		if !ok || len(docTypes) != 1 || docTypes[0] != "DOCX" {
+			t.Fatalf("doc_types=%#v, want [DOCX]", row["doc_types"])
+		}
+	})
+
+	t.Run("limits to top five", func(t *testing.T) {
+		t.Parallel()
+		items := make([]interface{}, 7)
+		for i := range items {
+			items[i] = map[string]interface{}{"title": strconv.Itoa(i)}
+		}
+
+		got := buildDriveSearchEvidenceTopResults(items)
+		if len(got) != driveSearchEvidenceTopLimit {
+			t.Fatalf("len=%d, want %d", len(got), driveSearchEvidenceTopLimit)
+		}
+		if got[4]["rank"] != 5 {
+			t.Fatalf("fifth rank=%v, want 5", got[4]["rank"])
+		}
+	})
+}
+
+func TestDriveSearchTokenFromURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		rawURL    string
+		wantToken string
+		wantType  string
+	}{
+		{
+			name:      "docx",
+			rawURL:    "https://example.feishu.cn/docx/doxcn123?from=copy",
+			wantToken: "doxcn123",
+			wantType:  "docx",
+		},
+		{
+			name:      "folder",
+			rawURL:    "https://example.feishu.cn/drive/folder/fldcn456",
+			wantToken: "fldcn456",
+			wantType:  "folder",
+		},
+		{
+			name:      "sheet",
+			rawURL:    "https://example.feishu.cn/sheets/shtcn789",
+			wantToken: "shtcn789",
+			wantType:  "sheet",
+		},
+		{
+			name:      "unknown",
+			rawURL:    "https://example.feishu.cn/unknown/path",
+			wantToken: "",
+			wantType:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotToken, gotType := driveSearchTokenFromURL(tt.rawURL)
+			if gotToken != tt.wantToken || gotType != tt.wantType {
+				t.Fatalf("driveSearchTokenFromURL() = (%q, %q), want (%q, %q)", gotToken, gotType, tt.wantToken, tt.wantType)
+			}
+		})
+	}
 }
 
 func TestEnrichDriveSearchError(t *testing.T) {

--- a/skills/lark-drive/references/lark-drive-search.md
+++ b/skills/lark-drive/references/lark-drive-search.md
@@ -156,7 +156,8 @@ stdout 的 JSON 输出不受影响。`open_time` / `create_time` 不做 snap。
 
 ## 输出
 
-- `--format json`（默认）：`{ total, has_more, page_token, results: [...] }`；所有 `*_time` 字段递归补 `*_time_iso`
+- `--format json`（默认）：`{ total, has_more, page_token, results: [...], evidence_top_results: [...] }`；所有 `*_time` 字段递归补 `*_time_iso`
+- `evidence_top_results` 是前 5 条结果的稳定摘要，包含可用的 `rank`、`title`、`entity_type`、`doc_types`、`id`、`token` / `token_type`、`url`、`time` / `time_iso` 和 `summary`。需要判断是否命中目标资源时，优先看这里的标题、token/URL、时间和摘要；需要完整原始字段时再看 `results`
 - `--format pretty`：4 列 table —— `type | title | edit_time | url`
 - `title_highlighted` / `summary_highlighted` 可能包含 `<h>` / `<hb>` 高亮标签，客户端对比前需先剥离
 


### PR DESCRIPTION
<!-- Generated by /eval-search propose-pr run-id: base-b1m-selected2-v2-20260521 -->

## Eval Summary

- Run: base-b1m-selected2-v2-20260521
- Dataset size: 2
- Scored: 2
- Total: 2/30 (6.7%)
- Primary bottleneck: search_strategy

## Findings

- F-002 [medium] tool_capability/drive -> shortcuts/drive: 没有可用 evidence_top_results；drive search shortcut 需要返回更稳定的标题、id/token、时间和摘要字段。 (cases: case_002)
- F-001 [low] search_strategy/drive -> skills/lark-drive/references/lark-drive-search.md: recall=1；应在 drive 搜索中优先使用 query 的时间/人员/状态过滤，并用非污染 evidence_top_results 验证目标资源。 (cases: case_001)
- F-003 [low] search_strategy/drive -> skills/lark-drive/references/lark-drive-search.md: recall=0；应在 drive 搜索中优先使用 query 的时间/人员/状态过滤，并用非污染 evidence_top_results 验证目标资源。 (cases: case_002)

## Review Notes

This PR was generated from eval-search findings. Reviewers should check that
changes are domain-specific, generic, and not tailored to one case's exact gold
answer.
