### PR TITLE
fix(cli): remove FLAGS section from root --help

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,10 +48,6 @@ EXAMPLES:
     # Generic API call
     lark-cli api GET /open-apis/calendar/v4/calendars
 
-FLAGS:
-    e.g. --as, --format, -q/--jq, --dry-run ...
-    Run lark-cli <command> --help for the full list.
-
 AI AGENT SKILLS:
     lark-cli pairs with AI agent skills (Claude Code, etc.) that
     teach the agent Lark API patterns, best practices, and workflows.

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -83,17 +83,6 @@ func TestRootLong_AgentSkillsLinkTargetsReadmeSection(t *testing.T) {
 	}
 }
 
-func TestRootLong_FlagsSectionPointsToCommandHelp(t *testing.T) {
-	// The flags shown in root help live on leaf commands (api, service), not
-	// on the root command — every one errors "unknown flag" at the top level.
-	// So the FLAGS section may only list them as examples and must route to
-	// `<command> --help` for the full set, rather than re-list them as if they
-	// were global root flags (which both lies and drifts as flags change).
-	if !strings.Contains(rootLong, "lark-cli <command> --help") {
-		t.Fatalf("root help FLAGS section must point to `lark-cli <command> --help` for the flag list, got:\n%s", rootLong)
-	}
-}
-
 func TestConfigureFlagCompletions(t *testing.T) {
 	t.Cleanup(func() { cmdutil.SetFlagCompletionsEnabled(false) })
 


### PR DESCRIPTION
Follow-up to #1223.

## Why

The `FLAGS:` block in `lark-cli --help` is hand-written text that restates flags belonging to leaf commands (`api`, `service`). Those flags are not registered on the root command and error `unknown flag` there:

```
$ lark-cli --params '{}'
Error: unknown flag: --params
```

#1223 trimmed it to a short illustrative example list, but even that duplicates what Cobra's per-command `--help` already renders authoritatively, and any static flag list maintained by hand in root help drifts from the real per-command sets over time.

## Change

Remove the `FLAGS:` section entirely. Cobra's per-command `Flags:` output is the single source of truth:

- `USAGE:` / `EXAMPLES:` still show these flags in their correct position, after a `<command>` (e.g. `lark-cli calendar events instance_view --params '...'`).
- The Cobra-generated `Flags:` block at the bottom of `lark-cli --help` still lists the actual root flags (`-h/--help`, `--profile`, `-v/--version`).
- Removes the now-obsolete `TestRootLong_FlagsSectionPointsToCommandHelp`, which asserted on the deleted text.

## Verification

- `lark-cli --help` now flows `EXAMPLES → AI AGENT SKILLS`.
- `go test ./cmd/ -run TestRoot` passes; `go vet ./cmd/` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated command help text to improve clarity and flow between API examples and AI AGENT SKILLS information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->