### PR TITLE
feat: add client-side page_size validation for service commands

### DIFF
--- a/cmd/service/param_validation.go
+++ b/cmd/service/param_validation.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/registry"
+)
+
+// serviceParamValidationAllowlist defines per-(schemaPath, paramName) local
+// validation entry points. Constraint details still come from metadata.
+var serviceParamValidationAllowlist = map[string]map[string]struct{}{
+	"mail.user_mailbox.messages.list": {
+		"page_size": {},
+	},
+}
+
+// validateQueryParamRange validates an allowlisted query parameter against the
+// type and range declared in the method metadata. Parameters not in the
+// allowlist are intentionally skipped to keep service command compatibility.
+func validateQueryParamRange(name string, value interface{}, paramSpec map[string]interface{}, schemaPath string) error {
+	if !shouldValidateServiceParam(schemaPath, name) || paramSpec == nil {
+		return nil
+	}
+
+	switch registry.GetStrFromMap(paramSpec, "type") {
+	case "integer":
+		return validateIntegerQueryParam(name, value, paramSpec, schemaPath)
+	default:
+		return nil
+	}
+}
+
+func shouldValidateServiceParam(schemaPath, name string) bool {
+	paramRules, ok := serviceParamValidationAllowlist[schemaPath]
+	if !ok {
+		return false
+	}
+	_, ok = paramRules[name]
+	return ok
+}
+
+func validateIntegerQueryParam(name string, value interface{}, paramSpec map[string]interface{}, schemaPath string) error {
+	intVal, rawStr, err := parseIntegerParamValue(value)
+	if err != nil {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument,
+			"invalid --params %s: %s is not a valid integer", name, rawStr).
+			WithHint("The parameter %s must be an integer. Run: lark-cli schema %s", name, schemaPath).
+			WithParam(name)
+	}
+
+	if minStr := registry.GetStrFromMap(paramSpec, "min"); minStr != "" {
+		if minVal, err := strconv.ParseInt(minStr, 10, 64); err == nil && intVal < minVal {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"invalid --params %s: %d is less than the minimum allowed value %s", name, intVal, minStr).
+				WithHint("The parameter %s must be at least %s. Run: lark-cli schema %s", name, minStr, schemaPath).
+				WithParam(name)
+		}
+	}
+	if maxStr := registry.GetStrFromMap(paramSpec, "max"); maxStr != "" {
+		if maxVal, err := strconv.ParseInt(maxStr, 10, 64); err == nil && intVal > maxVal {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"invalid --params %s: %d exceeds the maximum allowed value %s", name, intVal, maxStr).
+				WithHint("The parameter %s must be at most %s. Run: lark-cli schema %s", name, maxStr, schemaPath).
+				WithParam(name)
+		}
+	}
+	return nil
+}
+
+func parseIntegerParamValue(value interface{}) (int64, string, error) {
+	switch v := value.(type) {
+	case json.Number:
+		rawStr := v.String()
+		intVal, err := strconv.ParseInt(rawStr, 10, 64)
+		return intVal, rawStr, err
+	case string:
+		intVal, err := strconv.ParseInt(v, 10, 64)
+		return intVal, v, err
+	case float64:
+		rawStr := strconv.FormatFloat(v, 'f', -1, 64)
+		intVal, err := strconv.ParseInt(rawStr, 10, 64)
+		return intVal, rawStr, err
+	default:
+		rawStr := fmt.Sprintf("%v", value)
+		return 0, rawStr, fmt.Errorf("unsupported integer parameter type %T", value)
+	}
+}

--- a/cmd/service/param_validation_test.go
+++ b/cmd/service/param_validation_test.go
@@ -1,0 +1,270 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+)
+
+const testSchemaPath = "mail.user_mailbox.messages.list"
+
+func pageSizeParamSpec(min, max string) map[string]interface{} {
+	return map[string]interface{}{
+		"type":     "integer",
+		"location": "query",
+		"min":      min,
+		"max":      max,
+	}
+}
+
+func TestValidateQueryParamRange_AllowlistNonTargetSkipped(t *testing.T) {
+	if err := validateQueryParamRange("page_size", float64(50), pageSizeParamSpec("1", "20"), "calendar.events.list"); err != nil {
+		t.Errorf("expected nil for non-target schemaPath, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_NonTargetParamSkipped(t *testing.T) {
+	if err := validateQueryParamRange("other_param", float64(9999), pageSizeParamSpec("1", "20"), testSchemaPath); err != nil {
+		t.Errorf("expected nil for non-allowlisted param, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_NilSpec(t *testing.T) {
+	if err := validateQueryParamRange("page_size", float64(50), nil, testSchemaPath); err != nil {
+		t.Errorf("expected nil when allowlisted param has no schema metadata, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_WithinRange(t *testing.T) {
+	if err := validateQueryParamRange("page_size", float64(10), pageSizeParamSpec("1", "20"), testSchemaPath); err != nil {
+		t.Errorf("expected nil for value within range, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_ExactlyAtMax(t *testing.T) {
+	if err := validateQueryParamRange("page_size", float64(20), pageSizeParamSpec("1", "20"), testSchemaPath); err != nil {
+		t.Errorf("expected nil for value at max boundary, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_ExactlyAtMin(t *testing.T) {
+	if err := validateQueryParamRange("page_size", float64(1), pageSizeParamSpec("1", "20"), testSchemaPath); err != nil {
+		t.Errorf("expected nil for value at min boundary, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_ExceedsMax(t *testing.T) {
+	err := validateQueryParamRange("page_size", float64(21), pageSizeParamSpec("1", "20"), testSchemaPath)
+	if err == nil {
+		t.Fatal("expected error for page_size exceeding max")
+	}
+	if !strings.Contains(err.Error(), "exceeds the maximum") {
+		t.Errorf("expected 'exceeds the maximum' error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "20") {
+		t.Errorf("expected error to mention max value 20, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_BelowMin(t *testing.T) {
+	err := validateQueryParamRange("page_size", float64(0), pageSizeParamSpec("1", "20"), testSchemaPath)
+	if err == nil {
+		t.Fatal("expected error for page_size below min")
+	}
+	if !strings.Contains(err.Error(), "less than the minimum") {
+		t.Errorf("expected 'less than the minimum' error, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_StringIntegerPasses(t *testing.T) {
+	if err := validateQueryParamRange("page_size", "20", pageSizeParamSpec("1", "20"), testSchemaPath); err != nil {
+		t.Errorf("expected nil for string integer \"20\", got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_StringIntegerExceedsMax(t *testing.T) {
+	err := validateQueryParamRange("page_size", "21", pageSizeParamSpec("1", "20"), testSchemaPath)
+	if err == nil {
+		t.Fatal("expected error for string page_size exceeding max")
+	}
+	if !strings.Contains(err.Error(), "exceeds the maximum") {
+		t.Errorf("expected 'exceeds the maximum' error, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_FloatRejected(t *testing.T) {
+	err := validateQueryParamRange("page_size", 1.5, pageSizeParamSpec("1", "20"), testSchemaPath)
+	if err == nil {
+		t.Fatal("expected error for float page_size")
+	}
+	if !strings.Contains(err.Error(), "not a valid integer") {
+		t.Errorf("expected 'not a valid integer' error, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_StringFloatRejected(t *testing.T) {
+	err := validateQueryParamRange("page_size", "1.5", pageSizeParamSpec("1", "20"), testSchemaPath)
+	if err == nil {
+		t.Fatal("expected error for string float page_size")
+	}
+	if !strings.Contains(err.Error(), "not a valid integer") {
+		t.Errorf("expected 'not a valid integer' error, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_StringNonNumericRejected(t *testing.T) {
+	err := validateQueryParamRange("page_size", "abc", pageSizeParamSpec("1", "20"), testSchemaPath)
+	if err == nil {
+		t.Fatal("expected error for non-numeric string page_size")
+	}
+	if !strings.Contains(err.Error(), "not a valid integer") {
+		t.Errorf("expected 'not a valid integer' error, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_Float64WithinRange(t *testing.T) {
+	if err := validateQueryParamRange("page_size", float64(10), pageSizeParamSpec("1", "20"), testSchemaPath); err != nil {
+		t.Errorf("expected nil for float64 within range, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_JSONNumberPasses(t *testing.T) {
+	if err := validateQueryParamRange("page_size", json.Number("10"), pageSizeParamSpec("1", "20"), testSchemaPath); err != nil {
+		t.Errorf("expected nil for json.Number within range, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_UnsupportedTypesRejected(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+	}{
+		{"bool", true},
+		{"object", map[string]interface{}{"value": 20}},
+		{"array", []interface{}{20}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateQueryParamRange("page_size", tt.value, pageSizeParamSpec("1", "20"), testSchemaPath)
+			if err == nil {
+				t.Fatal("expected error for unsupported page_size type")
+			}
+			if !strings.Contains(err.Error(), "not a valid integer") {
+				t.Errorf("expected 'not a valid integer' error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateQueryParamRange_UsesParamSpecMax(t *testing.T) {
+	if err := validateQueryParamRange("page_size", float64(25), pageSizeParamSpec("1", "30"), testSchemaPath); err != nil {
+		t.Errorf("expected nil when schema max is 30, got: %v", err)
+	}
+}
+
+func TestValidateQueryParamRange_NonTargetServiceNotBlocked(t *testing.T) {
+	if err := validateQueryParamRange("limit", float64(200), pageSizeParamSpec("1", "100"), "calendar.events.list"); err != nil {
+		t.Errorf("expected nil for non-target service command, got: %v", err)
+	}
+}
+
+func TestServiceMethod_PageSizeExceedsMax(t *testing.T) {
+	spec := map[string]interface{}{
+		"name": "mail", "servicePath": "/open-apis/mail/v1",
+	}
+	method := map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/messages",
+		"httpMethod": "GET",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{
+				"type": "string", "location": "path", "required": true,
+			},
+			"page_size": map[string]interface{}{
+				"type": "integer", "location": "query", "required": true,
+				"min": "1", "max": "20",
+			},
+		},
+	}
+	f, _, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, spec, method, "list", "user_mailbox.messages", nil)
+	cmd.SetArgs([]string{"--params", `{"user_mailbox_id":"me","page_size":21}`, "--dry-run"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for page_size exceeding max")
+	}
+	if !strings.Contains(err.Error(), "exceeds the maximum") {
+		t.Errorf("expected 'exceeds the maximum' error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "20") {
+		t.Errorf("expected error to mention max value 20, got: %v", err)
+	}
+}
+
+func TestServiceMethod_PageSizeWithinMax(t *testing.T) {
+	spec := map[string]interface{}{
+		"name": "mail", "servicePath": "/open-apis/mail/v1",
+	}
+	method := map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/messages",
+		"httpMethod": "GET",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{
+				"type": "string", "location": "path", "required": true,
+			},
+			"page_size": map[string]interface{}{
+				"type": "integer", "location": "query", "required": false,
+				"min": "1", "max": "20",
+			},
+		},
+	}
+	f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, spec, method, "list", "user_mailbox.messages", nil)
+	cmd.SetArgs([]string{"--params", `{"user_mailbox_id":"me","page_size":20}`, "--dry-run"})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error for valid page_size, got: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Dry Run") {
+		t.Error("expected dry-run output")
+	}
+}
+
+func TestServiceMethod_PageAllSkipsRequiredCheck(t *testing.T) {
+	spec := map[string]interface{}{
+		"name": "mail", "servicePath": "/open-apis/mail/v1",
+	}
+	method := map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/messages",
+		"httpMethod": "GET",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{
+				"type": "string", "location": "path", "required": true,
+			},
+			"page_size": map[string]interface{}{
+				"type": "integer", "location": "query", "required": true,
+				"min": "1", "max": "20",
+			},
+			"page_token": map[string]interface{}{
+				"type": "string", "location": "query", "required": true,
+			},
+		},
+	}
+	f, stdout, _, _ := cmdutil.TestFactory(t, testConfig)
+	cmd := NewCmdServiceMethod(f, spec, method, "list", "user_mailbox.messages", nil)
+	cmd.SetArgs([]string{"--params", `{"user_mailbox_id":"me"}`, "--page-all", "--page-limit", "1", "--dry-run"})
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("expected no error for --page-all skipping required params, got: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "Dry Run") {
+		t.Error("expected dry-run output")
+	}
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -427,6 +427,9 @@ func buildServiceRequest(opts *ServiceMethodOptions) (client.RawApiRequest, *cmd
 				WithParam(name)
 		}
 		if exists && !util.IsEmptyValue(value) {
+			if err := validateQueryParamRange(name, value, p, schemaPath); err != nil {
+				return client.RawApiRequest{}, nil, err
+			}
 			queryParams[name] = value
 		}
 	}


### PR DESCRIPTION
Generated by the harness-coding skill (recovery run — original attempt crashed before MR open).

- **Branch**: feat/1694214
- **Target**: main

> The commits below were produced by a prior coding run on this branch. The current resume run regenerated the sprint plan from tech-specs and confirmed those commits already implement the work (sprint status `skipped:already_implemented`). Any sprint with status `passed` in the table below represents work this resume run added on top.

## Commits on branch (ahead of main)

| Commit | Subject |
|--------|---------|
| 7160473 | feat: add client-side page_size validation for service commands |

## This resume run

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Synthesize transport contract for larksuite/cli | passed | bc8e9bd |
| S2 | Add page_size client-side validation for mail user_mailbox.messages list command | passed | 7160473 |

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Query parameters for service commands now validate integer values against configured min/max bounds and reject out-of-range or non-integer inputs with clear messages. Pagination-exception and existing parameter behaviors remain unchanged; validation applies only to targeted service parameters.

* **Tests**
  * Added extensive tests covering range checks, parsing of numeric formats, allowlist behavior, and command-level dry-run scenarios (both failing and succeeding cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->