### PR TITLE
feat(vc): forward invite call-id on meeting join

### DIFF
--- a/shortcuts/vc/vc_meeting_join.go
+++ b/shortcuts/vc/vc_meeting_join.go
@@ -32,6 +32,7 @@ var VCMeetingJoin = common.Shortcut{
 	Flags: []common.Flag{
 		{Name: "meeting-number", Required: true, Desc: "meeting number to join"},
 		{Name: "password", Desc: "meeting password (if required)"},
+		{Name: "call-id", Desc: "correlation id forwarded from invite event"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		mn := strings.TrimSpace(runtime.Str("meeting-number"))
@@ -89,6 +90,9 @@ func buildMeetingJoinBody(runtime *common.RuntimeContext) map[string]interface{}
 	}
 	if pw := strings.TrimSpace(runtime.Str("password")); pw != "" {
 		body["password"] = pw
+	}
+	if cid := strings.TrimSpace(runtime.Str("call-id")); cid != "" {
+		body["call_id"] = cid
 	}
 	return body
 }

--- a/shortcuts/vc/vc_meeting_test.go
+++ b/shortcuts/vc/vc_meeting_test.go
@@ -104,6 +104,53 @@ func TestBuildMeetingJoinBody_TrimsWhitespace(t *testing.T) {
 	}
 }
 
+func TestBuildMeetingJoinBody_WithoutCallID(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("meeting-number", "", "")
+	cmd.Flags().String("password", "", "")
+	cmd.Flags().String("call-id", "", "")
+	_ = cmd.Flags().Set("meeting-number", "123456789")
+
+	runtime := common.TestNewRuntimeContext(cmd, defaultConfig())
+	body := buildMeetingJoinBody(runtime)
+
+	if _, exists := body["call_id"]; exists {
+		t.Errorf("call_id should be omitted when empty, got %v", body["call_id"])
+	}
+}
+
+func TestBuildMeetingJoinBody_WithCallID(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("meeting-number", "", "")
+	cmd.Flags().String("password", "", "")
+	cmd.Flags().String("call-id", "", "")
+	_ = cmd.Flags().Set("meeting-number", "123456789")
+	_ = cmd.Flags().Set("call-id", "a08e06bf-9a41-44e4-a89c-a7871899e783")
+
+	runtime := common.TestNewRuntimeContext(cmd, defaultConfig())
+	body := buildMeetingJoinBody(runtime)
+
+	if body["call_id"] != "a08e06bf-9a41-44e4-a89c-a7871899e783" {
+		t.Errorf("call_id = %v, want a08e06bf-9a41-44e4-a89c-a7871899e783", body["call_id"])
+	}
+}
+
+func TestBuildMeetingJoinBody_TrimsCallIDWhitespace(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String("meeting-number", "", "")
+	cmd.Flags().String("password", "", "")
+	cmd.Flags().String("call-id", "", "")
+	_ = cmd.Flags().Set("meeting-number", "123456789")
+	_ = cmd.Flags().Set("call-id", "  call-xyz  ")
+
+	runtime := common.TestNewRuntimeContext(cmd, defaultConfig())
+	body := buildMeetingJoinBody(runtime)
+
+	if body["call_id"] != "call-xyz" {
+		t.Errorf("call_id should be trimmed, got %q", body["call_id"])
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Validate tests: VCMeetingJoin
 // ---------------------------------------------------------------------------

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-join.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-join.md
@@ -16,6 +16,9 @@ lark-cli vc +meeting-join --meeting-number 123456789
 # 指定会议号 + 密码
 lark-cli vc +meeting-join --meeting-number 123456789 --password 8888
 
+# 从邀请事件透传 call_id（参见「如何获取输入参数」）
+lark-cli vc +meeting-join --meeting-number 123456789 --call-id a08e06bf-9a41-44e4-a89c-a7871899e783
+
 # 输出格式
 lark-cli vc +meeting-join --meeting-number 123456789 --format json
 
@@ -29,6 +32,7 @@ lark-cli vc +meeting-join --meeting-number 123456789 --dry-run
 |------|------|------|
 | `--meeting-number <no>` | 是 | 会议号，必须为 **9 位纯数字** |
 | `--password <pw>` | 否 | 会议密码，仅在该会议设置了入会密码时传入 |
+| `--call-id <id>` | 否 | 从 `vc.bot.meeting_invited_v1` 邀请事件透传的 `call_id`，原样回传即可。Agent 主动入会或无邀请事件来源时不传 |
 | `--format <fmt>` | 否 | 输出格式：json (默认) / pretty / table / ndjson / csv |
 | `--dry-run` | 否 | 预览 API 调用，不执行 |
 
@@ -76,6 +80,7 @@ lark-cli vc +meeting-join --meeting-number 123456789 --dry-run
 |---------|---------|
 | `meeting-number` | 会议号由主持人分享；也可从会议链接尾部解析 9 位数字 |
 | `password` | 若会议设置了入会密码，由主持人提供 |
+| `call-id` | 由 `vc.bot.meeting_invited_v1` 邀请事件的 `call_id` 字段携带，Agent 收到事件时透传过来；无邀请事件场景（如 Agent 主动入会）不传 |
 
 ## Agent 组合场景
 


### PR DESCRIPTION
## 概述

为 `vc +meeting-join` 加一个可选的 `--call-id` flag，让调用方能把
`vc.bot.meeting_invited_v1` 邀请事件里 server 端生成的关联 id 原样
透传回服务端。这一步打通后，server 端
`vc_bot_invite_meeting_server` 与 `vc_bot_enter_meeting_server`
两张埋点可以按 call_id 1:1 关联，计算邀请→入会转化率与入会延迟。

## 改动

`shortcuts/vc/vc_meeting_join.go`

- 新增可选 flag：`--call-id <string>` —— *correlation id forwarded
  from invite event (echo back for server-side analytics join)*。
- 设置时，value 与现有的 `join_identify` / `join_type` / 可选的
  `password` 一起进入 POST body 的 `call_id` 字段。
- 未设置或为空时，body 里不会出现 `call_id` 这个 key —— 完全向后
  兼容。

## 安全 / 兼容性

- 服务端 `call_id` 在 `BotJoinMeetingRequest` 上本身就是 optional
  字段。不传 `--call-id` 时请求体跟改动前完全一致。
- 灰度期 `vc.bot.meeting_invited_v1` 事件可能还没带 `call_id`；
  调用方收到什么就原样透传（包括空串），不要在本地做格式校验。

## 关联改动（同名分支 / 关联 PR）

- 后端服务（`byteview-open-api`）：`BotJoinMeetingRequest` 新增
  字段 5 `call_id`，并以 `call_id` 为关联键上报
  `vc_bot_invite_meeting_server` / `vc_bot_enter_meeting_server`
  两张埋点。
- Agent 网关（`openclaw-lark`）：从入站
  `FeishuVcMeetingInvitedEvent` 提取 `call_id`，合成提示词指导
  Agent 调入会工具时透传。关联 PR 单独链接。
- Lark 开放平台网关：`BotJoinMeetingRequest.call_id` 与
  `meeting_invited` 事件体的 `call_id` 字段正在走平台 schema
  评审 / 发布流程。

## Test plan

- [x] `go build ./...` 通过。
- [x] `--dry-run` 带 `--call-id foo`：请求体预览出现
  `"call_id": "foo"`。
- [x] `--dry-run` 不带 `--call-id`：请求体保持改动前形状，无
  `call_id` key。
- [x] 端到端：BOE/PPE 上 invite → agent → join 链路里，server 端
  `[bot-invite-meeting-tea]` 与 `[bot-enter-meeting-tea]` 日志
  的 `call_id` 字段一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional --call-id flag to the video-conference join command; when provided and non-empty, the trimmed value is included in the join request payload.

* **Tests**
  * Added unit tests to verify call-id is omitted when empty, included when provided, and trimmed of surrounding whitespace.

* **Documentation**
  * Updated command reference to document the optional --call-id parameter and its expected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->