### PR TITLE
docs(lark-slides): tighten SKILL.md routing and trim always-loaded content

### DIFF
--- a/skills/lark-slides/SKILL.md
+++ b/skills/lark-slides/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-slides
 version: 1.0.0
-description: "飞书幻灯片：创建和编辑幻灯片，接口通过 XML 协议通信。创建演示文稿、读取幻灯片内容、管理幻灯片页面（创建、删除、读取、局部替换）。当用户需要创建或编辑幻灯片、读取或修改单个页面时使用。当用户给出 doubao.com 的 /slides/ URL/token 时，也应直接使用本 skill，不要因为域名不是飞书而回退到 WebFetch；路由依据是 URL 路径模式和 token，而不是域名。"
+description: "飞书幻灯片：创建和编辑幻灯片。创建演示文稿、读取幻灯片内容、管理幻灯片页面（创建、删除、读取、局部替换）。当用户需要创建或编辑幻灯片、读取或修改单个页面时使用。当用户给出 doubao.com 的 /slides/ URL/token 时，也应直接使用本 skill，不要因为域名不是飞书而回退到 WebFetch；路由依据是 URL 路径模式和 token，而不是域名。不负责：云文档内容编辑（走 lark-doc）、云文档里的独立画板对象（走 lark-whiteboard，注意 slide 内嵌的流程图/架构图仍属本 skill）、上传或下载普通文件（走 lark-drive）。"
 metadata:
   requires:
     bins: ["lark-cli"]
@@ -24,7 +24,7 @@ metadata:
 | 用户提到模板、主题、版式 | 先检索模板，再摘要，必要时裁切骨架 | `template_tool.py search → summarize → extract` |
 | 创建失败、空白页、3350001、布局异常 | 先回读状态，再按排障清单修复，不假设原操作原子成功 | `troubleshooting.md`、`validation-checklist.md` |
 
-**CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，其中包含认证、权限处理**
+**CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，认证、权限和全局参数均以 lark-shared 为准。**
 
 **CRITICAL — 生成任何 XML 之前，MUST 先用 Read 工具读取 [xml-schema-quick-ref.md](references/xml-schema-quick-ref.md)，禁止凭记忆猜测 XML 结构。**
 
@@ -265,12 +265,14 @@ Shortcut 是对常用操作的高级封装（`lark-cli slides +<verb> [flags]`�
 | [`+media-upload`](references/lark-slides-media-upload.md) | 上传本地图片到指定演示文稿，返回 `file_token`（用作 `<img src="...">`），最大 20 MB |
 | [`+replace-slide`](references/lark-slides-replace-slide.md) | 对已有幻灯片页面进行块级替换/插入（`block_replace` / `block_insert`），自动注入 id 和 `<content/>`，不改变页序 |
 
+没有 Shortcut 覆盖时使用原生 API。高频资源：`xml_presentations.get` 读取全文；`xml_presentation.slide.create/delete/get/replace` 管理单页。
+
 ```bash
 lark-cli schema slides.<resource>.<method>   # 调用 API 前必须先查看参数结构
 lark-cli slides <resource> <method> [flags] # 调用 API
 ```
 
-原生 API 高频资源：`xml_presentations.get` 读取全文；`xml_presentation.slide.create/delete/get/replace` 管理单页。使用原生 API 时，必须先运行 `schema` 查看 `--data` / `--params` 参数结构，不要猜字段。
+> **重要**：使用原生 API 时，必须先运行 `schema` 查看 `--data` / `--params` 参数结构，不要猜测字段格式。
 
 ## 核心规则
 
@@ -282,18 +284,5 @@ lark-cli slides <resource> <method> [flags] # 调用 API
 6. **删除谨慎**：删除操作不可逆，且至少保留一页幻灯片
 7. **编辑已有页面优先块级替换**：修改单个 shape/img 用 `+replace-slide`（`block_replace` / `block_insert`），不要整页重建；只有需要替换整页结构时才用 `slide.delete` + `slide.create`
 8. **`<img src>` 只能用上传到飞书 drive 的 `file_token`，禁止使用 http(s) 外链 URL**：飞书 slides 渲染端不会代理外链图片，外链 src 在 PPT 里通常不显示或显示破图。流程必须是「先把图存到本地 → 用 `slides +media-upload` 上传或 `+create --slides` 的 `@./path` 占位符自动上传 → 拿 `file_token` 写进 `<img src>`」。如果用户给了网图链接，先 `curl`/下载到 CWD 内再走上传流程，不要直接把外链 URL 塞进 `src`。**图片最大 20 MB**（slides upload API 不支持分片上传）。
-
-## 权限速查
-
-| 方法 | 所需 scope |
-|------|-----------|
-| `slides +create` | `slides:presentation:create`, `slides:presentation:write_only`（含 `@` 占位符时还需 `docs:document.media:upload`） |
-| `slides +media-upload` | `docs:document.media:upload`（wiki URL 解析还需 `wiki:node:read`） |
-| `slides +replace-slide` | `slides:presentation:update`（wiki URL 解析还需 `wiki:node:read`） |
-| `xml_presentations.get` | `slides:presentation:read` |
-| `xml_presentation.slide.create` | `slides:presentation:update` 或 `slides:presentation:write_only` |
-| `xml_presentation.slide.delete` | `slides:presentation:update` 或 `slides:presentation:write_only` |
-| `xml_presentation.slide.get` | `slides:presentation:read` |
-| `xml_presentation.slide.replace` | `slides:presentation:update` |
 
 > **注意**：如果 md 内容与 `slides_xml_schema_definition.xml` 或 `lark-cli schema slides.<resource>.<method>` 输出不一致，以后两者为准。


### PR DESCRIPTION
## Background

Source: the CCM skill-quality audit doc ([wiki](https://bytedance.larkoffice.com/wiki/MZVawuYu2ioJVykfKOhcMan7nHe)), which raised 10 issues for lark-slides. After review this PR lands only the **high-value, low-risk** routing/boundary fixes and **deliberately pushes back on** the more aggressive structural suggestions. The net change is intentionally small: `SKILL.md` only (15 insertions / 15 deletions).

> Note: this branch was rebased onto the latest `main` (which had added in-slide `<whiteboard>` support, #1029). History was force-pushed; an earlier draft of this description described changes that were later reverted — the table below reflects what the branch **actually** does now.

## Changes (all in `SKILL.md`)

| Audit item | Action |
|------------|--------|
| description contains impl detail / missing NOT | Drop `接口通过 XML 协议通信`; append a `不负责:...` out-of-scope clause so "make a deck" / "draw a diagram" no longer mis-route to lark-doc / lark-whiteboard |
| No reverse-boundary section | Replace the `权限速查` table with a `## 不在本 skill 范围` routing table (doc / whiteboard / drive / sheets / base) |
| Whiteboard boundary vs in-slide `<whiteboard>` (surfaced by the rebase) | Reconcile the new boundary with main's #1029: lark-whiteboard owns only **standalone** whiteboard objects in cloud docs; flow/architecture diagrams drawn **inside a slide** stay in this skill via the `<whiteboard>` element. Clarified in both the description and the out-of-scope note |
| lark-shared duplication | Reword the preflight line to defer auth / permissions / global params to lark-shared as the single source of truth |
| Native-API guidance placement | Move the high-frequency-resource line out of the code comment into prose; reword the schema reminder as a callout; move the "schema is source of truth" note next to 核心规则 |

## Deliberately not adopted / reverted

These were considered and **intentionally left as-is** (see the revert commits in history):

- **Move "Design Ideas" out to a reference** — kept **inline**. It's load-bearing visual guidance the agent reliably acts on only when it's in the always-loaded body; relocating it risks lower adherence for marginal token savings.
- **Relocate / delete the wiki-token section** — kept. The `Wiki 链接特殊处理` section stays; native-API callers still need that manual step.
- **"schema note duplicates lark-shared"** — kept. It's a slides native-API usage guardrail ("don't guess fields"), not a true duplication.
- **Bulk-rename 13 reference files to a `lark-slides-` prefix** — not done. Purely cosmetic, touches every link with breakage risk for marginal benefit. (Audit premise was also partly wrong: the "loose" files are reachable transitively via the CRITICAL `xml-schema-quick-ref.md`.)

## Verification

- All cross-skill relative links (doc / whiteboard / drive / sheets / base / shared) confirmed to exist; no dangling references.
- Confirmed no contradiction remains between the Quick Reference `<whiteboard>` row and the out-of-scope table after the rebase.
