### PR TITLE
fix(contact): add actionable hint when fanout search all-fail with no API code

### DIFF
--- a/shortcuts/contact/contact_search_user_fanout.go
+++ b/shortcuts/contact/contact_search_user_fanout.go
@@ -176,7 +176,11 @@ func buildFanoutResponse(queries []string, results []fanoutResult) (*fanoutRespo
 		if firstErrCode != 0 {
 			return nil, output.ErrAPI(firstErrCode, msg, "")
 		}
-		return nil, output.ErrWithHint(output.ExitInternal, "fanout", msg, "")
+		// No structured API code — the failure was transport, parse, panic, or
+		// cancellation. Suggest the actionable next step rather than shipping
+		// an empty hint that would leave the calling agent with nothing to do.
+		return nil, output.ErrWithHint(output.ExitInternal, "fanout", msg,
+			"retry the command; if it persists, narrow --queries to a single term to isolate the failing input")
 	}
 	return out, nil
 }

--- a/shortcuts/contact/contact_search_user_test.go
+++ b/shortcuts/contact/contact_search_user_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
 )
@@ -1130,6 +1132,33 @@ func TestFanoutAssemble_AllFailed_ReturnsError(t *testing.T) {
 	// Document the count is part of the message — agents grep for it.
 	if !strings.Contains(err.Error(), "all 2 queries failed") {
 		t.Errorf("expected 'all 2 queries failed' substring; got %v", err)
+	}
+}
+
+// When all queries fail with no structured Lark API code (transport, parse,
+// panic, ctx-canceled), the returned ExitError must carry an actionable
+// hint so the calling agent has a next step to try instead of giving up.
+func TestFanoutAssemble_AllFailed_NoCode_HasActionableHint(t *testing.T) {
+	results := []fanoutResult{
+		{Index: 0, Query: "alice", ErrMsg: "transport: connection refused"},
+		{Index: 1, Query: "bob", ErrMsg: "transport: timeout"},
+	}
+	_, err := buildFanoutResponse([]string{"alice", "bob"}, results)
+	if err == nil {
+		t.Fatalf("expected error when all queries failed")
+	}
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected *output.ExitError, got %T", err)
+	}
+	if exitErr.Detail == nil {
+		t.Fatalf("expected Detail, got nil")
+	}
+	if exitErr.Detail.Hint == "" {
+		t.Errorf("expected non-empty Hint so agents have a next step; got empty")
+	}
+	if !strings.Contains(exitErr.Detail.Hint, "retry") {
+		t.Errorf("hint should suggest retry as the first action; got %q", exitErr.Detail.Hint)
 	}
 }
 


### PR DESCRIPTION
## Summary
In `shortcuts/contact/contact_search_user_fanout.go`, when **every** fanout query fails AND the first failure has no Lark API code (transport / parse / panic / context-cancel), the returned `ExitError` was carrying an **empty `Hint`**. This is the only `output.ErrWithHint` call in `shortcuts/` shipping an empty hint.

AGENTS.md is explicit on this:

> every error message you write will be parsed by an AI to decide its next action. Make errors structured, actionable, and specific.

An empty hint gives the agent nothing to do.

## Changes
- `shortcuts/contact/contact_search_user_fanout.go`: populate the hint on the no-API-code branch with the actionable next step — *"retry the command; if it persists, narrow --queries to a single term to isolate the failing input"*. The other branch (with a real Lark code) already routes through `output.ErrAPI` and is unchanged.
- `shortcuts/contact/contact_search_user_test.go`: add `TestFanoutAssemble_AllFailed_NoCode_HasActionableHint` that asserts the returned `*output.ExitError` carries a non-empty `Detail.Hint` containing `"retry"`. Confirmed it fails on `main` ("expected non-empty Hint so agents have a next step; got empty") and passes after the fix.

## Test Plan
- [x] `go test ./shortcuts/contact/ -run TestFanoutAssemble` — 6/6 sub-cases pass
- [x] `go test ./shortcuts/contact/` — full package passes
- [x] Confirmed the new test fails on `main` (empty Hint) and passes with the fix
- [x] `go vet ./shortcuts/contact/`, `gofmt -l` — clean
- [x] No behaviour change for the existing branch with a Lark API code (`output.ErrAPI`)

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for contact search failures: when all queries fail without a structured error code, users now receive an actionable hint (retry and try narrowing the query).
* **Tests**
  * Added a regression test to verify the actionable hint is included in the error details when this failure scenario occurs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1054?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->