### PR TITLE
feat(im): enrich messages with reactions + output update_time

### DIFF
--- a/shortcuts/im/convert_lib/content_convert.go
+++ b/shortcuts/im/convert_lib/content_convert.go
@@ -155,6 +155,20 @@ func FormatMessageItem(m map[string]interface{}, runtime *common.RuntimeContext,
 	}
 
 	// Preserve API-provided fields (even if this formatter doesn't otherwise use them).
+	// update_time is only meaningful when the message was actually edited;
+	// the server echoes update_time == create_time for unedited messages, which
+	// would otherwise make every output look "updated" to downstream consumers.
+	if updated {
+		if v, ok := m["update_time"]; ok && v != nil {
+			if s, isStr := v.(string); isStr {
+				if strings.TrimSpace(s) != "" {
+					msg["update_time"] = common.FormatTime(s)
+				}
+			} else {
+				msg["update_time"] = common.FormatTime(v)
+			}
+		}
+	}
 	if v, ok := m["chat_id"]; ok {
 		msg["chat_id"] = v
 	}

--- a/shortcuts/im/convert_lib/content_media_misc_test.go
+++ b/shortcuts/im/convert_lib/content_media_misc_test.go
@@ -95,6 +95,61 @@ func TestFormatMessageItem(t *testing.T) {
 	}
 }
 
+func TestFormatMessageItem_UpdateTime_Present(t *testing.T) {
+	raw := map[string]interface{}{
+		"msg_type":    "text",
+		"message_id":  "om_edit",
+		"updated":     true,
+		"create_time": "1710500000",
+		"update_time": "1710600000",
+		"sender":      map[string]interface{}{"id": "ou_sender", "sender_type": "user"},
+		"body":        map[string]interface{}{"content": `{"text":"edited"}`},
+	}
+
+	got := FormatMessageItem(raw, nil)
+	want := common.FormatTime("1710600000")
+	if got["update_time"] != want {
+		t.Fatalf("FormatMessageItem() update_time = %#v, want %#v", got["update_time"], want)
+	}
+}
+
+func TestFormatMessageItem_UpdateTime_Absent(t *testing.T) {
+	raw := map[string]interface{}{
+		"msg_type":    "text",
+		"message_id":  "om_no_edit",
+		"updated":     false,
+		"create_time": "1710500000",
+		"sender":      map[string]interface{}{"id": "ou_sender", "sender_type": "user"},
+		"body":        map[string]interface{}{"content": `{"text":"hi"}`},
+	}
+
+	got := FormatMessageItem(raw, nil)
+	if _, ok := got["update_time"]; ok {
+		t.Fatalf("FormatMessageItem() should not include update_time when absent, got = %#v", got["update_time"])
+	}
+}
+
+// TestFormatMessageItem_UpdateTime_UnchangedMessage: real API behavior — even
+// for unedited messages, server returns update_time == create_time. We must
+// NOT echo it through, otherwise every message looks "edited" to consumers.
+// Gate the output on updated==true.
+func TestFormatMessageItem_UpdateTime_UnchangedMessage(t *testing.T) {
+	raw := map[string]interface{}{
+		"msg_type":    "text",
+		"message_id":  "om_unchanged",
+		"updated":     false,
+		"create_time": "1710500000",
+		"update_time": "1710500000", // server echoes create_time
+		"sender":      map[string]interface{}{"id": "ou_sender", "sender_type": "user"},
+		"body":        map[string]interface{}{"content": `{"text":"hi"}`},
+	}
+
+	got := FormatMessageItem(raw, nil)
+	if v, ok := got["update_time"]; ok {
+		t.Fatalf("FormatMessageItem() must skip update_time for unedited message, got = %#v", v)
+	}
+}
+
 func TestResolveAppLinkDomain(t *testing.T) {
 	if got := resolveAppLinkDomain(core.BrandFeishu); got != "applink.feishu.cn" {
 		t.Fatalf("resolveAppLinkDomain(feishu) = %q", got)

--- a/shortcuts/im/convert_lib/reactions.go
+++ b/shortcuts/im/convert_lib/reactions.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package convertlib
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// reactionsBatchQueryMaxQueries is the server-side hard limit on queries[]
+// length for POST /im/v1/messages/reactions/batch_query (see
+// larkim/message/members/facade_reaction/service: batchListReactionsMaxMessageIDs).
+const reactionsBatchQueryMaxQueries = 20
+
+// EnrichReactions enriches messages with their reactions by calling the
+// im.reactions.batch_query API. Messages are modified in place: each message
+// that the server returns reactions for gets a "reactions" map attached.
+//
+// Failure modes (warning to stderr + skip; never aborts main message output):
+//   - batch_query call fails (network, 5xx, scope insufficient, rate limited):
+//     each message in the failed batch is marked with "reactions_error": true
+//     so callers can distinguish "fetch failed" from "no reactions exist".
+//   - batch_query returns a partial result: only messages the server failed on
+//     get "reactions_error": true; the successful ones get the reactions block.
+//
+// The "reactions_error" flag mirrors the "thread_replies_error" pattern in
+// thread.go so downstream consumers handle both enrichment failures uniformly.
+//
+// Output shape (only on messages that the server actually returned data for):
+//
+//	"reactions": {
+//	  "counts":  [{"reaction_type": "SMILE", "count": 3}],
+//	  "details": [{"reaction_id": "...", "emoji_type": "SMILE",
+//	                "operator": {...}, "action_time": "..."}]
+//	}
+//
+// The server caps queries[] at 20 per call, so messages are split into
+// batches of size <= 20 before invoking the API.
+func EnrichReactions(runtime *common.RuntimeContext, messages []map[string]interface{}) {
+	if len(messages) == 0 {
+		return
+	}
+
+	// Index messages by ID so we can merge reactions back later.
+	// A single message_id may appear more than once (e.g. mget --message-ids
+	// om_a,om_a); every occurrence must receive the reactions block, but the
+	// API should only be queried once per distinct id.
+	// Walks into msg["thread_replies"] recursively so replies attached by
+	// ExpandThreadReplies are enriched in the same batched call as their parent.
+	idIndex := make(map[string][]map[string]interface{}, len(messages))
+	var ids []string
+	collectMessageNodes(messages, idIndex, &ids)
+	if len(ids) == 0 {
+		return
+	}
+
+	for i := 0; i < len(ids); i += reactionsBatchQueryMaxQueries {
+		end := i + reactionsBatchQueryMaxQueries
+		if end > len(ids) {
+			end = len(ids)
+		}
+		fetchReactionsBatch(runtime, ids[i:end], idIndex)
+	}
+}
+
+// collectMessageNodes walks messages (and any nested thread_replies) and
+// records each map under its message_id. Distinct ids are appended to *ids in
+// first-seen order so the API is queried at most once per id.
+func collectMessageNodes(messages []map[string]interface{}, idIndex map[string][]map[string]interface{}, ids *[]string) {
+	for _, msg := range messages {
+		if id, _ := msg["message_id"].(string); id != "" {
+			if _, seen := idIndex[id]; !seen {
+				*ids = append(*ids, id)
+			}
+			idIndex[id] = append(idIndex[id], msg)
+		}
+		// thread_replies may arrive as a typed slice (set by ExpandThreadReplies)
+		// or as []interface{} (e.g. when produced via JSON round-trip).
+		switch nested := msg["thread_replies"].(type) {
+		case []map[string]interface{}:
+			collectMessageNodes(nested, idIndex, ids)
+		case []interface{}:
+			typed := make([]map[string]interface{}, 0, len(nested))
+			for _, raw := range nested {
+				if m, ok := raw.(map[string]interface{}); ok {
+					typed = append(typed, m)
+				}
+			}
+			collectMessageNodes(typed, idIndex, ids)
+		}
+	}
+}
+
+// fetchReactionsBatch invokes batch_query for one batch of <= 20 message IDs
+// and merges the results into idIndex. Failures are logged to stderr without
+// aborting subsequent batches.
+func fetchReactionsBatch(runtime *common.RuntimeContext, batchIDs []string, idIndex map[string][]map[string]interface{}) {
+	queries := make([]map[string]interface{}, 0, len(batchIDs))
+	for _, id := range batchIDs {
+		queries = append(queries, map[string]interface{}{"message_id": id})
+	}
+
+	data, err := runtime.DoAPIJSON(http.MethodPost,
+		"/open-apis/im/v1/messages/reactions/batch_query",
+		nil,
+		map[string]interface{}{"queries": queries},
+	)
+	if err != nil {
+		fmt.Fprintf(runtime.IO().ErrOut, "warning: reactions_batch_query_failed: %v\n", err)
+		markReactionsError(batchIDs, idIndex)
+		return
+	}
+
+	countsByMsg := groupReactionCounts(data["success_msg_reaction_counts"])
+	detailsByMsg := groupReactionDetails(data["success_msg_reaction_details"])
+
+	// Attach the merged reactions block to every message that had any data.
+	// Each id may map to >1 message map (duplicate input), so iterate the slice.
+	for _, id := range batchIDs {
+		msgs := idIndex[id]
+		if len(msgs) == 0 {
+			continue
+		}
+		counts := countsByMsg[id]
+		details := detailsByMsg[id]
+		if len(counts) == 0 && len(details) == 0 {
+			continue
+		}
+		block := make(map[string]interface{}, 2)
+		if len(counts) > 0 {
+			block["counts"] = counts
+		}
+		if len(details) > 0 {
+			block["details"] = details
+		}
+		for _, msg := range msgs {
+			msg["reactions"] = block
+		}
+	}
+
+	// Surface per-message failures from the API response.
+	if fails, _ := data["fail_msg_reaction_details"].([]interface{}); len(fails) > 0 {
+		var failedIDs []string
+		for _, raw := range fails {
+			item, _ := raw.(map[string]interface{})
+			if id, _ := item["message_id"].(string); id != "" {
+				failedIDs = append(failedIDs, id)
+			}
+		}
+		if len(failedIDs) > 0 {
+			fmt.Fprintf(runtime.IO().ErrOut,
+				"warning: reactions_partial_failed: %d message(s) failed (%v)\n",
+				len(failedIDs), failedIDs)
+			markReactionsError(failedIDs, idIndex)
+		}
+	}
+}
+
+// markReactionsError flags every message map indexed under the given ids with
+// reactions_error=true, so downstream consumers can distinguish "fetch failed"
+// from "no reactions exist" by reading stdout alone.
+func markReactionsError(ids []string, idIndex map[string][]map[string]interface{}) {
+	for _, id := range ids {
+		for _, msg := range idIndex[id] {
+			msg["reactions_error"] = true
+		}
+	}
+}
+
+func groupReactionCounts(raw interface{}) map[string][]interface{} {
+	groups := map[string][]interface{}{}
+	items, _ := raw.([]interface{})
+	for _, item := range items {
+		row, _ := item.(map[string]interface{})
+		msgID, _ := row["message_id"].(string)
+		if msgID == "" {
+			continue
+		}
+		entries, _ := row["reaction_count"].([]interface{})
+		if len(entries) == 0 {
+			continue
+		}
+		groups[msgID] = append(groups[msgID], entries...)
+	}
+	return groups
+}
+
+func groupReactionDetails(raw interface{}) map[string][]interface{} {
+	groups := map[string][]interface{}{}
+	items, _ := raw.([]interface{})
+	for _, item := range items {
+		row, _ := item.(map[string]interface{})
+		msgID, _ := row["message_id"].(string)
+		if msgID == "" {
+			continue
+		}
+		entries, _ := row["message_reaction_items"].([]interface{})
+		if len(entries) == 0 {
+			continue
+		}
+		groups[msgID] = append(groups[msgID], entries...)
+	}
+	return groups
+}

--- a/shortcuts/im/convert_lib/reactions_test.go
+++ b/shortcuts/im/convert_lib/reactions_test.go
@@ -1,0 +1,352 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package convertlib
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestEnrichReactions_Success exercises the basic happy path: messages that
+// carry reactions get a "reactions" field, messages without reactions stay
+// untouched.
+func TestEnrichReactions_Success(t *testing.T) {
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/open-apis/im/v1/messages/reactions/batch_query") {
+			return nil, fmt.Errorf("unexpected path: %s", req.URL.Path)
+		}
+		var payload map[string]interface{}
+		body, _ := io.ReadAll(req.Body)
+		_ = json.Unmarshal(body, &payload)
+		queries, _ := payload["queries"].([]interface{})
+		if len(queries) != 2 {
+			t.Fatalf("queries size = %d, want 2", len(queries))
+		}
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"success_msg_reaction_counts": []interface{}{
+					map[string]interface{}{
+						"message_id": "om_a",
+						"reaction_count": []interface{}{
+							map[string]interface{}{"reaction_type": "SMILE", "count": 3},
+						},
+					},
+				},
+				"success_msg_reaction_details": []interface{}{
+					map[string]interface{}{
+						"message_id": "om_a",
+						"message_reaction_items": []interface{}{
+							map[string]interface{}{
+								"reaction_id": "react_1",
+								"emoji_type":  "SMILE",
+								"operator":    map[string]interface{}{"operator_id": "ou_x", "operator_type": "user"},
+								"action_time": "1710600000",
+							},
+						},
+					},
+				},
+				"fail_msg_reaction_details": []interface{}{},
+			},
+		}), nil
+	}))
+
+	messages := []map[string]interface{}{
+		{"message_id": "om_a"},
+		{"message_id": "om_b"},
+	}
+
+	EnrichReactions(runtime, messages)
+
+	reactionsA, ok := messages[0]["reactions"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("message om_a missing reactions field: %#v", messages[0])
+	}
+	counts, _ := reactionsA["counts"].([]interface{})
+	if len(counts) != 1 {
+		t.Fatalf("om_a counts = %d, want 1", len(counts))
+	}
+	details, _ := reactionsA["details"].([]interface{})
+	if len(details) != 1 {
+		t.Fatalf("om_a details = %d, want 1", len(details))
+	}
+
+	if _, ok := messages[1]["reactions"]; ok {
+		t.Fatalf("message om_b should not have reactions field (none in response): %#v", messages[1])
+	}
+}
+
+// TestEnrichReactions_BatchSize splits queries into batches of 20 (server-side
+// max for batch_query).
+func TestEnrichReactions_BatchSize(t *testing.T) {
+	var observedBatchSizes []int
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		var payload map[string]interface{}
+		_ = json.Unmarshal(body, &payload)
+		queries, _ := payload["queries"].([]interface{})
+		observedBatchSizes = append(observedBatchSizes, len(queries))
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		}), nil
+	}))
+
+	messages := make([]map[string]interface{}, 25)
+	for i := range messages {
+		messages[i] = map[string]interface{}{"message_id": fmt.Sprintf("om_%02d", i)}
+	}
+
+	EnrichReactions(runtime, messages)
+
+	if want := []int{20, 5}; !reflect.DeepEqual(observedBatchSizes, want) {
+		t.Fatalf("batch sizes = %v, want %v", observedBatchSizes, want)
+	}
+}
+
+// TestEnrichReactions_APIFailure: when the API call fails, messages stay
+// without a reactions field but get marked with reactions_error=true so
+// downstream consumers can distinguish "fetch failed" from "no reactions".
+// Mirrors the thread_replies_error pattern in thread.go.
+func TestEnrichReactions_APIFailure(t *testing.T) {
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("simulated network error")
+	}))
+
+	messages := []map[string]interface{}{
+		{"message_id": "om_a"},
+		{"message_id": "om_b"},
+	}
+
+	EnrichReactions(runtime, messages)
+
+	for _, m := range messages {
+		if _, ok := m["reactions"]; ok {
+			t.Fatalf("message %v should have no reactions after API failure", m["message_id"])
+		}
+		if v, _ := m["reactions_error"].(bool); !v {
+			t.Fatalf("message %v should have reactions_error=true after API failure, got = %#v",
+				m["message_id"], m["reactions_error"])
+		}
+	}
+}
+
+// TestEnrichReactions_PartialFailure: when batch_query returns a fail entry
+// for one ID, that message gets reactions_error=true while the rest stay
+// clean (no error flag) and keep their normal reactions block.
+func TestEnrichReactions_PartialFailure(t *testing.T) {
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"success_msg_reaction_counts": []interface{}{
+					map[string]interface{}{
+						"message_id": "om_ok",
+						"reaction_count": []interface{}{
+							map[string]interface{}{"reaction_type": "SMILE", "count": 1},
+						},
+					},
+				},
+				"fail_msg_reaction_details": []interface{}{
+					map[string]interface{}{"message_id": "om_bad"},
+				},
+			},
+		}), nil
+	}))
+
+	ok := map[string]interface{}{"message_id": "om_ok"}
+	bad := map[string]interface{}{"message_id": "om_bad"}
+	EnrichReactions(runtime, []map[string]interface{}{ok, bad})
+
+	if _, has := ok["reactions"]; !has {
+		t.Fatalf("om_ok should have reactions: %#v", ok)
+	}
+	if v, _ := ok["reactions_error"].(bool); v {
+		t.Fatalf("om_ok must not carry reactions_error: %#v", ok)
+	}
+	if _, has := bad["reactions"]; has {
+		t.Fatalf("om_bad should have no reactions block: %#v", bad)
+	}
+	if v, _ := bad["reactions_error"].(bool); !v {
+		t.Fatalf("om_bad should have reactions_error=true, got = %#v", bad["reactions_error"])
+	}
+}
+
+// TestEnrichReactions_EmptyMessages: no messages -> no API call at all.
+func TestEnrichReactions_EmptyMessages(t *testing.T) {
+	called := false
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		called = true
+		return convertlibJSONResponse(200, map[string]interface{}{"code": 0, "data": map[string]interface{}{}}), nil
+	}))
+
+	EnrichReactions(runtime, nil)
+	EnrichReactions(runtime, []map[string]interface{}{})
+
+	if called {
+		t.Fatalf("API should not be called when messages list is empty")
+	}
+}
+
+// TestEnrichReactions_SkipsMessagesWithoutID: messages missing message_id
+// (defensive) should not crash and not be sent in queries.
+func TestEnrichReactions_SkipsMessagesWithoutID(t *testing.T) {
+	var sentIDs []string
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		var payload map[string]interface{}
+		_ = json.Unmarshal(body, &payload)
+		queries, _ := payload["queries"].([]interface{})
+		for _, q := range queries {
+			qm, _ := q.(map[string]interface{})
+			id, _ := qm["message_id"].(string)
+			sentIDs = append(sentIDs, id)
+		}
+		return convertlibJSONResponse(200, map[string]interface{}{"code": 0, "data": map[string]interface{}{}}), nil
+	}))
+
+	messages := []map[string]interface{}{
+		{"message_id": "om_a"},
+		{}, // no message_id
+		{"message_id": ""},
+		{"message_id": "om_b"},
+	}
+
+	EnrichReactions(runtime, messages)
+
+	if want := []string{"om_a", "om_b"}; !reflect.DeepEqual(sentIDs, want) {
+		t.Fatalf("sent IDs = %v, want %v", sentIDs, want)
+	}
+}
+
+// TestEnrichReactions_WalksThreadReplies: thread_replies nested under a parent
+// message must also be enriched, in the same batch_query call as the parent —
+// otherwise the parent gets reactions but its replies don't, leaving the output
+// inconsistent.
+func TestEnrichReactions_WalksThreadReplies(t *testing.T) {
+	var observedQueriedIDs []string
+	var observedCallCount int
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		observedCallCount++
+		body, _ := io.ReadAll(req.Body)
+		var payload map[string]interface{}
+		_ = json.Unmarshal(body, &payload)
+		queries, _ := payload["queries"].([]interface{})
+		for _, q := range queries {
+			qm, _ := q.(map[string]interface{})
+			id, _ := qm["message_id"].(string)
+			observedQueriedIDs = append(observedQueriedIDs, id)
+		}
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"success_msg_reaction_counts": []interface{}{
+					map[string]interface{}{
+						"message_id": "om_top",
+						"reaction_count": []interface{}{
+							map[string]interface{}{"reaction_type": "SMILE", "count": 1},
+						},
+					},
+					map[string]interface{}{
+						"message_id": "om_reply1",
+						"reaction_count": []interface{}{
+							map[string]interface{}{"reaction_type": "THUMBSUP", "count": 2},
+						},
+					},
+					map[string]interface{}{
+						"message_id": "om_reply2",
+						"reaction_count": []interface{}{
+							map[string]interface{}{"reaction_type": "HEART", "count": 3},
+						},
+					},
+				},
+			},
+		}), nil
+	}))
+
+	reply1 := map[string]interface{}{"message_id": "om_reply1"}
+	reply2 := map[string]interface{}{"message_id": "om_reply2"}
+	top := map[string]interface{}{
+		"message_id":     "om_top",
+		"thread_replies": []map[string]interface{}{reply1, reply2},
+	}
+	messages := []map[string]interface{}{top}
+
+	EnrichReactions(runtime, messages)
+
+	if observedCallCount != 1 {
+		t.Fatalf("expected 1 batched API call, got %d", observedCallCount)
+	}
+	sort.Strings(observedQueriedIDs)
+	if want := []string{"om_reply1", "om_reply2", "om_top"}; !reflect.DeepEqual(observedQueriedIDs, want) {
+		t.Fatalf("queried IDs = %v, want %v (top + thread_replies)", observedQueriedIDs, want)
+	}
+
+	if _, ok := top["reactions"]; !ok {
+		t.Fatalf("top message missing reactions")
+	}
+	if _, ok := reply1["reactions"]; !ok {
+		t.Fatalf("reply1 missing reactions — thread_replies were not walked")
+	}
+	if _, ok := reply2["reactions"]; !ok {
+		t.Fatalf("reply2 missing reactions — thread_replies were not walked")
+	}
+}
+
+// TestEnrichReactions_DuplicateMessageID: when the caller passes two distinct
+// message maps that share the same message_id (e.g. mget --message-ids om_a,om_a),
+// both maps must receive the same reactions block, and the API must be queried
+// for the id only once.
+func TestEnrichReactions_DuplicateMessageID(t *testing.T) {
+	var observedQueriesPerCall []int
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		var payload map[string]interface{}
+		_ = json.Unmarshal(body, &payload)
+		queries, _ := payload["queries"].([]interface{})
+		observedQueriesPerCall = append(observedQueriesPerCall, len(queries))
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"success_msg_reaction_counts": []interface{}{
+					map[string]interface{}{
+						"message_id": "om_a",
+						"reaction_count": []interface{}{
+							map[string]interface{}{"reaction_type": "SMILE", "count": 2},
+						},
+					},
+				},
+			},
+		}), nil
+	}))
+
+	first := map[string]interface{}{"message_id": "om_a"}
+	second := map[string]interface{}{"message_id": "om_a"}
+	other := map[string]interface{}{"message_id": "om_b"}
+	messages := []map[string]interface{}{first, other, second}
+
+	EnrichReactions(runtime, messages)
+
+	if want := []int{2}; !reflect.DeepEqual(observedQueriesPerCall, want) {
+		t.Fatalf("queries-per-call = %v, want %v (each id once, no dup fetch)", observedQueriesPerCall, want)
+	}
+
+	firstReactions, firstOK := first["reactions"]
+	secondReactions, secondOK := second["reactions"]
+	if !firstOK {
+		t.Fatalf("first om_a entry missing reactions")
+	}
+	if !secondOK {
+		t.Fatalf("second om_a entry missing reactions — dup msg_id was dropped")
+	}
+	if !reflect.DeepEqual(firstReactions, secondReactions) {
+		t.Fatalf("dup entries reactions differ: %#v vs %#v", firstReactions, secondReactions)
+	}
+}

--- a/shortcuts/im/im_chat_messages_list.go
+++ b/shortcuts/im/im_chat_messages_list.go
@@ -22,8 +22,8 @@ var ImChatMessageList = common.Shortcut{
 	Description: "List messages in a chat or P2P conversation; user/bot; accepts --chat-id or --user-id, resolves P2P chat_id, supports time range/sort/pagination",
 	Risk:        "read",
 	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "contact:user.base:readonly"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly"},
+	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read", "contact:user.base:readonly"},
+	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
@@ -34,6 +34,7 @@ var ImChatMessageList = common.Shortcut{
 		{Name: "sort", Default: "desc", Desc: "sort order", Enum: []string{"asc", "desc"}},
 		{Name: "page-size", Default: "50", Desc: "page size (1-50)"},
 		{Name: "page-token", Desc: "pagination token for next page"},
+		{Name: "no-reactions", Type: "bool", Desc: "skip auto-fetching reactions for each message (default: enrichment enabled)"},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		d := common.NewDryRunAPI()
@@ -54,7 +55,12 @@ var ImChatMessageList = common.Shortcut{
 				dryParams[k] = vs[0]
 			}
 		}
-		return d.GET("/open-apis/im/v1/messages").Params(dryParams)
+		d = d.GET("/open-apis/im/v1/messages").Params(dryParams)
+		if !runtime.Bool("no-reactions") {
+			d = d.POST("/open-apis/im/v1/messages/reactions/batch_query").
+				Desc("Reaction enrichment: queries returned messages (including thread_replies expanded inline) in batches of up to 20. Pass --no-reactions to skip.")
+		}
+		return d
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		// Under bot identity, --user-id is not supported; require --chat-id only.
@@ -121,6 +127,9 @@ var ImChatMessageList = common.Shortcut{
 		convertlib.ResolveSenderNames(runtime, messages, nameCache)
 		convertlib.AttachSenderNames(messages, nameCache)
 		convertlib.ExpandThreadReplies(runtime, messages, nameCache, convertlib.ThreadRepliesPerThread, convertlib.ThreadRepliesTotalLimit)
+		if !runtime.Bool("no-reactions") {
+			convertlib.EnrichReactions(runtime, messages)
+		}
 
 		outData := map[string]interface{}{
 			"messages":   messages,

--- a/shortcuts/im/im_messages_mget.go
+++ b/shortcuts/im/im_messages_mget.go
@@ -22,16 +22,22 @@ var ImMessagesMGet = common.Shortcut{
 	Description: "Batch get messages by IDs; user/bot; fetches up to 50 om_ message IDs, formats sender names, expands thread replies",
 	Risk:        "read",
 	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "contact:user.basic_profile:readonly"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "contact:user.base:readonly"},
+	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read", "contact:user.basic_profile:readonly"},
+	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read", "contact:user.base:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "message-ids", Desc: "message IDs, comma-separated (om_xxx,om_yyy)", Required: true},
+		{Name: "no-reactions", Type: "bool", Desc: "skip auto-fetching reactions for each message (default: enrichment enabled)"},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		ids := common.SplitCSV(runtime.Str("message-ids"))
-		return common.NewDryRunAPI().GET(buildMGetURL(ids))
+		d := common.NewDryRunAPI().GET(buildMGetURL(ids))
+		if !runtime.Bool("no-reactions") {
+			d = d.POST("/open-apis/im/v1/messages/reactions/batch_query").
+				Desc("Reaction enrichment: queries returned messages in batches of up to 20 to attach the reactions block (operator, action_time, counts). Pass --no-reactions to skip.")
+		}
+		return d
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		ids := common.SplitCSV(runtime.Str("message-ids"))
@@ -69,6 +75,9 @@ var ImMessagesMGet = common.Shortcut{
 		convertlib.ResolveSenderNames(runtime, messages, nameCache)
 		convertlib.AttachSenderNames(messages, nameCache)
 		convertlib.ExpandThreadReplies(runtime, messages, nameCache, convertlib.ThreadRepliesPerThread, convertlib.ThreadRepliesTotalLimit)
+		if !runtime.Bool("no-reactions") {
+			convertlib.EnrichReactions(runtime, messages)
+		}
 
 		outData := map[string]interface{}{
 			"messages": messages,

--- a/shortcuts/im/im_messages_search.go
+++ b/shortcuts/im/im_messages_search.go
@@ -30,7 +30,7 @@ var ImMessagesSearch = common.Shortcut{
 	Command:     "+messages-search",
 	Description: "Search messages across chats (supports keyword, sender, time range filters) with user identity; user-only; filters by chat/sender/attachment/time, enriches results via mget and chats batch_query",
 	Risk:        "read",
-	Scopes:      []string{"search:message", "contact:user.basic_profile:readonly"},
+	Scopes:      []string{"search:message", "im:message.reactions:read", "contact:user.basic_profile:readonly"},
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{
@@ -49,6 +49,7 @@ var ImMessagesSearch = common.Shortcut{
 		{Name: "page-token", Desc: "page token"},
 		{Name: "page-all", Type: "bool", Desc: "automatically paginate search results"},
 		{Name: "page-limit", Type: "int", Default: "20", Desc: "max search pages when auto-pagination is enabled (default 20, max 40)"},
+		{Name: "no-reactions", Type: "bool", Desc: "skip auto-fetching reactions for each message (default: enrichment enabled)"},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		req, err := buildMessagesSearchRequest(runtime)
@@ -68,12 +69,17 @@ var ImMessagesSearch = common.Shortcut{
 		} else {
 			d = d.Desc("Step 1: search messages")
 		}
-		return d.
+		d = d.
 			POST("/open-apis/im/v1/messages/search").
 			Params(dryParams).
 			Body(req.body).
 			Desc("Step 2 (if results): GET /open-apis/im/v1/messages/mget?message_ids=...  — batch fetch message details (max 50)").
 			Desc("Step 3 (if results): POST /open-apis/im/v1/chats/batch_query  — fetch chat names for context")
+		if !runtime.Bool("no-reactions") {
+			d = d.POST("/open-apis/im/v1/messages/reactions/batch_query").
+				Desc("Step 4 (if results): reaction enrichment in batches of up to 20 messages. Pass --no-reactions to skip.")
+		}
+		return d
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		_, err := buildMessagesSearchRequest(runtime)
@@ -184,6 +190,9 @@ var ImMessagesSearch = common.Shortcut{
 		// Enrich: resolve sender names for outer messages (reuses cache from merge_forward)
 		convertlib.ResolveSenderNames(runtime, enriched, nameCache)
 		convertlib.AttachSenderNames(enriched, nameCache)
+		if !runtime.Bool("no-reactions") {
+			convertlib.EnrichReactions(runtime, enriched)
+		}
 
 		outData := map[string]interface{}{
 			"messages":   enriched,

--- a/shortcuts/im/im_threads_messages_list.go
+++ b/shortcuts/im/im_threads_messages_list.go
@@ -24,8 +24,8 @@ var ImThreadsMessagesList = common.Shortcut{
 	Description: "List messages in a thread; user/bot; accepts om_/omt_ input, resolves message IDs to thread_id, supports sort/pagination",
 	Risk:        "read",
 	Scopes:      []string{"im:message:readonly"},
-	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "contact:user.basic_profile:readonly"},
-	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "contact:user.base:readonly"},
+	UserScopes:  []string{"im:message.group_msg:get_as_user", "im:message.p2p_msg:get_as_user", "im:message.reactions:read", "contact:user.basic_profile:readonly"},
+	BotScopes:   []string{"im:message.group_msg", "im:message.p2p_msg:readonly", "im:message.reactions:read", "contact:user.base:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
@@ -33,6 +33,7 @@ var ImThreadsMessagesList = common.Shortcut{
 		{Name: "sort", Default: "asc", Desc: "sort order", Enum: []string{"asc", "desc"}},
 		{Name: "page-size", Default: "50", Desc: "page size (1-500)"},
 		{Name: "page-token", Desc: "page token"},
+		{Name: "no-reactions", Type: "bool", Desc: "skip auto-fetching reactions for each message (default: enrichment enabled)"},
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		threadFlag := runtime.Str("thread")
@@ -65,10 +66,15 @@ var ImThreadsMessagesList = common.Shortcut{
 			params["page_token"] = pageToken
 		}
 
-		return d.
+		d = d.
 			GET("/open-apis/im/v1/messages").
 			Params(params).
 			Set("thread", threadFlag).Set("sort", sortFlag).Set("page_size", pageSizeStr)
+		if !runtime.Bool("no-reactions") {
+			d = d.POST("/open-apis/im/v1/messages/reactions/batch_query").
+				Desc("Reaction enrichment: queries returned thread messages in batches of up to 20. Pass --no-reactions to skip.")
+		}
+		return d
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		threadId := runtime.Str("thread")
@@ -124,6 +130,9 @@ var ImThreadsMessagesList = common.Shortcut{
 		// Enrich: resolve sender names for outer messages (reuses cache from merge_forward)
 		convertlib.ResolveSenderNames(runtime, messages, nameCache)
 		convertlib.AttachSenderNames(messages, nameCache)
+		if !runtime.Bool("no-reactions") {
+			convertlib.EnrichReactions(runtime, messages)
+		}
 
 		outData := map[string]interface{}{
 			"thread_id":  threadId,

--- a/skill-template/domains/im.md
+++ b/skill-template/domains/im.md
@@ -33,6 +33,10 @@ When using bot identity (`--as bot`) to fetch messages (e.g. `+chat-messages-lis
 
 **Solution**: Check the app's visibility settings in the Lark Developer Console — ensure the app's visible range covers the users whose names need to be resolved. Alternatively, use `--as user` to fetch messages with user identity, which typically has broader contact access.
 
+### Default message enrichment (reactions / update_time)
+
+The four message-pulling shortcuts (`+messages-mget`, `+chat-messages-list`, `+messages-search`, `+threads-messages-list`) automatically attach a `reactions` block and (for edited messages) `update_time` to each returned message — no separate `im.reactions.batch_query` call is needed. Pass `--no-reactions` to opt out. For the full contract (output shape, the `im:message.reactions:read` scope requirement, and the "missing field ≠ fetch failure" data rules), read [`references/lark-im-message-enrichment.md`](references/lark-im-message-enrichment.md).
+
 ### Card Messages (Interactive)
 
 Card messages (`interactive` type) are not yet supported for compact conversion in event subscriptions. The raw event data will be returned instead, with a hint printed to stderr.

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -47,6 +47,10 @@ When using bot identity (`--as bot`) to fetch messages (e.g. `+chat-messages-lis
 
 **Solution**: Check the app's visibility settings in the Lark Developer Console — ensure the app's visible range covers the users whose names need to be resolved. Alternatively, use `--as user` to fetch messages with user identity, which typically has broader contact access.
 
+### Default message enrichment (reactions / update_time)
+
+The four message-pulling shortcuts (`+messages-mget`, `+chat-messages-list`, `+messages-search`, `+threads-messages-list`) automatically attach a `reactions` block and (for edited messages) `update_time` to each returned message — no separate `im.reactions.batch_query` call is needed. Pass `--no-reactions` to opt out. For the full contract (output shape, the `im:message.reactions:read` scope requirement, and the "missing field ≠ fetch failure" data rules), read [`references/lark-im-message-enrichment.md`](references/lark-im-message-enrichment.md).
+
 ### Card Messages (Interactive)
 
 Card messages (`interactive` type) are not yet supported for compact conversion in event subscriptions. The raw event data will be returned instead, with a hint printed to stderr.

--- a/skills/lark-im/references/lark-im-chat-messages-list.md
+++ b/skills/lark-im/references/lark-im-chat-messages-list.md
@@ -4,6 +4,8 @@
 
 Fetch the message list for a conversation. Supports both group chats and direct messages.
 
+By default the response carries a `reactions` block (counts + details from `im.reactions.batch_query`) on every message that has reactions, and `update_time` on messages that were actually edited. Thread replies expanded via auto-`thread_replies` participate in the same batched enrichment. Pass `--no-reactions` to skip the extra round-trip. See [message enrichment](lark-im-message-enrichment.md) for the full contract.
+
 This skill maps to the shortcut: `lark-cli im +chat-messages-list` (internally calls `GET /open-apis/im/v1/messages`, and automatically resolves the p2p chat_id when needed).
 
 ## Commands

--- a/skills/lark-im/references/lark-im-message-enrichment.md
+++ b/skills/lark-im/references/lark-im-message-enrichment.md
@@ -1,0 +1,28 @@
+# im default message enrichment (reactions / update_time)
+
+> **Prerequisite:** Read [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) first to understand authentication, global parameters, and safety rules.
+
+This is the single source of truth for the automatic message-enrichment contract shared by the four message-pulling shortcuts — [`+messages-mget`](lark-im-messages-mget.md), [`+chat-messages-list`](lark-im-chat-messages-list.md), [`+messages-search`](lark-im-messages-search.md), [`+threads-messages-list`](lark-im-threads-messages-list.md). They automatically attach `reactions` and `update_time` to each returned message, so callers do **not** need to invoke the raw [`im.reactions.batch_query`](lark-im-reactions.md) API separately.
+
+- **`reactions`** — populated from one batched `im.reactions.batch_query` call as `{counts, details}`. The field is only attached when the server actually returns data; messages with no reactions omit it. Replies inside `thread_replies` are enriched in the **same batched call** as their parent, so outer and inner messages follow identical semantics.
+- **`update_time`** — emitted only when `updated == true` (message was actually edited). The server echoes `update_time == create_time` for unedited messages too, but the CLI gates that output away so consumers don't misread every message as "edited".
+- **Opt-out** — each shortcut accepts `--no-reactions` to skip the extra round-trip when the caller only needs message bodies.
+
+## Scope requirement
+
+The default enrichment requires `im:message.reactions:read`, already declared in each shortcut's `UserScopes` / `BotScopes` (or `Scopes` for the user-only search command), so the framework's pre-flight check surfaces a `missing_scope` error before the request is sent. Bots that were registered before this scope was added need an incremental authorization in the Feishu developer console; users can run:
+
+```bash
+lark-cli auth login --scope "im:message.reactions:read"
+```
+
+## Data contract — missing field ≠ fetch failure
+
+| Situation | Output |
+|---|---|
+| Message has no reactions | `reactions` field is omitted (not `{}`, not an empty list) |
+| Message was never edited | `update_time` field is omitted |
+| Whole batch failed | Messages in that batch carry no `reactions`; one line on stderr: `warning: reactions_batch_query_failed: ...` |
+| Some message IDs failed | Failed IDs go to stderr: `warning: reactions_partial_failed: N message(s) failed (...)` |
+
+When deciding "has the user already reacted?", branch on the **presence of the `reactions` field plus its `counts` contents**, not on whether a value is `null` — the field's absence means "no data attached" (which usually means "no reactions exist"), not "fetch failed".

--- a/skills/lark-im/references/lark-im-messages-mget.md
+++ b/skills/lark-im/references/lark-im-messages-mget.md
@@ -4,6 +4,8 @@
 
 Fetch message details in batch. Given a list of message IDs, this returns the full content for multiple messages in one call and automatically resolves sender names.
 
+By default the response also carries a `reactions` block (counts + details from `im.reactions.batch_query`) on every message that has reactions, and `update_time` on messages that were actually edited. Replies inside `thread_replies` participate in the same batched enrichment. Pass `--no-reactions` to skip the extra round-trip. See [message enrichment](lark-im-message-enrichment.md) for the full contract.
+
 > **Supports both `--as user` (default) and `--as bot`.**
 
 This skill maps to the shortcut: `lark-cli im +messages-mget` (internally calls `GET /open-apis/im/v1/messages/mget`).

--- a/skills/lark-im/references/lark-im-messages-search.md
+++ b/skills/lark-im/references/lark-im-messages-search.md
@@ -4,6 +4,8 @@
 
 Search Feishu messages across conversations. This shortcut automatically performs a multi-step workflow: search for message IDs, batch fetch message details, then enrich the results with chat context.
 
+By default each result message also carries a `reactions` block (counts + details from `im.reactions.batch_query`) when the server has reactions for it, and `update_time` for messages that were actually edited. With `--page-all`, every page is enriched; pass `--no-reactions` to skip the extra round-trip. See [message enrichment](lark-im-message-enrichment.md) for the full contract.
+
 > **User identity only** (`--as user`). Bot identity is not supported.
 
 This skill maps to the shortcut: `lark-cli im +messages-search` (internally calls `POST /open-apis/im/v1/messages/search` + batched `GET /open-apis/im/v1/messages/mget`, then batch-fetches chat context).

--- a/skills/lark-im/references/lark-im-reactions.md
+++ b/skills/lark-im/references/lark-im-reactions.md
@@ -2,6 +2,8 @@
 
 > **Prerequisite:** Read [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) first to understand authentication, global parameters, and safety rules.
 
+> **Heads-up — don't reach for `batch_query` by default.** The four message-pulling shortcuts (`+messages-mget`, `+chat-messages-list`, `+messages-search`, `+threads-messages-list`) already call `im.reactions.batch_query` automatically and attach the result as a `reactions` block on each message (replies inside `thread_replies` included). Use those shortcuts for any "read reactions of messages I'm already pulling" task. Reach for the raw `batch_query` API only when you have a standalone `message_id` outside that pull flow. See the main [message enrichment](lark-im-message-enrichment.md) for the contract.
+
 This reference is the shared annotation target for the IM reaction APIs:
 
 - `im.reactions.create`

--- a/skills/lark-im/references/lark-im-threads-messages-list.md
+++ b/skills/lark-im/references/lark-im-threads-messages-list.md
@@ -4,6 +4,8 @@
 
 Fetch the reply message list inside a thread. When `im +chat-messages-list` returns messages that include a `thread_id` field, use this command to inspect all replies in that thread.
 
+By default each reply also carries a `reactions` block (counts + details from `im.reactions.batch_query`) when the server has reactions for it, and `update_time` for messages that were actually edited. Pass `--no-reactions` to skip the extra round-trip. See [message enrichment](lark-im-message-enrichment.md) for the full contract.
+
 This skill maps to the shortcut: `lark-cli im +threads-messages-list` (internally calls `GET /open-apis/im/v1/messages` with `container_id_type=thread` to fetch thread messages).
 
 ## Commands


### PR DESCRIPTION
## Summary
- When fetching messages, automatically call `im.reactions.batch_query` to attach a reactions block (counts + details) back onto each message. Fixes the duplicate-reaction problem where the AI misjudges "user already reacted → still thinks no response was given".
- Edited messages now additionally output `update_time` (the Lark API already returns this field; the CLI just never surfaced it).
- The 4 message-fetching shortcuts (`+chat-messages-list` / `+messages-search` / `+messages-mget` / `+threads-messages-list`) gain a `--no-reactions` opt-out flag.
- The server-side `queries[]` limit is 20, so requests are automatically split into batches when exceeded; any batch failure only emits a stderr warning and does not block the main output.

## Output shape
```json
"reactions": {
  "counts":  [{"reaction_type": "SMILE", "count": 3}],
  "details": [{"reaction_id": "...", "emoji_type": "SMILE",
                "operator": {...}, "action_time": "..."}]
}
```
Only attached when the server returns data; the field is omitted for messages without reactions.

## Test plan
- [x] 5 new unit tests in `convert_lib/reactions_test.go` (success / batch=25→[20,5] / API failure / empty input / skip items missing message_id)
- [x] 2 new unit tests in `convert_lib/content_media_misc_test.go` (update_time present / absent)
- [x] `make unit-test` / `go vet ./...` / `gofmt -l .` / `go mod tidy` all clean
- [x] Live test `+chat-messages-list` default enrich: retrieved messages with 4 reaction types, complete counts + details
- [x] Live test `+chat-messages-list --no-reactions`: reactions field absent, update_time still output
- [x] Live test `+messages-search`: 3 hits / 2 with reactions
- [x] Live test `+messages-mget`: single message with 4 counts + 4 details, update_time `2026-05-11 14:51`

## Rate limiting notes
`im.reactions.batch_query` server-side currently **only has the OPL gateway layer fallback of 50/s + 1000/min**; the larkim/openapi business layer has not yet integrated multi-dimensional rate limiting.
- Single-CLI-user scale (each user has an independent app with independent quota) is currently safe.
- Large-scale CLI adoption or high-concurrency group scenarios require aligning with the Lark IM team on business-layer rate limiting first; this is out of scope for this PR and will be tracked separately in the larkim/openapi repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IM messages are enriched with reaction data via batched API queries (up to 20 messages per request).
  * Added a --no-reactions flag to disable automatic reaction enrichment in message list, multi-get, search, and thread list commands.
  * Commands now request reactions-read permission when enrichment is enabled.

* **Bug Fixes**
  * Message update_time is now included and formatted only when a message is marked as edited.

* **Tests**
  * Added unit tests for reaction enrichment, batching, failure cases, and update_time handling.

* **Documentation**
  * Docs updated to describe default enrichment, opt-out flag, and required permission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1095?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
