### PR TITLE
fix(sheets): support file input for values

### DIFF
--- a/shortcuts/sheets/lark_sheets_cell_data.go
+++ b/shortcuts/sheets/lark_sheets_cell_data.go
@@ -106,7 +106,7 @@ var SheetWrite = common.Shortcut{
 		{Name: "spreadsheet-token", Desc: "spreadsheet token"},
 		{Name: "range", Desc: "write range (<sheetId>!A1:D10, A1:D10 with --sheet-id, or a single cell like C2)"},
 		{Name: "sheet-id", Desc: "sheet ID"},
-		{Name: "values", Desc: "2D array JSON", Required: true},
+		{Name: "values", Desc: "2D array JSON (supports @file and - for stdin)", Required: true, Input: []string{common.File, common.Stdin}},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if _, err := validateSheetManageToken(runtime); err != nil {
@@ -182,7 +182,7 @@ var SheetAppend = common.Shortcut{
 		{Name: "spreadsheet-token", Desc: "spreadsheet token"},
 		{Name: "range", Desc: "append range (<sheetId>!A1:D10, A1:D10 with --sheet-id, or a single cell like C2)"},
 		{Name: "sheet-id", Desc: "sheet ID"},
-		{Name: "values", Desc: "2D array JSON", Required: true},
+		{Name: "values", Desc: "2D array JSON (supports @file and - for stdin)", Required: true, Input: []string{common.File, common.Stdin}},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if _, err := validateSheetManageToken(runtime); err != nil {

--- a/shortcuts/sheets/lark_sheets_sheet_ranges_test.go
+++ b/shortcuts/sheets/lark_sheets_sheet_ranges_test.go
@@ -6,9 +6,11 @@ package sheets
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
 )
@@ -123,6 +125,61 @@ func TestSheetAppendDryRunNormalizesEscapedSeparator(t *testing.T) {
 	got := mustMarshalSheetsDryRun(t, SheetAppend.DryRun(context.Background(), runtime))
 	if !strings.Contains(got, `"range":"sheet_123!A1:B2"`) {
 		t.Fatalf("SheetAppend.DryRun() = %s, want normalized escaped separator", got)
+	}
+}
+
+func TestSheetWriteDryRunAcceptsValuesFileInput(t *testing.T) {
+	dir := t.TempDir()
+	cmdutil.TestChdir(t, dir)
+	if err := os.WriteFile("values.json", []byte(`[
+		["2025-01", "产品A"],
+		["2025-02", "产品B"]
+	]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, sheetsTestConfig())
+	err := mountAndRunSheets(t, SheetWrite, []string{
+		"+write",
+		"--spreadsheet-token", "shtTOKEN",
+		"--range", "sheet1!A1",
+		"--values", "@values.json",
+		"--dry-run",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("dry-run should accept --values @file, got: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, `"range": "sheet1!A1:A1"`) {
+		t.Fatalf("dry-run should include normalized write range: %s", got)
+	}
+	if !strings.Contains(got, `"产品B"`) {
+		t.Fatalf("dry-run should include values loaded from file: %s", got)
+	}
+}
+
+func TestSheetAppendDryRunAcceptsValuesStdinInput(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, sheetsTestConfig())
+	f.IOStreams.In = strings.NewReader(`[["2025-01","产品A"]]`)
+
+	err := mountAndRunSheets(t, SheetAppend, []string{
+		"+append",
+		"--spreadsheet-token", "shtTOKEN",
+		"--range", "sheet1!A1",
+		"--values", "-",
+		"--dry-run",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("dry-run should accept --values - stdin, got: %v", err)
+	}
+	got := stdout.String()
+	if !strings.Contains(got, `"range": "sheet1!A1:A1"`) {
+		t.Fatalf("dry-run should preserve append point range: %s", got)
+	}
+	if !strings.Contains(got, `"产品A"`) {
+		t.Fatalf("dry-run should include values loaded from stdin: %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Allow `sheets +write --values` and `sheets +append --values` to use existing shortcut input conventions: `@file` and `-` for stdin.
- Update help text so large 2D JSON payloads can be passed without shell quoting fragile inline JSON.
- Add dry-run regression tests covering file input and stdin with Chinese cell values.

## Root cause
`sheets +write/+append` parsed the raw `--values` flag directly with `json.Unmarshal`, but the flag did not opt into the shortcut framework input resolver. As a result, `--values @values.json` was parsed literally as JSON and failed with `--values invalid JSON, must be a 2D array`.

## Reproduction
Before the fix, `lark-cli sheets +write --spreadsheet-token sht_test --range sheet1!A1 --values @./values.json --dry-run` failed with `--values invalid JSON, must be a 2D array`. With this branch, the same command resolves the file and includes the loaded 2D array in the dry-run body.

## Validation
- `go test ./shortcuts/sheets -run "TestSheetWriteDryRunAcceptsValuesFileInput|TestSheetAppendDryRunAcceptsValuesStdinInput|TestCellDataValidateRejectsNon2DValues" -count=1`
- `go test ./shortcuts/sheets -count=1`
- `go build -o /tmp/lark-cli-sheets-values .`
- Manual dry-run with built binary for `--values @file` and `--values -`

## Notes
`go test ./...` was also run. It failed in unrelated environment-dependent suites: schema tests could not find generated registry services such as `im`; e2e tests required a repo-root `./lark-cli` binary and live Feishu app scopes such as `calendar:calendar:read` / `space:folder:create`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sheet write and append operations now support flexible data input methods for the `values` parameter. Users can provide JSON directly, load data from files (using `@file`), or read from standard input (using -). This enables more convenient ways to supply large or dynamically generated datasets to spreadsheet operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->