### PR TITLE
feat: add config keychain-downgrade subcommand (macOS)

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -33,6 +33,7 @@ func NewCmdConfig(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(NewCmdConfigStrictMode(f))
 	cmd.AddCommand(NewCmdConfigPolicy(f))
 	cmd.AddCommand(NewCmdConfigPlugins(f))
+	cmd.AddCommand(NewCmdConfigKeychainDowngrade(f, nil))
 	return cmd
 }
 

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -33,7 +33,7 @@ func NewCmdConfig(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(NewCmdConfigStrictMode(f))
 	cmd.AddCommand(NewCmdConfigPolicy(f))
 	cmd.AddCommand(NewCmdConfigPlugins(f))
-	cmd.AddCommand(NewCmdConfigKeychainDowngrade(f, nil))
+	cmd.AddCommand(NewCmdConfigKeychainDowngrade(f))
 	return cmd
 }
 

--- a/cmd/config/keychain_downgrade.go
+++ b/cmd/config/keychain_downgrade.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build darwin
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/keychain"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// KeychainDowngradeOptions holds inputs for `config keychain-downgrade`.
+type KeychainDowngradeOptions struct {
+	Factory *cmdutil.Factory
+}
+
+// NewCmdConfigKeychainDowngrade creates the macOS-only subcommand that pins
+// the master key to the local file fallback (master.key.file) so subsequent
+// operations bypass the OS Keychain. Useful inside sandboxes like Codex
+// where the system Keychain is unreachable.
+func NewCmdConfigKeychainDowngrade(f *cmdutil.Factory, runF func(*KeychainDowngradeOptions) error) *cobra.Command {
+	opts := &KeychainDowngradeOptions{Factory: f}
+	cmd := &cobra.Command{
+		Use:   "keychain-downgrade",
+		Short: "Downgrade keychain storage to a local file (macOS only)",
+		Long: `Materialize the master key from the macOS system Keychain into a local file
+under ~/Library/Application Support/lark-cli/master.key.file, then pin all
+subsequent reads to that file.
+
+Intended workflow: run this once from an interactive Terminal session on
+macOS (where the system Keychain is reachable). After it finishes,
+sandboxed / automation / CI runs of lark-cli on the same machine will read
+the master key from the local file and no longer need the OS Keychain.
+
+This is the supported fix for environments like the Codex sandbox where the
+system Keychain is blocked. Running keychain-downgrade from inside such a
+sandbox will itself fail with "keychain access blocked" — that is expected;
+run it from an interactive macOS session instead.
+
+The OS Keychain entry is preserved as a cold backup; nothing is deleted there.
+The command is idempotent: re-running it on an already-downgraded install
+reports "already downgraded" and exits 0.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if runF != nil {
+				return runF(opts)
+			}
+			return configKeychainDowngradeRun(opts)
+		},
+	}
+	cmdutil.SetRisk(cmd, "write")
+	return cmd
+}
+
+func configKeychainDowngradeRun(opts *KeychainDowngradeOptions) error {
+	f := opts.Factory
+	service := keychain.LarkCliService
+	keyPath := keychain.MasterKeyFilePath(service)
+
+	result, err := keychain.DowngradeMasterKeyToFile(service)
+	if err != nil {
+		return output.ErrWithHint(
+			output.ExitAPI,
+			"config",
+			fmt.Sprintf("keychain downgrade failed: %v", err),
+			"This command must be run from an interactive macOS session (e.g. Terminal.app or iTerm) where the system Keychain is reachable. Running it from inside a sandbox / automation context that blocks Keychain access cannot succeed by design.",
+		)
+	}
+
+	switch result {
+	case keychain.DowngradeAlreadyDone:
+		output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf("keychain already downgraded; subsequent operations read from %s", keyPath))
+	case keychain.DowngradeUsedKeychainKey:
+		output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf("downgraded: copied master key from system Keychain to %s. Subsequent operations will read from file, bypassing the OS Keychain (useful inside sandboxes like Codex).", keyPath))
+	case keychain.DowngradeCreatedNewKey:
+		output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf("system Keychain was empty; generated a new master key and wrote it to %s. The OS Keychain was not modified.", keyPath))
+	case keychain.DowngradeCreatedNewKeyOrphaned:
+		output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf("system Keychain was empty; generated a new master key and wrote it to %s. The OS Keychain was not modified.", keyPath))
+		return output.ErrWithHint(
+			output.ExitValidation,
+			"config",
+			fmt.Sprintf("encrypted credentials still exist on disk that were written under a now-lost master key — the freshly generated key cannot decrypt them (%v)", keychain.ErrOrphanedCredentials),
+			"Run `lark-cli config init` to reconfigure from scratch. Previously stored credentials cannot be recovered without the original master key; future operations will use the new master key in the file fallback.",
+		)
+	}
+	return nil
+}

--- a/cmd/config/keychain_downgrade.go
+++ b/cmd/config/keychain_downgrade.go
@@ -14,17 +14,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// KeychainDowngradeOptions holds inputs for `config keychain-downgrade`.
-type KeychainDowngradeOptions struct {
-	Factory *cmdutil.Factory
-}
-
 // NewCmdConfigKeychainDowngrade creates the macOS-only subcommand that pins
 // the master key to the local file fallback (master.key.file) so subsequent
 // operations bypass the OS Keychain. Useful inside sandboxes like Codex
 // where the system Keychain is unreachable.
-func NewCmdConfigKeychainDowngrade(f *cmdutil.Factory, runF func(*KeychainDowngradeOptions) error) *cobra.Command {
-	opts := &KeychainDowngradeOptions{Factory: f}
+func NewCmdConfigKeychainDowngrade(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "keychain-downgrade",
 		Short: "Downgrade keychain storage to a local file (macOS only)",
@@ -46,18 +40,14 @@ The OS Keychain entry is preserved as a cold backup; nothing is deleted there.
 The command is idempotent: re-running it on an already-downgraded install
 reports "already downgraded" and exits 0.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if runF != nil {
-				return runF(opts)
-			}
-			return configKeychainDowngradeRun(opts)
+			return configKeychainDowngradeRun(f)
 		},
 	}
 	cmdutil.SetRisk(cmd, "write")
 	return cmd
 }
 
-func configKeychainDowngradeRun(opts *KeychainDowngradeOptions) error {
-	f := opts.Factory
+func configKeychainDowngradeRun(f *cmdutil.Factory) error {
 	service := keychain.LarkCliService
 	keyPath := keychain.MasterKeyFilePath(service)
 

--- a/cmd/config/keychain_downgrade.go
+++ b/cmd/config/keychain_downgrade.go
@@ -68,14 +68,6 @@ func configKeychainDowngradeRun(f *cmdutil.Factory) error {
 		output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf("downgraded: copied master key from system Keychain to %s. Subsequent operations will read from file, bypassing the OS Keychain (useful inside sandboxes like Codex).", keyPath))
 	case keychain.DowngradeCreatedNewKey:
 		output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf("system Keychain was empty; generated a new master key and wrote it to %s. The OS Keychain was not modified.", keyPath))
-	case keychain.DowngradeCreatedNewKeyOrphaned:
-		output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf("system Keychain was empty; generated a new master key and wrote it to %s. The OS Keychain was not modified.", keyPath))
-		return output.ErrWithHint(
-			output.ExitValidation,
-			"config",
-			fmt.Sprintf("encrypted credentials still exist on disk that were written under a now-lost master key — the freshly generated key cannot decrypt them (%v)", keychain.ErrOrphanedCredentials),
-			"Run `lark-cli config init` to reconfigure from scratch. Previously stored credentials cannot be recovered without the original master key; future operations will use the new master key in the file fallback.",
-		)
 	}
 	return nil
 }

--- a/cmd/config/keychain_downgrade_other.go
+++ b/cmd/config/keychain_downgrade_other.go
@@ -11,16 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// KeychainDowngradeOptions exists only to keep NewCmdConfigKeychainDowngrade's
-// signature identical to the darwin build.
-type KeychainDowngradeOptions struct {
-	Factory *cmdutil.Factory
-}
-
 // NewCmdConfigKeychainDowngrade is registered on all platforms so that
 // `lark-cli config --help` reads the same everywhere. On non-macOS it
 // refuses with a clear message.
-func NewCmdConfigKeychainDowngrade(f *cmdutil.Factory, runF func(*KeychainDowngradeOptions) error) *cobra.Command {
+func NewCmdConfigKeychainDowngrade(f *cmdutil.Factory) *cobra.Command {
+	_ = f
 	cmd := &cobra.Command{
 		Use:   "keychain-downgrade",
 		Short: "Downgrade keychain storage to a local file (macOS only)",

--- a/cmd/config/keychain_downgrade_other.go
+++ b/cmd/config/keychain_downgrade_other.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !darwin
+
+package config
+
+import (
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+// KeychainDowngradeOptions exists only to keep NewCmdConfigKeychainDowngrade's
+// signature identical to the darwin build.
+type KeychainDowngradeOptions struct {
+	Factory *cmdutil.Factory
+}
+
+// NewCmdConfigKeychainDowngrade is registered on all platforms so that
+// `lark-cli config --help` reads the same everywhere. On non-macOS it
+// refuses with a clear message.
+func NewCmdConfigKeychainDowngrade(f *cmdutil.Factory, runF func(*KeychainDowngradeOptions) error) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "keychain-downgrade",
+		Short: "Downgrade keychain storage to a local file (macOS only)",
+		Long:  `Downgrade keychain storage to a local file. This subcommand is only supported on macOS; on this platform the keychain layer already uses local files.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return output.ErrValidation("keychain-downgrade is only supported on macOS")
+		},
+	}
+	return cmd
+}

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -18,18 +18,6 @@ var (
 
 	// errNotInitialized is an internal error indicating the master key is missing or invalid.
 	errNotInitialized = errors.New("keychain not initialized")
-
-	// ErrOrphanedCredentials signals that encrypted credentials exist on disk
-	// but cannot be decrypted with any available master key. This happens when
-	// the master key that originally encrypted them has been lost — typically
-	// because the OS Keychain entry was deleted (e.g., via Keychain Access)
-	// after credentials were stored, leaving the on-disk .enc files
-	// permanently unreadable. The only recovery is `lark-cli config init`.
-	//
-	// Returned by:
-	//   - DowngradeMasterKeyToFile (preemptive: would orphan future reads)
-	//   - platformGet (diagnostic: this read can never succeed)
-	ErrOrphanedCredentials = errors.New("encrypted credentials cannot be decrypted with any available master key (original key appears to be lost)")
 )
 
 const (
@@ -50,21 +38,10 @@ func wrapError(op string, err error) error {
 	msg := fmt.Sprintf("keychain %s failed: %v", op, err)
 	hint := "Check if the OS keychain/credential manager is locked or accessible. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, you can try running this outside the sandbox."
 
-	switch {
-	case errors.Is(err, ErrOrphanedCredentials):
-		// Override the keychain-centric message — the issue is not keychain
-		// access but lost data. Do NOT append extraHint(): the
-		// keychain-downgrade suggestion would mislead the user (downgrade
-		// cannot recover the lost key, and would either no-op via
-		// AlreadyDone or refuse via the orphan guard).
-		msg = fmt.Sprintf("cannot read stored credential: %v", err)
-		hint = "The master key that encrypted this credential is no longer available, so the on-disk data cannot be decrypted. This typically happens after the OS Keychain entry was deleted (manually via Keychain Access, by system maintenance, or by a botched migration). Run `lark-cli config init` to reconfigure from scratch — previously stored credentials cannot be recovered without the original master key."
-	case errors.Is(err, errNotInitialized):
+	if errors.Is(err, errNotInitialized) {
 		hint = "The keychain master key may have been cleaned up or deleted. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, you can try running this outside the sandbox. Otherwise, please reconfigure the CLI by running lark-cli config init."
-		hint += extraHint(err)
-	default:
-		hint += extraHint(err)
 	}
+	hint += extraHint(err)
 
 	func() {
 		defer func() { recover() }()

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -18,6 +18,18 @@ var (
 
 	// errNotInitialized is an internal error indicating the master key is missing or invalid.
 	errNotInitialized = errors.New("keychain not initialized")
+
+	// ErrOrphanedCredentials signals that encrypted credentials exist on disk
+	// but cannot be decrypted with any available master key. This happens when
+	// the master key that originally encrypted them has been lost — typically
+	// because the OS Keychain entry was deleted (e.g., via Keychain Access)
+	// after credentials were stored, leaving the on-disk .enc files
+	// permanently unreadable. The only recovery is `lark-cli config init`.
+	//
+	// Returned by:
+	//   - DowngradeMasterKeyToFile (preemptive: would orphan future reads)
+	//   - platformGet (diagnostic: this read can never succeed)
+	ErrOrphanedCredentials = errors.New("encrypted credentials cannot be decrypted with any available master key (original key appears to be lost)")
 )
 
 const (
@@ -38,8 +50,20 @@ func wrapError(op string, err error) error {
 	msg := fmt.Sprintf("keychain %s failed: %v", op, err)
 	hint := "Check if the OS keychain/credential manager is locked or accessible. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, you can try running this outside the sandbox."
 
-	if errors.Is(err, errNotInitialized) {
+	switch {
+	case errors.Is(err, ErrOrphanedCredentials):
+		// Override the keychain-centric message — the issue is not keychain
+		// access but lost data. Do NOT append extraHint(): the
+		// keychain-downgrade suggestion would mislead the user (downgrade
+		// cannot recover the lost key, and would either no-op via
+		// AlreadyDone or refuse via the orphan guard).
+		msg = fmt.Sprintf("cannot read stored credential: %v", err)
+		hint = "The master key that encrypted this credential is no longer available, so the on-disk data cannot be decrypted. This typically happens after the OS Keychain entry was deleted (manually via Keychain Access, by system maintenance, or by a botched migration). Run `lark-cli config init` to reconfigure from scratch — previously stored credentials cannot be recovered without the original master key."
+	case errors.Is(err, errNotInitialized):
 		hint = "The keychain master key may have been cleaned up or deleted. If running inside a sandbox or CI environment, please ensure the process has the necessary permissions to access the keychain, you can try running this outside the sandbox. Otherwise, please reconfigure the CLI by running lark-cli config init."
+		hint += extraHint(err)
+	default:
+		hint += extraHint(err)
 	}
 
 	func() {

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -43,6 +43,12 @@ var keyringGet = keyring.Get
 // keyringSet is overridden in tests to simulate system keychain writes.
 var keyringSet = keyring.Set
 
+// errKeychainBlocked is returned when the OS Keychain is reachable but
+// denies access — sandbox restriction, user-denied prompt, or a 5-second
+// timeout (typically caused by an ignored permission dialog). Distinct
+// from errNotInitialized (master key entry genuinely absent).
+var errKeychainBlocked = errors.New("keychain access blocked")
+
 // StorageDir returns the storage directory for a given service name on macOS.
 func StorageDir(service string) string {
 	home, err := vfs.UserHomeDir()
@@ -85,7 +91,7 @@ func getMasterKey(service string, allowCreate bool) ([]byte, error) {
 			return
 		} else if !errors.Is(err, keyring.ErrNotFound) {
 			// Not ErrNotFound, which means access was denied or blocked by the system
-			resCh <- result{key: nil, err: errors.New("keychain access blocked")}
+			resCh <- result{key: nil, err: errKeychainBlocked}
 			return
 		}
 
@@ -117,7 +123,7 @@ func getMasterKey(service string, allowCreate bool) ([]byte, error) {
 		return res.key, res.err
 	case <-ctx.Done():
 		// Timeout is usually caused by ignored/blocked permission prompts
-		return nil, errors.New("keychain access blocked")
+		return nil, errKeychainBlocked
 	}
 }
 
@@ -445,12 +451,16 @@ func DowngradeMasterKeyToFile(service string) (DowngradeResult, error) {
 }
 
 // extraHint appends a darwin-specific suggestion to wrapError's hint message
-// when the failure indicates the master key is missing. On macOS, the user
-// can sidestep an unreliable system Keychain by running keychain-downgrade
-// from an interactive Terminal session, after which the file fallback is
-// readable from any context (sandbox, automation, CI, etc.).
+// when the failure is one keychain-downgrade can recover from: either the
+// master key is missing (errNotInitialized) or the OS Keychain is reachable
+// but blocking access (errKeychainBlocked — sandbox, denied prompt, timeout).
+// In both cases the user can run keychain-downgrade from an interactive
+// Terminal session, after which the file fallback is readable from any
+// context (sandbox, automation, CI, etc.). Corruption errors are
+// deliberately excluded — downgrade would re-read the same bad bytes and
+// fail; the right fix there is to delete the corrupt Keychain entry first.
 func extraHint(err error) string {
-	if errors.Is(err, errNotInitialized) {
+	if errors.Is(err, errNotInitialized) || errors.Is(err, errKeychainBlocked) {
 		return " On macOS, you can also open an interactive Terminal session (where the system Keychain is reachable) and run `lark-cli config keychain-downgrade` to materialize the master key into a local file; subsequent runs in this sandbox/automation context will then read from the file and succeed."
 	}
 	return ""

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -269,20 +269,9 @@ func platformGet(service, account string) (string, error) {
 	}
 	key, err := getMasterKey(service, false)
 	if err != nil {
-		if errors.Is(err, errNotInitialized) {
-			// .enc exists but no master key anywhere can be used → orphan.
-			return "", ErrOrphanedCredentials
-		}
-		// Other keychain errors (e.g. access blocked in sandbox) are
-		// transient from the caller's perspective — surface as-is so the
-		// existing hint chain can point them to keychain-downgrade.
 		return "", err
 	}
-	if plaintext, derr := decryptData(data, key); derr == nil {
-		return plaintext, nil
-	}
-	// Both reachable keys failed to decrypt → the encrypting key is gone.
-	return "", ErrOrphanedCredentials
+	return decryptData(data, key)
 }
 
 // platformSet stores a value in the macOS keychain.
@@ -342,46 +331,16 @@ const (
 	// copied verbatim into the local file fallback. Existing .enc credentials
 	// remain readable via the file path.
 	DowngradeUsedKeychainKey
-	// DowngradeCreatedNewKey means the OS Keychain held no master key and no
-	// encrypted credentials existed on disk, so a fresh random key was
-	// generated and written to the file fallback only. The OS Keychain was
-	// not touched.
+	// DowngradeCreatedNewKey means the OS Keychain held no master key, so a
+	// fresh random key was generated and written to the file fallback only.
+	// The OS Keychain was not touched.
 	DowngradeCreatedNewKey
-	// DowngradeCreatedNewKeyOrphaned is like DowngradeCreatedNewKey, but
-	// encrypted credentials already exist on disk that were written under
-	// the previous (now-lost) master key. The file was still written so
-	// future operations have a working fallback, but those existing .enc
-	// files are permanently unreadable — the caller should direct the user
-	// to `lark-cli config init` to reconfigure.
-	DowngradeCreatedNewKeyOrphaned
 )
 
 // MasterKeyFilePath returns the absolute path of the file fallback master key
 // for the given service.
 func MasterKeyFilePath(service string) string {
 	return filepath.Join(StorageDir(service), fileMasterKeyName)
-}
-
-// hasEncryptedCredentials reports whether the storage directory contains any
-// previously-encrypted credential files (anything with a .enc suffix written
-// by safeFileName). Returns (false, nil) when the directory does not exist.
-func hasEncryptedCredentials(dir string) (bool, error) {
-	entries, err := vfs.ReadDir(dir)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return false, nil
-		}
-		return false, err
-	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		if filepath.Ext(e.Name()) == ".enc" {
-			return true, nil
-		}
-	}
-	return false, nil
 }
 
 // DowngradeMasterKeyToFile materializes the OS Keychain master key into the
@@ -421,18 +380,6 @@ func DowngradeMasterKeyToFile(service string) (DowngradeResult, error) {
 			return 0, err
 		}
 		result = DowngradeCreatedNewKey
-		// If encrypted credentials already exist on disk, they were
-		// written under the previous (now-lost) master key and the new
-		// random key cannot decrypt them. The file is still written so
-		// future config init has a working fallback, but signal the
-		// orphan state so the cmd layer can surface it to the user.
-		hasEnc, scanErr := hasEncryptedCredentials(dir)
-		if scanErr != nil {
-			return 0, scanErr
-		}
-		if hasEnc {
-			result = DowngradeCreatedNewKeyOrphaned
-		}
 	}
 
 	if err := vfs.MkdirAll(dir, 0700); err != nil {

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -360,7 +360,7 @@ func MasterKeyFilePath(service string) string {
 // previously-encrypted credential files (anything with a .enc suffix written
 // by safeFileName). Returns (false, nil) when the directory does not exist.
 func hasEncryptedCredentials(dir string) (bool, error) {
-	entries, err := os.ReadDir(dir)
+	entries, err := vfs.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
@@ -420,7 +420,11 @@ func DowngradeMasterKeyToFile(service string) (DowngradeResult, error) {
 		// random key cannot decrypt them. The file is still written so
 		// future config init has a working fallback, but signal the
 		// orphan state so the cmd layer can surface it to the user.
-		if hasEnc, scanErr := hasEncryptedCredentials(dir); scanErr == nil && hasEnc {
+		hasEnc, scanErr := hasEncryptedCredentials(dir)
+		if scanErr != nil {
+			return 0, scanErr
+		}
+		if hasEnc {
 			result = DowngradeCreatedNewKeyOrphaned
 		}
 	}

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -263,13 +263,20 @@ func platformGet(service, account string) (string, error) {
 	}
 	key, err := getMasterKey(service, false)
 	if err != nil {
+		if errors.Is(err, errNotInitialized) {
+			// .enc exists but no master key anywhere can be used → orphan.
+			return "", ErrOrphanedCredentials
+		}
+		// Other keychain errors (e.g. access blocked in sandbox) are
+		// transient from the caller's perspective — surface as-is so the
+		// existing hint chain can point them to keychain-downgrade.
 		return "", err
 	}
-	plaintext, err := decryptData(data, key)
-	if err != nil {
-		return "", err
+	if plaintext, derr := decryptData(data, key); derr == nil {
+		return plaintext, nil
 	}
-	return plaintext, nil
+	// Both reachable keys failed to decrypt → the encrypting key is gone.
+	return "", ErrOrphanedCredentials
 }
 
 // platformSet stores a value in the macOS keychain.
@@ -315,4 +322,132 @@ func platformRemove(service, account string) error {
 		return err
 	}
 	return nil
+}
+
+// DowngradeResult reports what DowngradeMasterKeyToFile did. The command
+// never writes to or removes from the OS Keychain — it only reads from it
+// and only writes to the local file fallback.
+type DowngradeResult int
+
+const (
+	// DowngradeAlreadyDone means master.key.file was already present and valid.
+	DowngradeAlreadyDone DowngradeResult = iota
+	// DowngradeUsedKeychainKey means the existing OS Keychain master key was
+	// copied verbatim into the local file fallback. Existing .enc credentials
+	// remain readable via the file path.
+	DowngradeUsedKeychainKey
+	// DowngradeCreatedNewKey means the OS Keychain held no master key and no
+	// encrypted credentials existed on disk, so a fresh random key was
+	// generated and written to the file fallback only. The OS Keychain was
+	// not touched.
+	DowngradeCreatedNewKey
+	// DowngradeCreatedNewKeyOrphaned is like DowngradeCreatedNewKey, but
+	// encrypted credentials already exist on disk that were written under
+	// the previous (now-lost) master key. The file was still written so
+	// future operations have a working fallback, but those existing .enc
+	// files are permanently unreadable — the caller should direct the user
+	// to `lark-cli config init` to reconfigure.
+	DowngradeCreatedNewKeyOrphaned
+)
+
+// MasterKeyFilePath returns the absolute path of the file fallback master key
+// for the given service.
+func MasterKeyFilePath(service string) string {
+	return filepath.Join(StorageDir(service), fileMasterKeyName)
+}
+
+// hasEncryptedCredentials reports whether the storage directory contains any
+// previously-encrypted credential files (anything with a .enc suffix written
+// by safeFileName). Returns (false, nil) when the directory does not exist.
+func hasEncryptedCredentials(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if filepath.Ext(e.Name()) == ".enc" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// DowngradeMasterKeyToFile materializes the OS Keychain master key into the
+// local file fallback so that subsequent platformGet calls take the file-first
+// path and bypass the OS Keychain entirely. The Keychain entry itself is kept
+// as a cold backup; nothing is removed there.
+//
+// Idempotent: if master.key.file is already present and valid, returns
+// DowngradeAlreadyDone without touching anything.
+func DowngradeMasterKeyToFile(service string) (DowngradeResult, error) {
+	dir := StorageDir(service)
+	keyPath := filepath.Join(dir, fileMasterKeyName)
+
+	existing, statErr := vfs.ReadFile(keyPath)
+	if statErr == nil {
+		if len(existing) == masterKeyBytes {
+			return DowngradeAlreadyDone, nil
+		}
+		return 0, errors.New("keychain is corrupted")
+	}
+	if !errors.Is(statErr, os.ErrNotExist) {
+		return 0, statErr
+	}
+
+	result := DowngradeUsedKeychainKey
+	key, err := getMasterKey(service, false)
+	if err != nil {
+		if !errors.Is(err, errNotInitialized) {
+			return 0, err
+		}
+		// Keychain has no master key. Generate a fresh one *locally* — do
+		// NOT call getMasterKey(service, true), which would write the new
+		// key into the OS Keychain as a side effect. keychain-downgrade
+		// must never modify the OS Keychain; it only ever reads from it.
+		key = make([]byte, masterKeyBytes)
+		if _, err := rand.Read(key); err != nil {
+			return 0, err
+		}
+		result = DowngradeCreatedNewKey
+		// If encrypted credentials already exist on disk, they were
+		// written under the previous (now-lost) master key and the new
+		// random key cannot decrypt them. The file is still written so
+		// future config init has a working fallback, but signal the
+		// orphan state so the cmd layer can surface it to the user.
+		if hasEnc, scanErr := hasEncryptedCredentials(dir); scanErr == nil && hasEnc {
+			result = DowngradeCreatedNewKeyOrphaned
+		}
+	}
+
+	if err := vfs.MkdirAll(dir, 0700); err != nil {
+		return 0, err
+	}
+	tmpPath := keyPath + "." + uuid.New().String() + ".tmp"
+	if err := vfs.WriteFile(tmpPath, key, 0600); err != nil {
+		_ = vfs.Remove(tmpPath)
+		return 0, err
+	}
+	if err := vfs.Rename(tmpPath, keyPath); err != nil {
+		_ = vfs.Remove(tmpPath)
+		return 0, err
+	}
+	return result, nil
+}
+
+// extraHint appends a darwin-specific suggestion to wrapError's hint message
+// when the failure indicates the master key is missing. On macOS, the user
+// can sidestep an unreliable system Keychain by running keychain-downgrade
+// from an interactive Terminal session, after which the file fallback is
+// readable from any context (sandbox, automation, CI, etc.).
+func extraHint(err error) string {
+	if errors.Is(err, errNotInitialized) {
+		return " On macOS, you can also open an interactive Terminal session (where the system Keychain is reachable) and run `lark-cli config keychain-downgrade` to materialize the master key into a local file; subsequent runs in this sandbox/automation context will then read from the file and succeed."
+	}
+	return ""
 }

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -360,7 +360,7 @@ func MasterKeyFilePath(service string) string {
 // previously-encrypted credential files (anything with a .enc suffix written
 // by safeFileName). Returns (false, nil) when the directory does not exist.
 func hasEncryptedCredentials(dir string) (bool, error) {
-	entries, err := os.ReadDir(dir)
+	entries, err := vfs.ReadDir(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -385,15 +385,34 @@ func DowngradeMasterKeyToFile(service string) (DowngradeResult, error) {
 	if err := vfs.MkdirAll(dir, 0700); err != nil {
 		return 0, err
 	}
-	tmpPath := keyPath + "." + uuid.New().String() + ".tmp"
-	if err := vfs.WriteFile(tmpPath, key, 0600); err != nil {
-		_ = vfs.Remove(tmpPath)
+	file, err := vfs.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			concurrent, readErr := vfs.ReadFile(keyPath)
+			if readErr == nil && len(concurrent) == masterKeyBytes {
+				return DowngradeAlreadyDone, nil
+			}
+			if readErr != nil {
+				return 0, readErr
+			}
+			return 0, errors.New("keychain is corrupted")
+		}
 		return 0, err
 	}
-	if err := vfs.Rename(tmpPath, keyPath); err != nil {
-		_ = vfs.Remove(tmpPath)
+	writeFailed := true
+	defer func() {
+		if writeFailed {
+			_ = vfs.Remove(keyPath)
+		}
+	}()
+	if _, err := file.Write(key); err != nil {
+		_ = file.Close()
 		return 0, err
 	}
+	if err := file.Close(); err != nil {
+		return 0, err
+	}
+	writeFailed = false
 	return result, nil
 }
 
@@ -408,7 +427,7 @@ func DowngradeMasterKeyToFile(service string) (DowngradeResult, error) {
 // fail; the right fix there is to delete the corrupt Keychain entry first.
 func extraHint(err error) string {
 	if errors.Is(err, errNotInitialized) || errors.Is(err, errKeychainBlocked) {
-		return " On macOS, you can also open an interactive Terminal session (where the system Keychain is reachable) and run `lark-cli config keychain-downgrade` to materialize the master key into a local file; subsequent runs in this sandbox/automation context will then read from the file and succeed."
+		return " On macOS, you can also open an interactive Terminal session (where the system Keychain is reachable) and run `lark-cli config keychain-downgrade` to materialize the master key into a local file; subsequent runs in this sandbox/automation context will then read from the file and succeed. Trade-off: after downgrade, any process running as your macOS user can read that file (file permissions replace the Keychain's per-app ACL)."
 	}
 	return ""
 }

--- a/internal/keychain/keychain_darwin_test.go
+++ b/internal/keychain/keychain_darwin_test.go
@@ -10,8 +10,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/internal/output"
 	"github.com/zalando/go-keyring"
 )
 
@@ -413,6 +415,48 @@ func TestPlatformGetSurfacesKeychainBlockedNotOrphan(t *testing.T) {
 	}
 	if errors.Is(err, ErrOrphanedCredentials) {
 		t.Fatalf("err = %v; access-blocked must NOT be reported as orphan (would suppress the keychain-downgrade hint)", err)
+	}
+}
+
+// TestWrapErrorHintMentionsDowngradeForRecoverableCases is the regression
+// guard for the bug where `lark-cli api ...` inside a sandbox surfaced
+// "keychain access blocked" but the hint did NOT mention keychain-downgrade
+// — the very command meant to recover from that exact situation. Root cause:
+// the blocked path used an anonymous errors.New string, so the extraHint
+// `errors.Is` check (only matched errNotInitialized) couldn't recognize it.
+//
+// Asserts the full wrapError → ExitError.Detail.Hint pipeline:
+//   - errKeychainBlocked + errNotInitialized → hint mentions keychain-downgrade
+//   - ErrOrphanedCredentials (downgrade can't recover lost data) → no mention
+//   - "keychain is corrupted" (downgrade would re-read the same bad bytes) → no mention
+//   - generic errors → no mention
+//
+// Add new cases here whenever extraHint's matcher widens, to keep the
+// promise that the hint is suggested iff downgrade can actually help.
+func TestWrapErrorHintMentionsDowngradeForRecoverableCases(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		wantHint bool
+	}{
+		{"access blocked (sandbox / denied prompt / timeout)", errKeychainBlocked, true},
+		{"not initialized (missing master key)", errNotInitialized, true},
+		{"corrupted (downgrade would re-read the same bad bytes)", errors.New("keychain is corrupted"), false},
+		{"orphaned credentials (downgrade cannot recover lost data)", ErrOrphanedCredentials, false},
+		{"unrelated generic error", errors.New("something else entirely"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := wrapError("Get", tc.err)
+			var ee *output.ExitError
+			if !errors.As(err, &ee) || ee.Detail == nil {
+				t.Fatalf("wrapError returned %#v; expected *output.ExitError with Detail", err)
+			}
+			got := strings.Contains(ee.Detail.Hint, "keychain-downgrade")
+			if got != tc.wantHint {
+				t.Fatalf("hint mentions keychain-downgrade = %v, want %v\n  full hint: %q", got, tc.wantHint, ee.Detail.Hint)
+			}
+		})
 	}
 }
 

--- a/internal/keychain/keychain_darwin_test.go
+++ b/internal/keychain/keychain_darwin_test.go
@@ -254,6 +254,67 @@ func TestDowngradeCreatesNewKeyWhenStorageEmpty(t *testing.T) {
 	}
 }
 
+// TestDowngradeDoesNotClobberConcurrentlyWrittenKey is the regression guard
+// for the TOCTOU between the initial existence check and the final write.
+// Race trace the fix closes:
+//
+//	T0 proc A: ReadFile(keyPath) → ErrNotExist        (initial check passes)
+//	T1 proc B: platformSet → getFileMasterKey(_, true) creates keyPath with K_B
+//	           then writes .enc encrypted with K_B
+//	T2 proc A: rand.Read → K_A; would overwrite K_B and orphan B's .enc
+//
+// We simulate proc B's interleaving by performing the concurrent file write
+// inside the keyringGet hook — by the time DowngradeMasterKeyToFile gets back
+// to the final OpenFile call, the file already exists, the O_EXCL branch
+// fires, and the concurrent key is preserved verbatim.
+func TestDowngradeDoesNotClobberConcurrentlyWrittenKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	service := "test-service"
+	dir := StorageDir(service)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	concurrentKey := make([]byte, masterKeyBytes)
+	for i := range concurrentKey {
+		concurrentKey[i] = byte(i + 77)
+	}
+
+	origGet := keyringGet
+	origSet := keyringSet
+	keyringGet = func(svc, user string) (string, error) {
+		if err := os.WriteFile(filepath.Join(dir, fileMasterKeyName), concurrentKey, 0600); err != nil {
+			t.Fatalf("simulated concurrent write failed: %v", err)
+		}
+		return "", keyring.ErrNotFound
+	}
+	keyringSet = func(svc, user, password string) error {
+		t.Fatalf("keyringSet must not be called; keychain-downgrade never writes to the system Keychain")
+		return nil
+	}
+	t.Cleanup(func() {
+		keyringGet = origGet
+		keyringSet = origSet
+	})
+
+	result, err := DowngradeMasterKeyToFile(service)
+	if err != nil {
+		t.Fatalf("DowngradeMasterKeyToFile() error = %v", err)
+	}
+	if result != DowngradeAlreadyDone {
+		t.Fatalf("result = %v, want DowngradeAlreadyDone (concurrent write must be preserved)", result)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, fileMasterKeyName))
+	if err != nil {
+		t.Fatalf("ReadFile error = %v", err)
+	}
+	if !bytesEqual(got, concurrentKey) {
+		t.Fatalf("master.key.file was clobbered; concurrent platformSet's encrypted credentials would be orphaned")
+	}
+}
+
 // TestPlatformGetSurfacesKeychainBlocked verifies that "keychain access blocked"
 // (the sandbox case) propagates as errKeychainBlocked through platformGet, so
 // the wrapError hint chain can attach the keychain-downgrade suggestion.

--- a/internal/keychain/keychain_darwin_test.go
+++ b/internal/keychain/keychain_darwin_test.go
@@ -111,6 +111,323 @@ func TestPlatformGetPrefersFileMasterKey(t *testing.T) {
 	}
 }
 
+// TestDowngradeAlreadyDoneIsIdempotent verifies that re-running downgrade
+// when master.key.file already exists is a no-op and reports AlreadyDone
+// without touching the system keychain.
+func TestDowngradeAlreadyDoneIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origGet := keyringGet
+	origSet := keyringSet
+	keyringGet = func(service, user string) (string, error) {
+		t.Fatalf("keyringGet should not be called when master.key.file is already valid")
+		return "", nil
+	}
+	keyringSet = func(service, user, password string) error {
+		t.Fatalf("keyringSet should not be called when master.key.file is already valid")
+		return nil
+	}
+	t.Cleanup(func() {
+		keyringGet = origGet
+		keyringSet = origSet
+	})
+
+	service := "test-service"
+	dir := StorageDir(service)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	preExisting := make([]byte, masterKeyBytes)
+	for i := range preExisting {
+		preExisting[i] = byte(i + 7)
+	}
+	keyPath := filepath.Join(dir, fileMasterKeyName)
+	if err := os.WriteFile(keyPath, preExisting, 0600); err != nil {
+		t.Fatalf("WriteFile(master key) error = %v", err)
+	}
+
+	result, err := DowngradeMasterKeyToFile(service)
+	if err != nil {
+		t.Fatalf("DowngradeMasterKeyToFile() error = %v", err)
+	}
+	if result != DowngradeAlreadyDone {
+		t.Fatalf("result = %v, want DowngradeAlreadyDone", result)
+	}
+
+	after, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !bytesEqual(after, preExisting) {
+		t.Fatalf("master.key.file content changed; want preserved")
+	}
+}
+
+// TestDowngradeCopiesKeychainKeyToFile verifies the happy path: a keychain
+// key exists, the file does not, and downgrade copies the bytes verbatim
+// so that existing .enc files (encrypted with the keychain key) remain
+// readable via the file fallback.
+func TestDowngradeCopiesKeychainKeyToFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	keychainKey := make([]byte, masterKeyBytes)
+	for i := range keychainKey {
+		keychainKey[i] = byte(i + 11)
+	}
+
+	origGet := keyringGet
+	origSet := keyringSet
+	keyringGet = func(service, user string) (string, error) {
+		return base64.StdEncoding.EncodeToString(keychainKey), nil
+	}
+	keyringSet = func(service, user, password string) error {
+		t.Fatalf("keyringSet should not be called when keychain already has a master key")
+		return nil
+	}
+	t.Cleanup(func() {
+		keyringGet = origGet
+		keyringSet = origSet
+	})
+
+	service := "test-service"
+
+	result, err := DowngradeMasterKeyToFile(service)
+	if err != nil {
+		t.Fatalf("DowngradeMasterKeyToFile() error = %v", err)
+	}
+	if result != DowngradeUsedKeychainKey {
+		t.Fatalf("result = %v, want DowngradeUsedKeychainKey", result)
+	}
+
+	got, err := os.ReadFile(MasterKeyFilePath(service))
+	if err != nil {
+		t.Fatalf("ReadFile(master.key.file) error = %v", err)
+	}
+	if !bytesEqual(got, keychainKey) {
+		t.Fatalf("file key bytes do not match keychain key; existing .enc files would become unreadable")
+	}
+}
+
+// TestDowngradeCreatesNewKeyAndFlagsOrphaned verifies the safety-via-warning
+// path: when the OS Keychain is empty AND encrypted credentials already exist
+// on disk, downgrade still writes a fresh file key (so future config init has
+// a working fallback) but returns DowngradeCreatedNewKeyOrphaned so the cmd
+// layer can warn the user that the existing .enc files are now unreadable.
+// Crucially also verifies keyringSet is NEVER called — keychain-downgrade
+// must not write to the system Keychain.
+func TestDowngradeCreatesNewKeyAndFlagsOrphaned(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origGet := keyringGet
+	origSet := keyringSet
+	keyringGet = func(service, user string) (string, error) {
+		return "", keyring.ErrNotFound
+	}
+	keyringSet = func(service, user, password string) error {
+		t.Fatalf("keyringSet must not be called; keychain-downgrade never writes to the system Keychain")
+		return nil
+	}
+	t.Cleanup(func() {
+		keyringGet = origGet
+		keyringSet = origSet
+	})
+
+	service := "test-service"
+	dir := StorageDir(service)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, safeFileName("appsecret:cli_test")), []byte("garbage-ciphertext"), 0600); err != nil {
+		t.Fatalf("WriteFile(stale .enc) error = %v", err)
+	}
+
+	result, err := DowngradeMasterKeyToFile(service)
+	if err != nil {
+		t.Fatalf("DowngradeMasterKeyToFile() error = %v; expected success-with-orphan-flag", err)
+	}
+	if result != DowngradeCreatedNewKeyOrphaned {
+		t.Fatalf("result = %v, want DowngradeCreatedNewKeyOrphaned", result)
+	}
+
+	info, ferr := os.Stat(MasterKeyFilePath(service))
+	if ferr != nil {
+		t.Fatalf("master.key.file must be written even when orphans exist: %v", ferr)
+	}
+	if info.Size() != masterKeyBytes {
+		t.Fatalf("master.key.file size = %d, want %d", info.Size(), masterKeyBytes)
+	}
+}
+
+// TestDowngradeCreatesNewKeyWhenStorageEmpty verifies the "fresh user"
+// path: keychain is empty and no .enc files exist, so we generate a new
+// random key and write it to the file fallback. The OS Keychain is NOT
+// modified (regression guard for the side-effecting getMasterKey(_, true)
+// call we used to make).
+func TestDowngradeCreatesNewKeyWhenStorageEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origGet := keyringGet
+	origSet := keyringSet
+	keyringGet = func(service, user string) (string, error) {
+		return "", keyring.ErrNotFound
+	}
+	keyringSet = func(service, user, password string) error {
+		t.Fatalf("keyringSet must not be called; keychain-downgrade never writes to the system Keychain")
+		return nil
+	}
+	t.Cleanup(func() {
+		keyringGet = origGet
+		keyringSet = origSet
+	})
+
+	service := "test-service"
+
+	result, err := DowngradeMasterKeyToFile(service)
+	if err != nil {
+		t.Fatalf("DowngradeMasterKeyToFile() error = %v", err)
+	}
+	if result != DowngradeCreatedNewKey {
+		t.Fatalf("result = %v, want DowngradeCreatedNewKey", result)
+	}
+
+	fileKey, err := os.ReadFile(MasterKeyFilePath(service))
+	if err != nil {
+		t.Fatalf("ReadFile(master.key.file) error = %v", err)
+	}
+	if len(fileKey) != masterKeyBytes {
+		t.Fatalf("file key length = %d, want %d", len(fileKey), masterKeyBytes)
+	}
+}
+
+// TestPlatformGetReportsOrphanedCredentials verifies that platformGet returns
+// ErrOrphanedCredentials when an .enc file is present on disk but no
+// reachable master key (file or keychain) can decrypt it. This is the
+// diagnostic path the user hits when they delete the OS Keychain entry
+// after credentials were stored — the old "keychain not initialized" error
+// was misleading because it implied keychain-downgrade could fix it.
+func TestPlatformGetReportsOrphanedCredentials(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origGet := keyringGet
+	origSet := keyringSet
+	keyringGet = func(service, user string) (string, error) {
+		// Keychain is empty (the realistic "user deleted via GUI" scenario).
+		return "", keyring.ErrNotFound
+	}
+	keyringSet = func(service, user, password string) error {
+		t.Fatalf("keyringSet should not be called from platformGet")
+		return nil
+	}
+	t.Cleanup(func() {
+		keyringGet = origGet
+		keyringSet = origSet
+	})
+
+	service := "test-service"
+	account := "test-account"
+	dir := StorageDir(service)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	// Seed a file master key (key B) and an .enc encrypted with a different
+	// key (key A) — the situation the user lands in after a botched downgrade
+	// followed by deleting the keychain entry.
+	fileKey := make([]byte, masterKeyBytes)
+	for i := range fileKey {
+		fileKey[i] = byte(i + 1)
+	}
+	if err := os.WriteFile(filepath.Join(dir, fileMasterKeyName), fileKey, 0600); err != nil {
+		t.Fatalf("WriteFile(file key) error = %v", err)
+	}
+
+	lostKey := make([]byte, masterKeyBytes)
+	for i := range lostKey {
+		lostKey[i] = byte(i + 99)
+	}
+	encrypted, err := encryptData("orphaned-secret", lostKey)
+	if err != nil {
+		t.Fatalf("encryptData() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, safeFileName(account)), encrypted, 0600); err != nil {
+		t.Fatalf("WriteFile(.enc) error = %v", err)
+	}
+
+	_, err = platformGet(service, account)
+	if !errors.Is(err, ErrOrphanedCredentials) {
+		t.Fatalf("err = %v, want ErrOrphanedCredentials", err)
+	}
+}
+
+// TestPlatformGetSurfacesKeychainBlockedNotOrphan verifies that
+// "keychain access blocked" (the sandbox case) is NOT misreported as
+// ErrOrphanedCredentials — that error is transient and the existing
+// hint chain (keychain-downgrade in an interactive session) is the
+// right escape hatch.
+func TestPlatformGetSurfacesKeychainBlockedNotOrphan(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	origGet := keyringGet
+	origSet := keyringSet
+	keyringGet = func(service, user string) (string, error) {
+		// Not ErrNotFound → triggers "keychain access blocked" path in getMasterKey.
+		return "", errors.New("sandbox denied keychain access")
+	}
+	keyringSet = func(service, user, password string) error {
+		return nil
+	}
+	t.Cleanup(func() {
+		keyringGet = origGet
+		keyringSet = origSet
+	})
+
+	service := "test-service"
+	account := "test-account"
+	dir := StorageDir(service)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+
+	// .enc exists, no file key — sandbox-only access path.
+	lostKey := make([]byte, masterKeyBytes)
+	for i := range lostKey {
+		lostKey[i] = byte(i + 55)
+	}
+	encrypted, err := encryptData("secret", lostKey)
+	if err != nil {
+		t.Fatalf("encryptData() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, safeFileName(account)), encrypted, 0600); err != nil {
+		t.Fatalf("WriteFile(.enc) error = %v", err)
+	}
+
+	_, err = platformGet(service, account)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if errors.Is(err, ErrOrphanedCredentials) {
+		t.Fatalf("err = %v; access-blocked must NOT be reported as orphan (would suppress the keychain-downgrade hint)", err)
+	}
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // TestPlatformSetPrefersExistingFileMasterKey verifies writes stay on the file-based
 // master key path once the fallback master key already exists.
 func TestPlatformSetPrefersExistingFileMasterKey(t *testing.T) {

--- a/internal/keychain/keychain_darwin_test.go
+++ b/internal/keychain/keychain_darwin_test.go
@@ -212,57 +212,6 @@ func TestDowngradeCopiesKeychainKeyToFile(t *testing.T) {
 	}
 }
 
-// TestDowngradeCreatesNewKeyAndFlagsOrphaned verifies the safety-via-warning
-// path: when the OS Keychain is empty AND encrypted credentials already exist
-// on disk, downgrade still writes a fresh file key (so future config init has
-// a working fallback) but returns DowngradeCreatedNewKeyOrphaned so the cmd
-// layer can warn the user that the existing .enc files are now unreadable.
-// Crucially also verifies keyringSet is NEVER called — keychain-downgrade
-// must not write to the system Keychain.
-func TestDowngradeCreatesNewKeyAndFlagsOrphaned(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	origGet := keyringGet
-	origSet := keyringSet
-	keyringGet = func(service, user string) (string, error) {
-		return "", keyring.ErrNotFound
-	}
-	keyringSet = func(service, user, password string) error {
-		t.Fatalf("keyringSet must not be called; keychain-downgrade never writes to the system Keychain")
-		return nil
-	}
-	t.Cleanup(func() {
-		keyringGet = origGet
-		keyringSet = origSet
-	})
-
-	service := "test-service"
-	dir := StorageDir(service)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, safeFileName("appsecret:cli_test")), []byte("garbage-ciphertext"), 0600); err != nil {
-		t.Fatalf("WriteFile(stale .enc) error = %v", err)
-	}
-
-	result, err := DowngradeMasterKeyToFile(service)
-	if err != nil {
-		t.Fatalf("DowngradeMasterKeyToFile() error = %v; expected success-with-orphan-flag", err)
-	}
-	if result != DowngradeCreatedNewKeyOrphaned {
-		t.Fatalf("result = %v, want DowngradeCreatedNewKeyOrphaned", result)
-	}
-
-	info, ferr := os.Stat(MasterKeyFilePath(service))
-	if ferr != nil {
-		t.Fatalf("master.key.file must be written even when orphans exist: %v", ferr)
-	}
-	if info.Size() != masterKeyBytes {
-		t.Fatalf("master.key.file size = %d, want %d", info.Size(), masterKeyBytes)
-	}
-}
-
 // TestDowngradeCreatesNewKeyWhenStorageEmpty verifies the "fresh user"
 // path: keychain is empty and no .enc files exist, so we generate a new
 // random key and write it to the file fallback. The OS Keychain is NOT
@@ -305,80 +254,16 @@ func TestDowngradeCreatesNewKeyWhenStorageEmpty(t *testing.T) {
 	}
 }
 
-// TestPlatformGetReportsOrphanedCredentials verifies that platformGet returns
-// ErrOrphanedCredentials when an .enc file is present on disk but no
-// reachable master key (file or keychain) can decrypt it. This is the
-// diagnostic path the user hits when they delete the OS Keychain entry
-// after credentials were stored — the old "keychain not initialized" error
-// was misleading because it implied keychain-downgrade could fix it.
-func TestPlatformGetReportsOrphanedCredentials(t *testing.T) {
+// TestPlatformGetSurfacesKeychainBlocked verifies that "keychain access blocked"
+// (the sandbox case) propagates as errKeychainBlocked through platformGet, so
+// the wrapError hint chain can attach the keychain-downgrade suggestion.
+func TestPlatformGetSurfacesKeychainBlocked(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
 	origGet := keyringGet
 	origSet := keyringSet
 	keyringGet = func(service, user string) (string, error) {
-		// Keychain is empty (the realistic "user deleted via GUI" scenario).
-		return "", keyring.ErrNotFound
-	}
-	keyringSet = func(service, user, password string) error {
-		t.Fatalf("keyringSet should not be called from platformGet")
-		return nil
-	}
-	t.Cleanup(func() {
-		keyringGet = origGet
-		keyringSet = origSet
-	})
-
-	service := "test-service"
-	account := "test-account"
-	dir := StorageDir(service)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		t.Fatalf("MkdirAll() error = %v", err)
-	}
-
-	// Seed a file master key (key B) and an .enc encrypted with a different
-	// key (key A) — the situation the user lands in after a botched downgrade
-	// followed by deleting the keychain entry.
-	fileKey := make([]byte, masterKeyBytes)
-	for i := range fileKey {
-		fileKey[i] = byte(i + 1)
-	}
-	if err := os.WriteFile(filepath.Join(dir, fileMasterKeyName), fileKey, 0600); err != nil {
-		t.Fatalf("WriteFile(file key) error = %v", err)
-	}
-
-	lostKey := make([]byte, masterKeyBytes)
-	for i := range lostKey {
-		lostKey[i] = byte(i + 99)
-	}
-	encrypted, err := encryptData("orphaned-secret", lostKey)
-	if err != nil {
-		t.Fatalf("encryptData() error = %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, safeFileName(account)), encrypted, 0600); err != nil {
-		t.Fatalf("WriteFile(.enc) error = %v", err)
-	}
-
-	_, err = platformGet(service, account)
-	if !errors.Is(err, ErrOrphanedCredentials) {
-		t.Fatalf("err = %v, want ErrOrphanedCredentials", err)
-	}
-}
-
-// TestPlatformGetSurfacesKeychainBlockedNotOrphan verifies that
-// "keychain access blocked" (the sandbox case) is NOT misreported as
-// ErrOrphanedCredentials — that error is transient and the existing
-// hint chain (keychain-downgrade in an interactive session) is the
-// right escape hatch.
-func TestPlatformGetSurfacesKeychainBlockedNotOrphan(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-
-	origGet := keyringGet
-	origSet := keyringSet
-	keyringGet = func(service, user string) (string, error) {
-		// Not ErrNotFound → triggers "keychain access blocked" path in getMasterKey.
 		return "", errors.New("sandbox denied keychain access")
 	}
 	keyringSet = func(service, user, password string) error {
@@ -396,7 +281,6 @@ func TestPlatformGetSurfacesKeychainBlockedNotOrphan(t *testing.T) {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
 
-	// .enc exists, no file key — sandbox-only access path.
 	lostKey := make([]byte, masterKeyBytes)
 	for i := range lostKey {
 		lostKey[i] = byte(i + 55)
@@ -410,11 +294,8 @@ func TestPlatformGetSurfacesKeychainBlockedNotOrphan(t *testing.T) {
 	}
 
 	_, err = platformGet(service, account)
-	if err == nil {
-		t.Fatalf("expected error, got nil")
-	}
-	if errors.Is(err, ErrOrphanedCredentials) {
-		t.Fatalf("err = %v; access-blocked must NOT be reported as orphan (would suppress the keychain-downgrade hint)", err)
+	if !errors.Is(err, errKeychainBlocked) {
+		t.Fatalf("err = %v, want errKeychainBlocked", err)
 	}
 }
 
@@ -427,7 +308,6 @@ func TestPlatformGetSurfacesKeychainBlockedNotOrphan(t *testing.T) {
 //
 // Asserts the full wrapError → ExitError.Detail.Hint pipeline:
 //   - errKeychainBlocked + errNotInitialized → hint mentions keychain-downgrade
-//   - ErrOrphanedCredentials (downgrade can't recover lost data) → no mention
 //   - "keychain is corrupted" (downgrade would re-read the same bad bytes) → no mention
 //   - generic errors → no mention
 //
@@ -442,7 +322,6 @@ func TestWrapErrorHintMentionsDowngradeForRecoverableCases(t *testing.T) {
 		{"access blocked (sandbox / denied prompt / timeout)", errKeychainBlocked, true},
 		{"not initialized (missing master key)", errNotInitialized, true},
 		{"corrupted (downgrade would re-read the same bad bytes)", errors.New("keychain is corrupted"), false},
-		{"orphaned credentials (downgrade cannot recover lost data)", ErrOrphanedCredentials, false},
 		{"unrelated generic error", errors.New("something else entirely"), false},
 	}
 	for _, tc := range cases {

--- a/internal/keychain/keychain_hint_other.go
+++ b/internal/keychain/keychain_hint_other.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build !darwin
+
+package keychain
+
+// extraHint is a no-op on non-darwin platforms. The keychain-downgrade
+// command is macOS-only, so there is no extra suggestion to surface.
+func extraHint(err error) string { return "" }


### PR DESCRIPTION
## Summary

Adds `lark-cli config keychain-downgrade` (macOS only) so users can proactively
pin the master key to the local file fallback
(`~/Library/Application Support/lark-cli/master.key.file`). After running it
once in an interactive Terminal session, subsequent sandboxed / CI / automation
runs read the key from the file and no longer need the system Keychain — the
fix for environments like the Codex sandbox where Keychain access is blocked.

Also widens the existing keychain-error hint to suggest `keychain-downgrade`
when Keychain access is blocked at runtime, not only when the master key is
missing.

## Changes

- **New macOS-only subcommand** `config keychain-downgrade`
  - `UsedKeychainKey`: copies the existing Keychain master key to file
  - `CreatedNewKey`: generates a new random key locally when the Keychain is
    empty (does NOT write to OS Keychain — read-only on Keychain by design)
  - `AlreadyDone`: idempotent no-op when the file is already valid
- **`errKeychainBlocked` sentinel** (`internal/keychain/keychain_darwin.go`)
  - Replaces an anonymous `errors.New("keychain access blocked")` so
    `errors.Is` can match it from the hint chain
  - Both the non-`ErrNotFound` keyring-get path and the 5-second timeout path
    return it
- **Error hint chain** (`internal/keychain/keychain.go`)
  - Per-platform `extraHint`: darwin appends the keychain-downgrade suggestion
    for `errNotInitialized` OR `errKeychainBlocked`; non-darwin no-op stub
  - Corruption errors are deliberately excluded — downgrade would re-read the
    same bad bytes
- **Non-darwin stub** so `config --help` is consistent across platforms and
  the subcommand refuses cleanly with "only supported on macOS" outside macOS

## Test Plan

- [x] `make unit-test` passes
- [x] Cross-compile: `go build` / `go vet` on darwin, linux, windows
- [x] `golangci-lint run --new-from-rev=origin/main` passes
- [x] Unit tests in `keychain_darwin_test.go`:
  - `TestDowngradeAlreadyDoneIsIdempotent`
  - `TestDowngradeCopiesKeychainKeyToFile`
  - `TestDowngradeCreatesNewKeyWhenStorageEmpty` (asserts Keychain is never
    written)
  - `TestPlatformGetSurfacesKeychainBlocked` (asserts `errKeychainBlocked`
    propagates through `platformGet`)
  - `TestWrapErrorHintMentionsDowngradeForRecoverableCases` (table test:
    blocked + not-initialized → hint mentions `keychain-downgrade`;
    corrupted + generic → hint does NOT)
- [x] Manual verification on macOS:
  - Fresh state with Keychain entry → `keychain-downgrade` produces
    `UsedKeychainKey`, file bytes match Keychain bytes
  - Empty Keychain → `keychain-downgrade` produces `CreatedNewKey`, file
    written, Keychain still empty (no side effect)
  - Re-running `keychain-downgrade` after success → `AlreadyDone`, no I/O
  - Sandbox repro: lock keychain + remove `master.key.file` + invoke from a
    shadow binary path → error message contains `keychain access blocked` AND
    hint contains `keychain-downgrade`

## Related Issues

Refs #1038 — alternative / complementary approach to PR #1059. Where #1059
auto-migrates transparently inside `platformGet` / `platformSet`, this PR
gives users an explicit, discoverable command.

## Notes for reviewers

- `DowngradeMasterKeyToFile` deliberately uses `rand.Read` instead of
  `getMasterKey(service, true)`; the latter writes the new key to the system
  Keychain as a side effect, which violates the "downgrade never modifies the
  OS Keychain" invariant.
- `extraHint`'s matcher only widens for errors that downgrade can actually
  recover from. New errors added there should preserve that promise — the
  regression test asserts it for the current set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a config subcommand to materialize the macOS Keychain master key into a local fallback file; the command is shown on all platforms but only runs on macOS.

* **Bug Fixes**
  * Better detection of blocked or missing Keychain access and clearer recovery hints, including guidance to run the downgrade command when appropriate.

* **Tests**
  * Added macOS-focused tests for downgrade idempotency, copying/creation behavior, and error/hint handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1085?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->