### PR TITLE
test(drive): drop redundant CONFIG_DIR isolation in inspect Execute tests

### DIFF
--- a/shortcuts/drive/drive_inspect_test.go
+++ b/shortcuts/drive/drive_inspect_test.go
@@ -353,7 +353,6 @@ func TestDriveInspectDryRun_DoubaoDriveShareFolderURL(t *testing.T) {
 // --- Execute tests ---
 
 func TestDriveInspectExecute_DocxURL(t *testing.T) {
-	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	cfg := driveTestConfig()
 	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
 
@@ -395,7 +394,6 @@ func TestDriveInspectExecute_DocxURL(t *testing.T) {
 }
 
 func TestDriveInspectExecute_WikiURL(t *testing.T) {
-	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	cfg := driveTestConfig()
 	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
 
@@ -458,7 +456,6 @@ func TestDriveInspectExecute_WikiURL(t *testing.T) {
 }
 
 func TestDriveInspectExecute_WikiGetNodeIncompleteData(t *testing.T) {
-	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	cfg := driveTestConfig()
 	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
 
@@ -487,7 +484,6 @@ func TestDriveInspectExecute_WikiGetNodeIncompleteData(t *testing.T) {
 }
 
 func TestDriveInspectExecute_BareTokenWithType(t *testing.T) {
-	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	cfg := driveTestConfig()
 	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
 
@@ -524,7 +520,6 @@ func TestDriveInspectExecute_BareTokenWithType(t *testing.T) {
 }
 
 func TestDriveInspectExecute_BatchQueryError(t *testing.T) {
-	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	cfg := driveTestConfig()
 	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
 
@@ -548,7 +543,6 @@ func TestDriveInspectExecute_BatchQueryError(t *testing.T) {
 }
 
 func TestDriveInspectExecute_PrettyFormat(t *testing.T) {
-	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	cfg := driveTestConfig()
 	f, stdout, _, reg := cmdutil.TestFactory(t, cfg)
 


### PR DESCRIPTION
## Summary
`drive_inspect_test.go` 的六个 `TestDriveInspectExecute_*` 测试都调用了 `t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())`，但它们通过 `cmdutil.TestFactory(t, cfg)` 构建 CLI。`TestFactory` 提供的是内存 config 闭包（`Config: func() (*core.CliConfig, error) { return config, nil }`），不读文件系统，所以这个环境变量对这些测试毫无作用。

## Changes
- 删除 `drive_inspect_test.go` 中 6 处冗余的 `t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())`

## 依据
仓库已有 learning（来自 #343）：

> Only set `LARKSUITE_CLI_CONFIG_DIR` when the test exercises the real `NewDefault()` factory path that reads from the filesystem. Shortcut tests that build the CLI via `cmdutil.TestFactory(t, config)` should not set this env var because `TestFactory` provides an in-memory config closure and does not access the filesystem.

已确认这 6 个测试全部使用 `cmdutil.TestFactory`、`grep -c NewDefault` 为 0，因此这些调用是 dead code。

（这是在 #1114 的 review 讨论中发现的既有不一致，单独拆成一个 PR。）

## Test Plan
- [x] `go test -race -count=1 ./shortcuts/drive/ -run TestDriveInspect` 通过
- [x] `gofmt -l` 无输出
- [x] `go vet ./shortcuts/drive/` 通过
- [x] 无行为变更（纯删除无效的环境变量设置）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test environment setup across multiple test cases.

---

**Note:** This release contains internal testing optimizations with no user-visible changes or new functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->