### PR TITLE
fix(event): keep bounded consume alive after stdin EOF

### DIFF
--- a/cmd/event/consume.go
+++ b/cmd/event/consume.go
@@ -373,5 +373,5 @@ func watchStdinEOF(r io.Reader, cancel context.CancelFunc, errOut io.Writer) {
 }
 
 func shouldWatchStdinEOF(isTerminal bool, maxEvents int, timeout time.Duration) bool {
-	return !isTerminal && maxEvents == 0 && timeout == 0
+	return !isTerminal && maxEvents <= 0 && timeout <= 0
 }

--- a/cmd/event/consume.go
+++ b/cmd/event/consume.go
@@ -184,8 +184,9 @@ func runConsume(cmd *cobra.Command, f *cmdutil.Factory, eventKey string, o consu
 		errOut = io.Discard
 	}
 
-	// Non-TTY only: stdin EOF is shutdown for subprocess callers; in TTY Ctrl-D must not exit.
-	if !f.IOStreams.IsTerminal {
+	// Non-TTY unbounded consumers use stdin EOF as shutdown for subprocess callers.
+	// Bounded runs already have --max-events/--timeout as their lifecycle control.
+	if shouldWatchStdinEOF(f.IOStreams.IsTerminal, o.maxEvents, o.timeout) {
 		watchStdinEOF(os.Stdin, cancel, errOut)
 	}
 
@@ -369,4 +370,8 @@ func watchStdinEOF(r io.Reader, cancel context.CancelFunc, errOut io.Writer) {
 			"or stop via SIGTERM instead of closing stdin.")
 		cancel()
 	}()
+}
+
+func shouldWatchStdinEOF(isTerminal bool, maxEvents int, timeout time.Duration) bool {
+	return !isTerminal && maxEvents == 0 && timeout == 0
 }

--- a/cmd/event/consume_stdin_test.go
+++ b/cmd/event/consume_stdin_test.go
@@ -61,3 +61,42 @@ func TestWatchStdinEOF_DiagnosticMessage(t *testing.T) {
 		t.Fatal("watchStdinEOF did not cancel within 1s of EOF")
 	}
 }
+
+func TestShouldWatchStdinEOF(t *testing.T) {
+	tests := []struct {
+		name       string
+		isTerminal bool
+		maxEvents  int
+		timeout    time.Duration
+		want       bool
+	}{
+		{
+			name:       "terminal",
+			isTerminal: true,
+			want:       false,
+		},
+		{
+			name: "non terminal unbounded",
+			want: true,
+		},
+		{
+			name:      "non terminal max events bounded",
+			maxEvents: 1,
+			want:      false,
+		},
+		{
+			name:    "non terminal timeout bounded",
+			timeout: 10 * time.Minute,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldWatchStdinEOF(tt.isTerminal, tt.maxEvents, tt.timeout)
+			if got != tt.want {
+				t.Fatalf("shouldWatchStdinEOF() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/event/consume_stdin_test.go
+++ b/cmd/event/consume_stdin_test.go
@@ -80,6 +80,16 @@ func TestShouldWatchStdinEOF(t *testing.T) {
 			want: true,
 		},
 		{
+			name:      "non terminal negative max events is unbounded",
+			maxEvents: -1,
+			want:      true,
+		},
+		{
+			name:    "non terminal negative timeout is unbounded",
+			timeout: -1 * time.Second,
+			want:    true,
+		},
+		{
 			name:      "non terminal max events bounded",
 			maxEvents: 1,
 			want:      false,


### PR DESCRIPTION
## Summary

Fixes #1131.

`event consume` documented `--max-events` / `--timeout` as the way to run bounded non-interactive consumers, but the non-TTY stdin EOF watcher still canceled those runs immediately when a subprocess closed stdin. This keeps stdin EOF as the lifecycle signal only for unbounded non-TTY consumers, so bounded runs can exit by their own limit or timeout.

## Changes

- Gate the stdin EOF watcher on non-TTY *and* no bounded lifecycle flags.
- Add regression coverage for terminal, unbounded non-terminal, `--max-events`, and `--timeout` cases.

## Test Plan

- [x] Unit tests pass
- [ ] Manual local verification confirms the `lark-cli event consume` flow works as expected; not run because this local environment is not configured with Lark app credentials.

Commands run:

- `go test ./cmd/event -run TestShouldWatchStdinEOF -count=1` (failed before the fix)
- `go test ./cmd/event -run 'TestShouldWatchStdinEOF|TestWatchStdinEOF' -count=1`
- `go test ./cmd/event -count=1`
- `make unit-test`
- `go vet ./...`
- `gofmt -l .`
- `go mod tidy && git diff --exit-code -- go.mod go.sum`
- `make build`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main`
- `git diff --check`
- `make test` (unit/vet/examples stages passed; integration tests then failed because local `lark-cli` config is not configured, with `error.type=config` / `message=not configured`)

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The `consume` command no longer stops on stdin closure for bounded runs; stdin EOF is only observed for non-terminal sessions with no max-events or timeout set.
* **Tests**
  * Added tests validating stdin-EOF behavior across terminal vs non-terminal and bounded vs unbounded run configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/larksuite/cli/pull/1183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->