### PR TITLE
fix: whiteboard skill

### DIFF
--- a/skills/lark-whiteboard/SKILL.md
+++ b/skills/lark-whiteboard/SKILL.md
@@ -50,7 +50,7 @@ metadata:
 | 用户给了什么 | 怎么获取 |
 |---|---|
 | 直接给了 whiteboard token（`wbcnXXX`）| 直接使用 |
-| 文档 URL 或 doc_id，文档中已有画板 | `lark-cli docs +fetch --doc <URL> --as user`，从返回的 `<whiteboard token="xxx"/>` 提取 |
+| 文档 URL 或 doc_id，文档中已有画板 | `lark-cli docs +fetch --api-version v2 --doc <URL> --as user`，从返回的 `<whiteboard token="xxx"/>` 提取 |
 | 文档 URL 或 doc_id，需要新建画板 | `lark-cli docs +update --api-version v2 --doc <doc_id> --command append --content '<whiteboard type="blank"></whiteboard>' --as user`，从响应 `data.new_blocks[0].block_token` 取得（`block_type == "whiteboard"` 的那条；参数详见 lark-doc SKILL.md）|
 
 **Step 2：渲染 & 写入**


### PR DESCRIPTION
## Summary
fixed lark-doc refrences in lark-whiteboard skill

## Changes
fixed lark-doc refrences in lark-whiteboard skill

## Test Plan
- [x] Unit tests pass
- [x] Manual evaluated

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions for extracting whiteboard tokens from documents to include the `--api-version v2` flag in the fetch command for correct token parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->