### PR TITLE
docs(task): require --complete=false for pending standup summaries

### DIFF
--- a/skills/lark-task/references/lark-task-get-my-tasks.md
+++ b/skills/lark-task/references/lark-task-get-my-tasks.md
@@ -13,17 +13,23 @@ If the user query only specifies a task name (e.g., "Complete task Lobster No. 1
 List tasks assigned to the current user, with support for filtering by completion status, creation time, and due date.
 By default, the command will automatically paginate up to 20 times. Use `--page-all` to fetch more (up to 40 pages).
 
+> **Pending vs all tasks:** When `--complete` is not provided, the result contains **both completed and incomplete tasks**.
+> For standup / daily-summary / pending-todo scenarios, you **must** pass `--complete=false`; otherwise completed tasks will be surfaced as if they were still pending.
+
 ## Recommended Commands
 
 ```bash
 # Search for a specific task by name
 lark-cli task +get-my-tasks --query "Lobster No. 1"
 
-# Get all my tasks (fetches up to 20 pages by default)
+# Get all my tasks, both completed and incomplete (fetches up to 20 pages by default)
 lark-cli task +get-my-tasks
 
-# Get my incomplete tasks (fetches up to 20 pages by default)
+# Pending-only: my incomplete tasks (use this for standup/daily-summary)
 lark-cli task +get-my-tasks --complete=false
+
+# Pending-only with a due-date upper bound (e.g. end of today / this week)
+lark-cli task +get-my-tasks --complete=false --due-end "2026-03-27T23:59:59+08:00"
 
 # Fetch all my tasks (up to 40 pages)
 lark-cli task +get-my-tasks --page-all

--- a/skills/lark-workflow-standup-report/SKILL.md
+++ b/skills/lark-workflow-standup-report/SKILL.md
@@ -30,8 +30,8 @@ lark-cli auth login --domain calendar,task
 ## 工作流
 
 ```
-{date} ─┬─► calendar +agenda [--start/--end] ──► 日程列表（会议/事件）
-        └─► task +get-my-tasks [--due-end]    ──► 未完成待办列表
+{date} ─┬─► calendar +agenda [--start/--end]              ──► 日程列表（会议/事件）
+        └─► task +get-my-tasks --complete=false [--due-end] ──► 未完成待办列表
                     │
                     ▼
               AI 汇总（时间转换 + 冲突检测 + 排序）──► 摘要
@@ -54,19 +54,21 @@ lark-cli calendar +agenda --start "2026-03-26T00:00:00+08:00" --end "2026-03-26T
 ### Step 2: 获取未完成待办
 
 ```bash
-# 默认：返回分配给当前用户的未完成任务（最多 20 条）
-lark-cli task +get-my-tasks
+# 默认 pending 摘要：必须显式过滤未完成任务（最多 20 条）
+lark-cli task +get-my-tasks --complete=false
 
-# 只看指定日期前到期的（推荐用于摘要场景，减少数据量）
-lark-cli task +get-my-tasks --due-end "2026-03-27T23:59:59+08:00"
+# 只看指定日期前到期的未完成任务（推荐用于摘要场景，减少数据量）
+lark-cli task +get-my-tasks --complete=false --due-end "2026-03-27T23:59:59+08:00"
 
-# 获取全部（超过 20 条时）
-lark-cli task +get-my-tasks --page-all
+# 获取全部未完成任务（超过 20 条时）
+lark-cli task +get-my-tasks --complete=false --page-all
 ```
 
-> **注意**：不带过滤条件时可能返回大量历史待办（实测 30+ 条、100KB+），容易超出上下文限制。摘要场景建议：
+> **注意**：`+get-my-tasks` 不带 `--complete` 时会**同时返回已完成和未完成任务**，会把已完成任务当成"待办"展示进摘要里。站会/日报这种 pending 汇总场景**必须**显式带上 `--complete=false`，不要省略。
+>
+> 数据量层面也建议加过滤：
 > - 用 `--due-end` 过滤出目标日期前到期的任务
-> - 如果也需要无截止日期的任务，可不加过滤，但 AI 汇总时只展示**近 30 天内创建的**，其余折叠为"其他 N 项历史待办"
+> - 如果也需要无截止日期的任务，可不加 `--due-end`，但 AI 汇总时只展示**近 30 天内创建的**，其余折叠为"其他 N 项历史待办"
 
 ### Step 3: AI 汇总
 


### PR DESCRIPTION
## Summary

Closes #993

The standup workflow and the `+get-my-tasks` reference both described a "pending todo summary" use case but did not pass `--complete=false` in the example commands. AI agents copying those examples ended up surfacing already-completed tasks into standup/daily summaries as if they were still pending. This PR updates the workflow and reference docs only — the underlying command behavior is unchanged.

## Changes
- `skills/lark-workflow-standup-report/SKILL.md`
  - Workflow diagram updated: `task +get-my-tasks [--due-end]` → `task +get-my-tasks --complete=false [--due-end]`.
  - Step 2 example commands all pass `--complete=false` explicitly.
  - Note clarifies that omitting `--complete` returns both completed and incomplete tasks, so pending-only summary scenarios MUST pass `--complete=false`.
- `skills/lark-task/references/lark-task-get-my-tasks.md`
  - New "Pending vs all tasks" callout near the top.
  - Recommended-commands section now distinguishes the all-tasks default from the pending-only flow and adds a pending-only example with `--due-end`.

## Test Plan
- [x] Docs-only change; no code paths affected.
- [x] Manual review of the rendered Markdown for the updated workflow and reference files.

## Related Issues
- Closes #993

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified task filtering behavior: explicit guidance on using `--complete=false` for pending task workflows
  * Added recommended command examples with new filtering (`--due-end`) and pagination (`--page-all`) options
  * Documented that task summaries display only tasks created within the last 30 days

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->