### PR TITLE
fix(cli): stop root --help listing per-command flags as global

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,18 +49,8 @@ EXAMPLES:
     lark-cli api GET /open-apis/calendar/v4/calendars
 
 FLAGS:
-    --params <json>       URL/query parameters JSON
-    --data <json>         request body JSON (POST/PATCH/PUT/DELETE)
-    --as <type>           identity type: user | bot
-    --format <fmt>        output format: json (default) | ndjson | table | csv | pretty
-    --page-all            automatically paginate through all pages
-    --page-size <N>       page size (0 = use API default)
-    --page-limit <N>      max pages to fetch with --page-all (default: 10, 0 for unlimited)
-    --page-delay <MS>     delay in ms between pages (default: 200, only with --page-all)
-    -o, --output <path>   output file path for binary responses
-    --jq <expr>           jq expression to filter JSON output
-    -q <expr>             shorthand for --jq
-    --dry-run             print request without executing
+    e.g. --as, --format, -q/--jq, --dry-run ...
+    Run lark-cli <command> --help for the full list.
 
 AI AGENT SKILLS:
     lark-cli pairs with AI agent skills (Claude Code, etc.) that

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -83,6 +83,17 @@ func TestRootLong_AgentSkillsLinkTargetsReadmeSection(t *testing.T) {
 	}
 }
 
+func TestRootLong_FlagsSectionPointsToCommandHelp(t *testing.T) {
+	// The flags shown in root help live on leaf commands (api, service), not
+	// on the root command — every one errors "unknown flag" at the top level.
+	// So the FLAGS section may only list them as examples and must route to
+	// `<command> --help` for the full set, rather than re-list them as if they
+	// were global root flags (which both lies and drifts as flags change).
+	if !strings.Contains(rootLong, "lark-cli <command> --help") {
+		t.Fatalf("root help FLAGS section must point to `lark-cli <command> --help` for the flag list, got:\n%s", rootLong)
+	}
+}
+
 func TestConfigureFlagCompletions(t *testing.T) {
 	t.Cleanup(func() { cmdutil.SetFlagCompletionsEnabled(false) })
 


### PR DESCRIPTION
## Problem

`lark-cli --help` printed two flag lists that contradict each other. The hand-written `FLAGS:` block listed a dozen flags (`--params`, `--data`, `--format`, `--page-all`, `--jq`, `-o`, …) as if they were global — but none are registered on the root command. They all error at the top level and exist only on the leaf commands (`api`, `service`):

```
$ lark-cli --params '{}'
Error: unknown flag: --params
```

Cobra's own `Flags:` section, rendered right below, lists the *real* root flags — only `-h/--help`, `--profile`, `-v/--version`. The static block also flattened away the fact that the flag set varies by command (e.g. `contact +search-user` has `--page-size` but no `--page-all`/`--page-limit`/`--page-delay`) and hand-restated defaults that have to be kept in sync manually.

## Fix

**Before** (excerpt — 12 entries, each with description + defaults):
```
FLAGS:
    --params <json>       URL/query parameters JSON
    --data <json>         request body JSON (POST/PATCH/PUT/DELETE)
    --format <fmt>        output format: json (default) | ndjson | table | csv | pretty
    --page-limit <N>      max pages to fetch with --page-all (default: 10, 0 for unlimited)
    ... 8 more ...
```

**After:**
```
FLAGS:
    e.g. --as, --format, -q/--jq, --dry-run ...
    Run lark-cli <command> --help for the full list.
```

A short illustrative example list — the cross-cutting flags that work on any command, with `...` signalling it is not exhaustive — plus a pointer to the authoritative per-command source. Root help stays a discovery signpost without claiming the flags are global or restating defaults/descriptions that drift from the real flag sets. `USAGE:`/`EXAMPLES:` still show the flags in their correct position, after a `<command>`.

## Tests

- `go test ./cmd/ -run TestRootLong` passes.
- New `TestRootLong_FlagsSectionPointsToCommandHelp` guards against reverting to a standalone exhaustive root flag table (asserts the section points to `lark-cli <command> --help`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated main help text to streamline information and direct users to command-specific help for complete flag details.
* **Tests**
  * Added test to verify that help text appropriately points to per-command flag documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->