### PR TITLE
chore(release): v1.0.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.41] - 2026-05-26
+
+### Features
+
+- **minutes**: Add minutes edit shortcuts (#1036)
+- **minutes**: Get minutes keywords (#1079)
+- **slides**: Support importing pptx as slides (#1068)
+- **config**: Add `keychain-downgrade` subcommand (macOS) (#1085)
+- **errors**: Add structured CLI error contract (#984)
+- **apps**: Replace `+html-publish` cwd hard-reject with credential-file scan (#1072)
+
+### Bug Fixes
+
+- **drive**: Support doubao drive inspect URL variants (#1106)
+- **skills**: Sync skills incrementally during update (#1042)
+- **apps**: Read app object from `data.app` for `+create` and `+update` (#1087)
+- **common**: Escape special chars in multipart form filenames (#1037)
+- **auth**: Remove fenced code block guidance from auth URL output hints (#1088)
+
+### Documentation
+
+- **skills**: Fix agent routing for doubao.com URLs (#1082)
+- **task**: Require `--complete=false` for pending standup summaries (#1101)
+- **base**: Document UI-only field settings (#1078)
+- **contributing**: Clarify contributor guidance (#1096)
+
 ## [v1.0.40] - 2026-05-25
 
 ### Features
@@ -860,6 +886,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.41]: https://github.com/larksuite/cli/releases/tag/v1.0.41
 [v1.0.40]: https://github.com/larksuite/cli/releases/tag/v1.0.40
 [v1.0.39]: https://github.com/larksuite/cli/releases/tag/v1.0.39
 [v1.0.38]: https://github.com/larksuite/cli/releases/tag/v1.0.38

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

Release v1.0.41 — bundles 15 PRs merged after v1.0.40.

### Features
- minutes: edit shortcuts (#1036) + get keywords (#1079)
- slides: import pptx (#1068)
- config: `keychain-downgrade` subcommand on macOS (#1085)
- errors: structured CLI error contract (#984)
- apps: `+html-publish` cwd check replaced by credential-file scan (#1072)

### Bug Fixes
- drive: doubao inspect URL variants (#1106)
- skills: incremental sync during update (#1042)
- apps: read app object from `data.app` for `+create`/`+update` (#1087)
- common: escape special chars in multipart form filenames (#1037)
- auth: drop fenced code block guidance from auth URL hints (#1088)

### Documentation
- skills routing for doubao.com URLs (#1082)
- task standup `--complete=false` guidance (#1101)
- base UI-only field settings (#1078)
- contributor guidance (#1096)

## Test plan
- [ ] CI green
- [ ] `npm install -g @larksuite/cli@1.0.41` resolves correctly after publish
- [ ] Spot-check `lark-cli --version` reports `1.0.41`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v1.0.41

* **New Features**
  * Added minutes editing and keyboard shortcuts support
  * Introduced PowerPoint (.pptx) import functionality for slides

* **Bug Fixes**
  * Improved macOS keychain handling
  * Enhanced CLI error messaging and handling
  * Multiple stability improvements

* **Documentation**
  * Updated documentation with latest changes and improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->