### PR TITLE
fix(service): auto-register path-parameter flags for raw API commands

### DIFF
--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/larksuite/cli/internal/auth"
@@ -121,6 +122,56 @@ type ServiceMethodOptions struct {
 	DryRun     bool
 	File       string   // --file flag value
 	FileFields []string // auto-detected file field names from metadata
+
+	// PathParamFlags holds pointers to string values for auto-generated
+	// path-parameter flags (e.g. --calendar-id, --event-id). The map key is
+	// the original parameter name (snake_case, as used in the URL template).
+	// Populated at command registration time and read by buildServiceRequest.
+	PathParamFlags map[string]*string
+}
+
+// pathParamFlagName converts a snake_case path-parameter name (e.g. "calendar_id")
+// into the matching kebab-case CLI flag name (e.g. "calendar-id").
+func pathParamFlagName(name string) string {
+	return strings.ReplaceAll(name, "_", "-")
+}
+
+// reservedServiceFlags lists the flag names that the service-method command
+// always registers itself; auto-generated path-parameter flags must not
+// collide with any of them.
+var reservedServiceFlags = map[string]bool{
+	"params":     true,
+	"data":       true,
+	"as":         true,
+	"output":     true,
+	"page-all":   true,
+	"page-limit": true,
+	"page-delay": true,
+	"format":     true,
+	"jq":         true,
+	"dry-run":    true,
+	"file":       true,
+	"yes":        true,
+	"help":       true,
+}
+
+// collectPathParamNames returns the path-location parameter names declared by
+// the method metadata, sorted alphabetically for deterministic flag order.
+func collectPathParamNames(method map[string]interface{}) []string {
+	parameters, _ := method["parameters"].(map[string]interface{})
+	if len(parameters) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(parameters))
+	for name, param := range parameters {
+		p, _ := param.(map[string]interface{})
+		if registry.GetStrFromMap(p, "location") != "path" {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // detectFileFields delegates to the shared cmdutil.DetectFileFields helper.
@@ -191,6 +242,31 @@ func NewCmdServiceMethodWithContext(ctx context.Context, f *cmdutil.Factory, spe
 		switch httpMethod {
 		case "POST", "PUT", "PATCH", "DELETE":
 			cmd.Flags().StringVar(&opts.File, "file", "", "file to upload ([field=]path, supports - for stdin)")
+		}
+	}
+
+	// Auto-register --<kebab-case> flags for every path-location parameter so
+	// that callers do not have to hand-craft URL params via --params JSON
+	// (matches the convention used by `+create`, `+update` and other shortcuts).
+	if names := collectPathParamNames(method); len(names) > 0 {
+		opts.PathParamFlags = make(map[string]*string, len(names))
+		parameters, _ := method["parameters"].(map[string]interface{})
+		for _, name := range names {
+			flagName := pathParamFlagName(name)
+			if reservedServiceFlags[flagName] || cmd.Flags().Lookup(flagName) != nil {
+				// Collision with a built-in or already-registered flag: fall
+				// back to passing the value via --params JSON.
+				continue
+			}
+			pVal := new(string)
+			opts.PathParamFlags[name] = pVal
+
+			p, _ := parameters[name].(map[string]interface{})
+			desc := registry.GetStrFromMap(p, "description")
+			if desc == "" {
+				desc = fmt.Sprintf("URL path parameter %s", name)
+			}
+			cmd.Flags().StringVar(pVal, flagName, "", desc)
 		}
 	}
 	cmdutil.RegisterFlagCompletion(cmd, "format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
@@ -366,6 +442,20 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 	params, err := cmdutil.ParseJSONMap(opts.Params, "--params", stdin, fileIO)
 	if err != nil {
 		return client.RawApiRequest{}, nil, err
+	}
+
+	// Merge in values from auto-generated path-parameter flags (e.g.
+	// --calendar-id). Explicit JSON values in --params take precedence so
+	// that the long-standing workaround of stuffing all path/query params
+	// into --params keeps working.
+	for name, pVal := range opts.PathParamFlags {
+		if pVal == nil || *pVal == "" {
+			continue
+		}
+		if _, exists := params[name]; exists {
+			continue
+		}
+		params[name] = *pVal
 	}
 
 	url := registry.GetStrFromMap(spec, "servicePath") + "/" + registry.GetStrFromMap(method, "path")

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -820,6 +820,193 @@ func TestServiceMethod_FileUpload_DryRun(t *testing.T) {
 	}
 }
 
+// ── path parameter auto-flags ──
+
+func calendarEventDeleteSpec() map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "calendar",
+		"servicePath": "/open-apis/calendar/v4",
+	}
+}
+
+func calendarEventDeleteMethod() map[string]interface{} {
+	return map[string]interface{}{
+		"path":       "calendars/{calendar_id}/events/{event_id}",
+		"httpMethod": "DELETE",
+		"parameters": map[string]interface{}{
+			"calendar_id": map[string]interface{}{
+				"type": "string", "location": "path", "required": true,
+				"description": "calendar id",
+			},
+			"event_id": map[string]interface{}{
+				"type": "string", "location": "path", "required": true,
+				"description": "event id",
+			},
+			"need_notification": map[string]interface{}{
+				"type": "boolean", "location": "query",
+			},
+		},
+	}
+}
+
+func TestServiceMethod_PathParamFlagsRegistered(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, calendarEventDeleteSpec(), calendarEventDeleteMethod(), "delete", "events", nil)
+
+	for _, name := range []string{"calendar-id", "event-id"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("expected --%s flag to be auto-registered for path parameter", name)
+		}
+	}
+	// Query params must NOT be auto-registered as flags — they continue to flow through --params.
+	if cmd.Flags().Lookup("need-notification") != nil {
+		t.Error("--need-notification must not be auto-registered: it is a query parameter, not a path parameter")
+	}
+}
+
+func TestServiceMethod_PathParamFlagsAcceptedInDryRun(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, calendarEventDeleteSpec(), calendarEventDeleteMethod(), "delete", "events", nil)
+	cmd.SetArgs([]string{
+		"--calendar-id", "cal_abc",
+		"--event-id", "evt_xyz_0",
+		"--params", `{"need_notification":false}`,
+		"--dry-run",
+		"--as", "bot",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("expected --calendar-id / --event-id to be accepted, got: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "/open-apis/calendar/v4/calendars/cal_abc/events/evt_xyz_0") {
+		t.Errorf("expected URL with substituted path params, got:\n%s", out)
+	}
+	if !strings.Contains(out, "need_notification") {
+		t.Errorf("expected query param need_notification preserved, got:\n%s", out)
+	}
+}
+
+func TestServiceMethod_PathParamFlags_ParamsJSONStillSupported(t *testing.T) {
+	// Backward compatibility: callers who already worked around the bug by
+	// passing path params through --params JSON must keep working unchanged.
+	f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, calendarEventDeleteSpec(), calendarEventDeleteMethod(), "delete", "events", nil)
+	cmd.SetArgs([]string{
+		"--params", `{"calendar_id":"cal_abc","event_id":"evt_xyz_0","need_notification":false}`,
+		"--dry-run",
+		"--as", "bot",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "/open-apis/calendar/v4/calendars/cal_abc/events/evt_xyz_0") {
+		t.Errorf("expected --params JSON path values to drive URL, got:\n%s", stdout.String())
+	}
+}
+
+func TestServiceMethod_PathParamFlags_ParamsJSONTakesPrecedence(t *testing.T) {
+	// If a value is provided in BOTH --calendar-id and --params, the JSON
+	// value wins. This keeps `--params` as the canonical "I know exactly
+	// what I'm doing" escape hatch.
+	f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, calendarEventDeleteSpec(), calendarEventDeleteMethod(), "delete", "events", nil)
+	cmd.SetArgs([]string{
+		"--calendar-id", "cal_FROM_FLAG",
+		"--event-id", "evt_FROM_FLAG",
+		"--params", `{"calendar_id":"cal_FROM_JSON","event_id":"evt_FROM_JSON"}`,
+		"--dry-run",
+		"--as", "bot",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "cal_FROM_JSON") || !strings.Contains(out, "evt_FROM_JSON") {
+		t.Errorf("expected --params JSON to win over flags, got:\n%s", out)
+	}
+	if strings.Contains(out, "cal_FROM_FLAG") || strings.Contains(out, "evt_FROM_FLAG") {
+		t.Errorf("expected flag values to be overridden by --params JSON, got:\n%s", out)
+	}
+}
+
+func TestServiceMethod_PathParamFlags_RejectInvalid(t *testing.T) {
+	// Path-traversal rejection still applies regardless of which input
+	// channel (flag vs --params) supplied the value.
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, calendarEventDeleteSpec(), calendarEventDeleteMethod(), "delete", "events", nil)
+	cmd.SetArgs([]string{
+		"--calendar-id", "../admin",
+		"--event-id", "evt_ok",
+		"--dry-run",
+		"--as", "bot",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validation error for path traversal in --calendar-id")
+	}
+	if !strings.Contains(err.Error(), "path traversal") {
+		t.Errorf("expected 'path traversal' error, got: %v", err)
+	}
+}
+
+func TestServiceMethod_PathParamFlags_NotRegisteredWhenAbsent(t *testing.T) {
+	// Methods without path parameters must not gain spurious auto-flags.
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	spec := map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"}
+	method := map[string]interface{}{
+		"path": "items", "httpMethod": "GET",
+		"parameters": map[string]interface{}{
+			"q": map[string]interface{}{"location": "query"},
+		},
+	}
+	cmd := NewCmdServiceMethod(f, spec, method, "list", "items", nil)
+	if cmd.Flags().Lookup("q") != nil {
+		t.Error("query-only methods must not produce path-param flags")
+	}
+}
+
+func TestServiceMethod_PathParamFlags_DoNotShadowReservedFlags(t *testing.T) {
+	// A path parameter named "format" or "data" must not clobber the
+	// command's built-in flags. The collision-detection branch in the
+	// registration loop should silently skip the auto-flag and keep the
+	// reserved flag's behavior intact.
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	spec := map[string]interface{}{"name": "svc", "servicePath": "/open-apis/svc/v1"}
+	method := map[string]interface{}{
+		"path":       "items/{format}",
+		"httpMethod": "GET",
+		"parameters": map[string]interface{}{
+			"format": map[string]interface{}{"location": "path", "required": true},
+		},
+	}
+	cmd := NewCmdServiceMethod(f, spec, method, "get", "items", nil)
+	formatFlag := cmd.Flags().Lookup("format")
+	if formatFlag == nil {
+		t.Fatal("built-in --format flag must remain registered")
+	}
+	if formatFlag.Usage == "URL path parameter format" {
+		t.Error("auto-registration must not overwrite the built-in --format flag")
+	}
+}
+
+func TestPathParamFlagName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"calendar_id", "calendar-id"},
+		{"event_id", "event-id"},
+		{"file_token", "file-token"},
+		{"already-kebab", "already-kebab"}, // no-op
+		{"single", "single"},
+	}
+	for _, tt := range tests {
+		if got := pathParamFlagName(tt.in); got != tt.want {
+			t.Errorf("pathParamFlagName(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestDetectFileFields(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## Summary

Fixes #1066. Raw API commands such as `calendar events delete`, `calendar events get` and `calendar event.attendees create` rejected `--calendar-id` / `--event-id` with `Error: unknown flag: --calendar-id`, even though the bundled docs in `skills/lark-calendar/references/lark-calendar-create.md` (lines 84-86) instruct users to invoke them that way. This PR closes the gap by **auto-registering a `--<kebab-case>` flag for every `location: path` parameter** declared in the method metadata, matching the ergonomic convention already used by shortcut commands (`+create`, `+update`, …). The pre-existing `--params` JSON workaround keeps working and even takes precedence when both channels are supplied.

## Changes

- `cmd/service/service.go`
  - `ServiceMethodOptions` gains `PathParamFlags map[string]*string`.
  - New helpers `pathParamFlagName` (snake → kebab) and `collectPathParamNames` (deterministic alphabetical order).
  - `reservedServiceFlags` allow-list prevents an exotic API whose path parameter happens to be named `format` / `data` / `as` / etc. from shadowing the command's built-in flags — the auto-flag is silently skipped and `--params` JSON remains the escape hatch.
  - `NewCmdServiceMethodWithContext` registers the new `--<kebab>` flags after `--file`, reusing the parameter's `description` when present.
  - `buildServiceRequest` merges flag values into the params map; `--params` JSON values win on collision so existing call sites are unaffected.
- `cmd/service/service_test.go` adds 8 unit tests covering: path-only registration (no spurious flags for query params), URL substitution in dry-run, backward compatibility with the `--params` JSON workaround, JSON-takes-precedence semantics, path-traversal rejection still firing, no flags when there are no path params, no shadowing of reserved built-in flags, and kebab conversion correctness.

## Test Plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd/service/` is empty
- [x] `go test ./cmd/service/...` (existing + 8 new tests pass)
- [x] `go test -race ./cmd/service/...` clean
- [x] Manual dry-run reproduction:
  ```
  lark-cli calendar events delete \
    --calendar-id cal_abc \
    --event-id evt_xyz_0 \
    --params '{"need_notification":false}' \
    --dry-run --as bot
  ```
  produces the expected URL `/open-apis/calendar/v4/calendars/cal_abc/events/evt_xyz_0` instead of the previous `unknown flag` error.

## Related Issues

Closes #1066


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service-method commands now automatically register dedicated CLI flags for HTTP path parameters, allowing users to pass them directly (e.g., `--calendar-id`, `--event-id`) instead of only through `--params` JSON.
  * Path parameters can be provided via flags or JSON, with JSON values taking precedence when both are supplied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1070?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->