### PR TITLE
feat: get minutes keywords

### DIFF
--- a/shortcuts/vc/vc_notes.go
+++ b/shortcuts/vc/vc_notes.go
@@ -414,6 +414,9 @@ func fetchInlineArtifacts(runtime *common.RuntimeContext, minuteToken string, re
 	if chapters, ok := data["minute_chapters"].([]any); ok && len(chapters) > 0 {
 		result["chapters"] = chapters
 	}
+	if keywords, ok := data["keywords"].([]any); ok && len(keywords) > 0 {
+		result["keywords"] = keywords
+	}
 }
 
 // parseArtifactType extracts artifact_type as int from varying JSON number representations.

--- a/shortcuts/vc/vc_notes_test.go
+++ b/shortcuts/vc/vc_notes_test.go
@@ -126,6 +126,7 @@ func artifactsStub(token string) *httpmock.Stub {
 				"summary":         "Test summary content",
 				"minute_todos":    []interface{}{map[string]interface{}{"content": "Buy milk"}},
 				"minute_chapters": []interface{}{map[string]interface{}{"title": "Intro", "summary_content": "Opening"}},
+				"keywords":        []interface{}{"budget", "roadmap"},
 			},
 		},
 	}

--- a/skills/lark-vc/SKILL.md
+++ b/skills/lark-vc/SKILL.md
@@ -96,7 +96,8 @@ Meeting (视频会议)
     ├── Transcript (文字记录)
     ├── Summary (总结)
     ├── Todos (待办)
-    └── Chapters (章节)
+    ├── Chapters (章节)
+    └── Keywords (推荐关键词)
 ```
 
 > **注意**：`+search` 只能查询已结束的历史会议。查询未来的日程安排请使用 [lark-calendar](../lark-calendar/SKILL.md)。

--- a/skills/lark-vc/references/lark-vc-notes.md
+++ b/skills/lark-vc/references/lark-vc-notes.md
@@ -93,6 +93,7 @@ lark-cli vc +notes --meeting-ids 69xxxxxxxxxxxxx28 --dry-run
 | `artifacts.summary` | AI 总结（JSON 内联） |
 | `artifacts.todos` | 待办事项（JSON 内联） |
 | `artifacts.chapters` | 章节纪要（JSON 内联） |
+| `artifacts.keywords` | 妙记推荐关键词（JSON 内联） |
 | `artifacts.transcript_file` | 逐字稿本地文件路径。默认落到 `./minutes/{minute_token}/transcript.txt`（与 `minutes +download` 聚合）；显式 `--output-dir` 时走旧布局 `./{output-dir}/artifact-{title}-{token}/transcript.txt` |
 
 ## 如何获取输入参数


### PR DESCRIPTION
Parse keywords from minutes artifacts API in vc +notes and document the field in lark-vc skill references.

## Summary
<!-- Briefly describe the motivation and scope of this change in 1-3 sentences. -->

## Changes
<!-- List the main changes in this PR. -->
- Change 1
- Change 2

## Test Plan
<!-- Describe how this change was verified. -->
- [ ] Unit tests pass
- [ ] Manual local verification confirms the `lark xxx` command works as expected

## Related Issues
<!-- Link related issues. Use Closes/Fixes to close them automatically. -->
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meeting minutes processing now automatically extracts and returns AI-recommended keywords derived from transcript content.

* **Documentation**
  * Updated API schema documentation for the meeting minutes response to include the new keywords field.
  * Updated system resource architecture diagrams to reflect that meeting minutes now produce recommended keywords as an output artifact.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1079?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->