### PR TITLE
fix(drive): support doubao drive inspect URL variants

### DIFF
--- a/shortcuts/common/resource_url.go
+++ b/shortcuts/common/resource_url.go
@@ -73,6 +73,9 @@ var urlPathToType = []struct {
 	Type   string
 }{
 	{"/drive/folder/", "folder"},
+	{"/drive/file/", "file"},
+	{"/drive/shr/", "folder"},
+	{"/chat/drive/", "folder"},
 	{"/docx/", "docx"},
 	{"/doc/", "doc"},
 	{"/sheets/", "sheet"},

--- a/shortcuts/common/resource_url_test.go
+++ b/shortcuts/common/resource_url_test.go
@@ -28,6 +28,9 @@ func TestParseResourceURL(t *testing.T) {
 		{"wiki", "https://xxx.feishu.cn/wiki/wikcnABC", "wiki", "wikcnABC", true},
 		{"file", "https://xxx.feishu.cn/file/boxcnABC", "file", "boxcnABC", true},
 		{"folder", "https://xxx.feishu.cn/drive/folder/fldcnABC", "folder", "fldcnABC", true},
+		{"file via /drive/file/", "https://feishu.doubao.com/drive/file/boxcnABC", "file", "boxcnABC", true},
+		{"folder via /chat/drive/", "https://feishu.doubao.com/chat/drive/fldcnABC", "folder", "fldcnABC", true},
+		{"folder via /drive/shr/", "https://feishu.doubao.com/drive/shr/fldcnABC", "folder", "fldcnABC", true},
 		{"mindnote", "https://xxx.feishu.cn/mindnote/mncnABC", "mindnote", "mncnABC", true},
 		{"slides", "https://xxx.feishu.cn/slides/slkcnABC", "slides", "slkcnABC", true},
 

--- a/shortcuts/drive/drive_inspect_test.go
+++ b/shortcuts/drive/drive_inspect_test.go
@@ -109,6 +109,45 @@ func TestDriveInspectValidate_ValidWikiURL(t *testing.T) {
 	}
 }
 
+func TestDriveInspectValidate_ValidDoubaoDriveFileURL(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "https://feishu.doubao.com/drive/file/boxcnABC")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	err := DriveInspect.Validate(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestDriveInspectValidate_ValidDoubaoChatDriveFolderURL(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "https://feishu.doubao.com/chat/drive/fldcnABC")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	err := DriveInspect.Validate(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestDriveInspectValidate_ValidDoubaoDriveShareFolderURL(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "https://feishu.doubao.com/drive/shr/fldcnABC")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	err := DriveInspect.Validate(context.Background(), runtime)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
 // --- DryRun tests ---
 
 func TestDriveInspectDryRun_DocxURL(t *testing.T) {
@@ -232,6 +271,82 @@ func TestDriveInspectDryRun_BareTokenWithType(t *testing.T) {
 	}
 	if len(got.API) != 1 {
 		t.Fatalf("expected 1 API step, got %d", len(got.API))
+	}
+}
+
+func TestDriveInspectDryRun_DoubaoDriveFileURL(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "https://feishu.doubao.com/drive/file/boxcnABC")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	dry := DriveInspect.DryRun(context.Background(), runtime)
+	if dry == nil {
+		t.Fatal("DryRun returned nil")
+	}
+
+	data, err := json.Marshal(dry)
+	if err != nil {
+		t.Fatalf("marshal dry run: %v", err)
+	}
+
+	var got struct {
+		API []struct {
+			Body map[string]interface{} `json:"body"`
+		} `json:"api"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal dry run: %v", err)
+	}
+	reqDocs, ok := got.API[0].Body["request_docs"].([]interface{})
+	if !ok || len(reqDocs) != 1 {
+		t.Fatalf("expected request_docs with 1 entry, got %v", got.API[0].Body["request_docs"])
+	}
+	doc, _ := reqDocs[0].(map[string]interface{})
+	if doc["doc_token"] != "boxcnABC" {
+		t.Errorf("doc_token = %v, want boxcnABC", doc["doc_token"])
+	}
+	if doc["doc_type"] != "file" {
+		t.Errorf("doc_type = %v, want file", doc["doc_type"])
+	}
+}
+
+func TestDriveInspectDryRun_DoubaoDriveShareFolderURL(t *testing.T) {
+	cmd := &cobra.Command{Use: "drive +inspect"}
+	cmd.Flags().String("url", "", "")
+	cmd.Flags().String("type", "", "")
+	_ = cmd.Flags().Set("url", "https://feishu.doubao.com/drive/shr/fldcnABC")
+
+	runtime := common.TestNewRuntimeContext(cmd, &core.CliConfig{})
+	dry := DriveInspect.DryRun(context.Background(), runtime)
+	if dry == nil {
+		t.Fatal("DryRun returned nil")
+	}
+
+	data, err := json.Marshal(dry)
+	if err != nil {
+		t.Fatalf("marshal dry run: %v", err)
+	}
+
+	var got struct {
+		API []struct {
+			Body map[string]interface{} `json:"body"`
+		} `json:"api"`
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal dry run: %v", err)
+	}
+	reqDocs, ok := got.API[0].Body["request_docs"].([]interface{})
+	if !ok || len(reqDocs) != 1 {
+		t.Fatalf("expected request_docs with 1 entry, got %v", got.API[0].Body["request_docs"])
+	}
+	doc, _ := reqDocs[0].(map[string]interface{})
+	if doc["doc_token"] != "fldcnABC" {
+		t.Errorf("doc_token = %v, want fldcnABC", doc["doc_token"])
+	}
+	if doc["doc_type"] != "folder" {
+		t.Errorf("doc_type = %v, want folder", doc["doc_type"])
 	}
 }
 

--- a/tests/cli_e2e/drive/drive_inspect_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_inspect_dryrun_test.go
@@ -45,9 +45,27 @@ func TestDriveInspectDryRun_FileURL(t *testing.T) {
 	assertOneStepBatchQuery(t, result)
 }
 
+func TestDriveInspectDryRun_DoubaoDriveFileURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+	result := runInspectDryRun(t, "https://feishu.doubao.com/drive/file/boxcnDryRunE2E")
+	assertOneStepBatchQuery(t, result)
+}
+
 func TestDriveInspectDryRun_FolderURL(t *testing.T) {
 	setDriveInspectE2EEnv(t)
 	result := runInspectDryRun(t, "https://xxx.feishu.cn/drive/folder/fldcnDryRunE2E")
+	assertOneStepBatchQuery(t, result)
+}
+
+func TestDriveInspectDryRun_DoubaoChatDriveFolderURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+	result := runInspectDryRun(t, "https://feishu.doubao.com/chat/drive/fldcnDryRunE2E")
+	assertOneStepBatchQuery(t, result)
+}
+
+func TestDriveInspectDryRun_DoubaoDriveShareFolderURL(t *testing.T) {
+	setDriveInspectE2EEnv(t)
+	result := runInspectDryRun(t, "https://feishu.doubao.com/drive/shr/fldcnDryRunE2E")
 	assertOneStepBatchQuery(t, result)
 }
 


### PR DESCRIPTION
## Problem

`lark-cli drive +inspect` currently rejects some valid Doubao Drive URLs during local validation, even though the underlying resource token is valid and the command succeeds when called with a bare token plus `--type`.

This is a URL parsing gap, not a Drive API gap.

- Doubao file URLs use `/drive/file/{token}`
- Doubao folder URLs use `/chat/drive/{token}` and `/drive/shr/{token}`

Today `ParseResourceURL` recognizes:

- `/file/{token}` for files
- `/drive/folder/{token}` for folders

but does not recognize the Doubao path variants above, so `drive +inspect --url ...` fails early with `unsupported --url`.

## Changes

Add the missing URL aliases to `ParseResourceURL`:

- `/drive/file/` -> `file`
- `/chat/drive/` -> `folder`
- `/drive/shr/` -> `folder`

Canonical URL generation stays unchanged:

- files still resolve to `.../file/{token}`
- folders still resolve to `.../drive/folder/{token}`

## Why this is correct

This matches verified product behavior:

- file token `Gj7hbt9viouYCTxoqYRctqebnWb`
  - `https://feishu.doubao.com/drive/file/Gj7hbt9viouYCTxoqYRctqebnWb` should be accepted
- folder token `Gh4oflX5PlxnSjd0FFvcTmcan1X`
  - `https://feishu.doubao.com/chat/drive/Gh4oflX5PlxnSjd0FFvcTmcan1X` should be accepted
  - `https://feishu.doubao.com/drive/shr/Gh4oflX5PlxnSjd0FFvcTmcan1X` should be accepted

The same tokens already work when passed as bare tokens with `--type`, so this fix closes the URL parser gap without changing downstream API behavior.

## Test Plan

- [x] `go test ./shortcuts/common ./shortcuts/drive`
- [x] `go build -o lark-cli .`
- [x] `LARK_CLI_BIN=/Users/bytedance/Documents/Codex/2026-05-25/larksuite-cli-1082-https-github-com/lark-cli go test ./tests/cli_e2e/drive -run DriveInspect`

Added coverage for:

- `ParseResourceURL` accepting Doubao file and folder path variants
- `drive +inspect` validation accepting those URLs
- `drive +inspect --dry-run` producing the expected Drive metadata lookup flow for those URLs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recognizes additional Doubao drive URL patterns for file links, chat drive folder links, and share folder links.

* **Tests**
  * Added unit and end-to-end tests to validate parsing, validation, and dry-run behavior for the new Doubao URL patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->