### PR TITLE
refactor(auth): drop duplicate top-level user fields in status

### DIFF
--- a/cmd/auth/status.go
+++ b/cmd/auth/status.go
@@ -61,7 +61,6 @@ func authStatusRun(opts *StatusOptions) error {
 	diagnostics := identitydiag.Diagnose(context.Background(), f, config, opts.Verify)
 	result["identities"] = diagnostics
 	result["identity"] = effectiveIdentity(diagnostics)
-	addLegacyUserFields(result, diagnostics.User)
 	addEffectiveVerification(result, diagnostics)
 	addStatusNote(result, diagnostics)
 
@@ -83,29 +82,6 @@ func effectiveIdentity(d identitydiag.Result) string {
 		return identityBot
 	default:
 		return identityNone
-	}
-}
-
-func addLegacyUserFields(result map[string]interface{}, user identitydiag.Identity) {
-	if user.OpenID == "" {
-		return
-	}
-	result["userName"] = user.UserName
-	result["userOpenId"] = user.OpenID
-	if user.TokenStatus != "" {
-		result["tokenStatus"] = user.TokenStatus
-	}
-	if user.Scope != "" {
-		result["scope"] = user.Scope
-	}
-	if user.ExpiresAt != "" {
-		result["expiresAt"] = user.ExpiresAt
-	}
-	if user.RefreshExpiresAt != "" {
-		result["refreshExpiresAt"] = user.RefreshExpiresAt
-	}
-	if user.GrantedAt != "" {
-		result["grantedAt"] = user.GrantedAt
 	}
 }
 

--- a/skills/lark-task/references/lark-task-create.md
+++ b/skills/lark-task/references/lark-task-create.md
@@ -44,7 +44,7 @@ lark-cli task +create --summary "Test Task" --dry-run
 ## Workflow
 
 1. Confirm with the user: task summary, due date, assignee, and tasklist if necessary.
-   - **Crucial Rule for Assignee**: If the user explicitly or implicitly says "create a task for me" (给我创建一个任务), or "help me create a task" (帮我新建/创建一个任务), you MUST assign the task to the current logged-in user. You can get the current user's `open_id` by executing `lark-cli auth status` (it already outputs JSON by default, so do not add `--json`) or `lark-cli contact +get-user` first, extracting the `userOpenId` or `open_id`, and then passing it to the `--assignee` parameter.
+   - **Crucial Rule for Assignee**: If the user explicitly or implicitly says "create a task for me" (给我创建一个任务), or "help me create a task" (帮我新建/创建一个任务), you MUST assign the task to the current logged-in user. You can get the current user's `open_id` by executing `lark-cli auth status` (it already outputs JSON by default, so do not add `--json`) or `lark-cli contact +get-user` first, extracting `.identities.user.openId` (from `auth status`) or `open_id` (from `contact +get-user`), and then passing it to the `--assignee` parameter.
 2. Execute `lark-cli task +create --summary "..." ...`
 3. Report the result: task ID and summary.
 

--- a/skills/lark-task/references/lark-task-create.md
+++ b/skills/lark-task/references/lark-task-create.md
@@ -44,7 +44,7 @@ lark-cli task +create --summary "Test Task" --dry-run
 ## Workflow
 
 1. Confirm with the user: task summary, due date, assignee, and tasklist if necessary.
-   - **Crucial Rule for Assignee**: If the user explicitly or implicitly says "create a task for me" (给我创建一个任务), or "help me create a task" (帮我新建/创建一个任务), you MUST assign the task to the current logged-in user. You can get the current user's `open_id` by executing `lark-cli auth status` (it already outputs JSON by default, so do not add `--json`) or `lark-cli contact +get-user` first, extracting `.identities.user.openId` (from `auth status`) or `open_id` (from `contact +get-user`), and then passing it to the `--assignee` parameter.
+   - **Crucial Rule for Assignee**: If the user explicitly or implicitly says "create a task for me" (给我创建一个任务), or "help me create a task" (帮我新建/创建一个任务), you MUST assign the task to the current logged-in user. You can get the current user's `open_id` by executing `lark-cli auth status` (it already outputs JSON by default, so do not add `--json`) or `lark-cli contact +get-user` first, extracting `.identities.user.openId` (from `auth status`) or `.data.user.open_id` (from `contact +get-user`), and then passing it to the `--assignee` parameter.
 2. Execute `lark-cli task +create --summary "..." ...`
 3. Report the result: task ID and summary.
 


### PR DESCRIPTION
## Summary

`lark-cli auth status` previously emitted seven user-identity fields
(`userName`, `userOpenId`, `tokenStatus`, `scope`, `expiresAt`,
`refreshExpiresAt`, `grantedAt`) at both the top level and under
`identities.user.*`. This PR removes the top-level duplicates so all
user-identity data lives under `identities.user.*` only.

## Changes

- Remove `addLegacyUserFields` from `cmd/auth/status.go` (24 lines)
- Update `skills/lark-task/references/lark-task-create.md` to extract
  `open_id` from the canonical paths:
  - `.identities.user.openId` (from `auth status`)
  - `.data.user.open_id` (from `contact +get-user`)

## Breaking Change

The seven top-level fields above are no longer emitted by
`lark-cli auth status`. Consumers must read from `identities.user.*`
instead — the same data has always been available there, so the
migration is mechanical.

## Test Plan

- [x] `go test ./cmd/auth/... -count=1` passes
- [x] Manual verification: `lark-cli auth status` output contains
  no top-level user fields; all user data is under `identities.user.*`
- [x] End-to-end: both
  `lark-cli auth status | jq -r '.identities.user.openId'` and
  `lark-cli contact +get-user | jq -r '.data.user.open_id'`
  produce the same `open_id`, which flows through
  `task +create --assignee <id> --dry-run` correctly

## Related Issues

(none)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The `auth status` command's JSON output format has been updated to include verification status and notes.
* **Documentation**
  * Updated instructions for extracting the current user's open_id when assigning tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->