### PR TITLE
perf(im): parallelize thread_replies fetches with bounded concurrency

### DIFF
--- a/shortcuts/im/convert_lib/thread.go
+++ b/shortcuts/im/convert_lib/thread.go
@@ -6,6 +6,7 @@ package convertlib
 import (
 	"fmt"
 	"net/http"
+	"sync"
 
 	"github.com/larksuite/cli/shortcuts/common"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -17,10 +18,45 @@ const ThreadRepliesPerThread = 50
 // ThreadRepliesTotalLimit is the default max total thread replies across all threads.
 const ThreadRepliesTotalLimit = 500
 
+// threadRepliesFetchConcurrency caps in-flight per-thread GET /messages calls
+// when expanding multiple threads in one shortcut invocation. Each call is a
+// per-thread RTT (~1s observed), so a strictly serial loop turns N=10 thread
+// roots into ~10s of latency — the same multiplier that motivated the
+// reactions enrichment fan-out. Capping at 4 keeps the burst well under the
+// gateway-layer per-method ceiling while removing the linear stall.
+const threadRepliesFetchConcurrency = 4
+
 // ExpandThreadReplies fetches and embeds thread replies for messages that contain a thread_id.
 // For each unique thread_id found in messages, it fetches up to perThread replies (asc order)
-// and attaches them as "thread_replies" on the message. Expansion stops once totalLimit
-// cumulative replies have been fetched. nameCache is the shared open_id→name map.
+// and attaches them as "thread_replies" on the first outer message that referenced that thread.
+// Expansion stops once totalLimit cumulative replies have been allocated across planned fetches.
+// nameCache is the shared open_id→name map.
+//
+// Implementation is two-phase:
+//
+//  1. Plan + concurrent fetch. Walk messages in order, allocate a per-thread
+//     fetch limit greedily from the remaining totalLimit budget; once budget
+//     is exhausted, later threads are skipped (matching the pre-existing
+//     totalLimit semantic). Then dispatch the planned fetches with bounded
+//     concurrency — each fetch only writes to its own result slot, no shared
+//     mutable state besides that slot.
+//
+//  2. Sequential attach. Walk the planned threads in their original order
+//     and, for each successful result, FormatMessageItem + ResolveSenderNames
+//     + AttachSenderNames the replies before attaching to the outer message.
+//     This phase stays single-threaded because ResolveSenderNames writes to
+//     the shared nameCache, and FormatMessageItem may trigger merge_forward
+//     expansion that also touches nameCache.
+//
+// Compared to the pre-existing strictly-serial implementation, this trades a
+// minor pessimism on totalLimit (the budget is allocated based on the
+// planned per-thread limit rather than the actual returned count, so threads
+// that come in under their limit don't free budget for later threads) for a
+// large parallelism win on HTTP RTT — the dominant cost on busy chats with
+// many thread roots. The semantic difference is documented; in the default
+// configuration (totalLimit=500, perThread=50) it only matters in chats with
+// >10 thread roots whose returned reply counts are well under 50, which is
+// unusual.
 func ExpandThreadReplies(runtime *common.RuntimeContext, messages []map[string]interface{}, nameCache map[string]string, perThread, totalLimit int) {
 	if runtime == nil {
 		return
@@ -35,52 +71,116 @@ func ExpandThreadReplies(runtime *common.RuntimeContext, messages []map[string]i
 		totalLimit = ThreadRepliesTotalLimit
 	}
 
-	totalFetched := 0
+	// Phase 1a: enumerate unique thread_ids in first-seen order and allocate
+	// per-thread limits from the running budget. The first outer message
+	// referencing a given thread_id is the host that will receive the
+	// thread_replies attachment, matching the pre-existing behavior where
+	// duplicates inherited nothing.
+	type plan struct {
+		threadID string
+		limit    int
+		host     map[string]interface{}
+	}
+	var plans []plan
 	seen := make(map[string]bool)
-
+	remaining := totalLimit
 	for _, msg := range messages {
-		if totalFetched >= totalLimit {
-			break
-		}
 		tid, _ := msg["thread_id"].(string)
 		if tid == "" || seen[tid] {
 			continue
 		}
+		if remaining <= 0 {
+			break
+		}
 		seen[tid] = true
-
 		limit := perThread
-		if remaining := totalLimit - totalFetched; limit > remaining {
+		if limit > remaining {
 			limit = remaining
 		}
+		plans = append(plans, plan{threadID: tid, limit: limit, host: msg})
+		remaining -= limit
+	}
+	if len(plans) == 0 {
+		return
+	}
 
-		rawReplies, hasMore, fetchErr := fetchThreadReplies(runtime, tid, limit)
-		if fetchErr != nil {
-			// Preserve the outer message while surfacing that thread expansion failed.
-			msg["thread_replies_error"] = true
-			continue
+	// Phase 1b: concurrent fetch. Each goroutine writes only to its own
+	// results[i] slot, so there is no shared mutable state besides that
+	// slot. The single-batch fast path skips goroutine setup for clarity
+	// and to keep "one thread root" behavior identical to the old code.
+	type result struct {
+		rawReplies []map[string]interface{}
+		hasMore    bool
+		err        error
+	}
+	results := make([]result, len(plans))
+	if len(plans) == 1 {
+		items, hasMore, err := fetchThreadReplies(runtime, plans[0].threadID, plans[0].limit)
+		results[0] = result{rawReplies: items, hasMore: hasMore, err: err}
+	} else {
+		sem := make(chan struct{}, threadRepliesFetchConcurrency)
+		var wg sync.WaitGroup
+		for i, p := range plans {
+			i, p := i, p
+			sem <- struct{}{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+				items, hasMore, err := fetchThreadReplies(runtime, p.threadID, p.limit)
+				results[i] = result{rawReplies: items, hasMore: hasMore, err: err}
+			}()
 		}
-		// Successful fetches always return a non-nil (possibly empty) slice.
-		// A nil slice indicates thread expansion did not complete.
-		if rawReplies == nil {
-			msg["thread_replies_error"] = true
-			continue
-		}
-		if len(rawReplies) == 0 {
-			continue
-		}
+		wg.Wait()
+	}
 
-		replies := make([]map[string]interface{}, 0, len(rawReplies))
-		for _, r := range rawReplies {
-			replies = append(replies, FormatMessageItem(r, runtime, nameCache))
+	// Phase 2a: format every plan's replies sequentially. FormatMessageItem
+	// may trigger a merge_forward sub-message GET (which writes to nameCache
+	// via its own ResolveSenderNames call), so this stays single-threaded —
+	// concurrent writes to nameCache would race.
+	preparedReplies := make([][]map[string]interface{}, len(plans))
+	for i, p := range plans {
+		r := results[i]
+		if r.err != nil || r.rawReplies == nil {
+			p.host["thread_replies_error"] = true
+			continue
 		}
-		ResolveSenderNames(runtime, replies, nameCache)
+		if len(r.rawReplies) == 0 {
+			continue
+		}
+		replies := make([]map[string]interface{}, 0, len(r.rawReplies))
+		for _, raw := range r.rawReplies {
+			replies = append(replies, FormatMessageItem(raw, runtime, nameCache))
+		}
+		preparedReplies[i] = replies
+	}
+
+	// Phase 2b: one batched ResolveSenderNames across all replies from all
+	// threads. The pre-existing per-thread call pattern would issue a fresh
+	// contact API request for every thread that introduced a new sender,
+	// turning N threads into up to N serial contact RTTs even after the
+	// fetches themselves went parallel. Consolidating into a single call
+	// resolves every still-missing open_id in one request and lets the
+	// nameCache absorb the rest.
+	var combined []map[string]interface{}
+	for _, replies := range preparedReplies {
+		combined = append(combined, replies...)
+	}
+	if len(combined) > 0 {
+		ResolveSenderNames(runtime, combined, nameCache)
+	}
+
+	// Phase 2c: attach the (now name-resolved) replies to their hosts.
+	for i, p := range plans {
+		replies := preparedReplies[i]
+		if replies == nil {
+			continue
+		}
 		AttachSenderNames(replies, nameCache)
-
-		msg["thread_replies"] = replies
-		if hasMore {
-			msg["thread_has_more"] = true
+		p.host["thread_replies"] = replies
+		if results[i].hasMore {
+			p.host["thread_has_more"] = true
 		}
-		totalFetched += len(rawReplies)
 	}
 }
 

--- a/shortcuts/im/convert_lib/thread_test.go
+++ b/shortcuts/im/convert_lib/thread_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -86,6 +87,79 @@ func TestFetchThreadRepliesError(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatalf("fetchThreadReplies() err = nil, want non-nil")
+	}
+}
+
+// TestExpandThreadRepliesMultiThreadConcurrent exercises the bounded-concurrency
+// multi-thread path: every distinct thread_id gets its own GET fetched in
+// parallel, and the right replies land on the right outer host (the *first*
+// outer message that referenced each thread_id). A race or cross-thread
+// result mix-up would manifest as missing / mis-attached replies.
+func TestExpandThreadRepliesMultiThreadConcurrent(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		callCount int
+	)
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/open-apis/im/v1/messages") {
+			return nil, fmt.Errorf("unexpected path: %s", req.URL.Path)
+		}
+		tid := req.URL.Query().Get("container_id")
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		// Return one synthetic reply per thread, tagged with the thread id so
+		// we can assert that the right replies landed on the right host.
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"has_more": false,
+				"items": []interface{}{
+					map[string]interface{}{
+						"message_id":  "om_reply_" + tid,
+						"msg_type":    "text",
+						"create_time": "1710500000",
+						"thread_id":   tid,
+						"sender":      map[string]interface{}{"name": "Sender"},
+						"body":        map[string]interface{}{"content": `{"text":"reply for ` + tid + `"}`},
+					},
+				},
+			},
+		}), nil
+	}))
+
+	// 5 distinct thread roots → 5 planned fetches, dispatched under the
+	// concurrency cap. Enough to actually exercise the bounded fan-out
+	// rather than degenerate to the single-thread fast path.
+	messages := []map[string]interface{}{
+		{"message_id": "om_root_1", "thread_id": "omt_a"},
+		{"message_id": "om_root_2", "thread_id": "omt_b"},
+		{"message_id": "om_root_3", "thread_id": "omt_c"},
+		{"message_id": "om_root_4", "thread_id": "omt_d"},
+		{"message_id": "om_root_5", "thread_id": "omt_e"},
+	}
+
+	ExpandThreadReplies(runtime, messages, map[string]string{}, 10, 500)
+
+	if callCount != 5 {
+		t.Fatalf("expected 5 thread fetches, got %d", callCount)
+	}
+	for i, m := range messages {
+		tid := m["thread_id"].(string)
+		replies, ok := m["thread_replies"].([]map[string]interface{})
+		if !ok {
+			t.Fatalf("message %d (thread %s) missing thread_replies: %#v", i, tid, m)
+		}
+		if len(replies) != 1 {
+			t.Fatalf("message %d (thread %s) replies len = %d, want 1", i, tid, len(replies))
+		}
+		// Each thread's reply was tagged with its own thread_id; verify no
+		// goroutine cross-contamination.
+		gotTid, _ := replies[0]["thread_id"].(string)
+		if gotTid != tid {
+			t.Fatalf("message %d (thread %s) got reply tagged with thread_id=%q — cross-thread contamination",
+				i, tid, gotTid)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`ExpandThreadReplies` previously issued a strictly-serial GET per unique `thread_id`. Each call is ~1s RTT, so chats with N thread roots paid an N×~1s stall before the main message output could render — the same latency-multiplier pattern that motivated #1146 (reactions). This PR parallelizes the per-thread fetches with the same bounded fan-out pattern and consolidates the follow-up sender-name resolution into a single batched contact API call. Scope is limited to `convert_lib/thread.go` + its test.

## Changes

- **Phase 1 — plan + concurrent fetch.** Walk messages in first-seen order to enumerate unique `thread_id`s and allocate a per-thread limit greedily from the remaining `totalLimit` budget (threads past the budget skip outright, preserving the existing semantic). Dispatch the planned `fetchThreadReplies` calls under bounded concurrency (cap = 4 in flight, same as the reactions PR). Each goroutine writes only to its own `results[i]` slot — no shared mutable state.
- **Phase 2 — sequential attach.** Stays single-threaded because `FormatMessageItem` may trigger a `merge_forward` sub-message GET that writes to the shared `nameCache`. Phase 2 is now split into three sub-steps:
  - 2a) `FormatMessageItem` each thread's raw replies.
  - 2b) **One** batched `ResolveSenderNames` across **all** prepared replies (was previously called once per thread, potentially firing a contact API request per thread that introduced a new sender).
  - 2c) `AttachSenderNames` + write `thread_replies` onto each plan's host outer message (the first message that referenced that `thread_id` — preserves existing duplicate handling).
- **Semantics preserved.** First outer message per `thread_id` is still the host. `totalLimit` budget honored (with a documented mild pessimism: budget is allocated based on the planned per-thread limit, not the actual returned count). `thread_replies_error: true` on fetch failure unchanged. `thread_has_more: true` propagated unchanged.

## Test Plan

- [x] All three pre-existing tests pass unchanged (`TestExpandThreadReplies`, `TestFetchThreadRepliesError`, `TestExpandThreadRepliesMarksFetchError`) — they exercise the single-thread fast path.
- [x] New `TestExpandThreadRepliesMultiThreadConcurrent`: 5 distinct thread roots → 5 planned fetches under the bounded fan-out. Each thread's reply is tagged with its own `thread_id` so a goroutine cross-contamination bug would manifest as mis-attached replies. Assertion verifies `callCount=5` and every host received the right reply.
- [x] `go test -race -count=1 ./shortcuts/im/convert_lib/` clean.
- [x] `gofmt -l .` / `go vet ./...` clean.
- [x] Live `lark-cli im +chat-messages-list --chat-id <oc_xxx> --page-size 50 --format json --as user --no-reactions` against a real group chat with 4 thread roots:

  | variant | `--no-reactions` median wall time |
  |---|---|
  | before (serial fetches) | 14.3s |
  | after (parallel + batched sender resolve) | **12.8s** |

  Modest delta on this specific chat (~1.5s) because only 4 thread roots → serial path was 4 × ~1s of which parallel saves ~3 of 4. Improvement scales linearly with thread-root count: a chat with 10 thread roots would save proportionally more.

## Related Issues

- Orthogonal to #1146 (reactions parallelization). The two optimizations compose: with both merged, a busy chat's `--no-reactions` wall time drops further than either alone.
- Out of scope here (separate follow-ups when needed): parallelizing `merge_forward` sub-message expansion, and fixing the `fetchMergeForwardSubMessages` error-masking bug (`code != 0` with `data: null` currently surfaces as a generic `"empty data"` error, hiding the real `code` / `msg` / `log_id`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized thread reply fetching with enhanced concurrency handling.

* **Bug Fixes**
  * Improved error handling for thread reply fetch failures.

* **Tests**
  * Added test coverage for concurrent multi-thread reply expansion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->