### PR TITLE
fix(im): correct 64-bit MP4 box size handling to prevent panic on crafted media

### DIFF
--- a/shortcuts/im/helpers.go
+++ b/shortcuts/im/helpers.go
@@ -543,7 +543,17 @@ func findMP4Box(data []byte, start, end int, boxType string) (int, int) {
 			if offset+16 > end {
 				return -1, -1
 			}
-			boxEnd = int(binary.BigEndian.Uint64(data[offset+8:]))
+			// 64-bit "largesize" is the whole box length including its 16-byte
+			// header, so the box ends at offset+largesize (mirroring the
+			// offset+size used for 32-bit boxes below). Reject sizes that do not
+			// fit the search window; this also rejects values that would
+			// overflow int and drive boxEnd negative (CWE-190), which would
+			// otherwise index data out of range and panic.
+			largesize := binary.BigEndian.Uint64(data[offset+8:])
+			if largesize < 16 || largesize > uint64(end-offset) {
+				return -1, -1
+			}
+			boxEnd = offset + int(largesize)
 			dataStart = offset + 16
 		default:
 			if size < 8 {
@@ -688,7 +698,16 @@ func readMp4DurationBytes(data []byte) int64 {
 			if offset+16 > fileSize {
 				return 0
 			}
-			boxEnd = int64(binary.BigEndian.Uint64(data[offset+8 : offset+16]))
+			// 64-bit "largesize" is the whole box length including its 16-byte
+			// header, so the box ends at offset+largesize (mirroring offset+size
+			// for 32-bit boxes). Reject sizes that do not fit the file; this also
+			// rejects values that would overflow int64 and drive boxEnd negative
+			// (CWE-190), which would otherwise index data out of range and panic.
+			largesize := binary.BigEndian.Uint64(data[offset+8 : offset+16])
+			if largesize < 16 || largesize > uint64(fileSize-offset) {
+				return 0
+			}
+			boxEnd = offset + int64(largesize)
 			dataStart = offset + 16
 		case size < 8:
 			return 0
@@ -749,7 +768,16 @@ func readMp4Duration(f fileio.File, fileSize int64) int64 {
 			if _, err := f.ReadAt(hdr[8:16], offset+8); err != nil {
 				return 0
 			}
-			boxEnd = int64(binary.BigEndian.Uint64(hdr[8:16]))
+			// 64-bit "largesize" is the whole box length including its 16-byte
+			// header, so the box ends at offset+largesize (mirroring offset+size
+			// for 32-bit boxes). Reject sizes that do not fit the file; this also
+			// rejects values that would overflow int64 and drive boxEnd negative
+			// (CWE-190).
+			largesize := binary.BigEndian.Uint64(hdr[8:16])
+			if largesize < 16 || largesize > uint64(fileSize-offset) {
+				return 0
+			}
+			boxEnd = offset + int64(largesize)
 			dataStart = offset + 16
 		case size < 8:
 			return 0

--- a/shortcuts/im/mp4_box_test.go
+++ b/shortcuts/im/mp4_box_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// build64BitBox builds an ISO-BMFF box using the 64-bit "largesize" form: the
+// 32-bit size field is set to 1 and an 8-byte largesize follows the 4-byte box
+// type. largesize is the total box length including the 16-byte header.
+func build64BitBox(boxType string, largesize uint64, payload []byte) []byte {
+	box := make([]byte, 16+len(payload))
+	binary.BigEndian.PutUint32(box[0:4], 1) // size == 1 → 64-bit largesize follows
+	copy(box[4:8], boxType)
+	binary.BigEndian.PutUint64(box[8:16], largesize)
+	copy(box[16:], payload)
+	return box
+}
+
+// build32BitBox builds an ISO-BMFF box using the ordinary 32-bit size form.
+func build32BitBox(boxType string, payload []byte) []byte {
+	box := make([]byte, 8+len(payload))
+	binary.BigEndian.PutUint32(box[0:4], uint32(len(box)))
+	copy(box[4:8], boxType)
+	copy(box[8:], payload)
+	return box
+}
+
+// TestMP4BoxLargeSizeOverflowNoPanic guards the 64-bit box-size branch against
+// CWE-190 integer overflow. A largesize whose high bit is set converts to a
+// negative offset; without a bounds guard that offset indexes the input slice
+// out of range and panics, crashing the CLI on a crafted/corrupt MP4 (the
+// in-memory walkers run on URL-sourced media that the caller does not control).
+// The walkers' contract is best-effort: malformed input must return 0, not panic.
+func TestMP4BoxLargeSizeOverflowNoPanic(t *testing.T) {
+	// A single top-level box in the 64-bit form with largesize = 2^64-1.
+	data := build64BitBox("ftyp", 0xFFFFFFFFFFFFFFFF, nil)
+
+	if got := readMp4DurationBytes(data); got != 0 {
+		t.Errorf("readMp4DurationBytes(overflow largesize) = %d, want 0", got)
+	}
+	if got := parseMp4Duration(data); got != 0 {
+		t.Errorf("parseMp4Duration(overflow largesize) = %d, want 0", got)
+	}
+	if start, end := findMP4Box(data, 0, len(data), "ftyp"); start != -1 || end != -1 {
+		t.Errorf("findMP4Box(overflow largesize) = (%d, %d), want (-1, -1)", start, end)
+	}
+}
+
+// TestMP4Box64BitSizeAtNonZeroOffset locks in correct handling of a 64-bit box
+// that does not start at offset 0. boxEnd must be offset+largesize (as the
+// 32-bit branch already does with offset+size); dropping the offset truncates
+// the box and the duration is silently lost.
+func TestMP4Box64BitSizeAtNonZeroOffset(t *testing.T) {
+	mvhd := buildMvhdBox(0, 1000, 5000) // timescale=1000, duration=5000 → 5000ms
+	// moov carried as a 64-bit box: largesize = 16-byte header + mvhd payload.
+	moov := build64BitBox("moov", uint64(16+len(mvhd)), mvhd)
+	// Precede moov with a 32-bit ftyp box so it sits at a non-zero offset —
+	// that is where the missing "offset +" surfaces.
+	data := append(build32BitBox("ftyp", []byte("isom")), moov...)
+
+	if got := readMp4DurationBytes(data); got != 5000 {
+		t.Errorf("readMp4DurationBytes(64-bit moov at offset>0) = %d, want 5000", got)
+	}
+}
+
+// TestFindMP4Box64BitSizeAtNonZeroOffset is the findMP4Box-level analogue: a
+// 64-bit box preceding the target must advance the cursor by offset+largesize
+// so the following box is located at the right position.
+func TestFindMP4Box64BitSizeAtNonZeroOffset(t *testing.T) {
+	free := build64BitBox("free", 24, make([]byte, 8)) // 16-byte header + 8 bytes
+	target := build32BitBox("mvhd", []byte("payload!"))
+	data := append(free, target...)
+
+	start, end := findMP4Box(data, 0, len(data), "mvhd")
+	if start < 0 {
+		t.Fatalf("findMP4Box did not find mvhd after a 64-bit box (start=%d)", start)
+	}
+	if got := string(data[start:end]); got != "payload!" {
+		t.Errorf("findMP4Box returned %q, want %q", got, "payload!")
+	}
+}


### PR DESCRIPTION
## Summary

The three MP4 box walkers in `shortcuts/im/helpers.go` mishandle the 64-bit ("largesize") box-size form. They set `boxEnd` to the raw `largesize` instead of `offset + largesize` — even though the 32-bit branch directly below correctly uses `offset + size` — and convert the `uint64` to a signed int without any bounds check. This silently loses the duration of MP4s that carry a 64-bit box size at a non-zero offset, and **panics the CLI** (`slice bounds out of range`) on a crafted or corrupt MP4 whose `largesize` has the high bit set. The in-memory walkers run on URL-sourced IM media, whose bytes the caller does not control, so a malformed download crashes the process instead of degrading gracefully.

## Changes

- `findMP4Box`, `readMp4DurationBytes`, `readMp4Duration`: compute `boxEnd = offset + largesize`, mirroring the existing 32-bit `offset + size`.
- Reject `largesize` values smaller than the 16-byte 64-bit header or larger than the remaining input, so malformed media returns `0` / `-1` (the parsers' documented best-effort contract) instead of overflowing `uint64 → int(64)` into a negative `boxEnd` and panicking (CWE-190). The lower bound also guarantees the walk always makes forward progress.
- Add `shortcuts/im/mp4_box_test.go` covering the overflow (must not panic) and a 64-bit box at a non-zero offset (must walk correctly).

## Test Plan

- [x] `go test -race ./shortcuts/im/...` passes. The added regression tests panic / fail on the pre-fix code and pass after the fix.
- [x] `go build ./...`, `go vet ./...`, and `gofmt -l` are clean; no new dependencies (`go.mod` / `go.sum` unchanged).
- [ ] Manual `lark-cli <domain> <command>` verification — this is an internal binary-parser fix with no change to any shortcut's flags, params, or request structure, so per `AGENTS.md` no dry-run E2E is required; behavior is covered by the added unit tests.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened MP4 duration parsing to validate 64-bit box sizes before use, preventing integer overflows, out-of-bounds reads, and crashes when encountering malformed or oversized boxes.

* **Tests**
  * Added tests covering 64-bit box size scenarios, malformed largesize values, and non-zero offsets to ensure duration extraction and box searching behave correctly without panics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->