### PR TITLE
perf(im): parallelize reactions, thread_replies, and merge_forward fetches

### DIFF
--- a/shortcuts/im/convert_lib/content_convert.go
+++ b/shortcuts/im/convert_lib/content_convert.go
@@ -32,6 +32,14 @@ type ConvertContext struct {
 	// SenderNames is a shared cache of open_id -> display name, accumulated across messages
 	// to avoid redundant contact API calls. May be nil.
 	SenderNames map[string]string
+	// MergeForwardSubItems is an optional pre-fetched cache of merge_forward
+	// sub-message lists, keyed by merge_forward message_id. When set, the
+	// merge_forward converter uses the cached entry instead of issuing its
+	// own GET; populated by callers via PrefetchMergeForwardSubItems before
+	// the FormatMessageItem loop. nil means "no prefetch — fall back to the
+	// per-message inline GET", which keeps non-shortcut callers (events,
+	// ad-hoc tests) working unchanged.
+	MergeForwardSubItems map[string][]map[string]interface{}
 }
 
 // converters maps message types to their ContentConverter implementations.
@@ -119,6 +127,20 @@ func FormatMessageItem(m map[string]interface{}, runtime *common.RuntimeContext,
 	if len(senderNames) > 0 {
 		nameCache = senderNames[0]
 	}
+	return formatMessageItem(m, runtime, nameCache, nil)
+}
+
+// FormatMessageItemWithMergePrefetch is like FormatMessageItem but threads a
+// pre-fetched merge_forward sub-message map (typically built via
+// PrefetchMergeForwardSubItems) through to the merge_forward converter so it
+// can skip its own per-message GET. Shortcuts that iterate a page of raw
+// items should pre-fetch once and call this variant in the loop to avoid the
+// N × ~1s serial-merge_forward stall in the original code path.
+func FormatMessageItemWithMergePrefetch(m map[string]interface{}, runtime *common.RuntimeContext, nameCache map[string]string, mergePrefetch map[string][]map[string]interface{}) map[string]interface{} {
+	return formatMessageItem(m, runtime, nameCache, mergePrefetch)
+}
+
+func formatMessageItem(m map[string]interface{}, runtime *common.RuntimeContext, nameCache map[string]string, mergePrefetch map[string][]map[string]interface{}) map[string]interface{} {
 	msgType, _ := m["msg_type"].(string)
 	messageId, _ := m["message_id"].(string)
 	mentions, _ := m["mentions"].([]interface{})
@@ -129,11 +151,12 @@ func FormatMessageItem(m map[string]interface{}, runtime *common.RuntimeContext,
 	if body, ok := m["body"].(map[string]interface{}); ok {
 		rawContent, _ := body["content"].(string)
 		content = ConvertBodyContent(msgType, &ConvertContext{
-			RawContent:  rawContent,
-			MentionMap:  BuildMentionKeyMap(mentions),
-			MessageID:   messageId,
-			Runtime:     runtime,
-			SenderNames: nameCache,
+			RawContent:           rawContent,
+			MentionMap:           BuildMentionKeyMap(mentions),
+			MessageID:            messageId,
+			Runtime:              runtime,
+			SenderNames:          nameCache,
+			MergeForwardSubItems: mergePrefetch,
 		})
 	}
 

--- a/shortcuts/im/convert_lib/merge.go
+++ b/shortcuts/im/convert_lib/merge.go
@@ -4,11 +4,11 @@
 package convertlib
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/larksuite/cli/internal/validate"
@@ -16,28 +16,53 @@ import (
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
+// mergeForwardPrefetchConcurrency caps in-flight merge_forward sub-message
+// fetches when a shortcut pre-scans a page for merge_forward messages and
+// prefetches their children concurrently. Each call is one ~700ms-1s
+// GET /open-apis/im/v1/messages/{id} per merge_forward — strictly serial in
+// FormatMessageItem before this change, which turned page-size 50 + 5
+// merge_forward messages into ~8.5s of stall (measured on a real chat).
+// GET /open-apis/im/v1/messages/{id} has no published per-app rate-limit at
+// these levels, so we set this higher than the reactions batch_query cap
+// (which sits at 4 to stay well under the gateway-layer 50/s + 1000/min
+// explicit ceiling on the reactions endpoint).
+const mergeForwardPrefetchConcurrency = 8
+
 type mergeForwardConverter struct{}
 
-// Convert expands merge_forward sub-messages into a tree when runtime is available,
-// otherwise falls back to a summary string.
+// Convert expands merge_forward sub-messages into a tree when runtime is
+// available (or a pre-fetched cache was supplied), otherwise falls back to a
+// summary string.
+//
+// When ctx.MergeForwardSubItems is non-nil (set by callers that pre-fetched
+// the page's merge_forward children concurrently via
+// PrefetchMergeForwardSubItems), Convert uses the cached items and skips the
+// HTTP fetch entirely — this is how the shortcut layer turns N serial
+// per-merge_forward GETs into one bounded-concurrency fan-out before the
+// FormatMessageItem loop runs.
 func (mergeForwardConverter) Convert(ctx *ConvertContext) string {
-	// When runtime is available, fetch sub-messages via API and expand into a tree.
-	// merge_forward body.content is typically a plain-text placeholder (e.g. "Merged and Forwarded Message"),
-	// not JSON with create_message_ids, so we must rely on the API to get actual sub-messages.
+	// Fast path: caller pre-fetched this merge_forward's sub-tree.
+	if ctx.MergeForwardSubItems != nil && ctx.MessageID != "" {
+		if cached, ok := ctx.MergeForwardSubItems[ctx.MessageID]; ok {
+			return renderMergeForwardTree(ctx, cached)
+		}
+	}
+	// Slow path: no pre-fetch; fall back to a per-merge_forward GET. Kept so
+	// callers that don't pre-fetch (e.g. event subscribers, ad-hoc Convert
+	// invocations in tests) still produce correct output, just serially.
+	// merge_forward body.content is typically a plain-text placeholder, not
+	// JSON with create_message_ids, so we must rely on the API to get actual
+	// sub-messages.
 	if ctx.Runtime != nil && ctx.MessageID != "" {
 		subItems, err := fetchMergeForwardSubMessages(ctx.MessageID, ctx.Runtime)
 		if err != nil {
 			return fmt.Sprintf("[Merged forward: fetch failed: %s]", err)
 		}
 		if len(subItems) > 0 {
-			// Resolve sender names using shared cache to avoid redundant API calls across merge_forward messages
-			nameMap := ResolveSenderNames(ctx.Runtime, subItems, ctx.SenderNames)
-			AttachSenderNames(subItems, nameMap)
-			childrenMap := BuildMergeForwardChildrenMap(subItems, ctx.MessageID)
-			return FormatMergeForwardSubTree(ctx.MessageID, childrenMap)
+			return renderMergeForwardTree(ctx, subItems)
 		}
 	}
-	// Fallback: try to extract message IDs from content (some older formats include them)
+	// Final fallback: try to extract message IDs from content (some older formats include them)
 	ids := ParseMergeForwardIDs(ctx.RawContent)
 	if len(ids) > 0 {
 		return fmt.Sprintf("[Merged forward: %d messages]", len(ids))
@@ -45,31 +70,158 @@ func (mergeForwardConverter) Convert(ctx *ConvertContext) string {
 	return "[Merged forward]"
 }
 
-// fetchMergeForwardSubMessages fetches all sub-messages in a merge_forward container
-// via a single API call. Returns a flat list of raw message items with upper_message_id
-// for tree reconstruction.
+// renderMergeForwardTree resolves sender names for the supplied sub-items and
+// produces the formatted forwarded-messages tree. Shared by the prefetch fast
+// path and the inline fetch fallback so both produce identical output.
+func renderMergeForwardTree(ctx *ConvertContext, subItems []map[string]interface{}) string {
+	nameMap := ResolveSenderNames(ctx.Runtime, subItems, ctx.SenderNames)
+	AttachSenderNames(subItems, nameMap)
+	childrenMap := BuildMergeForwardChildrenMap(subItems, ctx.MessageID)
+	return FormatMergeForwardSubTree(ctx.MessageID, childrenMap)
+}
+
+// PrefetchMergeForwardSubItems scans rawItems for merge_forward messages,
+// concurrently fetches each one's flat sub-message list, and returns a map
+// keyed by the merge_forward message_id. Callers thread the returned map
+// through FormatMessageItemWithMergePrefetch (or directly into a
+// ConvertContext.MergeForwardSubItems) so the per-item conversion loop can
+// reuse cached sub-trees instead of issuing its own serial GET.
+//
+// Each fetch is independent (different message_id, different sub-tree), so
+// concurrent goroutines never contend on shared mutable state — the result
+// map is written under a mutex purely to make the map safe for concurrent
+// inserts.
+//
+// On fetch failure: emit a stderr warning and intentionally do NOT insert
+// the failed id into the result map. The downstream
+// mergeForwardConverter.Convert path keys off "is this id present in the
+// prefetch?" — by leaving the key absent on failure, Convert falls through
+// to its inline-fetch slow path, which (a) gets a second attempt at the
+// GET, and (b) if that ALSO fails, surfaces the real "[Merged forward:
+// fetch failed: ...]" string the user used to see in stdout. Inserting nil
+// would have silently produced an empty <forwarded_messages> tree instead,
+// dropping the failure signal from the user-visible output.
+//
+// When nameCache is non-nil, this function also runs one batched
+// ResolveSenderNames across every sub-item it fetched, populating the cache
+// before returning. Without this step, each per-merge_forward render in the
+// caller's loop would issue its own contact API request for any uncached
+// sender, re-introducing an N × ~400ms serial stall (measured at 5
+// merge_forwards × ~400ms = ~2s in production traces). Pre-populating the
+// cache makes those per-render ResolveSenderNames calls effective no-ops.
+func PrefetchMergeForwardSubItems(runtime *common.RuntimeContext, rawItems []interface{}, nameCache map[string]string) map[string][]map[string]interface{} {
+	if runtime == nil || len(rawItems) == 0 {
+		return nil
+	}
+	var ids []string
+	for _, item := range rawItems {
+		m, _ := item.(map[string]interface{})
+		if m == nil {
+			continue
+		}
+		if mt, _ := m["msg_type"].(string); mt != "merge_forward" {
+			continue
+		}
+		id, _ := m["message_id"].(string)
+		if id == "" {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	result := make(map[string][]map[string]interface{}, len(ids))
+	if len(ids) == 1 {
+		// Single-message fast path: no goroutine overhead. Matches the
+		// pre-existing serial behavior bit-for-bit when only one
+		// merge_forward is present.
+		items, err := fetchMergeForwardSubMessages(ids[0], runtime)
+		if err != nil {
+			fmt.Fprintf(runtime.IO().ErrOut, "warning: merge_forward_prefetch_failed: %s: %v\n", ids[0], err)
+			// Leave the key absent so Convert falls back to its inline GET
+			// path and surfaces "[Merged forward: fetch failed: ...]" if
+			// the retry also fails. See function godoc.
+		} else {
+			result[ids[0]] = items
+		}
+		batchResolveMergeForwardSenders(runtime, result, nameCache)
+		return result
+	}
+
+	var mu sync.Mutex
+	sem := make(chan struct{}, mergeForwardPrefetchConcurrency)
+	var wg sync.WaitGroup
+	for _, id := range ids {
+		// Add before the semaphore acquire — sync.WaitGroup godoc
+		// recommends Add precede the goroutine-spawning event.
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			items, err := fetchMergeForwardSubMessages(id, runtime)
+			mu.Lock()
+			if err != nil {
+				fmt.Fprintf(runtime.IO().ErrOut, "warning: merge_forward_prefetch_failed: %s: %v\n", id, err)
+				// Leave the key absent — see fast-path comment above.
+			} else {
+				result[id] = items
+			}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+	batchResolveMergeForwardSenders(runtime, result, nameCache)
+	return result
+}
+
+// batchResolveMergeForwardSenders gathers every sub-item across every
+// prefetched merge_forward and runs a single ResolveSenderNames call against
+// nameCache. No-op when nameCache is nil (callers that pre-fetched without
+// caring about sender resolution, e.g. event subscribers that render on the
+// fly) or when nothing was fetched.
+func batchResolveMergeForwardSenders(runtime *common.RuntimeContext, prefetch map[string][]map[string]interface{}, nameCache map[string]string) {
+	if nameCache == nil || len(prefetch) == 0 {
+		return
+	}
+	var allSubItems []map[string]interface{}
+	for _, items := range prefetch {
+		allSubItems = append(allSubItems, items...)
+	}
+	if len(allSubItems) == 0 {
+		return
+	}
+	ResolveSenderNames(runtime, allSubItems, nameCache)
+}
+
+// fetchMergeForwardSubMessages fetches all sub-messages in a merge_forward
+// container via a single API call. Returns a flat list of raw message items
+// with upper_message_id for tree reconstruction.
+//
+// Uses DoAPIJSON so the response envelope's code/msg are checked and surfaced
+// — earlier this used the low-level DoAPI and reported every non-zero code
+// as a generic "empty data" error, hiding the real failure (e.g. a server
+// "code: 2200 Internal Error" with its log_id would show up as just "empty
+// data" in the output).
 func fetchMergeForwardSubMessages(messageID string, runtime *common.RuntimeContext) ([]map[string]interface{}, error) {
-	apiResp, err := runtime.DoAPI(&larkcore.ApiReq{
-		HttpMethod: http.MethodGet,
-		ApiPath:    mergeForwardMessagesPath(messageID),
-		QueryParams: larkcore.QueryParams{
-			"user_id_type":          []string{"open_id"},
-			"card_msg_content_type": []string{"raw_card_content"},
-		},
-	})
+	data, err := runtime.DoAPIJSON(http.MethodGet, mergeForwardMessagesPath(messageID), larkcore.QueryParams{
+		"user_id_type":          []string{"open_id"},
+		"card_msg_content_type": []string{"raw_card_content"},
+	}, nil)
 	if err != nil {
 		return nil, err
 	}
-
-	var result map[string]interface{}
-	if err := json.Unmarshal(apiResp.RawBody, &result); err != nil {
-		return nil, fmt.Errorf("invalid response: %w", err)
-	}
-	data, _ := result["data"].(map[string]interface{})
+	// DoAPIJSON returns the envelope's `data` field; when the server's JSON
+	// has `code: 0` but omits `data` entirely, that field comes back as nil.
+	// Reading from a nil map in Go is safe (returns the zero value, never
+	// panics), but guarding explicitly makes the "successful empty
+	// response" path obvious and keeps a future signature change from
+	// silently introducing nil-deref hazards.
 	if data == nil {
-		return nil, fmt.Errorf("empty data")
+		return []map[string]interface{}{}, nil
 	}
-
 	rawItems, _ := data["items"].([]interface{})
 	items := make([]map[string]interface{}, 0, len(rawItems))
 	for _, raw := range rawItems {

--- a/shortcuts/im/convert_lib/merge_test.go
+++ b/shortcuts/im/convert_lib/merge_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -86,7 +87,14 @@ func TestFetchMergeForwardSubMessages(t *testing.T) {
 		}
 	})
 
-	t.Run("empty data", func(t *testing.T) {
+	t.Run("empty data treated as no children", func(t *testing.T) {
+		// `code: 0` with no data field is a successful "no children" response
+		// after the switch to DoAPIJSON (which checks the response envelope's
+		// code/msg directly). Previously this was reported as a generic
+		// "empty data" error — which also masked real failures like a
+		// non-zero code with data: null — so a successful empty payload now
+		// returns (nil, nil) and lets Convert fall through to its summary
+		// fallback string.
 		runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 			switch {
 			case strings.Contains(req.URL.Path, "/open-apis/im/v1/messages/om_bad"):
@@ -96,11 +104,193 @@ func TestFetchMergeForwardSubMessages(t *testing.T) {
 			}
 		}))
 
-		_, err := fetchMergeForwardSubMessages("om_bad", runtime)
-		if err == nil || !strings.Contains(err.Error(), "empty data") {
-			t.Fatalf("fetchMergeForwardSubMessages() error = %v", err)
+		items, err := fetchMergeForwardSubMessages("om_bad", runtime)
+		if err != nil {
+			t.Fatalf("fetchMergeForwardSubMessages(success-but-empty) err = %v, want nil", err)
+		}
+		if len(items) != 0 {
+			t.Fatalf("fetchMergeForwardSubMessages(success-but-empty) items = %#v, want empty", items)
 		}
 	})
+
+	t.Run("non-zero code surfaces real error", func(t *testing.T) {
+		// Regression coverage for the bug that motivated the DoAPIJSON
+		// switch: a server response with code != 0 (here: 2200 Internal
+		// Error, observed in production for some merge_forward IDs) used to
+		// be silently reported as the generic "empty data" string, hiding
+		// the real code/msg/log_id. With DoAPIJSON the envelope's code is
+		// checked and surfaced as an ErrAPI containing the real message.
+		runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return convertlibJSONResponse(200, map[string]interface{}{
+				"code": 2200,
+				"msg":  "Internal Error",
+			}), nil
+		}))
+
+		_, err := fetchMergeForwardSubMessages("om_err", runtime)
+		if err == nil {
+			t.Fatal("fetchMergeForwardSubMessages(code=2200) err = nil, want non-nil")
+		}
+		if !strings.Contains(err.Error(), "Internal Error") {
+			t.Fatalf("fetchMergeForwardSubMessages(code=2200) err = %q, want it to contain the real msg", err)
+		}
+	})
+}
+
+// TestPrefetchMergeForwardSubItems exercises the bounded-concurrency prefetch
+// path: each merge_forward in the input gets its own GET fetched in
+// parallel, and the returned map keys items by their merge_forward
+// message_id. A goroutine cross-contamination bug would manifest as
+// mis-keyed entries.
+func TestPrefetchMergeForwardSubItems(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		callCount int
+	)
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		// Each merge_forward's path ends with its message_id; key the
+		// returned child off that so the test can detect mis-attachment.
+		path := req.URL.Path
+		// The path looks like /open-apis/im/v1/messages/<encoded-id>; take
+		// the last segment.
+		lastSlash := strings.LastIndex(path, "/")
+		if lastSlash < 0 {
+			return nil, fmt.Errorf("unexpected path: %s", path)
+		}
+		hostID := path[lastSlash+1:]
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{
+						"message_id":  "om_child_of_" + hostID,
+						"create_time": "1710500000000",
+					},
+				},
+			},
+		}), nil
+	}))
+
+	// Mix of merge_forward and non-merge_forward messages — only the former
+	// should be fetched. 5 merge_forwards is enough to exercise the
+	// bounded fan-out (cap = 4) rather than fall into a single-message fast
+	// path.
+	rawItems := []interface{}{
+		map[string]interface{}{"message_id": "om_mf_1", "msg_type": "merge_forward"},
+		map[string]interface{}{"message_id": "om_text_a", "msg_type": "text"},
+		map[string]interface{}{"message_id": "om_mf_2", "msg_type": "merge_forward"},
+		map[string]interface{}{"message_id": "om_mf_3", "msg_type": "merge_forward"},
+		map[string]interface{}{"message_id": "om_image", "msg_type": "image"},
+		map[string]interface{}{"message_id": "om_mf_4", "msg_type": "merge_forward"},
+		map[string]interface{}{"message_id": "om_mf_5", "msg_type": "merge_forward"},
+	}
+
+	got := PrefetchMergeForwardSubItems(runtime, rawItems, nil)
+
+	if callCount != 5 {
+		t.Fatalf("expected 5 merge_forward fetches, got %d", callCount)
+	}
+	wantIDs := []string{"om_mf_1", "om_mf_2", "om_mf_3", "om_mf_4", "om_mf_5"}
+	for _, id := range wantIDs {
+		children, ok := got[id]
+		if !ok {
+			t.Fatalf("prefetch map missing key %q (cross-thread contamination?)", id)
+		}
+		if len(children) != 1 {
+			t.Fatalf("prefetch[%s] children len = %d, want 1", id, len(children))
+		}
+		want := "om_child_of_" + id
+		if children[0]["message_id"] != want {
+			t.Fatalf("prefetch[%s] child id = %v, want %q — mis-attributed result", id, children[0]["message_id"], want)
+		}
+	}
+	for _, missing := range []string{"om_text_a", "om_image"} {
+		if _, ok := got[missing]; ok {
+			t.Fatalf("prefetch map should not contain non-merge_forward key %q", missing)
+		}
+	}
+}
+
+// TestPrefetchMergeForwardSubItemsHTTPError covers the transport-level
+// failure path: server replies with a non-2xx status (e.g. 503). DoAPIJSON
+// surfaces this as a network error, the prefetch goroutine emits a stderr
+// warning, and — critically — does NOT insert the failed id into the
+// result map, so Convert falls back to inline retry (same contract as
+// envelope-level errors, exercised by
+// TestPrefetchMergeForwardSubItemsFailureFallsThroughToInlineFetch).
+func TestPrefetchMergeForwardSubItemsHTTPError(t *testing.T) {
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		// 503 Service Unavailable with no body — purely a transport-layer
+		// error. DoAPIJSON's `resp.StatusCode >= 400` branch handles this
+		// before it ever tries to parse an envelope, which is the path the
+		// envelope-error test doesn't reach.
+		return convertlibJSONResponse(503, map[string]interface{}{}), nil
+	}))
+
+	rawItems := []interface{}{
+		map[string]interface{}{"message_id": "om_mf_a", "msg_type": "merge_forward"},
+		map[string]interface{}{"message_id": "om_mf_b", "msg_type": "merge_forward"},
+	}
+
+	got := PrefetchMergeForwardSubItems(runtime, rawItems, nil)
+
+	for _, id := range []string{"om_mf_a", "om_mf_b"} {
+		if _, ok := got[id]; ok {
+			t.Fatalf("prefetch map contains transport-error id %q — Convert would render an empty tree instead of falling back to the inline retry path", id)
+		}
+	}
+}
+
+// TestPrefetchMergeForwardSubItemsFailureFallsThroughToInlineFetch is a
+// regression test for the silent-empty-tree bug: when a prefetch fails, the
+// failed id MUST be absent from the returned map (not present-with-nil).
+// Otherwise Convert's "if cached, ok := m[id]; ok { renderTree(cached) }"
+// path hits `ok=true, cached=nil`, renders an empty <forwarded_messages>
+// tree, and the user-visible "[Merged forward: fetch failed: ...]" string
+// that the inline path produced disappears.
+func TestPrefetchMergeForwardSubItemsFailureFallsThroughToInlineFetch(t *testing.T) {
+	// Mock: every fetch returns an API error.
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 2200,
+			"msg":  "Internal Error",
+		}), nil
+	}))
+
+	// Multiple ids so we hit the concurrent path (the single-id fast path
+	// has its own dedicated branch; covering the concurrent branch is more
+	// stringent since the bug originally hid inside its mu.Lock section).
+	rawItems := []interface{}{
+		map[string]interface{}{"message_id": "om_mf_1", "msg_type": "merge_forward"},
+		map[string]interface{}{"message_id": "om_mf_2", "msg_type": "merge_forward"},
+	}
+
+	got := PrefetchMergeForwardSubItems(runtime, rawItems, nil)
+
+	// Every failed id MUST be absent from the map (not present-with-nil).
+	for _, id := range []string{"om_mf_1", "om_mf_2"} {
+		if _, ok := got[id]; ok {
+			t.Fatalf("prefetch map contains failed id %q — this would cause Convert to render an empty <forwarded_messages> tree instead of falling back to the inline-fetch error path", id)
+		}
+	}
+
+	// And as the downstream effect: invoking the converter on the failed id
+	// with the (now-cleanly-absent-key) prefetch map must produce the
+	// inline-path error string, not an empty tree. The mocked inline fetch
+	// also errors with the same 2200 / Internal Error, so the rendered
+	// content should contain "Merged forward: fetch failed".
+	out := (mergeForwardConverter{}).Convert(&ConvertContext{
+		MessageID:            "om_mf_1",
+		Runtime:              runtime,
+		SenderNames:          map[string]string{},
+		MergeForwardSubItems: got,
+	})
+	if !strings.Contains(out, "Merged forward: fetch failed") {
+		t.Fatalf("Convert output after prefetch failure = %q, want it to contain \"Merged forward: fetch failed\" — failure signal lost", out)
+	}
 }
 
 func TestMergeForwardConverterWithRuntime(t *testing.T) {

--- a/shortcuts/im/convert_lib/reactions.go
+++ b/shortcuts/im/convert_lib/reactions.go
@@ -5,7 +5,9 @@ package convertlib
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"sync"
 
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -14,6 +16,16 @@ import (
 // length for POST /im/v1/messages/reactions/batch_query (see
 // larkim/message/members/facade_reaction/service: batchListReactionsMaxMessageIDs).
 const reactionsBatchQueryMaxQueries = 20
+
+// reactionsBatchQueryConcurrency caps in-flight batch_query requests. A single
+// batch_query call is observed at ~700ms RTT regardless of payload size, so a
+// fully serial loop turns N=550 (page-size 50 + 500 expanded thread_replies)
+// into ~20s of latency and lets outer wrappers (agents, shells with a wall
+// clock) time the whole command out. Bounded concurrency cuts that to ~5s
+// without risking the server's gateway-layer 50/s + 1000/min ceiling: even at
+// the worst sustained pattern (28 batches at 4-way fan-out finishing every
+// ~700ms) the effective rate stays well under 6/s.
+const reactionsBatchQueryConcurrency = 4
 
 // EnrichReactions enriches messages with their reactions by calling the
 // im.reactions.batch_query API. Messages are modified in place: each message
@@ -57,13 +69,51 @@ func EnrichReactions(runtime *common.RuntimeContext, messages []map[string]inter
 		return
 	}
 
+	// Slice the id list into batches of <= reactionsBatchQueryMaxQueries.
+	var batches [][]string
 	for i := 0; i < len(ids); i += reactionsBatchQueryMaxQueries {
 		end := i + reactionsBatchQueryMaxQueries
 		if end > len(ids) {
 			end = len(ids)
 		}
-		fetchReactionsBatch(runtime, ids[i:end], idIndex)
+		batches = append(batches, ids[i:end])
 	}
+
+	// Single-batch fast path: no goroutine overhead, fully deterministic
+	// stderr ordering, identical behavior to the original serial loop.
+	if len(batches) == 1 {
+		fetchReactionsBatch(runtime, batches[0], idIndex, nil)
+		return
+	}
+
+	// Multi-batch path: bounded-concurrency fan-out. Safety invariant:
+	// collectMessageNodes dedups ids on first-seen (the `if _, seen :=
+	// idIndex[id]; !seen` check above), so the slice ids — and therefore
+	// every batch[i:end] sub-slice we hand to a goroutine — contains each
+	// id at most once. Different batches operate on disjoint id sets,
+	// which means different idIndex buckets, which means different
+	// message-map pointers. Goroutines never write to the same map. The
+	// shared mutex serializes only the stderr warning lines so they don't
+	// interleave between goroutines. (Race detector verifies; see
+	// TestEnrichReactions_DuplicateMessageID and
+	// TestEnrichReactions_MultiBatchCorrectness for the round-trip.)
+	var stderrMu sync.Mutex
+	sem := make(chan struct{}, reactionsBatchQueryConcurrency)
+	var wg sync.WaitGroup
+	for _, batch := range batches {
+		// Add(1) before the semaphore acquire — sync.WaitGroup godoc
+		// recommends Add precede the goroutine-spawning event, and
+		// putting it ahead of the blocking sem read keeps the parent
+		// goroutine's bookkeeping monotonic.
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			fetchReactionsBatch(runtime, batch, idIndex, &stderrMu)
+		}()
+	}
+	wg.Wait()
 }
 
 // collectMessageNodes walks messages (and any nested thread_replies) and
@@ -97,7 +147,10 @@ func collectMessageNodes(messages []map[string]interface{}, idIndex map[string][
 // fetchReactionsBatch invokes batch_query for one batch of <= 20 message IDs
 // and merges the results into idIndex. Failures are logged to stderr without
 // aborting subsequent batches.
-func fetchReactionsBatch(runtime *common.RuntimeContext, batchIDs []string, idIndex map[string][]map[string]interface{}) {
+//
+// stderrMu is non-nil in the multi-batch concurrent path (serializes warning
+// lines so they don't interleave) and nil in the single-batch fast path.
+func fetchReactionsBatch(runtime *common.RuntimeContext, batchIDs []string, idIndex map[string][]map[string]interface{}, stderrMu *sync.Mutex) {
 	queries := make([]map[string]interface{}, 0, len(batchIDs))
 	for _, id := range batchIDs {
 		queries = append(queries, map[string]interface{}{"message_id": id})
@@ -109,7 +162,7 @@ func fetchReactionsBatch(runtime *common.RuntimeContext, batchIDs []string, idIn
 		map[string]interface{}{"queries": queries},
 	)
 	if err != nil {
-		fmt.Fprintf(runtime.IO().ErrOut, "warning: reactions_batch_query_failed: %v\n", err)
+		warnReactionsf(stderrMu, runtime.IO().ErrOut, "warning: reactions_batch_query_failed: %v\n", err)
 		markReactionsError(batchIDs, idIndex)
 		return
 	}
@@ -151,12 +204,24 @@ func fetchReactionsBatch(runtime *common.RuntimeContext, batchIDs []string, idIn
 			}
 		}
 		if len(failedIDs) > 0 {
-			fmt.Fprintf(runtime.IO().ErrOut,
+			warnReactionsf(stderrMu, runtime.IO().ErrOut,
 				"warning: reactions_partial_failed: %d message(s) failed (%v)\n",
 				len(failedIDs), failedIDs)
 			markReactionsError(failedIDs, idIndex)
 		}
 	}
+}
+
+// warnReactionsf writes a stderr warning under the supplied mutex when one is
+// provided (multi-batch concurrent path), so concurrent goroutines can't
+// interleave partial lines. mu == nil means the caller is on the single-batch
+// fast path where no synchronization is needed.
+func warnReactionsf(mu *sync.Mutex, w io.Writer, format string, args ...interface{}) {
+	if mu != nil {
+		mu.Lock()
+		defer mu.Unlock()
+	}
+	fmt.Fprintf(w, format, args...)
 }
 
 // markReactionsError flags every message map indexed under the given ids with

--- a/shortcuts/im/convert_lib/reactions_test.go
+++ b/shortcuts/im/convert_lib/reactions_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -84,15 +85,19 @@ func TestEnrichReactions_Success(t *testing.T) {
 }
 
 // TestEnrichReactions_BatchSize splits queries into batches of 20 (server-side
-// max for batch_query).
+// max for batch_query). Multi-batch dispatch is concurrent (bounded fan-out),
+// so callers must tolerate any ordering of batch arrivals at the transport.
 func TestEnrichReactions_BatchSize(t *testing.T) {
+	var mu sync.Mutex
 	var observedBatchSizes []int
 	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		body, _ := io.ReadAll(req.Body)
 		var payload map[string]interface{}
 		_ = json.Unmarshal(body, &payload)
 		queries, _ := payload["queries"].([]interface{})
+		mu.Lock()
 		observedBatchSizes = append(observedBatchSizes, len(queries))
+		mu.Unlock()
 		return convertlibJSONResponse(200, map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{},
@@ -106,8 +111,61 @@ func TestEnrichReactions_BatchSize(t *testing.T) {
 
 	EnrichReactions(runtime, messages)
 
-	if want := []int{20, 5}; !reflect.DeepEqual(observedBatchSizes, want) {
-		t.Fatalf("batch sizes = %v, want %v", observedBatchSizes, want)
+	sort.Ints(observedBatchSizes)
+	if want := []int{5, 20}; !reflect.DeepEqual(observedBatchSizes, want) {
+		t.Fatalf("batch sizes (sorted) = %v, want %v", observedBatchSizes, want)
+	}
+}
+
+// TestEnrichReactions_MultiBatchCorrectness exercises the bounded-concurrency
+// multi-batch path: every message across all batches must receive its own
+// reactions block regardless of which goroutine the batch ran on. A race or a
+// cross-batch index mix-up would manifest as missing or duplicated blocks.
+func TestEnrichReactions_MultiBatchCorrectness(t *testing.T) {
+	var mu sync.Mutex
+	var batchCalls int
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(req.Body)
+		var payload map[string]interface{}
+		_ = json.Unmarshal(body, &payload)
+		queries, _ := payload["queries"].([]interface{})
+		counts := make([]interface{}, 0, len(queries))
+		for _, q := range queries {
+			qm, _ := q.(map[string]interface{})
+			id, _ := qm["message_id"].(string)
+			counts = append(counts, map[string]interface{}{
+				"message_id": id,
+				"reaction_count": []interface{}{
+					map[string]interface{}{"reaction_type": "SMILE", "count": 1},
+				},
+			})
+		}
+		mu.Lock()
+		batchCalls++
+		mu.Unlock()
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"success_msg_reaction_counts": counts,
+			},
+		}), nil
+	}))
+
+	// 65 messages -> 4 batches (20+20+20+5), enough to actually exercise the
+	// bounded fan-out (concurrency cap = 4) rather than degenerate to 1-2 calls.
+	messages := make([]map[string]interface{}, 65)
+	for i := range messages {
+		messages[i] = map[string]interface{}{"message_id": fmt.Sprintf("om_%03d", i)}
+	}
+	EnrichReactions(runtime, messages)
+
+	if batchCalls != 4 {
+		t.Fatalf("expected 4 batched calls, got %d", batchCalls)
+	}
+	for i, m := range messages {
+		if _, ok := m["reactions"]; !ok {
+			t.Fatalf("message %d (%s) missing reactions after multi-batch run", i, m["message_id"])
+		}
 	}
 }
 

--- a/shortcuts/im/convert_lib/thread.go
+++ b/shortcuts/im/convert_lib/thread.go
@@ -6,6 +6,7 @@ package convertlib
 import (
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/larksuite/cli/shortcuts/common"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -17,10 +18,55 @@ const ThreadRepliesPerThread = 50
 // ThreadRepliesTotalLimit is the default max total thread replies across all threads.
 const ThreadRepliesTotalLimit = 500
 
+// threadRepliesFetchConcurrency caps in-flight per-thread GET /messages calls
+// when expanding multiple threads in one shortcut invocation. Each call is a
+// per-thread RTT (~1s observed), so a strictly serial loop turns N=10 thread
+// roots into ~10s of latency — the same multiplier that motivated the
+// reactions enrichment fan-out. GET /messages has no published per-app
+// rate-limit anywhere near these levels, so we set this higher than the
+// reactions batch_query cap (which sits at 4 to stay well under the
+// gateway-layer 50/s + 1000/min explicit ceiling on the reactions endpoint).
+const threadRepliesFetchConcurrency = 8
+
 // ExpandThreadReplies fetches and embeds thread replies for messages that contain a thread_id.
 // For each unique thread_id found in messages, it fetches up to perThread replies (asc order)
-// and attaches them as "thread_replies" on the message. Expansion stops once totalLimit
-// cumulative replies have been fetched. nameCache is the shared open_id→name map.
+// and attaches them as "thread_replies" on the first outer message that referenced that thread.
+// Expansion stops once totalLimit cumulative replies have been allocated across planned fetches.
+// nameCache is the shared open_id→name map.
+//
+// Implementation is two-phase:
+//
+//  1. Plan + concurrent fetch. Walk messages in order, recording every
+//     unique thread_id with a fetch limit of perThread (no upfront budget
+//     deduction — see below). Then dispatch the planned fetches with
+//     bounded concurrency; each goroutine writes only to its own result
+//     slot, no shared mutable state besides that slot.
+//
+//  2. Sequential attach with post-hoc budget enforcement. Walk the planned
+//     threads in their original first-seen order, accumulating actual
+//     returned reply counts against totalLimit. When a thread's actual
+//     replies would push the running total past totalLimit, its reply slice
+//     is truncated to fit the remaining budget and thread_has_more is set
+//     on its host so consumers know more replies exist server-side. Threads
+//     that arrive past a fully-exhausted budget keep their thread_id on the
+//     host but don't get thread_replies attached (semantically identical to
+//     the pre-existing serial behavior for over-budget threads). The phase
+//     stays single-threaded because ResolveSenderNames writes to the shared
+//     nameCache and FormatMessageItem may trigger merge_forward expansion
+//     that also touches nameCache.
+//
+// Budget semantics match the pre-existing serial implementation exactly:
+// each thread's actual returned count is what gets deducted from the
+// budget, not its planned per-thread ceiling. An earlier draft of this
+// refactor allocated the budget against the planned ceiling upfront for
+// implementation simplicity, but that silently dropped later threads in
+// chats where many threads return well under perThread replies (e.g.
+// totalLimit=500 + perThread=50 + 12 short threads of 3 replies each → old
+// code attached all 12, planned-allocation code attached only 10). The
+// trade-off here is a small amount of server-side over-fetching for
+// threads that will end up truncated or dropped — bounded by perThread per
+// thread — in exchange for preserving the original "every thread that fits
+// gets its data" guarantee.
 func ExpandThreadReplies(runtime *common.RuntimeContext, messages []map[string]interface{}, nameCache map[string]string, perThread, totalLimit int) {
 	if runtime == nil {
 		return
@@ -35,52 +81,161 @@ func ExpandThreadReplies(runtime *common.RuntimeContext, messages []map[string]i
 		totalLimit = ThreadRepliesTotalLimit
 	}
 
-	totalFetched := 0
+	// Phase 1a: enumerate every unique thread_id in first-seen order. We
+	// deliberately do NOT deduct anything from the totalLimit budget here —
+	// see the godoc above and the Phase 2 truncation step. The first outer
+	// message referencing a given thread_id is the host that will receive
+	// the thread_replies attachment, matching the pre-existing behavior
+	// where duplicates inherited nothing.
+	type plan struct {
+		threadID string
+		limit    int
+		host     map[string]interface{}
+	}
+	var plans []plan
 	seen := make(map[string]bool)
-
 	for _, msg := range messages {
-		if totalFetched >= totalLimit {
-			break
-		}
 		tid, _ := msg["thread_id"].(string)
 		if tid == "" || seen[tid] {
 			continue
 		}
 		seen[tid] = true
+		plans = append(plans, plan{threadID: tid, limit: perThread, host: msg})
+	}
+	if len(plans) == 0 {
+		return
+	}
 
-		limit := perThread
-		if remaining := totalLimit - totalFetched; limit > remaining {
-			limit = remaining
+	// Phase 1b: concurrent fetch. Each goroutine writes only to its own
+	// results[i] slot, so there is no shared mutable state besides that
+	// slot. The single-batch fast path skips goroutine setup for clarity
+	// and to keep "one thread root" behavior identical to the old code.
+	type result struct {
+		rawReplies []map[string]interface{}
+		hasMore    bool
+		err        error
+	}
+	results := make([]result, len(plans))
+	if len(plans) == 1 {
+		items, hasMore, err := fetchThreadReplies(runtime, plans[0].threadID, plans[0].limit)
+		results[0] = result{rawReplies: items, hasMore: hasMore, err: err}
+	} else {
+		sem := make(chan struct{}, threadRepliesFetchConcurrency)
+		var wg sync.WaitGroup
+		for i, p := range plans {
+			// Add before the semaphore acquire — sync.WaitGroup godoc
+			// recommends Add precede the goroutine-spawning event.
+			wg.Add(1)
+			sem <- struct{}{}
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+				items, hasMore, err := fetchThreadReplies(runtime, p.threadID, p.limit)
+				results[i] = result{rawReplies: items, hasMore: hasMore, err: err}
+			}()
 		}
+		wg.Wait()
+	}
 
-		rawReplies, hasMore, fetchErr := fetchThreadReplies(runtime, tid, limit)
-		if fetchErr != nil {
-			// Preserve the outer message while surfacing that thread expansion failed.
-			msg["thread_replies_error"] = true
+	// Phase 2a-pre: apply the totalLimit budget against actual returned
+	// counts (not planned ceilings) and trim each result in place. Walking
+	// in original plan order matches the pre-existing serial behavior so a
+	// chat with budget-exceeding total replies cuts off at the same thread
+	// position as the old code. Threads past a fully-drained budget have
+	// their slice cleared to an empty (non-nil) slice — distinct from a
+	// fetch error's nil rawReplies — so the attach loop below leaves the
+	// host alone without flagging thread_replies_error. Threads whose
+	// actual count crosses the boundary get their slice truncated and
+	// hasMore flagged so consumers know more exist server-side.
+	remaining := totalLimit
+	for i := range plans {
+		r := &results[i]
+		if r.err != nil || len(r.rawReplies) == 0 {
 			continue
 		}
-		// Successful fetches always return a non-nil (possibly empty) slice.
-		// A nil slice indicates thread expansion did not complete.
-		if rawReplies == nil {
-			msg["thread_replies_error"] = true
+		if remaining <= 0 {
+			// Budget already drained by earlier threads — discard this
+			// thread's fetched replies. We over-fetched on the wire (one
+			// of the explicit trade-offs documented on the function), but
+			// the user-visible output remains the same as the serial
+			// implementation, which would never have issued this fetch.
+			// Empty slice (not nil) so the attach loop treats this like
+			// "successfully returned no replies", not "fetch failed".
+			r.rawReplies = r.rawReplies[:0]
 			continue
 		}
-		if len(rawReplies) == 0 {
-			continue
+		if len(r.rawReplies) > remaining {
+			r.rawReplies = r.rawReplies[:remaining]
+			r.hasMore = true
 		}
+		remaining -= len(r.rawReplies)
+	}
 
-		replies := make([]map[string]interface{}, 0, len(rawReplies))
-		for _, r := range rawReplies {
-			replies = append(replies, FormatMessageItem(r, runtime, nameCache))
+	// Phase 2a-merge: collect every (post-truncation) raw reply across all
+	// threads and pre-fetch merge_forward sub-messages for the ones that
+	// need it. Without this, a thread reply that is itself a merge_forward
+	// would trigger another serial GET inside FormatMessageItem —
+	// re-introducing the same N × RTT stall pattern that Phase 1b just
+	// removed.
+	var allRawReplies []interface{}
+	for i := range plans {
+		r := results[i]
+		if len(r.rawReplies) == 0 {
+			continue
 		}
-		ResolveSenderNames(runtime, replies, nameCache)
+		for _, raw := range r.rawReplies {
+			allRawReplies = append(allRawReplies, raw)
+		}
+	}
+	mergePrefetch := PrefetchMergeForwardSubItems(runtime, allRawReplies, nameCache)
+
+	// Phase 2a: format every plan's replies sequentially. FormatMessageItem
+	// may still touch nameCache for non-merge_forward content types
+	// (e.g. mention resolution), so this stays single-threaded — concurrent
+	// writes to nameCache would race.
+	preparedReplies := make([][]map[string]interface{}, len(plans))
+	for i, p := range plans {
+		r := results[i]
+		if r.err != nil || r.rawReplies == nil {
+			p.host["thread_replies_error"] = true
+			continue
+		}
+		if len(r.rawReplies) == 0 {
+			continue
+		}
+		replies := make([]map[string]interface{}, 0, len(r.rawReplies))
+		for _, raw := range r.rawReplies {
+			replies = append(replies, FormatMessageItemWithMergePrefetch(raw, runtime, nameCache, mergePrefetch))
+		}
+		preparedReplies[i] = replies
+	}
+
+	// Phase 2b: one batched ResolveSenderNames across all replies from all
+	// threads. The pre-existing per-thread call pattern would issue a fresh
+	// contact API request for every thread that introduced a new sender,
+	// turning N threads into up to N serial contact RTTs even after the
+	// fetches themselves went parallel. Consolidating into a single call
+	// resolves every still-missing open_id in one request and lets the
+	// nameCache absorb the rest.
+	var combined []map[string]interface{}
+	for _, replies := range preparedReplies {
+		combined = append(combined, replies...)
+	}
+	if len(combined) > 0 {
+		ResolveSenderNames(runtime, combined, nameCache)
+	}
+
+	// Phase 2c: attach the (now name-resolved) replies to their hosts.
+	for i, p := range plans {
+		replies := preparedReplies[i]
+		if replies == nil {
+			continue
+		}
 		AttachSenderNames(replies, nameCache)
-
-		msg["thread_replies"] = replies
-		if hasMore {
-			msg["thread_has_more"] = true
+		p.host["thread_replies"] = replies
+		if results[i].hasMore {
+			p.host["thread_has_more"] = true
 		}
-		totalFetched += len(rawReplies)
 	}
 }
 

--- a/shortcuts/im/convert_lib/thread_test.go
+++ b/shortcuts/im/convert_lib/thread_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -86,6 +87,201 @@ func TestFetchThreadRepliesError(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatalf("fetchThreadReplies() err = nil, want non-nil")
+	}
+}
+
+// TestExpandThreadRepliesMultiThreadConcurrent exercises the bounded-concurrency
+// multi-thread path: every distinct thread_id gets its own GET fetched in
+// parallel, and the right replies land on the right outer host (the *first*
+// outer message that referenced each thread_id). A race or cross-thread
+// result mix-up would manifest as missing / mis-attached replies.
+func TestExpandThreadRepliesMultiThreadConcurrent(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		callCount int
+	)
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/open-apis/im/v1/messages") {
+			return nil, fmt.Errorf("unexpected path: %s", req.URL.Path)
+		}
+		tid := req.URL.Query().Get("container_id")
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		// Return one synthetic reply per thread, tagged with the thread id so
+		// we can assert that the right replies landed on the right host.
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"has_more": false,
+				"items": []interface{}{
+					map[string]interface{}{
+						"message_id":  "om_reply_" + tid,
+						"msg_type":    "text",
+						"create_time": "1710500000",
+						"thread_id":   tid,
+						"sender":      map[string]interface{}{"name": "Sender"},
+						"body":        map[string]interface{}{"content": `{"text":"reply for ` + tid + `"}`},
+					},
+				},
+			},
+		}), nil
+	}))
+
+	// 5 distinct thread roots → 5 planned fetches, dispatched under the
+	// concurrency cap. Enough to actually exercise the bounded fan-out
+	// rather than degenerate to the single-thread fast path.
+	messages := []map[string]interface{}{
+		{"message_id": "om_root_1", "thread_id": "omt_a"},
+		{"message_id": "om_root_2", "thread_id": "omt_b"},
+		{"message_id": "om_root_3", "thread_id": "omt_c"},
+		{"message_id": "om_root_4", "thread_id": "omt_d"},
+		{"message_id": "om_root_5", "thread_id": "omt_e"},
+	}
+
+	ExpandThreadReplies(runtime, messages, map[string]string{}, 10, 500)
+
+	if callCount != 5 {
+		t.Fatalf("expected 5 thread fetches, got %d", callCount)
+	}
+	for i, m := range messages {
+		tid := m["thread_id"].(string)
+		replies, ok := m["thread_replies"].([]map[string]interface{})
+		if !ok {
+			t.Fatalf("message %d (thread %s) missing thread_replies: %#v", i, tid, m)
+		}
+		if len(replies) != 1 {
+			t.Fatalf("message %d (thread %s) replies len = %d, want 1", i, tid, len(replies))
+		}
+		// Each thread's reply was tagged with its own thread_id; verify no
+		// goroutine cross-contamination.
+		gotTid, _ := replies[0]["thread_id"].(string)
+		if gotTid != tid {
+			t.Fatalf("message %d (thread %s) got reply tagged with thread_id=%q — cross-thread contamination",
+				i, tid, gotTid)
+		}
+	}
+}
+
+// TestExpandThreadRepliesTotalLimitUsesActualCounts is a regression test for
+// the budget-allocation refactor: the new concurrent path must deduct
+// totalLimit using the *actual* returned reply count per thread, not the
+// planned per-thread ceiling. Otherwise chats with many low-volume threads
+// (very common — most threads in a busy group have just a few replies)
+// silently drop later threads when the planned ceilings sum past totalLimit
+// well before the actual replies do.
+func TestExpandThreadRepliesTotalLimitUsesActualCounts(t *testing.T) {
+	// Synthetic API: every thread returns exactly 3 replies, regardless of
+	// the requested page_size. This is the "short threads" scenario where
+	// the difference between planned-ceiling and actual-count budget
+	// accounting becomes visible.
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		tid := req.URL.Query().Get("container_id")
+		items := make([]interface{}, 3)
+		for i := range items {
+			items[i] = map[string]interface{}{
+				"message_id":  fmt.Sprintf("om_reply_%s_%d", tid, i),
+				"msg_type":    "text",
+				"create_time": "1710500000",
+				"thread_id":   tid,
+				"sender":      map[string]interface{}{"name": "Sender"},
+				"body":        map[string]interface{}{"content": `{"text":"hi"}`},
+			}
+		}
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"has_more": false,
+				"items":    items,
+			},
+		}), nil
+	}))
+
+	// 12 distinct thread roots × 3 actual replies each = 36 total. With
+	// perThread=50 (the default ceiling), the old "deduct planned ceiling"
+	// implementation would have exhausted totalLimit=100 after just 2
+	// threads (2 × 50 = 100) and silently skipped the remaining 10. The
+	// correct behavior deducts actual counts (12 × 3 = 36 < 100), so all
+	// 12 threads should attach.
+	messages := make([]map[string]interface{}, 12)
+	for i := range messages {
+		messages[i] = map[string]interface{}{
+			"message_id": fmt.Sprintf("om_root_%02d", i),
+			"thread_id":  fmt.Sprintf("omt_%02d", i),
+		}
+	}
+
+	ExpandThreadReplies(runtime, messages, map[string]string{}, 50, 100)
+
+	for i, m := range messages {
+		replies, ok := m["thread_replies"].([]map[string]interface{})
+		if !ok {
+			t.Fatalf("thread %d (%s) silently dropped — thread_replies missing despite actual budget headroom",
+				i, m["thread_id"])
+		}
+		if len(replies) != 3 {
+			t.Fatalf("thread %d (%s) replies len = %d, want 3", i, m["thread_id"], len(replies))
+		}
+	}
+}
+
+// TestExpandThreadRepliesTruncatesOnBudgetBoundary covers the cross-boundary
+// case: a thread whose actual replies straddle the remaining budget gets
+// its slice truncated to fit and thread_has_more flagged so consumers know
+// more exist server-side.
+func TestExpandThreadRepliesTruncatesOnBudgetBoundary(t *testing.T) {
+	// Every thread returns exactly 4 replies.
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		tid := req.URL.Query().Get("container_id")
+		items := make([]interface{}, 4)
+		for i := range items {
+			items[i] = map[string]interface{}{
+				"message_id":  fmt.Sprintf("om_reply_%s_%d", tid, i),
+				"msg_type":    "text",
+				"create_time": "1710500000",
+				"thread_id":   tid,
+				"sender":      map[string]interface{}{"name": "Sender"},
+				"body":        map[string]interface{}{"content": `{"text":"hi"}`},
+			}
+		}
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"has_more": false,
+				"items":    items,
+			},
+		}), nil
+	}))
+
+	// 3 threads × 4 replies = 12, but totalLimit = 10. So:
+	//   - thread 0 fully attached (4 replies; running total 4)
+	//   - thread 1 fully attached (4 replies; running total 8)
+	//   - thread 2 truncated to 2 replies (running total 10), has_more=true
+	//   - any thread 3+ would be dropped entirely
+	messages := []map[string]interface{}{
+		{"message_id": "om_root_0", "thread_id": "omt_0"},
+		{"message_id": "om_root_1", "thread_id": "omt_1"},
+		{"message_id": "om_root_2", "thread_id": "omt_2"},
+	}
+
+	ExpandThreadReplies(runtime, messages, map[string]string{}, 10, 10)
+
+	for i, want := range []int{4, 4, 2} {
+		replies, _ := messages[i]["thread_replies"].([]map[string]interface{})
+		if len(replies) != want {
+			t.Fatalf("thread %d replies len = %d, want %d (post-budget truncation)", i, len(replies), want)
+		}
+	}
+	if messages[2]["thread_has_more"] != true {
+		t.Fatalf("thread 2 was truncated by budget but thread_has_more = %#v, want true",
+			messages[2]["thread_has_more"])
+	}
+	// And the truncated host must NOT be flagged with thread_replies_error —
+	// budget truncation is success, not failure.
+	for i, m := range messages {
+		if v, _ := m["thread_replies_error"].(bool); v {
+			t.Fatalf("message %d incorrectly flagged with thread_replies_error after budget truncation: %#v", i, m)
+		}
 	}
 }
 

--- a/shortcuts/im/im_chat_messages_list.go
+++ b/shortcuts/im/im_chat_messages_list.go
@@ -117,10 +117,19 @@ var ImChatMessageList = common.Shortcut{
 		hasMore, nextPageToken := common.PaginationMeta(data)
 
 		nameCache := make(map[string]string)
+		// Pre-fetch merge_forward sub-messages concurrently before the per-item
+		// conversion loop. Each merge_forward in the page would otherwise issue
+		// its own serial GET inside FormatMessageItem; N merge_forwards turned
+		// into N × ~1s of stall. Passing nameCache also lets the prefetch
+		// batch-resolve every sub-item's sender open_id in one contact API
+		// call, so the per-merge_forward render path doesn't fan out N more
+		// serial contact requests during the FormatMessageItem loop.
+		mergePrefetch := convertlib.PrefetchMergeForwardSubItems(runtime, rawItems, nameCache)
+
 		messages := make([]map[string]interface{}, 0, len(rawItems))
 		for _, item := range rawItems {
 			m, _ := item.(map[string]interface{})
-			messages = append(messages, convertlib.FormatMessageItem(m, runtime, nameCache))
+			messages = append(messages, convertlib.FormatMessageItemWithMergePrefetch(m, runtime, nameCache, mergePrefetch))
 		}
 
 		// Enrich: resolve sender names for outer messages (reuses cache from merge_forward)

--- a/shortcuts/im/im_messages_mget.go
+++ b/shortcuts/im/im_messages_mget.go
@@ -66,10 +66,17 @@ var ImMessagesMGet = common.Shortcut{
 		rawItems, _ := data["items"].([]interface{})
 
 		nameCache := make(map[string]string)
+		// Pre-fetch merge_forward sub-messages concurrently before the per-item
+		// conversion loop, so N merge_forwards in the input don't serialize
+		// into N × ~1s of stall inside FormatMessageItem. Passing nameCache
+		// also pre-resolves every sub-item's sender open_id in one batched
+		// contact API call.
+		mergePrefetch := convertlib.PrefetchMergeForwardSubItems(runtime, rawItems, nameCache)
+
 		messages := make([]map[string]interface{}, 0, len(rawItems))
 		for _, item := range rawItems {
 			m, _ := item.(map[string]interface{})
-			messages = append(messages, convertlib.FormatMessageItem(m, runtime, nameCache))
+			messages = append(messages, convertlib.FormatMessageItemWithMergePrefetch(m, runtime, nameCache, mergePrefetch))
 		}
 
 		convertlib.ResolveSenderNames(runtime, messages, nameCache)

--- a/shortcuts/im/im_messages_search.go
+++ b/shortcuts/im/im_messages_search.go
@@ -159,13 +159,19 @@ var ImMessagesSearch = common.Shortcut{
 
 		// ── Step 4: Format message content + attach chat context ──
 		nameCache := make(map[string]string)
+		// Pre-fetch merge_forward sub-messages concurrently before the per-item
+		// conversion loop, so N merge_forwards in the search hits don't
+		// serialize into N × ~1s of stall inside FormatMessageItem. Passing
+		// nameCache also pre-resolves every sub-item's sender open_id in one
+		// batched contact API call.
+		mergePrefetch := convertlib.PrefetchMergeForwardSubItems(runtime, msgItems, nameCache)
 		enriched := make([]map[string]interface{}, 0, len(msgItems))
 		for _, item := range msgItems {
 			m, _ := item.(map[string]interface{})
 			chatId, _ := m["chat_id"].(string)
 
 			// Reuse unified content converter
-			msg := convertlib.FormatMessageItem(m, runtime, nameCache)
+			msg := convertlib.FormatMessageItemWithMergePrefetch(m, runtime, nameCache, mergePrefetch)
 			if chatId != "" {
 				msg["chat_id"] = chatId
 			}

--- a/shortcuts/im/im_threads_messages_list.go
+++ b/shortcuts/im/im_threads_messages_list.go
@@ -121,10 +121,17 @@ var ImThreadsMessagesList = common.Shortcut{
 		hasMore, nextPageToken := common.PaginationMeta(data)
 
 		nameCache := make(map[string]string)
+		// Pre-fetch merge_forward sub-messages concurrently before the per-item
+		// conversion loop. Thread replies that are themselves merge_forward
+		// messages would otherwise issue serial GETs inside FormatMessageItem.
+		// Passing nameCache also pre-resolves every sub-item's sender open_id
+		// in one batched contact API call.
+		mergePrefetch := convertlib.PrefetchMergeForwardSubItems(runtime, rawItems, nameCache)
+
 		messages := make([]map[string]interface{}, 0, len(rawItems))
 		for _, item := range rawItems {
 			m, _ := item.(map[string]interface{})
-			messages = append(messages, convertlib.FormatMessageItem(m, runtime, nameCache))
+			messages = append(messages, convertlib.FormatMessageItemWithMergePrefetch(m, runtime, nameCache, mergePrefetch))
 		}
 
 		// Enrich: resolve sender names for outer messages (reuses cache from merge_forward)

--- a/skills/lark-im/references/lark-im-message-enrichment.md
+++ b/skills/lark-im/references/lark-im-message-enrichment.md
@@ -4,9 +4,20 @@
 
 This is the single source of truth for the automatic message-enrichment contract shared by the four message-pulling shortcuts — [`+messages-mget`](lark-im-messages-mget.md), [`+chat-messages-list`](lark-im-chat-messages-list.md), [`+messages-search`](lark-im-messages-search.md), [`+threads-messages-list`](lark-im-threads-messages-list.md). They automatically attach `reactions` and `update_time` to each returned message, so callers do **not** need to invoke the raw [`im.reactions.batch_query`](lark-im-reactions.md) API separately.
 
-- **`reactions`** — populated from one batched `im.reactions.batch_query` call as `{counts, details}`. The field is only attached when the server actually returns data; messages with no reactions omit it. Replies inside `thread_replies` are enriched in the **same batched call** as their parent, so outer and inner messages follow identical semantics.
+- **`reactions`** — populated from `im.reactions.batch_query` as `{counts, details}`. The field is only attached when the server actually returns data; messages with no reactions omit it. Replies inside `thread_replies` are enriched alongside their parent (collected into the same id set), so outer and inner messages follow identical semantics. The id set is split into batches of <= 20 (server-side cap) and the batches are dispatched with bounded concurrency (up to 4 in flight), so high-N pulls — e.g. page 50 + ~500 expanded thread replies = 550 ids → ⌈550 / 20⌉ = **28 batches** — finish in a few round-trips instead of serializing into tens of seconds.
 - **`update_time`** — emitted only when `updated == true` (message was actually edited). The server echoes `update_time == create_time` for unedited messages too, but the CLI gates that output away so consumers don't misread every message as "edited".
 - **Opt-out** — each shortcut accepts `--no-reactions` to skip the extra round-trip when the caller only needs message bodies.
+
+## Thread replies expansion
+
+`+messages-mget` and `+chat-messages-list` also auto-expand thread replies: any returned message that carries a `thread_id` triggers a fetch of that thread's replies, which are attached as a `thread_replies` array on the host. Fetches across distinct threads run with bounded concurrency (up to 4 in flight). Two caps gate the result:
+
+- **`perThread` (default 50)** — max replies fetched for any single thread.
+- **`totalLimit` (default 500)** — max cumulative replies across all threads on the page.
+
+`totalLimit` is enforced **post-fetch against actual returned reply counts**, not against the planned per-thread ceiling — so a chat with many short threads (e.g. 12 threads × 3 actual replies = 36 ≪ 500) attaches every thread, even though the planned sum (12 × 50 = 600) would exceed the budget. When a thread's actual replies push the running total across `totalLimit`, that thread is truncated to fit the remaining budget and its host is flagged with `thread_has_more: true` so consumers know the server has more.
+
+On per-thread fetch failure the host gets `thread_replies_error: true` (mirrors the reactions data contract); budget-truncated or budget-skipped threads do NOT carry that flag.
 
 ## Scope requirement
 


### PR DESCRIPTION
## Summary

Follow-up to #1095. The reactions auto-enrichment shipped, but on busy chats the strictly-serial per-resource fetches in `EnrichReactions`, `ExpandThreadReplies`, and `merge_forward` expansion stretched the command's wall time above 14s — enough that wrapper agents (30–60s wall-clock budgets) saw timeouts even though the CLI itself never errored. This PR parallelizes all three with the same bounded-concurrency pattern, batches the follow-up contact-API sender resolution so it doesn't fan back out into a serial stall, and fixes two correctness bugs that surfaced during review. Scoped to `convert_lib/{reactions,thread,merge,content_convert}.go` + tests + the 4 shortcut Execute hooks + the reference doc.

## Changes

### 1. `EnrichReactions` — bounded-concurrency batches (cap = 4)

`im.reactions.batch_query` is server-capped at 20 queries[] per call. Batches now dispatch under bounded concurrency. Cap stays at **4** because this endpoint has an explicit gateway-layer rate limit (50/s + 1000/min).

**Safety invariant documented inline:** `collectMessageNodes` dedups ids on first-seen, so every batch sub-slice carries each id at most once. Different batches therefore operate on disjoint `idIndex` buckets → disjoint message-map pointers → no concurrent writes to the same map. Race detector verifies; `TestEnrichReactions_DuplicateMessageID` + `TestEnrichReactions_MultiBatchCorrectness` cover the round-trip.

### 2. `ExpandThreadReplies` — bounded-concurrency fetches (cap = 8) + batched sender resolution + correct `totalLimit` accounting

Two-phase: **Phase 1** plans every unique `thread_id` and concurrently fetches all of them. **Phase 2** is single-threaded: pre-fetch merge_forward sub-messages for thread replies, format, one batched `ResolveSenderNames` across every reply, attach.

**`totalLimit` correctness (regression fix):** an earlier draft deducted the **planned** per-thread ceiling (`perThread`, default 50) from `totalLimit` upfront, which silently dropped later threads in chats with many short threads. Concretely: 12 threads × 3 actual replies each = 36 total, but planned-ceiling accounting (12 × 50 = 600) would have exceeded the default `totalLimit=500` after just 10 threads and silently skipped the last two. New code budgets against **actual returned counts** post-fetch: threads past a fully-drained budget have their slice cleared to an empty (non-nil) slice so the attach loop leaves the host alone; threads whose count straddles the budget boundary get truncated with `thread_has_more` flagged. Empty-slice vs nil-slice is the discriminator between "budget-skipped (success)" and "fetch error (mark `thread_replies_error`)". Regression covered by `TestExpandThreadRepliesTotalLimitUsesActualCounts` and `TestExpandThreadRepliesTruncatesOnBudgetBoundary`. Cost: under budget overflow, threads beyond the boundary are still fetched then discarded — bounded by `perThread` records each, an acceptable price for not losing data silently.

### 3. merge_forward — shortcut-level concurrent prefetch (cap = 8) + batched sub-item sender resolution + error-masking fix + correct prefetch-failure fallback

The previous `Convert` issued one GET per merge_forward inline inside `FormatMessageItem` — N merge_forwards × ~1.7s serial (5 merge_forwards = ~8.5s, 67% of total `--no-reactions` wall time).

`PrefetchMergeForwardSubItems` now pre-scans `rawItems`, picks out merge_forward `message_id`s, and concurrently fetches each sub-tree. Threaded into `FormatMessageItem` via the new `FormatMessageItemWithMergePrefetch` variant + `ConvertContext.MergeForwardSubItems`. `Convert` checks the prefetch cache first; missing key falls through to the inline GET so non-shortcut callers (event subscribers, ad-hoc tests) keep working.

**Prefetch-failure handling (regression fix):** an earlier draft inserted `result[id] = nil` on failure, which made `Convert`'s `if cached, ok := m[id]; ok { renderTree(cached) }` path hit `ok=true, cached=nil` and emit an empty `<forwarded_messages>` tree — silently swallowing the user-visible `[Merged forward: fetch failed: ...]` string that the inline path used to produce. The new code **does not insert the key at all** on failure; `ok=false` triggers the inline-fetch slow path which (a) gets a second attempt at the GET, (b) if that also fails, produces the proper error string. Regression covered by `TestPrefetchMergeForwardSubItemsFailureFallsThroughToInlineFetch`.

**Critical perf refinement:** `PrefetchMergeForwardSubItems` also takes a `nameCache` and runs **one batched `ResolveSenderNames`** across every sub-item it fetched before returning. Without this, each per-merge_forward render in the loop would issue its own contact API request for any uncached sender — re-introducing an N × ~400ms serial stall (~2s extra in `FormatMessageItem`). Pre-populating the cache makes those per-render calls no-ops; the `FormatMessageItem` loop dropped from **~2.3s → ~2ms** on the same test chat.

Also: switched `fetchMergeForwardSubMessages` from low-level `runtime.DoAPI` to `runtime.DoAPIJSON`. The old path only checked for the presence of `data` in the body, so a real server error like `{"code": 2200, "msg": "Internal Error", ...}` was reported as a generic `"empty data"` string. `DoAPIJSON` surfaces the real `msg` (and `log_id`) — `[Merged forward: fetch failed: API error 2200: Internal Error]` instead.

### 4. Confirmed: `mget` cannot batch-expand merge_forward

Empirically verified — `GET /open-apis/im/v1/messages/mget` with 5 merge_forward IDs returns exactly 5 items (all `msg_type=merge_forward`, no children attached). The flat sub-tree only comes back from the per-id `GET /messages/{merge_forward_id}` endpoint, so concurrent per-id GETs is the best the Feishu API surface allows.

### Concurrency caps

| endpoint | cap | reasoning |
|---|---|---|
| `im.reactions.batch_query` | 4 | explicit gateway 50/s + 1000/min ceiling |
| `GET /messages` (thread expansion) | 8 | no published per-app rate-limit at these levels |
| `GET /messages/{id}` (merge_forward) | 8 | no published per-app rate-limit at these levels |

## Test Plan

- [x] Reactions: `TestEnrichReactions_BatchSize` made order-tolerant; new `TestEnrichReactions_MultiBatchCorrectness` (65 msgs → 4 batches, every msg correctly attributed).
- [x] Threads: pre-existing tests pass; new `TestExpandThreadRepliesMultiThreadConcurrent` (5 distinct thread roots, tagged-by-thread_id anti-contamination); new `TestExpandThreadRepliesTotalLimitUsesActualCounts` (12 short threads × 3 replies vs `totalLimit=100` — all 12 must attach); new `TestExpandThreadRepliesTruncatesOnBudgetBoundary` (3 threads × 4 replies vs `totalLimit=10` — third thread truncated to 2 + `thread_has_more=true`).
- [x] merge_forward: replaced single `"empty data"` test with `empty_data_treated_as_no_children` + `non-zero_code_surfaces_real_error` (regression for the code:2200 production bug); new `TestPrefetchMergeForwardSubItems` (mixed 5 merge_forwards + 2 non-merge_forwards, path-derived child tags defeat goroutine cross-contamination); new `TestPrefetchMergeForwardSubItemsFailureFallsThroughToInlineFetch` (regression for the silent-empty-tree bug — confirms failed ids are absent from the prefetch map AND `Convert` produces the proper error string via inline retry).
- [x] `go test -race -count=1 ./shortcuts/im/convert_lib/` clean.
- [x] `gofmt -l .` / `go vet ./...` clean.
- [x] Live test on a real group chat (page-size 50, 39 outer messages, 5 merge_forwards, 4 thread roots with 14 nested replies, 15 messages with reactions). Output correctness verified — all merge_forwards expanded, all thread roots resolved with replies attached, reactions populated where the server returned data, only the expected `reactions_partial_failed` warning on stderr.

### Wall-time, median of 3 runs

| variant | before this PR | this PR | delta |
|---|---|---|---|
| `reactions ON` | 15.6s | **8.1s** | **−7.5s (−48%)** |
| `--no-reactions` | 14.3s | **6.6s** | **−7.7s (−54%)** |

### Stage breakdown (one-off instrumentation, then reverted)

| stage | 14.3s baseline | 6.6s after |
|---|---|---|
| `GET /messages` | ~1.7s | ~1.7s |
| `PrefetchMergeForwardSubItems` (5 GETs + batched contact API) | — | ~2.5s |
| `FormatMessageItem` loop | **~8.5s** (5 × serial merge_forward + per-render contact) | **~2ms** |
| outer `ResolveSenderNames` + Attach | ~0.5s | ~0.5s |
| `ExpandThreadReplies` (4 thread GETs + per-thread contact) | ~4s | ~2.0s |

## Related Issues

- Follow-up to #1095 (initial reactions enrichment).
- Out of scope (separate follow-ups when needed):
  - Decoupling `--no-reactions` from the `im:message.reactions:read` scope pre-flight (currently required even when the flag opts out) — UX change, not perf.
  - Running `PrefetchMergeForwardSubItems` and `ExpandThreadReplies` in parallel (they're independent and currently sequential, adding ~1.5s of avoidable sequencing). Adds nameCache-locking complexity; defer until needed.
