### PR TITLE
fix(config): allow lark-channel bind source override

### DIFF
--- a/cmd/config/binder.go
+++ b/cmd/config/binder.go
@@ -389,10 +389,12 @@ func resolveHermesEnvPath() string {
 }
 
 // resolveLarkChannelConfigPath returns the path to lark-channel-bridge's
-// config.json. Mirrors the bridge's src/config/paths.ts which hardcodes
-// ~/.lark-channel/config.json with no env override — multi-instance is not
-// a supported scenario today.
+// source config. LARK_CHANNEL_CONFIG lets a host point bind at a projected
+// single-account config without changing lark-cli's target config directory.
 func resolveLarkChannelConfigPath() string {
+	if p := os.Getenv("LARK_CHANNEL_CONFIG"); strings.TrimSpace(p) != "" {
+		return expandHome(p)
+	}
 	home, err := vfs.UserHomeDir()
 	if err != nil || home == "" {
 		fmt.Fprintf(os.Stderr, "warning: unable to determine home directory: %v\n", err)

--- a/cmd/config/binder_test.go
+++ b/cmd/config/binder_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -172,4 +173,28 @@ func TestSelectCandidate_AppIDFlag_WinsOverTUI(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	assertCandidate(t, got, Candidate{AppID: "cli_b"})
+}
+
+func TestResolveLarkChannelConfigPath_Default(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("LARK_CHANNEL_CONFIG", "")
+
+	got := resolveLarkChannelConfigPath()
+	want := filepath.Join(home, ".lark-channel", "config.json")
+	if got != want {
+		t.Fatalf("resolveLarkChannelConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveLarkChannelConfigPath_EnvOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("LARK_CHANNEL_CONFIG", "~/bridge/projection.json")
+
+	got := resolveLarkChannelConfigPath()
+	want := filepath.Join(home, "bridge", "projection.json")
+	if got != want {
+		t.Fatalf("resolveLarkChannelConfigPath() = %q, want %q", got, want)
+	}
 }


### PR DESCRIPTION
## Summary

Allow `lark-cli config bind --source lark-channel` to read the lark-channel source config from `LARK_CHANNEL_CONFIG` when provided, while keeping the existing `~/.lark-channel/config.json` default unchanged.

## Changes

- Add `LARK_CHANNEL_CONFIG` support to lark-channel bind source path resolution.
- Preserve the existing default path behavior when the env var is unset or empty.
- Add tests for both default path resolution and env override with `~` expansion.

## Test Plan

- [x] `go test ./cmd/config ./internal/binding`
- [x] `make build`
- [x] `git diff --check`

## Related Issues

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Lark channel config path can now be configured using the `LARK_CHANNEL_CONFIG` environment variable with tilde expansion support.

* **Tests**
  * Added comprehensive test coverage for config path resolution with default and environment override scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->