### PR TITLE
feat: unconditionally inject --format flag for all shortcuts

### DIFF
--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -842,9 +842,7 @@ func newRuntimeContext(cmd *cobra.Command, f *cmdutil.Factory, s *Shortcut, conf
 	}
 	rctx.larkSDK = sdk
 
-	if s.HasFormat {
-		rctx.Format = rctx.Str("format")
-	}
+	rctx.Format = rctx.Str("format")
 	rctx.JqExpr, _ = cmd.Flags().GetString("jq")
 	return rctx, nil
 }
@@ -1008,17 +1006,15 @@ func registerShortcutFlagsWithContext(ctx context.Context, cmd *cobra.Command, f
 	}
 
 	cmd.Flags().Bool("dry-run", false, "print request without executing")
-	if s.HasFormat {
+	if cmd.Flags().Lookup("format") == nil {
 		cmd.Flags().String("format", "json", "output format: json (default) | pretty | table | ndjson | csv")
+		cmdutil.RegisterFlagCompletion(cmd, "format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return []string{"json", "pretty", "table", "ndjson", "csv"}, cobra.ShellCompDirectiveNoFileComp
+		})
 	}
 	if s.Risk == "high-risk-write" {
 		cmd.Flags().Bool("yes", false, "confirm high-risk operation")
 	}
 	cmd.Flags().StringP("jq", "q", "", "jq expression to filter JSON output")
 	cmdutil.AddShortcutIdentityFlag(ctx, cmd, f, s.AuthTypes)
-	if s.HasFormat {
-		cmdutil.RegisterFlagCompletion(cmd, "format", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
-			return []string{"json", "pretty", "table", "ndjson", "csv"}, cobra.ShellCompDirectiveNoFileComp
-		})
-	}
 }

--- a/shortcuts/common/runner_format_universal_test.go
+++ b/shortcuts/common/runner_format_universal_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+// TestShortcutMount_FormatFlagAlwaysRegistered verifies that --format is
+// injected for every shortcut regardless of the HasFormat field value.
+func TestShortcutMount_FormatFlagAlwaysRegistered(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	parent := &cobra.Command{Use: "root"}
+	shortcut := Shortcut{
+		Service:     "im",
+		Command:     "+message-send",
+		Description: "send message",
+		HasFormat:   false, // explicitly false — format must still be registered
+		Execute:     func(context.Context, *RuntimeContext) error { return nil },
+	}
+	shortcut.Mount(parent, f)
+
+	cmd, _, err := parent.Find([]string{"+message-send"})
+	if err != nil {
+		t.Fatalf("Find() error = %v", err)
+	}
+	flag := cmd.Flags().Lookup("format")
+	if flag == nil {
+		t.Fatal("--format flag not registered; expected it to be injected even when HasFormat is false")
+	}
+	if flag.DefValue != "json" {
+		t.Errorf("--format default = %q, want %q", flag.DefValue, "json")
+	}
+}

--- a/shortcuts/common/runner_format_universal_test.go
+++ b/shortcuts/common/runner_format_universal_test.go
@@ -14,7 +14,6 @@ import (
 // TestShortcutMount_FormatFlagAlwaysRegistered verifies that --format is
 // injected for every shortcut regardless of the HasFormat field value.
 func TestShortcutMount_FormatFlagAlwaysRegistered(t *testing.T) {
-	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	f, _, _, _ := cmdutil.TestFactory(t, nil)
 	parent := &cobra.Command{Use: "root"}
 	shortcut := Shortcut{

--- a/shortcuts/common/runner_format_universal_test.go
+++ b/shortcuts/common/runner_format_universal_test.go
@@ -14,6 +14,7 @@ import (
 // TestShortcutMount_FormatFlagAlwaysRegistered verifies that --format is
 // injected for every shortcut regardless of the HasFormat field value.
 func TestShortcutMount_FormatFlagAlwaysRegistered(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	f, _, _, _ := cmdutil.TestFactory(t, nil)
 	parent := &cobra.Command{Use: "root"}
 	shortcut := Shortcut{

--- a/shortcuts/common/types.go
+++ b/shortcuts/common/types.go
@@ -49,7 +49,7 @@ type Shortcut struct {
 	// Declarative fields (new framework).
 	AuthTypes []string // supported identities: "user", "bot" (default: ["user"])
 	Flags     []Flag   // flag definitions; --dry-run is auto-injected
-	HasFormat bool     // auto-inject --format flag (json|pretty|table|ndjson|csv)
+	HasFormat bool     // Deprecated: --format is now always injected; this field has no effect.
 	Tips      []string // optional tips shown in --help output
 	Hidden    bool     // hide from --help / tab completion (still executable); use when deprecating a command in favor of a replacement
 


### PR DESCRIPTION
## Summary

`--format` flag was only injected for shortcuts that explicitly set `HasFormat: true`, leaving ~190 shortcuts without output format control. This PR removes the three `HasFormat` guards in `runner.go` so every shortcut gets `--format` unconditionally. Shortcuts that already define a custom `format` flag in `Flags[]` (e.g. `mail +triage`, `mail +watch`) are skipped via `Lookup("format") == nil` to avoid redefinition panics. `HasFormat` is retained in the struct but marked deprecated.

## Changes

- `shortcuts/common/runner.go`: remove three `if s.HasFormat` guards; add `cmd.Flags().Lookup("format") == nil` check before auto-injection to skip shortcuts with custom format flags
- `shortcuts/common/types.go`: mark `HasFormat` field as `Deprecated:`
- `shortcuts/common/runner_format_universal_test.go` (new): verify `HasFormat: false` shortcut still receives `--format` after mount

## Test Plan

- [x] `make unit-test` passed
- [x] validate passed (build / vet / unit / integration all green)
- [x] local-eval passed (E2E N/A lite mode, skillave N/A)
- [x] acceptance-reviewer passed (2/2 cases)
- [x] manual verification: `lark-cli calendar +rsvp --help` — `--format` now present; `lark-cli calendar +agenda --format table --dry-run` — no regression

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `--format` flag is now universally available for all shortcuts, defaulting to "json" for consistent output.

* **Tests**
  * Added a test that verifies the `--format` flag is always registered regardless of shortcut configuration.

* **Documentation**
  * Marked the per-shortcut "HasFormat" indicator as deprecated since it no longer affects flag injection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1156?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->