### PR TITLE
fix(docs): reject legacy create flags in v2

### DIFF
--- a/shortcuts/doc/docs_create_test.go
+++ b/shortcuts/doc/docs_create_test.go
@@ -249,6 +249,84 @@ func TestDocsCreateV2PreservesBackendURL(t *testing.T) {
 	}
 }
 
+func TestDocsCreateV2RejectsV1OnlyFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "markdown",
+			args: []string{
+				"+create",
+				"--api-version", "v2",
+				"--markdown", "## legacy",
+			},
+			wantErr: "use --content with --doc-format markdown",
+		},
+		{
+			name: "wiki node",
+			args: []string{
+				"+create",
+				"--api-version", "v2",
+				"--content", "<title>内容</title><p>正文</p>",
+				"--wiki-node", "wikcn_legacy_node",
+			},
+			wantErr: "use --parent-token",
+		},
+		{
+			name: "title",
+			args: []string{
+				"+create",
+				"--api-version", "v2",
+				"--content", "<p>正文</p>",
+				"--title", "Legacy title",
+			},
+			wantErr: "include the document title in --content",
+		},
+		{
+			name: "folder token",
+			args: []string{
+				"+create",
+				"--api-version", "v2",
+				"--content", "<title>内容</title><p>正文</p>",
+				"--folder-token", "fldcn_legacy_folder",
+			},
+			wantErr: "use --parent-token",
+		},
+		{
+			name: "wiki space",
+			args: []string{
+				"+create",
+				"--api-version", "v2",
+				"--content", "<title>内容</title><p>正文</p>",
+				"--wiki-space", "my_library",
+			},
+			wantErr: "use --parent-position or --parent-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			f, stdout, _, _ := cmdutil.TestFactory(t, docsCreateTestConfig(t, ""))
+			err := runDocsCreateShortcut(t, f, stdout, tt.args)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want to contain %q", err, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), "--api-version v2") {
+				t.Fatalf("error = %v, want v2 guidance", err)
+			}
+		})
+	}
+}
+
 // ── V1 (MCP) tests ──
 
 func TestDocsCreateV1BotAutoGrantSuccess(t *testing.T) {

--- a/shortcuts/doc/docs_create_v2.go
+++ b/shortcuts/doc/docs_create_v2.go
@@ -21,11 +21,33 @@ func v2CreateFlags() []common.Flag {
 }
 
 func validateCreateV2(_ context.Context, runtime *common.RuntimeContext) error {
+	if err := rejectV1CreateFlagsForV2(runtime); err != nil {
+		return err
+	}
 	if runtime.Str("content") == "" {
 		return common.FlagErrorf("--content is required")
 	}
 	if runtime.Str("parent-token") != "" && runtime.Str("parent-position") != "" {
 		return common.FlagErrorf("--parent-token and --parent-position are mutually exclusive")
+	}
+	return nil
+}
+
+func rejectV1CreateFlagsForV2(runtime *common.RuntimeContext) error {
+	v1Flags := []struct {
+		name string
+		hint string
+	}{
+		{name: "markdown", hint: "use --content with --doc-format markdown"},
+		{name: "title", hint: "include the document title in --content"},
+		{name: "folder-token", hint: "use --parent-token"},
+		{name: "wiki-node", hint: "use --parent-token"},
+		{name: "wiki-space", hint: "use --parent-position or --parent-token"},
+	}
+	for _, flag := range v1Flags {
+		if runtime.Str(flag.name) != "" {
+			return common.FlagErrorf("--%s is only supported by docs +create v1; for --api-version v2, %s", flag.name, flag.hint)
+		}
 	}
 	return nil
 }

--- a/tests/cli_e2e/docs/coverage.md
+++ b/tests/cli_e2e/docs/coverage.md
@@ -8,6 +8,7 @@
 ## Summary
 - TestDocs_CreateAndFetchWorkflow: proves `docs +create` and `docs +fetch`; key `t.Run(...)` proof points are `create as bot` and `fetch as bot`.
 - TestDocs_CreateAndFetchWorkflowAsUser: proves the same shortcut pair with UAT injection via `create as user` and `fetch as user`; creates its own Drive folder fixture first, then reads back the created doc by token.
+- TestDocs_CreateV2RejectsLegacyFlagsDryRun: proves `docs +create --api-version v2 --dry-run` rejects legacy v1-only flags before emitting any API steps.
 - TestDocs_UpdateWorkflow: proves `docs +update` via `update-title-and-content as bot`, then re-fetches the same doc in `verify as bot` to assert persisted title/content changes.
 - Setup note: docs workflows create a Drive folder through `drive files create_folder` in `helpers_test.go`; that helper is external to the docs domain and is not counted here.
 - Blocked area: media and search shortcuts still need deterministic fixtures and local file orchestration.
@@ -16,7 +17,7 @@
 
 | Status | Cmd | Type | Testcase | Key parameter shapes | Notes / uncovered reason |
 | --- | --- | --- | --- | --- | --- |
-| ✓ | docs +create | shortcut | docs/helpers_test.go::createDocWithRetry; docs_create_fetch_test.go::TestDocs_CreateAndFetchWorkflowAsUser/create as user | `--folder-token`; `--title`; `--markdown` | helper asserts returned doc id |
+| ✓ | docs +create | shortcut | docs/helpers_test.go::createDocWithRetry; docs_create_fetch_test.go::TestDocs_CreateAndFetchWorkflowAsUser/create as user; docs_create_dryrun_test.go::TestDocs_CreateV2RejectsLegacyFlagsDryRun | `--folder-token`; `--title`; `--markdown`; v2 legacy flag rejection under `--dry-run` | helper asserts returned doc id; dry-run case asserts no API calls on validation failure |
 | ✓ | docs +fetch | shortcut | docs_create_fetch_test.go::TestDocs_CreateAndFetchWorkflow/fetch as bot; docs_update_test.go::TestDocs_UpdateWorkflow/verify as bot; docs_create_fetch_test.go::TestDocs_CreateAndFetchWorkflowAsUser/fetch as user | `--doc <docToken>` | |
 | ✕ | docs +media-download | shortcut |  | none | no media fixture workflow yet |
 | ✕ | docs +media-insert | shortcut |  | none | requires deterministic upload fixture and rollback assertions |

--- a/tests/cli_e2e/docs/docs_create_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_create_dryrun_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package docs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestDocs_CreateV2RejectsLegacyFlagsDryRun(t *testing.T) {
+	setDocsDryRunEnv(t)
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "markdown",
+			args: []string{
+				"docs", "+create",
+				"--api-version", "v2",
+				"--markdown", "## legacy",
+				"--dry-run",
+			},
+			wantErr: "use --content with --doc-format markdown",
+		},
+		{
+			name: "wiki node",
+			args: []string{
+				"docs", "+create",
+				"--api-version", "v2",
+				"--content", "<title>内容</title><p>正文</p>",
+				"--wiki-node", "wikcn_legacy_node",
+				"--dry-run",
+			},
+			wantErr: "use --parent-token",
+		},
+		{
+			name: "title",
+			args: []string{
+				"docs", "+create",
+				"--api-version", "v2",
+				"--content", "<p>正文</p>",
+				"--title", "Legacy title",
+				"--dry-run",
+			},
+			wantErr: "include the document title in --content",
+		},
+		{
+			name: "folder token",
+			args: []string{
+				"docs", "+create",
+				"--api-version", "v2",
+				"--content", "<title>内容</title><p>正文</p>",
+				"--folder-token", "fldcn_legacy_folder",
+				"--dry-run",
+			},
+			wantErr: "use --parent-token",
+		},
+		{
+			name: "wiki space",
+			args: []string{
+				"docs", "+create",
+				"--api-version", "v2",
+				"--content", "<title>内容</title><p>正文</p>",
+				"--wiki-space", "my_library",
+				"--dry-run",
+			},
+			wantErr: "use --parent-position or --parent-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			t.Cleanup(cancel)
+
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args:      tt.args,
+				DefaultAs: "bot",
+			})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 2)
+			assert.Contains(t, docsValidationErrorMessage(result), tt.wantErr)
+			assert.Equal(t, int64(0), gjson.Get(result.Stdout, "api.#").Int(),
+				"validation failure must not produce dry-run API calls, stdout:\n%s", result.Stdout)
+		})
+	}
+}
+
+func setDocsDryRunEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "docs_dryrun_e2e_app")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "docs_dryrun_e2e_secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+}
+
+func docsValidationErrorMessage(r *clie2e.Result) string {
+	if msg := gjson.Get(r.Stdout, "error.message").String(); msg != "" {
+		return msg
+	}
+	return gjson.Get(r.Stderr, "error.message").String()
+}


### PR DESCRIPTION
## Summary

`docs +create` supports both the legacy v1 MCP flag set and the v2 OpenAPI flag set. When the v2 path is selected, passing v1-only flags should fail early instead of being accepted or producing a less actionable validation error.

## Reproduction

Before this change, this v2 dry-run accepted the legacy `--wiki-node` flag but silently omitted the intended parent placement from the request body:

```bash
lark-cli docs +create \
  --api-version v2 \
  --content '<title>x</title>' \
  --wiki-node wikcn_legacy_node \
  --dry-run
```

The emitted dry-run body contained `content` and `format`, but no `parent_token`. Similarly, `--api-version v2 --markdown ...` failed with `--content is required`, which did not explain that `--markdown` belongs to the v1 create path.

## Changes

- Reject v1-only `docs +create` flags on the v2 create path: `--markdown`, `--title`, `--folder-token`, `--wiki-node`, and `--wiki-space`.
- Add migration hints to the validation errors, pointing users to `--content`, `--doc-format markdown`, `--parent-token`, or `--parent-position` as appropriate.
- Add unit coverage for the v2 validation behavior.
- Add docs dry-run E2E coverage and update the docs E2E coverage inventory.

## Test Plan

- [x] `make build`
- [x] `make unit-test`
- [x] `go vet ./...`
- [x] `gofmt -l .` produced no output
- [x] `go mod tidy` produced no `go.mod` / `go.sum` diff
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main` (`0 issues`; emitted the existing gocritic disabled-check warning)
- [x] `go test ./shortcuts/doc -run TestDocsCreateV2RejectsV1OnlyFlags -count=1`
- [x] `go test ./tests/cli_e2e/docs -run TestDocs_CreateV2RejectsLegacyFlagsDryRun -count=1`
- [x] `go test ./shortcuts/...`

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * v2 create commands now reject legacy v1-only flags and display clear, per-flag guidance pointing to v2 alternatives.

* **Tests**
  * Added unit and end-to-end tests validating v2 flag rejection, dry-run behavior, exit codes, and that no API calls occur when validation fails.

* **Documentation**
  * Updated test coverage notes to include the v2 dry-run legacy-flag rejection scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->