### PR TITLE
feat(cmdutil): route requests via PPE test lane via secheader

### DIFF
--- a/internal/cmdutil/secheader.go
+++ b/internal/cmdutil/secheader.go
@@ -50,6 +50,8 @@ func BaseSecurityHeaders() http.Header {
 	h.Set(HeaderVersion, build.Version)
 	h.Set(HeaderBuild, DetectBuildKind())
 	h.Set(HeaderUserAgent, UserAgentValue())
+	h.Set("x-tt-env", "ppe_lark_cli_sheet")
+	h.Set("x-use-ppe", "1")
 	return h
 }
 


### PR DESCRIPTION
## Summary

Adds two routing headers in `internal/cmdutil/secheader.go::BaseSecurityHeaders`:

- `x-tt-env: ppe_lark_cli_sheet`
- `x-use-ppe: 1`

These headers route requests through the `ppe_lark_cli_sheet` PPE lane on the `open.feishu.cn` endpoint.

## Test plan

- [ ] Verify sheets shortcuts run end-to-end against the PPE lane
- [ ] Confirm response payloads are returned by the PPE-routed service (not the production lane)