### PR TITLE
feat(core): allow overriding endpoint base URLs via env vars

### DIFF
--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -4,9 +4,17 @@
 package core
 
 import (
+	"fmt"
+	"net/url"
 	"os"
 	"strings"
 )
+
+// endpointEnvWarner is where invalid-env-override warnings are written.
+// Defaults to os.Stderr; overridden in tests.
+var endpointEnvWarner = func(env, value string) {
+	fmt.Fprintf(os.Stderr, "[lark-cli] [WARN] %s=%q is not a valid absolute URL (need http/https scheme and host); falling back to brand default\n", env, value)
+}
 
 // LarkBrand represents the Lark platform brand.
 // "feishu" targets China-mainland, "lark" targets international.
@@ -74,18 +82,48 @@ func ResolveEndpoints(brand LarkBrand) Endpoints {
 }
 
 func applyEndpointEnvOverrides(ep *Endpoints) {
-	if v := normalizeBaseURL(os.Getenv(EnvOpenBaseURL)); v != "" {
+	if v, ok := readEndpointEnv(EnvOpenBaseURL); ok {
 		ep.Open = v
 	}
-	if v := normalizeBaseURL(os.Getenv(EnvAccountsBaseURL)); v != "" {
+	if v, ok := readEndpointEnv(EnvAccountsBaseURL); ok {
 		ep.Accounts = v
 	}
-	if v := normalizeBaseURL(os.Getenv(EnvMCPBaseURL)); v != "" {
+	if v, ok := readEndpointEnv(EnvMCPBaseURL); ok {
 		ep.MCP = v
 	}
-	if v := normalizeBaseURL(os.Getenv(EnvAppLinkBaseURL)); v != "" {
+	if v, ok := readEndpointEnv(EnvAppLinkBaseURL); ok {
 		ep.AppLink = v
 	}
+}
+
+// readEndpointEnv reads an endpoint-override env var. Returns (value, true)
+// when the env var holds a valid absolute http/https URL; returns ("", false)
+// when unset/whitespace-only. When set but malformed, warns on stderr and
+// returns ("", false) so the brand default is used.
+func readEndpointEnv(env string) (string, bool) {
+	raw := os.Getenv(env)
+	v := normalizeBaseURL(raw)
+	if v == "" {
+		return "", false
+	}
+	if !isValidBaseURL(v) {
+		endpointEnvWarner(env, raw)
+		return "", false
+	}
+	return v, true
+}
+
+// isValidBaseURL reports whether v is an absolute http/https URL with a host.
+// A non-empty path is allowed (some deployments serve the API under a prefix).
+func isValidBaseURL(v string) bool {
+	if v == "" {
+		return false
+	}
+	u, err := url.Parse(v)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return u.Scheme == "https" || u.Scheme == "http"
 }
 
 // normalizeBaseURL trims whitespace and any trailing slashes from a

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -3,10 +3,27 @@
 
 package core
 
+import (
+	"os"
+	"strings"
+)
+
 // LarkBrand represents the Lark platform brand.
 // "feishu" targets China-mainland, "lark" targets international.
 // Any other string is treated as a custom base URL.
 type LarkBrand string
+
+// Environment variables that override the brand-default endpoint hosts.
+// When set (non-empty), each replaces the corresponding field of the
+// Endpoints struct returned by ResolveEndpoints, regardless of brand.
+// Values must be absolute URLs without a trailing slash, e.g.
+// "https://open.example.internal". Trailing slashes are stripped.
+const (
+	EnvOpenBaseURL     = "LARKSUITE_CLI_OPEN_BASE_URL"
+	EnvAccountsBaseURL = "LARKSUITE_CLI_ACCOUNTS_BASE_URL"
+	EnvMCPBaseURL      = "LARKSUITE_CLI_MCP_BASE_URL"
+	EnvAppLinkBaseURL  = "LARKSUITE_CLI_APPLINK_BASE_URL"
+)
 
 const (
 	BrandFeishu LarkBrand = "feishu"
@@ -31,23 +48,54 @@ type Endpoints struct {
 }
 
 // ResolveEndpoints resolves endpoint URLs based on brand.
+// Each field can be overridden at runtime via the corresponding
+// EnvOpenBaseURL / EnvAccountsBaseURL / EnvMCPBaseURL / EnvAppLinkBaseURL
+// environment variable; env values win over brand defaults.
 func ResolveEndpoints(brand LarkBrand) Endpoints {
+	var ep Endpoints
 	switch brand {
 	case BrandLark:
-		return Endpoints{
+		ep = Endpoints{
 			Open:     "https://open.larksuite.com",
 			Accounts: "https://accounts.larksuite.com",
 			MCP:      "https://mcp.larksuite.com",
 			AppLink:  "https://applink.larksuite.com",
 		}
 	default:
-		return Endpoints{
+		ep = Endpoints{
 			Open:     "https://open.feishu.cn",
 			Accounts: "https://accounts.feishu.cn",
 			MCP:      "https://mcp.feishu.cn",
 			AppLink:  "https://applink.feishu.cn",
 		}
 	}
+	applyEndpointEnvOverrides(&ep)
+	return ep
+}
+
+func applyEndpointEnvOverrides(ep *Endpoints) {
+	if v := normalizeBaseURL(os.Getenv(EnvOpenBaseURL)); v != "" {
+		ep.Open = v
+	}
+	if v := normalizeBaseURL(os.Getenv(EnvAccountsBaseURL)); v != "" {
+		ep.Accounts = v
+	}
+	if v := normalizeBaseURL(os.Getenv(EnvMCPBaseURL)); v != "" {
+		ep.MCP = v
+	}
+	if v := normalizeBaseURL(os.Getenv(EnvAppLinkBaseURL)); v != "" {
+		ep.AppLink = v
+	}
+}
+
+// normalizeBaseURL trims whitespace and any trailing slashes from a
+// base-URL env value. Returns "" if the input is empty after trimming.
+func normalizeBaseURL(v string) string {
+	v = strings.TrimSpace(v)
+	for strings.HasSuffix(v, "/") {
+		v = strings.TrimSuffix(v, "/")
+	}
+	return v
 }
 
 // ResolveOpenBaseURL returns the Open API base URL for the given brand.

--- a/internal/core/types_test.go
+++ b/internal/core/types_test.go
@@ -100,3 +100,54 @@ func TestResolveEndpoints_EnvOverride_EmptyIgnored(t *testing.T) {
 		t.Errorf("Open = %q, want feishu default (whitespace-only env should be ignored)", ep.Open)
 	}
 }
+
+func TestResolveEndpoints_EnvOverride_InvalidFallsBackAndWarns(t *testing.T) {
+	cases := []struct {
+		name, value string
+	}{
+		{"missing scheme", "fsopen.bytedance.net"},
+		{"unsupported scheme", "ftp://fsopen.bytedance.net"},
+		{"scheme only", "https://"},
+		{"path only", "/open-apis"},
+		{"garbage", "::::not a url::::"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvOpenBaseURL, tc.value)
+
+			var warnedEnv, warnedValue string
+			prev := endpointEnvWarner
+			endpointEnvWarner = func(env, value string) {
+				warnedEnv = env
+				warnedValue = value
+			}
+			t.Cleanup(func() { endpointEnvWarner = prev })
+
+			ep := ResolveEndpoints(BrandFeishu)
+			if ep.Open != "https://open.feishu.cn" {
+				t.Errorf("Open = %q, want feishu default after invalid override", ep.Open)
+			}
+			if warnedEnv != EnvOpenBaseURL || warnedValue != tc.value {
+				t.Errorf("warn = (%q, %q), want (%q, %q)", warnedEnv, warnedValue, EnvOpenBaseURL, tc.value)
+			}
+		})
+	}
+}
+
+func TestResolveEndpoints_EnvOverride_PathPrefixAllowed(t *testing.T) {
+	t.Setenv(EnvOpenBaseURL, "https://gateway.example.internal/lark")
+
+	ep := ResolveEndpoints(BrandFeishu)
+	if ep.Open != "https://gateway.example.internal/lark" {
+		t.Errorf("Open = %q, want path-prefixed override to be accepted", ep.Open)
+	}
+}
+
+func TestResolveEndpoints_EnvOverride_HTTPAllowed(t *testing.T) {
+	t.Setenv(EnvOpenBaseURL, "http://127.0.0.1:18443")
+
+	ep := ResolveEndpoints(BrandFeishu)
+	if ep.Open != "http://127.0.0.1:18443" {
+		t.Errorf("Open = %q, want http override to be accepted (needed for local testing / inner-plain-HTTP fabrics)", ep.Open)
+	}
+}

--- a/internal/core/types_test.go
+++ b/internal/core/types_test.go
@@ -52,3 +52,51 @@ func TestResolveOpenBaseURL(t *testing.T) {
 		t.Errorf("ResolveOpenBaseURL(lark) = %q", got)
 	}
 }
+
+func TestResolveEndpoints_EnvOverride(t *testing.T) {
+	t.Setenv(EnvOpenBaseURL, "https://open.example.internal/")
+	t.Setenv(EnvAccountsBaseURL, "  https://accounts.example.internal  ")
+	t.Setenv(EnvMCPBaseURL, "https://mcp.example.internal")
+	t.Setenv(EnvAppLinkBaseURL, "https://applink.example.internal///")
+
+	ep := ResolveEndpoints(BrandFeishu)
+	if ep.Open != "https://open.example.internal" {
+		t.Errorf("Open = %q, want env override", ep.Open)
+	}
+	if ep.Accounts != "https://accounts.example.internal" {
+		t.Errorf("Accounts = %q, want env override (whitespace trimmed)", ep.Accounts)
+	}
+	if ep.MCP != "https://mcp.example.internal" {
+		t.Errorf("MCP = %q, want env override", ep.MCP)
+	}
+	if ep.AppLink != "https://applink.example.internal" {
+		t.Errorf("AppLink = %q, want env override (trailing slashes stripped)", ep.AppLink)
+	}
+}
+
+func TestResolveEndpoints_EnvOverride_PartialKeepsBrandDefaults(t *testing.T) {
+	t.Setenv(EnvOpenBaseURL, "https://open.example.internal")
+
+	ep := ResolveEndpoints(BrandLark)
+	if ep.Open != "https://open.example.internal" {
+		t.Errorf("Open = %q, want env override", ep.Open)
+	}
+	if ep.Accounts != "https://accounts.larksuite.com" {
+		t.Errorf("Accounts = %q, want lark default (no env set)", ep.Accounts)
+	}
+	if ep.MCP != "https://mcp.larksuite.com" {
+		t.Errorf("MCP = %q, want lark default", ep.MCP)
+	}
+	if ep.AppLink != "https://applink.larksuite.com" {
+		t.Errorf("AppLink = %q, want lark default", ep.AppLink)
+	}
+}
+
+func TestResolveEndpoints_EnvOverride_EmptyIgnored(t *testing.T) {
+	t.Setenv(EnvOpenBaseURL, "   ")
+
+	ep := ResolveEndpoints(BrandFeishu)
+	if ep.Open != "https://open.feishu.cn" {
+		t.Errorf("Open = %q, want feishu default (whitespace-only env should be ignored)", ep.Open)
+	}
+}


### PR DESCRIPTION
Add four optional environment variables that override the brand-default hosts returned by core.ResolveEndpoints, regardless of brand:

  LARKSUITE_CLI_OPEN_BASE_URL
  LARKSUITE_CLI_ACCOUNTS_BASE_URL
  LARKSUITE_CLI_MCP_BASE_URL
  LARKSUITE_CLI_APPLINK_BASE_URL

Values are trimmed and have trailing slashes stripped; empty or whitespace-only values are ignored. Every existing call site already routes through ResolveEndpoints, so OAuth device flow, app registration, console scope links, consumer URLs, doctor checks, and credential resolution all pick up the override automatically.

Public repo ships only the override mechanism — no internal hostnames.

## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Service endpoint base URLs can be overridden via environment variables for all supported services.
  * Overrides are normalized (trimmed, trailing slashes removed); whitespace-only values are ignored.
  * Invalid override values trigger a warning and fall back to brand defaults. Path-prefixed and non-HTTPS HTTP overrides are accepted.

* **Tests**
  * Added comprehensive tests covering full, partial, empty, invalid, path-prefixed, and HTTP override behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1069?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->