### PR TITLE
feat(core): support custom brands via extraBrands in config.json 

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -58,10 +58,11 @@ func (a *AppConfig) ProfileName() string {
 
 // MultiAppConfig is the multi-app config file format.
 type MultiAppConfig struct {
-	StrictMode  StrictMode  `json:"strictMode,omitempty"`
-	CurrentApp  string      `json:"currentApp,omitempty"`
-	PreviousApp string      `json:"previousApp,omitempty"`
-	Apps        []AppConfig `json:"apps"`
+	StrictMode  StrictMode             `json:"strictMode,omitempty"`
+	CurrentApp  string                 `json:"currentApp,omitempty"`
+	PreviousApp string                 `json:"previousApp,omitempty"`
+	ExtraBrands map[string]*Endpoints  `json:"extraBrands,omitempty"`
+	Apps        []AppConfig            `json:"apps"`
 }
 
 // CurrentAppConfig returns the currently active app config.
@@ -198,6 +199,9 @@ func LoadMultiAppConfig() (*MultiAppConfig, error) {
 	}
 	if len(multi.Apps) == 0 {
 		return nil, fmt.Errorf("invalid config format: no apps")
+	}
+	for name, ep := range multi.ExtraBrands {
+		RegisterBrand(name, *ep)
 	}
 	return &multi, nil
 }

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -201,7 +201,9 @@ func LoadMultiAppConfig() (*MultiAppConfig, error) {
 		return nil, fmt.Errorf("invalid config format: no apps")
 	}
 	for name, ep := range multi.ExtraBrands {
-		RegisterBrand(name, *ep)
+		if ep != nil {
+			RegisterBrand(name, *ep)
+		}
 	}
 	return &multi, nil
 }

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -30,24 +30,63 @@ type Endpoints struct {
 	AppLink  string // e.g. "https://applink.feishu.cn"
 }
 
+// brandRegistry maps brand names to their endpoint defaults.
+// Built-in brands (feishu, lark) are pre-registered via init.
+// Custom brands can be added via RegisterBrand.
+var brandRegistry = map[string]Endpoints{}
+
+func init() {
+	brandRegistry[string(BrandFeishu)] = Endpoints{
+		Open:     "https://open.feishu.cn",
+		Accounts: "https://accounts.feishu.cn",
+		MCP:      "https://mcp.feishu.cn",
+		AppLink:  "https://applink.feishu.cn",
+	}
+	brandRegistry[string(BrandLark)] = Endpoints{
+		Open:     "https://open.larksuite.com",
+		Accounts: "https://accounts.larksuite.com",
+		MCP:      "https://mcp.larksuite.com",
+		AppLink:  "https://applink.larksuite.com",
+	}
+}
+
+// RegisterBrand adds or updates a brand's endpoint defaults.
+// Partial overrides are merged on top of the "feishu" defaults.
+func RegisterBrand(name string, ep Endpoints) {
+	base := brandRegistry[string(BrandFeishu)]
+	if name == string(BrandLark) {
+		base = brandRegistry[string(BrandLark)]
+	}
+	brandRegistry[name] = MergeEndpointOverrides(base, &ep)
+}
+
+// MergeEndpointOverrides returns a copy of base with non-empty overrides applied.
+func MergeEndpointOverrides(base Endpoints, overrides *Endpoints) Endpoints {
+	if overrides == nil {
+		return base
+	}
+	result := base
+	if overrides.Open != "" {
+		result.Open = overrides.Open
+	}
+	if overrides.Accounts != "" {
+		result.Accounts = overrides.Accounts
+	}
+	if overrides.MCP != "" {
+		result.MCP = overrides.MCP
+	}
+	if overrides.AppLink != "" {
+		result.AppLink = overrides.AppLink
+	}
+	return result
+}
+
 // ResolveEndpoints resolves endpoint URLs based on brand.
 func ResolveEndpoints(brand LarkBrand) Endpoints {
-	switch brand {
-	case BrandLark:
-		return Endpoints{
-			Open:     "https://open.larksuite.com",
-			Accounts: "https://accounts.larksuite.com",
-			MCP:      "https://mcp.larksuite.com",
-			AppLink:  "https://applink.larksuite.com",
-		}
-	default:
-		return Endpoints{
-			Open:     "https://open.feishu.cn",
-			Accounts: "https://accounts.feishu.cn",
-			MCP:      "https://mcp.feishu.cn",
-			AppLink:  "https://applink.feishu.cn",
-		}
+	if ep, ok := brandRegistry[string(brand)]; ok {
+		return ep
 	}
+	return brandRegistry[string(BrandFeishu)]
 }
 
 // ResolveOpenBaseURL returns the Open API base URL for the given brand.

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -24,30 +24,69 @@ func ParseBrand(value string) LarkBrand {
 
 // Endpoints holds resolved endpoint URLs for different Lark services.
 type Endpoints struct {
-	Open     string // e.g. "https://open.feishu.cn"
-	Accounts string // e.g. "https://accounts.feishu.cn"
-	MCP      string // e.g. "https://mcp.feishu.cn"
-	AppLink  string // e.g. "https://applink.feishu.cn"
+	Open     string `json:"open"`     // e.g. "https://open.feishu.cn"
+	Accounts string `json:"accounts"` // e.g. "https://accounts.feishu.cn"
+	MCP      string `json:"mcp"`      // e.g. "https://mcp.feishu.cn"
+	AppLink  string `json:"applink"`  // e.g. "https://applink.feishu.cn"
+}
+
+// brandRegistry maps brand names to their endpoint defaults.
+// Built-in brands (feishu, lark) are pre-registered via init.
+// Custom brands can be added via RegisterBrand.
+var brandRegistry = map[string]Endpoints{}
+
+func init() {
+	brandRegistry[string(BrandFeishu)] = Endpoints{
+		Open:     "https://open.feishu.cn",
+		Accounts: "https://accounts.feishu.cn",
+		MCP:      "https://mcp.feishu.cn",
+		AppLink:  "https://applink.feishu.cn",
+	}
+	brandRegistry[string(BrandLark)] = Endpoints{
+		Open:     "https://open.larksuite.com",
+		Accounts: "https://accounts.larksuite.com",
+		MCP:      "https://mcp.larksuite.com",
+		AppLink:  "https://applink.larksuite.com",
+	}
+}
+
+// RegisterBrand adds or updates a brand's endpoint defaults.
+// Partial overrides are merged on top of the "feishu" defaults.
+func RegisterBrand(name string, ep Endpoints) {
+	base := brandRegistry[string(BrandFeishu)]
+	if name == string(BrandLark) {
+		base = brandRegistry[string(BrandLark)]
+	}
+	brandRegistry[name] = MergeEndpointOverrides(base, &ep)
+}
+
+// MergeEndpointOverrides returns a copy of base with non-empty overrides applied.
+func MergeEndpointOverrides(base Endpoints, overrides *Endpoints) Endpoints {
+	if overrides == nil {
+		return base
+	}
+	result := base
+	if overrides.Open != "" {
+		result.Open = overrides.Open
+	}
+	if overrides.Accounts != "" {
+		result.Accounts = overrides.Accounts
+	}
+	if overrides.MCP != "" {
+		result.MCP = overrides.MCP
+	}
+	if overrides.AppLink != "" {
+		result.AppLink = overrides.AppLink
+	}
+	return result
 }
 
 // ResolveEndpoints resolves endpoint URLs based on brand.
 func ResolveEndpoints(brand LarkBrand) Endpoints {
-	switch brand {
-	case BrandLark:
-		return Endpoints{
-			Open:     "https://open.larksuite.com",
-			Accounts: "https://accounts.larksuite.com",
-			MCP:      "https://mcp.larksuite.com",
-			AppLink:  "https://applink.larksuite.com",
-		}
-	default:
-		return Endpoints{
-			Open:     "https://open.feishu.cn",
-			Accounts: "https://accounts.feishu.cn",
-			MCP:      "https://mcp.feishu.cn",
-			AppLink:  "https://applink.feishu.cn",
-		}
+	if ep, ok := brandRegistry[string(brand)]; ok {
+		return ep
 	}
+	return brandRegistry[string(BrandFeishu)]
 }
 
 // ResolveOpenBaseURL returns the Open API base URL for the given brand.

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -50,64 +50,14 @@ func init() {
 	}
 }
 
-// RegisterBrand adds or updates a brand's endpoint defaults.
+// RegisterBrand adds or updates a custom brand's endpoint defaults.
 // Partial overrides are merged on top of the "feishu" defaults.
+// Built-in brands (feishu, lark) and empty names are silently ignored.
 func RegisterBrand(name string, ep Endpoints) {
+	if name == "" || name == string(BrandFeishu) || name == string(BrandLark) {
+		return
+	}
 	base := brandRegistry[string(BrandFeishu)]
-	if name == string(BrandLark) {
-		base = brandRegistry[string(BrandLark)]
-	}
-	brandRegistry[name] = MergeEndpointOverrides(base, &ep)
-}
-
-// MergeEndpointOverrides returns a copy of base with non-empty overrides applied.
-func MergeEndpointOverrides(base Endpoints, overrides *Endpoints) Endpoints {
-	if overrides == nil {
-		return base
-	}
-	result := base
-	if overrides.Open != "" {
-		result.Open = overrides.Open
-	}
-	if overrides.Accounts != "" {
-		result.Accounts = overrides.Accounts
-	}
-	if overrides.MCP != "" {
-		result.MCP = overrides.MCP
-	}
-	if overrides.AppLink != "" {
-		result.AppLink = overrides.AppLink
-	}
-	return result
-}
-
-// brandRegistry maps brand names to their endpoint defaults.
-// Built-in brands (feishu, lark) are pre-registered via init.
-// Custom brands can be added via RegisterBrand.
-var brandRegistry = map[string]Endpoints{}
-
-func init() {
-	brandRegistry[string(BrandFeishu)] = Endpoints{
-		Open:     "https://open.feishu.cn",
-		Accounts: "https://accounts.feishu.cn",
-		MCP:      "https://mcp.feishu.cn",
-		AppLink:  "https://applink.feishu.cn",
-	}
-	brandRegistry[string(BrandLark)] = Endpoints{
-		Open:     "https://open.larksuite.com",
-		Accounts: "https://accounts.larksuite.com",
-		MCP:      "https://mcp.larksuite.com",
-		AppLink:  "https://applink.larksuite.com",
-	}
-}
-
-// RegisterBrand adds or updates a brand's endpoint defaults.
-// Partial overrides are merged on top of the "feishu" defaults.
-func RegisterBrand(name string, ep Endpoints) {
-	base := brandRegistry[string(BrandFeishu)]
-	if name == string(BrandLark) {
-		base = brandRegistry[string(BrandLark)]
-	}
 	brandRegistry[name] = MergeEndpointOverrides(base, &ep)
 }
 

--- a/internal/core/types_test.go
+++ b/internal/core/types_test.go
@@ -52,3 +52,65 @@ func TestResolveOpenBaseURL(t *testing.T) {
 		t.Errorf("ResolveOpenBaseURL(lark) = %q", got)
 	}
 }
+
+func TestMergeEndpointOverrides(t *testing.T) {
+	base := Endpoints{
+		Open:     "https://open.feishu.cn",
+		Accounts: "https://accounts.feishu.cn",
+		MCP:      "https://mcp.feishu.cn",
+		AppLink:  "https://applink.feishu.cn",
+	}
+
+	t.Run("nil overrides returns base", func(t *testing.T) {
+		got := MergeEndpointOverrides(base, nil)
+		if got != base {
+			t.Errorf("got %v, want %v", got, base)
+		}
+	})
+
+	t.Run("partial override", func(t *testing.T) {
+		got := MergeEndpointOverrides(base, &Endpoints{Open: "https://proxy.example.com"})
+		if got.Open != "https://proxy.example.com" {
+			t.Errorf("Open = %q", got.Open)
+		}
+		if got.Accounts != "https://accounts.feishu.cn" {
+			t.Errorf("Accounts = %q, want unchanged", got.Accounts)
+		}
+	})
+
+	t.Run("full override", func(t *testing.T) {
+		overrides := Endpoints{
+			Open: "https://a.example.com", Accounts: "https://b.example.com",
+			MCP: "https://c.example.com", AppLink: "https://d.example.com",
+		}
+		got := MergeEndpointOverrides(base, &overrides)
+		if got != overrides {
+			t.Errorf("got %v, want %v", got, overrides)
+		}
+	})
+}
+
+func TestRegisterBrand(t *testing.T) {
+	RegisterBrand("staging", Endpoints{Open: "https://open-staging.feishu.cn"})
+	ep := ResolveEndpoints("staging")
+	if ep.Open != "https://open-staging.feishu.cn" {
+		t.Errorf("Open = %q, want staging URL", ep.Open)
+	}
+	if ep.Accounts != "https://accounts.feishu.cn" {
+		t.Errorf("Accounts = %q, want feishu default", ep.Accounts)
+	}
+}
+
+func TestRegisterBrand_Full(t *testing.T) {
+	RegisterBrand("proxy", Endpoints{
+		Open: "https://api-proxy.example.com", Accounts: "https://acct-proxy.example.com",
+		MCP: "https://mcp-proxy.example.com", AppLink: "https://applink-proxy.example.com",
+	})
+	ep := ResolveEndpoints("proxy")
+	if ep.Open != "https://api-proxy.example.com" {
+		t.Errorf("Open = %q", ep.Open)
+	}
+	if ep.Accounts != "https://acct-proxy.example.com" {
+		t.Errorf("Accounts = %q", ep.Accounts)
+	}
+}

--- a/internal/core/types_test.go
+++ b/internal/core/types_test.go
@@ -92,6 +92,8 @@ func TestMergeEndpointOverrides(t *testing.T) {
 
 func TestRegisterBrand(t *testing.T) {
 	RegisterBrand("staging", Endpoints{Open: "https://open-staging.feishu.cn"})
+	defer delete(brandRegistry, "staging")
+
 	ep := ResolveEndpoints("staging")
 	if ep.Open != "https://open-staging.feishu.cn" {
 		t.Errorf("Open = %q, want staging URL", ep.Open)
@@ -106,11 +108,27 @@ func TestRegisterBrand_Full(t *testing.T) {
 		Open: "https://api-proxy.example.com", Accounts: "https://acct-proxy.example.com",
 		MCP: "https://mcp-proxy.example.com", AppLink: "https://applink-proxy.example.com",
 	})
+	defer delete(brandRegistry, "proxy")
+
 	ep := ResolveEndpoints("proxy")
 	if ep.Open != "https://api-proxy.example.com" {
 		t.Errorf("Open = %q", ep.Open)
 	}
 	if ep.Accounts != "https://acct-proxy.example.com" {
 		t.Errorf("Accounts = %q", ep.Accounts)
+	}
+}
+
+func TestRegisterBrand_IgnoresBuiltIn(t *testing.T) {
+	original := brandRegistry[string(BrandFeishu)]
+	RegisterBrand("feishu", Endpoints{Open: "https://malicious.example.com"})
+	RegisterBrand("lark", Endpoints{Open: "https://malicious.example.com"})
+	RegisterBrand("", Endpoints{Open: "https://malicious.example.com"})
+
+	if brandRegistry[string(BrandFeishu)] != original {
+		t.Error("RegisterBrand should not overwrite built-in feishu brand")
+	}
+	if brandRegistry[string(BrandLark)].Open == "https://malicious.example.com" {
+		t.Error("RegisterBrand should not overwrite built-in lark brand")
 	}
 }


### PR DESCRIPTION
## Summary

  支持在 config.json 中通过 extraBrands 字段配置自定义brand（私有化部署），让 lark-cli 能够连接非
  feishu/lark 的自建飞书平台。

## Changes

  - internal/core/types.go: 重构 endpoint 解析为 registry 模式（brandRegistry + RegisterBrand +
  MergeEndpointOverrides），支持运行时注册自定义品牌；为 Endpoints 字段添加 json tag 修复反序列化问题
  - internal/core/config.go: LoadMultiAppConfig 加载配置时自动调用 RegisterBrand 注册 extraBrands
  中的自定义品牌
  - internal/core/types_test.go: 添加 RegisterBrand、MergeEndpointOverrides、ResolveEndpoints 的单元测试
  
## Usage

  在 `~/.lark-cli/config.json` 中添加 `extraBrands` 字段，设置自定义 endpoint base url。未指定的字段会自动继承 `feishu` 的默认值。

  ```json
  {

    "extraBrands": {
      "your-brand-name": {
        "open": "https://your-private-hosted-url",
        // "accounts": "",
        // "mcp": "",
        // "applink": "",
      }
    },
    "apps": [
      {
        "appId": "cli_xxx",
        "appSecret": "xxx",
        "brand": "your-brand-name"
      }
    ]
  }

  // brand 字段引用 extraBrands 中定义的 key，CLI 会自动使用该品牌对应的 endpoint 进行 API 调用。
  ```

## Test Plan

  - Unit tests pass (internal/core/types_test.go)
  - lark-cli doctor 验证自定义 brand 的 endpoint 正确解析

## Related Issues

  - Fixes #31
  - Fixes #14
  - Related: #167, #278, #73, #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure additional brand endpoints in app settings to add or override brand-specific service URLs for greater flexibility.

* **Tests**
  * Added unit tests covering endpoint merging, brand registration, and override behavior to ensure reliable endpoint resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->