### PR TITLE
chore(release): v1.0.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.46] - 2026-06-02
+
+### Features
+
+- **im**: Add card message format support (#1218)
+- **im**: Resolve markdown blank-line formatting inconsistency in post messages (#1216)
+- **vc**: Inline transcript from artifacts API and add keywords (#1206)
+- **transport**: Add proxy plugin mode for CLI HTTP transport (#1181)
+- **agent**: Increase agent trace max length to 1024 (#1211)
+- **shortcuts**: Unconditionally inject `--format` flag for all shortcuts (#1156)
+
+### Bug Fixes
+
+- **cli**: Remove FLAGS section from root `--help` (#1226)
+- **cli**: Stop root `--help` listing per-command flags as global (#1223)
+
+### Refactor
+
+- **transport**: Own all HTTP transport in `internal/transport`, fix util layering inversion (#1213)
+
+### Documentation
+
+- **base**: Optimize base skill references (#1171)
+- **drive**: Add Lark Drive knowledge organization workflow (#1028)
+
 ## [v1.0.45] - 2026-06-01
 
 ### Features
@@ -964,6 +989,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.46]: https://github.com/larksuite/cli/releases/tag/v1.0.46
 [v1.0.45]: https://github.com/larksuite/cli/releases/tag/v1.0.45
 [v1.0.44]: https://github.com/larksuite/cli/releases/tag/v1.0.44
 [v1.0.43]: https://github.com/larksuite/cli/releases/tag/v1.0.43

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary

Release v1.0.46.

- Bump version `1.0.45` → `1.0.46` in `package.json`
- Add `CHANGELOG.md` entry for v1.0.46 documenting the merged changes:
  - **Features**: im card message format (#1218), markdown blank-line formatting in post messages (#1216), vc inline transcript from artifacts API (#1206), proxy plugin mode for HTTP transport (#1181), agent trace max length → 1024 (#1211), unconditional `--format` injection for shortcuts (#1156)
  - **Bug Fixes**: remove FLAGS section from root `--help` (#1226), stop root `--help` listing per-command flags as global (#1223)
  - **Refactor**: own all HTTP transport in `internal/transport` (#1213)
  - **Docs**: optimize base skill references (#1171), Lark Drive knowledge organization workflow (#1028)

## Test Plan

- [ ] CI green (release commit touches only `package.json` + `CHANGELOG.md`; all referenced changes already merged to `main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 1.0.46 released with changelog updates documenting new features, bug fixes, refactoring, and documentation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->