### PR TITLE
fix(keychain): prefer file-based master key to fix background/automat…

### DIFF
--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -269,16 +269,41 @@ func platformGet(service, account string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
+	migrateToFileMasterKey(service, account, plaintext)
+
 	return plaintext, nil
+}
+
+// migrateToFileMasterKey re-encrypts a secret with the file-based master key
+// so that future reads work in background/automation contexts without system keychain access.
+func migrateToFileMasterKey(service, account, plaintext string) {
+	fileKey, err := getFileMasterKey(service, true)
+	if err != nil {
+		return
+	}
+	encrypted, err := encryptData(plaintext, fileKey)
+	if err != nil {
+		return
+	}
+	dir := StorageDir(service)
+	targetPath := filepath.Join(dir, safeFileName(account))
+	tmpPath := targetPath + "." + uuid.New().String() + ".tmp"
+	if vfs.WriteFile(tmpPath, encrypted, 0600) != nil {
+		return
+	}
+	if vfs.Rename(tmpPath, targetPath) != nil {
+		_ = vfs.Remove(tmpPath)
+	}
 }
 
 // platformSet stores a value in the macOS keychain.
 func platformSet(service, account, data string) error {
 	key, err := getFileMasterKey(service, false)
 	if err != nil {
-		key, err = getMasterKey(service, true)
+		key, err = getFileMasterKey(service, true)
 		if err != nil {
-			key, err = getFileMasterKey(service, true)
+			key, err = getMasterKey(service, true)
 			if err != nil {
 				return err
 			}

--- a/internal/keychain/keychain_darwin_test.go
+++ b/internal/keychain/keychain_darwin_test.go
@@ -55,6 +55,126 @@ func TestPlatformSetFallsBackToFileMasterKey(t *testing.T) {
 	}
 }
 
+// TestPlatformSetCreatesFileMasterKeyFirst verifies that platformSet creates a
+// file-based master key before attempting system keychain access, ensuring
+// credentials stored in interactive sessions are readable in background contexts.
+func TestPlatformSetCreatesFileMasterKeyFirst(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	keychainKey := make([]byte, masterKeyBytes)
+	for i := range keychainKey {
+		keychainKey[i] = byte(i + 33)
+	}
+
+	keyringGetCalled := false
+	origGet := keyringGet
+	origSet := keyringSet
+	keyringGet = func(service, user string) (string, error) {
+		keyringGetCalled = true
+		return "", keyring.ErrNotFound
+	}
+	keyringSet = func(service, user, password string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		keyringGet = origGet
+		keyringSet = origSet
+	})
+
+	service := "test-service"
+	account := "test-account"
+	secret := "secret-value"
+
+	if err := platformSet(service, account, secret); err != nil {
+		t.Fatalf("platformSet() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(StorageDir(service), fileMasterKeyName)); err != nil {
+		t.Fatalf("file master key not created: %v", err)
+	}
+
+	if keyringGetCalled {
+		t.Error("system keychain should not be accessed when file master key can be created")
+	}
+
+	got, err := platformGet(service, account)
+	if err != nil {
+		t.Fatalf("platformGet() error = %v", err)
+	}
+	if got != secret {
+		t.Fatalf("platformGet() = %q, want %q", got, secret)
+	}
+}
+
+// TestMigrateToFileMasterKey verifies that secrets encrypted with the system
+// keychain master key are automatically migrated to the file-based master key
+// on first successful read, enabling subsequent reads without system keychain access.
+func TestMigrateToFileMasterKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	keychainKey := make([]byte, masterKeyBytes)
+	for i := range keychainKey {
+		keychainKey[i] = byte(i + 33)
+	}
+
+	keyringAvailable := true
+	origGet := keyringGet
+	origSet := keyringSet
+	keyringGet = func(service, user string) (string, error) {
+		if !keyringAvailable {
+			return "", errors.New("keychain access blocked")
+		}
+		return base64.StdEncoding.EncodeToString(keychainKey), nil
+	}
+	keyringSet = func(service, user, password string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		keyringGet = origGet
+		keyringSet = origSet
+	})
+
+	service := "test-service"
+	account := "test-account"
+	secret := "secret-value"
+
+	dir := StorageDir(service)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	encrypted, err := encryptData(secret, keychainKey)
+	if err != nil {
+		t.Fatalf("encryptData() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, safeFileName(account)), encrypted, 0600); err != nil {
+		t.Fatalf("WriteFile(secret) error = %v", err)
+	}
+
+	got, err := platformGet(service, account)
+	if err != nil {
+		t.Fatalf("first platformGet() error = %v", err)
+	}
+	if got != secret {
+		t.Fatalf("first platformGet() = %q, want %q", got, secret)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, fileMasterKeyName)); err != nil {
+		t.Fatalf("file master key not created after migration: %v", err)
+	}
+
+	keyringAvailable = false
+
+	got2, err := platformGet(service, account)
+	if err != nil {
+		t.Fatalf("second platformGet() (no keychain) error = %v", err)
+	}
+	if got2 != secret {
+		t.Fatalf("second platformGet() = %q, want %q", got2, secret)
+	}
+}
+
 // TestPlatformGetPrefersFileMasterKey verifies reads prefer the file-based master key
 // before trying the system keychain master key.
 func TestPlatformGetPrefersFileMasterKey(t *testing.T) {


### PR DESCRIPTION
## 背景

Closes #1038

macOS 上在后台/自动化场景跑 `auth status --verify` 会报 "keychain not initialized"，但同一个 profile 在交互式终端里完全正常。

原因是 `platformSet` 优先用 system keychain 的 master key 来加密凭据，而 system keychain 在没有 GUI session 的情况下根本访问不了。用户在交互式终端里 `config init` 存的密钥，到了自动化脚本里就读不出来了。

## 改了什么

**1. `platformSet` 里调换了 key 优先级**

原来：读已有 file key → system keychain（允许创建）→ 创建 file key
现在：读已有 file key → 创建 file key → system keychain（允许创建）

这样新存的凭据一律用 file key 加密，后台和交互式都能读。

**2. `platformGet` 里加了自动迁移**

当 `platformGet` 通过 system keychain 成功解密后，会自动用 file key 重新加密。老用户不需要重新配置，下次读取就自动迁移了。

## What changed

**1. Swapped key priority in `platformSet`**

Before: existing file key → system keychain (allow create) → create file key
After: existing file key → create file key → system keychain (allow create)

New credentials are now always encrypted with the file-based key, which works in both interactive and background contexts.

**2. Added automatic migration in `platformGet`**

When a secret is successfully decrypted using the system keychain key, it gets re-encrypted with the file-based key. Existing users are migrated on their next read — no manual reconfiguration needed.

## 测试

- [x] `go test ./internal/keychain/... -race` — 5 个测试全过
- [x] `go vet` / `gofmt` — 没问题
- [x] `TestPlatformSetCreatesFileMasterKeyFirst` — 验证新凭据用 file key，不碰 system keychain
- [x] `TestMigrateToFileMasterKey` — 验证迁移：system keychain 解密 → file key 重加密 → 断掉 system keychain 后仍能读取
- [x] 在 macOS 自动化环境里手动验证

## Testing

- [x] `go test ./internal/keychain/... -race` — all 5 tests pass
- [x] `go vet` / `gofmt` — clean
- [x] `TestPlatformSetCreatesFileMasterKeyFirst` — new credentials use file key, not system keychain
- [x] `TestMigrateToFileMasterKey` — migration works: decrypt with system key → re-encrypt with file key → read works without system keychain
- [x] Manual verification in a macOS automation context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secrets stored in macOS system keychain are automatically migrated to local file-based storage on first access.

* **Bug Fixes**
  * Improved master key creation logic for local file-based storage when system keychain is unavailable.

* **Tests**
  * Added tests for file-based master key creation and automatic secret migration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->