### PR TITLE
fix: prevent silent exits on error (#1139) and fix whiteboard API encoding (#1155)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -214,7 +214,15 @@ func configureFlagCompletions(args []string) {
 //     per-domain typed migration in stage 2+.
 //  4. Cobra errors (required flags, unknown commands, etc.): plain text.
 func handleRootError(f *cmdutil.Factory, err error) int {
-	errOut := f.IOStreams.ErrOut
+	// Defensive: f or its IOStreams may be nil in exceptional situations
+	// (e.g. early bootstrap failure, plugin corruption). Guarantee stderr
+	// is always a valid writer so diagnostics are never swallowed.
+	var errOut io.Writer
+	if f != nil && f.IOStreams != nil && f.IOStreams.ErrOut != nil {
+		errOut = f.IOStreams.ErrOut
+	} else {
+		errOut = os.Stderr
+	}
 
 	// SecurityPolicyError keeps the legacy custom envelope (string codes,
 	// challenge_url, retryable) and exit code 1 — its wire shape predates the

--- a/internal/client/encoding.go
+++ b/internal/client/encoding.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package client
+
+import (
+	"bytes"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/unicode"
+)
+
+// autoDecodeBody attempts to detect and convert non-UTF-8 response bodies to
+// valid UTF-8. Some Lark APIs (e.g. whiteboard) occasionally return JSON with
+// Chinese characters in encodings other than UTF-8 despite the Content-Type
+// header claiming otherwise. See https://github.com/larksuite/cli/issues/1155
+func autoDecodeBody(body []byte) []byte {
+	// Fast path: already valid UTF-8 (common case).
+	if utf8.Valid(body) {
+		return body
+	}
+
+	// Strip UTF-8 BOM if present.
+	body = bytes.TrimPrefix(body, unicode.UTF8BOM)
+
+	// Try encodings in order of likelihood for Lark/Feishu APIs.
+	candidates := []struct {
+		enc encoding.Encoding
+		name string
+	}{
+		{simplifiedchinese.GBK, "GBK"},
+		{simplifiedchinese.GB18030, "GB18030"},
+		{simplifiedchinese.HZGB2312, "HZ-GB2312"},
+	}
+
+	for _, c := range candidates {
+		if decoded, err := c.enc.NewDecoder().Bytes(body); err == nil && utf8.Valid(decoded) {
+			return decoded
+		}
+	}
+
+	// Return original unchanged if no conversion succeeded.
+	return body
+}

--- a/internal/client/response.go
+++ b/internal/client/response.go
@@ -136,12 +136,15 @@ func IsJSONContentType(ct string) bool {
 
 // ParseJSONResponse decodes a raw SDK response body as JSON.
 // CallAPI and HandleResponse both delegate to this function.
+// It automatically detects and converts non-UTF-8 encodings (e.g. GBK) that
+// some APIs return despite claiming UTF-8 in the Content-Type header.
 func ParseJSONResponse(resp *larkcore.ApiResp) (interface{}, error) {
+	body := autoDecodeBody(resp.RawBody)
 	var result interface{}
-	dec := json.NewDecoder(bytes.NewReader(resp.RawBody))
+	dec := json.NewDecoder(bytes.NewReader(body))
 	dec.UseNumber()
 	if err := dec.Decode(&result); err != nil {
-		return nil, fmt.Errorf("response parse error: %w (body: %s)", err, util.TruncateStr(string(resp.RawBody), 500))
+		return nil, fmt.Errorf("response parse error: %w (body: %s)", err, util.TruncateStr(string(body), 500))
 	}
 	return result, nil
 }

--- a/internal/output/errors.go
+++ b/internal/output/errors.go
@@ -72,6 +72,13 @@ func MarkRaw(err error) error {
 // to the typed surface.
 func WriteErrorEnvelope(w io.Writer, err *ExitError, identity string) {
 	if err.Detail == nil {
+		// Even without structured detail, emit a minimal envelope so callers
+		// never see a completely empty stderr (https://github.com/larksuite/cli/issues/1139).
+		msg := err.Error()
+		if msg == "" {
+			msg = fmt.Sprintf("exit %d", err.Code)
+		}
+		fmt.Fprintf(w, `{"ok":false,"identity":%q,"error":{"type":"internal","message":%q}}`+"\n", identity, msg)
 		return
 	}
 	env := &ErrorEnvelope{

--- a/main.go
+++ b/main.go
@@ -5,7 +5,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/larksuite/cli/cmd"
 
@@ -13,5 +15,15 @@ import (
 )
 
 func main() {
+	// Recover from any unhandled panics to ensure stderr always receives
+	// diagnostics instead of crashing silently (especially in automation/
+	// CI contexts where a panic without stack trace looks like exit 1 with
+	// empty stdout/stderr). See https://github.com/larksuite/cli/issues/1139
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, "panic: %v\n%s\n", r, debug.Stack())
+			os.Exit(1)
+		}
+	}()
 	os.Exit(cmd.Execute())
 }


### PR DESCRIPTION
This PR addresses two reported issues:

## 1. Fix silent exit with empty stderr (#1139)

When `lark-cli` fails in certain conditions (large `--data` payload, keychain session conflict), it exits with code 1 but produces absolutely no output — stdout and stderr are both empty. This makes it impossible to diagnose the root cause in automated/scripted contexts.

### Changes:
- **main.go**: Add panic recovery to print diagnostics to stderr instead of crashing silently (especially affects automation/CI contexts where a panic without stack trace looks like exit 1 with empty stdout/stderr).
- **cmd/root.go**: Add defensive nil-checks in `handleRootError()` to guarantee a valid stderr writer even when `Factory`/`IOStreams` are unexpectedly nil.
- **internal/output/errors.go**: `WriteErrorEnvelope()` now emits a minimal JSON envelope when `ExitError.Detail` is nil, preventing completely empty stderr.

## 2. Fix Chinese character encoding in whiteboard API (#1155)

When fetching whiteboard node data via API, Chinese characters in the JSON response display as garbled text (e.g. "高" shows as "Ú«ÿ").

### Changes:
- **internal/client/encoding.go** (new): Add `autoDecodeBody()` to detect and convert non-UTF-8 response bodies (GBK, GB18030, HZ-GB2312) that some Lark APIs return despite Content-Type claiming UTF-8.
- **internal/client/response.go**: Integrate encoding auto-detection into `ParseJSONResponse()`.

---

Fixes #1139
Fixes #1155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error output handling during exceptional failures to prevent diagnostics from being lost
  * Added automatic encoding detection for response bodies, enabling support for international character sets
  * Enhanced error message reporting for legacy error types with missing details
  * Implemented panic recovery to gracefully handle and report unexpected runtime failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->