### PR TITLE
fix(apps): update miaoda scopes after platform consolidation

### DIFF
--- a/shortcuts/apps/apps_access_scope_get.go
+++ b/shortcuts/apps/apps_access_scope_get.go
@@ -21,7 +21,7 @@ var AppsAccessScopeGet = common.Shortcut{
 	Command:     "+access-scope-get",
 	Description: "Get Miaoda app access scope configuration",
 	Risk:        "read",
-	Scopes:      []string{"spark:app.access_scope:read"},
+	Scopes:      []string{"spark:app:read"},
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{

--- a/shortcuts/apps/apps_access_scope_set.go
+++ b/shortcuts/apps/apps_access_scope_set.go
@@ -27,7 +27,7 @@ var AppsAccessScopeSet = common.Shortcut{
 	Command:     "+access-scope-set",
 	Description: "Set Miaoda app access scope (specific / public / tenant)",
 	Risk:        "write",
-	Scopes:      []string{"spark:app.access_scope:write"},
+	Scopes:      []string{"spark:app:write"},
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{

--- a/shortcuts/apps/apps_html_publish.go
+++ b/shortcuts/apps/apps_html_publish.go
@@ -21,7 +21,7 @@ var AppsHTMLPublish = common.Shortcut{
 	Command:     "+html-publish",
 	Description: "Publish HTML to a Miaoda app (single multipart POST returns the access URL)",
 	Risk:        "write",
-	Scopes:      []string{"spark:app:publish"},
+	Scopes:      []string{"spark:app:write"},
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{


### PR DESCRIPTION
## What

妙搭/spark consolidated the `lark-apps` domain onto two scopes — `spark:app:read` and `spark:app:write`. The standalone `spark:app:publish` and `spark:app.access_scope:read/write` scopes are retired. This PR syncs the `Scopes` field of the three affected shortcuts to the new values.

| Shortcut | API | Old scope | New scope |
|---|---|---|---|
| `+html-publish` | `upload_and_release_html_code` | `spark:app:publish` | `spark:app:write` |
| `+access-scope-get` | `get_app_visibility` | `spark:app.access_scope:read` | `spark:app:read` |
| `+access-scope-set` | `update_app_visibility` | `spark:app.access_scope:write` | `spark:app:write` |

`+create` / `+update` / `+list` were already `spark:app:write` / `spark:app:read`, so no change.

## Verification

Checked the permission requirements against the official docs, one by one:
- [upload_html_code_and_release](https://open.larkoffice.com/document/uAjLw4CM/ukTMukTMukTM/spark-v1/app/upload_html_code_and_release) → `spark:app:write`
- [get_app_visibility](https://open.larkoffice.com/document/uAjLw4CM/ukTMukTMukTM/spark-v1/app/get_app_visibility) → `spark:app:read`
- [update_app_visibility](https://open.larkoffice.com/document/uAjLw4CM/ukTMukTMukTM/spark-v1/app/update_app_visibility) → `spark:app:write`

`go build ./shortcuts/apps/...` passes; no tests reference the old scope strings.

## Notes

`internal/registry/scope_priorities.json` still carries the three retired scope entries (`spark:app:publish`, `spark:app.access_scope:*`). They are no longer referenced by any shortcut, and the new scopes already exist in that table, so there is no functional impact. That file is synced from the scope platform, so this PR does not hand-edit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated required permission scopes for three app-related shortcuts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->