### PR TITLE
feat(wiki): add exponential backoff retry for +node-create lock contention

### DIFF
--- a/shortcuts/wiki/wiki_node_create.go
+++ b/shortcuts/wiki/wiki_node_create.go
@@ -5,8 +5,11 @@ package wiki
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
+	"time"
 
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
@@ -22,6 +25,16 @@ const (
 	wikiResolvedByExplicitSpaceID = "explicit_space_id"
 	wikiResolvedByParentNode      = "parent_node_token"
 	wikiResolvedByMyLibrary       = "my_library"
+)
+
+const (
+	// wikiNodeCreateMaxRetries is the maximum number of retry attempts after
+	// the initial request when the API returns lock contention (code 131009).
+	wikiNodeCreateMaxRetries = 2
+
+	// wikiNodeCreateRetryBaseDelay is the initial backoff delay for lock
+	// contention retries. Subsequent retries double the delay (250ms, 500ms).
+	wikiNodeCreateRetryBaseDelay = 250 * time.Millisecond
 )
 
 var wikiObjectTypes = []string{
@@ -68,7 +81,7 @@ var WikiNodeCreate = common.Shortcut{
 		spec := readWikiNodeCreateSpec(runtime)
 
 		fmt.Fprintf(runtime.IO().ErrOut, "Creating wiki node...\n")
-		execution, err := runWikiNodeCreate(ctx, wikiNodeCreateAPI{runtime: runtime}, runtime.As(), spec)
+		execution, err := runWikiNodeCreate(ctx, wikiNodeCreateAPI{runtime: runtime}, runtime.As(), spec, runtime.IO().ErrOut)
 		if err != nil {
 			return err
 		}
@@ -288,15 +301,37 @@ func needsMyLibraryLookup(spec wikiNodeCreateSpec) bool {
 	return spec.SpaceID == "" || spec.SpaceID == wikiMyLibrarySpaceID
 }
 
-func runWikiNodeCreate(ctx context.Context, client wikiNodeCreateClient, identity core.Identity, spec wikiNodeCreateSpec) (*wikiNodeCreateExecution, error) {
+func runWikiNodeCreate(ctx context.Context, client wikiNodeCreateClient, identity core.Identity, spec wikiNodeCreateSpec, errOut io.Writer) (*wikiNodeCreateExecution, error) {
 	resolvedSpace, err := resolveWikiNodeCreateSpace(ctx, client, identity, spec)
 	if err != nil {
 		return nil, err
 	}
 
-	node, err := client.CreateNode(ctx, resolvedSpace.SpaceID, spec)
-	if err != nil {
-		return nil, err
+	var (
+		node    *wikiNodeRecord
+		lastErr error
+	)
+	for attempt := 0; attempt <= wikiNodeCreateMaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := wikiNodeCreateRetryBaseDelay << uint(attempt-1)
+			fmt.Fprintf(errOut, "Wiki node create encountered lock contention, retrying (attempt %d/%d) in %v...\n", attempt, wikiNodeCreateMaxRetries, delay)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		node, lastErr = client.CreateNode(ctx, resolvedSpace.SpaceID, spec)
+		if lastErr == nil {
+			break
+		}
+		if !isWikiNodeLockContention(lastErr) {
+			return nil, lastErr
+		}
+	}
+	if lastErr != nil {
+		return nil, wrapWikiNodeCreateRetryError(lastErr)
 	}
 	if node == nil {
 		return nil, output.Errorf(output.ExitAPI, "api_error", "wiki node create returned no node")
@@ -306,6 +341,50 @@ func runWikiNodeCreate(ctx context.Context, client wikiNodeCreateClient, identit
 		Node:          node,
 		ResolvedSpace: resolvedSpace,
 	}, nil
+}
+
+// isWikiNodeLockContention returns true if the error is a Lark API error with
+// code 131009 (wiki node lock contention), which is retryable with backoff.
+func isWikiNodeLockContention(err error) bool {
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+		return false
+	}
+	return exitErr.Detail.Code == output.LarkErrWikiLockContention
+}
+
+// wrapWikiNodeCreateRetryError appends a retry-exhaustion hint to the original
+// API error. It builds the ExitError by hand (instead of using ErrWithHint) so
+// the original Lark error code survives in the envelope.
+func wrapWikiNodeCreateRetryError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+		return err
+	}
+	hint := fmt.Sprintf(
+		"wiki node create failed after %d retries due to lock contention; try again later or reduce concurrent node creations under the same parent",
+		wikiNodeCreateMaxRetries,
+	)
+	if existing := strings.TrimSpace(exitErr.Detail.Hint); existing != "" {
+		hint = existing + "\n" + hint
+	}
+	return &output.ExitError{
+		Code: exitErr.Code,
+		Detail: &output.ErrDetail{
+			Type:       exitErr.Detail.Type,
+			Code:       exitErr.Detail.Code,
+			Message:    exitErr.Detail.Message,
+			Hint:       hint,
+			ConsoleURL: exitErr.Detail.ConsoleURL,
+			Risk:       exitErr.Detail.Risk,
+			Detail:     exitErr.Detail.Detail,
+		},
+		Err: exitErr.Err,
+		Raw: exitErr.Raw,
+	}
 }
 
 // resolveWikiNodeCreateSpace applies the shortcut's precedence rules:

--- a/shortcuts/wiki/wiki_node_create_test.go
+++ b/shortcuts/wiki/wiki_node_create_test.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -17,6 +19,7 @@ import (
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -31,6 +34,7 @@ type fakeWikiNodeCreateClient struct {
 	createNode    *wikiNodeRecord
 	returnNilNode bool
 	createErr     error
+	createErrs    []error // consumed in order; takes precedence over createErr
 	getSpaceErr   error
 	getNodeErr    error
 	createInvoked []fakeWikiNodeCreateCall
@@ -63,6 +67,11 @@ func (fake *fakeWikiNodeCreateClient) CreateNode(ctx context.Context, spaceID st
 		SpaceID: spaceID,
 		Spec:    spec,
 	})
+	if len(fake.createErrs) > 0 {
+		err := fake.createErrs[0]
+		fake.createErrs = fake.createErrs[1:]
+		return nil, err
+	}
 	if fake.createErr != nil {
 		return nil, fake.createErr
 	}
@@ -248,7 +257,7 @@ func TestRunWikiNodeCreateCreatesNodeInResolvedSpace(t *testing.T) {
 		ObjType:  "docx",
 		Title:    "Roadmap",
 	}
-	execution, err := runWikiNodeCreate(context.Background(), client, core.AsUser, spec)
+	execution, err := runWikiNodeCreate(context.Background(), client, core.AsUser, spec, io.Discard)
 	if err != nil {
 		t.Fatalf("runWikiNodeCreate() error = %v", err)
 	}
@@ -280,7 +289,7 @@ func TestRunWikiNodeCreateRejectsNilCreatedNode(t *testing.T) {
 		NodeType: wikiNodeTypeOrigin,
 		ObjType:  "docx",
 		Title:    "Roadmap",
-	})
+	}, io.Discard)
 	if err == nil || !strings.Contains(err.Error(), "wiki node create returned no node") {
 		t.Fatalf("expected missing node error, got %v", err)
 	}
@@ -770,5 +779,239 @@ func TestWikiNodeURL(t *testing.T) {
 				t.Fatalf("wikiNodeURL() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRunWikiNodeCreateRetriesOnLockContention(t *testing.T) {
+	t.Parallel()
+
+	lockErr := output.ErrAPI(output.LarkErrWikiLockContention, "lock contention", nil)
+
+	client := &fakeWikiNodeCreateClient{
+		spaces: map[string]*wikiSpaceRecord{
+			wikiMyLibrarySpaceID: {SpaceID: "space_my_library"},
+		},
+		createNode: &wikiNodeRecord{
+			SpaceID:   "space_my_library",
+			NodeToken: "wik_created",
+			NodeType:  wikiNodeTypeOrigin,
+			ObjType:   "docx",
+			Title:     "Roadmap",
+		},
+		createErrs: []error{lockErr, lockErr}, // fail twice, then succeed
+	}
+
+	var stderr bytes.Buffer
+	spec := wikiNodeCreateSpec{
+		NodeType: wikiNodeTypeOrigin,
+		ObjType:  "docx",
+		Title:    "Roadmap",
+	}
+	execution, err := runWikiNodeCreate(context.Background(), client, core.AsUser, spec, &stderr)
+	if err != nil {
+		t.Fatalf("runWikiNodeCreate() error = %v", err)
+	}
+	if len(client.createInvoked) != 3 {
+		t.Fatalf("create invoked %d times, want 3", len(client.createInvoked))
+	}
+	if execution.Node.NodeToken != "wik_created" {
+		t.Fatalf("node token = %q, want %q", execution.Node.NodeToken, "wik_created")
+	}
+	if !strings.Contains(stderr.String(), "lock contention") {
+		t.Fatalf("stderr = %q, want lock contention log", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "retrying (attempt 1/") {
+		t.Fatalf("stderr = %q, want attempt 1 log", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "retrying (attempt 2/") {
+		t.Fatalf("stderr = %q, want attempt 2 log", stderr.String())
+	}
+}
+
+func TestRunWikiNodeCreateRetriesExhausted(t *testing.T) {
+	t.Parallel()
+
+	lockErr := output.ErrAPI(output.LarkErrWikiLockContention, "lock contention", nil)
+
+	client := &fakeWikiNodeCreateClient{
+		spaces: map[string]*wikiSpaceRecord{
+			wikiMyLibrarySpaceID: {SpaceID: "space_my_library"},
+		},
+		createErrs: []error{lockErr, lockErr, lockErr}, // all 3 attempts fail
+	}
+
+	var stderr bytes.Buffer
+	spec := wikiNodeCreateSpec{
+		NodeType: wikiNodeTypeOrigin,
+		ObjType:  "docx",
+		Title:    "Roadmap",
+	}
+	_, err := runWikiNodeCreate(context.Background(), client, core.AsUser, spec, &stderr)
+	if err == nil {
+		t.Fatalf("expected error after retries exhausted")
+	}
+	if len(client.createInvoked) != 3 {
+		t.Fatalf("create invoked %d times, want 3", len(client.createInvoked))
+	}
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+		t.Fatalf("expected ExitError, got %T: %v", err, err)
+	}
+	if exitErr.Detail.Code != output.LarkErrWikiLockContention {
+		t.Fatalf("error code = %d, want %d", exitErr.Detail.Code, output.LarkErrWikiLockContention)
+	}
+	if !strings.Contains(exitErr.Detail.Hint, "failed after 2 retries") {
+		t.Fatalf("hint = %q, want retry exhaustion message", exitErr.Detail.Hint)
+	}
+	if !strings.Contains(exitErr.Detail.Hint, "lock contention") {
+		t.Fatalf("hint = %q, want original classification hint preserved", exitErr.Detail.Hint)
+	}
+}
+
+func TestRunWikiNodeCreateNoRetryOnNonContentionError(t *testing.T) {
+	t.Parallel()
+
+	otherErr := output.ErrAPI(output.LarkErrRateLimit, "rate limit", nil) // rate limit, not lock contention
+
+	client := &fakeWikiNodeCreateClient{
+		spaces: map[string]*wikiSpaceRecord{
+			wikiMyLibrarySpaceID: {SpaceID: "space_my_library"},
+		},
+		createErrs: []error{otherErr},
+	}
+
+	var stderr bytes.Buffer
+	spec := wikiNodeCreateSpec{
+		NodeType: wikiNodeTypeOrigin,
+		ObjType:  "docx",
+		Title:    "Roadmap",
+	}
+	_, err := runWikiNodeCreate(context.Background(), client, core.AsUser, spec, &stderr)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if len(client.createInvoked) != 1 {
+		t.Fatalf("create invoked %d times, want 1 (no retry)", len(client.createInvoked))
+	}
+	if strings.Contains(stderr.String(), "retrying") {
+		t.Fatalf("stderr = %q, should not contain retry log for non-contention error", stderr.String())
+	}
+}
+
+func TestRunWikiNodeCreateRetriesOnFirstLockThenSucceeds(t *testing.T) {
+	t.Parallel()
+
+	lockErr := output.ErrAPI(output.LarkErrWikiLockContention, "lock contention", nil)
+
+	client := &fakeWikiNodeCreateClient{
+		spaces: map[string]*wikiSpaceRecord{
+			wikiMyLibrarySpaceID: {SpaceID: "space_my_library"},
+		},
+		createNode: &wikiNodeRecord{
+			SpaceID:   "space_my_library",
+			NodeToken: "wik_created",
+			NodeType:  wikiNodeTypeOrigin,
+			ObjType:   "docx",
+			Title:     "Roadmap",
+		},
+		createErrs: []error{lockErr}, // fail once, then succeed
+	}
+
+	var stderr bytes.Buffer
+	spec := wikiNodeCreateSpec{
+		NodeType: wikiNodeTypeOrigin,
+		ObjType:  "docx",
+		Title:    "Roadmap",
+	}
+	execution, err := runWikiNodeCreate(context.Background(), client, core.AsUser, spec, &stderr)
+	if err != nil {
+		t.Fatalf("runWikiNodeCreate() error = %v", err)
+	}
+	if len(client.createInvoked) != 2 {
+		t.Fatalf("create invoked %d times, want 2", len(client.createInvoked))
+	}
+	if execution.Node.NodeToken != "wik_created" {
+		t.Fatalf("node token = %q, want %q", execution.Node.NodeToken, "wik_created")
+	}
+	if !strings.Contains(stderr.String(), "retrying (attempt 1/") {
+		t.Fatalf("stderr = %q, want attempt 1 log", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "retrying (attempt 2/") {
+		t.Fatalf("stderr = %q, should not contain attempt 2 log", stderr.String())
+	}
+}
+
+func TestRunWikiNodeCreateRetryContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	lockErr := output.ErrAPI(output.LarkErrWikiLockContention, "lock contention", nil)
+
+	client := &fakeWikiNodeCreateClient{
+		spaces: map[string]*wikiSpaceRecord{
+			wikiMyLibrarySpaceID: {SpaceID: "space_my_library"},
+		},
+		createErrs: []error{lockErr, lockErr, lockErr}, // always fail
+	}
+
+	var stderr bytes.Buffer
+	spec := wikiNodeCreateSpec{
+		NodeType: wikiNodeTypeOrigin,
+		ObjType:  "docx",
+		Title:    "Roadmap",
+	}
+
+	// Pre-cancel the context so the retry loop's select picks up
+	// ctx.Done() immediately during the first backoff wait.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := runWikiNodeCreate(ctx, client, core.AsUser, spec, &stderr)
+	if err == nil {
+		t.Fatalf("expected error due to context cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	// The initial attempt runs (context is checked only during backoff
+	// wait), but no retries should complete.
+	if len(client.createInvoked) != 1 {
+		t.Fatalf("create invoked %d times, want 1 (no retries after cancel)", len(client.createInvoked))
+	}
+}
+
+func TestRunWikiNodeCreateNoRetryOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeWikiNodeCreateClient{
+		spaces: map[string]*wikiSpaceRecord{
+			wikiMyLibrarySpaceID: {SpaceID: "space_my_library"},
+		},
+		createNode: &wikiNodeRecord{
+			SpaceID:   "space_my_library",
+			NodeToken: "wik_created",
+			NodeType:  wikiNodeTypeOrigin,
+			ObjType:   "docx",
+			Title:     "Roadmap",
+		},
+	}
+
+	var stderr bytes.Buffer
+	spec := wikiNodeCreateSpec{
+		NodeType: wikiNodeTypeOrigin,
+		ObjType:  "docx",
+		Title:    "Roadmap",
+	}
+	execution, err := runWikiNodeCreate(context.Background(), client, core.AsUser, spec, &stderr)
+	if err != nil {
+		t.Fatalf("runWikiNodeCreate() error = %v", err)
+	}
+	if len(client.createInvoked) != 1 {
+		t.Fatalf("create invoked %d times, want 1", len(client.createInvoked))
+	}
+	if execution.Node.NodeToken != "wik_created" {
+		t.Fatalf("node token = %q, want %q", execution.Node.NodeToken, "wik_created")
+	}
+	if strings.Contains(stderr.String(), "retrying") {
+		t.Fatalf("stderr = %q, should not contain retry log on success", stderr.String())
 	}
 }

--- a/tests/cli_e2e/wiki/wiki_node_create_dryrun_test.go
+++ b/tests/cli_e2e/wiki/wiki_node_create_dryrun_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package wiki
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func setWikiNodeCreateDryRunEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "wiki_dryrun_test")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "wiki_dryrun_secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+}
+
+// TestWikiNodeCreateDryRun pins the request shape and Validate behavior for
+// `wiki +node-create`.
+func TestWikiNodeCreateDryRun(t *testing.T) {
+	setWikiNodeCreateDryRunEnv(t)
+
+	t.Run("HappyPath_ExplicitSpaceID", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"wiki", "+node-create",
+				"--space-id", "123456",
+				"--title", "TestDoc",
+				"--obj-type", "docx",
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+
+		assert.Equal(t, "POST", gjson.Get(result.Stdout, "api.0.method").String())
+		assert.Equal(t, "/open-apis/wiki/v2/spaces/123456/nodes", gjson.Get(result.Stdout, "api.0.url").String())
+		assert.Equal(t, "origin", gjson.Get(result.Stdout, "api.0.body.node_type").String())
+		assert.Equal(t, "docx", gjson.Get(result.Stdout, "api.0.body.obj_type").String())
+		assert.Equal(t, "TestDoc", gjson.Get(result.Stdout, "api.0.body.title").String())
+	})
+
+	t.Run("HappyPath_WithParentNodeToken", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"wiki", "+node-create",
+				"--space-id", "123456",
+				"--parent-node-token", "wikcnABC123",
+				"--title", "ChildDoc",
+				"--obj-type", "docx",
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+
+		// 2-step: resolve parent node -> create node
+		assert.Equal(t, "GET", gjson.Get(result.Stdout, "api.0.method").String())
+		assert.Equal(t, "/open-apis/wiki/v2/spaces/get_node", gjson.Get(result.Stdout, "api.0.url").String())
+		assert.Equal(t, "wikcnABC123", gjson.Get(result.Stdout, "api.0.params.token").String())
+
+		assert.Equal(t, "POST", gjson.Get(result.Stdout, "api.1.method").String())
+		assert.Equal(t, "/open-apis/wiki/v2/spaces/123456/nodes", gjson.Get(result.Stdout, "api.1.url").String())
+		assert.Equal(t, "wikcnABC123", gjson.Get(result.Stdout, "api.1.body.parent_node_token").String())
+	})
+
+	t.Run("HappyPath_ShortcutNodeType", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"wiki", "+node-create",
+				"--space-id", "123456",
+				"--node-type", "shortcut",
+				"--origin-node-token", "wikcnORIG",
+				"--title", "ShortcutDoc",
+				"--obj-type", "docx",
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 0)
+
+		assert.Equal(t, "shortcut", gjson.Get(result.Stdout, "api.0.body.node_type").String())
+		assert.Equal(t, "wikcnORIG", gjson.Get(result.Stdout, "api.0.body.origin_node_token").String())
+	})
+
+	t.Run("RejectsShortcutWithoutOriginNodeToken", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"wiki", "+node-create",
+				"--space-id", "123456",
+				"--node-type", "shortcut",
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 2)
+		msg := validateWikiErrorMessage(result)
+		assert.Contains(t, msg, "--origin-node-token is required")
+	})
+
+	t.Run("RejectsOriginNodeTokenWithoutShortcutType", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"wiki", "+node-create",
+				"--space-id", "123456",
+				"--origin-node-token", "wikcnORIG",
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 2)
+		msg := validateWikiErrorMessage(result)
+		assert.Contains(t, msg, "--origin-node-token can only be used when --node-type=shortcut")
+	})
+
+	t.Run("RejectsBotWithoutSpaceIDOrParentNodeToken", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"wiki", "+node-create",
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 2)
+		msg := validateWikiErrorMessage(result)
+		assert.Contains(t, msg, "bot identity requires --space-id or --parent-node-token")
+	})
+
+	t.Run("RejectsBotWithMyLibrarySpaceID", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"wiki", "+node-create",
+				"--space-id", "my_library",
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 2)
+		msg := validateWikiErrorMessage(result)
+		assert.Contains(t, msg, "bot identity does not support --space-id my_library")
+	})
+
+	t.Run("RejectsInvalidObjType", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		result, err := clie2e.RunCmd(ctx, clie2e.Request{
+			Args: []string{
+				"wiki", "+node-create",
+				"--space-id", "123456",
+				"--obj-type", "pdf",
+				"--dry-run",
+			},
+			DefaultAs: "bot",
+		})
+		require.NoError(t, err)
+		result.AssertExitCode(t, 2)
+		msg := validateWikiErrorMessage(result)
+		assert.Contains(t, msg, `"pdf"`)
+		assert.Contains(t, msg, "invalid value")
+	})
+}
+
+func validateWikiErrorMessage(r *clie2e.Result) string {
+	if msg := gjson.Get(r.Stdout, "error.message").String(); msg != "" {
+		return msg
+	}
+	if msg := gjson.Get(r.Stderr, "error.message").String(); msg != "" {
+		return msg
+	}
+	return r.Stdout + r.Stderr
+}


### PR DESCRIPTION
## Summary

Closes #1012

When creating wiki nodes under the same parent concurrently, the API returns error code 131009 (lock contention) ~5-15% of the time. This adds automatic retry with exponential backoff (250ms, 500ms; max 2 retries) so callers no longer need to implement retry logic themselves.

## Changes

- `shortcuts/wiki/wiki_node_create.go`: retry loop on code 131009 with exponential backoff, context cancellation support, retry-exhaustion hint preserving `Detail.Code`/`Err`/`Raw`
- `shortcuts/wiki/wiki_node_create_test.go`: 6 retry unit tests
- `tests/cli_e2e/wiki/wiki_node_create_dryrun_test.go`: dry-run E2E tests for `wiki +node-create`

## Test plan

```bash
go test ./shortcuts/wiki/ -run TestRunWikiNodeCreate -v
go test ./tests/cli_e2e/wiki/ -run TestWikiNodeCreateDryRun -v
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki node creation now automatically retries on detected lock contention, emits retry status messages, respects cancellation, and preserves original error codes while adding a retry-exhaustion hint when retries fail.
  * No retries occur for non-contention errors.

* **Tests**
  * Added unit tests covering retry scenarios (success after retries, exhaustion, no-retry cases, cancellation).
  * Added CLI end-to-end dry-run tests validating node-create behavior and flag validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->