### PR TITLE
fix: support project-scoped skills sync

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -82,10 +82,11 @@ func symArrow() string {
 
 // UpdateOptions holds inputs for the update command.
 type UpdateOptions struct {
-	Factory *cmdutil.Factory
-	JSON    bool
-	Force   bool
-	Check   bool
+	Factory       *cmdutil.Factory
+	JSON          bool
+	Force         bool
+	Check         bool
+	ProjectSkills bool
 }
 
 // NewCmdUpdate creates the update command.
@@ -102,7 +103,8 @@ Detects the installation method automatically:
   - manual/other: shows GitHub Releases download URL
 
 Use --json for structured output (for AI agents and scripts).
-Use --check to only check for updates without installing.`,
+Use --check to only check for updates without installing.
+Use --project to sync AI skills into the current project instead of globally.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return updateRun(opts)
 		},
@@ -111,6 +113,7 @@ Use --check to only check for updates without installing.`,
 	cmd.Flags().BoolVar(&opts.JSON, "json", false, "structured JSON output")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "force reinstall even if already up to date")
 	cmd.Flags().BoolVar(&opts.Check, "check", false, "only check for updates, do not install")
+	cmd.Flags().BoolVar(&opts.ProjectSkills, "project", false, "sync AI skills into the current project instead of globally")
 	cmdutil.SetRisk(cmd, "high-risk-write")
 
 	return cmd
@@ -143,7 +146,7 @@ func updateRun(opts *UpdateOptions) error {
 		// Skip side-effects under --check (pure report path per spec §3.6).
 		var skillsResult *selfupdate.NpmResult
 		if !opts.Check {
-			skillsResult = runSkillsAndStamp(updater, io, cur, opts.Force)
+			skillsResult = runSkillsAndStamp(updater, io, cur, opts.Force, opts.ProjectSkills)
 		}
 		return reportAlreadyUpToDate(opts, io, cur, latest, skillsResult, opts.Check)
 	}
@@ -210,7 +213,7 @@ func reportCheckResult(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest s
 }
 
 func doManualUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest string, detect selfupdate.DetectResult, updater *selfupdate.Updater) error {
-	skillsResult := runSkillsAndStamp(updater, io, cur, opts.Force)
+	skillsResult := runSkillsAndStamp(updater, io, cur, opts.Force, opts.ProjectSkills)
 
 	reason := detect.ManualReason()
 	if opts.JSON {
@@ -228,8 +231,8 @@ func doManualUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest stri
 	fmt.Fprintf(io.ErrOut, "To update manually, download the latest release:\n")
 	fmt.Fprintf(io.ErrOut, "  Release:   %s\n", releaseURL(latest))
 	fmt.Fprintf(io.ErrOut, "  Changelog: %s\n", changelogURL())
-	fmt.Fprintf(io.ErrOut, "\nOr install via npm (note: skills will not be synced):\n  npm install -g %s@%s\n  npx skills add larksuite/cli -y -g   # sync skills separately\n", selfupdate.NpmPackage, latest)
-	emitSkillsTextHints(io, skillsResult)
+	fmt.Fprintf(io.ErrOut, "\nOr install via npm (note: skills will not be synced):\n  npm install -g %s@%s\n  %s   # sync skills separately\n", selfupdate.NpmPackage, latest, skillsManualCommand(opts.ProjectSkills))
+	emitSkillsTextHints(io, skillsResult, opts.ProjectSkills)
 	return nil
 }
 
@@ -275,7 +278,7 @@ func doNpmUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest string,
 	if err := updater.VerifyBinary(latest); err != nil {
 		restore()
 		msg := fmt.Sprintf("new binary verification failed: %s", err)
-		hint := verificationFailureHint(updater, latest)
+		hint := verificationFailureHint(updater, latest, opts.ProjectSkills)
 		if opts.JSON {
 			output.PrintJson(io.Out, map[string]interface{}{
 				"ok":    false,
@@ -291,7 +294,7 @@ func doNpmUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest string,
 	// Skills update (best-effort) — uses runSkillsAndStamp so the
 	// stamp gets persisted on success and dedup applies if a previous
 	// run already stamped this version.
-	skillsResult := runSkillsAndStamp(updater, io, latest, opts.Force)
+	skillsResult := runSkillsAndStamp(updater, io, latest, opts.Force, opts.ProjectSkills)
 
 	if opts.JSON {
 		result := map[string]interface{}{
@@ -310,7 +313,7 @@ func doNpmUpdate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, latest string,
 	if skillsResult != nil {
 		fmt.Fprintf(io.ErrOut, "\nUpdating skills ...\n")
 	}
-	emitSkillsTextHints(io, skillsResult)
+	emitSkillsTextHints(io, skillsResult, opts.ProjectSkills)
 	return nil
 }
 
@@ -321,11 +324,11 @@ func permissionHint(npmOutput string) string {
 	return ""
 }
 
-func verificationFailureHint(updater *selfupdate.Updater, latest string) string {
+func verificationFailureHint(updater *selfupdate.Updater, latest string, projectSkills bool) string {
 	if updater.CanRestorePreviousVersion() {
 		return "the previous version has been restored"
 	}
-	return fmt.Sprintf("automatic rollback is unavailable on this platform; reinstall manually (skills will not be synced): npm install -g %s@%s && npx skills add larksuite/cli -y -g, or download %s", selfupdate.NpmPackage, latest, releaseURL(latest))
+	return fmt.Sprintf("automatic rollback is unavailable on this platform; reinstall manually (skills will not be synced): npm install -g %s@%s && %s, or download %s", selfupdate.NpmPackage, latest, skillsManualCommand(projectSkills), releaseURL(latest))
 }
 
 // runSkillsAndStamp triggers updater.RunSkillsUpdate and persists the
@@ -336,13 +339,16 @@ func verificationFailureHint(updater *selfupdate.Updater, latest string) string 
 // out-of-sync, so npx re-runs). Returns nil iff skipped due to stamp
 // dedup; otherwise returns the underlying *NpmResult with Err semantics
 // from RunSkillsUpdate.
-func runSkillsAndStamp(updater *selfupdate.Updater, io *cmdutil.IOStreams, stampVersion string, force bool) *selfupdate.NpmResult {
+func runSkillsAndStamp(updater *selfupdate.Updater, io *cmdutil.IOStreams, stampVersion string, force bool, projectSkills bool) *selfupdate.NpmResult {
+	if projectSkills {
+		return updater.RunSkillsUpdateWithScope(true)
+	}
 	if !force {
 		if existing, _ := skillscheck.ReadStamp(); normalizeVersion(existing) == normalizeVersion(stampVersion) {
 			return nil
 		}
 	}
-	r := updater.RunSkillsUpdate()
+	r := updater.RunSkillsUpdateWithScope(false)
 	if r.Err == nil {
 		if err := skillscheck.WriteStamp(stampVersion); err != nil {
 			fmt.Fprintf(io.ErrOut, "warning: skills synced but stamp not written: %v\n", err)
@@ -382,7 +388,7 @@ func reportAlreadyUpToDate(opts *UpdateOptions, io *cmdutil.IOStreams, cur, late
 	}
 	fmt.Fprintf(io.ErrOut, "%s lark-cli %s is already up to date\n", symOK(), cur)
 	if !check {
-		emitSkillsTextHints(io, skillsResult)
+		emitSkillsTextHints(io, skillsResult, opts.ProjectSkills)
 	}
 	return nil
 }
@@ -406,7 +412,7 @@ func applySkillsResult(env map[string]interface{}, r *selfupdate.NpmResult) {
 
 // emitSkillsTextHints prints human-readable feedback about the skills
 // sync result for non-JSON output.
-func emitSkillsTextHints(io *cmdutil.IOStreams, r *selfupdate.NpmResult) {
+func emitSkillsTextHints(io *cmdutil.IOStreams, r *selfupdate.NpmResult, projectSkills bool) {
 	switch {
 	case r == nil:
 		// dedup hit — silent (already up to date)
@@ -415,8 +421,16 @@ func emitSkillsTextHints(io *cmdutil.IOStreams, r *selfupdate.NpmResult) {
 		if detail := strings.TrimSpace(r.Stderr.String()); detail != "" {
 			fmt.Fprintf(io.ErrOut, "  %s\n", selfupdate.Truncate(detail, maxStderrDetail))
 		}
-		fmt.Fprintf(io.ErrOut, "  Run manually: npx -y skills add larksuite/cli -g -y\n")
+		fmt.Fprintf(io.ErrOut, "  Run manually: %s\n", skillsManualCommand(projectSkills))
 	default:
 		fmt.Fprintf(io.ErrOut, "%s Skills updated\n", symOK())
 	}
+}
+
+func skillsManualCommand(projectSkills bool) string {
+	scopeFlag := "-g"
+	if projectSkills {
+		scopeFlag = "-p"
+	}
+	return fmt.Sprintf("npx -y skills add larksuite/cli %s -y", scopeFlag)
 }

--- a/cmd/update/update_test.go
+++ b/cmd/update/update_test.go
@@ -484,7 +484,7 @@ func TestUpdateNpmVerifyFail_JSON_NoRestoreHintWhenBackupUnavailable(t *testing.
 	if !strings.Contains(out, "skills will not be synced") {
 		t.Errorf("expected skills-not-synced warning in rollback hint, got: %s", out)
 	}
-	if !strings.Contains(out, "npx skills add larksuite/cli -y -g") {
+	if !strings.Contains(out, "npx -y skills add larksuite/cli -g -y") {
 		t.Errorf("expected npx skills add hint for skills sync, got: %s", out)
 	}
 }
@@ -886,7 +886,7 @@ func TestRunSkillsAndStamp_DedupHit(t *testing.T) {
 			return &selfupdate.NpmResult{}
 		},
 	}
-	got := runSkillsAndStamp(updater, newTestIO(), "1.0.21", false)
+	got := runSkillsAndStamp(updater, newTestIO(), "1.0.21", false, false)
 	if got != nil {
 		t.Errorf("runSkillsAndStamp() = %+v, want nil for dedup hit", got)
 	}
@@ -908,7 +908,7 @@ func TestRunSkillsAndStamp_DedupForceBypass(t *testing.T) {
 			return &selfupdate.NpmResult{}
 		},
 	}
-	got := runSkillsAndStamp(updater, newTestIO(), "1.0.21", true)
+	got := runSkillsAndStamp(updater, newTestIO(), "1.0.21", true, false)
 	if got == nil {
 		t.Fatal("runSkillsAndStamp(force=true) = nil, want non-nil")
 	}
@@ -925,7 +925,7 @@ func TestRunSkillsAndStamp_SuccessWritesStamp(t *testing.T) {
 			return &selfupdate.NpmResult{}
 		},
 	}
-	got := runSkillsAndStamp(updater, newTestIO(), "1.0.21", false)
+	got := runSkillsAndStamp(updater, newTestIO(), "1.0.21", false, false)
 	if got == nil || got.Err != nil {
 		t.Fatalf("runSkillsAndStamp() = %+v, want non-nil with nil Err", got)
 	}
@@ -948,13 +948,44 @@ func TestRunSkillsAndStamp_FailureKeepsOldStamp(t *testing.T) {
 			return r
 		},
 	}
-	got := runSkillsAndStamp(updater, newTestIO(), "1.0.21", false)
+	got := runSkillsAndStamp(updater, newTestIO(), "1.0.21", false, false)
 	if got == nil || got.Err == nil {
 		t.Fatalf("runSkillsAndStamp() = %+v, want non-nil with non-nil Err", got)
 	}
 	stamp, _ := skillscheck.ReadStamp()
 	if stamp != "1.0.20" {
 		t.Errorf("stamp = %q, want \"1.0.20\" (failure must not overwrite)", stamp)
+	}
+}
+
+func TestRunSkillsAndStamp_ProjectScopeBypassesGlobalStamp(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", dir)
+	if err := skillscheck.WriteStamp("1.0.21"); err != nil {
+		t.Fatal(err)
+	}
+	called := false
+	projectScope := false
+	updater := &selfupdate.Updater{
+		SkillsUpdateWithScopeOverride: func(project bool) *selfupdate.NpmResult {
+			called = true
+			projectScope = project
+			return &selfupdate.NpmResult{}
+		},
+	}
+	got := runSkillsAndStamp(updater, newTestIO(), "1.0.21", false, true)
+	if got == nil || got.Err != nil {
+		t.Fatalf("runSkillsAndStamp(project=true) = %+v, want non-nil success", got)
+	}
+	if !called {
+		t.Fatal("RunSkillsUpdateWithScope not called for project scope")
+	}
+	if !projectScope {
+		t.Fatal("RunSkillsUpdateWithScope called with project=false, want true")
+	}
+	stamp, _ := skillscheck.ReadStamp()
+	if stamp != "1.0.21" {
+		t.Errorf("project scope must not mutate global stamp, got %q", stamp)
 	}
 }
 
@@ -1222,7 +1253,7 @@ func TestRunSkillsAndStamp_StampWriteFailureWarns(t *testing.T) {
 			return &selfupdate.NpmResult{} // success
 		},
 	}
-	got := runSkillsAndStamp(updater, f.IOStreams, "1.0.21", false)
+	got := runSkillsAndStamp(updater, f.IOStreams, "1.0.21", false, false)
 	if got == nil || got.Err != nil {
 		t.Fatalf("runSkillsAndStamp() = %+v, want non-nil with nil Err", got)
 	}
@@ -1235,8 +1266,46 @@ func TestRunSkillsAndStamp_StampWriteFailureWarns(t *testing.T) {
 // message is printed to ErrOut on a successful (Err == nil) result.
 func TestEmitSkillsTextHints_Success(t *testing.T) {
 	f, _, stderr := newTestFactory(t)
-	emitSkillsTextHints(f.IOStreams, &selfupdate.NpmResult{}) // Err==nil → success
+	emitSkillsTextHints(f.IOStreams, &selfupdate.NpmResult{}, false) // Err==nil → success
 	if !strings.Contains(stderr.String(), "Skills updated") {
 		t.Errorf("stderr does not contain 'Skills updated': %q", stderr.String())
+	}
+}
+
+func TestUpdateProjectFlagPassesProjectScope(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", dir)
+
+	origFetch := fetchLatest
+	origCur := currentVersion
+	t.Cleanup(func() { fetchLatest = origFetch; currentVersion = origCur })
+	fetchLatest = func() (string, error) { return "1.0.21", nil }
+	currentVersion = func() string { return "1.0.21" }
+
+	called := false
+	projectScope := false
+	origNew := newUpdater
+	t.Cleanup(func() { newUpdater = origNew })
+	newUpdater = func() *selfupdate.Updater {
+		return &selfupdate.Updater{
+			SkillsUpdateWithScopeOverride: func(project bool) *selfupdate.NpmResult {
+				called = true
+				projectScope = project
+				return &selfupdate.NpmResult{}
+			},
+		}
+	}
+
+	f, _, _ := newTestFactory(t)
+	cmd := NewCmdUpdate(f)
+	cmd.SetArgs([]string{"--project", "--json"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("cmd.Execute() err = %v, want nil", err)
+	}
+	if !called {
+		t.Fatal("skills update was not called")
+	}
+	if !projectScope {
+		t.Fatal("skills update got project=false, want true")
 	}
 }

--- a/internal/selfupdate/updater.go
+++ b/internal/selfupdate/updater.go
@@ -78,14 +78,16 @@ func (r *NpmResult) CombinedOutput() string {
 // Platform-specific methods (PrepareSelfReplace, CleanupStaleFiles)
 // are in updater_unix.go and updater_windows.go.
 //
-// Override DetectOverride / NpmInstallOverride / SkillsUpdateOverride / VerifyOverride
-// / RestoreAvailableOverride for testing.
+// Override DetectOverride / NpmInstallOverride / SkillsUpdateOverride /
+// SkillsUpdateWithScopeOverride / VerifyOverride / RestoreAvailableOverride
+// for testing.
 type Updater struct {
-	DetectOverride           func() DetectResult
-	NpmInstallOverride       func(version string) *NpmResult
-	SkillsUpdateOverride     func() *NpmResult
-	VerifyOverride           func(expectedVersion string) error
-	RestoreAvailableOverride func() bool
+	DetectOverride                func() DetectResult
+	NpmInstallOverride            func(version string) *NpmResult
+	SkillsUpdateOverride          func() *NpmResult
+	SkillsUpdateWithScopeOverride func(project bool) *NpmResult
+	VerifyOverride                func(expectedVersion string) error
+	RestoreAvailableOverride      func() bool
 
 	// backupCreated is set to true by PrepareSelfReplace (Windows) when the
 	// running binary is successfully renamed to .old. Used by
@@ -153,20 +155,29 @@ func (u *Updater) RunNpmInstall(version string) *NpmResult {
 	return r
 }
 
-// RunSkillsUpdate installs skills, trying the .well-known source first and
-// falling back to the GitHub repo on failure or timeout.
+// RunSkillsUpdate installs skills globally, trying the .well-known source
+// first and falling back to the GitHub repo on failure or timeout.
 func (u *Updater) RunSkillsUpdate() *NpmResult {
+	return u.RunSkillsUpdateWithScope(false)
+}
+
+// RunSkillsUpdateWithScope installs skills, optionally into the current
+// project instead of the global skills directory.
+func (u *Updater) RunSkillsUpdateWithScope(project bool) *NpmResult {
+	if u.SkillsUpdateWithScopeOverride != nil {
+		return u.SkillsUpdateWithScopeOverride(project)
+	}
 	if u.SkillsUpdateOverride != nil {
 		return u.SkillsUpdateOverride()
 	}
-	r := u.runSkillsAdd("https://open.feishu.cn")
+	r := u.runSkillsAdd("https://open.feishu.cn", project)
 	if r.Err != nil {
-		r = u.runSkillsAdd("larksuite/cli")
+		r = u.runSkillsAdd("larksuite/cli", project)
 	}
 	return r
 }
 
-func (u *Updater) runSkillsAdd(source string) *NpmResult {
+func (u *Updater) runSkillsAdd(source string, project bool) *NpmResult {
 	r := &NpmResult{}
 	npxPath, err := exec.LookPath("npx")
 	if err != nil {
@@ -175,7 +186,7 @@ func (u *Updater) runSkillsAdd(source string) *NpmResult {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), skillsUpdateTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, npxPath, "-y", "skills", "add", source, "-g", "-y")
+	cmd := exec.CommandContext(ctx, npxPath, skillsAddArgs(source, project)...)
 	cmd.Stdout = &r.Stdout
 	cmd.Stderr = &r.Stderr
 	r.Err = cmd.Run()
@@ -183,6 +194,14 @@ func (u *Updater) runSkillsAdd(source string) *NpmResult {
 		r.Err = fmt.Errorf("skills update timed out after %s", skillsUpdateTimeout)
 	}
 	return r
+}
+
+func skillsAddArgs(source string, project bool) []string {
+	scopeFlag := "-g"
+	if project {
+		scopeFlag = "-p"
+	}
+	return []string{"-y", "skills", "add", source, scopeFlag, "-y"}
 }
 
 // VerifyBinary checks that the installed binary reports the expected version

--- a/internal/selfupdate/updater_test.go
+++ b/internal/selfupdate/updater_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 
@@ -164,5 +165,21 @@ func TestVerifyBinaryEmptyOutput(t *testing.T) {
 
 	if err := New().VerifyBinary("2.0.0"); err == nil {
 		t.Fatal("VerifyBinary(empty output) expected error, got nil")
+	}
+}
+
+func TestSkillsAddArgs_GlobalScope(t *testing.T) {
+	got := skillsAddArgs("larksuite/cli", false)
+	want := []string{"-y", "skills", "add", "larksuite/cli", "-g", "-y"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("skillsAddArgs(global) = %#v, want %#v", got, want)
+	}
+}
+
+func TestSkillsAddArgs_ProjectScope(t *testing.T) {
+	got := skillsAddArgs("larksuite/cli", true)
+	want := []string{"-y", "skills", "add", "larksuite/cli", "-p", "-y"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("skillsAddArgs(project) = %#v, want %#v", got, want)
 	}
 }

--- a/scripts/install-wizard.js
+++ b/scripts/install-wizard.js
@@ -5,7 +5,8 @@
 const fs = require("fs");
 const path = require("path");
 const { execFileSync, execFile } = require("child_process");
-const p = require("@clack/prompts");
+const isTestMode = process.env.LARK_CLI_INSTALL_WIZARD_TEST === "1";
+const p = isTestMode ? null : require("@clack/prompts");
 
 const PKG = "@larksuite/cli";
 const SKILLS_REPO = "https://open.feishu.cn";
@@ -29,7 +30,7 @@ const messages = {
     step2Skip:      "已安装，跳过",
     step2Spinner:   "正在安装 Skills...",
     step2Done:      "Skills 已安装",
-    step2Fail:      "Skills 安装失败。运行以下命令重试: npx skills add %s -y -g",
+    step2Fail:      "Skills 安装失败。运行以下命令重试: %s",
     step3:          "正在配置应用...",
     step3NotFound:  "未找到 lark-cli，终止",
     step3Found:     "发现已配置应用 (App ID: %s)，继续使用？",
@@ -58,7 +59,7 @@ const messages = {
     step2Skip:      "Already installed. Skipped",
     step2Spinner:   "Installing skills...",
     step2Done:      "Skills installed",
-    step2Fail:      "Failed to install skills. Run manually: npx skills add %s -y -g",
+    step2Fail:      "Failed to install skills. Run manually: %s",
     step3:          "Configuring app...",
     step3NotFound:  "lark-cli not found. Aborting",
     step3Found:     "Found existing app (App ID: %s). Use this app?",
@@ -211,6 +212,24 @@ function parseLangArg() {
   return null;
 }
 
+/** Parse --project from process.argv. Default remains global skill install. */
+function parseProjectArg() {
+  const args = process.argv.slice(2);
+  return args.includes("--project");
+}
+
+function skillsScopeFlag(projectScope) {
+  return projectScope ? "-p" : "-g";
+}
+
+function skillsAddArgs(source, projectScope) {
+  return ["-y", "skills", "add", source, "-y", skillsScopeFlag(projectScope)];
+}
+
+function skillsAddCommand(source, projectScope) {
+  return ["npx", ...skillsAddArgs(source, projectScope)].join(" ");
+}
+
 // ---------------------------------------------------------------------------
 // Steps
 // ---------------------------------------------------------------------------
@@ -255,9 +274,9 @@ async function stepInstallGlobally(msg) {
   }
 }
 
-async function skillsAlreadyInstalled() {
+async function skillsAlreadyInstalled(projectScope) {
   try {
-    const out = await runSilentAsync("npx", ["-y", "skills", "ls", "-g"], {
+    const out = await runSilentAsync("npx", ["-y", "skills", "ls", skillsScopeFlag(projectScope)], {
       timeout: 120000,
     });
     return /^lark-/m.test(out.toString());
@@ -266,26 +285,26 @@ async function skillsAlreadyInstalled() {
   }
 }
 
-async function stepInstallSkills(msg) {
+async function stepInstallSkills(msg, projectScope) {
   const s = p.spinner();
   s.start(msg.step2Spinner);
   try {
-    if (await skillsAlreadyInstalled()) {
+    if (await skillsAlreadyInstalled(projectScope)) {
       s.stop(msg.step2Skip);
       return;
     }
     try {
-      await runSilentAsync("npx", ["-y", "skills", "add", SKILLS_REPO, "-y", "-g"], {
+      await runSilentAsync("npx", skillsAddArgs(SKILLS_REPO, projectScope), {
         timeout: 120000,
       });
     } catch (_) {
-      await runSilentAsync("npx", ["-y", "skills", "add", SKILLS_REPO_FALLBACK, "-y", "-g"], {
+      await runSilentAsync("npx", skillsAddArgs(SKILLS_REPO_FALLBACK, projectScope), {
         timeout: 120000,
       });
     }
     s.stop(msg.step2Done);
   } catch (_) {
-    s.stop(fmt(msg.step2Fail, SKILLS_REPO_FALLBACK));
+    s.stop(fmt(msg.step2Fail, skillsAddCommand(SKILLS_REPO_FALLBACK, projectScope)));
     process.exit(1);
   }
 }
@@ -357,24 +376,34 @@ async function stepAuthLogin(msg) {
 async function main() {
   const isInteractive = !!process.stdin.isTTY;
   const lang = isInteractive ? await stepSelectLang() : (parseLangArg() || "en");
+  const projectScope = parseProjectArg();
   const msg = messages[lang];
 
   if (isInteractive) {
     p.intro(msg.setup);
     await stepInstallGlobally(msg);
-    await stepInstallSkills(msg);
+    await stepInstallSkills(msg, projectScope);
     await stepConfigInit(msg, lang);
     await stepAuthLogin(msg);
     p.outro(msg.done);
   } else {
     console.log(msg.setup);
     await stepInstallGlobally(msg);
-    await stepInstallSkills(msg);
+    await stepInstallSkills(msg, projectScope);
     console.log(msg.nonTtyHint);
   }
 }
 
-main().catch((err) => {
-  p.cancel("Unexpected error: " + (err.message || err));
-  process.exit(1);
-});
+if (isTestMode) {
+  module.exports = {
+    parseProjectArg,
+    skillsAddArgs,
+    skillsAddCommand,
+    skillsScopeFlag,
+  };
+} else {
+  main().catch((err) => {
+    p.cancel("Unexpected error: " + (err.message || err));
+    process.exit(1);
+  });
+}

--- a/scripts/install-wizard.test.js
+++ b/scripts/install-wizard.test.js
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+process.env.LARK_CLI_INSTALL_WIZARD_TEST = "1";
+const {
+  skillsAddArgs,
+  skillsAddCommand,
+  skillsScopeFlag,
+} = require("./install-wizard.js");
+
+describe("install wizard skills scope", () => {
+  it("keeps global skills install by default", () => {
+    assert.equal(skillsScopeFlag(false), "-g");
+    assert.deepEqual(
+      skillsAddArgs("larksuite/cli", false),
+      ["-y", "skills", "add", "larksuite/cli", "-y", "-g"],
+    );
+  });
+
+  it("uses project scope when requested", () => {
+    assert.equal(skillsScopeFlag(true), "-p");
+    assert.deepEqual(
+      skillsAddArgs("larksuite/cli", true),
+      ["-y", "skills", "add", "larksuite/cli", "-y", "-p"],
+    );
+  });
+
+  it("prints retry command with matching scope", () => {
+    assert.equal(
+      skillsAddCommand("larksuite/cli", true),
+      "npx -y skills add larksuite/cli -y -p",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds a project-scoped skills sync option for the update/install flows so users can keep lark-* skills out of the global agent skill namespace when desired. Default behavior remains global for compatibility.

## Changes
- Add `lark-cli update --project` and plumb project scope through the self-update skills sync path.
- Use `npx skills add ... -p` when project scope is requested, while preserving `-g` by default.
- Add the same `--project` scope to the npm install wizard and retry command text.
- Avoid treating a project-scoped sync as a global skills stamp update.

## Test Plan
- [x] `go test ./internal/selfupdate ./cmd/update`
- [x] `node --test scripts/install-wizard.test.js`
- [x] `node --check scripts/install-wizard.js`

## Related Issues
- Refs #1055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--project` flag to the `lark-cli update` command, allowing AI skills to be installed at project scope instead of globally.
  * Skills syncing now respects the chosen scope with scope-aware command guidance in output messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1058?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->