### PR TITLE
feat: use description and command in affordance example schema

### DIFF
--- a/internal/schema/assembler_test.go
+++ b/internal/schema/assembler_test.go
@@ -575,7 +575,7 @@ func TestParseAffordance_FullPopulated(t *testing.T) {
 		"do_not_use_when": []interface{}{"已知具体某一个非主日历的 calendar_id"},
 		"prerequisites":   []interface{}{"user 身份登录"},
 		"examples": []interface{}{
-			map[string]interface{}{"title": "获取主日历", "input": map[string]interface{}{}},
+			map[string]interface{}{"description": "获取主日历", "command": "lark-cli calendar calendars primary"},
 		},
 		"related": []interface{}{"calendars.list"},
 	}
@@ -586,7 +586,8 @@ func TestParseAffordance_FullPopulated(t *testing.T) {
 	if len(a.UseWhen) != 1 || a.UseWhen[0] != "需要拿到当前用户的主日历 ID" {
 		t.Errorf("UseWhen = %v", a.UseWhen)
 	}
-	if len(a.Examples) != 1 || a.Examples[0].Title != "获取主日历" {
+	if len(a.Examples) != 1 || a.Examples[0].Description != "获取主日历" ||
+		a.Examples[0].Command != "lark-cli calendar calendars primary" {
 		t.Errorf("Examples = %+v", a.Examples)
 	}
 	if len(a.Related) != 1 || a.Related[0] != "calendars.list" {

--- a/internal/schema/types.go
+++ b/internal/schema/types.go
@@ -76,10 +76,11 @@ type Affordance struct {
 	Related       []string         `json:"related,omitempty"`
 }
 
-// AffordanceCase is one example entry.
+// AffordanceCase is one example entry: a one-line description plus a
+// ready-to-run lark-cli command string.
 type AffordanceCase struct {
-	Title string                 `json:"title"`
-	Input map[string]interface{} `json:"input"`
+	Description string `json:"description"`
+	Command     string `json:"command"`
 }
 
 // OrderedProps is map[string]Property with preserved key order on MarshalJSON.


### PR DESCRIPTION
## Summary

Affordance examples are the AI-facing usage snippets in an envelope's `_meta`. They previously used `title` plus a structured `input` object mirroring the inputSchema. This reshapes each example to `description` plus a `command` string holding a ready-to-run lark-cli invocation — what an agent driving the CLI actually consumes. The affordance type was only just introduced and has no data authored in the registry yet, so this is a pre-population contract change with no migration. (The internal authoring guide was updated in lockstep.)

## Changes

- Rename `AffordanceCase.Title` to `Description` (`json:"title"` -> `json:"description"`) and change `AffordanceCase.Input map[string]interface{}` (`json:"input"`) to `Command string` (`json:"command"`) in `internal/schema/types.go`
- Update the affordance fixture and assertions in `internal/schema/assembler_test.go` to the new keys, and add an assertion on the `Command` value

## Test Plan

- [x] `go test -race ./internal/schema/...` passed (affected package)
- [x] `go build ./...` passed; `gofmt -l` and `go vet ./internal/schema/...` clean
- [ ] `make unit-test` (full suite): hit an unrelated flaky crash in `extension/transport` under parallel `-race`; that package has zero dependency on `internal/schema` (`go list -deps`) and passes in isolation across repeated runs
- [x] manual end-to-end: authored an affordance on `calendar.calendars.primary` in registry-config.yaml, ran `gen-registry.py calendar`, copied the generated `meta_data.json`, and confirmed `lark-cli schema calendar calendars primary` renders `_meta.affordance.examples[0] = {description, command}`; `lark-cli calendar calendars primary --dry-run` confirmed the example command resolves to `POST /open-apis/calendar/v4/calendars/primary`
- [ ] local-eval / acceptance-reviewer / skill-eval: N/A — schema-type reshape with no new command, flag, or skill behavior

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured affordance examples to improve how actions are represented. Example metadata now emphasizes description and command information instead of title and input fields, enhancing clarity of available actions and workflows within the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->