### PR TITLE
fix(apps): read app object from data.app for +create and +update

### DIFF
--- a/shortcuts/apps/apps_create.go
+++ b/shortcuts/apps/apps_create.go
@@ -53,7 +53,7 @@ var AppsCreate = common.Shortcut{
 			return err
 		}
 		rctx.OutFormat(data, nil, func(w io.Writer) {
-			fmt.Fprintf(w, "created: %s\n", common.GetString(data, "app_id"))
+			fmt.Fprintf(w, "created: %s\n", common.GetString(data, "app", "app_id"))
 		})
 		return nil
 	},

--- a/shortcuts/apps/apps_create_test.go
+++ b/shortcuts/apps/apps_create_test.go
@@ -56,10 +56,12 @@ func TestAppsCreate_Success(t *testing.T) {
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
-				"app_id":     "app_x",
-				"name":       "Demo",
-				"icon_url":   "https://lf3-static.bytednsdoc.com/.../default.svg",
-				"created_at": "2026-05-18T10:00:00Z",
+				"app": map[string]interface{}{
+					"app_id":     "app_x",
+					"name":       "Demo",
+					"icon_url":   "https://lf3-static.bytednsdoc.com/.../default.svg",
+					"created_at": "2026-05-18T10:00:00Z",
+				},
 			},
 		},
 	}
@@ -99,7 +101,9 @@ func TestAppsCreate_WithIconURL(t *testing.T) {
 		URL:    "/open-apis/spark/v1/apps",
 		Body: map[string]interface{}{
 			"code": 0,
-			"data": map[string]interface{}{"app_id": "app_x", "name": "Demo"},
+			"data": map[string]interface{}{
+				"app": map[string]interface{}{"app_id": "app_x", "name": "Demo"},
+			},
 		},
 	})
 
@@ -107,6 +111,34 @@ func TestAppsCreate_WithIconURL(t *testing.T) {
 		[]string{"+create", "--name", "Demo", "--app-type", "HTML", "--icon-url", "https://example.com/icon.svg", "--as", "user"},
 		factory, stdout); err != nil {
 		t.Fatalf("execute err=%v", err)
+	}
+}
+
+// TestAppsCreate_PrettyOutputReadsNestedAppID exercises the prettyFn callback
+// passed to OutFormat (only invoked under --format pretty) so the new
+// data.app.app_id nesting is actually read by the text writer. Without this,
+// default --format json dumps the whole envelope and the substring assertion
+// in TestAppsCreate_Success would pass even if the GetString path were wrong.
+func TestAppsCreate_PrettyOutputReadsNestedAppID(t *testing.T) {
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/spark/v1/apps",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"app": map[string]interface{}{"app_id": "app_x", "name": "Demo"},
+			},
+		},
+	})
+
+	if err := runAppsShortcut(t, AppsCreate,
+		[]string{"+create", "--name", "Demo", "--app-type", "HTML", "--format", "pretty", "--as", "user"},
+		factory, stdout); err != nil {
+		t.Fatalf("execute err=%v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "created: app_x") {
+		t.Fatalf("pretty output should read app_id from data.app.app_id, got: %q", got)
 	}
 }
 

--- a/shortcuts/apps/apps_update.go
+++ b/shortcuts/apps/apps_update.go
@@ -53,7 +53,7 @@ var AppsUpdate = common.Shortcut{
 			return err
 		}
 		rctx.OutFormat(data, nil, func(w io.Writer) {
-			fmt.Fprintf(w, "updated: %s\n", common.GetString(data, "app_id"))
+			fmt.Fprintf(w, "updated: %s\n", common.GetString(data, "app", "app_id"))
 		})
 		return nil
 	},

--- a/shortcuts/apps/apps_update_test.go
+++ b/shortcuts/apps/apps_update_test.go
@@ -19,9 +19,11 @@ func TestAppsUpdate_PartialFields(t *testing.T) {
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
-				"app_id":     "app_x",
-				"name":       "renamed",
-				"updated_at": "2026-05-18T10:05:00Z",
+				"app": map[string]interface{}{
+					"app_id":     "app_x",
+					"name":       "renamed",
+					"updated_at": "2026-05-18T10:05:00Z",
+				},
 			},
 		},
 	}
@@ -73,7 +75,9 @@ func TestAppsUpdate_TrimsAppIDInPath(t *testing.T) {
 		URL:    "/open-apis/spark/v1/apps/app_x",
 		Body: map[string]interface{}{
 			"code": 0,
-			"data": map[string]interface{}{"app_id": "app_x"},
+			"data": map[string]interface{}{
+				"app": map[string]interface{}{"app_id": "app_x"},
+			},
 		},
 	}
 	reg.Register(stub)
@@ -82,5 +86,31 @@ func TestAppsUpdate_TrimsAppIDInPath(t *testing.T) {
 		[]string{"+update", "--app-id", "  app_x  ", "--name", "renamed", "--as", "user"},
 		factory, stdout); err != nil {
 		t.Fatalf("execute err=%v", err)
+	}
+}
+
+// TestAppsUpdate_PrettyOutputReadsNestedAppID exercises the prettyFn callback
+// passed to OutFormat (only invoked under --format pretty) so the new
+// data.app.app_id nesting is actually read by the text writer.
+func TestAppsUpdate_PrettyOutputReadsNestedAppID(t *testing.T) {
+	factory, stdout, reg := newAppsExecuteFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/spark/v1/apps/app_x",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"app": map[string]interface{}{"app_id": "app_x", "name": "renamed"},
+			},
+		},
+	})
+
+	if err := runAppsShortcut(t, AppsUpdate,
+		[]string{"+update", "--app-id", "app_x", "--name", "renamed", "--format", "pretty", "--as", "user"},
+		factory, stdout); err != nil {
+		t.Fatalf("execute err=%v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "updated: app_x") {
+		t.Fatalf("pretty output should read app_id from data.app.app_id, got: %q", got)
 	}
 }

--- a/skills/lark-apps/SKILL.md
+++ b/skills/lark-apps/SKILL.md
@@ -42,6 +42,14 @@ lark-cli apps +access-scope-set --app-id app_xxx --scope tenant
 lark-cli auth login --domain apps
 ```
 
+**命令失败且 `error.hint` 是授权类提示时（hint 含 `auth login` / `permission_violations` / `scope` / `unauthorized` 等关键词，或 envelope 含 `permission_violations` 字段），不要按 hint 里的 `--scope <single>` 逐个补**——本域命令链路（create → html-publish → access-scope-set/get）通常会接连触发多个 scope，逐个补会让用户反复授权。统一引导用户跑：
+
+```bash
+lark-cli auth login --domain apps
+```
+
+一次性把整个 apps 域的 scope 都拿到，授权成功后再重试失败的那条命令。Bot 身份（`--as bot`）不适用本规则，仍按 `lark-shared` 的 `console_url` 路径走。
+
 ## 写 HTML 前的硬约束（避免 publish 阶段被拒）
 
 - **入口文件必须叫 `index.html`** — 妙搭以 `index.html` 作为应用入口；目录形态时根目录下要有 `index.html`，单文件形态时文件名就是 `index.html`。命名成 `app.html` / `demo.html` 等会被 `+html-publish` 直接拒绝
@@ -84,7 +92,7 @@ lark-cli auth login --domain apps
 - `--path` 既可传单个 HTML 文件也可传目录；目录会**递归打包成 tar.gz 不做过滤**，要提醒用户传干净的产物目录（如 `./dist`），避免把 `.git` / `node_modules` 一起打进去
 - `apps +update` 只更新传入字段，未传字段保持不变；`--name` / `--description` 至少传一个，否则 Validate 阶段直接拦截
 - `apps +access-scope-set` 三种 scope **互斥**：specific 必传 `--targets`、不允许 `--require-login`；public 必传 `--require-login`、不允许 `--targets` / `--apply-enabled` / `--approver`；tenant 不允许任何其他 flag
-- 失败时**优先转述 `error.hint`**（CLI 给的可执行修复建议），hint 为空时退回 `error.message`；不要原样把 envelope JSON 复述给用户
+- 失败时**优先转述 `error.hint`**（CLI 给的可执行修复建议），hint 为空时退回 `error.message`；不要原样把 envelope JSON 复述给用户。**例外**：hint 是授权类（含 `auth login` / `permission_violations` / `scope` / `unauthorized` 等关键词）时，不要照抄 hint 里的 `--scope <single>`，按上面「身份与一次性授权」的恢复规则统一引导 `lark-cli auth login --domain apps`
 
 ## Shortcuts（推荐优先使用）
 

--- a/skills/lark-apps/SKILL.md
+++ b/skills/lark-apps/SKILL.md
@@ -42,13 +42,11 @@ lark-cli apps +access-scope-set --app-id app_xxx --scope tenant
 lark-cli auth login --domain apps
 ```
 
-**命令失败且 `error.hint` 是授权类提示时（hint 含 `auth login` / `permission_violations` / `scope` / `unauthorized` 等关键词，或 envelope 含 `permission_violations` 字段），不要按 hint 里的 `--scope <single>` 逐个补**——本域命令链路（create → html-publish → access-scope-set/get）通常会接连触发多个 scope，逐个补会让用户反复授权。统一引导用户跑：
+命令失败且 `error.type == "missing_scope"` 时，统一引导用户跑：
 
 ```bash
 lark-cli auth login --domain apps
 ```
-
-一次性把整个 apps 域的 scope 都拿到，授权成功后再重试失败的那条命令。Bot 身份（`--as bot`）不适用本规则，仍按 `lark-shared` 的 `console_url` 路径走。
 
 ## 写 HTML 前的硬约束（避免 publish 阶段被拒）
 
@@ -92,7 +90,7 @@ lark-cli auth login --domain apps
 - `--path` 既可传单个 HTML 文件也可传目录；目录会**递归打包成 tar.gz 不做过滤**，要提醒用户传干净的产物目录（如 `./dist`），避免把 `.git` / `node_modules` 一起打进去
 - `apps +update` 只更新传入字段，未传字段保持不变；`--name` / `--description` 至少传一个，否则 Validate 阶段直接拦截
 - `apps +access-scope-set` 三种 scope **互斥**：specific 必传 `--targets`、不允许 `--require-login`；public 必传 `--require-login`、不允许 `--targets` / `--apply-enabled` / `--approver`；tenant 不允许任何其他 flag
-- 失败时**优先转述 `error.hint`**（CLI 给的可执行修复建议），hint 为空时退回 `error.message`；不要原样把 envelope JSON 复述给用户。**例外**：hint 是授权类（含 `auth login` / `permission_violations` / `scope` / `unauthorized` 等关键词）时，不要照抄 hint 里的 `--scope <single>`，按上面「身份与一次性授权」的恢复规则统一引导 `lark-cli auth login --domain apps`
+- 失败时**优先转述 `error.hint`**（CLI 给的可执行修复建议），hint 为空时退回 `error.message`；不要原样把 envelope JSON 复述给用户。`error.type == "missing_scope"` 例外：按上面「身份与一次性授权」走
 
 ## Shortcuts（推荐优先使用）
 

--- a/skills/lark-apps/references/lark-apps-create.md
+++ b/skills/lark-apps/references/lark-apps-create.md
@@ -38,11 +38,13 @@ lark-cli apps +create --name "Demo" --app-type HTML --dry-run
 {
   "ok": true,
   "data": {
-    "app_id": "app_4k5jepcbjmv6m",
-    "name": "客户调研问卷",
-    "description": "本季度客户满意度调研",
-    "icon_url": "https://lf3-static.bytednsdoc.com/.../feisuda/avatar/5.svg",
-    "created_at": "2026-05-18T10:00:00Z"
+    "app": {
+      "app_id": "app_4k5jepcbjmv6m",
+      "name": "客户调研问卷",
+      "description": "本季度客户满意度调研",
+      "icon_url": "https://lf3-static.bytednsdoc.com/.../feisuda/avatar/5.svg",
+      "created_at": "2026-05-18T10:00:00Z"
+    }
   }
 }
 ```

--- a/skills/lark-apps/references/lark-apps-html-publish.md
+++ b/skills/lark-apps/references/lark-apps-html-publish.md
@@ -98,7 +98,7 @@ lark-cli apps +html-publish --app-id app_xxx --path ./dist
 ### 场景 2：用户没有 app_id
 
 ```bash
-APP=$(lark-cli apps +create --name "..." -q '.data.app.app_id' | tr -d '"')
+APP=$(lark-cli apps +create --name "..." --app-type HTML -q '.data.app.app_id' | tr -d '"')
 lark-cli apps +html-publish --app-id "$APP" --path ./dist
 ```
 

--- a/skills/lark-apps/references/lark-apps-html-publish.md
+++ b/skills/lark-apps/references/lark-apps-html-publish.md
@@ -98,7 +98,7 @@ lark-cli apps +html-publish --app-id app_xxx --path ./dist
 ### 场景 2：用户没有 app_id
 
 ```bash
-APP=$(lark-cli apps +create --name "..." -q '.data.app_id' | tr -d '"')
+APP=$(lark-cli apps +create --name "..." -q '.data.app.app_id' | tr -d '"')
 lark-cli apps +html-publish --app-id "$APP" --path ./dist
 ```
 

--- a/skills/lark-apps/references/lark-apps-update.md
+++ b/skills/lark-apps/references/lark-apps-update.md
@@ -30,12 +30,14 @@ lark-cli apps +update --app-id app_xxx --name "v2" --description "新描述"
 {
   "ok": true,
   "data": {
-    "app_id": "app_4k5jepcbjmv6m",
-    "name": "调研问卷 v2",
-    "description": "...",
-    "icon_url": "https://lf3-static.bytednsdoc.com/.../feisuda/avatar/5.svg",
-    "created_at": "2026-05-18T10:00:00Z",
-    "updated_at": "2026-05-18T10:05:00Z"
+    "app": {
+      "app_id": "app_4k5jepcbjmv6m",
+      "name": "调研问卷 v2",
+      "description": "...",
+      "icon_url": "https://lf3-static.bytednsdoc.com/.../feisuda/avatar/5.svg",
+      "created_at": "2026-05-18T10:00:00Z",
+      "updated_at": "2026-05-18T10:05:00Z"
+    }
   }
 }
 ```
@@ -51,7 +53,7 @@ lark-cli apps +update --app-id app_xxx --name "v2" --description "新描述"
 
 ## 字段语义
 
-- 响应 `data` 含完整应用对象（所有字段），不只是被改的
+- 响应 `data.app` 含完整应用对象（所有字段），不只是被改的
 - `created_at` / `updated_at` 都是 ISO 8601 UTC 时间字符串
 - 失败时优先转述 `error.hint`
 


### PR DESCRIPTION
## Summary

The Miaoda OpenAPI returns the application object nested under `data.app` for both `POST /apps` (create) and `PATCH /apps/{appId}` (update), per the design doc. The CLI text helper was reading `common.GetString(data, "app_id")`, which yields an empty string against the wire format — so `lark-cli apps +create --format pretty` printed `created: ` with no ID. Same defect on update.

## Changes

- `shortcuts/apps/apps_create.go`, `shortcuts/apps/apps_update.go`: navigate the new nested path via `common.GetString(data, "app", "app_id")`.
- `shortcuts/apps/apps_create_test.go`, `shortcuts/apps/apps_update_test.go`: wrap the mock response under `app` to match the wire shape.
- `skills/lark-apps/references/lark-apps-create.md`, `.../lark-apps-update.md`: update the example response with the `app` wrapper, plus a note about the new field path so agents read `data.app.app_id`.
- `skills/lark-apps/references/lark-apps-html-publish.md`: update the jq path in scenario 2 from `.data.app_id` to `.data.app.app_id`.

Wire format is passed through to the user's JSON envelope untouched — no unwrapping in CLI. Consumers reading the response should use `.data.app.app_id`.

The `GET /apps` list endpoint (`apps_list.go`) is unchanged: per the design doc its `items[]` are flat objects, no wrapper.

## Test Plan

- [x] `go test ./shortcuts/apps/ ./tests/cli_e2e/apps/` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l shortcuts/apps/` clean
- [x] Manual: rebuilt binary and confirmed `apps +create --help` / `apps +update --help` register without flag changes
- [x] Existing happy-path unit tests (`TestAppsCreate_Success`, `TestAppsCreate_WithIconURL`, `TestAppsUpdate_Success`, `TestAppsUpdate_TrimsAppIDInPath`) updated to the new mock shape and pass

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed create/update commands so the created/updated app ID is read and displayed from the corrected response structure.

* **Documentation**
  * Updated examples and docs to reflect the nested response format and correct path to the application object and ID.
  * Clarified recovery guidance for authorization failures to prefer a one-time domain login before retrying.

* **Tests**
  * Added tests verifying CLI/pretty output reads the app ID from the updated response shape.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1087?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->