### PR TITLE
fix(vc): correct --minute-token flag name in recording reference

### DIFF
--- a/skills/lark-vc/references/lark-vc-recording.md
+++ b/skills/lark-vc/references/lark-vc-recording.md
@@ -82,7 +82,7 @@ lark-cli vc +recording --meeting-ids 69xxxxxxxxxxxxx28 --dry-run
 lark-cli vc +recording --meeting-ids xxx
 
 # 第 2 步：使用上一步返回的 minute_token 下载妙记文件
-lark-cli minutes +download --minute-token <minute_token>
+lark-cli minutes +download --minute-tokens <minute_token>
 ```
 
 ### 场景 2：知道 meeting_id，想查询妙记基础信息
@@ -115,7 +115,7 @@ lark-cli vc +search --query "周会" --start 2026-03-10
 lark-cli vc +recording --meeting-ids <ids>
 
 # 第 3 步：使用其中一个 minute_token 下载妙记文件
-lark-cli minutes +download --minute-token <token>
+lark-cli minutes +download --minute-tokens <token>
 ```
 
 ### 场景 5：从日历事件获取录制
@@ -125,7 +125,7 @@ lark-cli minutes +download --minute-token <token>
 lark-cli vc +recording --calendar-event-ids <event_id>
 
 # 第 2 步：使用上一步返回的 minute_token 下载妙记文件
-lark-cli minutes +download --minute-token <minute_token>
+lark-cli minutes +download --minute-tokens <minute_token>
 ```
 
 ## 常见错误与排查


### PR DESCRIPTION
## Summary

Fix `--minute-token` (singular) → `--minute-tokens` (plural) in `lark-vc-recording.md`. The actual CLI flag defined in `minutes_download.go` is `--minute-tokens`, but the reference document had 3 occurrences using the wrong singular form.

## Changes

- `skills/lark-vc/references/lark-vc-recording.md`: lines 85, 118, 128

## Test plan

- [x] `grep -n 'minute-token' skills/lark-vc/references/lark-vc-recording.md` — no singular `--minute-token` remains
- [x] Verified against `shortcuts/minutes/minutes_download.go:48` — flag name is `minute-tokens`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `lark-cli minutes download` command documentation to reflect the correct plural option format for minute tokens across Agent combination scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->