### PR TITLE
docs(sheets): three SKILL-entry refinements derived from eval traces

### DIFF
--- a/skills/lark-sheets/SKILL.md
+++ b/skills/lark-sheets/SKILL.md
@@ -81,6 +81,7 @@ metadata:
    - ⚠️ **`/wiki/` 知识库链接不能直接当表格定位用**：wiki 链接背后可能是电子表格，也可能是文档 / 多维表格等其它类型，`--url` **不会**自动把 wiki token 解析成 spreadsheet token，直接传会失败。必须先把它解析成真实文档 token —— `lark-cli wiki +node-get --node-token "<wiki 链接或 token>"`，确认返回的 `obj_type` 为 `sheet` 后，取其 `obj_token` 作为 `--spreadsheet-token` 传入（解析细节见 [`../lark-wiki/SKILL.md`](../lark-wiki/SKILL.md)）。
    - **例外**：`+workbook-create` 是新建一个还不存在的表格，**不接受任何 spreadsheet / sheet 定位 flag**（只有 `--title` / `--folder-token` / `--headers` / `--values`）。
 2. **sheet 定位（公共四件套 shortcut 必填）**：`--sheet-id` 与 `--sheet-name` 二选一，**必须给其中之一**。两个都不给 → 校验报错 `specify at least one of --sheet-id or --sheet-name`。
+   - ⚠️ **不确定 sheet 名时禁止直接猜 `Sheet1`**：除非用户对话明确说出 sheet 名 / id，或上下文（之前的工具调用 / URL 锚点 `?sheet=xxx`）已经出现过具体值，否则**第一步先调 `+workbook-info --url "..."`**（或 `--spreadsheet-token`）拿 `sheets[].sheet_id` / `sheets[].title` 列表再选。中文环境下子表常叫"数据" / "Sheet"（无数字）/ "工作表 1" / 业务名，猜 `Sheet1` 大概率撞 `sheet not found`，比先查多耗一次失败调用 + 重试。
    - ⚠️ **`--range` 里的 `Sheet1!` 前缀不能替代 sheet 定位**：即使写了 `--range "'Sheet1'!A1:B2"`，仍**必须**额外传 `--sheet-id` 或 `--sheet-name`，否则照样报上面的错。
    - **例外**：徽章标为 `_公共：URL/token（无 sheet 定位）…_` 的 shortcut（如 `+workbook-info` / `+workbook-export` / `+batch-update` / `+dropdown-get|update|delete` / `+cells-batch-set-style` / `+cells-batch-clear` / `+sheet-create`）**不接受也不需要** sheet 定位，只给一组 spreadsheet 定位即可。`+pivot-create` 用 `--target-sheet-id` / `--target-sheet-name`（XOR，可都不传，落点细节见 `lark-sheets-pivot-table`）。
 
@@ -95,9 +96,10 @@ metadata:
 
 ```bash
 lark-cli sheets <shortcut> <workbook 定位> <sheet 定位> <其它 flag>
-#   workbook 定位：--url "..."        或 --spreadsheet-token "..."   （二选一，必给）
-#   sheet 定位：    --sheet-id "$SID"  或 --sheet-name "Sheet1"        （二选一，必给）
-# 例：lark-cli sheets +csv-get --url "https://.../sheets/shtXXX" --sheet-name "Sheet1" --range "A1:F30"
+#   workbook 定位：--url "..."        或 --spreadsheet-token "..."           （二选一，必给）
+#   sheet 定位：    --sheet-id "$SID"  或 --sheet-name "<真实表名>"            （二选一，必给；占位符不要原样填）
+# 例：lark-cli sheets +csv-get --url "https://.../sheets/shtXXX" --sheet-name "<真实表名>" --range "A1:F30"
+# 注意：真实表名不要直接填 "Sheet1"——大多数表的子表不叫这个；先 +workbook-info 拿 sheets[].title 再代入。
 ```
 
 ### 系统 flag

--- a/skills/lark-sheets/SKILL.md
+++ b/skills/lark-sheets/SKILL.md
@@ -82,7 +82,8 @@ metadata:
    - **例外**：`+workbook-create` 是新建一个还不存在的表格，**不接受任何 spreadsheet / sheet 定位 flag**（只有 `--title` / `--folder-token` / `--headers` / `--values`）。
 2. **sheet 定位（公共四件套 shortcut 必填）**：`--sheet-id` 与 `--sheet-name` 二选一，**必须给其中之一**。两个都不给 → 校验报错 `specify at least one of --sheet-id or --sheet-name`。
    - ⚠️ **不确定 sheet 名时禁止直接猜 `Sheet1`**：除非用户对话明确说出 sheet 名 / id，或上下文（之前的工具调用 / URL 锚点 `?sheet=xxx`）已经出现过具体值，否则**第一步先调 `+workbook-info --url "..."`**（或 `--spreadsheet-token`）拿 `sheets[].sheet_id` / `sheets[].title` 列表再选。中文环境下子表常叫"数据" / "Sheet"（无数字）/ "工作表 1" / 业务名，猜 `Sheet1` 大概率撞 `sheet not found`，比先查多耗一次失败调用 + 重试。
-   - ⚠️ **`--range` 里的 `Sheet1!` 前缀不能替代 sheet 定位**：即使写了 `--range "'Sheet1'!A1:B2"`，仍**必须**额外传 `--sheet-id` 或 `--sheet-name`，否则照样报上面的错。
+   - ⚠️ **`--range` 里的 `Sheet1!` 前缀不能替代 sheet 定位**：即使写了 `--range 'Sheet1!A1:B2'`，仍**必须**额外传 `--sheet-id` 或 `--sheet-name`，否则照样报上面的错。
+   - ⚠️ **A1 reference 含 `!`**（`--source` / `--range` / `--ranges`）**：shell session 起手先 `set +H`** 关 bash history expansion，否则 `"Sheet1!A1"` 会被拦成 `event not found`；含特殊字符（`-` / 空格 / 非 ASCII）的 sheet 名还要内部 single-quote 包，如 `--source "'Sales-2025'!A1:D100"`。
    - **例外**：徽章标为 `_公共：URL/token（无 sheet 定位）…_` 的 shortcut（如 `+workbook-info` / `+workbook-export` / `+batch-update` / `+dropdown-get|update|delete` / `+cells-batch-set-style` / `+cells-batch-clear` / `+sheet-create`）**不接受也不需要** sheet 定位，只给一组 spreadsheet 定位即可。`+pivot-create` 用 `--target-sheet-id` / `--target-sheet-name`（XOR，可都不传，落点细节见 `lark-sheets-pivot-table`）。
 
 | Flag | Type | 必填 | 说明 |


### PR DESCRIPTION
## Summary

Evaluation traces from the doubao sheets eval set surfaced three recurring failure patterns whose root cause traced back to the SKILL.md entry doc. This PR addresses all three.

## Problems

1. **Agent guesses `Sheet1` and hits `sheet not found`** — 6 of 12 tasks tripped on this. The skill entry only said `--sheet-id` / `--sheet-name` is required, never how to obtain it when unknown; the 统一调用范式 example using `--sheet-name "Sheet1"` reinforced the wrong baseline.
2. **Two truncation layers conflated** — the read-data reference lumped server-side `--max-chars` truncation and runtime stdout truncation together and mentioned a `truncated` envelope field that does not exist, so the agent could not tell which envelope signals were trustworthy or when it had to fall back to `annotated_csv` row markers.
3. **A1 references containing `!` hit bash history expansion** — `--source "Sheet1!A1"` in an interactive bash (the agent's sandbox) gets lexed as `!A1` history expansion and fails before lark-cli sees it.

## Changes

Three commits, all generated from upstream sheet-skill-spec:

- `e3eca66` — `skills/lark-sheets/SKILL.md`: new rule under sheet-locator section telling the agent to call `+workbook-info` to fetch `sheets[].sheet_id` / `sheets[].title` when sheet identity is not already in context. The 统一调用范式 example switches `--sheet-name "Sheet1"` → `<真实表名>` so the example stops suggesting `Sheet1` is a sensible default.
- `f8f6772` — `skills/lark-sheets/references/lark-sheets-read-data.md`: drop the non-existent `truncated` field; new section distinguishing server-side `--max-chars` truncation (envelope flags `has_more=true`, narrows `actual_range`, sets `warning_message`) from runtime stdout truncation (envelope intact, stdout cut mid-stream — only reliable detection is `annotated_csv` ending `[row=N]` matching the requested `--range` last row). Recommends `≤ 50 rows × ≤ 30 cols` per batch as a safe baseline.
- `cb1aa4d` — `skills/lark-sheets/SKILL.md`: another sheet-locator rule for A1 references containing `!`. The agent should run `set +H` at the start of the bash session to disable history expansion; for sheet names containing hyphens / spaces / non-ASCII chars, also wrap the sheet name in single quotes per A1 notation (`--source "'Sales-2025'!A1:D100"`).

## Test plan

- [ ] Manual: ask the agent to operate on a workbook whose first sub-sheet is not named `Sheet1`; confirm it calls `+workbook-info` first
- [ ] Manual: ask the agent to `+pivot-create` against a sheet name containing a hyphen; confirm it adds `set +H` and wraps the sheet name in A1 single quotes
- [ ] Manual: ask the agent to read a workbook large enough to trip runtime stdout truncation; confirm it cross-checks the `annotated_csv` last `[row=N]` against the requested `--range`
- [x] `npm run check:cli` passes in sheet-skill-spec
- [x] End-to-end bash histexpand verification on PPE: interactive bash + `set +H` + `--source "'Sales-2025'!A1:C5"` actually creates a pivot object
- [x] Synced from sheet-skill-spec; corresponding spec MR at code.byted.org/ee/sheet-skill-spec/merge_requests/17