### PR TITLE
fix(sheets): correct +dropdown-get sheet-locator doc, finalize skill to 2.0.0

### DIFF
--- a/skills/lark-sheets/SKILL.md
+++ b/skills/lark-sheets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lark-sheets
-version: 2.0.0-draft
+version: 2.0.0
 description: "飞书电子表格：创建和操作电子表格。支持创建表格、管理工作表与行列结构（增删/合并/调整尺寸/隐藏/冻结）、读写单元格（值/公式/样式/批注/单元格图片）、查找替换、多操作原子批量更新，以及图表、透视表、条件格式、筛选器、迷你图、浮动图片等对象的创建与维护。当用户需要创建电子表格、管理工作表、批量读写或编辑数据、统计汇总与可视化、表格美化、公式计算（含 Excel 公式迁移）等任务时使用。若用户是想按名称或关键词搜索云空间（云盘/云存储）里的表格文件，请改用 lark-drive 的 drive +search 先定位资源。当用户给出 doubao.com 的 /sheets/ URL/token 时，也应直接使用本 skill，不要因为域名不是飞书而回退到 WebFetch；路由依据是 URL 路径模式和 token，而不是域名。仅针对飞书在线电子表格，不适用于本地 Excel 文件。"
 metadata:
   requires:
@@ -107,7 +107,7 @@ metadata:
    - ⚠️ **不确定 sheet 名时禁止直接猜 `Sheet1`**：除非用户对话明确说出 sheet 名 / id，或上下文（之前的工具调用 / URL 锚点 `?sheet=xxx`）已经出现过具体值，否则**第一步先调 `+workbook-info --url "..."`**（或 `--spreadsheet-token`）拿 `sheets[].sheet_id` / `sheets[].title` 列表再选。中文环境下子表常叫"数据" / "Sheet"（无数字）/ "工作表 1" / 业务名，猜 `Sheet1` 大概率撞 `sheet not found`，比先查多耗一次失败调用 + 重试。
    - ⚠️ **`--range` 里的 `Sheet1!` 前缀不能替代 sheet 定位**：即使写了 `--range 'Sheet1!A1:B2'`，仍**必须**额外传 `--sheet-id` 或 `--sheet-name`，否则照样报上面的错。
    - ⚠️ **A1 reference 含 `!`**（`--source` / `--range` / `--ranges`）**：shell session 起手先 `set +H`** 关 bash history expansion，否则 `"Sheet1!A1"` 会被拦成 `event not found`；含特殊字符（`-` / 空格 / 非 ASCII）的 sheet 名还要内部 single-quote 包，如 `--source "'Sales-2025'!A1:D100"`。
-   - **例外**：徽章标为 `_公共：URL/token（无 sheet 定位）…_` 的 shortcut（如 `+workbook-info` / `+workbook-export` / `+batch-update` / `+dropdown-get|update|delete` / `+cells-batch-set-style` / `+cells-batch-clear` / `+sheet-create`）**不接受也不需要** sheet 定位，只给一组 spreadsheet 定位即可。`+pivot-create` 用 `--target-sheet-id` / `--target-sheet-name`（XOR，可都不传，落点细节见 `lark-sheets-pivot-table`）。
+   - **例外**：徽章标为 `_公共：URL/token（无 sheet 定位）…_` 的 shortcut（如 `+workbook-info` / `+workbook-export` / `+batch-update` / `+dropdown-update|delete` / `+cells-batch-set-style` / `+cells-batch-clear` / `+sheet-create`）**不接受也不需要** sheet 定位，只给一组 spreadsheet 定位即可。`+pivot-create` 用 `--target-sheet-id` / `--target-sheet-name`（XOR，可都不传，落点细节见 `lark-sheets-pivot-table`）。
 
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |


### PR DESCRIPTION
## What

Two small doc/metadata fixes in `skills/lark-sheets/SKILL.md`:

1. **`+dropdown-get` was misclassified as not taking a sheet selector.** The
   "common-flag cheat sheet" exception list grouped `+dropdown-get` with the
   shortcuts that accept only `--url`/`--spreadsheet-token` and no sheet
   locator. But `+dropdown-get`'s `Validate` calls `resolveSheetSelector`, so
   `--sheet-id`/`--sheet-name` is **mandatory** — it belongs to the full
   four-piece common-flag set, exactly as its own per-shortcut badge already
   states. Removed it from the exception list. `+dropdown-update` /
   `+dropdown-delete` (which genuinely take only `--ranges`) stay.

2. **Finalize skill version** `2.0.0-draft` → `2.0.0`, matching the version
   already promoted in this branch lineage.

## Why it matters

The cheat-sheet's whole purpose is to stop agents from omitting required
flags. Telling an agent `+dropdown-get` needs no sheet locator leads it to
drop a flag the command actually requires, causing a guaranteed first-try
failure.

## Scope

Docs/metadata only — no Go, schema, or tool-behavior change. The SKILL.md is
a sync product; the source change lives upstream in sheet-skill-spec
(canonical `surfaces/skill-template.md` + `bundle.json`). Diff here is 2 lines.