### PR TITLE
chore(release): v1.0.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.40] - 2026-05-25
+
+### Features
+
+- **wiki**: Add exponential backoff retry for `+node-create` lock contention (#1012)
+- **auth**: Add `auth qrcode` subcommand and update auth docs/hints (#968)
+
+### Bug Fixes
+
+- **wiki**: Rename `+node-get --token` to `--node-token`, keep alias (#1074)
+- **output**: Classify wiki lock-contention error (131009) with retry hint (#1014)
+- **contact**: Add actionable hint when fanout search all-fail with no API code (#1054)
+- **permission**: Annotate auto-grant permission failures with `required_scope` and `console_url` (#1045)
+- **validation**: Use `ErrValidation` instead of `fmt.Errorf` in `Validate` paths (#1001)
+
+### Documentation
+
+- **skills**: Add 云盘/云存储 alias alongside 云空间 for agent clarity (#1073)
+- **task**: Refresh `lark-task` shortcut docs (#1057)
+
 ## [v1.0.39] - 2026-05-22
 
 ### Features
@@ -840,6 +860,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.40]: https://github.com/larksuite/cli/releases/tag/v1.0.40
 [v1.0.39]: https://github.com/larksuite/cli/releases/tag/v1.0.39
 [v1.0.38]: https://github.com/larksuite/cli/releases/tag/v1.0.38
 [v1.0.37]: https://github.com/larksuite/cli/releases/tag/v1.0.37

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

Release v1.0.40 — 9 commits since v1.0.39 (2 features, 5 fixes, 2 docs).

### Features
- **wiki**: Exponential backoff retry for `+node-create` lock contention (#1012)
- **auth**: `auth qrcode` subcommand (#968)

### Bug Fixes
- **wiki**: Rename `+node-get --token` → `--node-token` with alias (#1074)
- **output**: Classify wiki lock-contention error 131009 with retry hint (#1014)
- **contact**: Actionable hint when fanout search all-fail with no API code (#1054)
- **permission**: Annotate auto-grant failures with `required_scope` / `console_url` (#1045)
- **validation**: Use `ErrValidation` in `Validate` paths (#1001)

### Documentation
- **skills**: 云盘/云存储 alias for lark-drive (#1073)
- **task**: Refresh `lark-task` shortcut docs (#1057)

## Test plan

- [ ] CI green
- [ ] Tag `v1.0.40` after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 1.0.40 released with features, bug fixes, and documentation updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->