### PR TITLE
docs(common): sync ParseResourceURL doc comment with new URL prefixes

### DIFF
--- a/shortcuts/common/resource_url.go
+++ b/shortcuts/common/resource_url.go
@@ -96,9 +96,13 @@ var urlPathToType = []struct {
 //	/doc/TOKEN       -> {Type: "doc",  Token: TOKEN}
 //	/sheets/TOKEN    -> {Type: "sheet", Token: TOKEN}
 //	/base/TOKEN      -> {Type: "bitable", Token: TOKEN}
+//	/bitable/TOKEN   -> {Type: "bitable", Token: TOKEN} (alias of /base/)
 //	/wiki/TOKEN      -> {Type: "wiki", Token: TOKEN}
 //	/file/TOKEN      -> {Type: "file", Token: TOKEN}
 //	/drive/folder/TOKEN -> {Type: "folder", Token: TOKEN}
+//	/drive/file/TOKEN   -> {Type: "file", Token: TOKEN}
+//	/drive/shr/TOKEN    -> {Type: "folder", Token: TOKEN}
+//	/chat/drive/TOKEN   -> {Type: "folder", Token: TOKEN}
 //	/mindnote/TOKEN  -> {Type: "mindnote", Token: TOKEN}
 //	/slides/TOKEN    -> {Type: "slides", Token: TOKEN}
 //


### PR DESCRIPTION
## Summary
[#1106](https://github.com/larksuite/cli/pull/1106) added three new URL prefixes to `urlPathToType` (`/drive/file/`, `/drive/shr/`, `/chat/drive/`), so `ParseResourceURL` recognizes them in practice — but the godoc comment above the function still listed only the original nine patterns. The `/bitable/` alias of `/base/` has also been absent from the comment.

AI agents and contributors reading the godoc were seeing an outdated supported-pattern list. This PR syncs the comment with the actual code.

## Changes
- `shortcuts/common/resource_url.go`: add the four missing entries (`/bitable/`, `/drive/file/`, `/drive/shr/`, `/chat/drive/`) to the godoc patterns list. Placement follows the order of the matching entries in `urlPathToType`. **+4 lines, no behavior change.**

## Test Plan
- [x] `go test ./shortcuts/common/ -run TestParseResourceURL` — passes (existing table-driven tests already cover all four prefixes, including doubao-host variants)
- [x] `gofmt -l shortcuts/common/resource_url.go` — clean
- [x] No source code touched outside the doc comment

## Related Issues
- Follow-up to #1106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for resource URL parsing to better explain supported URL path patterns and alias behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->