### PR TITLE
feat: increase agent trace max length to 1024

### DIFF
--- a/internal/cmdutil/secheader.go
+++ b/internal/cmdutil/secheader.go
@@ -41,7 +41,7 @@ const (
 
 	officialModulePath = "github.com/larksuite/cli"
 
-	agentTraceMaxLen = 256
+	agentTraceMaxLen = 1024
 )
 
 // UserAgentValue returns the User-Agent value: "lark-cli/{version}".


### PR DESCRIPTION
## Summary
increase agent trace max length to 1024

## Changes


## Test Plan


## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Increased the maximum length limit for trace configuration values, enabling longer trace identifiers to be accepted and included in request headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->