### PR TITLE
feat(calendar): emit typed error envelopes across the calendar domain

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,20 +73,20 @@ linters:
           - forbidigo
       # errs-typed-only enforced on paths already migrated to errs.NewXxxError.
       # Add a path when its migration is complete.
-      - path-except: (internal/auth/|internal/errcompat/|internal/errclass/|internal/client/|internal/cmdutil/factory\.go|cmd/auth/|cmd/config/|cmd/service/|shortcuts/common/mcp_client\.go|shortcuts/calendar/helpers\.go|shortcuts/drive/|shortcuts/mail/|shortcuts/base/)
+      - path-except: (internal/auth/|internal/errcompat/|internal/errclass/|internal/client/|internal/cmdutil/factory\.go|cmd/auth/|cmd/config/|cmd/service/|shortcuts/common/mcp_client\.go|shortcuts/calendar/|shortcuts/drive/|shortcuts/mail/|shortcuts/base/)
         text: errs-typed-only
         linters:
           - forbidigo
       # errs-no-bare-wrap enforced on paths fully migrated to typed final
       # errors. Scoped separately from errs-typed-only because cmd/auth/,
       # cmd/config/ still have residual fmt.Errorf and must not be caught.
-      - path-except: (shortcuts/drive/|shortcuts/mail/|shortcuts/base/|shortcuts/calendar/helpers\.go|shortcuts/common/mcp_client\.go)
+      - path-except: (shortcuts/drive/|shortcuts/mail/|shortcuts/base/|shortcuts/calendar/|shortcuts/common/mcp_client\.go)
         text: errs-no-bare-wrap
         linters:
           - forbidigo
-      # errs-no-legacy-helper is scoped to migrated domains: the shared helpers
-      # it bans are still used by other domains until their later migration phase.
-      - path-except: (shortcuts/drive/|shortcuts/mail/|shortcuts/base/)
+      # errs-no-legacy-helper enforced on domains whose shared validation/save
+      # helpers have migrated to typed final errors.
+      - path-except: (shortcuts/drive/|shortcuts/mail/|shortcuts/base/|shortcuts/calendar/)
         text: errs-no-legacy-helper
         linters:
           - forbidigo
@@ -116,16 +116,14 @@ linters:
             [errs-typed-only] use errs.NewXxxError(...) builder
             (see errs/types.go).
         # ── legacy shared error helpers banned on migrated domains ──
-        # These helpers internally produce legacy output.Err* shapes, so they
-        # are invisible to the errs-typed-only ban above. Migrated domains use
-        # typed errs.* builders or domain-local file-I/O helpers instead; this
-        # prevents reintroduction while unmigrated domains continue to use the
-        # shared helpers until their later migration phase.
-        - pattern: (common\.FlagErrorf|common\.WrapInputStatError|common\.WrapSaveErrorByCategory)\b
+        # These helpers emit legacy output.Err* / bare error shapes or drop
+        # typed metadata such as Param/Cause. Migrated domains must use typed
+        # common replacements or local typed helpers instead.
+        - pattern: (common\.FlagErrorf|common\.RejectDangerousChars|common\.WrapInputStatError|common\.WrapSaveErrorByCategory)\b
           msg: >-
-            [errs-no-legacy-helper] these shared helpers emit legacy output.Err*
-            shapes. Use typed errs.NewXxxError builders or a domain-local
-            file-I/O helper.
+            [errs-no-legacy-helper] these shared helpers emit legacy or
+            metadata-poor error shapes. Use typed common replacements, typed
+            errs.NewXxxError builders, or domain-local typed helpers.
         # ── bare error wraps banned on fully-typed paths ──
         - pattern: (fmt\.Errorf|errors\.New)\b
           msg: >-

--- a/internal/errclass/classify.go
+++ b/internal/errclass/classify.go
@@ -92,6 +92,18 @@ func BuildAPIError(resp map[string]any, cc ClassifyContext) error {
 			base.Troubleshooter = ts
 		}
 	}
+	// Upstream-provided field-level reasons (resp.error.details[].value). Lark
+	// returns these as free-text reason strings with no machine-readable field
+	// name (verified for code 190014:
+	// {"error":{"details":[{"value":"end_time should be later than start_time"}]}}),
+	// so they are lifted into Problem.Hint — the sanctioned free-text recovery
+	// prompt — rather than fabricated structured params. Lifted before the
+	// category switch so any classified arm inherits it; the CategoryAPI arm
+	// below prefers this server detail over the context-free APIHint default.
+	detailHint := liftErrorDetailValues(resp)
+	if detailHint != "" {
+		base.Hint = detailHint
+	}
 
 	switch meta.Category {
 	case errs.CategoryAuthorization:
@@ -129,7 +141,11 @@ func BuildAPIError(resp map[string]any, cc ClassifyContext) error {
 			Action:  action,
 		}
 	case errs.CategoryAPI:
-		base.Hint = APIHint(base.Subtype) // "" for subtypes without a context-free default
+		// A server-supplied detail (lifted into base.Hint above) wins over the
+		// context-free APIHint default; only fall back to APIHint when absent.
+		if base.Hint == "" {
+			base.Hint = APIHint(base.Subtype) // "" for subtypes without a context-free default
+		}
 		return &errs.APIError{Problem: base}
 	default:
 		// Fail closed: an unrecognized Category routes to InternalError
@@ -214,6 +230,10 @@ func stringFromAny(v any) string {
 // per-subtype recovery hint before returning it, so the wire envelope
 // emitted via BuildAPIError always carries a hint for known config subtypes.
 func buildConfigError(p errs.Problem) *errs.ConfigError {
+	// Config categories have authoritative recovery guidance, so the curated
+	// ConfigHint deliberately overrides any server detail lifted into p.Hint
+	// (the opposite precedence from the CategoryAPI arm, where the lifted
+	// detail wins).
 	p.Hint = ConfigHint(p.Subtype)
 	return &errs.ConfigError{Problem: p}
 }
@@ -258,6 +278,10 @@ func buildPermissionError(p errs.Problem, resp map[string]any, cc ClassifyContex
 	}
 	consoleURL := ConsoleURL(cc.Brand, cc.AppID, missing)
 	p.Message = CanonicalPermissionMessage(p.Subtype, cc.AppID, missing, p.Message)
+	// Permission categories have authoritative recovery guidance (scopes to
+	// grant, console URL), so the curated PermissionHint deliberately overrides
+	// any server detail lifted into p.Hint (the opposite precedence from the
+	// CategoryAPI arm, where the lifted detail wins).
 	p.Hint = PermissionHint(missing, identity, p.Subtype, consoleURL)
 	permErr := &errs.PermissionError{
 		Problem:       p,
@@ -364,6 +388,32 @@ func PermissionHint(missing []string, identity string, subtype errs.Subtype, con
 		return fmt.Sprintf("check the resource owner has granted access to %s", who)
 	}
 	return "check the calling identity has the required scope"
+}
+
+// liftErrorDetailValues collects the non-empty resp.error.details[].value reason
+// strings and joins them with "; ". Returns "" when the structure is absent or
+// carries no non-empty value. The shape (verified for code 190014) is
+// {"error":{"details":[{"value":"<reason>"}]}}.
+func liftErrorDetailValues(resp map[string]any) string {
+	errBlock, ok := resp["error"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	details, ok := errBlock["details"].([]any)
+	if !ok || len(details) == 0 {
+		return ""
+	}
+	var values []string
+	for _, d := range details {
+		m, ok := d.(map[string]any)
+		if !ok {
+			continue
+		}
+		if v, _ := m["value"].(string); v != "" {
+			values = append(values, v)
+		}
+	}
+	return strings.Join(values, "; ")
 }
 
 // extractMissingScopes walks resp["error"]["permission_violations"][].subject.

--- a/internal/errclass/classify_test.go
+++ b/internal/errclass/classify_test.go
@@ -220,6 +220,111 @@ func TestBuildAPIError_TroubleshooterLiftedOnPermissionArm(t *testing.T) {
 	}
 }
 
+// TestBuildAPIError_DetailsLiftedToHintOnAPIArm pins that BuildAPIError lifts
+// resp.error.details[].value into Problem.Hint when the response routes to the
+// catch-all CategoryAPI arm. The real Lark shape (verified for code 190014) is
+// {"error":{"details":[{"value":"end_time should be later than start_time"}]}}
+// — only a human-readable reason string, no machine-readable field name. It is
+// lifted into Hint (sanctioned free-text recovery prompt) rather than fabricated
+// structured params.
+func TestBuildAPIError_DetailsLiftedToHintOnAPIArm(t *testing.T) {
+	resp := map[string]any{
+		"code": 190014,
+		"msg":  "invalid params",
+		"error": map[string]any{
+			"details": []any{
+				map[string]any{"value": "end_time should be later than start_time"},
+			},
+		},
+	}
+	err := errclass.BuildAPIError(resp, errclass.ClassifyContext{})
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatal("ProblemOf returned !ok")
+	}
+	if !strings.Contains(p.Hint, "end_time should be later than start_time") {
+		t.Errorf("Hint = %q, want it to contain the server detail value", p.Hint)
+	}
+}
+
+// TestBuildAPIError_MultipleDetailsJoinedIntoHint pins that multiple non-empty
+// detail values are joined with "; " into a single Hint, and empty values are
+// skipped.
+func TestBuildAPIError_MultipleDetailsJoinedIntoHint(t *testing.T) {
+	resp := map[string]any{
+		"code": 190014,
+		"msg":  "invalid params",
+		"error": map[string]any{
+			"details": []any{
+				map[string]any{"value": "first reason"},
+				map[string]any{"value": ""},
+				map[string]any{"value": "second reason"},
+			},
+		},
+	}
+	err := errclass.BuildAPIError(resp, errclass.ClassifyContext{})
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatal("ProblemOf returned !ok")
+	}
+	if p.Hint != "first reason; second reason" {
+		t.Errorf("Hint = %q, want %q", p.Hint, "first reason; second reason")
+	}
+}
+
+// TestBuildAPIError_DetailsSkipsNonMapEntries pins that malformed entries in
+// the details array (not a JSON object) are skipped rather than panicking, and
+// well-formed siblings still surface in the Hint.
+func TestBuildAPIError_DetailsSkipsNonMapEntries(t *testing.T) {
+	resp := map[string]any{
+		"code": 190014,
+		"msg":  "invalid params",
+		"error": map[string]any{
+			"details": []any{
+				"i am a bare string, not an object",
+				map[string]any{"value": "the real reason"},
+				42,
+			},
+		},
+	}
+	err := errclass.BuildAPIError(resp, errclass.ClassifyContext{})
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatal("ProblemOf returned !ok")
+	}
+	if p.Hint != "the real reason" {
+		t.Errorf("Hint = %q, want %q", p.Hint, "the real reason")
+	}
+}
+
+// TestBuildAPIError_DetailsMalformedShapesNoHint pins that a missing error
+// block, a non-array details field, and an empty details array all leave the
+// Hint untouched (no lifted detail) instead of erroring.
+func TestBuildAPIError_DetailsMalformedShapesNoHint(t *testing.T) {
+	cases := []struct {
+		name string
+		resp map[string]any
+	}{
+		{"no error block", map[string]any{"code": 190014, "msg": "invalid params"}},
+		{"details not array", map[string]any{"code": 190014, "msg": "invalid params", "error": map[string]any{"details": "nope"}}},
+		{"empty details", map[string]any{"code": 190014, "msg": "invalid params", "error": map[string]any{"details": []any{}}}},
+		{"detail values all empty", map[string]any{"code": 190014, "msg": "invalid params", "error": map[string]any{"details": []any{map[string]any{"value": ""}}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := errclass.BuildAPIError(tc.resp, errclass.ClassifyContext{})
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatal("ProblemOf returned !ok")
+			}
+			// With no liftable detail, the Hint must not echo a server detail.
+			if strings.Contains(p.Hint, "nope") {
+				t.Errorf("Hint should not lift a non-array details field, got %q", p.Hint)
+			}
+		})
+	}
+}
+
 // TestBuildAPIError_TroubleshooterAbsent pins that Troubleshooter stays empty
 // when the upstream response omits it — wire envelope must omit the field.
 func TestBuildAPIError_TroubleshooterAbsent(t *testing.T) {

--- a/internal/errclass/codemeta_calendar.go
+++ b/internal/errclass/codemeta_calendar.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package errclass
+
+import "github.com/larksuite/cli/errs"
+
+// calendarCodeMeta holds calendar-service Lark code → CodeMeta mappings.
+// Only codes whose meaning is verifiable from repo evidence are registered;
+// ambiguous codes fall back to CategoryAPI via BuildAPIError.
+// BuildAPIError consumes this map via mergeCodeMeta + LookupCodeMeta.
+var calendarCodeMeta = map[int]CodeMeta{
+	190014: {Category: errs.CategoryAPI, Subtype: errs.SubtypeInvalidParameters}, // invalid params (carries a field-level detail lifted into Hint)
+}
+
+func init() { mergeCodeMeta(calendarCodeMeta, "calendar") }

--- a/internal/errclass/codemeta_calendar_test.go
+++ b/internal/errclass/codemeta_calendar_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package errclass
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+)
+
+// TestLookupCodeMeta_CalendarCodes pins each calendar-service code registered
+// via the codemeta_calendar.go init() merge to its expected
+// Category/Subtype/Retryable.
+func TestLookupCodeMeta_CalendarCodes(t *testing.T) {
+	cases := []struct {
+		code        int
+		wantCat     errs.Category
+		wantSubtype errs.Subtype
+		wantRetry   bool
+	}{
+		// 190014: calendar "invalid params" with a field-level detail
+		// (error.details[].value) lifted into Hint by BuildAPIError.
+		{190014, errs.CategoryAPI, errs.SubtypeInvalidParameters, false},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%d", tc.code), func(t *testing.T) {
+			meta, ok := LookupCodeMeta(tc.code)
+			if !ok {
+				t.Fatalf("code %d not registered in codeMeta", tc.code)
+			}
+			if meta.Category != tc.wantCat || meta.Subtype != tc.wantSubtype || meta.Retryable != tc.wantRetry {
+				t.Errorf("code %d: got %+v, want Category=%v Subtype=%v Retryable=%v",
+					tc.code, meta, tc.wantCat, tc.wantSubtype, tc.wantRetry)
+			}
+		})
+	}
+}

--- a/lint/errscontract/rule_no_legacy_common_helper_call.go
+++ b/lint/errscontract/rule_no_legacy_common_helper_call.go
@@ -18,6 +18,7 @@ var migratedCommonHelperPaths = []string{
 	"shortcuts/base/",
 	"shortcuts/drive/",
 	"shortcuts/mail/",
+	"shortcuts/calendar/",
 }
 
 const commonImportPath = "github.com/larksuite/cli/shortcuts/common"

--- a/lint/errscontract/rule_no_legacy_envelope_literal.go
+++ b/lint/errscontract/rule_no_legacy_envelope_literal.go
@@ -19,6 +19,7 @@ var migratedEnvelopePaths = []string{
 	"shortcuts/base/",
 	"shortcuts/drive/",
 	"shortcuts/mail/",
+	"shortcuts/calendar/",
 }
 
 // legacyOutputImportPath is the import path of the package that declares the

--- a/lint/errscontract/rules_test.go
+++ b/lint/errscontract/rules_test.go
@@ -662,7 +662,7 @@ func boom() error {
 	return &output.ExitError{Code: 1}
 }
 `
-	v := CheckNoLegacyEnvelopeLiteral("shortcuts/calendar/foo.go", src)
+	v := CheckNoLegacyEnvelopeLiteral("shortcuts/im/foo.go", src)
 	if len(v) != 0 {
 		t.Errorf("non-migrated path should pass, got: %+v", v)
 	}
@@ -921,6 +921,27 @@ common.` + helper + `()
 				}
 			})
 		}
+	}
+}
+
+func TestCheckNoLegacyCommonHelperCall_RejectsDangerousCharsOnCalendarPath(t *testing.T) {
+	src := `package calendar
+
+import "github.com/larksuite/cli/shortcuts/common"
+
+func boom() {
+	common.RejectDangerousChars("--summary", "x")
+}
+`
+	v := CheckNoLegacyCommonHelperCall("shortcuts/calendar/calendar_create.go", src)
+	if len(v) != 1 {
+		t.Fatalf("expected 1 violation, got %d: %+v", len(v), v)
+	}
+	if v[0].Action != ActionReject {
+		t.Errorf("action = %q, want REJECT", v[0].Action)
+	}
+	if !strings.Contains(v[0].Suggestion, "common.RejectDangerousCharsTyped") {
+		t.Errorf("suggestion should name typed replacement, got: %s", v[0].Suggestion)
 	}
 }
 

--- a/shortcuts/calendar/calendar_agenda.go
+++ b/shortcuts/calendar/calendar_agenda.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/output"
-	"github.com/larksuite/cli/internal/util"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -29,7 +29,7 @@ const (
 
 func fetchInstanceViewRange(ctx context.Context, runtime *common.RuntimeContext, calendarId string, startTime, endTime int64, depth int) ([]map[string]interface{}, error) {
 	if depth > 10 {
-		return nil, output.Errorf(output.ExitInternal, "recursion_limit", "too many splits for instance_view")
+		return nil, errs.NewInternalError(errs.SubtypeUnknown, "too many splits for instance_view")
 	}
 	if startTime > endTime {
 		return nil, nil
@@ -48,68 +48,67 @@ func fetchInstanceViewRange(ctx context.Context, runtime *common.RuntimeContext,
 		return append(left, right...), nil
 	}
 
-	result, err := runtime.RawAPI("GET",
+	data, err := runtime.CallAPITyped("GET",
 		fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/instance_view", validate.EncodePathSegment(calendarId)),
 		map[string]interface{}{
 			"start_time": fmt.Sprintf("%d", startTime),
 			"end_time":   fmt.Sprintf("%d", endTime),
 		}, nil)
-	err = wrapPredefinedError(err)
 	if err != nil {
-		return nil, output.Errorf(output.ExitAPI, "api_error", "API call failed: %s", err)
-	}
-
-	resultMap, _ := result.(map[string]interface{})
-	code, _ := util.ToFloat64(resultMap["code"])
-
-	if code == 0 {
-		data, _ := resultMap["data"].(map[string]interface{})
-		items, _ := data["items"].([]interface{})
-		var events []map[string]interface{}
-		for _, item := range items {
-			if m, ok := item.(map[string]interface{}); ok {
-				events = append(events, m)
+		// CallAPITyped returns a typed error for any non-zero API code. The two
+		// calendar instance_view limits (193103 time-range, 193104 too-many) are
+		// recoverable by narrowing the window, so inspect the typed code and
+		// recurse instead of treating them as fatal. Any other code falls through
+		// to return the typed error unchanged.
+		p, ok := errs.ProblemOf(err)
+		if !ok {
+			return nil, err
+		}
+		switch p.Code {
+		case larkErrCalendarTimeRangeExceeded:
+			mid := startTime + span/2
+			if mid <= startTime {
+				return nil, errs.NewAPIError(errs.SubtypeInvalidParameters,
+					"query failed: time range exceeds 40-day limit, please narrow the range").
+					WithCode(larkErrCalendarTimeRangeExceeded)
 			}
+			return fetchInstanceViewSplit(ctx, runtime, calendarId, startTime, mid, endTime, depth)
+		case larkErrCalendarTooManyInstances:
+			if span <= minSplitWindowSeconds {
+				return nil, errs.NewAPIError(errs.SubtypeInvalidParameters,
+					"query failed: more than 1000 instances in the time range, please narrow the range").
+					WithCode(larkErrCalendarTooManyInstances)
+			}
+			mid := startTime + span/2
+			return fetchInstanceViewSplit(ctx, runtime, calendarId, startTime, mid, endTime, depth)
+		default:
+			return nil, err
 		}
-		return events, nil
 	}
 
-	// Error 193103: time range exceeds limit -> split
-	if int(code) == larkErrCalendarTimeRangeExceeded {
-		mid := startTime + span/2
-		if mid <= startTime {
-			return nil, output.Errorf(output.ExitAPI, "api_error", "query failed: time range exceeds 40-day limit, please narrow the range")
+	items, _ := data["items"].([]interface{})
+	var events []map[string]interface{}
+	for _, item := range items {
+		if m, ok := item.(map[string]interface{}); ok {
+			events = append(events, m)
 		}
-		left, err := fetchInstanceViewRange(ctx, runtime, calendarId, startTime, mid, depth+1)
-		if err != nil {
-			return nil, err
-		}
-		right, err := fetchInstanceViewRange(ctx, runtime, calendarId, mid+1, endTime, depth+1)
-		if err != nil {
-			return nil, err
-		}
-		return append(left, right...), nil
 	}
+	return events, nil
+}
 
-	// Error 193104: too many instances -> split
-	if int(code) == larkErrCalendarTooManyInstances {
-		if span <= minSplitWindowSeconds {
-			return nil, output.Errorf(output.ExitAPI, "api_error", "query failed: more than 1000 instances in the time range, please narrow the range")
-		}
-		mid := startTime + span/2
-		left, err := fetchInstanceViewRange(ctx, runtime, calendarId, startTime, mid, depth+1)
-		if err != nil {
-			return nil, err
-		}
-		right, err := fetchInstanceViewRange(ctx, runtime, calendarId, mid+1, endTime, depth+1)
-		if err != nil {
-			return nil, err
-		}
-		return append(left, right...), nil
+// fetchInstanceViewSplit halves [startTime, endTime] at mid and concatenates the
+// results of the two recursive sub-range queries. Shared by the 193103/193104
+// split paths.
+func fetchInstanceViewSplit(ctx context.Context, runtime *common.RuntimeContext, calendarId string, startTime, mid, endTime int64, depth int) ([]map[string]interface{}, error) {
+	left, err := fetchInstanceViewRange(ctx, runtime, calendarId, startTime, mid, depth+1)
+	if err != nil {
+		return nil, err
 	}
-
-	msg, _ := resultMap["msg"].(string)
-	return nil, output.ErrAPI(int(code), msg, resultMap["error"])
+	right, err := fetchInstanceViewRange(ctx, runtime, calendarId, mid+1, endTime, depth+1)
+	if err != nil {
+		return nil, err
+	}
+	return append(left, right...), nil
 }
 
 func dedupeAndSortItems(items []map[string]interface{}) []map[string]interface{} {
@@ -147,20 +146,20 @@ func parseTimeRange(runtime *common.RuntimeContext) (int64, int64, error) {
 
 	startTime, err := common.ParseTime(startInput)
 	if err != nil {
-		return 0, 0, output.ErrValidation("--start: %v", err)
+		return 0, 0, errs.NewValidationError(errs.SubtypeInvalidArgument, "--start: %v", err).WithParam("--start")
 	}
 	endTime, err := common.ParseTime(endInput, "end")
 	if err != nil {
-		return 0, 0, output.ErrValidation("--end: %v", err)
+		return 0, 0, errs.NewValidationError(errs.SubtypeInvalidArgument, "--end: %v", err).WithParam("--end")
 	}
 
 	startInt, err := strconv.ParseInt(startTime, 10, 64)
 	if err != nil {
-		return 0, 0, output.ErrValidation("invalid start time: %v", err)
+		return 0, 0, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid start time: %v", err).WithParam("--start")
 	}
 	endInt, err := strconv.ParseInt(endTime, 10, 64)
 	if err != nil {
-		return 0, 0, output.ErrValidation("invalid end time: %v", err)
+		return 0, 0, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid end time: %v", err).WithParam("--end")
 	}
 
 	return startInt, endInt, nil

--- a/shortcuts/calendar/calendar_create.go
+++ b/shortcuts/calendar/calendar_create.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -60,7 +61,7 @@ func parseAttendees(attendeesStr string, currentUserId string) ([]map[string]str
 		case strings.HasPrefix(id, "ou_"):
 			attendees = append(attendees, map[string]string{"type": "user", "user_id": id})
 		default:
-			return nil, fmt.Errorf("unsupported attendee id format: %s", id)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "unsupported attendee id format: %s", id)
 		}
 	}
 	return attendees, nil
@@ -89,8 +90,8 @@ var CalendarCreate = common.Shortcut{
 		}
 		for _, flag := range []string{"summary", "description", "rrule", "calendar-id"} {
 			if val := runtime.Str(flag); val != "" {
-				if err := common.RejectDangerousChars("--"+flag, val); err != nil {
-					return output.ErrValidation(err.Error())
+				if err := common.RejectDangerousCharsTyped("--"+flag, val); err != nil {
+					return err
 				}
 			}
 		}
@@ -102,35 +103,35 @@ var CalendarCreate = common.Shortcut{
 					continue
 				}
 				if !strings.HasPrefix(id, "ou_") && !strings.HasPrefix(id, "oc_") && !strings.HasPrefix(id, "omm_") {
-					return output.ErrValidation("invalid attendee id format %q: should start with 'ou_', 'oc_', or 'omm_'", id)
+					return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid attendee id format %q: should start with 'ou_', 'oc_', or 'omm_'", id).WithParam("--attendee-ids")
 				}
 			}
 		}
 
 		if runtime.Str("start") == "" {
-			return common.FlagErrorf("specify --start (e.g. '2026-03-12T14:00+08:00')")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "specify --start (e.g. '2026-03-12T14:00+08:00')").WithParam("--start")
 		}
 		if runtime.Str("end") == "" {
-			return common.FlagErrorf("specify --end (e.g. '2026-03-12T15:00+08:00')")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "specify --end (e.g. '2026-03-12T15:00+08:00')").WithParam("--end")
 		}
 		startTs, err := common.ParseTime(runtime.Str("start"))
 		if err != nil {
-			return common.FlagErrorf("--start: %v", err)
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--start: %v", err).WithParam("--start")
 		}
 		endTs, err := common.ParseTime(runtime.Str("end"), "end")
 		if err != nil {
-			return common.FlagErrorf("--end: %v", err)
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--end: %v", err).WithParam("--end")
 		}
 		s, err := strconv.ParseInt(startTs, 10, 64)
 		if err != nil {
-			return common.FlagErrorf("invalid start time: %v", err)
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid start time: %v", err).WithParam("--start")
 		}
 		e, err := strconv.ParseInt(endTs, 10, 64)
 		if err != nil {
-			return common.FlagErrorf("invalid end time: %v", err)
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid end time: %v", err).WithParam("--end")
 		}
 		if e <= s {
-			return common.FlagErrorf("end time must be after start time")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "end time must be after start time")
 		}
 		return nil
 	},
@@ -183,27 +184,26 @@ var CalendarCreate = common.Shortcut{
 
 		startTs, err := common.ParseTime(runtime.Str("start"))
 		if err != nil {
-			return output.ErrValidation("--start: %v", err)
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--start: %v", err).WithParam("--start")
 		}
 		endTs, err := common.ParseTime(runtime.Str("end"), "end")
 		if err != nil {
-			return output.ErrValidation("--end: %v", err)
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--end: %v", err).WithParam("--end")
 		}
 
 		eventData := buildEventData(runtime, startTs, endTs)
 
 		// Create event
-		data, err := runtime.CallAPI("POST",
+		data, err := runtime.CallAPITyped("POST",
 			fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events", validate.EncodePathSegment(calendarId)),
 			nil, eventData)
-		err = wrapPredefinedError(err)
 		if err != nil {
 			return err
 		}
 		event, _ := data["event"].(map[string]interface{})
 		eventId, _ := event["event_id"].(string)
 		if eventId == "" {
-			return output.Errorf(output.ExitAPI, "api_error", "failed to create event: no event_id returned")
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "failed to create event: no event_id returned")
 		}
 
 		// Add attendees if specified
@@ -214,27 +214,25 @@ var CalendarCreate = common.Shortcut{
 			}
 			attendees, err := parseAttendees(attendeesStr, currentUserId)
 			if err != nil {
-				return output.ErrValidation("invalid attendee id: %v", err)
+				return withParam(err, "--attendee-ids")
 			}
 
-			_, err = runtime.CallAPI("POST",
+			_, err = runtime.CallAPITyped("POST",
 				fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/%s/attendees", validate.EncodePathSegment(calendarId), validate.EncodePathSegment(eventId)),
 				map[string]interface{}{"user_id_type": "open_id"},
 				map[string]interface{}{
 					"attendees":         attendees,
 					"need_notification": true,
 				})
-			err = wrapPredefinedError(err)
 			if err != nil {
 				// Rollback: delete the event
-				_, rollbackErr := runtime.RawAPI("DELETE",
+				_, rollbackErr := runtime.CallAPITyped("DELETE",
 					fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/%s", validate.EncodePathSegment(calendarId), validate.EncodePathSegment(eventId)),
 					map[string]interface{}{"need_notification": false}, nil)
-				rollbackErr = wrapPredefinedError(rollbackErr)
 				if rollbackErr != nil {
-					return output.Errorf(output.ExitAPI, "api_error", "failed to add attendees: %v; rollback also failed, orphan event_id=%s needs manual cleanup", rollbackErr, eventId)
+					return withStepContext(err, "rollback also failed (%v); orphan event_id=%s needs manual cleanup", rollbackErr, eventId)
 				}
-				return output.Errorf(output.ExitAPI, "api_error", "failed to add attendees: %v; event rolled back successfully", err)
+				return withStepContext(err, "event rolled back successfully")
 			}
 		}
 

--- a/shortcuts/calendar/calendar_freebusy.go
+++ b/shortcuts/calendar/calendar_freebusy.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -20,20 +21,20 @@ func parseFreebusyTimeRange(runtime *common.RuntimeContext) (string, string, err
 
 	startTs, err := common.ParseTime(startInput)
 	if err != nil {
-		return "", "", output.ErrValidation("--start: %v", err)
+		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--start: %v", err).WithParam("--start")
 	}
 	endTs, err := common.ParseTime(endInput, "end")
 	if err != nil {
-		return "", "", output.ErrValidation("--end: %v", err)
+		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--end: %v", err).WithParam("--end")
 	}
 
 	startSec, err := strconv.ParseInt(startTs, 10, 64)
 	if err != nil {
-		return "", "", output.ErrValidation("invalid start timestamp: %v", err)
+		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid start timestamp: %v", err)
 	}
 	endSec, err := strconv.ParseInt(endTs, 10, 64)
 	if err != nil {
-		return "", "", output.ErrValidation("invalid end timestamp: %v", err)
+		return "", "", errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid end timestamp: %v", err)
 	}
 
 	timeMin := time.Unix(startSec, 0).Format(time.RFC3339)
@@ -73,13 +74,13 @@ var CalendarFreebusy = common.Shortcut{
 		}
 		userId := runtime.Str("user-id")
 		if userId == "" && runtime.IsBot() {
-			return common.FlagErrorf("--user-id is required for bot identity")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--user-id is required for bot identity").WithParam("--user-id")
 		}
 		if userId == "" && runtime.UserOpenId() == "" {
-			return common.FlagErrorf("cannot determine user ID, specify --user-id or ensure you are logged in")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "cannot determine user ID, specify --user-id or ensure you are logged in").WithParam("--user-id")
 		}
 		if userId != "" {
-			if _, err := common.ValidateUserID(userId); err != nil {
+			if _, err := common.ValidateUserIDTyped("--user-id", userId); err != nil {
 				return err
 			}
 		}
@@ -93,16 +94,17 @@ var CalendarFreebusy = common.Shortcut{
 
 		timeMin, timeMax, err := parseFreebusyTimeRange(runtime)
 		if err != nil {
-			return output.ErrValidation("--start/--end: %v", err)
+			// parseFreebusyTimeRange already returns a typed *errs.ValidationError
+			// carrying the offending flag in .Param; pass it through unchanged.
+			return err
 		}
 
-		data, err := runtime.CallAPI("POST", "/open-apis/calendar/v4/freebusy/list", nil, map[string]interface{}{
+		data, err := runtime.CallAPITyped("POST", "/open-apis/calendar/v4/freebusy/list", nil, map[string]interface{}{
 			"time_min":         timeMin,
 			"time_max":         timeMax,
 			"user_id":          userId,
 			"need_rsvp_status": true,
 		})
-		err = wrapPredefinedError(err)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/calendar/calendar_room_find.go
+++ b/shortcuts/calendar/calendar_room_find.go
@@ -8,13 +8,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -126,40 +126,40 @@ func collectRoomFindResults(slots []roomFindSlot, limit int, fetch func(roomFind
 func parseRoomFindSlots(runtime *common.RuntimeContext) ([]roomFindSlot, error) {
 	rawSlots := runtime.StrArray(flagSlot)
 	if len(rawSlots) == 0 {
-		return nil, output.ErrValidation("specify at least one --slot")
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "specify at least one --slot").WithParam("--slot")
 	}
 	slots := make([]roomFindSlot, 0, len(rawSlots))
 	for _, raw := range rawSlots {
 		parts := strings.Split(strings.TrimSpace(raw), "~")
 		if len(parts) != 2 {
-			return nil, output.ErrValidation("invalid --slot format %q, expected start~end", raw)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --slot format %q, expected start~end", raw).WithParam("--slot")
 		}
 		startTs, err := common.ParseTime(parts[0])
 		if err != nil {
-			return nil, output.ErrValidation("invalid slot start time %q: %v", parts[0], err)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid slot start time %q: %v", parts[0], err).WithParam("--slot")
 		}
 		endTs, err := common.ParseTime(parts[1])
 		if err != nil {
-			return nil, output.ErrValidation("invalid slot end time %q: %v", parts[1], err)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid slot end time %q: %v", parts[1], err).WithParam("--slot")
 		}
 		startSec, err := strconv.ParseInt(startTs, 10, 64)
 		if err != nil {
-			return nil, output.ErrValidation("invalid slot start timestamp %q: %v", startTs, err)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid slot start timestamp %q: %v", startTs, err).WithParam("--slot")
 		}
 		endSec, err := strconv.ParseInt(endTs, 10, 64)
 		if err != nil {
-			return nil, output.ErrValidation("invalid slot end timestamp %q: %v", endTs, err)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid slot end timestamp %q: %v", endTs, err).WithParam("--slot")
 		}
 		if endSec <= startSec {
-			return nil, output.ErrValidation("--slot end time must be after start time: %q", raw)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--slot end time must be after start time: %q", raw).WithParam("--slot")
 		}
 		startRFC3339, err := unixStringToRFC3339(startTs)
 		if err != nil {
-			return nil, output.ErrValidation("invalid slot start timestamp %q: %v", startTs, err)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid slot start timestamp %q: %v", startTs, err).WithParam("--slot")
 		}
 		endRFC3339, err := unixStringToRFC3339(endTs)
 		if err != nil {
-			return nil, output.ErrValidation("invalid slot end timestamp %q: %v", endTs, err)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid slot end timestamp %q: %v", endTs, err).WithParam("--slot")
 		}
 		slots = append(slots, roomFindSlot{Start: startRFC3339, End: endRFC3339})
 	}
@@ -196,7 +196,7 @@ func parseRoomFindAttendees(attendeesStr string, currentUserID string) ([]string
 				seenChats[id] = true
 			}
 		default:
-			return nil, nil, output.ErrValidation("invalid attendee id format %q: should start with 'ou_' or 'oc_'", id)
+			return nil, nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid attendee id format %q: should start with 'ou_' or 'oc_'", id).WithParam("--" + flagAttendees)
 		}
 	}
 	if currentUserID != "" && !seenUsers[currentUserID] {
@@ -249,20 +249,19 @@ func callRoomFind(runtime *common.RuntimeContext, req *roomFindRequest) ([]*room
 		Body:       req,
 	})
 	if err != nil {
-		return nil, err
+		if _, ok := errs.ProblemOf(err); ok {
+			return nil, err
+		}
+		return nil, errs.WrapInternal(err)
 	}
 
-	if apiResp.StatusCode < http.StatusOK || apiResp.StatusCode >= http.StatusMultipleChoices {
-		return nil, output.ErrAPI(apiResp.StatusCode, "", string(apiResp.RawBody))
+	if _, err := runtime.ClassifyAPIResponse(apiResp); err != nil {
+		return nil, err
 	}
 
 	var resp = &OpenAPIResponse[*roomFindData]{}
 	if err := json.Unmarshal(apiResp.RawBody, &resp); err != nil {
-		return nil, output.ErrWithHint(output.ExitInternal, "validation", "unmarshal response fail", err.Error())
-	}
-
-	if resp.Code != 0 {
-		return nil, output.ErrAPI(resp.Code, resp.Msg, resp.Data)
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "unmarshal response fail").WithCause(err)
 	}
 
 	if resp.Data != nil {
@@ -317,8 +316,8 @@ var CalendarRoomFind = common.Shortcut{
 		}
 		for _, flag := range []string{flagCity, flagBuilding, flagFloor, flagEventRrule, flagTimezone} {
 			if val := strings.TrimSpace(runtime.Str(flag)); val != "" {
-				if err := common.RejectDangerousChars("--"+flag, val); err != nil {
-					return output.ErrValidation(err.Error())
+				if err := common.RejectDangerousCharsTyped("--"+flag, val); err != nil {
+					return err
 				}
 			}
 		}
@@ -327,8 +326,8 @@ var CalendarRoomFind = common.Shortcut{
 			if name == "" {
 				continue
 			}
-			if err := common.RejectDangerousChars("--"+flagRoomName, name); err != nil {
-				return output.ErrValidation(err.Error())
+			if err := common.RejectDangerousCharsTyped("--"+flagRoomName, name); err != nil {
+				return err
 			}
 		}
 		if _, err := parseRoomFindSlots(runtime); err != nil {
@@ -338,13 +337,13 @@ var CalendarRoomFind = common.Shortcut{
 			return err
 		}
 		if minCapacity := runtime.Int(flagMinCapacity); minCapacity < 0 {
-			return output.ErrValidation("--min-capacity must be >= 0")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--min-capacity must be >= 0").WithParam("--min-capacity")
 		}
 		if maxCapacity := runtime.Int(flagMaxCapacity); maxCapacity < 0 {
-			return output.ErrValidation("--max-capacity must be >= 0")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--max-capacity must be >= 0").WithParam("--max-capacity")
 		}
 		if minCapacity, maxCapacity := runtime.Int(flagMinCapacity), runtime.Int(flagMaxCapacity); minCapacity > 0 && maxCapacity > 0 && minCapacity > maxCapacity {
-			return output.ErrValidation("--min-capacity must be <= --max-capacity")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--min-capacity must be <= --max-capacity").WithParam("--min-capacity")
 		}
 		return nil
 	},

--- a/shortcuts/calendar/calendar_rsvp.go
+++ b/shortcuts/calendar/calendar_rsvp.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -51,15 +51,15 @@ var CalendarRsvp = common.Shortcut{
 		}
 		for _, flag := range []string{"calendar-id", "event-id", "rsvp-status"} {
 			if val := strings.TrimSpace(runtime.Str(flag)); val != "" {
-				if err := common.RejectDangerousChars("--"+flag, val); err != nil {
-					return output.ErrValidation(err.Error())
+				if err := common.RejectDangerousCharsTyped("--"+flag, val); err != nil {
+					return err
 				}
 			}
 		}
 
 		eventId := strings.TrimSpace(runtime.Str("event-id"))
 		if eventId == "" {
-			return output.ErrValidation("event-id cannot be empty")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "event-id cannot be empty").WithParam("--event-id")
 		}
 		return nil
 	},
@@ -71,7 +71,7 @@ var CalendarRsvp = common.Shortcut{
 		eventId := strings.TrimSpace(runtime.Str("event-id"))
 		status := strings.TrimSpace(runtime.Str("rsvp-status"))
 
-		_, err := runtime.DoAPIJSON("POST",
+		_, err := runtime.CallAPITyped("POST",
 			fmt.Sprintf("/open-apis/calendar/v4/calendars/%s/events/%s/reply",
 				validate.EncodePathSegment(calendarId),
 				validate.EncodePathSegment(eventId)),

--- a/shortcuts/calendar/calendar_suggestion.go
+++ b/shortcuts/calendar/calendar_suggestion.go
@@ -8,13 +8,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -70,11 +70,11 @@ func buildSuggestionRequest(runtime *common.RuntimeContext) (*SuggestionRequest,
 
 	timeMin, err := common.ParseTime(startInput)
 	if err != nil {
-		return nil, output.ErrValidation("invalid --start: %v", err)
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --start: %v", err).WithParam("--start")
 	}
 	minSec, err := strconv.ParseInt(timeMin, 10, 64)
 	if err != nil {
-		return nil, output.ErrValidation("invalid start timestamp: %v", err)
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid start timestamp: %v", err)
 	}
 	startTime := time.Unix(minSec, 0)
 
@@ -87,12 +87,12 @@ func buildSuggestionRequest(runtime *common.RuntimeContext) (*SuggestionRequest,
 
 	timeMax, err := common.ParseTime(endInput, "end")
 	if err != nil {
-		return nil, output.ErrValidation("invalid --end: %v", err)
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --end: %v", err).WithParam("--end")
 	}
 	// Convert Unix timestamp string back to RFC3339 since the API requires RFC3339
 	maxSec, err := strconv.ParseInt(timeMax, 10, 64)
 	if err != nil {
-		return nil, output.ErrValidation("invalid end timestamp: %v", err)
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid end timestamp: %v", err)
 	}
 	req.SearchStartTime = startTime.Format(time.RFC3339)
 	req.SearchEndTime = time.Unix(maxSec, 0).Format(time.RFC3339)
@@ -157,23 +157,23 @@ func buildSuggestionRequest(runtime *common.RuntimeContext) (*SuggestionRequest,
 			}
 			parts := strings.Split(r, "~")
 			if len(parts) != 2 {
-				return nil, output.ErrValidation("invalid --exclude format %q, expected 'start~end'", r)
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --exclude format %q, expected 'start~end'", r).WithParam("--exclude")
 			}
 			startTsStr, err := common.ParseTime(parts[0])
 			if err != nil {
-				return nil, output.ErrValidation("invalid start time in --exclude: %q (%v)", parts[0], err)
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid start time in --exclude: %q (%v)", parts[0], err).WithParam("--exclude")
 			}
 			endTsStr, err := common.ParseTime(parts[1], "end")
 			if err != nil {
-				return nil, output.ErrValidation("invalid end time in --exclude: %q (%v)", parts[1], err)
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid end time in --exclude: %q (%v)", parts[1], err).WithParam("--exclude")
 			}
 			startSec, err := strconv.ParseInt(startTsStr, 10, 64)
 			if err != nil {
-				return nil, output.ErrValidation("invalid start timestamp in --exclude: %v", err)
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid start timestamp in --exclude: %v", err).WithParam("--exclude")
 			}
 			endSec, err := strconv.ParseInt(endTsStr, 10, 64)
 			if err != nil {
-				return nil, output.ErrValidation("invalid end timestamp in --exclude: %v", err)
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid end timestamp in --exclude: %v", err).WithParam("--exclude")
 			}
 			excludedTimes = append(excludedTimes, &EventTime{
 				EventStartTime: time.Unix(startSec, 0).Format(time.RFC3339),
@@ -219,13 +219,13 @@ var CalendarSuggestion = common.Shortcut{
 		}
 		durationMinutes := runtime.Int(flagDurationMinutes)
 		if durationMinutes != 0 && (durationMinutes < 1 || durationMinutes > 1440) {
-			return output.ErrValidation("--duration-minutes must be between 1 and 1440")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--duration-minutes must be between 1 and 1440").WithParam("--duration-minutes")
 		}
 
 		for _, flag := range []string{flagEventRrule, flagTimezone} {
 			if val := runtime.Str(flag); val != "" {
-				if err := common.RejectDangerousChars("--"+flag, val); err != nil {
-					return output.ErrValidation(err.Error())
+				if err := common.RejectDangerousCharsTyped("--"+flag, val); err != nil {
+					return err
 				}
 			}
 		}
@@ -237,7 +237,7 @@ var CalendarSuggestion = common.Shortcut{
 					continue
 				}
 				if !strings.HasPrefix(id, "ou_") && !strings.HasPrefix(id, "oc_") {
-					return output.ErrValidation("invalid attendee id format %q: should start with 'ou_' or 'oc_'", id)
+					return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid attendee id format %q: should start with 'ou_' or 'oc_'", id).WithParam("--" + flagAttendees)
 				}
 			}
 		}
@@ -245,14 +245,14 @@ var CalendarSuggestion = common.Shortcut{
 		startInput := runtime.Str(flagStart)
 		if startInput != "" {
 			if _, err := common.ParseTime(startInput); err != nil {
-				return output.ErrValidation("invalid start time: %v", err)
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid start time: %v", err).WithParam("--start")
 			}
 		}
 
 		endInput := runtime.Str(flagEnd)
 		if endInput != "" {
 			if _, err := common.ParseTime(endInput, "end"); err != nil {
-				return output.ErrValidation("invalid end time: %v", err)
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid end time: %v", err).WithParam("--end")
 			}
 		}
 
@@ -267,13 +267,13 @@ var CalendarSuggestion = common.Shortcut{
 				}
 				parts := strings.Split(r, "~")
 				if len(parts) != 2 {
-					return output.ErrValidation("invalid range format in --exclude: %q, expect start~end", r)
+					return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid range format in --exclude: %q, expect start~end", r).WithParam("--exclude")
 				}
 				if _, err := common.ParseTime(parts[0]); err != nil {
-					return output.ErrValidation("invalid start time in --exclude: %q (%v)", parts[0], err)
+					return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid start time in --exclude: %q (%v)", parts[0], err).WithParam("--exclude")
 				}
 				if _, err := common.ParseTime(parts[1], "end"); err != nil {
-					return output.ErrValidation("invalid end time in --exclude: %q (%v)", parts[1], err)
+					return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid end time in --exclude: %q (%v)", parts[1], err).WithParam("--exclude")
 				}
 			}
 		}
@@ -292,20 +292,19 @@ var CalendarSuggestion = common.Shortcut{
 			Body:       req,
 		})
 		if err != nil {
-			return err
+			if _, ok := errs.ProblemOf(err); ok {
+				return err
+			}
+			return errs.WrapInternal(err)
 		}
 
-		if apiResp.StatusCode < http.StatusOK || apiResp.StatusCode >= http.StatusMultipleChoices {
-			return output.ErrAPI(apiResp.StatusCode, "", string(apiResp.RawBody))
+		if _, err := runtime.ClassifyAPIResponse(apiResp); err != nil {
+			return err
 		}
 
 		var resp = &OpenAPIResponse[*SuggestionResponse]{}
 		if err := json.Unmarshal(apiResp.RawBody, &resp); err != nil {
-			return output.ErrWithHint(output.ExitInternal, "validation", "unmarshal response fail", err.Error())
-		}
-
-		if resp.Code != 0 {
-			return output.ErrAPI(resp.Code, resp.Msg, resp.Data)
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "unmarshal response fail").WithCause(err)
 		}
 
 		data := resp.Data

--- a/shortcuts/calendar/calendar_test.go
+++ b/shortcuts/calendar/calendar_test.go
@@ -8,10 +8,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
@@ -19,6 +21,11 @@ import (
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
 )
+
+// codeInvalidParamsWithDetail is the Lark "invalid params" code (190014) used
+// across the API-error fixtures below. It mirrors the value registered in
+// internal/errclass/codemeta_calendar.go.
+const codeInvalidParamsWithDetail = 190014
 
 // ---------------------------------------------------------------------------
 // helpers
@@ -295,8 +302,17 @@ func TestCreate_WithAttendees_APIError_RollsBack(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid attendees, got nil")
 	}
-	if !strings.Contains(err.Error(), "rolled back successfully") && !strings.Contains(err.Error(), "auto-rolled back") {
-		t.Fatalf("error should mention rollback, got: %v", err)
+	// Enrich-in-place: classification of the add-attendees failure is preserved
+	// (APIError / code 190002) and the rollback context rides on the Hint.
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
+	}
+	if ae.Code != 190002 {
+		t.Errorf("expected preserved code 190002, got %d", ae.Code)
+	}
+	if !strings.Contains(ae.Hint, "rolled back successfully") {
+		t.Fatalf("hint should mention rollback, got: %q", ae.Hint)
 	}
 }
 
@@ -412,7 +428,7 @@ func TestCreate_CreateEvent_InvalidParamsWithDetail(t *testing.T) {
 		Method: "POST",
 		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events",
 		Body: map[string]interface{}{
-			"code": errCodeInvalidParamsWithDetail,
+			"code": codeInvalidParamsWithDetail,
 			"msg":  "invalid params",
 			"error": map[string]interface{}{
 				"details": []interface{}{
@@ -434,15 +450,18 @@ func TestCreate_CreateEvent_InvalidParamsWithDetail(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 190014, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
 	}
-	if exitErr.Detail.Code != errCodeInvalidParamsWithDetail {
-		t.Errorf("expected code %d, got %d", errCodeInvalidParamsWithDetail, exitErr.Detail.Code)
+	if ae.Subtype != errs.SubtypeInvalidParameters {
+		t.Errorf("subtype=%q, want invalid_parameters", ae.Subtype)
 	}
-	if !strings.Contains(exitErr.Detail.Message, "end_time should be later than start_time") {
-		t.Errorf("expected detail value in message, got %q", exitErr.Detail.Message)
+	if ae.Code != codeInvalidParamsWithDetail {
+		t.Errorf("expected code %d, got %d", codeInvalidParamsWithDetail, ae.Code)
+	}
+	if !strings.Contains(ae.Hint, "end_time should be later than start_time") {
+		t.Errorf("expected detail value in hint, got %q", ae.Hint)
 	}
 }
 
@@ -453,7 +472,7 @@ func TestCreate_CreateEvent_InvalidParamsWithoutDetailValue(t *testing.T) {
 		Method: "POST",
 		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events",
 		Body: map[string]interface{}{
-			"code": errCodeInvalidParamsWithDetail,
+			"code": codeInvalidParamsWithDetail,
 			"msg":  "invalid params",
 		},
 	})
@@ -470,12 +489,15 @@ func TestCreate_CreateEvent_InvalidParamsWithoutDetailValue(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 190014, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
 	}
-	if exitErr.Detail.Code != errCodeInvalidParamsWithDetail {
-		t.Errorf("expected code %d, got %d", errCodeInvalidParamsWithDetail, exitErr.Detail.Code)
+	if ae.Subtype != errs.SubtypeInvalidParameters {
+		t.Errorf("subtype=%q, want invalid_parameters", ae.Subtype)
+	}
+	if ae.Code != codeInvalidParamsWithDetail {
+		t.Errorf("expected code %d, got %d", codeInvalidParamsWithDetail, ae.Code)
 	}
 }
 
@@ -501,12 +523,12 @@ func TestCreate_CreateEvent_InvalidParams_ErrorNotMap(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 190014, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
 	}
-	if exitErr.Detail.Code != errCodeInvalidParamsWithDetail {
-		t.Errorf("expected code %d, got %d", errCodeInvalidParamsWithDetail, exitErr.Detail.Code)
+	if ae.Code != codeInvalidParamsWithDetail {
+		t.Errorf("expected code %d, got %d", codeInvalidParamsWithDetail, ae.Code)
 	}
 }
 
@@ -517,7 +539,7 @@ func TestCreate_CreateEvent_InvalidParams_NoDetailsKey(t *testing.T) {
 		Method: "POST",
 		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events",
 		Body: map[string]interface{}{
-			"code": errCodeInvalidParamsWithDetail,
+			"code": codeInvalidParamsWithDetail,
 			"msg":  "invalid params",
 			"error": map[string]interface{}{
 				"other_key": "no details here",
@@ -537,12 +559,12 @@ func TestCreate_CreateEvent_InvalidParams_NoDetailsKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 190014, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
 	}
-	if exitErr.Detail.Code != errCodeInvalidParamsWithDetail {
-		t.Errorf("expected code %d, got %d", errCodeInvalidParamsWithDetail, exitErr.Detail.Code)
+	if ae.Code != codeInvalidParamsWithDetail {
+		t.Errorf("expected code %d, got %d", codeInvalidParamsWithDetail, ae.Code)
 	}
 }
 
@@ -553,7 +575,7 @@ func TestCreate_CreateEvent_InvalidParams_DetailItemNotMap(t *testing.T) {
 		Method: "POST",
 		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events",
 		Body: map[string]interface{}{
-			"code": errCodeInvalidParamsWithDetail,
+			"code": codeInvalidParamsWithDetail,
 			"msg":  "invalid params",
 			"error": map[string]interface{}{
 				"details": []interface{}{nil},
@@ -573,12 +595,12 @@ func TestCreate_CreateEvent_InvalidParams_DetailItemNotMap(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 190014, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
 	}
-	if exitErr.Detail.Code != errCodeInvalidParamsWithDetail {
-		t.Errorf("expected code %d, got %d", errCodeInvalidParamsWithDetail, exitErr.Detail.Code)
+	if ae.Code != codeInvalidParamsWithDetail {
+		t.Errorf("expected code %d, got %d", codeInvalidParamsWithDetail, ae.Code)
 	}
 }
 
@@ -604,7 +626,7 @@ func TestCreate_WithAttendees_InvalidParamsWithDetail_RollsBack(t *testing.T) {
 		Method: "POST",
 		URL:    "/events/evt_190014/attendees",
 		Body: map[string]interface{}{
-			"code": errCodeInvalidParamsWithDetail,
+			"code": codeInvalidParamsWithDetail,
 			"msg":  "invalid params",
 			"error": map[string]interface{}{
 				"details": []interface{}{
@@ -632,8 +654,90 @@ func TestCreate_WithAttendees_InvalidParamsWithDetail_RollsBack(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid attendees with 190014, got nil")
 	}
-	if !strings.Contains(err.Error(), "invalid attendee open_id") {
-		t.Errorf("expected detail value in error, got: %v", err)
+	// Enrich-in-place: the underlying typed add-attendees failure is returned
+	// unchanged except that the rollback context is appended to its Hint. Its
+	// classification (APIError / code 190014) and the lifted server detail are
+	// preserved.
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
+	}
+	if ae.Code != codeInvalidParamsWithDetail {
+		t.Errorf("expected preserved code %d, got %d", codeInvalidParamsWithDetail, ae.Code)
+	}
+	if !strings.Contains(ae.Hint, "invalid attendee open_id") {
+		t.Errorf("expected lifted server detail preserved in hint, got: %q", ae.Hint)
+	}
+	if !strings.Contains(ae.Hint, "rolled back successfully") {
+		t.Errorf("expected rollback context appended to hint, got: %q", ae.Hint)
+	}
+}
+
+// When the add-attendees call fails AND the rollback DELETE also fails, the
+// primary error stays the add failure (classification preserved) and the Hint
+// must surface BOTH the rollback failure reason and the orphan event_id so the
+// user can clean up manually.
+func TestCreate_WithAttendees_RollbackAlsoFails(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"event": map[string]interface{}{
+					"event_id":   "evt_orphan",
+					"summary":    "Bad Attendees",
+					"start_time": map[string]interface{}{"timestamp": "1742515200"},
+					"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+				},
+			},
+		},
+	})
+	// Add-attendees fails with a business code.
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/events/evt_orphan/attendees",
+		Body:   map[string]interface{}{"code": 190002, "msg": "invalid user_id"},
+	})
+	// Rollback DELETE also fails with a distinct business code.
+	reg.Register(&httpmock.Stub{
+		Method: "DELETE",
+		URL:    "/events/evt_orphan",
+		Body:   map[string]interface{}{"code": 230098, "msg": "delete blocked"},
+	})
+
+	err := mountAndRun(t, CalendarCreate, []string{
+		"+create",
+		"--summary", "Bad Attendees",
+		"--start", "2025-03-21T00:00:00+08:00",
+		"--end", "2025-03-21T01:00:00+08:00",
+		"--calendar-id", "cal_test123",
+		"--attendee-ids", "ou_invalid",
+		"--as", "bot",
+	}, f, nil)
+
+	if err == nil {
+		t.Fatal("expected error when both add and rollback fail, got nil")
+	}
+	// Primary error is the add failure: classification preserved (code 190002).
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
+	}
+	if ae.Code != 190002 {
+		t.Errorf("expected preserved add-failure code 190002, got %d", ae.Code)
+	}
+	// The Hint must surface the rollback failure (its signal) and the orphan id.
+	if !strings.Contains(ae.Hint, "rollback also failed") {
+		t.Errorf("expected rollback-failure context in hint, got: %q", ae.Hint)
+	}
+	if !strings.Contains(ae.Hint, "delete blocked") {
+		t.Errorf("expected rollbackErr signal in hint, got: %q", ae.Hint)
+	}
+	if !strings.Contains(ae.Hint, "orphan event_id=evt_orphan") {
+		t.Errorf("expected orphan event_id in hint, got: %q", ae.Hint)
 	}
 }
 
@@ -1173,7 +1277,7 @@ func TestAgenda_InvalidParamsWithDetail(t *testing.T) {
 		Method: "GET",
 		URL:    "/events/instance_view",
 		Body: map[string]interface{}{
-			"code": errCodeInvalidParamsWithDetail,
+			"code": codeInvalidParamsWithDetail,
 			"msg":  "invalid params",
 			"error": map[string]interface{}{
 				"details": []interface{}{
@@ -1193,16 +1297,22 @@ func TestAgenda_InvalidParamsWithDetail(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 190014, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
 	}
-	if exitErr.Detail.Code != errCodeInvalidParamsWithDetail {
-		t.Errorf("expected code %d, got %d", errCodeInvalidParamsWithDetail, exitErr.Detail.Code)
+	if ae.Subtype != errs.SubtypeInvalidParameters {
+		t.Errorf("subtype=%q, want invalid_parameters", ae.Subtype)
+	}
+	if ae.Code != codeInvalidParamsWithDetail {
+		t.Errorf("expected code %d, got %d", codeInvalidParamsWithDetail, ae.Code)
+	}
+	if !strings.Contains(ae.Hint, "start_time is required") {
+		t.Errorf("expected detail value in hint, got %q", ae.Hint)
 	}
 }
 
-func TestAgenda_NonExitError_Passthrough(t *testing.T) {
+func TestAgenda_NonAPIError_Passthrough(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
 
 	reg.Register(&httpmock.Stub{
@@ -1221,9 +1331,123 @@ func TestAgenda_NonExitError_Passthrough(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for non-JSON response, got nil")
 	}
-	var exitErr *output.ExitError
-	if errors.As(err, &exitErr) && exitErr.Detail != nil && exitErr.Detail.Code != 0 {
-		t.Fatalf("expected non-API error passthrough, got API error code %d", exitErr.Detail.Code)
+	// A non-JSON 200 body is not an API business error: it surfaces as a typed
+	// InternalError{SubtypeInvalidResponse} from WrapJSONResponseParseError.
+	var ie *errs.InternalError
+	if !errors.As(err, &ie) {
+		t.Fatalf("expected *errs.InternalError, got %T", err)
+	}
+	if ie.Subtype != errs.SubtypeInvalidResponse {
+		t.Errorf("subtype=%q, want invalid_response", ie.Subtype)
+	}
+}
+
+// TestAgenda_TimeRangeExceeded_RecursiveSplit pins that a 193103 ("time range
+// exceeds 40-day limit") response from CallAPITyped is caught, the range is
+// split, and the successful sub-range results are aggregated. The stubs are
+// consumed in registration order: full range → 193103, then the two halves
+// succeed.
+func TestAgenda_TimeRangeExceeded_RecursiveSplit(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	// Full range rejected with the time-range-exceeded code.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/events/instance_view",
+		Body:   map[string]interface{}{"code": 193103, "msg": "time range exceeds limit"},
+	})
+	// Left half succeeds with one event.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/events/instance_view",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{
+						"event_id":   "evt_left",
+						"summary":    "Left",
+						"status":     "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1742515200"},
+						"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+					},
+				},
+			},
+		},
+	})
+	// Right half succeeds with one event.
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/events/instance_view",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{
+						"event_id":   "evt_right",
+						"summary":    "Right",
+						"status":     "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1742519000"},
+						"end_time":   map[string]interface{}{"timestamp": "1742522600"},
+					},
+				},
+			},
+		},
+	})
+
+	err := mountAndRun(t, CalendarAgenda, []string{
+		"+agenda",
+		"--start", "2025-03-21T00:00:00+08:00",
+		"--end", "2025-03-21T06:00:00+08:00",
+		"--as", "bot",
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "evt_left") || !strings.Contains(out, "evt_right") {
+		t.Errorf("expected aggregated split results, got: %s", out)
+	}
+}
+
+// TestAgenda_TooManyInstances_SplitExhausted pins that when the range is already
+// at or below the minimum split window and the server still returns 193104, the
+// recursion stops and surfaces a typed APIError carrying code 193104 (exit 1).
+func TestAgenda_TooManyInstances_SplitExhausted(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/events/instance_view",
+		Reusable: true,
+		Body:     map[string]interface{}{"code": 193104, "msg": "too many instances"},
+	})
+
+	// A 1-hour span is below minSplitWindowSeconds (2h), so the 193104 branch
+	// cannot split further and must surface the typed error.
+	err := mountAndRun(t, CalendarAgenda, []string{
+		"+agenda",
+		"--start", "2025-03-21T00:00:00+08:00",
+		"--end", "2025-03-21T01:00:00+08:00",
+		"--as", "bot",
+	}, f, nil)
+
+	if err == nil {
+		t.Fatal("expected error when split is exhausted, got nil")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
+	}
+	if ae.Code != 193104 {
+		t.Errorf("code=%d, want 193104", ae.Code)
+	}
+	if output.ExitCodeOf(err) != output.ExitAPI {
+		t.Errorf("exit=%d, want ExitAPI", output.ExitCodeOf(err))
+	}
+	if !strings.Contains(ae.Error(), "narrow the range") {
+		t.Errorf("expected narrow-the-range guidance, got: %q", ae.Error())
 	}
 }
 
@@ -1314,7 +1538,7 @@ func TestFreebusy_InvalidParamsWithDetail(t *testing.T) {
 		Method: "POST",
 		URL:    "/open-apis/calendar/v4/freebusy/list",
 		Body: map[string]interface{}{
-			"code": errCodeInvalidParamsWithDetail,
+			"code": codeInvalidParamsWithDetail,
 			"msg":  "invalid params",
 			"error": map[string]interface{}{
 				"details": []interface{}{
@@ -1335,15 +1559,18 @@ func TestFreebusy_InvalidParamsWithDetail(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 190014, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
 	}
-	if exitErr.Detail.Code != errCodeInvalidParamsWithDetail {
-		t.Errorf("expected code %d, got %d", errCodeInvalidParamsWithDetail, exitErr.Detail.Code)
+	if ae.Subtype != errs.SubtypeInvalidParameters {
+		t.Errorf("subtype=%q, want invalid_parameters", ae.Subtype)
 	}
-	if !strings.Contains(exitErr.Detail.Message, "user_id is invalid") {
-		t.Errorf("expected detail value in message, got %q", exitErr.Detail.Message)
+	if ae.Code != codeInvalidParamsWithDetail {
+		t.Errorf("expected code %d, got %d", codeInvalidParamsWithDetail, ae.Code)
+	}
+	if !strings.Contains(ae.Hint, "user_id is invalid") {
+		t.Errorf("expected detail value in hint, got %q", ae.Hint)
 	}
 }
 
@@ -1440,6 +1667,13 @@ func TestRsvp_RejectsDangerousChars(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "dangerous Unicode") && !strings.Contains(err.Error(), "control character") {
 		t.Errorf("error should mention dangerous input, got: %v", err)
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--event-id" {
+		t.Errorf("param=%q, want --event-id", ve.Param)
 	}
 }
 
@@ -1644,6 +1878,61 @@ func TestSuggestion_InvalidAttendee_Fails(t *testing.T) {
 	if !strings.Contains(err.Error(), "invalid attendee id format") {
 		t.Errorf("error should mention attendee id format, got: %v", err)
 	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--attendee-ids" {
+		t.Errorf("param=%q, want --attendee-ids", ve.Param)
+	}
+}
+
+func TestSuggestion_HTTPNon2xx_Typed(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{Method: "POST", URL: suggestionPath, Status: 500, Body: map[string]interface{}{"code": 500, "msg": "server error"}})
+	err := mountAndRun(t, CalendarSuggestion, []string{"+suggestion", "--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *errs.APIError, got %T", err)
+	}
+	if ae.Code != 500 {
+		t.Errorf("code=%d, want 500", ae.Code)
+	}
+}
+
+func TestSuggestion_UnmarshalFail_Typed(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{Method: "POST", URL: suggestionPath, Status: 200, RawBody: []byte("not json")})
+	err := mountAndRun(t, CalendarSuggestion, []string{"+suggestion", "--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ie *errs.InternalError
+	if !errors.As(err, &ie) {
+		t.Fatalf("want *errs.InternalError, got %T", err)
+	}
+	if ie.Subtype != errs.SubtypeInvalidResponse {
+		t.Errorf("subtype=%q, want invalid_response", ie.Subtype)
+	}
+}
+
+func TestRoomFind_UnmarshalFail_Typed(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{Method: "POST", URL: roomFindPath, Status: 200, RawBody: []byte("not json")})
+	err := mountAndRun(t, CalendarRoomFind, []string{"+room-find", "--slot", "2025-03-21T10:00:00+08:00~2025-03-21T11:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ie *errs.InternalError
+	if !errors.As(err, &ie) {
+		t.Fatalf("want *errs.InternalError, got %T", err)
+	}
+	if ie.Subtype != errs.SubtypeInvalidResponse {
+		t.Errorf("subtype=%q, want invalid_response", ie.Subtype)
+	}
 }
 
 func TestSuggestion_InvalidExclude_Fails(t *testing.T) {
@@ -1746,6 +2035,13 @@ func TestRoomFind_RejectsDangerousChars(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--room-name") {
 		t.Fatalf("expected dangerous char error for --room-name, got: %v", err)
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--room-name" {
+		t.Errorf("param=%q, want --room-name", ve.Param)
 	}
 }
 
@@ -1960,5 +2256,855 @@ func TestShortcuts_AllHaveScopes(t *testing.T) {
 		if s.Scopes == nil {
 			t.Errorf("shortcut %s: Scopes is nil", s.Command)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Typed error shape tests (typed-errs migration pass 1)
+// ---------------------------------------------------------------------------
+
+// Task 1: calendar_agenda.go
+func TestAgenda_ParseTimeRange_InvalidStart_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarAgenda, []string{"+agenda", "--start", "not-a-time", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q", ve.Subtype)
+	}
+	if ve.Param != "--start" {
+		t.Errorf("param=%q, want --start", ve.Param)
+	}
+}
+
+// Task 2: calendar_create.go
+func TestCreate_InvalidAttendeeID_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarCreate, []string{"+create", "--summary", "x", "--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00", "--calendar-id", "cal_test123", "--attendee-ids", "bad_id", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q", ve.Subtype)
+	}
+}
+
+func TestCreate_NoEventID_TypedInternal(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{Method: "POST", URL: "/open-apis/calendar/v4/calendars/cal_test123/events", Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{"event": map[string]interface{}{}}}})
+	err := mountAndRun(t, CalendarCreate, []string{"+create", "--summary", "x", "--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00", "--calendar-id", "cal_test123", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ie *errs.InternalError
+	if !errors.As(err, &ie) {
+		t.Fatalf("want *errs.InternalError, got %T", err)
+	}
+	if ie.Subtype != errs.SubtypeInvalidResponse {
+		t.Errorf("subtype=%q", ie.Subtype)
+	}
+}
+
+// Task 3: calendar_freebusy.go
+func TestFreebusy_InvalidStart_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarFreebusy, []string{"+freebusy", "--start", "not-a-time", "--user-id", "ou_someone", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q", ve.Subtype)
+	}
+	if ve.Param != "--start" {
+		t.Errorf("param=%q, want --start", ve.Param)
+	}
+}
+
+// Task 4: calendar_rsvp.go
+func TestRsvp_EmptyEventID_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarRsvp, []string{"+rsvp", "--event-id", "   ", "--rsvp-status", "accept", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q", ve.Subtype)
+	}
+	if ve.Param != "--event-id" {
+		t.Errorf("param=%q, want --event-id", ve.Param)
+	}
+}
+
+// Task 5: calendar_room_find.go
+func TestRoomFind_MissingSlot_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarRoomFind, []string{"+room-find", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q", ve.Subtype)
+	}
+	if ve.Param != "--slot" {
+		t.Errorf("param=%q, want --slot", ve.Param)
+	}
+}
+
+func TestRoomFind_APICodeError_Typed(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{Method: "POST", URL: roomFindPath, Body: map[string]interface{}{"code": 99991, "msg": "boom"}})
+	err := mountAndRun(t, CalendarRoomFind, []string{"+room-find", "--slot", "2025-03-21T10:00:00+08:00~2025-03-21T11:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *errs.APIError, got %T", err)
+	}
+	if ae.Subtype != errs.SubtypeUnknown {
+		t.Errorf("subtype=%q, want unknown", ae.Subtype)
+	}
+	if ae.Code != 99991 {
+		t.Errorf("code=%d, want 99991", ae.Code)
+	}
+	if output.ExitCodeOf(err) != output.ExitAPI {
+		t.Errorf("exit=%d want ExitAPI", output.ExitCodeOf(err))
+	}
+}
+
+func TestRoomFind_APICodeError_PreservesEnvelopeDetails(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    roomFindPath,
+		Headers: http.Header{
+			"Content-Type": []string{"application/json"},
+			"X-Tt-Logid":   []string{"log-room-find"},
+		},
+		Body: map[string]interface{}{
+			"code": codeInvalidParamsWithDetail,
+			"msg":  "invalid params",
+			"error": map[string]interface{}{
+				"details": []interface{}{
+					map[string]interface{}{"value": "event_start_time is required"},
+				},
+			},
+		},
+	})
+	err := mountAndRun(t, CalendarRoomFind, []string{"+room-find", "--slot", "2025-03-21T10:00:00+08:00~2025-03-21T11:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *errs.APIError, got %T", err)
+	}
+	if ae.Code != codeInvalidParamsWithDetail {
+		t.Errorf("code=%d, want %d", ae.Code, codeInvalidParamsWithDetail)
+	}
+	if !strings.Contains(ae.Hint, "event_start_time is required") {
+		t.Errorf("expected server detail in hint, got %q", ae.Hint)
+	}
+	if ae.LogID != "log-room-find" {
+		t.Errorf("log_id=%q, want log-room-find", ae.LogID)
+	}
+}
+
+func TestRoomFind_HTTPNon2xx_Typed(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{Method: "POST", URL: roomFindPath, Status: 500, Body: map[string]interface{}{"code": 500, "msg": "server error"}})
+	err := mountAndRun(t, CalendarRoomFind, []string{"+room-find", "--slot", "2025-03-21T10:00:00+08:00~2025-03-21T11:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *errs.APIError, got %T", err)
+	}
+	if ae.Subtype != errs.SubtypeUnknown {
+		t.Errorf("subtype=%q, want unknown", ae.Subtype)
+	}
+	if ae.Code != 500 {
+		t.Errorf("code=%d, want 500", ae.Code)
+	}
+	if output.ExitCodeOf(err) != output.ExitAPI {
+		t.Errorf("exit=%d want ExitAPI", output.ExitCodeOf(err))
+	}
+}
+
+// Task 6: calendar_suggestion.go
+func TestSuggestion_InvalidExclude_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarSuggestion, []string{"+suggestion", "--exclude", "not-a-range", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q", ve.Subtype)
+	}
+	if ve.Param != "--exclude" {
+		t.Errorf("param=%q, want --exclude", ve.Param)
+	}
+}
+
+func TestSuggestion_APICodeError_Typed(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{Method: "POST", URL: suggestionPath, Body: map[string]interface{}{"code": 99991, "msg": "boom"}})
+	err := mountAndRun(t, CalendarSuggestion, []string{"+suggestion", "--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *errs.APIError, got %T", err)
+	}
+	if ae.Subtype != errs.SubtypeUnknown {
+		t.Errorf("subtype=%q, want unknown", ae.Subtype)
+	}
+	if ae.Code != 99991 {
+		t.Errorf("code=%d, want 99991", ae.Code)
+	}
+	if output.ExitCodeOf(err) != output.ExitAPI {
+		t.Errorf("exit=%d want ExitAPI", output.ExitCodeOf(err))
+	}
+}
+
+func TestSuggestion_APICodeError_PreservesEnvelopeDetails(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    suggestionPath,
+		Headers: http.Header{
+			"Content-Type": []string{"application/json"},
+			"X-Tt-Logid":   []string{"log-suggestion"},
+		},
+		Body: map[string]interface{}{
+			"code": codeInvalidParamsWithDetail,
+			"msg":  "invalid params",
+			"error": map[string]interface{}{
+				"details": []interface{}{
+					map[string]interface{}{"value": "search_end_time must be after search_start_time"},
+				},
+			},
+		},
+	})
+	err := mountAndRun(t, CalendarSuggestion, []string{"+suggestion", "--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("want *errs.APIError, got %T", err)
+	}
+	if ae.Code != codeInvalidParamsWithDetail {
+		t.Errorf("code=%d, want %d", ae.Code, codeInvalidParamsWithDetail)
+	}
+	if !strings.Contains(ae.Hint, "search_end_time must be after search_start_time") {
+		t.Errorf("expected server detail in hint, got %q", ae.Hint)
+	}
+	if ae.LogID != "log-suggestion" {
+		t.Errorf("log_id=%q, want log-suggestion", ae.LogID)
+	}
+}
+
+// Task 7: calendar_update.go
+func TestUpdate_AttendeeConflict_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarUpdate, []string{"+update", "--event-id", "evt_1", "--add-attendee-ids", "ou_dup", "--remove-attendee-ids", "ou_dup", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q", ve.Subtype)
+	}
+	if ve.Param != "" {
+		t.Errorf("param=%q, want empty (cross-flag)", ve.Param)
+	}
+}
+
+// The empty-event-id guard at executeCalendarUpdate is defensive: the Validate
+// hook (validateCalendarUpdate) rejects an empty --event-id before Execute runs,
+// so the :283 guard is unreachable through the normal CLI flow. Exercise it
+// directly to pin the migrated typed shape (ValidationError / invalid_argument /
+// --event-id).
+func TestUpdate_EmptyEventID_Typed(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("calendar-id", "", "")
+	cmd.Flags().String("event-id", "", "")
+	runtime := common.TestNewRuntimeContextWithCtx(context.Background(), cmd, defaultConfig())
+	err := executeCalendarUpdate(context.Background(), runtime)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q, want invalid_argument", ve.Subtype)
+	}
+	if ve.Param != "--event-id" {
+		t.Errorf("param=%q, want --event-id", ve.Param)
+	}
+}
+
+// Round-1 completeness: FlagErrorf call sites migrated to typed errs.
+
+// calendar_create.go start/end validation block.
+func TestCreate_MissingStart_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	// --start is a Required flag; pass it empty to satisfy cobra's required-flag
+	// check and reach the in-builder empty-value guard.
+	err := mountAndRun(t, CalendarCreate, []string{"+create", "--summary", "x", "--calendar-id", "cal_test123", "--start", "", "--end", "2025-03-21T11:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q, want invalid_argument", ve.Subtype)
+	}
+	if ve.Param != "--start" {
+		t.Errorf("param=%q, want --start", ve.Param)
+	}
+}
+
+// calendar_freebusy.go bot-identity guard.
+func TestFreebusy_BotMissingUserID_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarFreebusy, []string{"+freebusy", "--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q, want invalid_argument", ve.Subtype)
+	}
+	if ve.Param != "--user-id" {
+		t.Errorf("param=%q, want --user-id", ve.Param)
+	}
+}
+
+// calendar_update.go buildCalendarUpdateEventData time-pairing guard.
+func TestUpdate_StartWithoutEnd_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarUpdate, []string{"+update", "--event-id", "evt_1", "--start", "2025-03-21T10:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype=%q, want invalid_argument", ve.Subtype)
+	}
+}
+
+// calendar_update.go invalid start-time guard carries the offending flag.
+func TestUpdate_InvalidStartTime_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarUpdate, []string{"+update", "--event-id", "evt_1", "--start", "not-a-time", "--end", "2025-03-21T11:00:00+08:00", "--as", "bot"}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--start" {
+		t.Errorf("param=%q, want --start", ve.Param)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Additional success / branch coverage for the migrated command paths.
+// ---------------------------------------------------------------------------
+
+// TestAgenda_TooManyInstances_SplitSucceeds pins the 193104 recovery path: the
+// full range trips the too-many-instances limit, the window is halved via
+// fetchInstanceViewSplit, and both sub-ranges succeed and aggregate.
+func TestAgenda_TooManyInstances_SplitSucceeds(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/events/instance_view",
+		Body:   map[string]interface{}{"code": 193104, "msg": "too many instances"},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/events/instance_view",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{
+						"event_id":   "evt_left",
+						"summary":    "Left",
+						"status":     "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1742515200"},
+						"end_time":   map[string]interface{}{"timestamp": "1742518800"},
+					},
+				},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/events/instance_view",
+		Body: map[string]interface{}{
+			"code": 0, "msg": "ok",
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{
+						"event_id":   "evt_right",
+						"summary":    "Right",
+						"status":     "confirmed",
+						"start_time": map[string]interface{}{"timestamp": "1745193600"},
+						"end_time":   map[string]interface{}{"timestamp": "1745197200"},
+					},
+				},
+			},
+		},
+	})
+
+	// A 30-day span is above minSplitWindowSeconds (2h), so the 193104 branch
+	// halves the window and aggregates the two successful sub-ranges.
+	err := mountAndRun(t, CalendarAgenda, []string{
+		"+agenda",
+		"--start", "2025-03-21T00:00:00+08:00",
+		"--end", "2025-04-20T00:00:00+08:00",
+		"--as", "bot",
+	}, f, stdout)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "evt_left") || !strings.Contains(out, "evt_right") {
+		t.Errorf("expected aggregated events from both halves, got: %s", out)
+	}
+}
+
+// TestAgenda_TimeRangeExceeded_CannotSplit pins the 193103 guard where the
+// window is a single point (mid <= startTime), so the range cannot be narrowed
+// further and the typed error surfaces.
+func TestAgenda_TimeRangeExceeded_CannotSplit(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+
+	reg.Register(&httpmock.Stub{
+		Method:   "GET",
+		URL:      "/events/instance_view",
+		Reusable: true,
+		Body:     map[string]interface{}{"code": 193103, "msg": "time range exceeds limit"},
+	})
+
+	// start == end gives a zero-length span; the 193103 branch computes
+	// mid == startTime and bails with the typed "narrow the range" error.
+	err := mountAndRun(t, CalendarAgenda, []string{
+		"+agenda",
+		"--start", "2025-03-21T00:00:00+08:00",
+		"--end", "2025-03-21T00:00:00+08:00",
+		"--as", "bot",
+	}, f, nil)
+
+	if err == nil {
+		t.Fatal("expected typed error when 193103 range cannot be split, got nil")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
+	}
+	if ae.Code != 193103 {
+		t.Errorf("code=%d, want 193103", ae.Code)
+	}
+	if !strings.Contains(ae.Error(), "narrow the range") {
+		t.Errorf("expected narrow-the-range guidance, got: %q", ae.Error())
+	}
+}
+
+// TestUpdate_PatchStepFails_TypedError pins that a failed event PATCH surfaces
+// the typed API error wrapped with completed-step context.
+func TestUpdate_PatchStepFails_TypedError(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/calendar/v4/calendars/cal_test123/events/evt_patchfail",
+		Body:   map[string]interface{}{"code": 190001, "msg": "permission denied"},
+	})
+
+	err := mountAndRun(t, CalendarUpdate, []string{
+		"+update",
+		"--event-id", "evt_patchfail",
+		"--calendar-id", "cal_test123",
+		"--summary", "New title",
+		"--as", "bot",
+	}, f, nil)
+
+	if err == nil {
+		t.Fatal("expected error when PATCH step fails, got nil")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
+	}
+}
+
+// TestUpdate_RemoveStepFails_TypedError pins the batch_delete failure path.
+func TestUpdate_RemoveStepFails_TypedError(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/events/evt_removefail/attendees/batch_delete",
+		Body:   map[string]interface{}{"code": 190001, "msg": "permission denied"},
+	})
+
+	err := mountAndRun(t, CalendarUpdate, []string{
+		"+update",
+		"--event-id", "evt_removefail",
+		"--remove-attendee-ids", "ou_user1",
+		"--as", "bot",
+	}, f, nil)
+
+	if err == nil {
+		t.Fatal("expected error when remove step fails, got nil")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
+	}
+}
+
+// TestUpdate_AddStepFails_TypedError pins the add-attendees failure path.
+func TestUpdate_AddStepFails_TypedError(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/events/evt_addfail/attendees",
+		Body:   map[string]interface{}{"code": 190001, "msg": "permission denied"},
+	})
+
+	err := mountAndRun(t, CalendarUpdate, []string{
+		"+update",
+		"--event-id", "evt_addfail",
+		"--add-attendee-ids", "ou_user1",
+		"--as", "bot",
+	}, f, nil)
+
+	if err == nil {
+		t.Fatal("expected error when add step fails, got nil")
+	}
+	var ae *errs.APIError
+	if !errors.As(err, &ae) {
+		t.Fatalf("expected *errs.APIError, got %T", err)
+	}
+}
+
+// TestUpdate_InvalidEndTime_TypedFlag pins the --end parse error inside
+// buildCalendarUpdateEventData (start valid, end malformed).
+func TestUpdate_InvalidEndTime_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarUpdate, []string{
+		"+update", "--event-id", "evt_1",
+		"--start", "2025-03-21T10:00:00+08:00", "--end", "not-a-time", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--end" {
+		t.Errorf("param=%q, want --end", ve.Param)
+	}
+}
+
+// TestUpdate_RejectsDangerousChars pins the dangerous-character guard.
+func TestUpdate_RejectsDangerousChars(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarUpdate, []string{
+		"+update", "--event-id", "evt_1", "--summary", "bad\x7ftitle", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected error for dangerous chars, got nil")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--summary" {
+		t.Errorf("param=%q, want --summary", ve.Param)
+	}
+}
+
+// TestCreate_InvalidEndTime_TypedFlag pins the --end parse error in Validate.
+func TestCreate_InvalidEndTime_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarCreate, []string{
+		"+create", "--summary", "X",
+		"--start", "2025-03-21T10:00:00+08:00", "--end", "not-a-time", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--end" {
+		t.Errorf("param=%q, want --end", ve.Param)
+	}
+}
+
+// TestCreate_RejectsDangerousChars pins the dangerous-character guard on
+// --summary.
+func TestCreate_RejectsDangerousChars(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarCreate, []string{
+		"+create", "--summary", "bad\x7ftitle",
+		"--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected error for dangerous chars, got nil")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--summary" {
+		t.Errorf("param=%q, want --summary", ve.Param)
+	}
+}
+
+// TestFreebusy_InvalidEnd_TypedFlag pins the --end parse error in
+// parseFreebusyTimeRange.
+func TestFreebusy_InvalidEnd_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy", "--start", "2025-03-21", "--end", "not-a-time",
+		"--user-id", "ou_someone", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--end" {
+		t.Errorf("param=%q, want --end", ve.Param)
+	}
+}
+
+// TestFreebusy_InvalidUserID_TypedFlag pins the --user-id format guard.
+func TestFreebusy_InvalidUserID_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy", "--start", "2025-03-21", "--end", "2025-03-21",
+		"--user-id", "not-an-open-id", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--user-id" {
+		t.Errorf("param=%q, want --user-id", ve.Param)
+	}
+}
+
+// TestRoomFind_InvalidCapacity_TypedFlag pins the --min-capacity / --max-capacity
+// ordering guard.
+func TestRoomFind_InvalidCapacity_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarRoomFind, []string{
+		"+room-find",
+		"--slot", "2025-03-21T10:00:00+08:00~2025-03-21T11:00:00+08:00",
+		"--min-capacity", "10", "--max-capacity", "5", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--min-capacity" {
+		t.Errorf("param=%q, want --min-capacity", ve.Param)
+	}
+}
+
+// TestFreebusy_NoLoginNoUserID_TypedFlag pins the "cannot determine user ID"
+// guard: no --user-id, not bot, and no logged-in user.
+func TestFreebusy_NoLoginNoUserID_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, noLoginConfig())
+	err := mountAndRun(t, CalendarFreebusy, []string{
+		"+freebusy", "--start", "2025-03-21", "--end", "2025-03-21",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	// May surface as a login/identity guard or the --user-id validation guard;
+	// either way it must be a typed error, never a panic or nil.
+	if _, ok := errs.ProblemOf(err); !ok {
+		t.Fatalf("expected a typed problem error, got %T: %v", err, err)
+	}
+}
+
+// TestSuggestion_DurationOutOfRange_TypedFlag pins the --duration-minutes range
+// guard (must be 1..1440).
+func TestSuggestion_DurationOutOfRange_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarSuggestion, []string{
+		"+suggestion",
+		"--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00",
+		"--duration-minutes", "5000", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--duration-minutes" {
+		t.Errorf("param=%q, want --duration-minutes", ve.Param)
+	}
+}
+
+// TestSuggestion_InvalidStart_TypedFlag pins the --start parse guard in Validate.
+func TestSuggestion_InvalidStart_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarSuggestion, []string{
+		"+suggestion", "--start", "not-a-time", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--start" {
+		t.Errorf("param=%q, want --start", ve.Param)
+	}
+}
+
+// TestSuggestion_InvalidEnd_TypedFlag pins the --end parse guard in Validate.
+func TestSuggestion_InvalidEnd_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarSuggestion, []string{
+		"+suggestion", "--start", "2025-03-21T10:00:00+08:00", "--end", "not-a-time", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--end" {
+		t.Errorf("param=%q, want --end", ve.Param)
+	}
+}
+
+// TestSuggestion_InvalidExcludeStart_TypedFlag pins the malformed --exclude
+// start-time guard in Validate.
+func TestSuggestion_InvalidExcludeStart_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarSuggestion, []string{
+		"+suggestion",
+		"--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T18:00:00+08:00",
+		"--exclude", "not-a-time~2025-03-21T12:00:00+08:00", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--exclude" {
+		t.Errorf("param=%q, want --exclude", ve.Param)
+	}
+}
+
+// TestSuggestion_InvalidExcludeEnd_TypedFlag pins the malformed --exclude
+// end-time guard in Validate.
+func TestSuggestion_InvalidExcludeEnd_TypedFlag(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarSuggestion, []string{
+		"+suggestion",
+		"--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T18:00:00+08:00",
+		"--exclude", "2025-03-21T11:00:00+08:00~not-a-time", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--exclude" {
+		t.Errorf("param=%q, want --exclude", ve.Param)
+	}
+}
+
+// TestSuggestion_RejectsDangerousTimezone_Typed pins the dangerous-character
+// guard on --timezone.
+func TestSuggestion_RejectsDangerousTimezone_Typed(t *testing.T) {
+	f, _, _, _ := cmdutil.TestFactory(t, defaultConfig())
+	err := mountAndRun(t, CalendarSuggestion, []string{
+		"+suggestion",
+		"--start", "2025-03-21T10:00:00+08:00", "--end", "2025-03-21T11:00:00+08:00",
+		"--timezone", "Asia/Shanghai\x7f", "--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("want error")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("want *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "--timezone" {
+		t.Errorf("param=%q, want --timezone", ve.Param)
 	}
 }

--- a/shortcuts/calendar/calendar_update.go
+++ b/shortcuts/calendar/calendar_update.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -53,14 +54,14 @@ func validateCalendarUpdate(runtime *common.RuntimeContext) error {
 	}
 	for _, flag := range []string{"event-id", "summary", "description", "rrule", "calendar-id", "start", "end", "add-attendee-ids", "remove-attendee-ids"} {
 		if val := runtime.Str(flag); val != "" {
-			if err := common.RejectDangerousChars("--"+flag, val); err != nil {
-				return output.ErrValidation(err.Error())
+			if err := common.RejectDangerousCharsTyped("--"+flag, val); err != nil {
+				return err
 			}
 		}
 	}
 
 	if strings.TrimSpace(runtime.Str("event-id")) == "" {
-		return common.FlagErrorf("specify --event-id")
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "specify --event-id").WithParam("--event-id")
 	}
 	if _, _, err := buildCalendarUpdateEventData(runtime); err != nil {
 		return err
@@ -69,7 +70,7 @@ func validateCalendarUpdate(runtime *common.RuntimeContext) error {
 		return err
 	}
 	if !hasCalendarUpdateOperation(runtime) {
-		return common.FlagErrorf("nothing to update: specify at least one of --summary, --description, --start/--end, --rrule, --add-attendee-ids, or --remove-attendee-ids")
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "nothing to update: specify at least one of --summary, --description, --start/--end, --rrule, --add-attendee-ids, or --remove-attendee-ids")
 	}
 	return nil
 }
@@ -77,11 +78,11 @@ func validateCalendarUpdate(runtime *common.RuntimeContext) error {
 func validateCalendarUpdateAttendees(runtime *common.RuntimeContext) error {
 	addIDs, err := parseCalendarAttendeeIDs(runtime.Str("add-attendee-ids"))
 	if err != nil {
-		return err
+		return withParam(err, "--add-attendee-ids")
 	}
 	removeIDs, err := parseCalendarAttendeeIDs(runtime.Str("remove-attendee-ids"))
 	if err != nil {
-		return err
+		return withParam(err, "--remove-attendee-ids")
 	}
 	removeSet := make(map[string]struct{}, len(removeIDs))
 	for _, id := range removeIDs {
@@ -89,7 +90,7 @@ func validateCalendarUpdateAttendees(runtime *common.RuntimeContext) error {
 	}
 	for _, id := range addIDs {
 		if _, ok := removeSet[id]; ok {
-			return output.ErrValidation("attendee id %q appears in both --add-attendee-ids and --remove-attendee-ids", id)
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "attendee id %q appears in both --add-attendee-ids and --remove-attendee-ids", id)
 		}
 	}
 	return nil
@@ -124,27 +125,27 @@ func buildCalendarUpdateEventData(runtime *common.RuntimeContext) (map[string]in
 	startChanged := runtime.Cmd.Flags().Changed("start")
 	endChanged := runtime.Cmd.Flags().Changed("end")
 	if startChanged != endChanged {
-		return nil, false, common.FlagErrorf("--start and --end must be specified together when updating event time")
+		return nil, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--start and --end must be specified together when updating event time")
 	}
 	if startChanged {
 		startTs, err := common.ParseTime(runtime.Str("start"))
 		if err != nil {
-			return nil, false, common.FlagErrorf("--start: %v", err)
+			return nil, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--start: %v", err).WithParam("--start")
 		}
 		endTs, err := common.ParseTime(runtime.Str("end"), "end")
 		if err != nil {
-			return nil, false, common.FlagErrorf("--end: %v", err)
+			return nil, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "--end: %v", err).WithParam("--end")
 		}
 		s, err := strconv.ParseInt(startTs, 10, 64)
 		if err != nil {
-			return nil, false, common.FlagErrorf("invalid start time: %v", err)
+			return nil, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid start time: %v", err).WithParam("--start")
 		}
 		e, err := strconv.ParseInt(endTs, 10, 64)
 		if err != nil {
-			return nil, false, common.FlagErrorf("invalid end time: %v", err)
+			return nil, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid end time: %v", err).WithParam("--end")
 		}
 		if e <= s {
-			return nil, false, common.FlagErrorf("end time must be after start time")
+			return nil, false, errs.NewValidationError(errs.SubtypeInvalidArgument, "end time must be after start time")
 		}
 		body["start_time"] = map[string]string{"timestamp": startTs}
 		body["end_time"] = map[string]string{"timestamp": endTs}
@@ -169,7 +170,7 @@ func parseCalendarAttendeeIDs(attendeesStr string) ([]string, error) {
 			continue
 		}
 		if !strings.HasPrefix(id, "ou_") && !strings.HasPrefix(id, "oc_") && !strings.HasPrefix(id, "omm_") {
-			return nil, output.ErrValidation("invalid attendee id format %q: should start with 'ou_', 'oc_', or 'omm_'", id)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid attendee id format %q: should start with 'ou_', 'oc_', or 'omm_'", id)
 		}
 		if _, ok := seen[id]; ok {
 			continue
@@ -195,7 +196,7 @@ func attendeeDeleteIDs(attendeesStr string) ([]map[string]string, error) {
 		case strings.HasPrefix(id, "ou_"):
 			deleteIDs = append(deleteIDs, map[string]string{"type": "user", "user_id": id})
 		default:
-			return nil, output.ErrValidation("invalid attendee id format %q: should start with 'ou_', 'oc_', or 'omm_'", id)
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid attendee id format %q: should start with 'ou_', 'oc_', or 'omm_'", id).WithParam("--remove-attendee-ids")
 		}
 	}
 	return deleteIDs, nil
@@ -280,7 +281,7 @@ func dryRunCalendarUpdate(runtime *common.RuntimeContext) *common.DryRunAPI {
 func executeCalendarUpdate(_ context.Context, runtime *common.RuntimeContext) error {
 	calendarID, eventID := calendarUpdateIDs(runtime)
 	if eventID == "" {
-		return output.ErrValidation("specify --event-id")
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "specify --event-id").WithParam("--event-id")
 	}
 
 	body, hasEventFields, err := buildCalendarUpdateEventData(runtime)
@@ -291,10 +292,9 @@ func executeCalendarUpdate(_ context.Context, runtime *common.RuntimeContext) er
 	completed := []string{}
 	event := map[string]interface{}{}
 	if hasEventFields {
-		data, err := runtime.CallAPI("PATCH", calendarUpdateEventPath(calendarID, eventID), map[string]interface{}{"user_id_type": "open_id"}, body)
-		err = wrapPredefinedError(err)
+		data, err := runtime.CallAPITyped("PATCH", calendarUpdateEventPath(calendarID, eventID), map[string]interface{}{"user_id_type": "open_id"}, body)
 		if err != nil {
-			return output.Errorf(output.ExitAPI, "api_error", "failed to update event %s: %v", eventID, err)
+			return withStepContext(err, "failed to update event %s after completed steps %v", eventID, completed)
 		}
 		if v, _ := data["event"].(map[string]interface{}); v != nil {
 			event = v
@@ -308,12 +308,11 @@ func executeCalendarUpdate(_ context.Context, runtime *common.RuntimeContext) er
 		if err != nil {
 			return err
 		}
-		_, err = runtime.CallAPI("POST", calendarUpdateAttendeesPath(calendarID, eventID)+"/batch_delete",
+		_, err = runtime.CallAPITyped("POST", calendarUpdateAttendeesPath(calendarID, eventID)+"/batch_delete",
 			map[string]interface{}{"user_id_type": "open_id"},
 			map[string]interface{}{"delete_ids": deleteIDs, "need_notification": runtime.Bool("notify")})
-		err = wrapPredefinedError(err)
 		if err != nil {
-			return output.Errorf(output.ExitAPI, "api_error", "failed to remove attendees from event %s after completed steps %v: %v", eventID, completed, err)
+			return withStepContext(err, "failed to remove attendees from event %s after completed steps %v", eventID, completed)
 		}
 		removedCount = len(deleteIDs)
 		completed = append(completed, "remove_attendees")
@@ -323,14 +322,13 @@ func executeCalendarUpdate(_ context.Context, runtime *common.RuntimeContext) er
 	if addStr := runtime.Str("add-attendee-ids"); strings.TrimSpace(addStr) != "" {
 		attendees, err := parseAttendees(addStr, "")
 		if err != nil {
-			return output.ErrValidation("invalid attendee id: %v", err)
+			return withParam(err, "--add-attendee-ids")
 		}
-		_, err = runtime.CallAPI("POST", calendarUpdateAttendeesPath(calendarID, eventID),
+		_, err = runtime.CallAPITyped("POST", calendarUpdateAttendeesPath(calendarID, eventID),
 			map[string]interface{}{"user_id_type": "open_id"},
 			map[string]interface{}{"attendees": attendees, "need_notification": runtime.Bool("notify")})
-		err = wrapPredefinedError(err)
 		if err != nil {
-			return output.Errorf(output.ExitAPI, "api_error", "failed to add attendees to event %s after completed steps %v: %v", eventID, completed, err)
+			return withStepContext(err, "failed to add attendees to event %s after completed steps %v", eventID, completed)
 		}
 		addedCount = len(attendees)
 	}

--- a/shortcuts/calendar/errors.go
+++ b/shortcuts/calendar/errors.go
@@ -6,68 +6,39 @@ package calendar
 import (
 	"errors"
 	"fmt"
+	"strings"
 
-	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/errs"
 )
 
-const (
-	errCodeInvalidParamsWithDetail = 190014
-)
-
-// getErrorDetailValue extracts the first detail value from the output.ErrDetail.
-// It assumes Detail is a map containing a "details" array of objects with "value" string fields.
-// For example: {"details": [{"value": "error message 1"}, {"value": "error message 2"}]}
-// Returns an empty string if the structure doesn't match or the array is empty.
-//
-// Deprecated: getErrorDetailValue reads from the legacy *output.ErrDetail
-// that predates the typed error contract introduced by errs/. New code MUST
-// NOT use it — typed errs.* errors expose Message, Hint, and extension
-// fields directly on the typed struct via errors.As / errs.ProblemOf. This
-// helper is retained only while existing call sites are migrated; it will
-// be removed once they have moved to the typed surface.
-func getErrorDetailValue(e *output.ErrDetail) string {
-	if e == nil || e.Detail == nil {
-		return ""
-	}
-
-	errMap, ok := e.Detail.(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	details, ok := errMap["details"].([]interface{})
-	if !ok || len(details) == 0 {
-		return ""
-	}
-
-	detailObj, ok := details[0].(map[string]interface{})
-	if !ok {
-		return ""
-	}
-
-	val, _ := detailObj["value"].(string)
-	return val
-}
-
-// wrapPredefinedError wraps an error into *output.ExitError if it matches predefined error codes.
-// Currently handles error code 190014 (invalid params with detail), extracting the detail value into the message.
-// If the error is nil or doesn't match predefined codes, returns the original error.
-func wrapPredefinedError(err error) error {
+// withStepContext annotates err with multi-step context (e.g. which steps
+// already completed, or that a rollback ran) while preserving the underlying
+// failure's classification. An already-typed error keeps its own
+// category/subtype/code/log_id; we only append the formatted context to its
+// Hint so the top-level envelope still tells the truth about what failed.
+// Only an unclassified error falls back to a typed internal wrap.
+func withStepContext(err error, format string, args ...any) error {
 	if err == nil {
 		return nil
 	}
-
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+	extra := fmt.Sprintf(format, args...)
+	if p, ok := errs.ProblemOf(err); ok {
+		if strings.TrimSpace(p.Hint) != "" {
+			p.Hint = p.Hint + "\n" + extra
+		} else {
+			p.Hint = extra
+		}
 		return err
 	}
+	return errs.NewInternalError(errs.SubtypeSDKError, "%s", err.Error()).WithHint(extra).WithCause(err)
+}
 
-	if exitErr.Detail.Code == errCodeInvalidParamsWithDetail {
-		if val := getErrorDetailValue(exitErr.Detail); val != "" {
-			fullMsg := fmt.Sprintf("%s: %s", exitErr.Detail.Message, val)
-			return output.ErrAPI(exitErr.Detail.Code, fullMsg, exitErr.Detail.Detail)
-		}
+// withParam attaches the offending flag to a typed validation error, preserving
+// the original error instead of re-wrapping it. Non-validation errors pass through.
+func withParam(err error, flag string) error {
+	var ve *errs.ValidationError
+	if errors.As(err, &ve) {
+		return ve.WithParam(flag)
 	}
-
 	return err
 }

--- a/shortcuts/calendar/errors_attribution_test.go
+++ b/shortcuts/calendar/errors_attribution_test.go
@@ -1,0 +1,242 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package calendar
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+// newAttendeeValidateRuntime builds a RuntimeContext with the add/remove
+// attendee-id flags set, for exercising validateCalendarUpdateAttendees.
+func newAttendeeValidateRuntime(t *testing.T, add, remove string) *common.RuntimeContext {
+	t.Helper()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("add-attendee-ids", "", "")
+	cmd.Flags().String("remove-attendee-ids", "", "")
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	if add != "" {
+		_ = cmd.Flags().Set("add-attendee-ids", add)
+	}
+	if remove != "" {
+		_ = cmd.Flags().Set("remove-attendee-ids", remove)
+	}
+	return &common.RuntimeContext{Cmd: cmd}
+}
+
+// assertValidationParam asserts err is a *errs.ValidationError whose Param
+// equals wantParam, and returns it for any further message assertions.
+func assertValidationParam(t *testing.T, err error, wantParam string) *errs.ValidationError {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *errs.ValidationError, got %T (%v)", err, err)
+	}
+	if ve.Param != wantParam {
+		t.Errorf("Param = %q, want %q", ve.Param, wantParam)
+	}
+	return ve
+}
+
+// ---------------------------------------------------------------------------
+// withStepContext helper
+// ---------------------------------------------------------------------------
+
+func TestWithStepContext_Nil(t *testing.T) {
+	if got := withStepContext(nil, "step %d", 1); got != nil {
+		t.Fatalf("withStepContext(nil) = %v, want nil", got)
+	}
+}
+
+func TestWithStepContext_AppendsToTypedHint(t *testing.T) {
+	// A typed error keeps its classification; the context is appended to Hint.
+	inner := errs.NewAPIError(errs.SubtypeUnknown, "boom").WithHint("first")
+	got := withStepContext(inner, "after steps %v", []string{"event"})
+	var ae *errs.APIError
+	if !errors.As(got, &ae) {
+		t.Fatalf("want *errs.APIError, got %T", got)
+	}
+	if ae.Hint == "" || !strings.Contains(ae.Hint, "first") || !strings.Contains(ae.Hint, "after steps") {
+		t.Errorf("hint should append context, got %q", ae.Hint)
+	}
+}
+
+func TestWithStepContext_SetsHintWhenEmpty(t *testing.T) {
+	inner := errs.NewAPIError(errs.SubtypeUnknown, "boom")
+	got := withStepContext(inner, "after steps %v", []string{"event"})
+	var ae *errs.APIError
+	if !errors.As(got, &ae) {
+		t.Fatalf("want *errs.APIError, got %T", got)
+	}
+	if !strings.Contains(ae.Hint, "after steps") {
+		t.Errorf("hint should be set, got %q", ae.Hint)
+	}
+}
+
+func TestWithStepContext_UnclassifiedFallsBackToInternal(t *testing.T) {
+	// A plain, unclassified error is wrapped into a typed internal error so the
+	// envelope still tells the truth.
+	got := withStepContext(errors.New("raw failure"), "after steps %v", []string{"event"})
+	var ie *errs.InternalError
+	if !errors.As(got, &ie) {
+		t.Fatalf("want *errs.InternalError, got %T", got)
+	}
+	if ie.Subtype != errs.SubtypeSDKError {
+		t.Errorf("subtype=%q, want sdk_error", ie.Subtype)
+	}
+	if !strings.Contains(ie.Message, "raw failure") {
+		t.Errorf("message should preserve original, got %q", ie.Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// withParam helper
+// ---------------------------------------------------------------------------
+
+func TestWithParam_AttachesToValidationError(t *testing.T) {
+	inner := errs.NewValidationError(errs.SubtypeInvalidArgument, "boom")
+	got := withParam(inner, "--attendee-ids")
+	ve := assertValidationParam(t, got, "--attendee-ids")
+	if ve != inner {
+		t.Errorf("withParam should return the same underlying error, got a different pointer")
+	}
+	if ve.Message != "boom" {
+		t.Errorf("message mutated: got %q, want %q", ve.Message, "boom")
+	}
+}
+
+func TestWithParam_NonValidationPassesThrough(t *testing.T) {
+	inner := errs.NewInternalError(errs.SubtypeSDKError, "io failure")
+	got := withParam(inner, "--attendee-ids")
+	if got != inner {
+		t.Fatalf("non-validation error should pass through unchanged, got %v", got)
+	}
+	var ve *errs.ValidationError
+	if errors.As(got, &ve) {
+		t.Fatalf("non-validation error must not become a ValidationError")
+	}
+}
+
+func TestWithParam_NilPassesThrough(t *testing.T) {
+	if got := withParam(nil, "--attendee-ids"); got != nil {
+		t.Fatalf("withParam(nil) = %v, want nil", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Part A — re-wrap sites: the parseAttendees error, attributed by the caller's
+// flag, must be the inner typed error (not a re-wrapped nesting).
+// ---------------------------------------------------------------------------
+
+func TestParseAttendees_AttributedToCreateFlag(t *testing.T) {
+	_, err := parseAttendees("bad-id", "")
+	// create's add path: withParam(err, "--attendee-ids")
+	got := withParam(err, "--attendee-ids")
+	assertValidationParam(t, got, "--attendee-ids")
+}
+
+func TestParseAttendees_AttributedToAddFlag(t *testing.T) {
+	_, err := parseAttendees("bad-id", "")
+	// update's add path: withParam(err, "--add-attendee-ids")
+	got := withParam(err, "--add-attendee-ids")
+	assertValidationParam(t, got, "--add-attendee-ids")
+}
+
+func TestParseAttendees_InnerStaysFlagAgnostic(t *testing.T) {
+	// The shared inner parser must not pre-attribute a flag; callers do.
+	_, err := parseAttendees("bad-id", "")
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "" {
+		t.Errorf("inner parseAttendees should stay flag-agnostic, got Param = %q", ve.Param)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Part B — direct attendee-id format validations carry their flag.
+// ---------------------------------------------------------------------------
+
+func TestParseRoomFindAttendees_FormatErrorParam(t *testing.T) {
+	_, _, err := parseRoomFindAttendees("bad-id", "")
+	assertValidationParam(t, err, "--"+flagAttendees)
+}
+
+func TestParseRoomFindAttendees_RejectsRoomID(t *testing.T) {
+	// room find only supports ou_/oc_; omm_ rooms are not valid attendees.
+	_, _, err := parseRoomFindAttendees("omm_room", "")
+	assertValidationParam(t, err, "--"+flagAttendees)
+}
+
+func TestParseCalendarAttendeeIDs_StaysFlagAgnostic(t *testing.T) {
+	// parseCalendarAttendeeIDs serves BOTH --add-attendee-ids and
+	// --remove-attendee-ids, so it must not pre-attribute a flag.
+	_, err := parseCalendarAttendeeIDs("bad-id")
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *errs.ValidationError, got %T", err)
+	}
+	if ve.Param != "" {
+		t.Errorf("shared parser should stay flag-agnostic, got Param = %q", ve.Param)
+	}
+}
+
+func TestValidateCalendarUpdateAttendees_RemoveFormatParam(t *testing.T) {
+	// The remove path attributes its parser error to --remove-attendee-ids.
+	rt := newAttendeeValidateRuntime(t, "", "bad-id")
+	err := validateCalendarUpdateAttendees(rt)
+	assertValidationParam(t, err, "--remove-attendee-ids")
+}
+
+func TestValidateCalendarUpdateAttendees_AddFormatParam(t *testing.T) {
+	// The add path attributes its parser error to --add-attendee-ids.
+	rt := newAttendeeValidateRuntime(t, "bad-id", "")
+	err := validateCalendarUpdateAttendees(rt)
+	assertValidationParam(t, err, "--add-attendee-ids")
+}
+
+// attendeeDeleteIDs's switch default is defensive: parseCalendarAttendeeIDs
+// already rejects any non-ou_/oc_/omm_ id, so only a well-formed id reaches the
+// switch and the valid branches map it. This asserts the happy path maps types.
+func TestAttendeeDeleteIDs_MapsKnownTypes(t *testing.T) {
+	got, err := attendeeDeleteIDs("ou_a,oc_b,omm_c")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 delete ids, got %d: %v", len(got), got)
+	}
+	wantTypes := map[string]string{"user": "user_id", "chat": "chat_id", "resource": "room_id"}
+	for _, m := range got {
+		key, ok := wantTypes[m["type"]]
+		if !ok {
+			t.Errorf("unexpected type %q in %v", m["type"], m)
+			continue
+		}
+		if m[key] == "" {
+			t.Errorf("missing %s for type %q in %v", key, m["type"], m)
+		}
+	}
+}
+
+func TestParseCalendarAttendeeIDs_Valid(t *testing.T) {
+	ids, err := parseCalendarAttendeeIDs(" ou_a , oc_b , ou_a ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != "ou_a" || ids[1] != "oc_b" {
+		t.Errorf("dedup/trim failed: got %v", ids)
+	}
+}

--- a/shortcuts/common/validate.go
+++ b/shortcuts/common/validate.go
@@ -4,7 +4,6 @@
 package common
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -173,25 +172,6 @@ func ValidateSafePathTyped(fio fileio.FileIO, path string) error {
 	_, err := fio.ResolvePath(path)
 	if err != nil {
 		return ValidationErrorf("%s", err).WithCause(err)
-	}
-	return nil
-}
-
-// RejectDangerousChars returns an error if value contains ASCII control
-// characters or dangerous Unicode code points.
-//
-// Deprecated: use RejectDangerousCharsTyped for typed error envelopes.
-func RejectDangerousChars(paramName, value string) error {
-	for _, r := range value {
-		if r < 0x20 && r != '\t' && r != '\n' {
-			return fmt.Errorf("parameter %q contains control character U+%04X", paramName, r)
-		}
-		if r == 0x7F {
-			return fmt.Errorf("parameter %q contains DEL character", paramName)
-		}
-		if IsDangerousUnicode(r) {
-			return fmt.Errorf("parameter %q contains dangerous Unicode character U+%04X", paramName, r)
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Calendar commands now return structured, typed error envelopes across the **whole domain** — input validation, internal faults, and API-response failures — replacing the previous legacy/generic errors. Callers, including AI agents, get consistent exit codes and a machine-readable shape (`type` / `subtype` / `code` / `hint`), so bad input, an internal fault, and an API rejection are reliably distinguishable.

This also lands a small **shared classifier improvement** (server `error.details` → the typed `hint`) that benefits every domain, and **lint-locks** the calendar domain against reintroducing legacy error constructors.

## Changes

- Flag/argument validation across `+agenda`, `+create`, `+freebusy`, `+rsvp`, `+room-find`, `+suggestion`, `+update` → typed validation errors with the offending flag attributed.
- Internal faults (missing field in a successful response, unparseable response) → typed internal errors.
- All API calls migrated to the typed API path (`CallAPITyped` / the shared classifier); the legacy predefined-error wrapper is removed.
- `+agenda`'s recursive time-window split now keys on the typed error code.
- Multi-step operations (`+create` with-attendees rollback, multi-field `+update`) preserve the underlying failure's real classification and report which steps completed plus rollback diagnostics.
- Shared: the API classifier lifts server-supplied `error.details` into the typed `hint` (generic — all domains benefit).
- The calendar domain is registered in the typed-error lint guards (forbidigo + errscontract).
- Tests assert the typed shapes (category/subtype, attributed flag, code, hint); `+agenda` split and the create rollback-failure path are covered.

## Test Plan

- `go build ./...`
- `go vet ./shortcuts/calendar/... ./internal/errclass/...`
- `go test ./shortcuts/calendar/... ./internal/errclass/...` — all pass
- `gofmt -l .` — clean
- `golangci-lint run --new-from-rev=origin/main` — 0 issues
- `errscontract` (`go run -C lint . ..`) — 0 violations (calendar now in scope)

## Related Issues

Part of the typed-error envelope rollout across CLI domains (follows the drive domain). No linked issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Calendar commands now surface consistent typed validation/API/internal errors, narrow or split oversized agenda queries, and preserve server detail strings in error hints; step and rollback failures include contextual hints.

* **Tests**
  * Expanded coverage asserting typed error shapes, parameter attribution, rollback scenarios, split/exhaustion branches, and HTTP/JSON failure handling across calendar flows.

* **Chores**
  * Linter/config tuned to enforce typed-error patterns.

* **Refactor**
  * Centralized error attribution and classification for clearer user-facing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->