### PR TITLE
fix: parse grouped skills list output

### DIFF
--- a/internal/skillscheck/sync.go
+++ b/internal/skillscheck/sync.go
@@ -77,14 +77,12 @@ func parseGlobalSkillsList(lines []string) []string {
 			continue
 		}
 
-		// Skip indented lines (Agents: ...)
-		if strings.HasPrefix(line, "  ") || strings.HasPrefix(line, "\t") {
-			continue
-		}
-
 		// Extract skill name, format is typically "skill-name /path/to/skill"
 		parts := strings.Fields(trimmed)
-		if len(parts) == 0 {
+		if len(parts) < 2 {
+			continue
+		}
+		if !looksLikeSkillPath(parts[1]) {
 			continue
 		}
 
@@ -104,6 +102,15 @@ func parseGlobalSkillsList(lines []string) []string {
 	}
 
 	return sortedKeys(seen)
+}
+
+func looksLikeSkillPath(s string) bool {
+	return strings.HasPrefix(s, "~/") ||
+		strings.HasPrefix(s, "/") ||
+		strings.HasPrefix(s, "./") ||
+		strings.HasPrefix(s, "../") ||
+		strings.Contains(s, `:\`) ||
+		strings.Contains(s, `/`)
 }
 
 // parseOfficialSkillsList parses the output of "npx -y skills add ... --list"

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -53,6 +53,30 @@ yuanbao ~/.hermes/skills/yuanbao
 	}
 }
 
+func TestParseGlobalSkillsListWithGroupedIndentedSkills(t *testing.T) {
+	input := `Global Skills
+
+General
+  lark-apps ~/.agents/skills/lark-apps
+  lark-base ~/.agents/skills/lark-base
+  lark-contact ~/.agents/skills/lark-contact
+
+Document
+  lark-doc ~/.agents/skills/lark-doc
+  lark-openapi-explorer ~/.agents/skills/lark-openapi-explorer
+
+Knowledge Base
+  lark-wiki /Users/me/.agents/skills/lark-wiki
+
+Tip: Use the -y flag to run in non-interactive mode (for CI and AI agents).
+`
+	got := ParseSkillsList(input)
+	want := []string{"lark-apps", "lark-base", "lark-contact", "lark-doc", "lark-openapi-explorer", "lark-wiki"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ParseSkillsList() (grouped Global Skills) = %#v, want %#v", got, want)
+	}
+}
+
 func TestParseGlobalSkillsListWithANSI(t *testing.T) {
 	input := "\x1b[1mGlobal Skills\x1b[0m\n\n" +
 		"\x1b[36mlark-calendar\x1b[0m \x1b[38;5;102m~/.agents/skills/lark-calendar\x1b[0m\n" +


### PR DESCRIPTION
## Summary
Fix the incremental skills sync local-skill detection when `npx skills ls -g` prints grouped, indented human-readable output. The parser now recognizes indented skill rows without treating category headings as skills.

## Changes
- Allow global skills parser to parse indented skill rows that include a skill path.
- Ignore category headings, including multi-word headings, by requiring the second token to look like a path.
- Add regression coverage for the grouped output shape reported in #1186.

## Test Plan
- [x] Unit tests pass: `go test ./internal/skillscheck -count=1`
- [x] Unit tests pass: `go test ./cmd/update -count=1`
- [x] Unit tests pass: `go test ./internal/skillscheck ./cmd/update -count=1`
- [ ] Manual local verification confirms the `lark-cli update` flow works as expected

## Related Issues
- Fixes #1186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill extraction to correctly parse grouped and indented skills from the Global Skills list, ensuring all skills are properly identified and processed.

* **Tests**
  * Added test coverage for skill extraction with grouped indented sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->