### PR TITLE
feat(okr,whiteboard): emit typed error envelopes across both domains

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,20 +73,20 @@ linters:
           - forbidigo
       # errs-typed-only enforced on paths already migrated to errs.NewXxxError.
       # Add a path when its migration is complete.
-      - path-except: (internal/auth/|internal/errcompat/|internal/errclass/|internal/client/|internal/cmdutil/factory\.go|cmd/auth/|cmd/config/|cmd/service/|shortcuts/common/mcp_client\.go|shortcuts/calendar/|shortcuts/drive/|shortcuts/mail/|shortcuts/base/)
+      - path-except: (internal/auth/|internal/errcompat/|internal/errclass/|internal/client/|internal/cmdutil/factory\.go|cmd/auth/|cmd/config/|cmd/service/|shortcuts/common/mcp_client\.go|shortcuts/calendar/|shortcuts/drive/|shortcuts/mail/|shortcuts/base/|shortcuts/okr/|shortcuts/whiteboard/)
         text: errs-typed-only
         linters:
           - forbidigo
       # errs-no-bare-wrap enforced on paths fully migrated to typed final
       # errors. Scoped separately from errs-typed-only because cmd/auth/,
       # cmd/config/ still have residual fmt.Errorf and must not be caught.
-      - path-except: (shortcuts/drive/|shortcuts/mail/|shortcuts/base/|shortcuts/calendar/|shortcuts/common/mcp_client\.go)
+      - path-except: (shortcuts/drive/|shortcuts/mail/|shortcuts/base/|shortcuts/calendar/|shortcuts/okr/|shortcuts/whiteboard/|shortcuts/common/mcp_client\.go)
         text: errs-no-bare-wrap
         linters:
           - forbidigo
       # errs-no-legacy-helper enforced on domains whose shared validation/save
       # helpers have migrated to typed final errors.
-      - path-except: (shortcuts/drive/|shortcuts/mail/|shortcuts/base/|shortcuts/calendar/)
+      - path-except: (shortcuts/drive/|shortcuts/mail/|shortcuts/base/|shortcuts/calendar/|shortcuts/okr/|shortcuts/whiteboard/)
         text: errs-no-legacy-helper
         linters:
           - forbidigo

--- a/lint/errscontract/rule_no_legacy_common_helper_call.go
+++ b/lint/errscontract/rule_no_legacy_common_helper_call.go
@@ -19,6 +19,8 @@ var migratedCommonHelperPaths = []string{
 	"shortcuts/drive/",
 	"shortcuts/mail/",
 	"shortcuts/calendar/",
+	"shortcuts/okr/",
+	"shortcuts/whiteboard/",
 }
 
 const commonImportPath = "github.com/larksuite/cli/shortcuts/common"

--- a/lint/errscontract/rule_no_legacy_envelope_literal.go
+++ b/lint/errscontract/rule_no_legacy_envelope_literal.go
@@ -20,6 +20,8 @@ var migratedEnvelopePaths = []string{
 	"shortcuts/drive/",
 	"shortcuts/mail/",
 	"shortcuts/calendar/",
+	"shortcuts/okr/",
+	"shortcuts/whiteboard/",
 }
 
 // legacyOutputImportPath is the import path of the package that declares the

--- a/lint/errscontract/rules_test.go
+++ b/lint/errscontract/rules_test.go
@@ -618,6 +618,31 @@ func boom() error {
 	}
 }
 
+func TestCheckNoLegacyEnvelopeLiteral_RejectsExitErrorLiteralOnOkrAndWhiteboardPaths(t *testing.T) {
+	for _, path := range []string{
+		"shortcuts/okr/okr_image_upload.go",
+		"shortcuts/whiteboard/whiteboard_update.go",
+	} {
+		t.Run(path, func(t *testing.T) {
+			src := `package migrated
+
+import "github.com/larksuite/cli/internal/output"
+
+func boom() error {
+	return &output.ExitError{Code: 1}
+}
+`
+			v := CheckNoLegacyEnvelopeLiteral(path, src)
+			if len(v) != 1 {
+				t.Fatalf("expected 1 violation, got %d: %+v", len(v), v)
+			}
+			if v[0].Action != ActionReject {
+				t.Errorf("action = %q, want REJECT", v[0].Action)
+			}
+		})
+	}
+}
+
 func TestCheckNoLegacyEnvelopeLiteral_RejectsErrDetailLiteralOnDrivePath(t *testing.T) {
 	src := `package drive
 
@@ -897,6 +922,8 @@ func TestCheckNoLegacyCommonHelperCall_RejectsLegacyHelpersOnMigratedPath(t *tes
 	paths := []string{
 		"shortcuts/drive/drive_search.go",
 		"shortcuts/mail/mail_send.go",
+		"shortcuts/okr/okr_progress_create.go",
+		"shortcuts/whiteboard/whiteboard_query.go",
 	}
 	for _, path := range paths {
 		for _, helper := range helpers {

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -603,27 +603,6 @@ func (ctx *RuntimeContext) ResolveSavePath(path string) (string, error) {
 	return resolved, nil
 }
 
-// WrapSaveError matches a FileIO.Save error against known categories and wraps
-// it with the caller-provided message prefix, preserving backward-compatible
-// error text per shortcut.
-func WrapSaveError(err error, pathMsg, mkdirMsg, writeMsg string) error {
-	if err == nil {
-		return nil
-	}
-	var me *fileio.MkdirError
-	var we *fileio.WriteError
-	switch {
-	case errors.Is(err, fileio.ErrPathValidation):
-		return fmt.Errorf("%s: %w", pathMsg, err)
-	case errors.As(err, &me):
-		return fmt.Errorf("%s: %w", mkdirMsg, err)
-	case errors.As(err, &we):
-		return fmt.Errorf("%s: %w", writeMsg, err)
-	default:
-		return fmt.Errorf("%s: %w", writeMsg, err)
-	}
-}
-
 // WrapOpenError matches a FileIO.Open/Stat error and wraps it with the
 // caller-provided message prefix.
 func WrapOpenError(err error, pathMsg, readMsg string) error {

--- a/shortcuts/okr/okr_cycle_detail.go
+++ b/shortcuts/okr/okr_cycle_detail.go
@@ -11,8 +11,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
-	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
 // OKRCycleDetail lists all objectives and their key results under a given OKR cycle.
@@ -30,10 +30,10 @@ var OKRCycleDetail = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		cycleID := runtime.Str("cycle-id")
 		if cycleID == "" {
-			return common.FlagErrorf("--cycle-id is required")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--cycle-id is required").WithParam("--cycle-id")
 		}
 		if id, err := strconv.ParseInt(cycleID, 10, 64); err != nil || id <= 0 {
-			return common.FlagErrorf("--cycle-id must be a positive int64")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--cycle-id must be a positive int64").WithParam("--cycle-id")
 		}
 		return nil
 	},
@@ -52,8 +52,7 @@ var OKRCycleDetail = common.Shortcut{
 		cycleID := runtime.Str("cycle-id")
 
 		// Paginate objectives under the cycle.
-		queryParams := make(larkcore.QueryParams)
-		queryParams.Set("page_size", "100")
+		queryParams := map[string]interface{}{"page_size": "100"}
 
 		var objectives []Objective
 		page := 0
@@ -71,7 +70,7 @@ var OKRCycleDetail = common.Shortcut{
 			page++
 
 			path := fmt.Sprintf("/open-apis/okr/v2/cycles/%s/objectives", cycleID)
-			data, err := runtime.DoAPIJSON("GET", path, queryParams, nil)
+			data, err := runtime.CallAPITyped("GET", path, queryParams, nil)
 			if err != nil {
 				return err
 			}
@@ -93,7 +92,7 @@ var OKRCycleDetail = common.Shortcut{
 			if !hasMore || pageToken == "" {
 				break
 			}
-			queryParams.Set("page_token", pageToken)
+			queryParams["page_token"] = pageToken
 		}
 
 		// For each objective, paginate key results and convert to response format.
@@ -104,8 +103,7 @@ var OKRCycleDetail = common.Shortcut{
 			}
 			obj := &objectives[i]
 
-			krQuery := make(larkcore.QueryParams)
-			krQuery.Set("page_size", "100")
+			krQuery := map[string]interface{}{"page_size": "100"}
 
 			var keyResults []KeyResult
 			krPage := 0
@@ -123,7 +121,7 @@ var OKRCycleDetail = common.Shortcut{
 				krPage++
 
 				path := fmt.Sprintf("/open-apis/okr/v2/objectives/%s/key_results", obj.ID)
-				data, err := runtime.DoAPIJSON("GET", path, krQuery, nil)
+				data, err := runtime.CallAPITyped("GET", path, krQuery, nil)
 				if err != nil {
 					return err
 				}
@@ -145,7 +143,7 @@ var OKRCycleDetail = common.Shortcut{
 				if !hasMore || pageToken == "" {
 					break
 				}
-				krQuery.Set("page_token", pageToken)
+				krQuery["page_token"] = pageToken
 			}
 
 			respObj := obj.ToResp()

--- a/shortcuts/okr/okr_cycle_detail_test.go
+++ b/shortcuts/okr/okr_cycle_detail_test.go
@@ -6,11 +6,13 @@ package okr
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
@@ -103,6 +105,31 @@ func TestCycleDetailValidate_InvalidCycleID_Negative(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--cycle-id must be a positive int64") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestCycleDetailValidate_TypedError locks the typed-envelope contract shared by
+// every okr flag check: an invalid flag surfaces as *errs.ValidationError carrying
+// SubtypeInvalidArgument and the offending --flag (readable via errors.As /
+// errs.ProblemOf), and maps to the validation exit code rather than a legacy api error.
+func TestCycleDetailValidate_TypedError(t *testing.T) {
+	t.Parallel()
+	f, stdout, _, _ := cmdutil.TestFactory(t, cycleDetailTestConfig(t))
+	err := runCycleDetailShortcut(t, f, stdout, []string{"+cycle-detail", "--cycle-id", "0"})
+
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("error is not *errs.ValidationError: %T (%v)", err, err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("Subtype = %q, want %q", ve.Subtype, errs.SubtypeInvalidArgument)
+	}
+	if ve.Param != "--cycle-id" {
+		t.Errorf("Param = %q, want %q", ve.Param, "--cycle-id")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok || p.Category != errs.CategoryValidation {
+		t.Errorf("ProblemOf category = %v (ok=%v), want %q", p, ok, errs.CategoryValidation)
 	}
 }
 

--- a/shortcuts/okr/okr_cycle_list.go
+++ b/shortcuts/okr/okr_cycle_list.go
@@ -12,9 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
-	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
 // parseTimeRange parses a "YYYY-MM--YYYY-MM" string into two time.Time values.
@@ -22,20 +21,20 @@ import (
 func parseTimeRange(s string) (start, end time.Time, err error) {
 	parts := strings.SplitN(s, "--", 2)
 	if len(parts) != 2 {
-		return time.Time{}, time.Time{}, fmt.Errorf("invalid time-range format %q, expected YYYY-MM--YYYY-MM", s)
+		return time.Time{}, time.Time{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --time-range format %q, expected YYYY-MM--YYYY-MM", s).WithParam("--time-range")
 	}
 	start, err = time.Parse("2006-01", strings.TrimSpace(parts[0]))
 	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("invalid start month %q: %w", parts[0], err)
+		return time.Time{}, time.Time{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --time-range start month %q: %v", parts[0], err).WithParam("--time-range").WithCause(err)
 	}
 	end, err = time.Parse("2006-01", strings.TrimSpace(parts[1]))
 	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("invalid end month %q: %w", parts[1], err)
+		return time.Time{}, time.Time{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --time-range end month %q: %v", parts[1], err).WithParam("--time-range").WithCause(err)
 	}
 	// end is the last moment of the end month
 	end = end.AddDate(0, 1, 0).Add(-time.Millisecond)
 	if start.After(end) {
-		return time.Time{}, time.Time{}, fmt.Errorf("start month %s is after end month %s", parts[0], parts[1])
+		return time.Time{}, time.Time{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid --time-range: start month %s is after end month %s", parts[0], parts[1]).WithParam("--time-range")
 	}
 	return start, end, nil
 }
@@ -69,20 +68,20 @@ var OKRListCycles = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		idType := runtime.Str("user-id-type")
 		if idType != "open_id" && idType != "union_id" && idType != "user_id" {
-			return common.FlagErrorf("--user-id-type must be one of: open_id | union_id | user_id")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--user-id-type must be one of: open_id | union_id | user_id").WithParam("--user-id-type")
 		}
 		userID := runtime.Str("user-id")
-		if err := validate.RejectControlChars(userID, "user-id"); err != nil {
+		if err := common.RejectDangerousCharsTyped("--user-id", userID); err != nil {
 			return err
 		}
 
 		tr := runtime.Str("time-range")
 		if tr != "" {
-			if err := validate.RejectControlChars(tr, "time-range"); err != nil {
+			if err := common.RejectDangerousCharsTyped("--time-range", tr); err != nil {
 				return err
 			}
 			if _, _, err := parseTimeRange(tr); err != nil {
-				return common.FlagErrorf("--time-range: %s", err)
+				return err
 			}
 		}
 		return nil
@@ -110,16 +109,17 @@ var OKRListCycles = common.Shortcut{
 			var err error
 			rangeStart, rangeEnd, err = parseTimeRange(timeRange)
 			if err != nil {
-				return common.FlagErrorf("--time-range: %s", err)
+				return err
 			}
 			hasRange = true
 		}
 
 		// Paginated fetch of all cycles
-		queryParams := make(larkcore.QueryParams)
-		queryParams.Set("user_id", userID)
-		queryParams.Set("user_id_type", userIDType)
-		queryParams.Set("page_size", "100")
+		queryParams := map[string]interface{}{
+			"user_id":      userID,
+			"user_id_type": userIDType,
+			"page_size":    "100",
+		}
 
 		var allCycles []Cycle
 		page := 0
@@ -136,7 +136,7 @@ var OKRListCycles = common.Shortcut{
 			}
 			page++
 
-			data, err := runtime.DoAPIJSON("GET", "/open-apis/okr/v2/cycles", queryParams, nil)
+			data, err := runtime.CallAPITyped("GET", "/open-apis/okr/v2/cycles", queryParams, nil)
 			if err != nil {
 				return err
 			}
@@ -158,7 +158,7 @@ var OKRListCycles = common.Shortcut{
 			if !hasMore || pageToken == "" {
 				break
 			}
-			queryParams.Set("page_token", pageToken)
+			queryParams["page_token"] = pageToken
 		}
 
 		// Filter by time-range overlap

--- a/shortcuts/okr/okr_errors.go
+++ b/shortcuts/okr/okr_errors.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package okr
+
+import (
+	"errors"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/extension/fileio"
+)
+
+// okrInputStatError maps a FileIO.Stat/Open error for input file validation to
+// a typed validation error: path validation failures read as "unsafe file
+// path", other errors as "cannot read file".
+func okrInputStatError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, fileio.ErrPathValidation) {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "unsafe file path: %s", err).
+			WithParam("--file").
+			WithCause(err)
+	}
+	return errs.NewValidationError(errs.SubtypeInvalidArgument, "cannot read file: %s", err).
+		WithParam("--file").
+		WithCause(err)
+}
+
+// wrapOkrNetworkErr returns err unchanged when it is already a typed errs.*
+// error (preserving subtype / code / log_id from the runtime boundary) and only
+// wraps a raw, unclassified error as a transport-level network error.
+func wrapOkrNetworkErr(err error, format string, args ...any) error {
+	if _, ok := errs.ProblemOf(err); ok {
+		return err
+	}
+	return errs.NewNetworkError(errs.SubtypeNetworkTransport, format, args...).WithCause(err)
+}

--- a/shortcuts/okr/okr_errors_test.go
+++ b/shortcuts/okr/okr_errors_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package okr
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/extension/fileio"
+)
+
+func TestOkrInputStatError(t *testing.T) {
+	if okrInputStatError(nil) != nil {
+		t.Fatal("nil error should map to nil")
+	}
+
+	var ve *errs.ValidationError
+
+	pathCause := errors.New("traversal")
+	pathErr := okrInputStatError(&fileio.PathValidationError{Err: pathCause})
+	if !errors.As(pathErr, &ve) || ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("path validation: got %T (%v)", pathErr, pathErr)
+	}
+	if ve.Param != "--file" {
+		t.Fatalf("path validation param = %q, want --file", ve.Param)
+	}
+	if !errors.Is(pathErr, fileio.ErrPathValidation) || !errors.Is(pathErr, pathCause) {
+		t.Fatal("path validation cause should be retained")
+	}
+
+	genericCause := errors.New("permission denied")
+	genericErr := okrInputStatError(genericCause)
+	if !errors.As(genericErr, &ve) || ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("generic: got %T (%v)", genericErr, genericErr)
+	}
+	if ve.Param != "--file" {
+		t.Fatalf("generic param = %q, want --file", ve.Param)
+	}
+	if !errors.Is(genericErr, genericCause) {
+		t.Fatal("generic cause should be retained")
+	}
+}
+
+func TestWrapOkrNetworkErr(t *testing.T) {
+	typed := errs.NewValidationError(errs.SubtypeInvalidArgument, "already typed")
+	if got := wrapOkrNetworkErr(typed, "wrap %v", typed); got != error(typed) {
+		t.Fatalf("typed error must pass through unchanged, got %v", got)
+	}
+
+	raw := errors.New("dial tcp: i/o timeout")
+	got := wrapOkrNetworkErr(raw, "upload failed: %v", raw)
+	var ne *errs.NetworkError
+	if !errors.As(got, &ne) || ne.Subtype != errs.SubtypeNetworkTransport {
+		t.Fatalf("raw error: got %T (%v)", got, got)
+	}
+	if !errors.Is(got, raw) {
+		t.Fatal("raw cause should be retained via WithCause")
+	}
+}

--- a/shortcuts/okr/okr_image_upload.go
+++ b/shortcuts/okr/okr_image_upload.go
@@ -5,8 +5,6 @@ package okr
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strconv"
@@ -14,7 +12,7 @@ import (
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 
-	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -43,24 +41,24 @@ var OKRUploadImage = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		filePath := runtime.Str("file")
 		if filePath == "" {
-			return common.FlagErrorf("--file is required")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--file is required").WithParam("--file")
 		}
 		ext := strings.ToLower(filepath.Ext(filePath))
 		if !allowedImageExts[ext] {
-			return common.FlagErrorf("--file must be an image (supported: JPG, JPEG, PNG, GIF, BMP), got %q", ext)
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--file must be an image (supported: JPG, JPEG, PNG, GIF, BMP), got %q", ext).WithParam("--file")
 		}
 
 		targetID := runtime.Str("target-id")
 		if targetID == "" {
-			return common.FlagErrorf("--target-id is required")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--target-id is required").WithParam("--target-id")
 		}
 		if id, err := strconv.ParseInt(targetID, 10, 64); err != nil || id <= 0 {
-			return common.FlagErrorf("--target-id must be a positive int64")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--target-id must be a positive int64").WithParam("--target-id")
 		}
 
 		targetType := runtime.Str("target-type")
 		if _, ok := targetTypeAllowed[targetType]; !ok {
-			return common.FlagErrorf("--target-type must be one of: objective | key_result")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--target-type must be one of: objective | key_result").WithParam("--target-type")
 		}
 		return nil
 	},
@@ -87,12 +85,12 @@ var OKRUploadImage = common.Shortcut{
 
 		info, err := runtime.FileIO().Stat(filePath)
 		if err != nil {
-			return common.WrapInputStatError(err)
+			return okrInputStatError(err)
 		}
 
 		f, err := runtime.FileIO().Open(filePath)
 		if err != nil {
-			return common.WrapInputStatError(err)
+			return okrInputStatError(err)
 		}
 		defer f.Close()
 
@@ -110,30 +108,22 @@ var OKRUploadImage = common.Shortcut{
 			Body:       fd,
 		}, larkcore.WithFileUpload())
 		if err != nil {
-			var exitErr *output.ExitError
-			if errors.As(err, &exitErr) {
-				return err
-			}
-			return output.ErrNetwork("upload failed: %v", err)
+			// The DoAPI boundary already returns typed errs.* (auth →
+			// AuthenticationError, transport → NetworkError, etc.); wrapOkrNetworkErr
+			// passes those through via ProblemOf and only wraps a still-untyped error.
+			return wrapOkrNetworkErr(err, "upload failed: %v", err)
 		}
 
-		var result map[string]interface{}
-		if err := json.Unmarshal(apiResp.RawBody, &result); err != nil {
-			return output.Errorf(output.ExitAPI, "api_error", "upload failed: invalid response JSON: %v", err)
+		data, err := runtime.ClassifyAPIResponse(apiResp)
+		if err != nil {
+			return err
 		}
 
-		if larkCode := int(common.GetFloat(result, "code")); larkCode != 0 {
-			msg, _ := result["msg"].(string)
-			return output.ErrAPI(larkCode, fmt.Sprintf("upload failed: [%d] %s", larkCode, msg), result["error"])
-		}
-
-		data, _ := result["data"].(map[string]interface{})
-		fileToken, _ := data["file_token"].(string)
-		url, _ := data["url"].(string)
-
+		fileToken := common.GetString(data, "file_token")
 		if fileToken == "" {
-			return output.Errorf(output.ExitAPI, "api_error", "upload failed: no file_token returned")
+			return errs.NewInternalError(errs.SubtypeInvalidResponse, "upload failed: no file_token returned")
 		}
+		url := common.GetString(data, "url")
 
 		runtime.Out(map[string]interface{}{
 			"file_token": fileToken,

--- a/shortcuts/okr/okr_image_upload_test.go
+++ b/shortcuts/okr/okr_image_upload_test.go
@@ -5,6 +5,7 @@ package okr
 
 import (
 	"bytes"
+	"errors"
 	"mime"
 	"mime/multipart"
 	"os"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
@@ -360,6 +362,15 @@ func TestUploadImageExecute_APIError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for API failure")
 	}
+	// The upload boundary now classifies the Lark error code into a typed
+	// envelope carrying the numeric code, instead of a flat legacy error.
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("error is not a typed errs.* envelope: %T (%v)", err, err)
+	}
+	if p.Code != 1001001 {
+		t.Errorf("Problem.Code = %d, want 1001001", p.Code)
+	}
 }
 
 func TestUploadImageExecute_FileNotFound(t *testing.T) {
@@ -406,6 +417,15 @@ func TestUploadImageExecute_NoFileTokenInResponse(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for missing file_token in response")
+	}
+	// A 2xx response that omits the expected file_token is a malformed response,
+	// surfaced as a typed internal/invalid_response error.
+	var ie *errs.InternalError
+	if !errors.As(err, &ie) {
+		t.Fatalf("error is not *errs.InternalError: %T (%v)", err, err)
+	}
+	if ie.Subtype != errs.SubtypeInvalidResponse {
+		t.Errorf("Subtype = %q, want %q", ie.Subtype, errs.SubtypeInvalidResponse)
 	}
 	if !strings.Contains(err.Error(), "no file_token returned") {
 		t.Fatalf("unexpected error: %v", err)

--- a/shortcuts/okr/okr_progress_create.go
+++ b/shortcuts/okr/okr_progress_create.go
@@ -11,10 +11,9 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/core"
-	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
-	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
 // targetTypeAllowed values for --target-type flag
@@ -39,7 +38,7 @@ func parseCreateProgressRecordParams(runtime *common.RuntimeContext) (*createPro
 	content := runtime.Str("content")
 	var cb ContentBlock
 	if err := json.Unmarshal([]byte(content), &cb); err != nil {
-		return nil, common.FlagErrorf("--content must be valid ContentBlock JSON: %s", err)
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--content must be valid ContentBlock JSON: %s", err).WithParam("--content").WithCause(err)
 	}
 	contentV1 := cb.ToV1()
 
@@ -60,13 +59,13 @@ func parseCreateProgressRecordParams(runtime *common.RuntimeContext) (*createPro
 	if v := runtime.Str("progress-percent"); v != "" {
 		percent, err := strconv.ParseFloat(v, 64)
 		if err != nil || math.IsNaN(percent) || math.IsInf(percent, 0) || percent < -99999999999 || percent > 99999999999 {
-			return nil, common.FlagErrorf("--progress-percent must be a number between -99999999999 and 99999999999")
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-percent must be a number between -99999999999 and 99999999999").WithParam("--progress-percent")
 		}
 		progressRate = &ProgressRateV1{Percent: &percent}
 		if s := runtime.Str("progress-status"); s != "" {
 			status, ok := ParseProgressStatus(s)
 			if !ok {
-				return nil, common.FlagErrorf("--progress-status must be one of: normal | overdue | done")
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-status must be one of: normal | overdue | done").WithParam("--progress-status")
 			}
 			progressRate.Status = int32Ptr(int32(status))
 		}
@@ -105,40 +104,40 @@ var OKRCreateProgressRecord = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		content := runtime.Str("content")
 		if content == "" {
-			return common.FlagErrorf("--content is required")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--content is required").WithParam("--content")
 		}
-		if err := validate.RejectControlChars(content, "content"); err != nil {
+		if err := common.RejectDangerousCharsTyped("--content", content); err != nil {
 			return err
 		}
 		// Validate content is valid JSON and can be parsed as ContentBlock
 		var cb ContentBlock
 		if err := json.Unmarshal([]byte(content), &cb); err != nil {
-			return common.FlagErrorf("--content must be valid ContentBlock JSON: %s", err)
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--content must be valid ContentBlock JSON: %s", err).WithParam("--content").WithCause(err)
 		}
 
 		targetID := runtime.Str("target-id")
 		if targetID == "" {
-			return common.FlagErrorf("--target-id is required")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--target-id is required").WithParam("--target-id")
 		}
-		if err := validate.RejectControlChars(targetID, "target-id"); err != nil {
+		if err := common.RejectDangerousCharsTyped("--target-id", targetID); err != nil {
 			return err
 		}
 		if id, err := strconv.ParseInt(targetID, 10, 64); err != nil || id <= 0 {
-			return common.FlagErrorf("--target-id must be a positive int64")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--target-id must be a positive int64").WithParam("--target-id")
 		}
 
 		targetType := runtime.Str("target-type")
 		if _, ok := targetTypeAllowed[targetType]; !ok {
-			return common.FlagErrorf("--target-type must be one of: objective | key_result")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--target-type must be one of: objective | key_result").WithParam("--target-type")
 		}
 
 		if v := runtime.Str("source-title"); v != "" {
-			if err := validate.RejectControlChars(v, "source-title"); err != nil {
+			if err := common.RejectDangerousCharsTyped("--source-title", v); err != nil {
 				return err
 			}
 		}
 		if v := runtime.Str("source-url"); v != "" {
-			if err := validate.RejectControlChars(v, "source-url"); err != nil {
+			if err := common.RejectDangerousCharsTyped("--source-url", v); err != nil {
 				return err
 			}
 		}
@@ -146,21 +145,21 @@ var OKRCreateProgressRecord = common.Shortcut{
 		if v := runtime.Str("progress-percent"); v != "" {
 			percent, err := strconv.ParseFloat(v, 64)
 			if err != nil || math.IsNaN(percent) || math.IsInf(percent, 0) || percent < -99999999999 || percent > 99999999999 {
-				return common.FlagErrorf("--progress-percent must be a number between -99999999999 and 99999999999")
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-percent must be a number between -99999999999 and 99999999999").WithParam("--progress-percent")
 			}
 		}
 		if v := runtime.Str("progress-status"); v != "" {
 			if _, ok := ParseProgressStatus(v); !ok {
-				return common.FlagErrorf("--progress-status must be one of: normal | overdue | done")
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-status must be one of: normal | overdue | done").WithParam("--progress-status")
 			}
 			if v := runtime.Str("progress-percent"); v == "" {
-				return common.FlagErrorf("--progress-percent must provided with --progress-status")
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-percent must provided with --progress-status").WithParam("--progress-percent")
 			}
 		}
 
 		idType := runtime.Str("user-id-type")
 		if idType != "open_id" && idType != "union_id" && idType != "user_id" {
-			return common.FlagErrorf("--user-id-type must be one of: open_id | union_id | user_id")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--user-id-type must be one of: open_id | union_id | user_id").WithParam("--user-id-type")
 		}
 		return nil
 	},
@@ -202,10 +201,9 @@ var OKRCreateProgressRecord = common.Shortcut{
 			body["progress_rate"] = p.ProgressRate
 		}
 
-		queryParams := make(larkcore.QueryParams)
-		queryParams.Set("user_id_type", p.UserIDType)
+		queryParams := map[string]interface{}{"user_id_type": p.UserIDType}
 
-		data, err := runtime.DoAPIJSON("POST", "/open-apis/okr/v1/progress_records/", queryParams, body)
+		data, err := runtime.CallAPITyped("POST", "/open-apis/okr/v1/progress_records/", queryParams, body)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/okr/okr_progress_delete.go
+++ b/shortcuts/okr/okr_progress_delete.go
@@ -9,8 +9,8 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
-	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
 // OKRDeleteProgressRecord deletes a progress by ID.
@@ -28,10 +28,10 @@ var OKRDeleteProgressRecord = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		progressID := runtime.Str("progress-id")
 		if progressID == "" {
-			return common.FlagErrorf("--progress-id is required")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-id is required").WithParam("--progress-id")
 		}
 		if id, err := strconv.ParseInt(progressID, 10, 64); err != nil || id <= 0 {
-			return common.FlagErrorf("--progress-id must be a positive int64")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-id must be a positive int64").WithParam("--progress-id")
 		}
 		return nil
 	},
@@ -46,7 +46,7 @@ var OKRDeleteProgressRecord = common.Shortcut{
 		progressID := runtime.Str("progress-id")
 
 		path := fmt.Sprintf("/open-apis/okr/v1/progress_records/%s", progressID)
-		_, err := runtime.DoAPIJSON("DELETE", path, larkcore.QueryParams{}, nil)
+		_, err := runtime.CallAPITyped("DELETE", path, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/okr/okr_progress_get.go
+++ b/shortcuts/okr/okr_progress_get.go
@@ -10,8 +10,8 @@ import (
 	"io"
 	"strconv"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
-	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
 // OKRGetProgressRecord gets a progress by ID.
@@ -30,14 +30,14 @@ var OKRGetProgressRecord = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		progressID := runtime.Str("progress-id")
 		if progressID == "" {
-			return common.FlagErrorf("--progress-id is required")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-id is required").WithParam("--progress-id")
 		}
 		if id, err := strconv.ParseInt(progressID, 10, 64); err != nil || id <= 0 {
-			return common.FlagErrorf("--progress-id must be a positive int64")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-id must be a positive int64").WithParam("--progress-id")
 		}
 		idType := runtime.Str("user-id-type")
 		if idType != "open_id" && idType != "union_id" && idType != "user_id" {
-			return common.FlagErrorf("--user-id-type must be one of: open_id | union_id | user_id")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--user-id-type must be one of: open_id | union_id | user_id").WithParam("--user-id-type")
 		}
 		return nil
 	},
@@ -56,11 +56,10 @@ var OKRGetProgressRecord = common.Shortcut{
 		progressID := runtime.Str("progress-id")
 		userIDType := runtime.Str("user-id-type")
 
-		queryParams := make(larkcore.QueryParams)
-		queryParams.Set("user_id_type", userIDType)
+		queryParams := map[string]interface{}{"user_id_type": userIDType}
 
 		path := fmt.Sprintf("/open-apis/okr/v1/progress_records/%s", progressID)
-		data, err := runtime.DoAPIJSON("GET", path, queryParams, nil)
+		data, err := runtime.CallAPITyped("GET", path, queryParams, nil)
 		if err != nil {
 			return err
 		}
@@ -93,11 +92,11 @@ var OKRGetProgressRecord = common.Shortcut{
 func parseProgressRecord(data map[string]any) (*ProgressV1, error) {
 	raw, err := json.Marshal(data)
 	if err != nil {
-		return nil, err
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "invalid progress response: marshal failed: %s", err).WithCause(err)
 	}
 	var record ProgressV1
 	if err := json.Unmarshal(raw, &record); err != nil {
-		return nil, err
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "invalid progress response: unmarshal failed: %s", err).WithCause(err)
 	}
 	return &record, nil
 }

--- a/shortcuts/okr/okr_progress_get_test.go
+++ b/shortcuts/okr/okr_progress_get_test.go
@@ -5,11 +5,13 @@ package okr
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
@@ -188,5 +190,21 @@ func TestProgressGetExecute_APIError(t *testing.T) {
 	err := runProgressGetShortcut(t, f, stdout, []string{"+progress-get", "--progress-id", "999"})
 	if err == nil {
 		t.Fatal("expected error for API failure")
+	}
+}
+
+func TestParseProgressRecord_InvalidResponseTypedError(t *testing.T) {
+	_, err := parseProgressRecord(map[string]any{
+		"progress_rate": "not-an-object",
+	})
+	if err == nil {
+		t.Fatal("expected invalid response error")
+	}
+	var ie *errs.InternalError
+	if !errors.As(err, &ie) {
+		t.Fatalf("error is not *errs.InternalError: %T (%v)", err, err)
+	}
+	if ie.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("Subtype = %q, want %q", ie.Subtype, errs.SubtypeInvalidResponse)
 	}
 }

--- a/shortcuts/okr/okr_progress_list.go
+++ b/shortcuts/okr/okr_progress_list.go
@@ -10,9 +10,8 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
-	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
 // OKRListProgress lists progress for an objective or key result.
@@ -33,28 +32,28 @@ var OKRListProgress = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		targetID := runtime.Str("target-id")
 		if targetID == "" {
-			return common.FlagErrorf("--target-id is required")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--target-id is required").WithParam("--target-id")
 		}
-		if err := validate.RejectControlChars(targetID, "target-id"); err != nil {
+		if err := common.RejectDangerousCharsTyped("--target-id", targetID); err != nil {
 			return err
 		}
 		if id, err := strconv.ParseInt(targetID, 10, 64); err != nil || id <= 0 {
-			return common.FlagErrorf("--target-id must be a positive int64")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--target-id must be a positive int64").WithParam("--target-id")
 		}
 
 		targetType := runtime.Str("target-type")
 		if _, ok := targetTypeAllowed[targetType]; !ok {
-			return common.FlagErrorf("--target-type must be one of: objective | key_result")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--target-type must be one of: objective | key_result").WithParam("--target-type")
 		}
 
 		idType := runtime.Str("user-id-type")
 		if idType != "open_id" && idType != "union_id" && idType != "user_id" {
-			return common.FlagErrorf("--user-id-type must be one of: open_id | union_id | user_id")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--user-id-type must be one of: open_id | union_id | user_id").WithParam("--user-id-type")
 		}
 
 		deptIDType := runtime.Str("department-id-type")
 		if deptIDType != "department_id" && deptIDType != "open_department_id" {
-			return common.FlagErrorf("--department-id-type must be one of: department_id | open_department_id")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--department-id-type must be one of: department_id | open_department_id").WithParam("--department-id-type")
 		}
 		return nil
 	},
@@ -89,10 +88,11 @@ var OKRListProgress = common.Shortcut{
 		userIDType := runtime.Str("user-id-type")
 		deptIDType := runtime.Str("department-id-type")
 
-		queryParams := make(larkcore.QueryParams)
-		queryParams.Set("user_id_type", userIDType)
-		queryParams.Set("department_id_type", deptIDType)
-		queryParams.Set("page_size", "100")
+		queryParams := map[string]interface{}{
+			"user_id_type":       userIDType,
+			"department_id_type": deptIDType,
+			"page_size":          "100",
+		}
 
 		var apiPath string
 		switch targetType {
@@ -108,7 +108,7 @@ var OKRListProgress = common.Shortcut{
 				return err
 			}
 
-			data, err := runtime.DoAPIJSON("GET", apiPath, queryParams, nil)
+			data, err := runtime.CallAPITyped("GET", apiPath, queryParams, nil)
 			if err != nil {
 				return err
 			}
@@ -130,7 +130,7 @@ var OKRListProgress = common.Shortcut{
 			if !hasMore || pageToken == "" {
 				break
 			}
-			queryParams.Set("page_token", pageToken)
+			queryParams["page_token"] = pageToken
 		}
 
 		// Convert to response format

--- a/shortcuts/okr/okr_progress_update.go
+++ b/shortcuts/okr/okr_progress_update.go
@@ -11,9 +11,8 @@ import (
 	"math"
 	"strconv"
 
-	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
-	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
 // updateProgressRecordParams holds the parsed parameters for updating a progress.
@@ -29,7 +28,7 @@ func parseUpdateProgressRecordParams(runtime *common.RuntimeContext) (*updatePro
 	content := runtime.Str("content")
 	var cb ContentBlock
 	if err := json.Unmarshal([]byte(content), &cb); err != nil {
-		return nil, common.FlagErrorf("--content must be valid ContentBlock JSON: %s", err)
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--content must be valid ContentBlock JSON: %s", err).WithParam("--content").WithCause(err)
 	}
 	contentV1 := cb.ToV1()
 
@@ -37,13 +36,13 @@ func parseUpdateProgressRecordParams(runtime *common.RuntimeContext) (*updatePro
 	if v := runtime.Str("progress-percent"); v != "" {
 		percent, err := strconv.ParseFloat(v, 64)
 		if err != nil || math.IsNaN(percent) || math.IsInf(percent, 0) || percent < -99999999999 || percent > 99999999999 {
-			return nil, common.FlagErrorf("--progress-percent must be a number between -99999999999 and 99999999999")
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-percent must be a number between -99999999999 and 99999999999").WithParam("--progress-percent")
 		}
 		progressRate = &ProgressRateV1{Percent: &percent}
 		if s := runtime.Str("progress-status"); s != "" {
 			status, ok := ParseProgressStatus(s)
 			if !ok {
-				return nil, common.FlagErrorf("--progress-status must be one of: normal | overdue | done")
+				return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-status must be one of: normal | overdue | done").WithParam("--progress-status")
 			}
 			progressRate.Status = int32Ptr(int32(status))
 		}
@@ -76,42 +75,42 @@ var OKRUpdateProgressRecord = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		progressID := runtime.Str("progress-id")
 		if progressID == "" {
-			return common.FlagErrorf("--progress-id is required")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-id is required").WithParam("--progress-id")
 		}
 		if id, err := strconv.ParseInt(progressID, 10, 64); err != nil || id <= 0 {
-			return common.FlagErrorf("--progress-id must be a positive int64")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-id must be a positive int64").WithParam("--progress-id")
 		}
 
 		content := runtime.Str("content")
 		if content == "" {
-			return common.FlagErrorf("--content is required")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--content is required").WithParam("--content")
 		}
-		if err := validate.RejectControlChars(content, "content"); err != nil {
+		if err := common.RejectDangerousCharsTyped("--content", content); err != nil {
 			return err
 		}
 		var cb ContentBlock
 		if err := json.Unmarshal([]byte(content), &cb); err != nil {
-			return common.FlagErrorf("--content must be valid ContentBlock JSON: %s", err)
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--content must be valid ContentBlock JSON: %s", err).WithParam("--content").WithCause(err)
 		}
 
 		if v := runtime.Str("progress-percent"); v != "" {
 			percent, err := strconv.ParseFloat(v, 64)
 			if err != nil || math.IsNaN(percent) || math.IsInf(percent, 0) || percent < -99999999999 || percent > 99999999999 {
-				return common.FlagErrorf("--progress-percent must be a number between -99999999999 and 99999999999")
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-percent must be a number between -99999999999 and 99999999999").WithParam("--progress-percent")
 			}
 		}
 		if v := runtime.Str("progress-status"); v != "" {
 			if _, ok := ParseProgressStatus(v); !ok {
-				return common.FlagErrorf("--progress-status must be one of: normal | overdue | done")
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-status must be one of: normal | overdue | done").WithParam("--progress-status")
 			}
 			if v := runtime.Str("progress-percent"); v == "" {
-				return common.FlagErrorf("--progress-percent must provided with --progress-status")
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--progress-percent must provided with --progress-status").WithParam("--progress-percent")
 			}
 		}
 
 		idType := runtime.Str("user-id-type")
 		if idType != "open_id" && idType != "union_id" && idType != "user_id" {
-			return common.FlagErrorf("--user-id-type must be one of: open_id | union_id | user_id")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--user-id-type must be one of: open_id | union_id | user_id").WithParam("--user-id-type")
 		}
 		return nil
 	},
@@ -146,11 +145,10 @@ var OKRUpdateProgressRecord = common.Shortcut{
 			body["progress_rate"] = p.ProgressRate
 		}
 
-		queryParams := make(larkcore.QueryParams)
-		queryParams.Set("user_id_type", p.UserIDType)
+		queryParams := map[string]interface{}{"user_id_type": p.UserIDType}
 
 		path := fmt.Sprintf("/open-apis/okr/v1/progress_records/%s", p.ProgressID)
-		data, err := runtime.DoAPIJSON("PUT", path, queryParams, body)
+		data, err := runtime.CallAPITyped("PUT", path, queryParams, body)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/whiteboard/whiteboard_errors.go
+++ b/shortcuts/whiteboard/whiteboard_errors.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"errors"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/extension/fileio"
+)
+
+// wrapWbNetworkErr returns err unchanged when it is already a typed errs.* error
+// (preserving subtype / code / log_id from the runtime boundary) and only wraps
+// a raw, unclassified error as a transport-level network error.
+func wrapWbNetworkErr(err error, format string, args ...any) error {
+	if _, ok := errs.ProblemOf(err); ok {
+		return err
+	}
+	return errs.NewNetworkError(errs.SubtypeNetworkTransport, format, args...).WithCause(err)
+}
+
+// wbSaveError maps a FileIO.Save error to a typed error. Path validation
+// failures are validation errors (exit code 2); mkdir / write failures are
+// internal file-I/O errors (exit code 5).
+func wbSaveError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var me *fileio.MkdirError
+	switch {
+	case errors.Is(err, fileio.ErrPathValidation):
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "unsafe output path: %s", err).
+			WithParam("--output").
+			WithCause(err)
+	case errors.As(err, &me):
+		return errs.NewInternalError(errs.SubtypeFileIO, "cannot create parent directory: %s", err).WithCause(err)
+	default:
+		return errs.NewInternalError(errs.SubtypeFileIO, "cannot create file: %s", err).WithCause(err)
+	}
+}
+
+func wbInvalidResponse(format string, args ...any) error {
+	return errs.NewInternalError(errs.SubtypeInvalidResponse, format, args...)
+}

--- a/shortcuts/whiteboard/whiteboard_errors_test.go
+++ b/shortcuts/whiteboard/whiteboard_errors_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package whiteboard
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/extension/fileio"
+)
+
+func TestWrapWbNetworkErr(t *testing.T) {
+	typed := errs.NewAPIError(errs.SubtypeRateLimit, "already typed")
+	if got := wrapWbNetworkErr(typed, "wrap"); got != error(typed) {
+		t.Fatalf("typed error must pass through unchanged, got %v", got)
+	}
+
+	raw := errors.New("connection reset by peer")
+	got := wrapWbNetworkErr(raw, "fetch failed: %v", raw)
+	var ne *errs.NetworkError
+	if !errors.As(got, &ne) || ne.Subtype != errs.SubtypeNetworkTransport {
+		t.Fatalf("raw error: got %T (%v)", got, got)
+	}
+	if !errors.Is(got, raw) {
+		t.Fatal("raw cause should be retained via WithCause")
+	}
+}
+
+func TestWbSaveError(t *testing.T) {
+	if wbSaveError(nil) != nil {
+		t.Fatal("nil error should map to nil")
+	}
+
+	var ve *errs.ValidationError
+	pathCause := errors.New("escape")
+	if got := wbSaveError(&fileio.PathValidationError{Err: pathCause}); !errors.As(got, &ve) || ve.Subtype != errs.SubtypeInvalidArgument || !errors.Is(got, pathCause) {
+		t.Fatalf("path validation: got %T (%v)", got, got)
+	}
+	if ve.Param != "--output" {
+		t.Fatalf("path validation param = %q, want --output", ve.Param)
+	}
+
+	var ie *errs.InternalError
+	mkdirCause := errors.New("mkdir denied")
+	if got := wbSaveError(&fileio.MkdirError{Err: mkdirCause}); !errors.As(got, &ie) || ie.Subtype != errs.SubtypeFileIO || !errors.Is(got, mkdirCause) {
+		t.Fatalf("mkdir: got %T (%v)", got, got)
+	}
+	writeCause := errors.New("disk full")
+	if got := wbSaveError(writeCause); !errors.As(got, &ie) || ie.Subtype != errs.SubtypeFileIO || !errors.Is(got, writeCause) {
+		t.Fatalf("default: got %T (%v)", got, got)
+	}
+}

--- a/shortcuts/whiteboard/whiteboard_query.go
+++ b/shortcuts/whiteboard/whiteboard_query.go
@@ -14,9 +14,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
-	"github.com/larksuite/cli/internal/output"
-	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
@@ -73,22 +72,22 @@ var WhiteboardQuery = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		// Check if token contains control characters
 		token := runtime.Str("whiteboard-token")
-		if err := validate.RejectControlChars(token, "whiteboard-token"); err != nil {
+		if err := common.RejectDangerousCharsTyped("--whiteboard-token", token); err != nil {
 			return err
 		}
 		out := runtime.Str("output")
 		if out != "" {
-			if err := runtime.ValidatePath(out); err != nil {
-				return output.ErrValidation("invalid output path: %s", err)
+			if _, err := runtime.ResolveSavePath(out); err != nil {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid output path: %s", err).WithParam("--output").WithCause(err)
 			}
 		}
 		if out == "" && runtime.Str("output_as") == WhiteboardQueryAsImage {
-			return output.ErrValidation("need a output directory to query whiteboard as image")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "need a output directory to query whiteboard as image").WithParam("--output")
 		}
 
 		as := runtime.Str("output_as")
 		if as != WhiteboardQueryAsImage && as != WhiteboardQueryAsCode && as != WhiteboardQueryAsRaw {
-			return common.FlagErrorf("--output_as flag must be one of: image | code | raw")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output_as flag must be one of: image | code | raw").WithParam("--output_as")
 		}
 		return nil
 	},
@@ -125,7 +124,7 @@ var WhiteboardQuery = common.Shortcut{
 		case WhiteboardQueryAsRaw:
 			return exportWhiteboardRaw(runtime, token, outDir)
 		default:
-			return output.ErrValidation("--as flag must be one of: image | code | raw")
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--output_as flag must be one of: image | code | raw").WithParam("--output_as")
 		}
 
 	},
@@ -136,14 +135,26 @@ func exportWhiteboardPreview(ctx context.Context, runtime *common.RuntimeContext
 		HttpMethod: http.MethodGet,
 		ApiPath:    fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/download_as_image", url.PathEscape(wbToken)),
 	}
-	// Execute API request
+	// Execute API request. The preview endpoint streams raw image bytes (not a
+	// JSON envelope), so classify by HTTP status: 5xx is retryable network,
+	// while 4xx remains an API-side rejection.
 	resp, err := runtime.DoAPI(req, larkcore.WithFileDownload())
 	if err != nil {
-		return output.ErrNetwork(fmt.Sprintf("get whiteboard preview failed: %v", err))
+		return wrapWbNetworkErr(err, "get whiteboard preview failed: %v", err)
 	}
-	// Check response status code
-	if resp.StatusCode != http.StatusOK {
-		return output.ErrAPI(resp.StatusCode, string(resp.RawBody), nil)
+	if resp.StatusCode >= 400 {
+		body := common.TruncateStr(strings.TrimSpace(string(resp.RawBody)), 500)
+		if resp.StatusCode >= 500 {
+			return errs.NewNetworkError(errs.SubtypeNetworkServer, "get whiteboard preview failed: HTTP %d: %s", resp.StatusCode, body).
+				WithCode(resp.StatusCode).
+				WithRetryable()
+		}
+		subtype := errs.SubtypeUnknown
+		if resp.StatusCode == http.StatusNotFound {
+			subtype = errs.SubtypeNotFound
+		}
+		return errs.NewAPIError(subtype, "get whiteboard preview failed: HTTP %d: %s", resp.StatusCode, body).
+			WithCode(resp.StatusCode)
 	}
 
 	finalPath, size, err := saveOutputFile(outDir, ".png", wbToken, runtime, bytes.NewReader(resp.RawBody))
@@ -162,33 +173,27 @@ func exportWhiteboardPreview(ctx context.Context, runtime *common.RuntimeContext
 }
 
 type wbNodesResp struct {
-	Code int    `json:"code"`
-	Msg  string `json:"msg"`
 	Data struct {
 		Nodes []interface{} `json:"nodes"`
 	} `json:"data"`
 }
 
 func fetchWhiteboardNodes(runtime *common.RuntimeContext, wbToken string) (*wbNodesResp, error) {
-	req := &larkcore.ApiReq{
-		HttpMethod: http.MethodGet,
-		ApiPath:    fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes", wbToken),
-	}
-	resp, err := runtime.DoAPI(req)
+	data, err := runtime.CallAPITyped(http.MethodGet, fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes", url.PathEscape(wbToken)), nil, nil)
 	if err != nil {
-		return nil, output.ErrNetwork(fmt.Sprintf("get whiteboard nodes failed: %v", err))
-	}
-	// 检查响应状态码
-	if resp.StatusCode != http.StatusOK {
-		return nil, output.ErrAPI(resp.StatusCode, string(resp.RawBody), nil)
+		return nil, err
 	}
 	var nodes wbNodesResp
-	err = json.Unmarshal(resp.RawBody, &nodes)
-	if err != nil {
-		return nil, output.Errorf(output.ExitInternal, "parsing", fmt.Sprintf("parse whiteboard nodes failed: %v", err))
+	rawNodes, ok := data["nodes"]
+	if !ok {
+		return nil, wbInvalidResponse("get whiteboard nodes failed: missing data.nodes")
 	}
-	if nodes.Code != 0 {
-		return nil, output.ErrAPI(nodes.Code, "get whiteboard nodes failed", fmt.Sprintf("get whiteboard nodes failed: %s", nodes.Msg))
+	if rawNodes != nil {
+		var ok bool
+		nodes.Data.Nodes, ok = rawNodes.([]interface{})
+		if !ok {
+			return nil, wbInvalidResponse("get whiteboard nodes failed: data.nodes must be an array")
+		}
 	}
 	return &nodes, nil
 }
@@ -229,6 +234,12 @@ func exportWhiteboardCode(runtime *common.RuntimeContext, wbToken, outDir string
 		code, _ := syntaxMap["code"].(string)
 		var syntaxType SyntaxType
 		switch v := syntaxMap["syntax_type"].(type) {
+		case json.Number:
+			// runtime.ClassifyAPIResponse decodes the response with UseNumber,
+			// so numeric fields arrive as json.Number rather than float64.
+			if n, err := v.Int64(); err == nil {
+				syntaxType = SyntaxType(n)
+			}
 		case float64:
 			syntaxType = SyntaxType(v)
 		case SyntaxType:
@@ -299,7 +310,7 @@ func exportWhiteboardRaw(runtime *common.RuntimeContext, wbToken, outDir string)
 
 	jsonData, err := json.MarshalIndent(wbNodes.Data, "", "  ")
 	if err != nil {
-		return output.Errorf(output.ExitInternal, "json_error", "cannot marshal whiteboard data: %s", err)
+		return errs.NewInternalError(errs.SubtypeInvalidResponse, "cannot marshal whiteboard data: %s", err).WithCause(err)
 	}
 
 	if outDir == "" {
@@ -340,18 +351,18 @@ func saveOutputFile(outPath, ext, token string, runtime *common.RuntimeContext, 
 		}
 		finalPath = outPath
 	}
-	if err := runtime.ValidatePath(finalPath); err != nil { // double check
-		return "", 0, err
+	if _, err := runtime.ResolveSavePath(finalPath); err != nil { // double check
+		return "", 0, errs.NewValidationError(errs.SubtypeInvalidArgument, "invalid output path: %s", err).WithParam("--output").WithCause(err)
 	}
 
 	// Step 2: Check overwrite
 	_, err = runtime.FileIO().Stat(finalPath)
 	if err == nil {
 		if !runtime.Bool("overwrite") {
-			return "", 0, output.ErrValidation(fmt.Sprintf("file already exists: %s (use --overwrite to overwrite)", finalPath))
+			return "", 0, errs.NewValidationError(errs.SubtypeInvalidArgument, "file already exists: %s (use --overwrite to overwrite)", finalPath).WithParam("--overwrite")
 		}
 	} else if !os.IsNotExist(err) {
-		return "", 0, output.Errorf(output.ExitInternal, "io_error", "cannot check file existence: %s", err)
+		return "", 0, errs.NewInternalError(errs.SubtypeFileIO, "cannot check file existence: %s", err).WithCause(err)
 	}
 
 	// Step 3: Save file
@@ -369,7 +380,7 @@ func saveOutputFile(outPath, ext, token string, runtime *common.RuntimeContext, 
 		ContentType: contentType,
 	}, data)
 	if err != nil {
-		return "", 0, common.WrapSaveError(err, "unsafe file path", "cannot create parent directory", "cannot create file")
+		return "", 0, wbSaveError(err)
 	}
 
 	return finalPath, savResult.Size(), nil

--- a/shortcuts/whiteboard/whiteboard_query_test.go
+++ b/shortcuts/whiteboard/whiteboard_query_test.go
@@ -6,11 +6,13 @@ package whiteboard
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
@@ -146,6 +148,110 @@ func TestWhiteboardQuery_Validate(t *testing.T) {
 				t.Errorf("WhiteboardQuery.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestWhiteboardQuery_Validate_TypedErrors locks the typed-envelope contract:
+// input-validation failures surface as *errs.ValidationError carrying
+// SubtypeInvalidArgument and the offending --flag, readable via errs.ProblemOf
+// and errors.As — the shape downstream consumers (and exit-code mapping) rely on.
+func TestWhiteboardQuery_Validate_TypedErrors(t *testing.T) {
+	ctx := context.Background()
+	chdirTemp(t)
+
+	tests := []struct {
+		name      string
+		flags     map[string]string
+		wantParam string
+	}{
+		{
+			name:      "image without output",
+			flags:     map[string]string{"whiteboard-token": "t", "output_as": "image"},
+			wantParam: "--output",
+		},
+		{
+			name:      "bad output_as value",
+			flags:     map[string]string{"whiteboard-token": "t", "output_as": "invalid"},
+			wantParam: "--output_as",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := WhiteboardQuery.Validate(ctx, newTestRuntime(tt.flags, nil))
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			var ve *errs.ValidationError
+			if !errors.As(err, &ve) {
+				t.Fatalf("error is not *errs.ValidationError: %T", err)
+			}
+			if ve.Subtype != errs.SubtypeInvalidArgument {
+				t.Errorf("Subtype = %q, want %q", ve.Subtype, errs.SubtypeInvalidArgument)
+			}
+			if ve.Param != tt.wantParam {
+				t.Errorf("Param = %q, want %q", ve.Param, tt.wantParam)
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("errs.ProblemOf returned false")
+			}
+			if p.Category != errs.CategoryValidation {
+				t.Errorf("Category = %q, want %q", p.Category, errs.CategoryValidation)
+			}
+		})
+	}
+}
+
+// TestExportWhiteboardPreview_HTTPError locks the download-path failure
+// behavior: a failed preview download surfaces as a typed errs.* envelope, not
+// a flat legacy error.
+func TestExportWhiteboardPreview_HTTPError(t *testing.T) {
+	factory, stdout, reg := newExecuteFactory(t)
+	chdirTemp(t)
+
+	reg.Register(&httpmock.Stub{
+		Method:      "GET",
+		URL:         "/open-apis/board/v1/whiteboards/test-token-preview-5xx/download_as_image",
+		Status:      500,
+		RawBody:     []byte("gateway error"),
+		ContentType: "text/plain",
+	})
+
+	args := []string{"+query", "--whiteboard-token", "test-token-preview-5xx", "--output_as", "image", "--output", "output"}
+	err := runShortcut(t, WhiteboardQuery, args, factory, stdout)
+	if err == nil {
+		t.Fatal("expected error for HTTP 500 download")
+	}
+	if _, ok := errs.ProblemOf(err); !ok {
+		t.Fatalf("error is not a typed errs.* envelope: %T (%v)", err, err)
+	}
+	var ne *errs.NetworkError
+	if !errors.As(err, &ne) || ne.Subtype != errs.SubtypeNetworkServer || ne.Code != 500 || !ne.Retryable {
+		t.Fatalf("HTTP 500 should be retryable network/server_error, got %T (%v)", err, err)
+	}
+}
+
+func TestExportWhiteboardPreview_HTTPNotFoundIsAPIError(t *testing.T) {
+	factory, stdout, reg := newExecuteFactory(t)
+	chdirTemp(t)
+
+	reg.Register(&httpmock.Stub{
+		Method:      "GET",
+		URL:         "/open-apis/board/v1/whiteboards/missing-token/download_as_image",
+		Status:      404,
+		RawBody:     []byte("not found"),
+		ContentType: "text/plain",
+	})
+
+	args := []string{"+query", "--whiteboard-token", "missing-token", "--output_as", "image", "--output", "output"}
+	err := runShortcut(t, WhiteboardQuery, args, factory, stdout)
+	if err == nil {
+		t.Fatal("expected error for HTTP 404 download")
+	}
+	var apiErr *errs.APIError
+	if !errors.As(err, &apiErr) || apiErr.Subtype != errs.SubtypeNotFound || apiErr.Code != 404 {
+		t.Fatalf("HTTP 404 should be api/not_found, got %T (%v)", err, err)
 	}
 }
 
@@ -367,6 +473,23 @@ func TestSaveOutputFile(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSaveOutputFile_InvalidFinalPathTypedError(t *testing.T) {
+	chdirTemp(t)
+
+	rt := newTestRuntime(nil, nil)
+	_, _, err := saveOutputFile("../escape", ".png", "token123", rt, strings.NewReader("test content"))
+	if err == nil {
+		t.Fatal("expected error for unsafe final path")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("error is not *errs.ValidationError: %T (%v)", err, err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument || ve.Param != "--output" {
+		t.Fatalf("validation details = subtype %q param %q, want %q --output", ve.Subtype, ve.Param, errs.SubtypeInvalidArgument)
 	}
 }
 
@@ -705,9 +828,69 @@ func TestFetchWhiteboardNodes_APIError(t *testing.T) {
 
 	args := []string{"+query", "--whiteboard-token", "test-token-api-error", "--output_as", "raw"}
 	err := runShortcut(t, WhiteboardQuery, args, factory, stdout)
-	// We expect an error here, but don't fail the test because it's testing error path
 	if err == nil {
 		t.Fatalf("Expected API error, but got none")
+	}
+	// The nodes fetch now classifies the Lark error code into a typed envelope
+	// carrying the numeric code.
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("error is not a typed errs.* envelope: %T (%v)", err, err)
+	}
+	if p.Code != 10001 {
+		t.Errorf("Problem.Code = %d, want 10001", p.Code)
+	}
+}
+
+func TestFetchWhiteboardNodes_InvalidResponseTypedError(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		data  map[string]interface{}
+	}{
+		{
+			name:  "missing nodes",
+			token: "test-token-missing-nodes",
+			data:  map[string]interface{}{},
+		},
+		{
+			name:  "nodes not array",
+			token: "test-token-bad-nodes",
+			data:  map[string]interface{}{"nodes": "not-an-array"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory, stdout, reg := newExecuteFactory(t)
+			reg.Register(&httpmock.Stub{
+				Method: "GET",
+				URL:    "/open-apis/board/v1/whiteboards/" + tt.token + "/nodes",
+				Body: map[string]interface{}{
+					"code": 0,
+					"msg":  "success",
+					"data": tt.data,
+				},
+			})
+
+			args := []string{"+query", "--whiteboard-token", tt.token, "--output_as", "raw"}
+			err := runShortcut(t, WhiteboardQuery, args, factory, stdout)
+			assertInvalidResponse(t, err)
+		})
+	}
+}
+
+func assertInvalidResponse(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected invalid response error")
+	}
+	var ie *errs.InternalError
+	if !errors.As(err, &ie) {
+		t.Fatalf("error is not *errs.InternalError: %T (%v)", err, err)
+	}
+	if ie.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("Subtype = %q, want %q", ie.Subtype, errs.SubtypeInvalidResponse)
 	}
 }
 

--- a/shortcuts/whiteboard/whiteboard_update.go
+++ b/shortcuts/whiteboard/whiteboard_update.go
@@ -12,10 +12,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/larksuite/cli/internal/output"
-	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
-	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 )
 
 const (
@@ -42,21 +40,21 @@ var wbUpdateFlags = []common.Flag{
 
 func wbUpdateValidate(ctx context.Context, runtime *common.RuntimeContext) error {
 	// 检查 token 是否包含控制字符（空字符串下自动跳过了）
-	if err := validate.RejectControlChars(runtime.Str("whiteboard-token"), "whiteboard-token"); err != nil {
+	if err := common.RejectDangerousCharsTyped("--whiteboard-token", runtime.Str("whiteboard-token")); err != nil {
 		return err
 	}
 	itoken := runtime.Str("idempotent-token")
-	if err := validate.RejectControlChars(itoken, "idempotent-token"); err != nil {
+	if err := common.RejectDangerousCharsTyped("--idempotent-token", itoken); err != nil {
 		return err
 	}
 	if itoken != "" && len(itoken) < 10 {
-		return common.FlagErrorf("--idempotent-token must be at least 10 characters long.")
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--idempotent-token must be at least 10 characters long.").WithParam("--idempotent-token")
 	}
 
 	// 检查 --input_format 标志
 	format := getFormat(runtime)
 	if format != FormatRaw && format != FormatPlantUML && format != FormatMermaid {
-		return common.FlagErrorf("--input_format must be one of: raw | plantuml | mermaid")
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--input_format must be one of: raw | plantuml | mermaid").WithParam("--input_format")
 	}
 	return nil
 }
@@ -116,7 +114,7 @@ func wbUpdateExecute(ctx context.Context, runtime *common.RuntimeContext) error 
 
 	input := runtime.Str("source")
 	if input == "" {
-		return output.ErrValidation("read input failed: source is required")
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "read input failed: source is required").WithParam("--source")
 	}
 
 	switch format {
@@ -125,7 +123,7 @@ func wbUpdateExecute(ctx context.Context, runtime *common.RuntimeContext) error 
 	case FormatPlantUML, FormatMermaid:
 		return updateWhiteboardByCode(ctx, runtime, token, []byte(input), format, overwrite, idempotentToken)
 	default:
-		return output.ErrValidation(fmt.Sprintf("unsupported format: %s", format))
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "unsupported format: %s", format).WithParam("--input_format")
 	}
 }
 
@@ -160,15 +158,6 @@ var WhiteboardUpdateOld = common.Shortcut{
 	Execute:     wbUpdateExecute,
 }
 
-type createResponse struct {
-	Code int    `json:"code"`
-	Msg  string `json:"msg"`
-	Data struct {
-		NodeIDs         []string `json:"ids"`
-		IdempotentToken string   `json:"client_token"`
-	} `json:"data"`
-}
-
 type plantumlCreateReq struct {
 	PlantUmlCode string `json:"plant_uml_code"`
 	SyntaxType   int    `json:"syntax_type"`
@@ -182,28 +171,20 @@ type rawNodesCreateReq struct {
 	Overwrite bool          `json:"overwrite,omitempty"`
 }
 
-type plantumlCreateResp struct {
-	Code int    `json:"code"`
-	Msg  string `json:"msg"`
-	Data struct {
-		NodeID string `json:"node_id"`
-	} `json:"data"`
-}
-
 func parseWBcliNodes(rawjson []byte) (wbNodes []interface{}, err error, isRaw bool) {
 	var wbOutput WbCliOutput
 	if err := json.Unmarshal(rawjson, &wbOutput); err != nil {
-		return nil, output.Errorf(output.ExitValidation, "parsing", fmt.Sprintf("unmarshal input json failed: %v", err)), false
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "unmarshal input json failed: %v", err).WithParam("--source").WithCause(err), false
 	}
 	if (wbOutput.Code != 0 || wbOutput.Data.To != "openapi") && wbOutput.RawNodes == nil {
-		return nil, output.Errorf(output.ExitValidation, "whiteboard-cli", "whiteboard-cli failed. please check previous log."), false
+		return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "whiteboard-cli failed. please check previous log.").WithParam("--source"), false
 	}
 	if wbOutput.RawNodes != nil {
 		wbNodes = wbOutput.RawNodes
 		isRaw = true
 	} else {
 		if wbOutput.Data.Result.Nodes == nil {
-			return nil, output.Errorf(output.ExitValidation, "whiteboard-cli", "whiteboard-cli failed. please check previous log."), false
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "whiteboard-cli failed. please check previous log.").WithParam("--source"), false
 		}
 		wbNodes = wbOutput.Data.Result.Nodes
 	}
@@ -221,39 +202,23 @@ func updateWhiteboardByCode(ctx context.Context, runtime *common.RuntimeContext,
 		Overwrite:    overwrite,
 	}
 
-	req := &larkcore.ApiReq{
-		HttpMethod:  http.MethodPost,
-		ApiPath:     fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes/plantuml", url.PathEscape(wbToken)),
-		Body:        reqBody,
-		QueryParams: map[string][]string{},
-	}
+	params := map[string]interface{}{}
 	if idempotentToken != "" {
-		req.QueryParams["client_token"] = []string{idempotentToken}
+		params["client_token"] = idempotentToken
 	}
 
-	resp, err := runtime.DoAPI(req)
+	data, err := runtime.CallAPITyped(http.MethodPost, fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes/plantuml", url.PathEscape(wbToken)), params, reqBody)
 	if err != nil {
-		return output.ErrNetwork(fmt.Sprintf("update whiteboard by code failed: %v", err))
-	}
-	if resp.StatusCode != http.StatusOK {
-		return output.ErrAPI(resp.StatusCode, string(resp.RawBody), nil)
+		return err
 	}
 
-	var createResp plantumlCreateResp
-	err = json.Unmarshal(resp.RawBody, &createResp)
-	if err != nil {
-		return output.Errorf(output.ExitInternal, "parsing", fmt.Sprintf("parse whiteboard create response failed: %v", err))
+	nodeID := common.GetString(data, "node_id")
+	if nodeID == "" {
+		return wbInvalidResponse("update whiteboard by code failed: missing data.node_id")
 	}
-	if createResp.Code != 0 {
-		return output.ErrAPI(createResp.Code, "update whiteboard by code failed", fmt.Sprintf("update whiteboard by code failed: %s", createResp.Msg))
-	}
-
-	outData := make(map[string]string)
-	outData["created_node_id"] = createResp.Data.NodeID
+	outData := map[string]string{"created_node_id": nodeID}
 	runtime.OutFormat(outData, nil, func(w io.Writer) {
-		if outData["created_node_id"] != "" {
-			fmt.Fprintf(w, "New node created.\n")
-		}
+		fmt.Fprintf(w, "New node created.\n")
 		fmt.Fprintf(w, "Update whiteboard success")
 	})
 
@@ -266,56 +231,67 @@ func updateWhiteboardByRawNodes(ctx context.Context, runtime *common.RuntimeCont
 	if err != nil {
 		return err
 	}
-	outData := make(map[string]string)
 	reqBody := rawNodesCreateReq{
 		Nodes:     nodes,
 		Overwrite: overwrite,
 	}
 
-	req := &larkcore.ApiReq{
-		HttpMethod:  http.MethodPost,
-		ApiPath:     fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes", url.PathEscape(wbToken)),
-		Body:        reqBody,
-		QueryParams: map[string][]string{},
-	}
+	params := map[string]interface{}{}
 	if idempotentToken != "" {
-		req.QueryParams["client_token"] = []string{idempotentToken}
+		params["client_token"] = idempotentToken
 	}
 
-	resp, err := runtime.DoAPI(req)
+	data, err := runtime.CallAPITyped(http.MethodPost, fmt.Sprintf("/open-apis/board/v1/whiteboards/%s/nodes", url.PathEscape(wbToken)), params, reqBody)
 	if err != nil {
-		return output.ErrNetwork(fmt.Sprintf("update whiteboard failed: %v", err))
-	}
-	if resp.StatusCode != http.StatusOK {
-		var detail string
+		// Raw open-api JSON is hand-edited far more often than the DSL path, so
+		// steer the user back to the recommended workflow on any API failure.
 		if isRaw {
-			detail = fmt.Sprintf("It is not advised to edit openapi format json directly. Please follow instruction in lark-whiteboard skill, " +
-				"using whiteboard-cli to transcript Whiteboard DSL pattern instead.")
+			if p, ok := errs.ProblemOf(err); ok {
+				rawHint := "It is not advised to edit openapi format json directly. " +
+					"Please follow instruction in lark-whiteboard skill, using whiteboard-cli " +
+					"to transcript Whiteboard DSL pattern instead."
+				if strings.TrimSpace(p.Hint) != "" {
+					p.Hint = p.Hint + "\n" + rawHint
+				} else {
+					p.Hint = rawHint
+				}
+			}
 		}
-		return output.ErrAPI(resp.StatusCode, string(resp.RawBody), detail)
+		return err
 	}
 
-	var createResp createResponse
-	err = json.Unmarshal(resp.RawBody, &createResp)
+	nodeIDs, err := stringSlice(data["ids"])
 	if err != nil {
-		return output.Errorf(output.ExitInternal, "parsing", fmt.Sprintf("parse whiteboard create response failed: %v", err))
+		return err
 	}
-	if createResp.Code != 0 {
-		detail := fmt.Sprintf("update whiteboard failed: %s", createResp.Msg)
-		if isRaw {
-			detail += fmt.Sprintf("\n It is not advised to edit openapi format json directly. Please follow instruction in lark-whiteboard skill, " +
-				"using whiteboard-cli to transcript Whiteboard DSL pattern instead.")
-		}
-		return output.ErrAPI(createResp.Code, "update whiteboard failed", detail)
-	}
-
-	outData["created_node_ids"] = strings.Join(createResp.Data.NodeIDs, ",")
+	outData := map[string]string{"created_node_ids": strings.Join(nodeIDs, ",")}
 	runtime.OutFormat(outData, nil, func(w io.Writer) {
 		if outData["created_node_ids"] != "" {
-			fmt.Fprintf(w, "%d new nodes created.\n", len(createResp.Data.NodeIDs))
+			fmt.Fprintf(w, "%d new nodes created.\n", len(nodeIDs))
 		}
 		fmt.Fprintf(w, "Update whiteboard success")
 	})
 
 	return nil
+}
+
+// stringSlice coerces the JSON ids array into []string. A missing or malformed
+// ids field is a response-shape bug, not a successful update with no output.
+func stringSlice(v interface{}) ([]string, error) {
+	switch raw := v.(type) {
+	case []interface{}:
+		out := make([]string, 0, len(raw))
+		for i, e := range raw {
+			s, ok := e.(string)
+			if !ok {
+				return nil, wbInvalidResponse("update whiteboard failed: data.ids[%d] must be a string", i)
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	case []string:
+		return append([]string(nil), raw...), nil
+	default:
+		return nil, wbInvalidResponse("update whiteboard failed: data.ids must be an array of strings")
+	}
 }

--- a/shortcuts/whiteboard/whiteboard_update_test.go
+++ b/shortcuts/whiteboard/whiteboard_update_test.go
@@ -6,9 +6,11 @@ package whiteboard
 import (
 	"bytes"
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
@@ -99,6 +101,54 @@ func TestWhiteboardUpdate_Validate(t *testing.T) {
 				t.Errorf("wbUpdateValidate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestWhiteboardUpdate_Validate_TypedErrors locks the typed-envelope contract
+// for +update input validation: failures are *errs.ValidationError with
+// SubtypeInvalidArgument and the offending --flag. parseWBcliNodes likewise
+// reports malformed --source input as a typed validation error.
+func TestWhiteboardUpdate_Validate_TypedErrors(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("idempotent-token too short", func(t *testing.T) {
+		rt := newTestRuntime(map[string]string{
+			"whiteboard-token": "t",
+			"idempotent-token": "short",
+			"source":           "{}",
+		}, nil)
+		assertValidationParam(t, wbUpdateValidate(ctx, rt), "--idempotent-token")
+	})
+
+	t.Run("bad input_format", func(t *testing.T) {
+		rt := newTestRuntime(map[string]string{
+			"whiteboard-token": "t",
+			"input_format":     "svg",
+			"source":           "{}",
+		}, nil)
+		assertValidationParam(t, wbUpdateValidate(ctx, rt), "--input_format")
+	})
+
+	t.Run("malformed source json", func(t *testing.T) {
+		_, err, _ := parseWBcliNodes([]byte("not-json"))
+		assertValidationParam(t, err, "--source")
+	})
+}
+
+func assertValidationParam(t *testing.T, err error, wantParam string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("error is not *errs.ValidationError: %T", err)
+	}
+	if ve.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("Subtype = %q, want %q", ve.Subtype, errs.SubtypeInvalidArgument)
+	}
+	if ve.Param != wantParam {
+		t.Errorf("Param = %q, want %q", ve.Param, wantParam)
 	}
 }
 
@@ -360,6 +410,27 @@ Bob -> Alice : hello
 	}
 }
 
+func TestWhiteboardUpdateExecute_PlantUMLInvalidResponse(t *testing.T) {
+	factory, stdout, reg := newUpdateExecuteFactory(t)
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/board/v1/whiteboards/test-token-plantuml-invalid-response/nodes/plantuml",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{},
+		},
+	})
+
+	source := `@@startuml
+Bob -> Alice : hello
+@@enduml`
+	args := []string{"+update", "--whiteboard-token", "test-token-plantuml-invalid-response", "--input_format", "plantuml", "--source", source}
+	err := runUpdateShortcut(t, WhiteboardUpdate, args, factory, stdout)
+	assertInvalidResponse(t, err)
+}
+
 func TestWhiteboardUpdateExecute_MermaidFormat(t *testing.T) {
 	factory, stdout, reg := newUpdateExecuteFactory(t)
 
@@ -381,6 +452,45 @@ A-->B`
 	args := []string{"+update", "--whiteboard-token", "test-token-mermaid", "--input_format", "mermaid", "--source", source}
 	if err := runUpdateShortcut(t, WhiteboardUpdate, args, factory, stdout); err != nil {
 		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestWhiteboardUpdateExecute_RawInvalidResponse(t *testing.T) {
+	tests := []struct {
+		name  string
+		token string
+		data  map[string]interface{}
+	}{
+		{
+			name:  "missing ids",
+			token: "test-token-raw-missing-ids",
+			data:  map[string]interface{}{},
+		},
+		{
+			name:  "non-string id",
+			token: "test-token-raw-bad-id",
+			data:  map[string]interface{}{"ids": []interface{}{"node1", 2}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			factory, stdout, reg := newUpdateExecuteFactory(t)
+			reg.Register(&httpmock.Stub{
+				Method: "POST",
+				URL:    "/open-apis/board/v1/whiteboards/" + tt.token + "/nodes",
+				Body: map[string]interface{}{
+					"code": 0,
+					"msg":  "success",
+					"data": tt.data,
+				},
+			})
+
+			source := `{"code":0,"data":{"to":"openapi","result":{"nodes":[]}}}`
+			args := []string{"+update", "--whiteboard-token", tt.token, "--input_format", "raw", "--source", source}
+			err := runUpdateShortcut(t, WhiteboardUpdate, args, factory, stdout)
+			assertInvalidResponse(t, err)
+		})
 	}
 }
 
@@ -444,12 +554,26 @@ func TestWhiteboardUpdateExecute_RawAPIError(t *testing.T) {
 		},
 	})
 
-	source := `{"code":0,"data":{"to":"openapi","result":{"nodes":[]}}}`
+	// Top-level "nodes" is the raw open-api format (isRaw=true), which triggers
+	// the raw-edit recovery hint on API failure.
+	source := `{"nodes":[{"type":"composite_shape"}]}`
 	args := []string{"+update", "--whiteboard-token", "test-token-raw-api-error", "--input_format", "raw", "--source", source}
 	err := runUpdateShortcut(t, WhiteboardUpdate, args, factory, stdout)
-	// We expect an error here, but don't fail the test because it's testing error path
 	if err == nil {
-		t.Logf("Expected API error, but got none")
+		t.Fatalf("expected API error, but got none")
+	}
+	// The update boundary now yields a typed envelope carrying the Lark code.
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("error is not a typed errs.* envelope: %T (%v)", err, err)
+	}
+	if p.Code != 10001 {
+		t.Errorf("Problem.Code = %d, want 10001", p.Code)
+	}
+	// Raw (open-api JSON) input failures steer the user back to the recommended
+	// DSL workflow via a recovery hint on the typed envelope.
+	if !strings.Contains(p.Hint, "not advised to edit openapi format json directly") {
+		t.Errorf("Problem.Hint missing raw-edit guidance, got %q", p.Hint)
 	}
 }
 
@@ -471,9 +595,15 @@ invalid
 @@enduml`
 	args := []string{"+update", "--whiteboard-token", "test-token-plantuml-error", "--input_format", "plantuml", "--source", source}
 	err := runUpdateShortcut(t, WhiteboardUpdate, args, factory, stdout)
-	// We expect an error here, but don't fail the test because it's testing error path
 	if err == nil {
-		t.Logf("Expected API error, but got none")
+		t.Fatalf("expected API error, but got none")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("error is not a typed errs.* envelope: %T (%v)", err, err)
+	}
+	if p.Code != 10001 {
+		t.Errorf("Problem.Code = %d, want 10001", p.Code)
 	}
 }
 


### PR DESCRIPTION
## Summary

Completes the cli-errors-refactor migration for the **okr** and **whiteboard** commands: every failure now leaves the command as a typed `errs.*` envelope instead of a flat legacy string. Each error carries a stable category, subtype, the offending `--flag` or upstream Lark code, and a meaningful exit code, so scripts and agents can branch on the error shape rather than scraping messages.

## Changes

- **Input/validation errors** (`output.ErrValidation` / `common.FlagErrorf`) → `errs.NewValidationError(SubtypeInvalidArgument).WithParam("--flag")`.
- **API boundary** (`DoAPIJSON` / raw `DoAPI`) → `runtime.CallAPITyped` / `runtime.ClassifyAPIResponse`, with query params unified to `map[string]interface{}`. Already-typed transport/auth errors pass through via `errs.ProblemOf` and are never downgraded.
- **Local file errors** → domain-local typed helpers (`okrInputStatError`, `wbSaveError`, `wrapOkrNetworkErr` / `wrapWbNetworkErr`), replacing the shared `common.Wrap*` helpers that emitted legacy shapes.
- **Lint guards**: added both domains to the `errs-typed-only` / `errs-no-bare-wrap` / `errs-no-legacy-helper` path-except lists so legacy shapes cannot regress.
- Removed the now-orphaned `common.WrapSaveError` helper.

### Behavior notes (exit-code reclassification)

- Malformed or unparsable API responses, and missing expected fields, are now `internal` (exit 5, previously api/1) — they are response-shape bugs, not API business errors.
- Preview-image download HTTP failures are now `network` (exit 4).
- Validation stays exit 2; API business errors keep exit 1.

## Test Plan

- `gofmt -l`, `go vet`, `go build ./...`: clean
- `go test ./shortcuts/okr/... ./shortcuts/whiteboard/... ./shortcuts/common/...`: pass
- `golangci-lint run` (full, all three legacy-ban guards active on both domains): 0 issues
- `golangci-lint run --new-from-rev=origin/main`: 0 issues
- incremental `deadcode -test ./...`: no new dead code
- errscontract (`go run -C lint . ..`): 0 violations
- Dual-shape tests assert the typed envelope (`errors.As` / `errs.ProblemOf`, subtype, offending param or Lark code) survives command dispatch.

## Related Issues

Part of the cli-errors-refactor domain migration (follows the drive domain, #1205). No tracking issue.
