### PR TITLE
fix(sheets): apply lark-sheets audit 20260521 + sync spec docs

### DIFF
--- a/shortcuts/sheets/batch_op_contract_test.go
+++ b/shortcuts/sheets/batch_op_contract_test.go
@@ -531,6 +531,16 @@ func TestBatchOp_RejectsBadSubOpInput(t *testing.T) {
 			`{"sheet-name":"Sheet1"}`,
 			"+filter-delete requires --sheet-id",
 		},
+		// +sparkline-update requires sparkline_id on every
+		// properties.sparklines[i] (server contract). CLI surfaces this
+		// with a pointer to +sparkline-list so the agent doesn't have to
+		// guess the id from an opaque server-side rejection.
+		{
+			"+sparkline-update item missing sparkline_id",
+			"+sparkline-update",
+			`{"sheet-id":"sh1","group-id":"g1","properties":{"sparklines":[{"position":{"row":0,"col":"A"}}]}}`,
+			"missing sparkline_id",
+		},
 	}
 
 	for _, tc := range cases {

--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -1119,14 +1119,14 @@
         "kind": "own",
         "type": "int",
         "required": "required",
-        "desc": "Source range start position (0-based, inclusive)"
+        "desc": "Source range start position (0-based)"
       },
       {
         "name": "end",
         "kind": "own",
         "type": "int",
         "required": "required",
-        "desc": "Source range end position (0-based, inclusive)"
+        "desc": "Source range end position (inclusive)"
       },
       {
         "name": "target",
@@ -3241,7 +3241,7 @@
         "kind": "own",
         "type": "string",
         "required": "required",
-        "desc": "JSON: {\"rows\":[...],\"columns\":[...],\"values\":[...],\"filters\":[...],\"show_row_grand_total\":true,\"show_col_grand_total\":true} (data source goes through --source; do not put data_range here)",
+        "desc": "JSON: {\"rows\":[...],\"columns\":[...],\"values\":[...],\"filters\":[...],\"show_row_grand_total\":true,\"show_col_grand_total\":true} (data source goes through --source; do not put source here)",
         "input": [
           "file",
           "stdin"
@@ -4523,7 +4523,7 @@
         "name": "image-name",
         "kind": "own",
         "type": "string",
-        "required": "required",
+        "required": "optional",
         "desc": "Image name, including extension (e.g. `logo.png`)"
       },
       {
@@ -4544,28 +4544,28 @@
         "name": "position-row",
         "kind": "own",
         "type": "int",
-        "required": "required",
+        "required": "optional",
         "desc": "Row anchor of the image's top-left corner (0-based)"
       },
       {
         "name": "position-col",
         "kind": "own",
         "type": "string",
-        "required": "required",
+        "required": "optional",
         "desc": "Column anchor of the image's top-left corner (column letter, e.g. `A` / `B`)"
       },
       {
         "name": "size-width",
         "kind": "own",
         "type": "int",
-        "required": "required",
+        "required": "optional",
         "desc": "Image width in pixels"
       },
       {
         "name": "size-height",
         "kind": "own",
         "type": "int",
-        "required": "required",
+        "required": "optional",
         "desc": "Image height in pixels"
       },
       {

--- a/shortcuts/sheets/lark_sheet_object_crud.go
+++ b/shortcuts/sheets/lark_sheet_object_crud.go
@@ -44,6 +44,13 @@ type objectCRUDSpec struct {
 	// right nesting level.
 	enhanceCreateInput func(rt flagView, input map[string]interface{})
 	enhanceUpdateInput func(rt flagView, input map[string]interface{})
+	// validateUpdateInput, when set, runs after enhanceUpdateInput to
+	// enforce constraints that span across input fields (e.g. sparkline
+	// requires properties.sparklines[i] to carry sparkline_id on update —
+	// a server contract the CLI now surfaces with a pointer to
+	// +sparkline-list instead of letting the caller hit an opaque
+	// server-side rejection).
+	validateUpdateInput func(input map[string]interface{}) error
 }
 
 func newObjectCreateShortcut(spec objectCRUDSpec) common.Shortcut {
@@ -188,6 +195,11 @@ func objectUpdateInput(runtime flagView, token, sheetID, sheetName string, spec 
 	}
 	if spec.enhanceUpdateInput != nil {
 		spec.enhanceUpdateInput(runtime, input)
+	}
+	if spec.validateUpdateInput != nil {
+		if err := spec.validateUpdateInput(input); err != nil {
+			return nil, err
+		}
 	}
 	return input, nil
 }
@@ -342,11 +354,51 @@ var CondFormatUpdate = newObjectUpdateShortcut(condFormatSpec)
 var CondFormatDelete = newObjectDeleteShortcut(condFormatSpec)
 
 // sparkline — CLI uses --group-id (higher level) as the object selector.
+// Two-layer ID model: --group-id picks the sparkline group; individual
+// items inside properties.sparklines[] are addressed by sparkline_id.
+// On update the server requires sparkline_id on every item (it's how
+// the server maps each entry back to an existing sparkline);
+// validateSparklineUpdateItems surfaces that requirement CLI-side with
+// a pointer to +sparkline-list instead of letting the caller hit a
+// server-side rejection that doesn't mention sparkline_id at all.
+//
+// (sparkline-delete is intentionally not pre-checked here:
+// objectDeleteInput doesn't pass properties through, so the partial-
+// delete branch — properties.sparklines: [{sparkline_id}] — silently
+// degrades to whole-group delete today. Surfacing that gap is a
+// separate fix; this validator stays scoped to update.)
+func validateSparklineUpdateItems(input map[string]interface{}) error {
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		return nil
+	}
+	raw, ok := props["sparklines"]
+	if !ok {
+		return nil // config-only update — fine
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return common.FlagErrorf("+sparkline-update properties.sparklines must be an array")
+	}
+	for i, item := range arr {
+		m, _ := item.(map[string]interface{})
+		if m == nil {
+			return common.FlagErrorf("+sparkline-update properties.sparklines[%d] must be an object", i)
+		}
+		id, _ := m["sparkline_id"].(string)
+		if strings.TrimSpace(id) == "" {
+			return common.FlagErrorf("+sparkline-update properties.sparklines[%d] missing sparkline_id (run `+sparkline-list --group-id <id>` first to read sparkline_id for each item, then echo each id back on the corresponding update entry)", i)
+		}
+	}
+	return nil
+}
+
 var sparklineSpec = objectCRUDSpec{
-	commandPrefix: "+sparkline",
-	toolName:      "manage_sparkline_object",
-	idFlag:        "group-id",
-	idField:       "group_id",
+	commandPrefix:       "+sparkline",
+	toolName:            "manage_sparkline_object",
+	idFlag:              "group-id",
+	idField:             "group_id",
+	validateUpdateInput: validateSparklineUpdateItems,
 }
 var SparklineCreate = newObjectCreateShortcut(sparklineSpec)
 var SparklineUpdate = newObjectUpdateShortcut(sparklineSpec)

--- a/shortcuts/sheets/lark_sheet_object_crud_test.go
+++ b/shortcuts/sheets/lark_sheet_object_crud_test.go
@@ -216,6 +216,27 @@ func TestObjectCRUDShortcuts_DryRun(t *testing.T) {
 				"properties": map[string]interface{}{"type": "line"},
 			},
 		},
+		{
+			// happy path for the new sparkline_id check: each
+			// properties.sparklines[i] carries sparkline_id, so the
+			// validator passes through cleanly.
+			name: "+sparkline-update properties.sparklines[] with sparkline_id passes",
+			sc:   SparklineUpdate,
+			args: []string{
+				"--url", testURL, "--sheet-id", testSheetID, "--group-id", "grpA",
+				"--properties", `{"sparklines":[{"sparkline_id":"sl1","source":"Sheet1!A1:A10"}]}`,
+			},
+			toolName: "manage_sparkline_object",
+			wantInput: map[string]interface{}{
+				"group_id":  "grpA",
+				"operation": "update",
+				"properties": map[string]interface{}{
+					"sparklines": []interface{}{
+						map[string]interface{}{"sparkline_id": "sl1", "source": "Sheet1!A1:A10"},
+					},
+				},
+			},
+		},
 		// float-image — fully hoisted to flat flags
 		{
 			name: "+float-image-create with image-token + position/size",
@@ -249,6 +270,28 @@ func TestObjectCRUDShortcuts_DryRun(t *testing.T) {
 			got := decodeToolInput(t, body, tt.toolName)
 			assertInputEquals(t, got, tt.wantInput)
 		})
+	}
+}
+
+// TestSparklineUpdate_MissingSparklineID confirms the standalone-path
+// pre-check fires: +sparkline-update with properties.sparklines[] but no
+// per-item sparkline_id must fail CLI-side with a pointer to
+// +sparkline-list, before any server call goes out.
+func TestSparklineUpdate_MissingSparklineID(t *testing.T) {
+	t.Parallel()
+	_, stderr, err := runShortcutCapturingErr(t, SparklineUpdate, []string{
+		"--url", testURL, "--sheet-id", testSheetID, "--group-id", "grpA",
+		"--properties", `{"sparklines":[{"source":"Sheet1!A1:A10"}]}`,
+	})
+	if err == nil {
+		t.Fatalf("expected CLI to reject missing sparkline_id; stderr=%s", stderr)
+	}
+	combined := stderr + err.Error()
+	if !strings.Contains(combined, "missing sparkline_id") {
+		t.Errorf("expected error to mention missing sparkline_id; got=%s|%v", stderr, err)
+	}
+	if !strings.Contains(combined, "+sparkline-list") {
+		t.Errorf("expected error to point at +sparkline-list; got=%s|%v", stderr, err)
 	}
 }
 

--- a/skills/lark-sheets/references/lark-sheets-conditional-format.md
+++ b/skills/lark-sheets/references/lark-sheets-conditional-format.md
@@ -146,7 +146,7 @@ _创建/更新的条件格式属性_
 ```bash
 # 重复值高亮
 lark-cli sheets +cond-format-create --url "..." --sheet-id "$SID" \
-  --rule-type duplicate --ranges '["A1:A100"]' \
+  --rule-type duplicateValues --ranges '["A1:A100"]' \
   --properties '{"style":{"back_color":"#FFD7D7"}}'
 
 # 数据条
@@ -163,6 +163,6 @@ lark-cli sheets +cond-format-create --url "..." --sheet-id "$SID" \
 
 ### Validate / DryRun / Execute 约束
 
-- `Validate`：XOR 公共四件套；`--rule-type` / `--ranges` 必填；`--properties` 必须能解析为合法 JSON；按 `--rule-type` 检查必填子字段（`cellValue` 需 `attrs.operator` + `attrs.value`、`formula` 需 `attrs.expression`、`colorScale` 需 `min/mid/max` 配色等）；`+cond-format-delete` 强制 `--yes` 或 `--dry-run`。
+- `Validate`：XOR 公共四件套；`--rule-type` / `--ranges` 必填；`--properties` 必须能解析为合法 JSON；按 `--rule-type` 检查必填子字段（`cellIs` 需 `attrs.operator` + `attrs.value`、`expression` 需 `attrs.formula`、`colorScale` 需 `min/mid/max` 配色等）；`+cond-format-delete` 强制 `--yes` 或 `--dry-run`。
 - `DryRun`：写操作输出"将要 POST/PATCH/DELETE 的 conditional_format 请求模板"。
 - `Execute`：写后调用 `+cond-format-list --rule-id <id>` 回读，envelope.meta.verification 给出规则 / 范围 / 样式对比。

--- a/skills/lark-sheets/references/lark-sheets-float-image.md
+++ b/skills/lark-sheets/references/lark-sheets-float-image.md
@@ -77,13 +77,13 @@ _公共四件套 · 系统：`--dry-run`_
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `--float-image-id` | string | required | 目标图片 id |
-| `--image-name` | string | required | 图片名称，含扩展名（如 `logo.png`） |
+| `--image-name` | string | optional | 图片名称，含扩展名（如 `logo.png`） |
 | `--image-token` | string | xor | 图片 file_token（与 `--image-uri` 二选一）。常见来源：`+float-image-list` 返回的 `image_token` |
 | `--image-uri` | string | xor | 图片 reference_id（与 `--image-token` 二选一）；形如 `<\|image\|>:abcdef` 这种带前缀的字符串 |
-| `--position-row` | int | required | 图片左上角所在行（0-based） |
-| `--position-col` | string | required | 图片左上角所在列（列字母，如 `A` / `B`） |
-| `--size-width` | int | required | 图片宽度（像素） |
-| `--size-height` | int | required | 图片高度（像素） |
+| `--position-row` | int | optional | 图片左上角所在行（0-based） |
+| `--position-col` | string | optional | 图片左上角所在列（列字母，如 `A` / `B`） |
+| `--size-width` | int | optional | 图片宽度（像素） |
+| `--size-height` | int | optional | 图片高度（像素） |
 | `--offset-row` | int | optional | 在 `--position-row` 基础上的行内偏移（像素） |
 | `--offset-col` | int | optional | 在 `--position-col` 基础上的列内偏移（像素） |
 | `--z-index` | int | optional | 图片 Z 轴层级，控制重叠顺序 |

--- a/skills/lark-sheets/references/lark-sheets-pivot-table.md
+++ b/skills/lark-sheets/references/lark-sheets-pivot-table.md
@@ -61,7 +61,7 @@ _公共四件套 · 系统：`--dry-run`_
 
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
-| `--properties` | string + File + Stdin（复合 JSON） | required | JSON：{"rows":[...],"columns":[...],"values":[...],"filters":[...],"show_row_grand_total":true,"show_col_grand_total":true}（数据源走 --source，不要再放进 properties.data_range） |
+| `--properties` | string + File + Stdin（复合 JSON） | required | JSON：{"rows":[...],"columns":[...],"values":[...],"filters":[...],"show_row_grand_total":true,"show_col_grand_total":true}（数据源走 --source，不要再放进 properties.source） |
 | `--target-sheet-id` | string | optional | 透视表落点子表 id；省略时自动新建子表（推荐） |
 | `--target-position` | string | optional | 落点起始 cell（A1 格式，如 `A1`），默认 `A1` |
 | `--source` | string | required | 透视表源数据区域（A1 表示法，格式 `SheetName!StartCell:EndCell`，如 `Sheet1!A1:D100`） |

--- a/skills/lark-sheets/references/lark-sheets-range-operations.md
+++ b/skills/lark-sheets/references/lark-sheets-range-operations.md
@@ -233,7 +233,7 @@ lark-cli sheets +rows-resize --url "..." --sheet-id "$SID" --start 0 --end 0 --t
 lark-cli sheets +cols-resize --url "..." --sheet-id "$SID" --start 0 --end 5 --type standard
 ```
 
-> 同时出现在 `lark_sheet_sheet_structure/cli-shortcuts.md` —— 行高 / 列宽调整也算行列结构层动作。
+> 同时出现在 `lark-sheets-sheet-structure.md` —— 行高 / 列宽调整也算行列结构层动作。
 
 ### `+range-move` / `+range-copy`
 

--- a/skills/lark-sheets/references/lark-sheets-sheet-structure.md
+++ b/skills/lark-sheets/references/lark-sheets-sheet-structure.md
@@ -140,8 +140,8 @@ _公共四件套 · 系统：`--dry-run`_
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
 | `--dimension` | string | required | 维度方向（行或列）（可选值：`row` / `column`） |
-| `--start` | int | required | 源起止区间的起始位置（0-based, inclusive） |
-| `--end` | int | required | 源起止区间的结束位置（0-based, inclusive） |
+| `--start` | int | required | 源起止区间的起始位置（0-based） |
+| `--end` | int | required | 源起止区间的结束位置（inclusive） |
 | `--target` | int | required | 目标位置（move 到该 index 之前；0-based） |
 
 ## Examples
@@ -168,7 +168,7 @@ lark-cli sheets +dim-insert --url "https://example.feishu.cn/sheets/shtXXX" \
 
 ### `+rows-resize` / `+cols-resize`
 
-> ⚠️ 这两条 shortcut 来自 `lark-sheets-range-operations` 的 `+rows-resize / +cols-resize` tool（分组在"工作表"是为了发现性）。详细参数和示例在 `lark_sheet_range_operations/cli-shortcuts.md`。
+> ⚠️ 这两条 shortcut 来自 `lark-sheets-range-operations` 的 `+rows-resize / +cols-resize` tool（分组在"工作表"是为了发现性）。详细参数和示例在 `lark-sheets-range-operations.md`。
 >
 > 行 vs 列底层 schema 有差异：`+rows-resize.--type` 支持 `pixel` / `standard` / `auto`，`+cols-resize.--type` 只支持 `pixel` / `standard`（列宽不支持自动适应）。
 
@@ -180,6 +180,6 @@ lark-cli sheets +dim-insert --url "https://example.feishu.cn/sheets/shtXXX" \
 
 ### Validate / DryRun / Execute 约束
 
-- `Validate`：XOR 公共四件套；`--start ≤ --end`；`+dim-delete` 强制 `--yes` 或 `--dry-run`；`+rows-resize` / `+cols-resize` 的 `--type` 必填，`--type pixel` 时 `--size` 必填、其它 type 时 `--size` 应省略；`+cols-resize.--type` 不接受 `auto`（详见 `lark_sheet_range_operations/cli-shortcuts.md`）。
+- `Validate`：XOR 公共四件套；`--start ≤ --end`；`+dim-delete` 强制 `--yes` 或 `--dry-run`；`+rows-resize` / `+cols-resize` 的 `--type` 必填，`--type pixel` 时 `--size` 必填、其它 type 时 `--size` 应省略；`+rows-resize` / `+cols-resize` 的行 vs 列 `--type` 差异详见 `lark-sheets-range-operations.md`。
 - `DryRun`：写操作输出"将要 PATCH 的 dimension 区间 + 目标参数"。
 - `Execute`：写后自动调用 `+sheet-info --include row_heights,col_widths,hidden_rows,hidden_cols,groups,frozen` 回读对比，envelope.meta.verification 给出受影响的范围。

--- a/skills/lark-sheets/references/lark-sheets-sparkline.md
+++ b/skills/lark-sheets/references/lark-sheets-sparkline.md
@@ -152,7 +152,7 @@ lark-cli sheets +sparkline-delete --url "..." --sheet-id "$SID" --group-id "grpA
   - XOR 公共四件套；`+sparkline-{update,delete}` 必须 `--group-id`。
   - **`+sparkline-update`**：当 `properties.sparklines` 非空时，每一项必须含 `sparkline_id`（CLI 预检，错误信息会指回 `+sparkline-list`，避免命中服务端的不可读拒绝）；只传 `properties.config`（config-only update）合法、不触发 sparkline_id 检查。
   - **`+sparkline-delete`**：不传 `--properties` = 删整组（合法路径，不需要 sparkline_id）；传 `properties.sparklines` 时每项必须含 `sparkline_id`（server contract；CLI 本地暂未预检 delete 的 partial-item 分支，缺 id 会到 server 端才被拒）。
-  - `--properties.type`（仅 create / 整组改样式时）必须命中 enum（`line` / `column` / `winLoss`）；`--properties.data_range` 与 `--properties.target_range` 行/列数需对齐。
+  - `--properties` 顶层只接 `config`（同组共享样式）和 `sparklines`（迷你图项数组）；`+sparkline-create` 要求每个 `sparklines[i]` 含 `position` 与 `source`（或 `source_range`，二选一）。
   - `+sparkline-delete` 强制 `--yes` 或 `--dry-run`。
 - `DryRun`：写操作输出"将要 POST/PATCH/DELETE 的 sparkline group 请求模板"。
-- `Execute`：写后调用 `+sparkline-list --group-id <id>` 回读，envelope.meta.verification 给出 type / style / 生成范围对比。
+- `Execute`：写后调用 `+sparkline-list --group-id <id>` 回读，envelope.meta.verification 给出 `config` / `sparklines` 字段级对比。

--- a/skills/lark-sheets/references/lark-sheets-write-cells.md
+++ b/skills/lark-sheets/references/lark-sheets-write-cells.md
@@ -341,15 +341,24 @@ lark-cli sheets +cells-set-image --url "..." --sheet-name "Sheet1" \
 ```bash
 # 内联 CSV
 lark-cli sheets +csv-put --url "https://example.feishu.cn/sheets/shtXXX" \
-  --sheet-name "Sheet1" --range "A1" --allow-overwrite \
+  --sheet-name "Sheet1" --start-cell "A1" \
   --csv $'name,score\nalice,95\nbob,87'
 
 # 从文件
 lark-cli sheets +csv-put --spreadsheet-token shtXXX --sheet-id "$SID" \
-  --range "A1" --csv @data.csv --allow-overwrite
+  --start-cell "A1" --csv @data.csv
 ```
 
 > `+csv-put` 比 `+cells-set` 短得多——只想批量灌纯值时优先用它。需要公式/样式才换 `+cells-set`。
+>
+> ⚠️ `=` 开头的字符串会被当字面量写入（**不会变公式**）：
+>
+> ```bash
+> lark-cli sheets +csv-put --url "..." --sheet-name "Sheet1" \
+>   --start-cell "A1" \
+>   --csv $'name,score\nalice,=SUM(B2:B10)'
+> # ↑ A2 实际写入字符串 "=SUM(B2:B10)"，**不是公式**。需要写公式请用 +cells-set。
+> ```
 
 ### Validate / DryRun / Execute 约束
 


### PR DESCRIPTION
## Summary

Two-commit follow-up to the lark-sheets audit (review report `lark-sheets-review-20260521`):

### Commit 1 — `fix(sheets): require sparkline_id on +sparkline-update items`

`manage_sparkline_object` uses two layers of IDs: `--group-id` picks the sparkline group, and `properties.sparklines[i].sparkline_id` picks each item inside the group. The server requires `sparkline_id` on every update item; agents that called `+sparkline-update` without per-item ids hit an opaque server-side rejection and got stuck in a try-fail-list-retry loop.

Pre-check CLI-side in `objectUpdateInput` via a new `validateUpdateInput` hook on `objectCRUDSpec`. `sparklineSpec` wires `validateSparklineUpdateItems`, which walks `properties.sparklines[]` and rejects with a message that points at `+sparkline-list`:

> `+sparkline-update properties.sparklines[N] missing sparkline_id (run +sparkline-list --group-id <id> first to read sparkline_id for each item, then echo each id back on the corresponding update entry)`

Covers audit finding **A7** (sparkline schema alignment).

### Commit 2 — `docs(sheets): sync lark-sheets skill from spec`

Pulls latest spec from sheet-skill-spec (MR ee/sheet-skill-spec!6 + earlier develop commits) into `skills/lark-sheets/` and `shortcuts/sheets/data/`. Audit findings now reflected in CLI docs:

| Finding | Fix |
|---|---|
| **A2** | `+cond-format-create` example: `--rule-type duplicate` → `duplicateValues` |
| **A3** | `+cond-format-create` Validate: `cellValue`/`formula` → `cellIs`/`expression` |
| **A5** | `+csv-put` examples: `--range` → `--start-cell`; drop redundant `--allow-overwrite` |
| **A7** | `+sparkline-create`: Validate / Examples aligned with real schema (`config`/`sparklines`), executable JSON example added |
| **B13** | cross-doc dead links: `lark_sheet_*/cli-shortcuts.md` → `lark-sheets-*.md` |
| **C2** | `+csv-put`: `=` literal warning next to Examples |
| **CC5** | `+rows-resize`/`+cols-resize` `--type auto`: single point of truth in range-operations reference |

`flag-defs.json` description / required sync (from base):

- **A4** `+float-image-update`: `image-name` / `position-*` / `size-*` required → optional (patch mode)
- **A8** `+dim-move` `--start`/`--end` description cleanup
- **B3** `+pivot-create --properties`: `data_range` → `source` (real field name)

Also picks up the `+cells-batch-clear` shortcut doc (introduced in spec develop). Go-side dispatch for that shortcut is implemented in `5f3e8c6` already on the refactor branch; this PR just brings the matching doc + flag-defs sync.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./shortcuts/sheets/...` passes

## Out of scope

- **A1 / CC1** (5 `--info_type=…` MCP-style leftovers in SKILL.md) — needs `generate_cli.mjs` translation layer in sheet-skill-spec, follow-up MR.
- **A6** `+cells-set --copy-to-range` — needs base record + Go wiring, follow-up.
- **B1 / B9 / C3** generator rendering improvements (enum truncation, `cell_styles` flatten, conditions schema depth).
- **A8 / CC4** `+dim-move` `--end` inclusive vs exclusive — binary behaviour change, separate discussion.
- **B6 / C1 / CC3** SKILL.md cross-cutting conventions (composite flag types, brace-expansion shorthand, dropdown index).