### PR TITLE
fix(scripts): write meta_data.json with explicit utf-8 encoding

### DIFF
--- a/scripts/fetch_meta.py
+++ b/scripts/fetch_meta.py
@@ -89,7 +89,7 @@ def main():
     count = len(data.get("services", []))
     print(f"fetch-meta: OK, {count} services from remote API", file=sys.stderr)
 
-    with open(OUT_PATH, "w") as fp:
+    with open(OUT_PATH, "w", encoding="utf-8") as fp:
         json.dump(data, fp, ensure_ascii=False, indent=2)
         fp.write("\n")
 


### PR DESCRIPTION
## Summary
On Windows with a non-UTF-8 locale (e.g. CP936/GBK), `scripts/fetch_meta.py` crashes at `json.dump(..., ensure_ascii=False)` whenever the API metadata contains characters outside the locale's range (e.g. Thai `U+0E42` from regional service descriptions). This breaks `make build` on every fresh checkout for affected users.

## Changes
- Pin `open(OUT_PATH, "w")` to `encoding="utf-8"` so the write side matches the existing utf-8 read at line 77.

## Test Plan
- [x] Reproduced the original `UnicodeEncodeError: 'gbk' codec can't encode character 'โ'` on Windows zh-CN before the fix.
- [x] After the fix, `python3 scripts/fetch_meta.py` writes a complete \`internal/registry/meta_data.json\` (~1.4 MB, 13 services) and exits 0 under the same locale.
- [x] No behavior change on platforms where the default encoding is already utf-8 (Linux, macOS).

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved consistency of internal data handling by specifying explicit character encoding for better reliability across different systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1047?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->