### PR TITLE
fix(install): detect curl version before using --ssl-revoke-best-effort

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -110,6 +110,31 @@ function getMirrorUrls(env) {
   return urls;
 }
 
+/**
+ * Detect whether the system curl supports --ssl-revoke-best-effort.
+ * This flag was introduced in curl 7.70.0 (2020-04-29). Older versions
+ * (notably the curl 7.55.1 shipped with older Windows 10 builds) will
+ * exit with "unknown option" if it is passed.
+ *
+ * @returns {boolean} true when curl >= 7.70.0 is available
+ */
+function curlSupportsSslRevokeBestEffort() {
+  try {
+    const output = execFileSync("curl", ["--version"], {
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+      timeout: 5000,
+    });
+    const match = output.match(/curl\s+(\d+)\.(\d+)\.(\d+)/i);
+    if (!match) return false;
+    const major = parseInt(match[1], 10);
+    const minor = parseInt(match[2], 10);
+    return major > 7 || (major === 7 && minor >= 70);
+  } catch (_) {
+    return false;
+  }
+}
+
 function download(url, destPath) {
   assertAllowedHost(url);
   const args = [
@@ -119,8 +144,11 @@ function download(url, destPath) {
     "--output", destPath,
   ];
   // --ssl-revoke-best-effort: on Windows (Schannel), avoid CRYPT_E_REVOCATION_OFFLINE
-  // errors when the certificate revocation list server is unreachable
-  if (isWindows) args.unshift("--ssl-revoke-best-effort");
+  // errors when the certificate revocation list server is unreachable.
+  // Only use it when the system curl is new enough (>= 7.70.0).
+  if (isWindows && curlSupportsSslRevokeBestEffort()) {
+    args.unshift("--ssl-revoke-best-effort");
+  }
   args.push(url);
   execFileSync("curl", args, { stdio: ["ignore", "ignore", "pipe"] });
 }
@@ -294,4 +322,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { getExpectedChecksum, verifyChecksum, assertAllowedHost, resolveMirrorUrls };
+module.exports = { getExpectedChecksum, verifyChecksum, assertAllowedHost, resolveMirrorUrls, curlSupportsSslRevokeBestEffort };

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -111,28 +111,49 @@ function getMirrorUrls(env) {
 }
 
 /**
- * Detect whether the system curl supports --ssl-revoke-best-effort.
- * This flag was introduced in curl 7.70.0 (2020-04-29). Older versions
- * (notably the curl 7.55.1 shipped with older Windows 10 builds) will
- * exit with "unknown option" if it is passed.
+ * Decide from a `curl --version` output whether curl is >= 7.70.0 — the
+ * release (2020-04-29) that introduced --ssl-revoke-best-effort. Kept pure
+ * (no I/O) so the version-comparison logic can be unit tested without
+ * spawning a process. Reads the leading "curl X.Y.Z" token, ignoring the
+ * trailing "libcurl/X.Y.Z" that may report a different version.
+ *
+ * @param {string} versionOutput raw stdout of `curl --version`
+ * @returns {boolean} true when the parsed version is >= 7.70.0
+ */
+function isCurlVersionSupported(versionOutput) {
+  const match = String(versionOutput).match(/^\s*curl\s+(\d+)\.(\d+)\.(\d+)/i);
+  if (!match) return false;
+  const major = parseInt(match[1], 10);
+  const minor = parseInt(match[2], 10);
+  return major > 7 || (major === 7 && minor >= 70);
+}
+
+// Memoized probe result. curl's version is invariant for the lifetime of the
+// install, while download() runs once per mirror URL — so probe at most once.
+let _curlSupportsSslRevokeBestEffort;
+
+/**
+ * Detect whether the system curl supports --ssl-revoke-best-effort. Older
+ * versions (notably the curl 7.55.1 shipped with older Windows 10 builds)
+ * exit with "unknown option" if the flag is passed.
  *
  * @returns {boolean} true when curl >= 7.70.0 is available
  */
 function curlSupportsSslRevokeBestEffort() {
+  if (_curlSupportsSslRevokeBestEffort !== undefined) {
+    return _curlSupportsSslRevokeBestEffort;
+  }
   try {
     const output = execFileSync("curl", ["--version"], {
       stdio: ["ignore", "pipe", "ignore"],
       encoding: "utf8",
       timeout: 5000,
     });
-    const match = output.match(/curl\s+(\d+)\.(\d+)\.(\d+)/i);
-    if (!match) return false;
-    const major = parseInt(match[1], 10);
-    const minor = parseInt(match[2], 10);
-    return major > 7 || (major === 7 && minor >= 70);
+    _curlSupportsSslRevokeBestEffort = isCurlVersionSupported(output);
   } catch (_) {
-    return false;
+    _curlSupportsSslRevokeBestEffort = false;
   }
+  return _curlSupportsSslRevokeBestEffort;
 }
 
 function download(url, destPath) {
@@ -322,4 +343,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { getExpectedChecksum, verifyChecksum, assertAllowedHost, resolveMirrorUrls, curlSupportsSslRevokeBestEffort };
+module.exports = { getExpectedChecksum, verifyChecksum, assertAllowedHost, resolveMirrorUrls, curlSupportsSslRevokeBestEffort, isCurlVersionSupported };

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -9,7 +9,7 @@ const os = require("os");
 
 const crypto = require("crypto");
 
-const { getExpectedChecksum, verifyChecksum, assertAllowedHost, resolveMirrorUrls } = require("./install.js");
+const { getExpectedChecksum, verifyChecksum, assertAllowedHost, resolveMirrorUrls, isCurlVersionSupported } = require("./install.js");
 
 describe("getExpectedChecksum", () => {
   function makeTmpChecksums(content) {
@@ -276,5 +276,57 @@ describe("resolveMirrorUrls", () => {
       ),
       [DEFAULT]
     );
+  });
+});
+
+describe("isCurlVersionSupported", () => {
+  // --ssl-revoke-best-effort was introduced in curl 7.70.0; below that the
+  // flag is unknown and `curl` exits non-zero (see issue #1099).
+  it("returns false for curl 7.55.1 (older Windows 10, flag unknown)", () => {
+    assert.equal(
+      isCurlVersionSupported("curl 7.55.1 (x86_64-pc-win32) libcurl/7.55.1"),
+      false
+    );
+  });
+
+  it("returns false for curl 7.69.0 (just below the 7.70.0 threshold)", () => {
+    assert.equal(
+      isCurlVersionSupported("curl 7.69.0 (x86_64-pc-win32) libcurl/7.69.0"),
+      false
+    );
+  });
+
+  it("returns true for curl 7.70.0 (flag introduced here)", () => {
+    assert.equal(
+      isCurlVersionSupported("curl 7.70.0 (x86_64-pc-win32) libcurl/7.70.0"),
+      true
+    );
+  });
+
+  it("returns true for a future major (curl 8.x)", () => {
+    assert.equal(
+      isCurlVersionSupported("curl 8.5.0 (x86_64-apple-darwin) libcurl/8.5.0"),
+      true
+    );
+  });
+
+  it("returns false when no version can be parsed", () => {
+    assert.equal(isCurlVersionSupported("not a curl version string"), false);
+    assert.equal(isCurlVersionSupported(""), false);
+  });
+
+  it("reads the leading 'curl X.Y.Z', not the trailing libcurl/X.Y.Z", () => {
+    // Guards the regex against latching onto "libcurl/7.55.1" when the
+    // curl binary itself is new enough.
+    assert.equal(
+      isCurlVersionSupported("curl 8.0.0 (x86_64) libcurl/7.55.1"),
+      true
+    );
+  });
+
+  it("does not match a 'libcurl X.Y.Z' token (anchored to leading curl)", () => {
+    // "libcurl 8.0.0" contains the substring "curl 8.0.0"; the leading
+    // anchor keeps it from being mistaken for a real curl version line.
+    assert.equal(isCurlVersionSupported("libcurl 8.0.0"), false);
   });
 });


### PR DESCRIPTION
## Problem

On older Windows systems (e.g. Windows 10 build 19044 with curl 7.55.1), `npm install` fails during `postinstall` because `scripts/install.js` unconditionally adds `--ssl-revoke-best-effort` on Windows. That flag was only introduced in **curl 7.70.0** (2020-04-29), so older curl exits with:

```
curl: option --ssl-revoke-best-effort: is unknown
```

Fixes #1099.

## Solution

Gate the flag behind a runtime curl-version probe: only pass `--ssl-revoke-best-effort` when `isWindows && curl >= 7.70.0`. Older curl falls back to standard SSL revocation checks and installs successfully; modern Windows curl behaves exactly as before (still avoids `CRYPT_E_REVOCATION_OFFLINE`).

## Credit

The original fix is by @Ellien-Tang in #1116 — cherry-picked here with authorship preserved (first commit). This PR supersedes #1116 and adds maintainer follow-ups on top (second commit).

## Follow-ups added on top

- **Testability refactor** — extracted the version comparison into a pure `isCurlVersionSupported(output)` (no I/O), so the `>= 7.70.0` logic is unit-testable without spawning a process.
- **Real tests** — `scripts/install.test.js` now covers `7.55.1` / `7.69.0` / `7.70.0` / `8.x`, the unparseable case, and a regression guard ensuring the regex reads the leading `curl X.Y.Z` rather than the trailing `libcurl/X.Y.Z`.
- **Memoized probe** — `download()` runs once per mirror URL; the `curl --version` result is now cached so curl is probed at most once per install instead of on every attempt.

## Test

```
$ node --test scripts/install.test.js
# tests 31   # pass 31   # fail 0
```

| curl version | `--ssl-revoke-best-effort` |
|---|---|
| 7.55.1 (old Windows 10) | not used |
| 7.69.0 (just below threshold) | not used |
| 7.70.0 (minimum supported) | used |
| 8.x+ | used |

## Backward compatibility

- **curl >= 7.70.0**: unchanged.
- **curl < 7.70.0**: install now succeeds (previously failed outright).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows installer compatibility by detecting curl capability once and only supplying the newer curl flag when supported, preventing errors on older curl releases.

* **Tests**
  * Added comprehensive tests covering multiple curl version strings and edge cases to ensure reliable detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->