### PR TITLE
feat(mail): return typed error envelopes across the mail domain

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,20 +73,20 @@ linters:
           - forbidigo
       # errs-typed-only enforced on paths already migrated to errs.NewXxxError.
       # Add a path when its migration is complete.
-      - path-except: (internal/auth/|internal/errcompat/|internal/errclass/|internal/client/|internal/cmdutil/factory\.go|cmd/auth/|cmd/config/|cmd/service/|shortcuts/common/mcp_client\.go|shortcuts/calendar/helpers\.go|shortcuts/drive/)
+      - path-except: (internal/auth/|internal/errcompat/|internal/errclass/|internal/client/|internal/cmdutil/factory\.go|cmd/auth/|cmd/config/|cmd/service/|shortcuts/common/mcp_client\.go|shortcuts/calendar/helpers\.go|shortcuts/drive/|shortcuts/mail/)
         text: errs-typed-only
         linters:
           - forbidigo
       # errs-no-bare-wrap enforced on paths fully migrated to typed final
       # errors. Scoped separately from errs-typed-only because cmd/auth/,
       # cmd/config/ still have residual fmt.Errorf and must not be caught.
-      - path-except: (shortcuts/drive/|shortcuts/calendar/helpers\.go|shortcuts/common/mcp_client\.go)
+      - path-except: (shortcuts/drive/|shortcuts/mail/|shortcuts/calendar/helpers\.go|shortcuts/common/mcp_client\.go)
         text: errs-no-bare-wrap
         linters:
           - forbidigo
-      # errs-no-legacy-helper is drive-only: the shared helpers it bans are
-      # still used by other domains until their later migration phase.
-      - path-except: (shortcuts/drive/)
+      # errs-no-legacy-helper is scoped to migrated domains: the shared helpers
+      # it bans are still used by other domains until their later migration phase.
+      - path-except: (shortcuts/drive/|shortcuts/mail/)
         text: errs-no-legacy-helper
         linters:
           - forbidigo
@@ -115,17 +115,17 @@ linters:
           msg: >-
             [errs-typed-only] use errs.NewXxxError(...) builder
             (see errs/types.go).
-        # ── legacy shared error helpers banned on drive ──
+        # ── legacy shared error helpers banned on migrated domains ──
         # These helpers internally produce legacy output.Err* shapes, so they
-        # are invisible to the errs-typed-only ban above. Drive has migrated its
-        # calls to typed errs.* (drive-local driveInputStatError / driveSaveError);
-        # this prevents reintroduction. Other domains still use the shared
-        # helpers (migrated globally in a later phase), so this is drive-scoped.
+        # are invisible to the errs-typed-only ban above. Migrated domains use
+        # typed errs.* builders or domain-local file-I/O helpers instead; this
+        # prevents reintroduction while unmigrated domains continue to use the
+        # shared helpers until their later migration phase.
         - pattern: (common\.FlagErrorf|common\.WrapInputStatError|common\.WrapSaveErrorByCategory)\b
           msg: >-
             [errs-no-legacy-helper] these shared helpers emit legacy output.Err*
-            shapes. Use the typed errs.NewXxxError builders or the drive-local
-            driveInputStatError / driveSaveError helpers (shortcuts/drive/drive_errors.go).
+            shapes. Use typed errs.NewXxxError builders or a domain-local
+            file-I/O helper.
         # ── bare error wraps banned on fully-typed paths ──
         - pattern: (fmt\.Errorf|errors\.New)\b
           msg: >-

--- a/internal/errclass/classify.go
+++ b/internal/errclass/classify.go
@@ -244,6 +244,8 @@ func APIHint(subtype errs.Subtype) string {
 		return "operate on source and target within the same tenant and region/unit"
 	case errs.SubtypeCrossBrand:
 		return "operate on source and target within the same brand environment"
+	case errs.SubtypeQuotaExceeded:
+		return "reduce the request volume or free quota, then retry after the relevant quota resets"
 	}
 	return ""
 }

--- a/internal/errclass/codemeta_mail.go
+++ b/internal/errclass/codemeta_mail.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package errclass
+
+import "github.com/larksuite/cli/errs"
+
+// mailCodeMeta holds mail-service Lark code -> CodeMeta mappings.
+// Only codes whose meaning is verifiable from repo evidence are registered;
+// ambiguous codes fall back to CategoryAPI via BuildAPIError.
+var mailCodeMeta = map[int]CodeMeta{
+	1234013: {Category: errs.CategoryAPI, Subtype: errs.SubtypeNotFound},      // mailbox not found or not active
+	1236007: {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded}, // user daily send count exceeded
+	1236008: {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded}, // user daily external recipient count exceeded
+	1236009: {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded}, // tenant daily external recipient count exceeded
+	1236010: {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded}, // mail quota limit
+	1236013: {Category: errs.CategoryAPI, Subtype: errs.SubtypeQuotaExceeded}, // tenant storage limit exceeded
+}
+
+func init() { mergeCodeMeta(mailCodeMeta, "mail") }

--- a/lint/errscontract/rule_no_legacy_common_helper_call.go
+++ b/lint/errscontract/rule_no_legacy_common_helper_call.go
@@ -16,6 +16,7 @@ import (
 // common replacements or construct an errs.* typed error directly.
 var migratedCommonHelperPaths = []string{
 	"shortcuts/drive/",
+	"shortcuts/mail/",
 }
 
 const commonImportPath = "github.com/larksuite/cli/shortcuts/common"

--- a/lint/errscontract/rule_no_legacy_envelope_literal.go
+++ b/lint/errscontract/rule_no_legacy_envelope_literal.go
@@ -17,6 +17,7 @@ import (
 // appending their path prefix here.
 var migratedEnvelopePaths = []string{
 	"shortcuts/drive/",
+	"shortcuts/mail/",
 }
 
 // legacyOutputImportPath is the import path of the package that declares the

--- a/lint/errscontract/rules_test.go
+++ b/lint/errscontract/rules_test.go
@@ -894,27 +894,33 @@ func TestCheckNoLegacyCommonHelperCall_RejectsLegacyHelpersOnMigratedPath(t *tes
 		"ResolveOpenIDs",
 		"HandleApiResult",
 	}
-	for _, helper := range helpers {
-		t.Run(helper, func(t *testing.T) {
-			src := `package drive
+	paths := []string{
+		"shortcuts/drive/drive_search.go",
+		"shortcuts/mail/mail_send.go",
+	}
+	for _, path := range paths {
+		for _, helper := range helpers {
+			t.Run(path+"_"+helper, func(t *testing.T) {
+				src := `package migrated
 
 import "github.com/larksuite/cli/shortcuts/common"
 
 func boom() {
-	common.` + helper + `()
+common.` + helper + `()
 }
 `
-			v := CheckNoLegacyCommonHelperCall("shortcuts/drive/drive_search.go", src)
-			if len(v) != 1 {
-				t.Fatalf("expected 1 violation for %s, got %d: %+v", helper, len(v), v)
-			}
-			if v[0].Action != ActionReject {
-				t.Errorf("action = %q, want REJECT", v[0].Action)
-			}
-			if !strings.Contains(v[0].Message, "common."+helper) {
-				t.Errorf("message should name helper %s: %s", helper, v[0].Message)
-			}
-		})
+				v := CheckNoLegacyCommonHelperCall(path, src)
+				if len(v) != 1 {
+					t.Fatalf("expected 1 violation for %s on %s, got %d: %+v", helper, path, len(v), v)
+				}
+				if v[0].Action != ActionReject {
+					t.Errorf("action = %q, want REJECT", v[0].Action)
+				}
+				if !strings.Contains(v[0].Message, "common."+helper) {
+					t.Errorf("message should name helper %s: %s", helper, v[0].Message)
+				}
+			})
+		}
 	}
 }
 

--- a/shortcuts/common/drive_media_upload.go
+++ b/shortcuts/common/drive_media_upload.go
@@ -15,6 +15,7 @@ import (
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
 	"github.com/larksuite/cli/internal/output"
 )
 
@@ -57,6 +58,7 @@ type DriveMediaMultipartUploadConfig struct {
 	Reader io.Reader
 }
 
+// Deprecated: use UploadDriveMediaAllTyped for typed error envelopes.
 func UploadDriveMediaAll(runtime *RuntimeContext, cfg DriveMediaUploadAllConfig) (string, error) {
 	var fileReader io.Reader
 	if cfg.Reader != nil {
@@ -98,6 +100,52 @@ func UploadDriveMediaAll(runtime *RuntimeContext, cfg DriveMediaUploadAllConfig)
 	return ExtractDriveMediaUploadFileToken(data, driveMediaUploadAllAction)
 }
 
+// UploadDriveMediaAllTyped is the typed-error counterpart of
+// UploadDriveMediaAll: file-open failures surface as typed validation errors,
+// transport failures as typed network errors, and API failures are classified
+// via ClassifyAPIResponse so subtype / code / log_id survive on the error.
+func UploadDriveMediaAllTyped(runtime *RuntimeContext, cfg DriveMediaUploadAllConfig) (string, error) {
+	var fileReader io.Reader
+	if cfg.Reader != nil {
+		fileReader = cfg.Reader
+	} else {
+		f, err := runtime.FileIO().Open(cfg.FilePath)
+		if err != nil {
+			return "", WrapInputStatErrorTyped(err)
+		}
+		defer f.Close()
+		fileReader = f
+	}
+
+	fd := larkcore.NewFormdata()
+	fd.AddField("file_name", cfg.FileName)
+	fd.AddField("parent_type", cfg.ParentType)
+	fd.AddField("size", fmt.Sprintf("%d", cfg.FileSize))
+	if cfg.ParentNode != nil {
+		fd.AddField("parent_node", *cfg.ParentNode)
+	}
+	if cfg.Extra != "" {
+		fd.AddField("extra", cfg.Extra)
+	}
+	fd.AddFile("file", fileReader)
+
+	apiResp, err := runtime.DoAPI(&larkcore.ApiReq{
+		HttpMethod: http.MethodPost,
+		ApiPath:    "/open-apis/drive/v1/medias/upload_all",
+		Body:       fd,
+	}, larkcore.WithFileUpload())
+	if err != nil {
+		return "", prefixDriveMediaUploadProblem(client.WrapDoAPIError(err), driveMediaUploadAllAction)
+	}
+
+	data, err := runtime.ClassifyAPIResponse(apiResp)
+	if err != nil {
+		return "", prefixDriveMediaUploadProblem(err, driveMediaUploadAllAction)
+	}
+	return extractDriveMediaUploadFileTokenTyped(data, driveMediaUploadAllAction)
+}
+
+// Deprecated: use UploadDriveMediaMultipartTyped for typed error envelopes.
 func UploadDriveMediaMultipart(runtime *RuntimeContext, cfg DriveMediaMultipartUploadConfig) (string, error) {
 	// upload_prepare expects parent_node to be present even when the caller wants
 	// the service default/root behavior, so multipart callers pass an explicit
@@ -128,6 +176,43 @@ func UploadDriveMediaMultipart(runtime *RuntimeContext, cfg DriveMediaMultipartU
 	}
 
 	return finishDriveMediaMultipartUpload(runtime, session.UploadID, session.BlockNum)
+}
+
+// UploadDriveMediaMultipartTyped is the typed-error counterpart of
+// UploadDriveMediaMultipart: prepare/finish failures come back typed from
+// CallAPITyped, malformed session plans surface as invalid-response internal
+// errors, and per-part transport/API failures are classified the same way as
+// UploadDriveMediaAllTyped.
+func UploadDriveMediaMultipartTyped(runtime *RuntimeContext, cfg DriveMediaMultipartUploadConfig) (string, error) {
+	// upload_prepare expects parent_node to be present even when the caller wants
+	// the service default/root behavior, so multipart callers pass an explicit
+	// string instead of relying on field omission like upload_all does.
+	prepareBody := map[string]interface{}{
+		"file_name":   cfg.FileName,
+		"parent_type": cfg.ParentType,
+		"parent_node": cfg.ParentNode,
+		"size":        cfg.FileSize,
+	}
+	if cfg.Extra != "" {
+		prepareBody["extra"] = cfg.Extra
+	}
+
+	data, err := runtime.CallAPITyped("POST", "/open-apis/drive/v1/medias/upload_prepare", nil, prepareBody)
+	if err != nil {
+		return "", err
+	}
+
+	session, err := parseDriveMediaMultipartUploadSessionTyped(data)
+	if err != nil {
+		return "", err
+	}
+	fmt.Fprintf(runtime.IO().ErrOut, "Multipart upload initialized: %d chunks x %s\n", session.BlockNum, FormatSize(session.BlockSize))
+
+	if err = uploadDriveMediaMultipartPartsTyped(runtime, cfg, session); err != nil {
+		return "", err
+	}
+
+	return finishDriveMediaMultipartUploadTyped(runtime, session.UploadID, session.BlockNum)
 }
 
 func ParseDriveMediaMultipartUploadSession(data map[string]interface{}) (DriveMediaMultipartUploadSession, error) {
@@ -279,4 +364,123 @@ func finishDriveMediaMultipartUpload(runtime *RuntimeContext, uploadID string, b
 		return "", err
 	}
 	return ExtractDriveMediaUploadFileToken(data, driveMediaUploadFinishAction)
+}
+
+// prefixDriveMediaUploadProblem prepends the upload action to a typed error's
+// message so callers see which upload step failed. Non-typed errors are
+// returned unchanged.
+func prefixDriveMediaUploadProblem(err error, action string) error {
+	if p, ok := errs.ProblemOf(err); ok {
+		p.Message = action + ": " + p.Message
+	}
+	return err
+}
+
+// parseDriveMediaMultipartUploadSessionTyped validates the upload_prepare
+// session plan like ParseDriveMediaMultipartUploadSession, but reports a
+// malformed plan as a typed invalid-response internal error.
+func parseDriveMediaMultipartUploadSessionTyped(data map[string]interface{}) (DriveMediaMultipartUploadSession, error) {
+	session := DriveMediaMultipartUploadSession{
+		UploadID:  GetString(data, "upload_id"),
+		BlockSize: int64(GetFloat(data, "block_size")),
+		BlockNum:  int(GetFloat(data, "block_num")),
+	}
+	if session.UploadID == "" {
+		return DriveMediaMultipartUploadSession{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "upload prepare failed: no upload_id returned")
+	}
+	if session.BlockSize <= 0 {
+		return DriveMediaMultipartUploadSession{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "upload prepare failed: invalid block_size returned")
+	}
+	if session.BlockNum <= 0 {
+		return DriveMediaMultipartUploadSession{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "upload prepare failed: invalid block_num returned")
+	}
+	return session, nil
+}
+
+// extractDriveMediaUploadFileTokenTyped mirrors ExtractDriveMediaUploadFileToken
+// with a typed invalid-response internal error for a missing file_token.
+func extractDriveMediaUploadFileTokenTyped(data map[string]interface{}, action string) (string, error) {
+	fileToken := GetString(data, "file_token")
+	if fileToken == "" {
+		return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "%s: no file_token returned", action)
+	}
+	return fileToken, nil
+}
+
+// uploadDriveMediaMultipartPartsTyped mirrors uploadDriveMediaMultipartParts
+// with typed errors for file-open, file-read, and per-part upload failures.
+func uploadDriveMediaMultipartPartsTyped(runtime *RuntimeContext, cfg DriveMediaMultipartUploadConfig, session DriveMediaMultipartUploadSession) error {
+	var r io.Reader
+	if cfg.Reader != nil {
+		r = cfg.Reader
+	} else {
+		f, err := runtime.FileIO().Open(cfg.FilePath)
+		if err != nil {
+			return WrapInputStatErrorTyped(err)
+		}
+		defer f.Close()
+		r = f
+	}
+
+	maxInt := int64(^uint(0) >> 1)
+	bufferSize := session.BlockSize
+	if bufferSize <= 0 || bufferSize > maxInt {
+		return errs.NewInternalError(errs.SubtypeInvalidResponse, "upload prepare failed: invalid block_size returned")
+	}
+	buffer := make([]byte, int(bufferSize))
+	remaining := cfg.FileSize
+	// Follow the server-declared block plan exactly; upload_finish expects the
+	// same block count returned by upload_prepare.
+	for seq := 0; seq < session.BlockNum; seq++ {
+		chunkSize := session.BlockSize
+		if remaining > 0 && chunkSize > remaining {
+			chunkSize = remaining
+		}
+
+		n, readErr := io.ReadFull(r, buffer[:int(chunkSize)])
+		if readErr != nil {
+			return WrapInputStatErrorTyped(readErr)
+		}
+
+		if err := uploadDriveMediaMultipartPartTyped(runtime, session.UploadID, seq, buffer[:n]); err != nil {
+			return err
+		}
+		fmt.Fprintf(runtime.IO().ErrOut, "  Block %d/%d uploaded (%s)\n", seq+1, session.BlockNum, FormatSize(int64(n)))
+		remaining -= int64(n)
+	}
+
+	return nil
+}
+
+func uploadDriveMediaMultipartPartTyped(runtime *RuntimeContext, uploadID string, seq int, chunk []byte) error {
+	fd := larkcore.NewFormdata()
+	fd.AddField("upload_id", uploadID)
+	fd.AddField("seq", fmt.Sprintf("%d", seq))
+	fd.AddField("size", fmt.Sprintf("%d", len(chunk)))
+	fd.AddFile("file", bytes.NewReader(chunk))
+
+	apiResp, err := runtime.DoAPI(&larkcore.ApiReq{
+		HttpMethod: http.MethodPost,
+		ApiPath:    "/open-apis/drive/v1/medias/upload_part",
+		Body:       fd,
+	}, larkcore.WithFileUpload())
+	if err != nil {
+		return prefixDriveMediaUploadProblem(client.WrapDoAPIError(err), driveMediaUploadPartAction)
+	}
+
+	if _, err := runtime.ClassifyAPIResponse(apiResp); err != nil {
+		return prefixDriveMediaUploadProblem(err, driveMediaUploadPartAction)
+	}
+	return nil
+}
+
+func finishDriveMediaMultipartUploadTyped(runtime *RuntimeContext, uploadID string, blockNum int) (string, error) {
+	data, err := runtime.CallAPITyped("POST", "/open-apis/drive/v1/medias/upload_finish", nil, map[string]interface{}{
+		"upload_id": uploadID,
+		"block_num": blockNum,
+	})
+	if err != nil {
+		return "", err
+	}
+	return extractDriveMediaUploadFileTokenTyped(data, driveMediaUploadFinishAction)
 }

--- a/shortcuts/common/drive_media_upload_typed_test.go
+++ b/shortcuts/common/drive_media_upload_typed_test.go
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package common
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestUploadDriveMediaAllTypedWithInMemoryContent(t *testing.T) {
+	runtime, reg := newDriveMediaUploadTestRuntime(t)
+	withDriveMediaUploadWorkingDir(t, t.TempDir())
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_all",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"file_token": "file_typed_123"},
+		},
+	})
+
+	payload := []byte{0x89, 0x50, 0x4e, 0x47}
+	fileToken, err := UploadDriveMediaAllTyped(runtime, DriveMediaUploadAllConfig{
+		Reader:     bytes.NewReader(payload),
+		FileName:   "clipboard.png",
+		FileSize:   int64(len(payload)),
+		ParentType: "docx_image",
+		ParentNode: strPtr("blk_parent"),
+	})
+	if err != nil {
+		t.Fatalf("UploadDriveMediaAllTyped() error: %v", err)
+	}
+	if fileToken != "file_typed_123" {
+		t.Fatalf("fileToken = %q, want %q", fileToken, "file_typed_123")
+	}
+}
+
+func TestUploadDriveMediaAllTypedClassifiesAPIFailure(t *testing.T) {
+	runtime, reg := newDriveMediaUploadTestRuntime(t)
+	withDriveMediaUploadWorkingDir(t, t.TempDir())
+
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_all",
+		Body: map[string]interface{}{
+			"code": 999,
+			"msg":  "upload rejected",
+		},
+	})
+
+	payload := []byte{0x01}
+	_, err := UploadDriveMediaAllTyped(runtime, DriveMediaUploadAllConfig{
+		Reader:     bytes.NewReader(payload),
+		FileName:   "clipboard.png",
+		FileSize:   int64(len(payload)),
+		ParentType: "docx_image",
+		ParentNode: strPtr("blk_parent"),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T (%v)", err, err)
+	}
+	if p.Category != errs.CategoryAPI {
+		t.Fatalf("category = %s, want api", p.Category)
+	}
+	if p.Code != 999 {
+		t.Fatalf("code = %d, want 999", p.Code)
+	}
+	if !strings.HasPrefix(p.Message, "upload media failed: ") || !strings.Contains(p.Message, "upload rejected") {
+		t.Fatalf("message = %q, want action prefix and server msg", p.Message)
+	}
+}
+
+func TestUploadDriveMediaAllTypedFileOpenFailure(t *testing.T) {
+	runtime, _ := newDriveMediaUploadTestRuntime(t)
+	withDriveMediaUploadWorkingDir(t, t.TempDir())
+
+	_, err := UploadDriveMediaAllTyped(runtime, DriveMediaUploadAllConfig{
+		FilePath:   "missing.bin",
+		FileName:   "missing.bin",
+		FileSize:   1,
+		ParentType: "docx_image",
+		ParentNode: strPtr("blk_parent"),
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected typed validation error, got %T (%v)", err, err)
+	}
+}
+
+func TestUploadDriveMediaMultipartTypedBuildsPreparePartsAndFinish(t *testing.T) {
+	runtime, reg := newDriveMediaUploadTestRuntime(t)
+	withDriveMediaUploadWorkingDir(t, t.TempDir())
+
+	size := MaxDriveMediaUploadSinglePartSize + 1
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_prepare",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"upload_id":  "upload_typed_1",
+				"block_size": float64(4 * 1024 * 1024),
+				"block_num":  float64(6),
+			},
+		},
+	})
+	for i := 0; i < 6; i++ {
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "/open-apis/drive/v1/medias/upload_part",
+			Body:   map[string]interface{}{"code": 0, "msg": "ok"},
+		})
+	}
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_finish",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"file_token": "file_typed_multi"},
+		},
+	})
+
+	payload := bytes.Repeat([]byte{0xCD}, int(size))
+	fileToken, err := UploadDriveMediaMultipartTyped(runtime, DriveMediaMultipartUploadConfig{
+		Reader:     bytes.NewReader(payload),
+		FileName:   "clipboard.png",
+		FileSize:   size,
+		ParentType: "docx_image",
+		ParentNode: "",
+	})
+	if err != nil {
+		t.Fatalf("UploadDriveMediaMultipartTyped() error: %v", err)
+	}
+	if fileToken != "file_typed_multi" {
+		t.Fatalf("fileToken = %q, want %q", fileToken, "file_typed_multi")
+	}
+}
+
+func TestParseDriveMediaMultipartUploadSessionTypedValidatesResponseFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		data     map[string]interface{}
+		wantText string
+	}{
+		{
+			name: "missing upload id",
+			data: map[string]interface{}{
+				"block_size": 4 * 1024 * 1024,
+				"block_num":  6,
+			},
+			wantText: "upload prepare failed: no upload_id returned",
+		},
+		{
+			name: "missing block size",
+			data: map[string]interface{}{
+				"upload_id": "upload_123",
+				"block_num": 6,
+			},
+			wantText: "upload prepare failed: invalid block_size returned",
+		},
+		{
+			name: "missing block num",
+			data: map[string]interface{}{
+				"upload_id":  "upload_123",
+				"block_size": 4 * 1024 * 1024,
+			},
+			wantText: "upload prepare failed: invalid block_num returned",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseDriveMediaMultipartUploadSessionTyped(tt.data)
+			if err == nil || !strings.Contains(err.Error(), tt.wantText) {
+				t.Fatalf("err = %v, want substring %q", err, tt.wantText)
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("expected typed problem, got %T (%v)", err, err)
+			}
+			if p.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf("subtype = %s, want invalid_response", p.Subtype)
+			}
+		})
+	}
+}
+
+func TestUploadDriveMediaMultipartTypedPartAPIFailure(t *testing.T) {
+	runtime, reg := newDriveMediaUploadTestRuntime(t)
+	withDriveMediaUploadWorkingDir(t, t.TempDir())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_prepare",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"upload_id":  "upload_123",
+				"block_size": float64(4 * 1024 * 1024),
+				"block_num":  float64(6),
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_part",
+		Body: map[string]interface{}{
+			"code": 999,
+			"msg":  "chunk rejected",
+		},
+	})
+
+	filePath := writeDriveMediaUploadSizedFile(t, "large.bin", MaxDriveMediaUploadSinglePartSize+1)
+	_, err := UploadDriveMediaMultipartTyped(runtime, DriveMediaMultipartUploadConfig{
+		FilePath:   filePath,
+		FileName:   "large.bin",
+		FileSize:   MaxDriveMediaUploadSinglePartSize + 1,
+		ParentType: "ccm_import_open",
+		ParentNode: "",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T (%v)", err, err)
+	}
+	if p.Category != errs.CategoryAPI || p.Code != 999 {
+		t.Fatalf("category/code = %s/%d, want api/999", p.Category, p.Code)
+	}
+	if !strings.HasPrefix(p.Message, "upload media part failed: ") || !strings.Contains(p.Message, "chunk rejected") {
+		t.Fatalf("message = %q, want action prefix and server msg", p.Message)
+	}
+}
+
+func TestUploadDriveMediaMultipartTypedFinishRequiresFileToken(t *testing.T) {
+	runtime, reg := newDriveMediaUploadTestRuntime(t)
+	withDriveMediaUploadWorkingDir(t, t.TempDir())
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_prepare",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"upload_id":  "upload_123",
+				"block_size": float64(4 * 1024 * 1024),
+				"block_num":  float64(6),
+			},
+		},
+	})
+	for i := 0; i < 6; i++ {
+		reg.Register(&httpmock.Stub{
+			Method: "POST",
+			URL:    "/open-apis/drive/v1/medias/upload_part",
+			Body:   map[string]interface{}{"code": 0, "msg": "ok"},
+		})
+	}
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_finish",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		},
+	})
+
+	filePath := writeDriveMediaUploadSizedFile(t, "large.bin", MaxDriveMediaUploadSinglePartSize+1)
+	_, err := UploadDriveMediaMultipartTyped(runtime, DriveMediaMultipartUploadConfig{
+		FilePath:   filePath,
+		FileName:   "large.bin",
+		FileSize:   MaxDriveMediaUploadSinglePartSize + 1,
+		ParentType: "ccm_import_open",
+		ParentNode: "",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T (%v)", err, err)
+	}
+	if p.Subtype != errs.SubtypeInvalidResponse {
+		t.Fatalf("subtype = %s, want invalid_response", p.Subtype)
+	}
+	if !strings.Contains(p.Message, "upload media finish failed: no file_token returned") {
+		t.Fatalf("message = %q", p.Message)
+	}
+}

--- a/shortcuts/mail/body_file.go
+++ b/shortcuts/mail/body_file.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/larksuite/cli/extension/fileio"
-	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -51,11 +50,15 @@ const maxBodyFileSize = 32 * 1024 * 1024 // 32 MB
 func validateBodyFileMutex(bodyFlag, bodyFile string, validatePath func(string) error) error {
 	bodyEmpty := strings.TrimSpace(bodyFlag) == ""
 	if !bodyEmpty && bodyFile != "" {
-		return output.ErrValidation("--body and --body-file are mutually exclusive; pass exactly one")
+		return mailValidationError("--body and --body-file are mutually exclusive; pass exactly one").
+			WithParams(
+				mailInvalidParam("--body", "mutually exclusive with --body-file"),
+				mailInvalidParam("--body-file", "mutually exclusive with --body"),
+			)
 	}
 	if bodyFile != "" {
 		if err := validatePath(bodyFile); err != nil {
-			return output.ErrValidation("--body-file: %v", err)
+			return mailValidationParamError("--body-file", "--body-file: %v", err).WithCause(err)
 		}
 	}
 	return nil
@@ -79,7 +82,7 @@ func resolveBodyFromFlags(runtime *common.RuntimeContext) (string, error) {
 
 func validateRequiredResolvedBody(body string, hasTemplate bool, message string) error {
 	if !hasTemplate && strings.TrimSpace(body) == "" {
-		return output.ErrValidation(message)
+		return mailValidationError("%s", message)
 	}
 	return nil
 }
@@ -95,15 +98,15 @@ func validateRequiredResolvedBody(body string, hasTemplate bool, message string)
 func readBodyFile(fio fileio.FileIO, path string) (string, error) {
 	f, err := fio.Open(path)
 	if err != nil {
-		return "", output.ErrValidation("open --body-file %s: %v", path, err)
+		return "", mailValidationParamError("--body-file", "open --body-file %s: %v", path, err).WithCause(mailInputStatError(err))
 	}
 	defer f.Close()
 	buf, err := io.ReadAll(io.LimitReader(f, maxBodyFileSize+1))
 	if err != nil {
-		return "", output.ErrValidation("read --body-file %s: %v", path, err)
+		return "", mailValidationParamError("--body-file", "read --body-file %s: %v", path, err).WithCause(err)
 	}
 	if len(buf) > maxBodyFileSize {
-		return "", output.ErrValidation("--body-file: file exceeds %d MB limit", maxBodyFileSize/1024/1024)
+		return "", mailValidationParamError("--body-file", "--body-file: file exceeds %d MB limit", maxBodyFileSize/1024/1024)
 	}
 	return string(buf), nil
 }

--- a/shortcuts/mail/draft/charset.go
+++ b/shortcuts/mail/draft/charset.go
@@ -49,7 +49,7 @@ func encodeTextCharset(body []byte, label string) ([]byte, error) {
 	}
 	enc, _ := htmlcharset.Lookup(label)
 	if enc == nil {
-		return nil, fmt.Errorf("unsupported charset %q", label)
+		return nil, fmt.Errorf("unsupported charset %q", label) //nolint:forbidigo // intermediate draft charset error; mail command layer wraps into typed ValidationError.
 	}
 	var buf bytes.Buffer
 	writer := transform.NewWriter(&buf, enc.NewEncoder())

--- a/shortcuts/mail/draft/large_attachment_parse.go
+++ b/shortcuts/mail/draft/large_attachment_parse.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Lark Technologies Pte. Ltd.
 // SPDX-License-Identifier: MIT
 
+//nolint:forbidigo // intermediate draft large-attachment parser errors; mail command layer wraps into typed ValidationError.
 package draft
 
 import (

--- a/shortcuts/mail/draft/limits.go
+++ b/shortcuts/mail/draft/limits.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Lark Technologies Pte. Ltd.
 // SPDX-License-Identifier: MIT
 
+//nolint:forbidigo // intermediate draft attachment limit errors; mail command layer wraps into typed ValidationError.
 package draft
 
 import (

--- a/shortcuts/mail/draft/model.go
+++ b/shortcuts/mail/draft/model.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Lark Technologies Pte. Ltd.
 // SPDX-License-Identifier: MIT
 
+//nolint:forbidigo // intermediate draft patch model errors; mail command layer wraps into typed ValidationError.
 package draft
 
 import (

--- a/shortcuts/mail/draft/parse.go
+++ b/shortcuts/mail/draft/parse.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Lark Technologies Pte. Ltd.
 // SPDX-License-Identifier: MIT
 
+//nolint:forbidigo // intermediate draft EML parser errors; mail command layer wraps into typed ValidationError.
 package draft
 
 import (

--- a/shortcuts/mail/draft/patch.go
+++ b/shortcuts/mail/draft/patch.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Lark Technologies Pte. Ltd.
 // SPDX-License-Identifier: MIT
 
+//nolint:forbidigo // intermediate draft patch application errors; mail command layer wraps into typed ValidationError.
 package draft
 
 import (

--- a/shortcuts/mail/draft/patch_calendar.go
+++ b/shortcuts/mail/draft/patch_calendar.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Lark Technologies Pte. Ltd.
 // SPDX-License-Identifier: MIT
 
+//nolint:forbidigo // intermediate draft calendar patch errors; mail command layer wraps into typed ValidationError.
 package draft
 
 import (

--- a/shortcuts/mail/draft/serialize.go
+++ b/shortcuts/mail/draft/serialize.go
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Lark Technologies Pte. Ltd.
 // SPDX-License-Identifier: MIT
 
+//nolint:forbidigo // intermediate draft serializer errors; mail command layer wraps into typed ValidationError.
 package draft
 
 import (

--- a/shortcuts/mail/draft/service.go
+++ b/shortcuts/mail/draft/service.go
@@ -4,10 +4,10 @@
 package draft
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -31,13 +31,13 @@ func mailboxPath(mailboxID string, segments ...string) string {
 // draft_id, the input draftID is echoed back so callers always have a
 // non-empty identifier to round-trip.
 func GetRaw(runtime *common.RuntimeContext, mailboxID, draftID string) (DraftRaw, error) {
-	data, err := runtime.CallAPI("GET", mailboxPath(mailboxID, "drafts", draftID), map[string]interface{}{"format": "raw"}, nil)
+	data, err := runtime.CallAPITyped("GET", mailboxPath(mailboxID, "drafts", draftID), map[string]interface{}{"format": "raw"}, nil)
 	if err != nil {
 		return DraftRaw{}, err
 	}
 	raw := extractRawEML(data)
 	if raw == "" {
-		return DraftRaw{}, fmt.Errorf("API response missing draft raw EML; the backend returned an empty raw body for this draft")
+		return DraftRaw{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "API response missing draft raw EML; the backend returned an empty raw body for this draft")
 	}
 	gotDraftID := extractDraftID(data)
 	if gotDraftID == "" {
@@ -55,13 +55,13 @@ func GetRaw(runtime *common.RuntimeContext, mailboxID, draftID string) (DraftRaw
 // assembled the EML with emlbuilder; for high-level compose paths use the
 // MailDraftCreate shortcut instead.
 func CreateWithRaw(runtime *common.RuntimeContext, mailboxID, rawEML string) (DraftResult, error) {
-	data, err := runtime.CallAPI("POST", mailboxPath(mailboxID, "drafts"), nil, map[string]interface{}{"raw": rawEML})
+	data, err := runtime.CallAPITyped("POST", mailboxPath(mailboxID, "drafts"), nil, map[string]interface{}{"raw": rawEML})
 	if err != nil {
 		return DraftResult{}, err
 	}
 	draftID := extractDraftID(data)
 	if draftID == "" {
-		return DraftResult{}, fmt.Errorf("API response missing draft_id")
+		return DraftResult{}, errs.NewInternalError(errs.SubtypeInvalidResponse, "API response missing draft_id")
 	}
 	return DraftResult{
 		DraftID:   draftID,
@@ -76,7 +76,7 @@ func CreateWithRaw(runtime *common.RuntimeContext, mailboxID, rawEML string) (Dr
 // carries the (possibly re-issued) draft ID and the preview reference URL
 // when the backend provides one.
 func UpdateWithRaw(runtime *common.RuntimeContext, mailboxID, draftID, rawEML string) (DraftResult, error) {
-	data, err := runtime.CallAPI("PUT", mailboxPath(mailboxID, "drafts", draftID), nil, map[string]interface{}{"raw": rawEML})
+	data, err := runtime.CallAPITyped("PUT", mailboxPath(mailboxID, "drafts", draftID), nil, map[string]interface{}{"raw": rawEML})
 	if err != nil {
 		return DraftResult{}, err
 	}
@@ -99,7 +99,7 @@ func Send(runtime *common.RuntimeContext, mailboxID, draftID, sendTime string) (
 	if sendTime != "" {
 		bodyParams = map[string]interface{}{"send_time": sendTime}
 	}
-	return runtime.CallAPI("POST", mailboxPath(mailboxID, "drafts", draftID, "send"), nil, bodyParams)
+	return runtime.CallAPITyped("POST", mailboxPath(mailboxID, "drafts", draftID, "send"), nil, bodyParams)
 }
 
 // extractDraftID returns the first non-empty draft identifier found in the

--- a/shortcuts/mail/emlbuilder/builder.go
+++ b/shortcuts/mail/emlbuilder/builder.go
@@ -53,6 +53,7 @@ import (
 	"time"
 
 	"github.com/larksuite/cli/extension/fileio"
+	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/mail/filecheck"
 )
 
@@ -61,9 +62,12 @@ const MaxEMLSize = 25 * 1024 * 1024 // 25 MB
 
 // readFile reads the named file and returns its contents via FileIO.
 func readFile(fio fileio.FileIO, path string) ([]byte, error) {
+	if _, err := validate.SafeInputPath(path); err != nil {
+		return nil, fmt.Errorf("attachment %q: %w", path, err) //nolint:forbidigo // intermediate EML builder error; mail command layer wraps into typed ValidationError.
+	}
 	f, err := fio.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("attachment %q: %w", path, err)
+		return nil, fmt.Errorf("attachment %q: %w", path, err) //nolint:forbidigo // intermediate EML builder error; mail command layer wraps into typed ValidationError.
 	}
 	defer f.Close()
 	return io.ReadAll(f)
@@ -133,10 +137,10 @@ func New() Builder {
 func validateHeaderValue(v string) error {
 	for _, r := range v {
 		if r != '\t' && (r < 0x20 || r == 0x7f) {
-			return fmt.Errorf("emlbuilder: header value contains control character: %q", v)
+			return fmt.Errorf("emlbuilder: header value contains control character: %q", v) //nolint:forbidigo // intermediate EML builder error; mail command layer wraps into typed ValidationError.
 		}
 		if isHeaderDangerousUnicode(r) {
-			return fmt.Errorf("emlbuilder: header value contains dangerous Unicode character: %q", v)
+			return fmt.Errorf("emlbuilder: header value contains dangerous Unicode character: %q", v) //nolint:forbidigo // intermediate EML builder error; mail command layer wraps into typed ValidationError.
 		}
 	}
 	return nil
@@ -165,11 +169,11 @@ func isHeaderDangerousUnicode(r rune) bool {
 // or non-printable ASCII characters, as required by RFC 5322 field-name syntax.
 func validateHeaderName(n string) error {
 	if strings.ContainsAny(n, ":\r\n") {
-		return fmt.Errorf("emlbuilder: header name contains ':', CR, or LF: %q", n)
+		return fmt.Errorf("emlbuilder: header name contains ':', CR, or LF: %q", n) //nolint:forbidigo // intermediate EML builder error; mail command layer wraps into typed ValidationError.
 	}
 	for _, r := range n {
 		if r < 0x21 || r > 0x7e {
-			return fmt.Errorf("emlbuilder: header name contains non-printable character: %q", n)
+			return fmt.Errorf("emlbuilder: header name contains non-printable character: %q", n) //nolint:forbidigo // intermediate EML builder error; mail command layer wraps into typed ValidationError.
 		}
 	}
 	return nil
@@ -179,7 +183,7 @@ func validateHeaderName(n string) error {
 // escape the quoted-string encoding used by mail.Address.String() and inject headers.
 func validateDisplayName(name string) error {
 	if strings.ContainsAny(name, "\r\n") {
-		return fmt.Errorf("emlbuilder: display name contains CR or LF: %q", name)
+		return fmt.Errorf("emlbuilder: display name contains CR or LF: %q", name) //nolint:forbidigo // intermediate EML builder error; mail command layer wraps into typed ValidationError.
 	}
 	return nil
 }
@@ -189,7 +193,7 @@ func validateDisplayName(name string) error {
 func validateCID(cid string) error {
 	for _, r := range cid {
 		if r < 0x20 || r == 0x7f {
-			return fmt.Errorf("emlbuilder: content ID contains control character: %q", cid)
+			return fmt.Errorf("emlbuilder: content ID contains control character: %q", cid) //nolint:forbidigo // intermediate EML builder error; mail command layer wraps into typed ValidationError.
 		}
 	}
 	return nil
@@ -672,10 +676,10 @@ func (b Builder) Build() ([]byte, error) {
 		return nil, b.err
 	}
 	if b.from.Address == "" {
-		return nil, fmt.Errorf("emlbuilder: From address is required")
+		return nil, fmt.Errorf("emlbuilder: From address is required") //nolint:forbidigo // intermediate EML builder error; mail command layer wraps into typed ValidationError.
 	}
 	if !b.allowNoRecipients && len(b.to)+len(b.cc)+len(b.bcc) == 0 {
-		return nil, fmt.Errorf("emlbuilder: at least one recipient (To/CC/BCC) is required")
+		return nil, fmt.Errorf("emlbuilder: at least one recipient (To/CC/BCC) is required") //nolint:forbidigo // intermediate EML builder error; mail command layer wraps into typed ValidationError.
 	}
 
 	date := b.date
@@ -754,7 +758,7 @@ func (b Builder) Build() ([]byte, error) {
 
 	raw := buf.Bytes()
 	if len(raw) > MaxEMLSize {
-		return nil, fmt.Errorf("emlbuilder: EML size %.1f MB exceeds the %.0f MB limit",
+		return nil, fmt.Errorf("emlbuilder: EML size %.1f MB exceeds the %.0f MB limit", //nolint:forbidigo // intermediate EML builder error; mail command layer wraps into typed ValidationError.
 			float64(len(raw))/1024/1024, float64(MaxEMLSize)/1024/1024)
 	}
 	return raw, nil

--- a/shortcuts/mail/filecheck/filecheck.go
+++ b/shortcuts/mail/filecheck/filecheck.go
@@ -124,7 +124,7 @@ func CheckBlockedExtension(filename string) error {
 		return nil
 	}
 	if _, ok := blockedExtensions[ext]; ok {
-		return fmt.Errorf("file extension %q is not allowed as a mail attachment", "."+ext)
+		return fmt.Errorf("file extension %q is not allowed as a mail attachment", "."+ext) //nolint:forbidigo // intermediate mail file-format check; mail command layer wraps into typed ValidationError.
 	}
 	return nil
 }
@@ -156,7 +156,7 @@ var allowedInlineMIMETypes = map[string]struct{}{
 func CheckInlineImageFormat(filename string, content []byte) (string, error) {
 	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(filename), "."))
 	if _, ok := allowedInlineExtensions[ext]; !ok {
-		return "", fmt.Errorf("inline image extension %q is not allowed; supported formats: jpg, jpeg, png, gif, webp", ext)
+		return "", fmt.Errorf("inline image extension %q is not allowed; supported formats: jpg, jpeg, png, gif, webp", ext) //nolint:forbidigo // intermediate mail file-format check; mail command layer wraps into typed ValidationError.
 	}
 	detected := http.DetectContentType(content)
 	// DetectContentType may return params (e.g. "text/plain; charset=utf-8"),
@@ -165,7 +165,7 @@ func CheckInlineImageFormat(filename string, content []byte) (string, error) {
 		detected = strings.TrimSpace(detected[:i])
 	}
 	if _, ok := allowedInlineMIMETypes[detected]; !ok {
-		return "", fmt.Errorf("inline image content type %q does not match an allowed image format; supported: image/jpeg, image/png, image/gif, image/webp", detected)
+		return "", fmt.Errorf("inline image content type %q does not match an allowed image format; supported: image/jpeg, image/png, image/gif, image/webp", detected) //nolint:forbidigo // intermediate mail file-format check; mail command layer wraps into typed ValidationError.
 	}
 	return detected, nil
 }

--- a/shortcuts/mail/flag_suggest.go
+++ b/shortcuts/mail/flag_suggest.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/errs"
 )
 
 // flagName is a package-private snapshot of a pflag.Flag's identity.
@@ -21,8 +21,7 @@ type flagName struct {
 }
 
 // Candidate is a single suggested flag returned to the user when an
-// unknown flag is detected. It is serialised into the ErrorEnvelope's
-// error.detail.candidates[] array.
+// unknown flag is detected.
 type Candidate struct {
 	// Flag is the long-form spelling of the suggested flag, e.g. "--to".
 	Flag string `json:"flag"`
@@ -56,9 +55,9 @@ func InstallOnMail(svc *cobra.Command) {
 	svc.SetFlagErrorFunc(flagSuggestErrorFunc)
 }
 
-// flagSuggestErrorFunc converts pflag's unknown-flag errors into a
-// structured *output.ExitError carrying candidate suggestions. Any other
-// error is passed through unchanged so cobra's existing handling kicks in.
+// flagSuggestErrorFunc converts pflag's unknown-flag errors into a typed
+// validation error carrying candidate suggestions. Any other error is passed
+// through unchanged so cobra's existing handling kicks in.
 func flagSuggestErrorFunc(c *cobra.Command, err error) error {
 	if err == nil {
 		return nil
@@ -83,22 +82,21 @@ func flagSuggestErrorFunc(c *cobra.Command, err error) error {
 		matches = []Candidate{}
 	}
 	hint := buildHint(c, matches)
-	detail := map[string]any{
-		"unknown":      rawUnknownToken(token, isShorthand),
-		"command_path": c.CommandPath(),
-		"candidates":   matches,
+	params := []errs.InvalidParam{{
+		Name:   rawUnknownToken(token, isShorthand),
+		Reason: "unknown flag",
+	}}
+	for _, match := range matches {
+		reason := fmt.Sprintf("candidate (%s, distance=%d)", match.Reason, match.Distance)
+		if match.Shorthand != "" {
+			reason += fmt.Sprintf(", shorthand=-%s", match.Shorthand)
+		}
+		params = append(params, errs.InvalidParam{Name: match.Flag, Reason: reason})
 	}
-	// Code is ExitAPI (=1), matching cobra's default unknown-flag exit
-	// code. The structured type discrimination lives in error.type.
-	return &output.ExitError{
-		Code: output.ExitAPI,
-		Detail: &output.ErrDetail{
-			Type:    "unknown_flag",
-			Message: err.Error(),
-			Hint:    hint,
-			Detail:  detail,
-		},
-	}
+	return errs.NewValidationError(errs.SubtypeInvalidArgument, err.Error()).
+		WithHint("%s", hint).
+		WithParam(rawUnknownToken(token, isShorthand)).
+		WithParams(params...)
 }
 
 // parseUnknownToken extracts the offending flag name from a pflag error

--- a/shortcuts/mail/flag_suggest_test.go
+++ b/shortcuts/mail/flag_suggest_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/errs"
 )
 
 // --- suggest (long-flag) ---
@@ -175,35 +175,41 @@ func newFakeMailCmd() *cobra.Command {
 	return c
 }
 
-func TestFlagSuggestErrorFunc_LongUnknown_ReturnsExitError(t *testing.T) {
+func requireFlagSuggestValidation(t *testing.T, got error) *errs.ValidationError {
+	t.Helper()
+	var validationErr *errs.ValidationError
+	require.True(t, errors.As(got, &validationErr), "expected *errs.ValidationError, got %T", got)
+	p, ok := errs.ProblemOf(got)
+	require.True(t, ok, "expected typed Problem")
+	assert.Equal(t, errs.CategoryValidation, p.Category)
+	assert.Equal(t, errs.SubtypeInvalidArgument, p.Subtype)
+	return validationErr
+}
+
+func paramReason(params []errs.InvalidParam, name string) (string, bool) {
+	for _, p := range params {
+		if p.Name == name {
+			return p.Reason, true
+		}
+	}
+	return "", false
+}
+
+func TestFlagSuggestErrorFunc_LongUnknown_ReturnsTypedValidation(t *testing.T) {
 	cmd := newFakeMailCmd()
 	got := flagSuggestErrorFunc(cmd, errors.New("unknown flag: --tos"))
 
-	var exitErr *output.ExitError
-	require.True(t, errors.As(got, &exitErr), "expected *output.ExitError, got %T", got)
-	require.NotNil(t, exitErr.Detail)
-	assert.Equal(t, "unknown_flag", exitErr.Detail.Type)
-	assert.Equal(t, "unknown flag: --tos", exitErr.Detail.Message)
-	assert.Contains(t, exitErr.Detail.Hint, "--to")
+	validationErr := requireFlagSuggestValidation(t, got)
+	assert.Equal(t, "unknown flag: --tos", validationErr.Message)
+	assert.Equal(t, "--tos", validationErr.Param)
+	assert.Contains(t, validationErr.Hint, "--to")
 
-	detail, ok := exitErr.Detail.Detail.(map[string]any)
-	require.True(t, ok, "Detail.Detail should be map[string]any")
-	assert.Equal(t, "--tos", detail["unknown"])
-	assert.Equal(t, cmd.CommandPath(), detail["command_path"])
-
-	cands, ok := detail["candidates"].([]Candidate)
-	require.True(t, ok, "candidates should be []Candidate")
-	require.NotEmpty(t, cands)
-
-	var foundTo bool
-	for _, c := range cands {
-		if c.Flag == "--to" {
-			foundTo = true
-			assert.Equal(t, "prefix", c.Reason)
-			break
-		}
-	}
-	assert.True(t, foundTo, "expected --to in candidates")
+	reason, ok := paramReason(validationErr.Params, "--tos")
+	require.True(t, ok, "unknown flag should be included in params")
+	assert.Equal(t, "unknown flag", reason)
+	reason, ok = paramReason(validationErr.Params, "--to")
+	require.True(t, ok, "expected --to in candidate params")
+	assert.Contains(t, reason, "candidate (prefix")
 }
 
 func TestFlagSuggestErrorFunc_NotUnknownFlag_PassesThrough(t *testing.T) {
@@ -214,14 +220,13 @@ func TestFlagSuggestErrorFunc_NotUnknownFlag_PassesThrough(t *testing.T) {
 	assert.Same(t, in, got, "non-unknown-flag errors must be returned unchanged")
 }
 
-func TestFlagSuggestErrorFunc_ExitCodeIsOne(t *testing.T) {
+func TestFlagSuggestErrorFunc_TypedCategoryAndSubtype(t *testing.T) {
 	cmd := newFakeMailCmd()
 	got := flagSuggestErrorFunc(cmd, errors.New("unknown flag: --tos"))
-	var exitErr *output.ExitError
-	require.True(t, errors.As(got, &exitErr))
-	// Hard contract — both compile-time and runtime guards:
-	assert.Equal(t, output.ExitAPI, exitErr.Code, "unknown_flag must use ExitAPI, not ExitValidation")
-	assert.Equal(t, 1, output.ExitAPI, "ExitAPI constant must remain 1")
+	p, ok := errs.ProblemOf(got)
+	require.True(t, ok)
+	assert.Equal(t, errs.CategoryValidation, p.Category)
+	assert.Equal(t, errs.SubtypeInvalidArgument, p.Subtype)
 }
 
 // --- edge-case coverage ---
@@ -236,9 +241,8 @@ func TestInstallOnMail_InstallsHook(t *testing.T) {
 	InstallOnMail(c)
 	require.NotNil(t, c.FlagErrorFunc())
 	got := c.FlagErrorFunc()(c, errors.New("unknown flag: --tos"))
-	var exitErr *output.ExitError
-	require.True(t, errors.As(got, &exitErr), "installed hook must produce *output.ExitError")
-	assert.Equal(t, "unknown_flag", exitErr.Detail.Type)
+	validationErr := requireFlagSuggestValidation(t, got)
+	assert.Equal(t, "--tos", validationErr.Param)
 }
 
 func TestFlagSuggestErrorFunc_NilError(t *testing.T) {
@@ -249,50 +253,47 @@ func TestFlagSuggestErrorFunc_NilError(t *testing.T) {
 func TestFlagSuggestErrorFunc_LongUnknown_StripsValueTail(t *testing.T) {
 	cmd := newFakeMailCmd()
 	got := flagSuggestErrorFunc(cmd, errors.New("unknown flag: --tos=alice@example.com"))
-	var exitErr *output.ExitError
-	require.True(t, errors.As(got, &exitErr))
-	detail := exitErr.Detail.Detail.(map[string]any)
-	assert.Equal(t, "--tos", detail["unknown"], "value tail must be stripped before echoing")
+	validationErr := requireFlagSuggestValidation(t, got)
+	assert.Equal(t, "--tos", validationErr.Param, "value tail must be stripped before echoing")
+	reason, ok := paramReason(validationErr.Params, "--tos")
+	require.True(t, ok)
+	assert.Equal(t, "unknown flag", reason)
 }
 
 func TestFlagSuggestErrorFunc_ShorthandUnknown(t *testing.T) {
 	cmd := newFakeMailCmd()
 	got := flagSuggestErrorFunc(cmd, errors.New("unknown shorthand flag: 'b' in -bXY"))
-	var exitErr *output.ExitError
-	require.True(t, errors.As(got, &exitErr))
-	detail := exitErr.Detail.Detail.(map[string]any)
-	assert.Equal(t, "-b", detail["unknown"])
-	cands, ok := detail["candidates"].([]Candidate)
+	validationErr := requireFlagSuggestValidation(t, got)
+	assert.Equal(t, "-b", validationErr.Param)
+	reason, ok := paramReason(validationErr.Params, "-b")
 	require.True(t, ok)
+	assert.Equal(t, "unknown flag", reason)
 	// newFakeMailCmd has --body/-b; exact shorthand hit expected.
-	require.NotEmpty(t, cands)
-	assert.Equal(t, "--body", cands[0].Flag)
-	assert.Equal(t, "b", cands[0].Shorthand)
+	reason, ok = paramReason(validationErr.Params, "--body")
+	require.True(t, ok)
+	assert.Contains(t, reason, "candidate (prefix")
+	assert.Contains(t, reason, "shorthand=-b")
 }
 
-func TestFlagSuggestErrorFunc_CandidatesAlwaysArray(t *testing.T) {
+func TestFlagSuggestErrorFunc_ParamsAlwaysPresent(t *testing.T) {
 	// A cobra command with no flags forces collectFlags → empty names →
-	// suggest → nil. The envelope must still expose candidates as a
-	// non-nil []Candidate so the JSON wire shape is "candidates: []"
-	// rather than "candidates: null".
+	// suggest → nil. The typed validation error must still expose the unknown
+	// flag in Params so downstream parsers have a stable structured field.
 	bare := &cobra.Command{Use: "mail"}
 	got := flagSuggestErrorFunc(bare, errors.New("unknown flag: --bogus"))
-	var exitErr *output.ExitError
-	require.True(t, errors.As(got, &exitErr))
-	detail := exitErr.Detail.Detail.(map[string]any)
-	cands, ok := detail["candidates"].([]Candidate)
-	require.True(t, ok, "candidates must be []Candidate even when empty")
-	assert.NotNil(t, cands, "candidates must be non-nil empty slice, not nil")
-	assert.Empty(t, cands)
+	validationErr := requireFlagSuggestValidation(t, got)
+	assert.NotNil(t, validationErr.Params)
+	require.Len(t, validationErr.Params, 1)
+	assert.Equal(t, "--bogus", validationErr.Params[0].Name)
+	assert.Equal(t, "unknown flag", validationErr.Params[0].Reason)
 }
 
 func TestFlagSuggestErrorFunc_NoCandidatesUsesHelpHint(t *testing.T) {
 	cmd := newFakeMailCmd()
 	// Token with no plausible neighbor in {to, cc, subject, body}.
 	got := flagSuggestErrorFunc(cmd, errors.New("unknown flag: --zzzzzzz"))
-	var exitErr *output.ExitError
-	require.True(t, errors.As(got, &exitErr))
-	assert.Contains(t, exitErr.Detail.Hint, "--help")
+	validationErr := requireFlagSuggestValidation(t, got)
+	assert.Contains(t, validationErr.Hint, "--help")
 }
 
 func TestParseUnknownToken_EmptyAndMalformed(t *testing.T) {

--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -6,6 +6,7 @@ package mail
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -21,7 +22,6 @@ import (
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
 	"github.com/larksuite/cli/internal/auth"
-	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
@@ -111,7 +111,7 @@ func requireSenderForRequestReceipt(runtime *common.RuntimeContext, senderEmail 
 		return nil
 	}
 	if strings.TrimSpace(senderEmail) == "" {
-		return output.ErrValidation(
+		return mailValidationError(
 			"--request-receipt requires a resolvable sender address; specify a sender address where supported, or ensure the draft has a From address")
 	}
 	return nil
@@ -130,10 +130,10 @@ func requireSenderForRequestReceipt(runtime *common.RuntimeContext, senderEmail 
 func validateHeaderAddress(addr string) error {
 	for _, r := range addr {
 		if r != '\t' && (r < 0x20 || r == 0x7f) {
-			return fmt.Errorf("address contains control character: %q", addr)
+			return mailValidationError("address contains control character: %q", addr)
 		}
 		if common.IsDangerousUnicode(r) {
-			return fmt.Errorf("address contains dangerous Unicode code point: %q", addr)
+			return mailValidationError("address contains dangerous Unicode code point: %q", addr)
 		}
 	}
 	return nil
@@ -324,7 +324,7 @@ func fetchMailboxPrimaryEmail(runtime *common.RuntimeContext, mailboxID string) 
 	if mailboxID == "" {
 		mailboxID = "me"
 	}
-	data, err := runtime.CallAPI("GET", mailboxPath(mailboxID, "profile"), nil, nil)
+	data, err := runtime.CallAPITyped("GET", mailboxPath(mailboxID, "profile"), nil, nil)
 	if err != nil {
 		return "", err
 	}
@@ -336,7 +336,7 @@ func fetchMailboxPrimaryEmail(runtime *common.RuntimeContext, mailboxID string) 
 			return email, nil
 		}
 	}
-	return "", fmt.Errorf("profile API returned no primary_email_address")
+	return "", mailInvalidResponseError("profile API returned no primary_email_address")
 }
 
 // extractPrimaryEmail returns the user's primary email address from a
@@ -503,12 +503,14 @@ func resolveFolderID(runtime *common.RuntimeContext, mailboxID, input string) (s
 	if err != nil {
 		return "", err
 	}
-	return resolveByID("folder", value, mailboxID, folders, func(item folderInfo) string { return item.ID })
+	return resolveByName("folder", value, mailboxID, folders,
+		func(item folderInfo) string { return item.ID },
+		func(item folderInfo) string { return item.Name },
+	)
 }
 
 // resolveFolderName accepts either a folder ID or a folder name and returns
-// the human-readable folder name. Used for output rendering where the user
-// wants to see the name they originally chose, not the opaque ID.
+// the canonical folder ID.
 func resolveFolderName(runtime *common.RuntimeContext, mailboxID, input string) (string, error) {
 	value := strings.TrimSpace(input)
 	if value == "" {
@@ -542,11 +544,14 @@ func resolveLabelID(runtime *common.RuntimeContext, mailboxID, input string) (st
 	if err != nil {
 		return "", err
 	}
-	return resolveByID("label", value, mailboxID, labels, func(item labelInfo) string { return item.ID })
+	return resolveByName("label", value, mailboxID, labels,
+		func(item labelInfo) string { return item.ID },
+		func(item labelInfo) string { return item.Name },
+	)
 }
 
 // resolveLabelName accepts either a label ID or a label name and returns
-// the human-readable label name (mirror of resolveFolderName for labels).
+// the canonical label ID (mirror of resolveFolderName for labels).
 func resolveLabelName(runtime *common.RuntimeContext, mailboxID, input string) (string, error) {
 	value := strings.TrimSpace(input)
 	if value == "" {
@@ -846,9 +851,11 @@ func listMailboxFolders(runtime *common.RuntimeContext, mailboxID string) ([]fol
 	if err := validateFolderReadScope(runtime); err != nil {
 		return nil, err
 	}
-	data, err := runtime.CallAPI("GET", mailboxPath(mailboxID, "folders"), nil, nil)
+	data, err := runtime.CallAPITyped("GET", mailboxPath(mailboxID, "folders"), nil, nil)
 	if err != nil {
-		return nil, output.ErrValidation("unable to resolve --folder: failed to list folders (%v). %s", err, resolveLookupHint("folder", mailboxID))
+		return nil, mailAppendProblemHint(
+			mailDecorateProblemMessage(err, "unable to resolve --folder: failed to list folders"),
+			resolveLookupHint("folder", mailboxID))
 	}
 	items, _ := data["items"].([]interface{})
 	folders := make([]folderInfo, 0, len(items))
@@ -871,9 +878,11 @@ func listMailboxLabels(runtime *common.RuntimeContext, mailboxID string) ([]labe
 	if err := validateLabelReadScope(runtime); err != nil {
 		return nil, err
 	}
-	data, err := runtime.CallAPI("GET", mailboxPath(mailboxID, "labels"), nil, nil)
+	data, err := runtime.CallAPITyped("GET", mailboxPath(mailboxID, "labels"), nil, nil)
 	if err != nil {
-		return nil, output.ErrValidation("unable to resolve --label: failed to list labels (%v). %s", err, resolveLookupHint("label", mailboxID))
+		return nil, mailAppendProblemHint(
+			mailDecorateProblemMessage(err, "unable to resolve --label: failed to list labels"),
+			resolveLookupHint("label", mailboxID))
 	}
 	items, _ := data["items"].([]interface{})
 	labels := make([]labelInfo, 0, len(items))
@@ -891,26 +900,9 @@ func listMailboxLabels(runtime *common.RuntimeContext, mailboxID string) ([]labe
 	return labels, nil
 }
 
-// resolveByID looks up input as an ID in items, returning input itself when
-// found. kind ("folder" / "label") and mailboxID are used to construct the
-// not-found hint. Generic over T so the same logic serves both folder and
-// label tables.
-func resolveByID[T any](kind, input, mailboxID string, items []T, idFn func(T) string) (string, error) {
-	value := strings.TrimSpace(input)
-	if value == "" {
-		return "", nil
-	}
-	for _, item := range items {
-		if id := idFn(item); id != "" && id == value {
-			return id, nil
-		}
-	}
-	return "", output.ErrValidation("%s %q not_exists. %s", kind, value, resolveLookupHint(kind, mailboxID))
-}
-
-// resolveByName looks up input as a name in items and returns the matching
-// ID. Errors out on duplicates so callers get a clear "ambiguous name"
-// signal rather than silently picking one match.
+// resolveByName looks up input as an exact ID first, then as a name, and
+// returns the matching ID. Errors out on duplicate names so callers get a clear
+// "ambiguous name" signal rather than silently picking one match.
 func resolveByName[T any](kind, input, mailboxID string, items []T, idFn func(T) string, nameFn func(T) string) (string, error) {
 	value := strings.TrimSpace(input)
 	if value == "" {
@@ -919,7 +911,7 @@ func resolveByName[T any](kind, input, mailboxID string, items []T, idFn func(T)
 
 	for _, item := range items {
 		if id := idFn(item); id != "" && id == value {
-			return "", output.ErrValidation("%s %q looks like an ID; please use %s_id", kind, value, kind)
+			return id, nil
 		}
 	}
 
@@ -943,9 +935,9 @@ func resolveByName[T any](kind, input, mailboxID string, items []T, idFn func(T)
 		return matches[0], nil
 	}
 	if len(matches) > 1 {
-		return "", output.ErrValidation("%s name %q matches multiple IDs (%s); please use an ID", kind, value, strings.Join(matches, ","))
+		return "", mailValidationError("%s name %q matches multiple IDs (%s); please use an ID", kind, value, strings.Join(matches, ","))
 	}
-	return "", output.ErrValidation("%s %q not_exists. %s", kind, value, resolveLookupHint(kind, mailboxID))
+	return "", mailValidationError("%s %q not_exists. %s", kind, value, resolveLookupHint(kind, mailboxID))
 }
 
 // resolveNameValueByID is the inverse of resolveByID: it looks up an ID
@@ -959,18 +951,18 @@ func resolveNameValueByID[T any](kind, input, mailboxID string, items []T, idFn 
 		if id := idFn(item); id != "" && id == value {
 			name := strings.TrimSpace(nameFn(item))
 			if name == "" {
-				return "", output.ErrValidation("%s %q has empty name; cannot use it with query filters", kind, value)
+				return "", mailValidationError("%s %q has empty name; cannot use it with query filters", kind, value)
 			}
 			return name, nil
 		}
 	}
-	return "", output.ErrValidation("%s %q not_exists. %s", kind, value, resolveLookupHint(kind, mailboxID))
+	return "", mailValidationError("%s %q not_exists. %s", kind, value, resolveLookupHint(kind, mailboxID))
 }
 
-// resolveNameValueByNameAllowDuplicates is like resolveByName but tolerates
-// duplicate names — returning the first match. Used in query-style contexts
-// where ambiguity is acceptable because the API itself disambiguates server-
-// side.
+// resolveNameValueByNameAllowDuplicates looks up input as an exact ID first,
+// then as a name, and returns the matching name. Duplicate names are tolerated
+// by returning the first match. Used in query-style contexts where ambiguity is
+// acceptable because the API itself disambiguates server-side.
 func resolveNameValueByNameAllowDuplicates[T any](kind, input, mailboxID string, items []T, idFn func(T) string, nameFn func(T) string) (string, error) {
 	value := strings.TrimSpace(input)
 	if value == "" {
@@ -978,7 +970,11 @@ func resolveNameValueByNameAllowDuplicates[T any](kind, input, mailboxID string,
 	}
 	for _, item := range items {
 		if id := idFn(item); id != "" && id == value {
-			return "", output.ErrValidation("%s %q looks like an ID; please use %s_id", kind, value, kind)
+			name := strings.TrimSpace(nameFn(item))
+			if name == "" {
+				return "", mailValidationError("%s %q has empty name; cannot use it with query filters", kind, value)
+			}
+			return name, nil
 		}
 	}
 	lower := strings.ToLower(value)
@@ -989,7 +985,7 @@ func resolveNameValueByNameAllowDuplicates[T any](kind, input, mailboxID string,
 		}
 		return name, nil
 	}
-	return "", output.ErrValidation("%s %q not_exists. %s", kind, value, resolveLookupHint(kind, mailboxID))
+	return "", mailValidationError("%s %q not_exists. %s", kind, value, resolveLookupHint(kind, mailboxID))
 }
 
 // resolveLookupHint returns the CLI command a user should run to list
@@ -1015,13 +1011,13 @@ func resolveLookupHint(kind, mailboxID string) string {
 // html=false -> format=plain_text_full (server omits body_html)
 func fetchFullMessage(runtime *common.RuntimeContext, mailboxID, messageID string, html bool) (map[string]interface{}, error) {
 	params := map[string]interface{}{"format": messageGetFormat(html)}
-	data, err := runtime.CallAPI("GET", mailboxPath(mailboxID, "messages", messageID), params, nil)
+	data, err := runtime.CallAPITyped("GET", mailboxPath(mailboxID, "messages", messageID), params, nil)
 	if err != nil {
 		return nil, err
 	}
 	msg, _ := data["message"].(map[string]interface{})
 	if msg == nil {
-		return nil, fmt.Errorf("API response missing message field")
+		return nil, mailInvalidResponseError("API response missing message field")
 	}
 	return msg, nil
 }
@@ -1039,7 +1035,7 @@ func fetchFullMessages(runtime *common.RuntimeContext, mailboxID string, message
 		if end > len(messageIDs) {
 			end = len(messageIDs)
 		}
-		data, err := runtime.CallAPI("POST", mailboxPath(mailboxID, "messages", "batch_get"), nil, map[string]interface{}{
+		data, err := runtime.CallAPITyped("POST", mailboxPath(mailboxID, "messages", "batch_get"), nil, map[string]interface{}{
 			"format":      messageGetFormat(html),
 			"message_ids": messageIDs[start:end],
 		})
@@ -1232,7 +1228,7 @@ type calendarEventOutput struct {
 // It never returns an error: failed batches/IDs are converted to structured warnings so caller can continue.
 func fetchAttachmentURLs(runtime *common.RuntimeContext, mailboxID, messageID string, ids []string) (map[string]string, []warningEntry) {
 	callAPI := func(url string) (map[string]interface{}, error) {
-		return runtime.CallAPI("GET", url, nil, nil)
+		return runtime.CallAPITyped("GET", url, nil, nil)
 	}
 	emitWarning := func(w warningEntry) {
 		fmt.Fprintf(runtime.IO().ErrOut, "warning: code=%s message_id=%s attachment_id=%s retryable=%t detail=%s\n", w.Code, w.MessageID, w.AttachmentID, w.Retryable, w.Detail)
@@ -1668,7 +1664,7 @@ func validateForwardAttachmentURLs(src composeSourceMessage) error {
 		}
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("failed to fetch download URLs for: %s", strings.Join(missing, ", "))
+		return mailInvalidResponseError("failed to fetch download URLs for: %s", strings.Join(missing, ", "))
 	}
 	return nil
 }
@@ -1683,7 +1679,7 @@ func validateInlineImageURLs(src composeSourceMessage) error {
 		}
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("failed to fetch download URLs for: %s", strings.Join(missing, ", "))
+		return mailInvalidResponseError("failed to fetch download URLs for: %s", strings.Join(missing, ", "))
 	}
 	return nil
 }
@@ -1786,41 +1782,51 @@ func toInlineSourceParts(out normalizedMessageForCompose) []inlineSourcePart {
 func downloadAttachmentContent(runtime *common.RuntimeContext, downloadURL string) ([]byte, error) {
 	u, err := url.Parse(downloadURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid attachment download URL: %w", err)
+		return nil, mailInvalidResponseError("invalid attachment download URL: %v", err).WithCause(err)
 	}
 	if u.Scheme != "https" {
-		return nil, fmt.Errorf("attachment download URL must use https (got %q)", u.Scheme)
+		return nil, mailInvalidResponseError("attachment download URL must use https (got %q)", u.Scheme)
 	}
 	if u.Host == "" {
-		return nil, fmt.Errorf("attachment download URL has no host")
+		return nil, mailInvalidResponseError("attachment download URL has no host")
 	}
 
 	httpClient, err := runtime.Factory.HttpClient()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get HTTP client: %w", err)
+		return nil, errs.NewInternalError(errs.SubtypeSDKError, "failed to get HTTP client: %v", err).WithCause(err)
 	}
 	req, err := http.NewRequestWithContext(runtime.Ctx(), http.MethodGet, downloadURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build attachment download request: %w", err)
+		return nil, errs.NewInternalError(errs.SubtypeSDKError, "failed to build attachment download request: %v", err).WithCause(err)
 	}
 	// Do NOT send Authorization: the download_url is a pre-signed URL with an
 	// authcode embedded in the query string. Attaching the Bearer token would
 	// leak it to whatever host the URL points at (SSRF / token exfiltration).
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to download attachment: %w", err)
+		return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport, "failed to download attachment: %v", err).WithCause(err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("failed to download attachment: HTTP %d", resp.StatusCode)
+		if resp.StatusCode >= 500 {
+			return nil, errs.NewNetworkError(errs.SubtypeNetworkServer, "failed to download attachment: HTTP %d", resp.StatusCode).
+				WithCode(resp.StatusCode).
+				WithRetryable()
+		}
+		subtype := errs.SubtypeUnknown
+		if resp.StatusCode == http.StatusNotFound {
+			subtype = errs.SubtypeNotFound
+		}
+		return nil, errs.NewAPIError(subtype, "failed to download attachment: HTTP %d", resp.StatusCode).WithCode(resp.StatusCode)
 	}
 	limitedReader := io.LimitReader(resp.Body, int64(MaxAttachmentDownloadBytes)+1)
 	data, err := io.ReadAll(limitedReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read attachment content: %w", err)
+		return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport, "failed to read attachment content: %v", err).WithCause(err)
 	}
 	if len(data) > MaxAttachmentDownloadBytes {
-		return nil, fmt.Errorf("attachment download exceeds %d MB size limit", MaxAttachmentDownloadBytes/1024/1024)
+		return nil, mailFailedPreconditionError("attachment download exceeds %d MB size limit", MaxAttachmentDownloadBytes/1024/1024).
+			WithHint("download or forward this large attachment outside the inline/small-attachment path")
 	}
 	return data, nil
 }
@@ -2062,7 +2068,7 @@ func parsePriority(value string) (string, error) {
 	case "low":
 		return "5", nil
 	default:
-		return "", fmt.Errorf("invalid --priority value %q: expected high, normal, or low", value)
+		return "", mailValidationParamError("--priority", "invalid --priority value %q: expected high, normal, or low", value)
 	}
 }
 
@@ -2232,7 +2238,7 @@ func validateInlineCIDs(html string, userCIDs, extraCIDs []string) error {
 	if len(userCIDs) > 0 {
 		orphaned := draftpkg.FindOrphanedCIDs(html, userCIDs)
 		if len(orphaned) > 0 {
-			return fmt.Errorf("inline images with cids %v are not referenced by any <img src=\"cid:...\"> in the HTML body and will appear as unexpected attachments; remove unused --inline entries or add matching <img> tags", orphaned)
+			return mailValidationParamError("--inline", "inline images with cids %v are not referenced by any <img src=\"cid:...\"> in the HTML body and will appear as unexpected attachments; remove unused --inline entries or add matching <img> tags", orphaned)
 		}
 	}
 	return nil
@@ -2251,7 +2257,7 @@ func addInlineImagesToBuilder(runtime *common.RuntimeContext, bld emlbuilder.Bui
 	for _, img := range images {
 		content, err := downloadAttachmentContent(runtime, img.DownloadURL)
 		if err != nil {
-			return bld, nil, 0, fmt.Errorf("failed to download inline resource %s: %w", img.Filename, err)
+			return bld, nil, 0, mailDecorateProblemMessage(err, "failed to download inline resource %s", img.Filename)
 		}
 		cid := normalizeInlineCID(img.CID)
 		if cid == "" {
@@ -2284,14 +2290,14 @@ func parseInlineSpecs(raw string) ([]InlineSpec, error) {
 	}
 	var specs []InlineSpec
 	if err := json.Unmarshal([]byte(raw), &specs); err != nil {
-		return nil, fmt.Errorf("--inline must be a JSON array, e.g. '[{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}]': %w", err)
+		return nil, mailValidationParamError("--inline", "--inline must be a JSON array, e.g. '[{\"cid\":\"a1b2c3d4e5f6a7b8c9d0\",\"file_path\":\"./banner.png\"}]': %v", err).WithCause(err)
 	}
 	for i, s := range specs {
 		if strings.TrimSpace(s.CID) == "" {
-			return nil, fmt.Errorf("--inline entry %d: \"cid\" must not be empty", i)
+			return nil, mailValidationParamError("--inline", "--inline entry %d: \"cid\" must not be empty", i)
 		}
 		if strings.TrimSpace(s.FilePath) == "" {
-			return nil, fmt.Errorf("--inline entry %d: \"file_path\" must not be empty", i)
+			return nil, mailValidationParamError("--inline", "--inline entry %d: \"file_path\" must not be empty", i)
 		}
 	}
 	return specs, nil
@@ -2318,7 +2324,11 @@ func validateEventSendTimeExclusion(runtime *common.RuntimeContext) error {
 	}
 	for _, f := range []string{"event-summary", "event-start", "event-end", "event-location"} {
 		if runtime.Str(f) != "" {
-			return common.FlagErrorf("--send-time and --event-* are mutually exclusive: a calendar invitation must be sent immediately so recipients can respond before the event")
+			return mailValidationError("--send-time and --event-* are mutually exclusive: a calendar invitation must be sent immediately so recipients can respond before the event").
+				WithParams(
+					mailInvalidParam("--send-time", "mutually exclusive with --event-*"),
+					mailInvalidParam("--event-*", "mutually exclusive with --send-time"),
+				)
 		}
 	}
 	return nil
@@ -2332,15 +2342,15 @@ func validateSendTime(runtime *common.RuntimeContext) error {
 		return nil
 	}
 	if !runtime.Bool("confirm-send") {
-		return output.ErrValidation("--send-time requires --confirm-send to be set")
+		return mailValidationParamError("--send-time", "--send-time requires --confirm-send to be set")
 	}
 	ts, err := strconv.ParseInt(sendTime, 10, 64)
 	if err != nil {
-		return output.ErrValidation("--send-time must be a valid Unix timestamp in seconds, got %q", sendTime)
+		return mailValidationParamError("--send-time", "--send-time must be a valid Unix timestamp in seconds, got %q", sendTime).WithCause(err)
 	}
 	minTime := time.Now().Unix() + 5*60
 	if ts < minTime {
-		return output.ErrValidation("--send-time must be at least 5 minutes in the future (minimum: %d, got: %d)", minTime, ts)
+		return mailValidationParamError("--send-time", "--send-time must be at least 5 minutes in the future (minimum: %d, got: %d)", minTime, ts)
 	}
 	return nil
 }
@@ -2429,7 +2439,12 @@ func validateLabelReadScope(runtime *common.RuntimeContext) error {
 // all three (to/cc/bcc) are empty or whitespace-only.
 func validateComposeHasAtLeastOneRecipient(to, cc, bcc string) error {
 	if strings.TrimSpace(to) == "" && strings.TrimSpace(cc) == "" && strings.TrimSpace(bcc) == "" {
-		return fmt.Errorf("at least one recipient (--to, --cc, or --bcc) is required")
+		return mailValidationError("at least one recipient (--to, --cc, or --bcc) is required").
+			WithParams(
+				mailInvalidParam("--to", "at least one recipient is required"),
+				mailInvalidParam("--cc", "at least one recipient is required"),
+				mailInvalidParam("--bcc", "at least one recipient is required"),
+			)
 	}
 	return validateRecipientCount(to, cc, bcc)
 }
@@ -2439,7 +2454,12 @@ func validateComposeHasAtLeastOneRecipient(to, cc, bcc string) error {
 func validateRecipientCount(to, cc, bcc string) error {
 	count := len(ParseMailboxList(to)) + len(ParseMailboxList(cc)) + len(ParseMailboxList(bcc))
 	if count > MaxRecipientCount {
-		return fmt.Errorf("total recipient count %d exceeds the limit of %d (To + CC + BCC combined)", count, MaxRecipientCount)
+		return mailValidationError("total recipient count %d exceeds the limit of %d (To + CC + BCC combined)", count, MaxRecipientCount).
+			WithParams(
+				mailInvalidParam("--to", "recipient count contributes to combined limit"),
+				mailInvalidParam("--cc", "recipient count contributes to combined limit"),
+				mailInvalidParam("--bcc", "recipient count contributes to combined limit"),
+			)
 	}
 	return nil
 }
@@ -2451,10 +2471,14 @@ func validateRecipientCount(to, cc, bcc string) error {
 func validateComposeInlineAndAttachments(fio fileio.FileIO, attachFlag, inlineFlag string, plainText bool, body string) error {
 	if strings.TrimSpace(inlineFlag) != "" {
 		if plainText {
-			return output.ErrValidation("--inline is not supported with --plain-text (inline images require HTML body)")
+			return mailValidationError("--inline is not supported with --plain-text (inline images require HTML body)").
+				WithParams(
+					mailInvalidParam("--inline", "requires HTML body"),
+					mailInvalidParam("--plain-text", "mutually exclusive with --inline"),
+				)
 		}
 		if body != "" && !bodyIsHTML(body) {
-			return output.ErrValidation("--inline requires an HTML body (the provided body appears to be plain text; add HTML tags or remove --inline)")
+			return mailValidationParamError("--inline", "--inline requires an HTML body (the provided body appears to be plain text; add HTML tags or remove --inline)")
 		}
 	}
 	inlineSpecs, err := parseInlineSpecs(inlineFlag)
@@ -2536,7 +2560,12 @@ func validateEventFlags(runtime *common.RuntimeContext) error {
 	hasAll := summary != "" && start != "" && end != ""
 
 	if hasAny && !hasAll {
-		return output.ErrValidation("--event-summary, --event-start, and --event-end must all be provided together")
+		return mailValidationError("--event-summary, --event-start, and --event-end must all be provided together").
+			WithParams(
+				mailInvalidParam("--event-summary", "required with --event-start/--event-end"),
+				mailInvalidParam("--event-start", "required with --event-summary/--event-end"),
+				mailInvalidParam("--event-end", "required with --event-summary/--event-start"),
+			)
 	}
 	if summary == "" {
 		return nil
@@ -2553,14 +2582,14 @@ func validateEventFlags(runtime *common.RuntimeContext) error {
 func parseEventTimeRange(start, end string) (time.Time, time.Time, error) {
 	startT, err := parseISO8601(start)
 	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("start: invalid ISO 8601 time %q", start)
+		return time.Time{}, time.Time{}, mailValidationError("start: invalid ISO 8601 time %q", start).WithCause(err)
 	}
 	endT, err := parseISO8601(end)
 	if err != nil {
-		return time.Time{}, time.Time{}, fmt.Errorf("end: invalid ISO 8601 time %q", end)
+		return time.Time{}, time.Time{}, mailValidationError("end: invalid ISO 8601 time %q", end).WithCause(err)
 	}
 	if !endT.After(startT) {
-		return time.Time{}, time.Time{}, fmt.Errorf("end time must be after start time")
+		return time.Time{}, time.Time{}, mailValidationError("end time must be after start time")
 	}
 	return startT, endT, nil
 }
@@ -2569,12 +2598,27 @@ func parseEventTimeRange(start, end string) (time.Time, time.Time, error) {
 // error with the caller's flag-name prefix so users see the exact flag
 // that caused the failure.
 func prefixEventRangeError(flagPrefix string, err error) error {
-	msg := err.Error()
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		return err
+	}
+	var validationErr *errs.ValidationError
+	msg := p.Message
 	switch {
 	case strings.HasPrefix(msg, "start: "):
-		return fmt.Errorf("%sstart: %s", flagPrefix, strings.TrimPrefix(msg, "start: "))
+		p.Message = fmt.Sprintf("%sstart: %s", flagPrefix, strings.TrimPrefix(msg, "start: "))
+		p.Subtype = errs.SubtypeInvalidArgument
+		if strings.HasPrefix(flagPrefix, "--") && errors.As(err, &validationErr) {
+			validationErr.Param = flagPrefix + "start"
+		}
+		return err
 	case strings.HasPrefix(msg, "end: "):
-		return fmt.Errorf("%send: %s", flagPrefix, strings.TrimPrefix(msg, "end: "))
+		p.Message = fmt.Sprintf("%send: %s", flagPrefix, strings.TrimPrefix(msg, "end: "))
+		p.Subtype = errs.SubtypeInvalidArgument
+		if strings.HasPrefix(flagPrefix, "--") && errors.As(err, &validationErr) {
+			validationErr.Param = flagPrefix + "end"
+		}
+		return err
 	default:
 		return err
 	}
@@ -2595,7 +2639,7 @@ func parseISO8601(s string) (time.Time, error) {
 			return t, nil
 		}
 	}
-	return time.Time{}, fmt.Errorf("cannot parse %q as ISO 8601", s)
+	return time.Time{}, mailValidationError("cannot parse %q as ISO 8601", s)
 }
 
 // buildCalendarBody generates an ICS VCALENDAR from compose flags and returns the bytes.
@@ -2614,8 +2658,8 @@ func buildCalendarBody(runtime *common.RuntimeContext, senderEmail string, toAdd
 // bot uses tenant access token; "me" cannot be resolved to a user mailbox under TAT.
 func validateBotMailboxNotMe(runtime *common.RuntimeContext) error {
 	if runtime.IsBot() && runtime.Str("mailbox") == "me" {
-		return output.ErrValidation(
-			"--as bot does not support --mailbox me: bot identity uses a tenant token and cannot resolve \"me\" to a user mailbox; " +
+		return mailValidationParamError("--mailbox",
+			"--as bot does not support --mailbox me: bot identity uses a tenant token and cannot resolve \"me\" to a user mailbox; "+
 				"pass an explicit email address, e.g. --mailbox alice@example.com")
 	}
 	return nil
@@ -2627,7 +2671,7 @@ func validateBotMailboxNotMe(runtime *common.RuntimeContext) error {
 // fetchFullMessages chunks backend requests into batches of 20.
 func validateMessageIDs(raw string) ([]string, error) {
 	if strings.TrimSpace(raw) == "" {
-		return nil, output.ErrValidation("--message-ids is required; provide one or more message IDs separated by commas")
+		return nil, mailValidationParamError("--message-ids", "--message-ids is required; provide one or more message IDs separated by commas")
 	}
 	parts := strings.Split(raw, ",")
 	ids := make([]string, 0, len(parts))
@@ -2635,16 +2679,16 @@ func validateMessageIDs(raw string) ([]string, error) {
 	for i, part := range parts {
 		id := strings.TrimSpace(part)
 		if id == "" {
-			return nil, output.ErrValidation("--message-ids entry %d is empty; remove extra commas or provide valid message IDs", i+1)
+			return nil, mailValidationParamError("--message-ids", "--message-ids entry %d is empty; remove extra commas or provide valid message IDs", i+1)
 		}
 		if part != id {
-			return nil, output.ErrValidation("--message-ids entry %d (%q): must not contain leading or trailing whitespace", i+1, part)
+			return nil, mailValidationParamError("--message-ids", "--message-ids entry %d (%q): must not contain leading or trailing whitespace", i+1, part)
 		}
 		if err := validateBatchGetMessageID(id, i); err != nil {
 			return nil, err
 		}
 		if _, ok := seen[id]; ok {
-			return nil, output.ErrValidation("--message-ids entry %d (%q): duplicate message ID is not allowed", i+1, id)
+			return nil, mailValidationParamError("--message-ids", "--message-ids entry %d (%q): duplicate message ID is not allowed", i+1, id)
 		}
 		seen[id] = struct{}{}
 		ids = append(ids, id)
@@ -2654,11 +2698,14 @@ func validateMessageIDs(raw string) ([]string, error) {
 
 func validateBatchGetMessageID(id string, index int) error {
 	if strings.Trim(id, "0123456789") == "" {
-		return output.ErrValidation("--message-ids entry %d (%q): numeric primary IDs are not supported by mail +messages; pass the Open API message_id from mail output", index+1, id)
+		return mailValidationParamError("--message-ids", "--message-ids entry %d (%q): numeric primary IDs are not supported by mail +messages; pass the Open API message_id from mail output", index+1, id)
 	}
-	decoded, err := base64.URLEncoding.DecodeString(id)
-	if err != nil || len(decoded) == 0 {
-		return output.ErrValidation("--message-ids entry %d (%q): expected a base64url Open API mail message_id from mail output", index+1, id)
+	decoded, rawErr := base64.RawURLEncoding.DecodeString(id)
+	if rawErr != nil {
+		decoded, rawErr = base64.URLEncoding.DecodeString(id)
+	}
+	if rawErr != nil || len(decoded) == 0 {
+		return mailValidationParamError("--message-ids", "--message-ids entry %d (%q): expected a base64url Open API mail message_id from mail output", index+1, id)
 	}
 	return nil
 }

--- a/shortcuts/mail/helpers_test.go
+++ b/shortcuts/mail/helpers_test.go
@@ -1353,6 +1353,34 @@ func TestValidateComposeInlineAndAttachments(t *testing.T) {
 	})
 }
 
+func TestResolveByNameAcceptsExactID(t *testing.T) {
+	folders := []folderInfo{{ID: "fld_custom", Name: "Team"}}
+	got, err := resolveByName("folder", "fld_custom", "me", folders,
+		func(item folderInfo) string { return item.ID },
+		func(item folderInfo) string { return item.Name },
+	)
+	if err != nil {
+		t.Fatalf("resolveByName returned error: %v", err)
+	}
+	if got != "fld_custom" {
+		t.Fatalf("resolveByName exact ID = %q, want fld_custom", got)
+	}
+}
+
+func TestResolveNameValueByNameAllowDuplicatesAcceptsExactID(t *testing.T) {
+	folders := []folderInfo{{ID: "fld_custom", Name: "Parent/Team"}}
+	got, err := resolveNameValueByNameAllowDuplicates("folder", "fld_custom", "me", folders,
+		func(item folderInfo) string { return item.ID },
+		func(item folderInfo) string { return item.Name },
+	)
+	if err != nil {
+		t.Fatalf("resolveNameValueByNameAllowDuplicates returned error: %v", err)
+	}
+	if got != "Parent/Team" {
+		t.Fatalf("query name for exact ID = %q, want Parent/Team", got)
+	}
+}
+
 // newRequestReceiptRuntime registers the --request-receipt bool flag alone
 // (no --from), so requireSenderForRequestReceipt tests can drive the flag
 // directly without pulling in unrelated compose plumbing.
@@ -1522,16 +1550,16 @@ func TestParseEventTimeRange_InvalidEnd(t *testing.T) {
 }
 
 func TestPrefixEventRangeError(t *testing.T) {
-	start := fmt.Errorf("start: invalid ISO 8601 time %q", "x")
+	start := mailValidationError("start: invalid ISO 8601 time %q", "x")
 	if got := prefixEventRangeError("--event-", start).Error(); got != `--event-start: invalid ISO 8601 time "x"` {
 		t.Errorf("got %q", got)
 	}
-	end := fmt.Errorf("end: invalid ISO 8601 time %q", "x")
+	end := mailValidationError("end: invalid ISO 8601 time %q", "x")
 	if got := prefixEventRangeError("--set-event-", end).Error(); got != `--set-event-end: invalid ISO 8601 time "x"` {
 		t.Errorf("got %q", got)
 	}
 	// Non-prefixed error passes through unchanged.
-	other := fmt.Errorf("end time must be after start time")
+	other := mailValidationError("end time must be after start time")
 	if got := prefixEventRangeError("--event-", other).Error(); got != "end time must be after start time" {
 		t.Errorf("got %q", got)
 	}

--- a/shortcuts/mail/large_attachment.go
+++ b/shortcuts/mail/large_attachment.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/extension/fileio"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -121,11 +122,11 @@ func statAttachmentFiles(fio fileio.FileIO, paths []string) ([]attachmentFile, e
 		}
 		name := filepath.Base(p)
 		if err := filecheck.CheckBlockedExtension(name); err != nil {
-			return nil, err
+			return nil, mailValidationError("%v", err).WithCause(err)
 		}
 		info, err := fio.Stat(p)
 		if err != nil {
-			return nil, fmt.Errorf("failed to stat attachment %s: %w", p, err)
+			return nil, mailInputStatError(err)
 		}
 		files = append(files, attachmentFile{
 			Path:     p,
@@ -144,7 +145,7 @@ func uploadLargeAttachments(ctx context.Context, runtime *common.RuntimeContext,
 	}
 	userOpenId := runtime.UserOpenId()
 	if userOpenId == "" {
-		return nil, fmt.Errorf("large attachment upload requires user identity (user open_id not available)")
+		return nil, mailFailedPreconditionError("large attachment upload requires user identity (user open_id not available)")
 	}
 
 	results := make([]largeAttachmentResult, 0, len(files))
@@ -156,7 +157,7 @@ func uploadLargeAttachments(ctx context.Context, runtime *common.RuntimeContext,
 			err       error
 		)
 		if f.Data != nil {
-			fileToken, err = common.UploadDriveMediaAll(runtime, common.DriveMediaUploadAllConfig{
+			fileToken, err = common.UploadDriveMediaAllTyped(runtime, common.DriveMediaUploadAllConfig{
 				FileName:   f.FileName,
 				FileSize:   f.Size,
 				ParentType: "email",
@@ -164,7 +165,7 @@ func uploadLargeAttachments(ctx context.Context, runtime *common.RuntimeContext,
 				Reader:     bytes.NewReader(f.Data),
 			})
 		} else if f.Size <= common.MaxDriveMediaUploadSinglePartSize {
-			fileToken, err = common.UploadDriveMediaAll(runtime, common.DriveMediaUploadAllConfig{
+			fileToken, err = common.UploadDriveMediaAllTyped(runtime, common.DriveMediaUploadAllConfig{
 				FilePath:   f.Path,
 				FileName:   f.FileName,
 				FileSize:   f.Size,
@@ -172,7 +173,7 @@ func uploadLargeAttachments(ctx context.Context, runtime *common.RuntimeContext,
 				ParentNode: &userOpenId,
 			})
 		} else {
-			fileToken, err = common.UploadDriveMediaMultipart(runtime, common.DriveMediaMultipartUploadConfig{
+			fileToken, err = common.UploadDriveMediaMultipartTyped(runtime, common.DriveMediaMultipartUploadConfig{
 				FilePath:   f.Path,
 				FileName:   f.FileName,
 				FileSize:   f.Size,
@@ -181,7 +182,7 @@ func uploadLargeAttachments(ctx context.Context, runtime *common.RuntimeContext,
 			})
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to upload large attachment %s: %w", f.FileName, err)
+			return nil, mailDecorateProblemMessage(err, "failed to upload large attachment %s", f.FileName)
 		}
 
 		results = append(results, largeAttachmentResult{
@@ -397,7 +398,7 @@ func processLargeAttachments(
 ) (emlbuilder.Builder, error) {
 	totalCount := extraAttachCount + len(attachPaths)
 	if totalCount > MaxAttachmentCount {
-		return bld, fmt.Errorf("attachment count %d exceeds the limit of %d", totalCount, MaxAttachmentCount)
+		return bld, mailFailedPreconditionError("attachment count %d exceeds the limit of %d", totalCount, MaxAttachmentCount)
 	}
 
 	files, err := statAttachmentFiles(runtime.FileIO(), attachPaths)
@@ -407,7 +408,7 @@ func processLargeAttachments(
 
 	for _, f := range files {
 		if f.Size > MaxLargeAttachmentSize {
-			return bld, fmt.Errorf("attachment %s (%.1f GB) exceeds the %.0f GB single file limit",
+			return bld, mailFailedPreconditionError("attachment %s (%.1f GB) exceeds the %.0f GB single file limit",
 				f.FileName, float64(f.Size)/1024/1024/1024, float64(MaxLargeAttachmentSize)/1024/1024/1024)
 		}
 	}
@@ -422,7 +423,7 @@ func processLargeAttachments(
 	}
 
 	if htmlBody == "" && textBody == "" {
-		return bld, fmt.Errorf("large attachments require a body; " +
+		return bld, mailFailedPreconditionError("large attachments require a body; " +
 			"empty messages cannot include the download link")
 	}
 
@@ -431,7 +432,7 @@ func processLargeAttachments(
 		for _, f := range files {
 			totalBytes += f.Size
 		}
-		return bld, fmt.Errorf("total attachment size %.1f MB exceeds the 25 MB EML limit; "+
+		return bld, mailFailedPreconditionError("total attachment size %.1f MB exceeds the 25 MB EML limit; "+
 			"large attachment upload requires user identity (--as user)",
 			float64(totalBytes)/1024/1024)
 	}
@@ -455,7 +456,7 @@ func processLargeAttachments(
 	}
 	idsJSON, err := json.Marshal(ids)
 	if err != nil {
-		return bld, fmt.Errorf("failed to encode large attachment IDs: %w", err)
+		return bld, errs.NewInternalError(errs.SubtypeSDKError, "failed to encode large attachment IDs: %v", err).WithCause(err)
 	}
 	bld = bld.Header(draftpkg.LargeAttachmentIDsHeader, base64.StdEncoding.EncodeToString(idsJSON))
 
@@ -588,7 +589,7 @@ func preprocessLargeAttachmentsForDraftEdit(
 	// Check 3GB single file limit.
 	for _, f := range files {
 		if f.Size > MaxLargeAttachmentSize {
-			return patch, fmt.Errorf("attachment %s (%.1f GB) exceeds the %.0f GB single file limit",
+			return patch, mailFailedPreconditionError("attachment %s (%.1f GB) exceeds the %.0f GB single file limit",
 				f.FileName, float64(f.Size)/1024/1024/1024, float64(MaxLargeAttachmentSize)/1024/1024/1024)
 		}
 	}
@@ -606,7 +607,7 @@ func preprocessLargeAttachmentsForDraftEdit(
 	hasHTML := draftpkg.FindHTMLBodyPart(snapshot.Body) != nil
 	hasText := draftpkg.FindTextBodyPart(snapshot.Body) != nil
 	if !hasHTML && !hasText {
-		return patch, fmt.Errorf("large attachments require a body; " +
+		return patch, mailFailedPreconditionError("large attachments require a body; " +
 			"empty drafts cannot include the download link")
 	}
 
@@ -616,7 +617,7 @@ func preprocessLargeAttachmentsForDraftEdit(
 		for _, f := range files {
 			totalBytes += f.Size
 		}
-		return patch, fmt.Errorf("total attachment size %.1f MB exceeds the 25 MB EML limit; "+
+		return patch, mailFailedPreconditionError("total attachment size %.1f MB exceeds the 25 MB EML limit; "+
 			"large attachment upload requires user identity (--as user)",
 			float64(totalBytes)/1024/1024)
 	}
@@ -672,7 +673,7 @@ func preprocessLargeAttachmentsForDraftEdit(
 	}
 	idsJSON, err := json.Marshal(merged)
 	if err != nil {
-		return patch, fmt.Errorf("failed to encode large attachment IDs: %w", err)
+		return patch, errs.NewInternalError(errs.SubtypeSDKError, "failed to encode large attachment IDs: %v", err).WithCause(err)
 	}
 	headerValue := base64.StdEncoding.EncodeToString(idsJSON)
 	if existingIdx >= 0 {

--- a/shortcuts/mail/large_attachment_test.go
+++ b/shortcuts/mail/large_attachment_test.go
@@ -974,7 +974,7 @@ func TestStatAttachmentFiles_FileNotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
-	if !strings.Contains(err.Error(), "failed to stat") {
+	if !strings.Contains(err.Error(), "cannot read file") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/shortcuts/mail/lint/linter.go
+++ b/shortcuts/mail/lint/linter.go
@@ -395,8 +395,7 @@ func sanitiseStyleAttr(raw string) (cleaned string, dropped []string) {
 	return cleaned, dropped
 }
 
-// hintForBlockedTag returns a hint for an error-blocked tag (matching
-// the `output.ErrWithHint` convention used elsewhere in the cli).
+// hintForBlockedTag returns a hint for an error-blocked tag.
 func hintForBlockedTag(tag string) string {
 	switch tag {
 	case "script":

--- a/shortcuts/mail/mail_decline_receipt.go
+++ b/shortcuts/mail/mail_decline_receipt.go
@@ -59,7 +59,7 @@ var MailDeclineReceipt = common.Shortcut{
 
 		msg, err := fetchFullMessage(runtime, mailboxID, messageID, false)
 		if err != nil {
-			return fmt.Errorf("failed to fetch original message: %w", err)
+			return mailDecorateProblemMessage(err, "failed to fetch original message")
 		}
 
 		out := map[string]interface{}{
@@ -77,14 +77,14 @@ var MailDeclineReceipt = common.Shortcut{
 			return nil
 		}
 
-		if _, err := runtime.CallAPI("PUT",
+		if _, err := runtime.CallAPITyped("PUT",
 			mailboxPath(mailboxID, "messages", messageID, "modify"),
 			nil,
 			map[string]interface{}{
 				"remove_label_ids": []string{readReceiptRequestLabel},
 			},
 		); err != nil {
-			return fmt.Errorf("failed to clear READ_RECEIPT_REQUEST label: %w", err)
+			return mailDecorateProblemMessage(err, "failed to clear READ_RECEIPT_REQUEST label")
 		}
 
 		out["declined"] = true

--- a/shortcuts/mail/mail_draft_create.go
+++ b/shortcuts/mail/mail_draft_create.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
 	"github.com/larksuite/cli/shortcuts/mail/emlbuilder"
@@ -91,7 +90,7 @@ var MailDraftCreate = common.Shortcut{
 			return err
 		}
 		if !hasTemplate && strings.TrimSpace(runtime.Str("subject")) == "" {
-			return output.ErrValidation("--subject is required; pass the final email subject (or use --template-id)")
+			return mailValidationParamError("--subject", "--subject is required; pass the final email subject (or use --template-id)")
 		}
 		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
 			return err
@@ -176,10 +175,10 @@ var MailDraftCreate = common.Shortcut{
 			})
 		}
 		if strings.TrimSpace(input.Subject) == "" {
-			return output.ErrValidation("effective subject is empty after applying template; pass --subject explicitly")
+			return mailValidationParamError("--subject", "effective subject is empty after applying template; pass --subject explicitly")
 		}
 		if strings.TrimSpace(input.Body) == "" {
-			return output.ErrValidation("effective body is empty after applying template; pass --body explicitly")
+			return mailValidationParamError("--body", "effective body is empty after applying template; pass --body explicitly")
 		}
 		sigResult, err := resolveSignature(ctx, runtime, mailboxID, runtime.Str("signature-id"), runtime.Str("from"))
 		if err != nil {
@@ -192,7 +191,7 @@ var MailDraftCreate = common.Shortcut{
 		}
 		draftResult, err := draftpkg.CreateWithRaw(runtime, mailboxID, rawEML)
 		if err != nil {
-			return fmt.Errorf("create draft failed: %w", err)
+			return mailDecorateProblemMessage(err, "create draft failed")
 		}
 		out := map[string]interface{}{"draft_id": draftResult.DraftID}
 		if draftResult.Reference != "" {
@@ -250,7 +249,7 @@ func buildRawEMLForDraftCreate(
 
 	senderEmail := resolveComposeSenderEmail(runtime)
 	if senderEmail == "" {
-		return "", lintApplied, lintBlocked, fmt.Errorf("unable to determine sender email; please specify --from explicitly")
+		return "", lintApplied, lintBlocked, mailValidationParamError("--from", "unable to determine sender email; please specify --from explicitly")
 	}
 
 	if err := validateRecipientCount(input.To, input.CC, input.BCC); err != nil {
@@ -285,7 +284,7 @@ func buildRawEMLForDraftCreate(
 	}
 	inlineSpecs, parseErr := parseInlineSpecs(input.Inline)
 	if parseErr != nil {
-		return "", lintApplied, lintBlocked, output.ErrValidation("%v", parseErr)
+		return "", lintApplied, lintBlocked, parseErr
 	}
 	var autoResolvedPaths []string
 	var composedHTMLBody string
@@ -300,7 +299,7 @@ func buildRawEMLForDraftCreate(
 		}
 		resolved, refs, resolveErr := draftpkg.ResolveLocalImagePaths(htmlBody)
 		if resolveErr != nil {
-			return "", lintApplied, lintBlocked, resolveErr
+			return "", lintApplied, lintBlocked, mailValidationError("failed to resolve local image paths: %v", resolveErr).WithCause(resolveErr)
 		}
 		resolved = injectSignatureIntoBody(resolved, sigResult)
 		// Writing-path lint: AutoFix=true / Strict=false — the writing-path
@@ -365,7 +364,7 @@ func buildRawEMLForDraftCreate(
 	}
 	rawEML, buildErr := bld.BuildBase64URL()
 	if buildErr != nil {
-		return "", lintApplied, lintBlocked, output.ErrValidation("build EML failed: %v", buildErr)
+		return "", lintApplied, lintBlocked, mailValidationError("build EML failed: %v", buildErr).WithCause(buildErr)
 	}
 	return rawEML, lintApplied, lintBlocked, nil
 }

--- a/shortcuts/mail/mail_draft_edit.go
+++ b/shortcuts/mail/mail_draft_edit.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
 	"github.com/larksuite/cli/shortcuts/mail/ics"
@@ -88,7 +87,7 @@ var MailDraftEdit = common.Shortcut{
 		}
 		draftID := runtime.Str("draft-id")
 		if draftID == "" {
-			return output.ErrValidation("--draft-id is required for real draft edits; if you only need a patch template, run with --print-patch-template")
+			return mailValidationParamError("--draft-id", "--draft-id is required for real draft edits; if you only need a patch template, run with --print-patch-template")
 		}
 		mailboxID := resolveComposeMailboxID(runtime)
 		if runtime.Bool("inspect") {
@@ -100,11 +99,11 @@ var MailDraftEdit = common.Shortcut{
 		}
 		rawDraft, err := draftpkg.GetRaw(runtime, mailboxID, draftID)
 		if err != nil {
-			return fmt.Errorf("read draft raw EML failed: %w", err)
+			return mailDecorateProblemMessage(err, "read draft raw EML failed")
 		}
 		snapshot, err := draftpkg.Parse(rawDraft)
 		if err != nil {
-			return output.ErrValidation("parse draft raw EML failed: %v", err)
+			return mailFailedPreconditionError("parse draft raw EML failed: %v", err).WithCause(err)
 		}
 		// Pre-process ops that need snapshot context: resolve signature using
 		// the draft's From address, and build ICS for set_calendar using the
@@ -123,8 +122,8 @@ var MailDraftEdit = common.Shortcut{
 			// Going straight into PatchOp.Value would bypass emlbuilder's
 			// validateHeaderValue gate, so repeat the check here explicitly.
 			if err := validateHeaderAddress(draftFromEmail); err != nil {
-				return output.ErrValidation(
-					"cannot set --request-receipt: draft From address is unsafe for a header (%v)", err)
+				return mailFailedPreconditionError(
+					"cannot set --request-receipt: draft From address is unsafe for a header (%v)", err).WithCause(err)
 			}
 			patch.Ops = append(patch.Ops, draftpkg.PatchOp{
 				Op:    "set_header",
@@ -147,11 +146,11 @@ var MailDraftEdit = common.Shortcut{
 				if calPart := draftpkg.FindPartByMediaType(snapshot.Body, "text/calendar"); calPart != nil {
 					parsed := ics.ParseEvent(string(calPart.Body))
 					if parsed == nil || !parsed.IsLarkDraft {
-						return output.ErrValidation("set_calendar: calendar event has already been created and is read-only; use --remove-event to remove it, then --set-event-* to create a new one")
+						return mailFailedPreconditionError("set_calendar: calendar event has already been created and is read-only; use --remove-event to remove it, then --set-event-* to create a new one")
 					}
 				}
 				if _, _, err := parseEventTimeRange(patch.Ops[i].EventStart, patch.Ops[i].EventEnd); err != nil {
-					return output.ErrValidation("set_calendar: %v", err)
+					return prefixEventRangeError("set_calendar: ", err)
 				}
 				// Derive effective To/Cc by replaying all pending recipient ops so
 				// the ICS ATTENDEE list matches the final post-edit recipients.
@@ -166,7 +165,7 @@ var MailDraftEdit = common.Shortcut{
 					joinAddresses(ccAddrs),
 				)
 				if calData == nil {
-					return output.ErrValidation("set_calendar: failed to build ICS from event fields")
+					return mailValidationError("set_calendar: failed to build ICS from event fields")
 				}
 				patch.Ops[i].CalendarICS = calData
 			}
@@ -206,16 +205,16 @@ var MailDraftEdit = common.Shortcut{
 		dctx := &draftpkg.DraftCtx{FIO: runtime.FileIO()}
 		if len(patch.Ops) > 0 {
 			if err := draftpkg.Apply(dctx, snapshot, patch); err != nil {
-				return output.ErrValidation("apply draft patch failed: %v", err)
+				return mailValidationError("apply draft patch failed: %v", err).WithCause(err)
 			}
 		}
 		serialized, err := draftpkg.Serialize(snapshot)
 		if err != nil {
-			return output.ErrValidation("serialize draft failed: %v", err)
+			return mailValidationError("serialize draft failed: %v", err).WithCause(err)
 		}
 		updateResult, err := draftpkg.UpdateWithRaw(runtime, mailboxID, draftID, serialized)
 		if err != nil {
-			return fmt.Errorf("update draft failed: %w", err)
+			return mailDecorateProblemMessage(err, "update draft failed")
 		}
 		projection := draftpkg.Project(snapshot)
 		out := map[string]interface{}{
@@ -270,11 +269,11 @@ var MailDraftEdit = common.Shortcut{
 func executeDraftInspect(runtime *common.RuntimeContext, mailboxID, draftID string) error {
 	rawDraft, err := draftpkg.GetRaw(runtime, mailboxID, draftID)
 	if err != nil {
-		return fmt.Errorf("read draft raw EML failed: %w", err)
+		return mailDecorateProblemMessage(err, "read draft raw EML failed")
 	}
 	snapshot, err := draftpkg.Parse(rawDraft)
 	if err != nil {
-		return output.ErrValidation("parse draft raw EML failed: %v", err)
+		return mailFailedPreconditionError("parse draft raw EML failed: %v", err).WithCause(err)
 	}
 	projection := draftpkg.Project(snapshot)
 	out := map[string]interface{}{
@@ -422,7 +421,12 @@ func buildDraftEditPatch(runtime *common.RuntimeContext) (draftpkg.Patch, error)
 	if bodyVal != "" {
 		for _, op := range patch.Ops {
 			if op.Op == "set_body" || op.Op == "set_reply_body" {
-				return patch, output.ErrValidation("--body / --body-file and --patch-file body ops (set_body/set_reply_body) are mutually exclusive; use one or the other")
+				return patch, mailValidationError("--body / --body-file and --patch-file body ops (set_body/set_reply_body) are mutually exclusive; use one or the other").
+					WithParams(
+						mailInvalidParam("--body", "mutually exclusive with --patch-file body ops"),
+						mailInvalidParam("--body-file", "mutually exclusive with --patch-file body ops"),
+						mailInvalidParam("--patch-file", "mutually exclusive with direct body flags"),
+					)
 			}
 		}
 		patch.Ops = append(patch.Ops, draftpkg.PatchOp{Op: "set_body", Value: bodyVal})
@@ -448,20 +452,29 @@ func buildDraftEditPatch(runtime *common.RuntimeContext) (draftpkg.Patch, error)
 	hasEventSet := runtime.Str("set-event-summary") != ""
 	hasEventRemove := runtime.Bool("remove-event")
 	if !hasEventSet && (runtime.Str("set-event-start") != "" || runtime.Str("set-event-end") != "" || runtime.Str("set-event-location") != "") {
-		return patch, output.ErrValidation("--set-event-start, --set-event-end, and --set-event-location require --set-event-summary")
+		return patch, mailValidationParamError("--set-event-summary", "--set-event-start, --set-event-end, and --set-event-location require --set-event-summary")
 	}
 	if hasEventSet && hasEventRemove {
-		return patch, output.ErrValidation("--set-event-summary and --remove-event are mutually exclusive")
+		return patch, mailValidationError("--set-event-summary and --remove-event are mutually exclusive").
+			WithParams(
+				mailInvalidParam("--set-event-summary", "mutually exclusive with --remove-event"),
+				mailInvalidParam("--remove-event", "mutually exclusive with --set-event-summary"),
+			)
 	}
 	if hasEventSet {
 		summary := runtime.Str("set-event-summary")
 		start := runtime.Str("set-event-start")
 		end := runtime.Str("set-event-end")
 		if summary == "" || start == "" || end == "" {
-			return patch, output.ErrValidation("--set-event-summary, --set-event-start, and --set-event-end must all be provided together")
+			return patch, mailValidationError("--set-event-summary, --set-event-start, and --set-event-end must all be provided together").
+				WithParams(
+					mailInvalidParam("--set-event-summary", "required with --set-event-start/--set-event-end"),
+					mailInvalidParam("--set-event-start", "required with --set-event-summary/--set-event-end"),
+					mailInvalidParam("--set-event-end", "required with --set-event-summary/--set-event-start"),
+				)
 		}
 		if _, _, err := parseEventTimeRange(start, end); err != nil {
-			return patch, output.ErrValidation("%s", prefixEventRangeError("--set-event-", err).Error())
+			return patch, prefixEventRangeError("--set-event-", err)
 		}
 		patch.Ops = append(patch.Ops, draftpkg.PatchOp{
 			Op:            "set_calendar",
@@ -475,7 +488,7 @@ func buildDraftEditPatch(runtime *common.RuntimeContext) (draftpkg.Patch, error)
 	}
 
 	if len(patch.Ops) == 0 && !runtime.Bool("request-receipt") {
-		return patch, output.ErrValidation("at least one edit operation is required; use direct flags such as --set-subject/--set-to, or use --patch-file for body edits and other advanced operations (run --print-patch-template first)")
+		return patch, mailValidationError("at least one edit operation is required; use direct flags such as --set-subject/--set-to, or use --patch-file for body edits and other advanced operations (run --print-patch-template first)")
 	}
 	if len(patch.Ops) == 0 {
 		// --request-receipt only: Validate() would reject empty Ops, so skip it
@@ -483,7 +496,10 @@ func buildDraftEditPatch(runtime *common.RuntimeContext) (draftpkg.Patch, error)
 		// the draft's From address is known.
 		return patch, nil
 	}
-	return patch, patch.Validate()
+	if err := patch.Validate(); err != nil {
+		return patch, mailValidationError("%v", err).WithCause(err)
+	}
+	return patch, nil
 }
 
 // loadPatchFile reads and JSON-decodes a patch file from a relative path
@@ -492,19 +508,25 @@ func buildDraftEditPatch(runtime *common.RuntimeContext) (draftpkg.Patch, error)
 // internal stack traces.
 func loadPatchFile(runtime *common.RuntimeContext, path string) (draftpkg.Patch, error) {
 	var patch draftpkg.Patch
+	if err := runtime.ValidatePath(path); err != nil {
+		return patch, mailValidationParamError("--patch-file", "--patch-file %q: %v", path, err).WithCause(mailInputStatError(err))
+	}
 	f, err := runtime.FileIO().Open(path)
 	if err != nil {
-		return patch, fmt.Errorf("--patch-file %q: %w", path, err)
+		return patch, mailValidationParamError("--patch-file", "--patch-file %q: %v", path, err).WithCause(mailInputStatError(err))
 	}
 	defer f.Close()
 	data, err := io.ReadAll(f)
 	if err != nil {
-		return patch, err
+		return patch, mailValidationParamError("--patch-file", "read --patch-file %q: %v", path, err).WithCause(err)
 	}
 	if err := json.Unmarshal(data, &patch); err != nil {
-		return patch, fmt.Errorf("parse patch file: %w", err)
+		return patch, mailValidationParamError("--patch-file", "parse patch file: %v", err).WithCause(err)
 	}
-	return patch, patch.Validate()
+	if err := patch.Validate(); err != nil {
+		return patch, mailValidationParamError("--patch-file", "validate patch file: %v", err).WithCause(err)
+	}
+	return patch, nil
 }
 
 // buildDraftEditPatchTemplate returns the JSON template emitted by

--- a/shortcuts/mail/mail_draft_edit_test.go
+++ b/shortcuts/mail/mail_draft_edit_test.go
@@ -4,8 +4,11 @@
 package mail
 
 import (
+	"errors"
+	"os"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
 	"github.com/spf13/cobra"
@@ -79,6 +82,43 @@ func TestBuildDraftEditPatch_InvalidPriority(t *testing.T) {
 	rt := newDraftEditRuntime(map[string]string{"set-priority": "urgent"})
 	if _, err := buildDraftEditPatch(rt); err == nil {
 		t.Fatal("expected error for invalid --set-priority value")
+	}
+}
+
+func TestLoadPatchFileRejectsUnsafePathWithTypedParam(t *testing.T) {
+	chdirTemp(t)
+	f, _, _, _ := mailShortcutTestFactory(t)
+	rt := &common.RuntimeContext{Cmd: &cobra.Command{Use: "test"}, Factory: f, Config: mailTestConfig()}
+	_, err := loadPatchFile(rt, "../patch.json")
+	if err == nil {
+		t.Fatal("expected unsafe patch path to fail")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	if validationErr.Param != "--patch-file" {
+		t.Fatalf("param = %q, want --patch-file", validationErr.Param)
+	}
+}
+
+func TestLoadPatchFileValidateFailureKeepsPatchFileParam(t *testing.T) {
+	chdirTemp(t)
+	if err := os.WriteFile("patch.json", []byte(`{"ops":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, _, _, _ := mailShortcutTestFactory(t)
+	rt := &common.RuntimeContext{Cmd: &cobra.Command{Use: "test"}, Factory: f, Config: mailTestConfig()}
+	_, err := loadPatchFile(rt, "patch.json")
+	if err == nil {
+		t.Fatal("expected invalid patch file to fail")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	if validationErr.Param != "--patch-file" {
+		t.Fatalf("param = %q, want --patch-file", validationErr.Param)
 	}
 }
 

--- a/shortcuts/mail/mail_draft_send.go
+++ b/shortcuts/mail/mail_draft_send.go
@@ -5,11 +5,10 @@ package mail
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -66,9 +65,9 @@ type batchSendOutput struct {
 // drafts are user-owned resources and bot has no coherent semantics here.
 //
 // Output schema is the batchSendOutput type above. Partial failures (any
-// failed[]) return exit 1 with envelope.error.type="partial_failure" so that
-// agents can distinguish "all sent" from "some sent" without parsing the
-// success_count field.
+// failed[]) emit an ok:false multi-status envelope so that agents can
+// distinguish "all sent" from "some sent" without parsing the success_count
+// field.
 var MailDraftSend = common.Shortcut{
 	Service: "mail",
 	Command: "+draft-send",
@@ -101,14 +100,14 @@ var MailDraftSend = common.Shortcut{
 //  2. Validate the draft-id slice (non-empty, under MaxBatchSendDrafts cap,
 //     no empty elements).
 //  3. Loop over each draft ID, calling POST .../drafts/:id/send directly via
-//     runtime.CallAPI. Per-draft outcomes:
+//     runtime.CallAPITyped. Per-draft outcomes:
 //     - fatal err (isFatalSendErr) → return immediately (bypasses --stop-on-error).
 //     - recoverable err → append to failed[]; honor --stop-on-error.
-//     - success + automation_send_disable signal → return immediately with
-//     ExitAPI/"automation_send_disabled".
+//     - success + automation_send_disable signal → return immediately with a
+//     failed-precondition error.
 //     - success → append to sent[].
 //  4. Emit batchSendOutput via runtime.Out.
-//  5. If any draft failed, return ExitAPI/"partial_failure" so exit code = 1.
+//  5. If any draft failed, emit ok:false via runtime.OutPartialFailure.
 func executeDraftSend(ctx context.Context, rt *common.RuntimeContext) error {
 	mailboxID := resolveComposeMailboxID(rt)
 	draftIDs, err := normalizedDraftSendIDs(rt)
@@ -122,9 +121,9 @@ func executeDraftSend(ctx context.Context, rt *common.RuntimeContext) error {
 		idx := i + 1
 		writeDraftSendProgressf(rt, "[%d/%d] sending draft %s",
 			idx, len(draftIDs), sanitizeForSingleLine(id))
-		// Direct CallAPI rather than draftpkg.Send: this shortcut never sends
+		// Direct CallAPITyped rather than draftpkg.Send: this shortcut never sends
 		// a body, so the helper's send_time-aware envelope would add no value.
-		data, err := rt.CallAPI("POST",
+		data, err := rt.CallAPITyped("POST",
 			mailboxPath(mailboxID, "drafts", id, "send"), nil, nil)
 		if err != nil {
 			if isFatalSendErr(err) {
@@ -133,7 +132,7 @@ func executeDraftSend(ctx context.Context, rt *common.RuntimeContext) error {
 				hadProgress := out.hasProgress()
 				out.Failed = append(out.Failed, failedDraft{DraftID: id, Error: err.Error()})
 				if hadProgress {
-					emitDraftSendOutput(rt, &out)
+					_ = emitDraftSendPartialFailure(rt, &out)
 				}
 				// Account- / mailbox-level failures (auth, permission, network,
 				// quota) will repeat identically for every remaining draft —
@@ -150,13 +149,14 @@ func executeDraftSend(ctx context.Context, rt *common.RuntimeContext) error {
 			continue
 		}
 		if reason := extractAutomationDisabledReason(data); reason != "" {
-			err := output.Errorf(output.ExitAPI, "automation_send_disabled",
-				"automation send is disabled for this mailbox: %s", reason)
+			err := mailFailedPreconditionError(
+				"automation send is disabled for this mailbox: %s", reason).
+				WithHint("enable automation send for this mailbox, or send the draft from the Lark client")
 			writeDraftSendProgressf(rt, "[%d/%d] aborting after draft %s: %s",
 				idx, len(draftIDs), sanitizeForSingleLine(id), sanitizeForSingleLine(err.Error()))
 			if out.hasProgress() {
 				out.Failed = append(out.Failed, failedDraft{DraftID: id, Error: err.Error()})
-				emitDraftSendOutput(rt, &out)
+				_ = emitDraftSendPartialFailure(rt, &out)
 			}
 			// HTTP success (code: 0) but the backend signaled automation send
 			// is disabled — every subsequent send will fail the same way, so
@@ -179,13 +179,11 @@ func executeDraftSend(ctx context.Context, rt *common.RuntimeContext) error {
 				idx, len(draftIDs), sanitizeForSingleLine(id))
 		}
 	}
-	emitDraftSendOutput(rt, &out)
-
-	if out.FailureCount == 0 {
+	if len(out.Failed) == 0 {
+		emitDraftSendOutput(rt, &out)
 		return nil
 	}
-	return output.Errorf(output.ExitAPI, "partial_failure",
-		"%d of %d drafts failed to send", out.FailureCount, out.Total)
+	return emitDraftSendPartialFailure(rt, &out)
 }
 
 // dryRunDraftSend builds the --dry-run preview: one POST call per draft ID,
@@ -212,7 +210,7 @@ func normalizedDraftSendIDs(rt *common.RuntimeContext) ([]string, error) {
 
 func normalizeDraftSendIDs(draftIDs []string) ([]string, error) {
 	if len(draftIDs) == 0 {
-		return nil, output.ErrValidation("--draft-id is required")
+		return nil, mailValidationParamError("--draft-id", "--draft-id is required")
 	}
 
 	normalized := make([]string, 0, len(draftIDs))
@@ -220,16 +218,16 @@ func normalizeDraftSendIDs(draftIDs []string) ([]string, error) {
 	for _, id := range draftIDs {
 		trimmed := strings.TrimSpace(id)
 		if trimmed == "" {
-			return nil, output.ErrValidation("--draft-id contains empty value")
+			return nil, mailValidationParamError("--draft-id", "--draft-id contains empty value")
 		}
 		if _, ok := seen[trimmed]; ok {
-			return nil, output.ErrValidation("--draft-id contains duplicate value: %s", trimmed)
+			return nil, mailValidationParamError("--draft-id", "--draft-id contains duplicate value: %s", trimmed)
 		}
 		seen[trimmed] = struct{}{}
 		normalized = append(normalized, trimmed)
 	}
 	if len(normalized) > MaxBatchSendDrafts {
-		return nil, output.ErrValidation(
+		return nil, mailValidationParamError("--draft-id",
 			"too many drafts: %d > %d (split into multiple batches)",
 			len(normalized), MaxBatchSendDrafts)
 	}
@@ -246,6 +244,12 @@ func emitDraftSendOutput(rt *common.RuntimeContext, out *batchSendOutput) {
 	rt.Out(*out, nil)
 }
 
+func emitDraftSendPartialFailure(rt *common.RuntimeContext, out *batchSendOutput) error {
+	out.SuccessCount = len(out.Sent)
+	out.FailureCount = len(out.Failed)
+	return rt.OutPartialFailure(*out, nil)
+}
+
 func writeDraftSendProgressf(rt *common.RuntimeContext, format string, args ...interface{}) {
 	if rt == nil || rt.Factory == nil || rt.Factory.IOStreams == nil || rt.Factory.IOStreams.ErrOut == nil {
 		return
@@ -259,48 +263,34 @@ func writeDraftSendProgressf(rt *common.RuntimeContext, format string, args ...i
 //
 // Trigger conditions:
 //
-//   - err does not unwrap to an *output.ExitError, or its Detail is missing:
+//   - err does not expose a typed Problem:
 //     unknown shapes are treated as fatal so they cannot accidentally
 //     accumulate into failed[] for every remaining draft.
-//   - Detail.Type ∈ {"auth", "app_status", "config", "permission",
-//     "rate_limit", "network"}: token, scope, app-installation problems,
-//     throttling, and connectivity are account-level.
-//   - Code == output.ExitNetwork: connectivity loss is account-level.
-//   - Detail.Code ∈ {LarkErrMailboxNotFound, LarkErrMailSendQuotaUser,
-//     LarkErrMailSendQuotaUserExt, LarkErrMailSendQuotaTenantExt,
-//     LarkErrMailQuota, LarkErrTenantStorageLimit}: mailbox / quota
-//     exhaustion is account-level.
+//   - Problem.Category ∈ {authentication, authorization, config, network,
+//     internal}: token, scope, app-installation problems, throttling,
+//     connectivity, SDK, and invalid-response failures are account-level.
+//   - Problem.Subtype ∈ {rate_limit, quota_exceeded}: throttling and quota
+//     exhaustion are account-level.
+//   - Problem.Code ∈ {1234013, 1236007, 1236008, 1236009, 1236010, 1236013}:
+//     mailbox missing / quota exhaustion is account-level. Mailbox-not-found
+//     stays code-scoped (1234013) rather than matching subtype not_found, so
+//     an unrelated not_found — e.g. a single bad draft ID — remains a
+//     per-draft recoverable failure.
 func isFatalSendErr(err error) bool {
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) || exitErr.Detail == nil {
+	p, ok := errs.ProblemOf(err)
+	if !ok {
 		return true
 	}
-	switch exitErr.Detail.Type {
-	case "auth", "app_status", "config":
-		return true
-	case "permission", "rate_limit", "network":
+	switch p.Category {
+	case errs.CategoryAuthentication, errs.CategoryAuthorization, errs.CategoryConfig, errs.CategoryNetwork, errs.CategoryInternal:
 		return true
 	}
-	if exitErr.Code == output.ExitNetwork || wrapsExitCode(err, output.ExitNetwork) {
+	if p.Subtype == errs.SubtypeRateLimit || p.Subtype == errs.SubtypeQuotaExceeded {
 		return true
 	}
-	switch exitErr.Detail.Code {
-	case output.LarkErrMailboxNotFound,
-		output.LarkErrMailSendQuotaUser,
-		output.LarkErrMailSendQuotaUserExt,
-		output.LarkErrMailSendQuotaTenantExt,
-		output.LarkErrMailQuota,
-		output.LarkErrTenantStorageLimit:
+	switch p.Code {
+	case 1234013, 1236007, 1236008, 1236009, 1236010, 1236013:
 		return true
-	}
-	return false
-}
-
-func wrapsExitCode(err error, code int) bool {
-	for unwrapped := errors.Unwrap(err); unwrapped != nil; unwrapped = errors.Unwrap(unwrapped) {
-		if exitErr, ok := unwrapped.(*output.ExitError); ok && exitErr.Code == code {
-			return true
-		}
 	}
 	return false
 }

--- a/shortcuts/mail/mail_draft_send.go
+++ b/shortcuts/mail/mail_draft_send.go
@@ -45,11 +45,21 @@ type failedDraft struct {
 //	  "success_count":  2,
 //	  "failure_count":  1,
 //	  "sent":  [{"draft_id":..., "message_id":..., "thread_id":...}, ...],
-//	  "failed":[{"draft_id":..., "error":...}]
+//	  "failed":[{"draft_id":..., "error":...}],
+//	  "aborted":     true,
+//	  "abort_error": {"type":..., "subtype":..., "code":..., "message":..., "hint":...}
 //	}
 //
 // failed is marked omitempty so a fully successful batch returns a clean shape
 // without an empty array.
+//
+// aborted reports an account-level abort: the failure repeats identically for
+// every draft, so the remaining drafts were not attempted and retrying the
+// batch as-is fails the same way. abort_error carries the typed error that
+// triggered the abort (same wire shape as a stderr error envelope's error
+// object) so callers can route recovery from stdout alone. A --stop-on-error
+// stop does NOT set aborted: there the failure is draft-level and the caller
+// chose to stop early.
 type batchSendOutput struct {
 	MailboxID    string        `json:"mailbox_id"`
 	Total        int           `json:"total"`
@@ -57,6 +67,8 @@ type batchSendOutput struct {
 	FailureCount int           `json:"failure_count"`
 	Sent         []sentDraft   `json:"sent"`
 	Failed       []failedDraft `json:"failed,omitempty"`
+	Aborted      bool          `json:"aborted,omitempty"`
+	AbortError   interface{}   `json:"abort_error,omitempty"`
 }
 
 // MailDraftSend is the `+draft-send` shortcut: send N existing drafts
@@ -101,9 +113,11 @@ var MailDraftSend = common.Shortcut{
 //     no empty elements).
 //  3. Loop over each draft ID, calling POST .../drafts/:id/send directly via
 //     runtime.CallAPITyped. Per-draft outcomes:
-//     - fatal err (isFatalSendErr) → return immediately (bypasses --stop-on-error).
+//     - fatal err (isFatalSendErr) → abort immediately (bypasses
+//     --stop-on-error): with earlier progress, emit the aborted ledger as the
+//     single failure result; with none, return the typed error directly.
 //     - recoverable err → append to failed[]; honor --stop-on-error.
-//     - success + automation_send_disable signal → return immediately with a
+//     - success + automation_send_disable signal → abort the same way with a
 //     failed-precondition error.
 //     - success → append to sent[].
 //  4. Emit batchSendOutput via runtime.Out.
@@ -131,13 +145,15 @@ func executeDraftSend(ctx context.Context, rt *common.RuntimeContext) error {
 					idx, len(draftIDs), sanitizeForSingleLine(id), sanitizeForSingleLine(err.Error()))
 				hadProgress := out.hasProgress()
 				out.Failed = append(out.Failed, failedDraft{DraftID: id, Error: err.Error()})
-				if hadProgress {
-					_ = emitDraftSendPartialFailure(rt, &out)
-				}
 				// Account- / mailbox-level failures (auth, permission, network,
 				// quota) will repeat identically for every remaining draft —
 				// abort immediately so the caller sees a single clear error
-				// instead of 100 redundant failed[] entries.
+				// instead of 100 redundant failed[] entries. With earlier
+				// progress the aborted ledger is the single failure result;
+				// with none, stdout stays empty and the typed error envelope is.
+				if hadProgress {
+					return emitDraftSendAborted(rt, &out, err)
+				}
 				return err
 			}
 			writeDraftSendProgressf(rt, "[%d/%d] failed draft %s: %s",
@@ -154,13 +170,14 @@ func executeDraftSend(ctx context.Context, rt *common.RuntimeContext) error {
 				WithHint("enable automation send for this mailbox, or send the draft from the Lark client")
 			writeDraftSendProgressf(rt, "[%d/%d] aborting after draft %s: %s",
 				idx, len(draftIDs), sanitizeForSingleLine(id), sanitizeForSingleLine(err.Error()))
-			if out.hasProgress() {
-				out.Failed = append(out.Failed, failedDraft{DraftID: id, Error: err.Error()})
-				_ = emitDraftSendPartialFailure(rt, &out)
-			}
 			// HTTP success (code: 0) but the backend signaled automation send
 			// is disabled — every subsequent send will fail the same way, so
-			// abort the batch with a single descriptive error.
+			// abort the batch with a single failure result: the aborted ledger
+			// when earlier drafts made progress, the typed error otherwise.
+			if out.hasProgress() {
+				out.Failed = append(out.Failed, failedDraft{DraftID: id, Error: err.Error()})
+				return emitDraftSendAborted(rt, &out, err)
+			}
 			return err
 		}
 		s := sentDraft{DraftID: id}
@@ -248,6 +265,18 @@ func emitDraftSendPartialFailure(rt *common.RuntimeContext, out *batchSendOutput
 	out.SuccessCount = len(out.Sent)
 	out.FailureCount = len(out.Failed)
 	return rt.OutPartialFailure(*out, nil)
+}
+
+// emitDraftSendAborted emits the batch ledger as the single failure result for
+// an account-level abort: the ledger carries aborted/abort_error and the
+// returned partial-failure signal sets the exit code without a second error
+// envelope on stderr.
+func emitDraftSendAborted(rt *common.RuntimeContext, out *batchSendOutput, cause error) error {
+	out.Aborted = true
+	if typed, ok := errs.UnwrapTypedError(errs.WrapInternal(cause)); ok {
+		out.AbortError = typed
+	}
+	return emitDraftSendPartialFailure(rt, out)
 }
 
 func writeDraftSendProgressf(rt *common.RuntimeContext, format string, args ...interface{}) {

--- a/shortcuts/mail/mail_draft_send_test.go
+++ b/shortcuts/mail/mail_draft_send_test.go
@@ -4,6 +4,7 @@
 package mail
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -89,6 +91,32 @@ func stubDraftSend(reg *httpmock.Registry, draftID string, body map[string]inter
 	}
 	reg.Register(stub)
 	return stub
+}
+
+func decodeDraftSendPartialEnvelopeData(t *testing.T, stdout *bytes.Buffer) map[string]interface{} {
+	t.Helper()
+	var envelope struct {
+		OK   bool                   `json:"ok"`
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("Unmarshal(stdout) error = %v, stdout=%s", err, stdout.String())
+	}
+	if envelope.OK {
+		t.Fatalf("expected ok:false partial-failure output, stdout=%s", stdout.String())
+	}
+	return envelope.Data
+}
+
+func assertPartialFailureSignal(t *testing.T, err error) {
+	t.Helper()
+	var pfErr *output.PartialFailureError
+	if !errors.As(err, &pfErr) {
+		t.Fatalf("expected *output.PartialFailureError, got %T: %v", err, err)
+	}
+	if pfErr.Code != output.ExitAPI {
+		t.Errorf("PartialFailureError.Code = %d, want ExitAPI=%d", pfErr.Code, output.ExitAPI)
+	}
 }
 
 // TestMailDraftSend_AllSuccess verifies the happy path: every draft sends
@@ -190,7 +218,8 @@ func TestMailDraftSend_ProgressWritesToStderr(t *testing.T) {
 	if strings.Contains(stdout.String(), "mail +draft-send:") {
 		t.Errorf("stdout must not contain progress lines; got %s", stdout.String())
 	}
-	data := decodeShortcutEnvelopeData(t, stdout)
+	assertPartialFailureSignal(t, err)
+	data := decodeDraftSendPartialEnvelopeData(t, stdout)
 	if data["success_count"].(float64) != 2 || data["failure_count"].(float64) != 1 {
 		t.Errorf("unexpected aggregate counts: %#v", data)
 	}
@@ -198,7 +227,7 @@ func TestMailDraftSend_ProgressWritesToStderr(t *testing.T) {
 
 // TestMailDraftSend_PartialFailure verifies that one recoverable per-draft
 // failure does not abort the batch; the remaining drafts are attempted; both
-// arrays are populated; and the call returns ExitAPI/"partial_failure".
+// arrays are populated; and the call returns the multi-status partial-failure signal.
 func TestMailDraftSend_PartialFailure(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
 	stubDraftSend(reg, "d1", map[string]interface{}{
@@ -225,18 +254,9 @@ func TestMailDraftSend_PartialFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected partial_failure error, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T: %v", err, err)
-	}
-	if exitErr.Code != output.ExitAPI {
-		t.Errorf("Code = %d, want ExitAPI=%d", exitErr.Code, output.ExitAPI)
-	}
-	if exitErr.Detail == nil || exitErr.Detail.Type != "partial_failure" {
-		t.Errorf("Detail.Type = %v, want partial_failure", exitErr.Detail)
-	}
+	assertPartialFailureSignal(t, err)
 
-	data := decodeShortcutEnvelopeData(t, stdout)
+	data := decodeDraftSendPartialEnvelopeData(t, stdout)
 	if data["total"].(float64) != 3 {
 		t.Errorf("total = %v, want 3", data["total"])
 	}
@@ -284,7 +304,8 @@ func TestMailDraftSend_StopOnError(t *testing.T) {
 		t.Fatal("expected partial_failure error, got nil")
 	}
 
-	data := decodeShortcutEnvelopeData(t, stdout)
+	assertPartialFailureSignal(t, err)
+	data := decodeDraftSendPartialEnvelopeData(t, stdout)
 	if data["success_count"].(float64) != 1 {
 		t.Errorf("success_count = %v, want 1", data["success_count"])
 	}
@@ -315,12 +336,12 @@ func TestMailDraftSend_FatalAborts(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected fatal abort error, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
 	}
-	if exitErr.Detail == nil || exitErr.Detail.Code != output.LarkErrMailboxNotFound {
-		t.Errorf("expected Detail.Code = %d, got %#v", output.LarkErrMailboxNotFound, exitErr.Detail)
+	if p.Code != output.LarkErrMailboxNotFound {
+		t.Errorf("expected code = %d, got %#v", output.LarkErrMailboxNotFound, p)
 	}
 	// No JSON envelope on stdout because Execute returned early before rt.Out.
 	if stdout.Len() != 0 {
@@ -351,15 +372,15 @@ func TestMailDraftSend_FatalAfterSuccessEmitsLedger(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected fatal abort error, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
 	}
-	if exitErr.Detail == nil || exitErr.Detail.Code != output.LarkErrMailSendQuotaUser {
-		t.Errorf("expected Detail.Code = %d, got %#v", output.LarkErrMailSendQuotaUser, exitErr.Detail)
+	if p.Code != output.LarkErrMailSendQuotaUser {
+		t.Errorf("expected code = %d, got %#v", output.LarkErrMailSendQuotaUser, p)
 	}
 
-	data := decodeShortcutEnvelopeData(t, stdout)
+	data := decodeDraftSendPartialEnvelopeData(t, stdout)
 	if data["total"].(float64) != 3 {
 		t.Errorf("total = %v, want 3", data["total"])
 	}
@@ -402,18 +423,15 @@ func TestMailDraftSend_AutomationDisabled(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected automation_send_disabled error, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
 	}
-	if exitErr.Code != output.ExitAPI {
-		t.Errorf("Code = %d, want ExitAPI=%d", exitErr.Code, output.ExitAPI)
+	if p.Category != errs.CategoryValidation || p.Subtype != errs.SubtypeFailedPrecondition {
+		t.Errorf("problem = %#v, want validation/failed_precondition", p)
 	}
-	if exitErr.Detail == nil || exitErr.Detail.Type != "automation_send_disabled" {
-		t.Errorf("Detail.Type = %v, want automation_send_disabled", exitErr.Detail)
-	}
-	if !strings.Contains(exitErr.Error(), "outbound automation disabled") {
-		t.Errorf("error message should propagate reason, got %q", exitErr.Error())
+	if !strings.Contains(p.Message, "outbound automation disabled") {
+		t.Errorf("error message should propagate reason, got %q", p.Message)
 	}
 }
 
@@ -444,15 +462,15 @@ func TestMailDraftSend_AutomationDisabledAfterSuccessEmitsLedger(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected automation_send_disabled error, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
 	}
-	if exitErr.Detail == nil || exitErr.Detail.Type != "automation_send_disabled" {
-		t.Errorf("Detail.Type = %v, want automation_send_disabled", exitErr.Detail)
+	if p.Subtype != errs.SubtypeFailedPrecondition {
+		t.Errorf("Subtype = %v, want failed_precondition", p.Subtype)
 	}
 
-	data := decodeShortcutEnvelopeData(t, stdout)
+	data := decodeDraftSendPartialEnvelopeData(t, stdout)
 	if data["total"].(float64) != 3 {
 		t.Errorf("total = %v, want 3", data["total"])
 	}
@@ -600,12 +618,8 @@ func TestMailDraftSend_MissingYes(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected ExitConfirmationRequired, got nil")
 	}
-	var exitErr *output.ExitError
-	if !errors.As(err, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T", err)
-	}
-	if exitErr.Code != output.ExitConfirmationRequired {
-		t.Errorf("Code = %d, want ExitConfirmationRequired=%d", exitErr.Code, output.ExitConfirmationRequired)
+	if code := output.ExitCodeOf(err); code != output.ExitConfirmationRequired {
+		t.Errorf("Code = %d, want ExitConfirmationRequired=%d", code, output.ExitConfirmationRequired)
 	}
 }
 
@@ -788,93 +802,58 @@ func TestIsFatalSendErr(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "ExitError without Detail → fatal",
-			err:  &output.ExitError{Code: output.ExitInternal},
+			name: "internal typed fallback → fatal",
+			err:  errs.NewInternalError(errs.SubtypeSDKError, "unexpected shape"),
 			want: true,
 		},
 		{
-			name: "auth → fatal",
-			err: &output.ExitError{
-				Code:   output.ExitAuth,
-				Detail: &output.ErrDetail{Type: "auth", Message: "token expired"},
-			},
+			name: "authentication → fatal",
+			err:  errs.NewAuthenticationError(errs.SubtypeTokenExpired, "token expired"),
 			want: true,
 		},
 		{
-			name: "app_status → fatal",
-			err: &output.ExitError{
-				Code:   output.ExitAuth,
-				Detail: &output.ErrDetail{Type: "app_status", Message: "app disabled"},
-			},
+			name: "authorization → fatal",
+			err:  errs.NewPermissionError(errs.SubtypePermissionDenied, "denied"),
 			want: true,
 		},
 		{
 			name: "config → fatal",
-			err: &output.ExitError{
-				Code:   output.ExitAuth,
-				Detail: &output.ErrDetail{Type: "config", Message: "bad app_id"},
-			},
+			err:  errs.NewConfigError(errs.SubtypeInvalidConfig, "bad app_id"),
 			want: true,
 		},
 		{
-			name: "permission → fatal",
-			err: &output.ExitError{
-				Code:   output.ExitAPI,
-				Detail: &output.ErrDetail{Type: "permission", Message: "denied"},
-			},
+			name: "network → fatal",
+			err:  errs.NewNetworkError(errs.SubtypeNetworkTransport, "DNS timeout"),
 			want: true,
 		},
 		{
 			name: "rate_limit → fatal",
-			err: &output.ExitError{
-				Code:   output.ExitAPI,
-				Detail: &output.ErrDetail{Type: "rate_limit", Code: output.LarkErrRateLimit},
-			},
-			want: true,
-		},
-		{
-			name: "ExitNetwork → fatal",
-			err: &output.ExitError{
-				Code:   output.ExitNetwork,
-				Detail: &output.ErrDetail{Type: "network", Message: "DNS timeout"},
-			},
-			want: true,
-		},
-		{
-			name: "wrapped ExitNetwork → fatal",
-			err:  output.Errorf(output.ExitAPI, "api_error", "API call failed: %s", output.ErrNetwork("DNS timeout")),
+			err:  errs.NewAPIError(errs.SubtypeRateLimit, "rate limited").WithCode(output.LarkErrRateLimit),
 			want: true,
 		},
 		{
 			name: "LarkErrMailboxNotFound → fatal",
-			err: &output.ExitError{
-				Code:   output.ExitAPI,
-				Detail: &output.ErrDetail{Type: "api_error", Code: output.LarkErrMailboxNotFound},
-			},
+			err:  errs.NewAPIError(errs.SubtypeNotFound, "mailbox not found").WithCode(output.LarkErrMailboxNotFound),
 			want: true,
 		},
 		{
 			name: "LarkErrMailSendQuotaUser → fatal",
-			err: &output.ExitError{
-				Code:   output.ExitAPI,
-				Detail: &output.ErrDetail{Type: "api_error", Code: output.LarkErrMailSendQuotaUser},
-			},
+			err:  errs.NewAPIError(errs.SubtypeQuotaExceeded, "user daily send count exceeded").WithCode(output.LarkErrMailSendQuotaUser),
 			want: true,
 		},
 		{
 			name: "LarkErrTenantStorageLimit → fatal",
-			err: &output.ExitError{
-				Code:   output.ExitAPI,
-				Detail: &output.ErrDetail{Type: "api_error", Code: output.LarkErrTenantStorageLimit},
-			},
+			err:  errs.NewAPIError(errs.SubtypeQuotaExceeded, "tenant storage limit").WithCode(output.LarkErrTenantStorageLimit),
 			want: true,
 		},
 		{
-			name: "generic api_error → recoverable",
-			err: &output.ExitError{
-				Code:   output.ExitAPI,
-				Detail: &output.ErrDetail{Type: "api_error", Code: 230001},
-			},
+			name: "generic api unknown → recoverable",
+			err:  errs.NewAPIError(errs.SubtypeUnknown, "draft not found").WithCode(230001),
+			want: false,
+		},
+		{
+			name: "not_found without account-level code → recoverable",
+			err:  errs.NewAPIError(errs.SubtypeNotFound, "draft not found").WithCode(230002),
 			want: false,
 		},
 	}

--- a/shortcuts/mail/mail_draft_send_test.go
+++ b/shortcuts/mail/mail_draft_send_test.go
@@ -315,6 +315,14 @@ func TestMailDraftSend_StopOnError(t *testing.T) {
 	if data["total"].(float64) != 3 {
 		t.Errorf("total = %v, want 3", data["total"])
 	}
+	// A --stop-on-error stop is a caller choice over a draft-level failure,
+	// not an account-level abort: the aborted/abort_error fields stay unset.
+	if _, present := data["aborted"]; present {
+		t.Errorf("aborted should be unset for --stop-on-error, got %v", data["aborted"])
+	}
+	if _, present := data["abort_error"]; present {
+		t.Errorf("abort_error should be unset for --stop-on-error, got %v", data["abort_error"])
+	}
 }
 
 // TestMailDraftSend_FatalAborts verifies that a fatal errno (mailbox not
@@ -350,9 +358,10 @@ func TestMailDraftSend_FatalAborts(t *testing.T) {
 }
 
 // TestMailDraftSend_FatalAfterSuccessEmitsLedger verifies that a fatal error
-// after earlier side effects still emits the aggregate stdout ledger before
-// returning the fatal stderr error. This lets callers avoid blindly retrying a
-// draft that was already sent.
+// after earlier side effects emits the aborted stdout ledger as the single
+// failure result: the returned partial-failure signal sets the exit code
+// without a second error envelope, and abort_error carries the typed cause so
+// callers can avoid blindly retrying a draft that was already sent.
 func TestMailDraftSend_FatalAfterSuccessEmitsLedger(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
 	stubDraftSend(reg, "d1", map[string]interface{}{
@@ -370,14 +379,14 @@ func TestMailDraftSend_FatalAfterSuccessEmitsLedger(t *testing.T) {
 		"--yes",
 	}, f, stdout)
 	if err == nil {
-		t.Fatal("expected fatal abort error, got nil")
+		t.Fatal("expected partial-failure abort signal, got nil")
 	}
-	p, ok := errs.ProblemOf(err)
-	if !ok {
-		t.Fatalf("expected typed problem, got %T", err)
-	}
-	if p.Code != output.LarkErrMailSendQuotaUser {
-		t.Errorf("expected code = %d, got %#v", output.LarkErrMailSendQuotaUser, p)
+	// The ledger is the single failure result: the returned error must be the
+	// envelope-less partial-failure signal, not a typed error that the root
+	// dispatcher would render as a second failure envelope on stderr.
+	assertPartialFailureSignal(t, err)
+	if _, ok := errs.ProblemOf(err); ok {
+		t.Fatalf("abort signal must not carry a typed problem, got %v", err)
 	}
 
 	data := decodeDraftSendPartialEnvelopeData(t, stdout)
@@ -395,6 +404,19 @@ func TestMailDraftSend_FatalAfterSuccessEmitsLedger(t *testing.T) {
 	}
 	if got := gjsonLikeString(t, data, "failed", 0, "draft_id"); got != "d2" {
 		t.Errorf("failed[0].draft_id = %q, want d2", got)
+	}
+	if data["aborted"] != true {
+		t.Errorf("aborted = %v, want true", data["aborted"])
+	}
+	abortErr, ok := data["abort_error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("abort_error = %v, want object", data["abort_error"])
+	}
+	if abortErr["type"] != "api" {
+		t.Errorf("abort_error.type = %v, want api", abortErr["type"])
+	}
+	if abortErr["code"].(float64) != float64(output.LarkErrMailSendQuotaUser) {
+		t.Errorf("abort_error.code = %v, want %d", abortErr["code"], output.LarkErrMailSendQuotaUser)
 	}
 }
 
@@ -436,8 +458,9 @@ func TestMailDraftSend_AutomationDisabled(t *testing.T) {
 }
 
 // TestMailDraftSend_AutomationDisabledAfterSuccessEmitsLedger verifies that an
-// automation-send policy stop after earlier successful sends still writes the
-// batch ledger to stdout before returning the structured fatal error.
+// automation-send policy stop after earlier successful sends emits the aborted
+// batch ledger as the single failure result, with the failed-precondition
+// cause carried in abort_error.
 func TestMailDraftSend_AutomationDisabledAfterSuccessEmitsLedger(t *testing.T) {
 	f, stdout, _, reg := mailShortcutTestFactory(t)
 	stubDraftSend(reg, "d1", map[string]interface{}{
@@ -460,17 +483,27 @@ func TestMailDraftSend_AutomationDisabledAfterSuccessEmitsLedger(t *testing.T) {
 		"--yes",
 	}, f, stdout)
 	if err == nil {
-		t.Fatal("expected automation_send_disabled error, got nil")
+		t.Fatal("expected partial-failure abort signal, got nil")
 	}
-	p, ok := errs.ProblemOf(err)
-	if !ok {
-		t.Fatalf("expected typed problem, got %T", err)
-	}
-	if p.Subtype != errs.SubtypeFailedPrecondition {
-		t.Errorf("Subtype = %v, want failed_precondition", p.Subtype)
+	assertPartialFailureSignal(t, err)
+	if _, ok := errs.ProblemOf(err); ok {
+		t.Fatalf("abort signal must not carry a typed problem, got %v", err)
 	}
 
 	data := decodeDraftSendPartialEnvelopeData(t, stdout)
+	if data["aborted"] != true {
+		t.Errorf("aborted = %v, want true", data["aborted"])
+	}
+	abortErr, ok := data["abort_error"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("abort_error = %v, want object", data["abort_error"])
+	}
+	if abortErr["type"] != "validation" || abortErr["subtype"] != "failed_precondition" {
+		t.Errorf("abort_error type/subtype = %v/%v, want validation/failed_precondition", abortErr["type"], abortErr["subtype"])
+	}
+	if msg, _ := abortErr["message"].(string); !strings.Contains(msg, "outbound automation disabled") {
+		t.Errorf("abort_error.message should carry the reason, got %q", msg)
+	}
 	if data["total"].(float64) != 3 {
 		t.Errorf("total = %v, want 3", data["total"])
 	}

--- a/shortcuts/mail/mail_errors.go
+++ b/shortcuts/mail/mail_errors.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/extension/fileio"
+)
+
+func mailValidationError(format string, args ...any) *errs.ValidationError {
+	return errs.NewValidationError(errs.SubtypeInvalidArgument, format, args...)
+}
+
+func mailValidationParamError(param, format string, args ...any) *errs.ValidationError {
+	return mailValidationError(format, args...).WithParam(param)
+}
+
+func mailInvalidParam(name, reason string) errs.InvalidParam {
+	return errs.InvalidParam{Name: name, Reason: reason}
+}
+
+func mailFailedPreconditionError(format string, args ...any) *errs.ValidationError {
+	return errs.NewValidationError(errs.SubtypeFailedPrecondition, format, args...)
+}
+
+func mailInvalidResponseError(format string, args ...any) *errs.InternalError {
+	return errs.NewInternalError(errs.SubtypeInvalidResponse, format, args...)
+}
+
+func mailFileIOError(format string, err error, args ...any) *errs.InternalError {
+	return errs.NewInternalError(errs.SubtypeFileIO, format, args...).WithCause(err)
+}
+
+func mailInputStatError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, fileio.ErrPathValidation) {
+		return mailValidationError("unsafe file path: %s", err).WithCause(err)
+	}
+	return mailValidationError("cannot read file: %s", err).WithCause(err)
+}
+
+func mailDecorateProblemMessage(err error, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+	prefix := fmt.Sprintf(format, args...)
+	if p, ok := errs.ProblemOf(err); ok {
+		if strings.TrimSpace(prefix) != "" {
+			p.Message = prefix + ": " + p.Message
+		}
+		return err
+	}
+	return errs.NewInternalError(errs.SubtypeSDKError, "%s: %s", prefix, err.Error()).WithCause(err)
+}
+
+func mailAppendProblemHint(err error, hint string) error {
+	if err == nil {
+		return nil
+	}
+	if p, ok := errs.ProblemOf(err); ok {
+		if strings.TrimSpace(p.Hint) != "" {
+			p.Hint = p.Hint + "; " + hint
+		} else {
+			p.Hint = hint
+		}
+		return err
+	}
+	return errs.NewAPIError(errs.SubtypeUnknown, "%s", err.Error()).WithHint("%s", hint).WithCause(err)
+}

--- a/shortcuts/mail/mail_errors_test.go
+++ b/shortcuts/mail/mail_errors_test.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/extension/fileio"
+)
+
+func TestMailFileIOErrorTyped(t *testing.T) {
+	cause := errors.New("disk read failed")
+
+	err := mailFileIOError("load %s: %v", cause, "body.html", cause)
+
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("expected internal error, got %T", err)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatalf("cause not preserved: %v", err)
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if p.Subtype != errs.SubtypeFileIO {
+		t.Fatalf("subtype = %q, want %q", p.Subtype, errs.SubtypeFileIO)
+	}
+	if !strings.Contains(p.Message, "body.html") || !strings.Contains(p.Message, "disk read failed") {
+		t.Fatalf("message missing context: %q", p.Message)
+	}
+}
+
+func TestMailFileIOErrorDoesNotAppendCauseAsFormatArg(t *testing.T) {
+	cause := errors.New("mkdir denied")
+
+	err := mailFileIOError("cannot create output directory %q", cause, "out")
+
+	if !errors.Is(err, cause) {
+		t.Fatalf("cause not preserved: %v", err)
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if strings.Contains(p.Message, "%!(") {
+		t.Fatalf("message contains fmt extra marker: %q", p.Message)
+	}
+	if strings.Contains(p.Message, "mkdir denied") {
+		t.Fatalf("cause should not be implicitly appended to message: %q", p.Message)
+	}
+}
+
+func TestMailInputStatErrorTyped(t *testing.T) {
+	if err := mailInputStatError(nil); err != nil {
+		t.Fatalf("nil input should stay nil, got %v", err)
+	}
+
+	pathErr := fileio.ErrPathValidation
+	err := mailInputStatError(pathErr)
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T", err)
+	}
+	if !errors.Is(err, pathErr) {
+		t.Fatalf("cause not preserved: %v", err)
+	}
+	if !strings.Contains(err.Error(), "unsafe file path") {
+		t.Fatalf("unexpected path validation message: %v", err)
+	}
+
+	statErr := errors.New("permission denied")
+	err = mailInputStatError(statErr)
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T", err)
+	}
+	if !errors.Is(err, statErr) {
+		t.Fatalf("stat cause not preserved: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot read file") {
+		t.Fatalf("unexpected stat message: %v", err)
+	}
+}
+
+func TestMailDecorateProblemMessageTypedAndPlain(t *testing.T) {
+	if err := mailDecorateProblemMessage(nil, "fetch profile"); err != nil {
+		t.Fatalf("nil input should stay nil, got %v", err)
+	}
+
+	typedErr := errs.NewAPIError(errs.SubtypeRateLimit, "too many requests")
+	err := mailDecorateProblemMessage(typedErr, "fetch %s", "profile")
+	if err != typedErr {
+		t.Fatalf("typed error should be decorated in place")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if p.Message != "fetch profile: too many requests" {
+		t.Fatalf("message = %q", p.Message)
+	}
+
+	blankPrefixErr := errs.NewAPIError(errs.SubtypeUnknown, "unchanged")
+	err = mailDecorateProblemMessage(blankPrefixErr, "  ")
+	p, ok = errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if p.Message != "unchanged" {
+		t.Fatalf("blank prefix should not change message, got %q", p.Message)
+	}
+
+	plainCause := errors.New("sdk failed")
+	err = mailDecorateProblemMessage(plainCause, "fetch mailbox")
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("plain error should be upgraded to internal SDK error, got %T", err)
+	}
+	if !errors.Is(err, plainCause) {
+		t.Fatalf("cause not preserved: %v", err)
+	}
+	p, ok = errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if p.Subtype != errs.SubtypeSDKError || !strings.Contains(p.Message, "fetch mailbox: sdk failed") {
+		t.Fatalf("unexpected problem: %+v", p)
+	}
+}
+
+func TestMailAppendProblemHintTypedAndPlain(t *testing.T) {
+	if err := mailAppendProblemHint(nil, "retry later"); err != nil {
+		t.Fatalf("nil input should stay nil, got %v", err)
+	}
+
+	withoutHint := errs.NewAPIError(errs.SubtypeUnknown, "failed")
+	err := mailAppendProblemHint(withoutHint, "retry later")
+	if err != withoutHint {
+		t.Fatalf("typed error should be updated in place")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if p.Hint != "retry later" {
+		t.Fatalf("hint = %q", p.Hint)
+	}
+
+	withHint := errs.NewAPIError(errs.SubtypeUnknown, "failed").WithHint("check scope")
+	err = mailAppendProblemHint(withHint, "retry later")
+	p, ok = errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if p.Hint != "check scope; retry later" {
+		t.Fatalf("hint = %q", p.Hint)
+	}
+
+	plainCause := errors.New("legacy api failed")
+	err = mailAppendProblemHint(plainCause, "retry later")
+	var apiErr *errs.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("plain error should be upgraded to API error, got %T", err)
+	}
+	if !errors.Is(err, plainCause) {
+		t.Fatalf("cause not preserved: %v", err)
+	}
+	p, ok = errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if p.Hint != "retry later" || p.Subtype != errs.SubtypeUnknown {
+		t.Fatalf("unexpected problem: %+v", p)
+	}
+}
+
+func TestValidateBodyFileMutexTypedErrors(t *testing.T) {
+	err := validateBodyFileMutex("<p>Hello</p>", "body.html", func(string) error { return nil })
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T", err)
+	}
+	if len(validationErr.Params) != 2 {
+		t.Fatalf("params = %#v, want two conflicting params", validationErr.Params)
+	}
+	if validationErr.Params[0].Name != "--body" || validationErr.Params[1].Name != "--body-file" {
+		t.Fatalf("unexpected params: %#v", validationErr.Params)
+	}
+
+	pathErr := errors.New("outside cwd")
+	err = validateBodyFileMutex("", "body.html", func(string) error { return pathErr })
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T", err)
+	}
+	if validationErr.Param != "--body-file" {
+		t.Fatalf("param = %q, want --body-file", validationErr.Param)
+	}
+	if !errors.Is(err, pathErr) {
+		t.Fatalf("cause not preserved: %v", err)
+	}
+}
+
+func TestReadBodyFileTypedErrors(t *testing.T) {
+	openErr := errors.New("missing")
+	_, err := readBodyFile(bodyFileTestIO{
+		open: func(string) (fileio.File, error) { return nil, openErr },
+	}, "missing.html")
+	requireBodyFileValidationError(t, err, openErr)
+	if !strings.Contains(err.Error(), "open --body-file missing.html") {
+		t.Fatalf("unexpected open message: %v", err)
+	}
+
+	readErr := errors.New("read broken")
+	_, err = readBodyFile(bodyFileTestIO{
+		open: func(string) (fileio.File, error) {
+			return &bodyFileTestFile{readErr: readErr}, nil
+		},
+	}, "body.html")
+	requireBodyFileValidationError(t, err, readErr)
+	if !strings.Contains(err.Error(), "read --body-file body.html") {
+		t.Fatalf("unexpected read message: %v", err)
+	}
+
+	_, err = readBodyFile(bodyFileTestIO{
+		open: func(string) (fileio.File, error) {
+			return &bodyFileTestFile{remaining: maxBodyFileSize + 1}, nil
+		},
+	}, "huge.html")
+	requireBodyFileValidationError(t, err, nil)
+	if !strings.Contains(err.Error(), "file exceeds 32 MB limit") {
+		t.Fatalf("unexpected size message: %v", err)
+	}
+}
+
+func requireBodyFileValidationError(t *testing.T, err error, cause error) {
+	t.Helper()
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T (%v)", err, err)
+	}
+	if validationErr.Param != "--body-file" {
+		t.Fatalf("param = %q, want --body-file", validationErr.Param)
+	}
+	if cause != nil && !errors.Is(err, cause) {
+		t.Fatalf("cause %v not preserved in %v", cause, err)
+	}
+}
+
+type bodyFileTestIO struct {
+	open func(string) (fileio.File, error)
+}
+
+func (fio bodyFileTestIO) Open(name string) (fileio.File, error) {
+	return fio.open(name)
+}
+
+func (fio bodyFileTestIO) Stat(string) (fileio.FileInfo, error) {
+	return nil, errors.New("unused")
+}
+
+func (fio bodyFileTestIO) ResolvePath(path string) (string, error) {
+	return path, nil
+}
+
+func (fio bodyFileTestIO) Save(string, fileio.SaveOptions, io.Reader) (fileio.SaveResult, error) {
+	return nil, errors.New("unused")
+}
+
+type bodyFileTestFile struct {
+	readErr   error
+	remaining int
+}
+
+func (f *bodyFileTestFile) Read(p []byte) (int, error) {
+	if f.readErr != nil {
+		return 0, f.readErr
+	}
+	if f.remaining <= 0 {
+		return 0, io.EOF
+	}
+	n := len(p)
+	if n > f.remaining {
+		n = f.remaining
+	}
+	for i := range p[:n] {
+		p[i] = 'x'
+	}
+	f.remaining -= n
+	return n, nil
+}
+
+func (f *bodyFileTestFile) ReadAt([]byte, int64) (int, error) {
+	return 0, errors.New("unused")
+}
+
+func (f *bodyFileTestFile) Close() error {
+	return nil
+}
+
+var _ fileio.FileIO = bodyFileTestIO{}
+var _ fileio.File = (*bodyFileTestFile)(nil)

--- a/shortcuts/mail/mail_forward.go
+++ b/shortcuts/mail/mail_forward.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
 	"github.com/larksuite/cli/shortcuts/mail/emlbuilder"
@@ -135,10 +135,10 @@ var MailForward = common.Shortcut{
 		}
 		sourceMsg, err := fetchComposeSourceMessage(runtime, mailboxID, messageId)
 		if err != nil {
-			return fmt.Errorf("failed to fetch original message: %w", err)
+			return mailDecorateProblemMessage(err, "failed to fetch original message")
 		}
 		if err := validateForwardAttachmentURLs(sourceMsg); err != nil {
-			return fmt.Errorf("forward blocked: %w", err)
+			return mailDecorateProblemMessage(err, "forward blocked")
 		}
 		orig := sourceMsg.Original
 
@@ -243,7 +243,7 @@ var MailForward = common.Shortcut{
 		}
 		useHTML := !plainText && (bodyIsHTML(body) || bodyIsHTML(orig.bodyRaw) || sigResult != nil)
 		if strings.TrimSpace(inlineFlag) != "" && !useHTML {
-			return fmt.Errorf("--inline requires HTML mode, but neither the new body nor the original message contains HTML")
+			return mailValidationParamError("--inline", "--inline requires HTML mode, but neither the new body nor the original message contains HTML")
 		}
 		inlineSpecs, err := parseInlineSpecs(inlineFlag)
 		if err != nil {
@@ -257,7 +257,7 @@ var MailForward = common.Shortcut{
 		lintApplied, lintBlocked := emptyLintEnvelopeFields()
 		if useHTML {
 			if err := validateInlineImageURLs(sourceMsg); err != nil {
-				return fmt.Errorf("forward blocked: %w", err)
+				return mailDecorateProblemMessage(err, "forward blocked")
 			}
 			processedBody := buildBodyDiv(body, bodyIsHTML(body))
 			origLargeAttCard := stripLargeAttachmentCard(&orig)
@@ -274,7 +274,7 @@ var MailForward = common.Shortcut{
 			}
 			resolved, refs, resolveErr := draftpkg.ResolveLocalImagePaths(processedBody)
 			if resolveErr != nil {
-				return resolveErr
+				return mailValidationError("failed to resolve local image paths: %v", resolveErr).WithCause(resolveErr)
 			}
 			bodyWithSig := resolved
 			if sigResult != nil {
@@ -347,7 +347,7 @@ var MailForward = common.Shortcut{
 			}
 			content, err := downloadAttachmentContent(runtime, att.DownloadURL)
 			if err != nil {
-				return fmt.Errorf("failed to download original attachment %s: %w", att.Filename, err)
+				return mailDecorateProblemMessage(err, "failed to download original attachment %s", att.Filename)
 			}
 			contentType := att.ContentType
 			if contentType == "" {
@@ -381,13 +381,13 @@ var MailForward = common.Shortcut{
 		}
 		for _, f := range userFiles {
 			if f.Size > MaxLargeAttachmentSize {
-				return output.ErrValidation("attachment %s (%.1f GB) exceeds the %.0f GB single file limit",
+				return mailFailedPreconditionError("attachment %s (%.1f GB) exceeds the %.0f GB single file limit",
 					f.FileName, float64(f.Size)/1024/1024/1024, float64(MaxLargeAttachmentSize)/1024/1024/1024)
 			}
 		}
 		totalCount := len(origAtts) + len(largeAttIDs) + len(userFiles)
 		if totalCount > MaxAttachmentCount {
-			return output.ErrValidation("attachment count %d exceeds the limit of %d", totalCount, MaxAttachmentCount)
+			return mailFailedPreconditionError("attachment count %d exceeds the limit of %d", totalCount, MaxAttachmentCount)
 		}
 		allFiles = append(allFiles, userFiles...)
 		classified := classifyAttachments(allFiles, emlBase)
@@ -413,7 +413,7 @@ var MailForward = common.Shortcut{
 		// Upload oversized attachments as large attachments.
 		if len(classified.Oversized) > 0 {
 			if composedHTMLBody == "" && composedTextBody == "" {
-				return output.ErrValidation("large attachments require a body; " +
+				return mailFailedPreconditionError("large attachments require a body; " +
 					"empty messages cannot include the download link")
 			}
 			if runtime.Config == nil || runtime.UserOpenId() == "" {
@@ -421,7 +421,7 @@ var MailForward = common.Shortcut{
 				for _, f := range classified.Oversized {
 					totalBytes += f.Size
 				}
-				return output.ErrValidation("total attachment size %.1f MB exceeds the 25 MB EML limit; "+
+				return mailFailedPreconditionError("total attachment size %.1f MB exceeds the 25 MB EML limit; "+
 					"large attachment upload requires user identity (--as user)",
 					float64(totalBytes)/1024/1024)
 			}
@@ -486,18 +486,18 @@ var MailForward = common.Shortcut{
 		if len(mergedLargeAttIDs) > 0 {
 			idsJSON, err := json.Marshal(mergedLargeAttIDs)
 			if err != nil {
-				return fmt.Errorf("failed to encode large attachment IDs: %w", err)
+				return errs.NewInternalError(errs.SubtypeSDKError, "failed to encode large attachment IDs: %v", err).WithCause(err)
 			}
 			bld = bld.Header(draftpkg.LargeAttachmentIDsHeader, base64.StdEncoding.EncodeToString(idsJSON))
 		}
 		rawEML, err := bld.BuildBase64URL()
 		if err != nil {
-			return fmt.Errorf("failed to build EML: %w", err)
+			return mailValidationError("failed to build EML: %v", err).WithCause(err)
 		}
 
 		draftResult, err := draftpkg.CreateWithRaw(runtime, mailboxID, rawEML)
 		if err != nil {
-			return fmt.Errorf("failed to create draft: %w", err)
+			return mailDecorateProblemMessage(err, "failed to create draft")
 		}
 		showLintDetails := runtime.Bool("show-lint-details")
 		if !confirmSend {
@@ -510,7 +510,7 @@ var MailForward = common.Shortcut{
 		}
 		resData, err := draftpkg.Send(runtime, mailboxID, draftResult.DraftID, sendTime)
 		if err != nil {
-			return fmt.Errorf("failed to send forward (draft %s created but not sent): %w", draftResult.DraftID, err)
+			return mailDecorateProblemMessage(err, "failed to send forward (draft %s created but not sent)", draftResult.DraftID)
 		}
 		out := buildDraftSendOutput(resData, mailboxID)
 		applyLintToEnvelope(out, lintApplied, lintBlocked, showLintDetails)

--- a/shortcuts/mail/mail_lint_html.go
+++ b/shortcuts/mail/mail_lint_html.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/larksuite/cli/shortcuts/mail/lint"
@@ -54,10 +55,18 @@ var MailLintHTML = common.Shortcut{
 		// Mutual exclusion + exactly-one-of validation for --body / --body-file.
 		bodyEmpty := strings.TrimSpace(body) == ""
 		if bodyEmpty && bodyFile == "" {
-			return output.ErrValidation("exactly one of --body or --body-file is required")
+			return mailValidationError("exactly one of --body or --body-file is required").
+				WithParams(
+					mailInvalidParam("--body", "required when --body-file is empty"),
+					mailInvalidParam("--body-file", "required when --body is empty"),
+				)
 		}
 		if !bodyEmpty && bodyFile != "" {
-			return output.ErrValidation("--body and --body-file are mutually exclusive; pass exactly one")
+			return mailValidationError("--body and --body-file are mutually exclusive; pass exactly one").
+				WithParams(
+					mailInvalidParam("--body", "mutually exclusive with --body-file"),
+					mailInvalidParam("--body-file", "mutually exclusive with --body"),
+				)
 		}
 
 		// --body-file safety: cwd-subtree only. Mirrors the existing pattern
@@ -65,7 +74,7 @@ var MailLintHTML = common.Shortcut{
 		// runtime.ValidatePath.
 		if bodyFile != "" {
 			if err := runtime.ValidatePath(bodyFile); err != nil {
-				return output.ErrValidation("--body-file: %v", err)
+				return mailValidationParamError("--body-file", "--body-file: %v", err).WithCause(err)
 			}
 		}
 
@@ -141,7 +150,7 @@ func readLintHTMLBody(runtime *common.RuntimeContext) (string, error) {
 	path := strings.TrimSpace(runtime.Str("body-file"))
 	if path == "" {
 		// Should be unreachable given Validate, but defensive.
-		return "", output.ErrValidation("internal: --body-file empty after Validate")
+		return "", errs.NewInternalError(errs.SubtypeUnknown, "internal: --body-file empty after Validate")
 	}
 	return readBodyFile(runtime.FileIO(), path)
 }

--- a/shortcuts/mail/mail_message.go
+++ b/shortcuts/mail/mail_message.go
@@ -5,7 +5,6 @@ package mail
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -48,7 +47,7 @@ var MailMessage = common.Shortcut{
 
 		msg, err := fetchFullMessage(runtime, mailboxID, messageID, html)
 		if err != nil {
-			return fmt.Errorf("failed to fetch email: %w", err)
+			return mailDecorateProblemMessage(err, "failed to fetch email")
 		}
 
 		out := buildMessageOutput(msg, html)

--- a/shortcuts/mail/mail_reply.go
+++ b/shortcuts/mail/mail_reply.go
@@ -137,7 +137,7 @@ var MailReply = common.Shortcut{
 		}
 		sourceMsg, err := fetchComposeSourceMessage(runtime, mailboxID, messageId)
 		if err != nil {
-			return fmt.Errorf("failed to fetch original message: %w", err)
+			return mailDecorateProblemMessage(err, "failed to fetch original message")
 		}
 		orig := sourceMsg.Original
 		stripLargeAttachmentCard(&orig)
@@ -213,7 +213,7 @@ var MailReply = common.Shortcut{
 
 		useHTML := !plainText && (bodyIsHTML(body) || bodyIsHTML(orig.bodyRaw) || sigResult != nil)
 		if strings.TrimSpace(inlineFlag) != "" && !useHTML {
-			return fmt.Errorf("--inline requires HTML mode, but neither the new body nor the original message contains HTML")
+			return mailValidationParamError("--inline", "--inline requires HTML mode, but neither the new body nor the original message contains HTML")
 		}
 		var bodyStr string
 		if useHTML {
@@ -264,7 +264,7 @@ var MailReply = common.Shortcut{
 		lintApplied, lintBlocked := emptyLintEnvelopeFields()
 		if useHTML {
 			if err := validateInlineImageURLs(sourceMsg); err != nil {
-				return fmt.Errorf("HTML reply blocked: %w", err)
+				return mailDecorateProblemMessage(err, "HTML reply blocked")
 			}
 			var srcCIDs []string
 			bld, srcCIDs, srcInlineBytes, err = addInlineImagesToBuilder(runtime, bld, sourceMsg.InlineImages)
@@ -273,7 +273,7 @@ var MailReply = common.Shortcut{
 			}
 			resolved, refs, resolveErr := draftpkg.ResolveLocalImagePaths(bodyStr)
 			if resolveErr != nil {
-				return resolveErr
+				return mailValidationError("failed to resolve local image paths: %v", resolveErr).WithCause(resolveErr)
 			}
 			bodyWithSig := resolved
 			if sigResult != nil {
@@ -336,12 +336,12 @@ var MailReply = common.Shortcut{
 		}
 		rawEML, err := bld.BuildBase64URL()
 		if err != nil {
-			return fmt.Errorf("failed to build EML: %w", err)
+			return mailValidationError("failed to build EML: %v", err).WithCause(err)
 		}
 
 		draftResult, err := draftpkg.CreateWithRaw(runtime, mailboxID, rawEML)
 		if err != nil {
-			return fmt.Errorf("failed to create draft: %w", err)
+			return mailDecorateProblemMessage(err, "failed to create draft")
 		}
 		showLintDetails := runtime.Bool("show-lint-details")
 		if !confirmSend {
@@ -354,7 +354,7 @@ var MailReply = common.Shortcut{
 		}
 		resData, err := draftpkg.Send(runtime, mailboxID, draftResult.DraftID, sendTime)
 		if err != nil {
-			return fmt.Errorf("failed to send reply (draft %s created but not sent): %w", draftResult.DraftID, err)
+			return mailDecorateProblemMessage(err, "failed to send reply (draft %s created but not sent)", draftResult.DraftID)
 		}
 		out := buildDraftSendOutput(resData, mailboxID)
 		applyLintToEnvelope(out, lintApplied, lintBlocked, showLintDetails)

--- a/shortcuts/mail/mail_reply_all.go
+++ b/shortcuts/mail/mail_reply_all.go
@@ -139,7 +139,7 @@ var MailReplyAll = common.Shortcut{
 		}
 		sourceMsg, err := fetchComposeSourceMessage(runtime, mailboxID, messageId)
 		if err != nil {
-			return fmt.Errorf("failed to fetch original message: %w", err)
+			return mailDecorateProblemMessage(err, "failed to fetch original message")
 		}
 		orig := sourceMsg.Original
 		stripLargeAttachmentCard(&orig)
@@ -226,7 +226,7 @@ var MailReplyAll = common.Shortcut{
 
 		useHTML := !plainText && (bodyIsHTML(body) || bodyIsHTML(orig.bodyRaw) || sigResult != nil)
 		if strings.TrimSpace(inlineFlag) != "" && !useHTML {
-			return fmt.Errorf("--inline requires HTML mode, but neither the new body nor the original message contains HTML")
+			return mailValidationParamError("--inline", "--inline requires HTML mode, but neither the new body nor the original message contains HTML")
 		}
 		var bodyStr string
 		if useHTML {
@@ -271,7 +271,7 @@ var MailReplyAll = common.Shortcut{
 		lintApplied, lintBlocked := emptyLintEnvelopeFields()
 		if useHTML {
 			if err := validateInlineImageURLs(sourceMsg); err != nil {
-				return fmt.Errorf("HTML reply-all blocked: %w", err)
+				return mailDecorateProblemMessage(err, "HTML reply-all blocked")
 			}
 			var srcCIDs []string
 			bld, srcCIDs, srcInlineBytes, err = addInlineImagesToBuilder(runtime, bld, sourceMsg.InlineImages)
@@ -280,7 +280,7 @@ var MailReplyAll = common.Shortcut{
 			}
 			resolved, refs, resolveErr := draftpkg.ResolveLocalImagePaths(bodyStr)
 			if resolveErr != nil {
-				return resolveErr
+				return mailValidationError("failed to resolve local image paths: %v", resolveErr).WithCause(resolveErr)
 			}
 			bodyWithSig := resolved
 			if sigResult != nil {
@@ -341,12 +341,12 @@ var MailReplyAll = common.Shortcut{
 		}
 		rawEML, err := bld.BuildBase64URL()
 		if err != nil {
-			return fmt.Errorf("failed to build EML: %w", err)
+			return mailValidationError("failed to build EML: %v", err).WithCause(err)
 		}
 
 		draftResult, err := draftpkg.CreateWithRaw(runtime, mailboxID, rawEML)
 		if err != nil {
-			return fmt.Errorf("failed to create draft: %w", err)
+			return mailDecorateProblemMessage(err, "failed to create draft")
 		}
 		showLintDetails := runtime.Bool("show-lint-details")
 		if !confirmSend {
@@ -359,7 +359,7 @@ var MailReplyAll = common.Shortcut{
 		}
 		resData, err := draftpkg.Send(runtime, mailboxID, draftResult.DraftID, sendTime)
 		if err != nil {
-			return fmt.Errorf("failed to send reply-all (draft %s created but not sent): %w", draftResult.DraftID, err)
+			return mailDecorateProblemMessage(err, "failed to send reply-all (draft %s created but not sent)", draftResult.DraftID)
 		}
 		out := buildDraftSendOutput(resData, mailboxID)
 		applyLintToEnvelope(out, lintApplied, lintBlocked, showLintDetails)

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
 	"github.com/larksuite/cli/shortcuts/mail/emlbuilder"
@@ -83,7 +82,7 @@ var MailSend = common.Shortcut{
 			return err
 		}
 		if !hasTemplate && strings.TrimSpace(runtime.Str("subject")) == "" {
-			return output.ErrValidation("--subject is required; pass the final email subject (or use --template-id)")
+			return mailValidationParamError("--subject", "--subject is required; pass the final email subject (or use --template-id)")
 		}
 		// With --template-id, tos/ccs/bccs may come from the template, so
 		// defer the at-least-one-recipient check to Execute (after
@@ -241,7 +240,7 @@ var MailSend = common.Shortcut{
 			}
 			resolved, refs, resolveErr := draftpkg.ResolveLocalImagePaths(htmlBody)
 			if resolveErr != nil {
-				return resolveErr
+				return mailValidationError("failed to resolve local image paths: %v", resolveErr).WithCause(resolveErr)
 			}
 			resolved = injectSignatureIntoBody(resolved, sigResult)
 			// Writing-path lint: AutoFix=true / Strict=false — the writing-path
@@ -308,12 +307,12 @@ var MailSend = common.Shortcut{
 
 		rawEML, err := bld.BuildBase64URL()
 		if err != nil {
-			return fmt.Errorf("failed to build EML: %w", err)
+			return mailValidationError("failed to build EML: %v", err).WithCause(err)
 		}
 
 		draftResult, err := draftpkg.CreateWithRaw(runtime, mailboxID, rawEML)
 		if err != nil {
-			return fmt.Errorf("failed to create draft: %w", err)
+			return mailDecorateProblemMessage(err, "failed to create draft")
 		}
 		showLintDetails := runtime.Bool("show-lint-details")
 		if !confirmSend {
@@ -326,7 +325,7 @@ var MailSend = common.Shortcut{
 		}
 		resData, err := draftpkg.Send(runtime, mailboxID, draftResult.DraftID, sendTime)
 		if err != nil {
-			return fmt.Errorf("failed to send email (draft %s created but not sent): %w", draftResult.DraftID, err)
+			return mailDecorateProblemMessage(err, "failed to send email (draft %s created but not sent)", draftResult.DraftID)
 		}
 		out := buildDraftSendOutput(resData, mailboxID)
 		applyLintToEnvelope(out, lintApplied, lintBlocked, showLintDetails)

--- a/shortcuts/mail/mail_send_receipt.go
+++ b/shortcuts/mail/mail_send_receipt.go
@@ -113,10 +113,11 @@ var MailSendReceipt = common.Shortcut{
 
 		msg, err := fetchFullMessage(runtime, mailboxID, messageID, false)
 		if err != nil {
-			return fmt.Errorf("failed to fetch original message: %w", err)
+			return mailDecorateProblemMessage(err, "failed to fetch original message")
 		}
 		if !hasReadReceiptRequestLabel(msg) {
-			return fmt.Errorf("message %s did not request a read receipt (no %s label); refusing to send receipt", messageID, readReceiptRequestLabel)
+			return mailFailedPreconditionError("message %s did not request a read receipt (no %s label); refusing to send receipt", messageID, readReceiptRequestLabel).
+				WithHint("only run +send-receipt for incoming messages that carry the READ_RECEIPT_REQUEST label")
 		}
 
 		origSubject := strVal(msg["subject"])
@@ -126,12 +127,12 @@ var MailSendReceipt = common.Shortcut{
 		origSendMillis := parseInternalDateMillis(msg["internal_date"])
 
 		if origFromEmail == "" {
-			return fmt.Errorf("original message %s has no sender address; cannot address receipt", messageID)
+			return mailFailedPreconditionError("original message %s has no sender address; cannot address receipt", messageID)
 		}
 
 		senderEmail := resolveComposeSenderEmail(runtime)
 		if senderEmail == "" {
-			return fmt.Errorf("unable to determine sender email; please specify --from explicitly")
+			return mailValidationParamError("--from", "unable to determine sender email; please specify --from explicitly")
 		}
 
 		lang := detectSubjectLang(origSubject)
@@ -158,16 +159,16 @@ var MailSendReceipt = common.Shortcut{
 
 		rawEML, err := bld.BuildBase64URL()
 		if err != nil {
-			return fmt.Errorf("failed to build receipt EML: %w", err)
+			return mailValidationError("failed to build receipt EML: %v", err).WithCause(err)
 		}
 
 		draftResult, err := draftpkg.CreateWithRaw(runtime, mailboxID, rawEML)
 		if err != nil {
-			return fmt.Errorf("failed to create receipt draft: %w", err)
+			return mailDecorateProblemMessage(err, "failed to create receipt draft")
 		}
 		resData, err := draftpkg.Send(runtime, mailboxID, draftResult.DraftID, "")
 		if err != nil {
-			return fmt.Errorf("failed to send receipt (draft %s created but not sent): %w", draftResult.DraftID, err)
+			return mailDecorateProblemMessage(err, "failed to send receipt (draft %s created but not sent)", draftResult.DraftID)
 		}
 
 		out := buildDraftSendOutput(resData, mailboxID)

--- a/shortcuts/mail/mail_share_to_chat.go
+++ b/shortcuts/mail/mail_share_to_chat.go
@@ -5,9 +5,7 @@ package mail
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -66,14 +64,22 @@ var MailShareToChat = common.Shortcut{
 		msgID := runtime.Str("message-id")
 		threadID := runtime.Str("thread-id")
 		if msgID == "" && threadID == "" {
-			return output.ErrValidation("either --message-id or --thread-id is required")
+			return mailValidationError("either --message-id or --thread-id is required").
+				WithParams(
+					mailInvalidParam("--message-id", "required when --thread-id is empty"),
+					mailInvalidParam("--thread-id", "required when --message-id is empty"),
+				)
 		}
 		if msgID != "" && threadID != "" {
-			return output.ErrValidation("--message-id and --thread-id are mutually exclusive")
+			return mailValidationError("--message-id and --thread-id are mutually exclusive").
+				WithParams(
+					mailInvalidParam("--message-id", "mutually exclusive with --thread-id"),
+					mailInvalidParam("--thread-id", "mutually exclusive with --message-id"),
+				)
 		}
 		idType := runtime.Str("receive-id-type")
 		if !validReceiveIDTypes[idType] {
-			return output.ErrValidation("--receive-id-type must be one of: chat_id, open_id, user_id, union_id, email")
+			return mailValidationParamError("--receive-id-type", "--receive-id-type must be one of: chat_id, open_id, user_id, union_id, email")
 		}
 		return nil
 	},
@@ -90,23 +96,23 @@ var MailShareToChat = common.Shortcut{
 		} else {
 			createBody = map[string]interface{}{"message_id": msgID}
 		}
-		createResp, err := runtime.CallAPI("POST",
+		createResp, err := runtime.CallAPITyped("POST",
 			mailboxPath(mailboxID, "messages", "share_token"),
 			nil, createBody)
 		if err != nil {
-			return fmt.Errorf("create share token: %w", err)
+			return mailDecorateProblemMessage(err, "create share token")
 		}
 		cardID, _ := createResp["card_id"].(string)
 		if cardID == "" {
-			return fmt.Errorf("create share token: response missing card_id")
+			return mailInvalidResponseError("create share token: response missing card_id")
 		}
 
-		sendResp, err := runtime.CallAPI("POST",
+		sendResp, err := runtime.CallAPITyped("POST",
 			mailboxPath(mailboxID, "share_tokens", cardID, "send"),
 			map[string]interface{}{"receive_id_type": receiveIDType},
 			map[string]interface{}{"receive_id": receiveID})
 		if err != nil {
-			return fmt.Errorf("share token created (card_id=%s) but send failed: %w", cardID, err)
+			return mailDecorateProblemMessage(err, "share token created (card_id=%s) but send failed", cardID)
 		}
 
 		runtime.Out(map[string]interface{}{

--- a/shortcuts/mail/mail_shortcut_validation_test.go
+++ b/shortcuts/mail/mail_shortcut_validation_test.go
@@ -16,16 +16,13 @@ import (
 
 // assertValidationError fails the test unless err carries the validation
 // category with ExitValidation exit code and a message containing wantSubstr.
-// Accepts both typed *errs.ValidationError and legacy *output.ExitError so
-// the helper survives the error-contract migration.
+// Mail-produced validation errors should be typed; the exit-code fallback keeps
+// shared framework validation gates covered without asserting their shape here.
 func assertValidationError(t *testing.T, err error, wantSubstr string) {
 	t.Helper()
 	if err == nil {
 		t.Fatal("expected a validation error, got nil")
 	}
-	// Accept both typed *errs.ValidationError and legacy *output.ExitError —
-	// the helper's purpose is to assert "this is a validation-category
-	// error" via either contract, so the dual-path matches the docstring.
 	code := output.ExitCodeOf(err)
 	if !errs.IsValidation(err) && code != output.ExitValidation {
 		t.Fatalf("expected a validation-category error, got %T: %v", err, err)
@@ -190,10 +187,21 @@ func validMessageIDForTest(s string) string {
 	return base64.URLEncoding.EncodeToString([]byte(s))
 }
 
+func rawMessageIDForTest(s string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(s))
+}
+
 func TestValidateMessageIDsAcceptsValidIDs(t *testing.T) {
 	_, err := validateMessageIDs(validMessageIDForTest("biz-001") + "," + validMessageIDForTest("biz-002"))
 	if err != nil {
 		t.Fatalf("expected nil error for valid IDs, got: %v", err)
+	}
+}
+
+func TestValidateMessageIDsAcceptsRawBase64URLIDs(t *testing.T) {
+	_, err := validateMessageIDs(rawMessageIDForTest("biz-raw-001"))
+	if err != nil {
+		t.Fatalf("expected nil error for raw base64url ID, got: %v", err)
 	}
 }
 

--- a/shortcuts/mail/mail_signature.go
+++ b/shortcuts/mail/mail_signature.go
@@ -110,7 +110,7 @@ func executeSignatureDetail(runtime *common.RuntimeContext, resp *signature.GetS
 		}
 	}
 	if sig == nil {
-		return output.ErrValidation("signature not found: %s", sigID)
+		return mailValidationParamError("--detail", "signature not found: %s", sigID)
 	}
 
 	lang := resolveLang(runtime)

--- a/shortcuts/mail/mail_template_create.go
+++ b/shortcuts/mail/mail_template_create.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -79,13 +78,17 @@ var MailTemplateCreate = common.Shortcut{
 			return err
 		}
 		if strings.TrimSpace(runtime.Str("name")) == "" {
-			return output.ErrValidation("--name is required")
+			return mailValidationParamError("--name", "--name is required")
 		}
 		if len([]rune(runtime.Str("name"))) > 100 {
-			return output.ErrValidation("--name must be at most 100 characters")
+			return mailValidationParamError("--name", "--name must be at most 100 characters")
 		}
 		if runtime.Str("template-content") != "" && runtime.Str("template-content-file") != "" {
-			return output.ErrValidation("--template-content and --template-content-file are mutually exclusive")
+			return mailValidationError("--template-content and --template-content-file are mutually exclusive").
+				WithParams(
+					mailInvalidParam("--template-content", "mutually exclusive with --template-content-file"),
+					mailInvalidParam("--template-content-file", "mutually exclusive with --template-content"),
+				)
 		}
 		return nil
 	},
@@ -104,7 +107,7 @@ var MailTemplateCreate = common.Shortcut{
 
 		content = wrapTemplateContentIfNeeded(content, isPlainText)
 		if int64(len(content)) > maxTemplateContentBytes {
-			return output.ErrValidation("template content exceeds %d MB (got %.1f MB)",
+			return mailFailedPreconditionError("template content exceeds %d MB (got %.1f MB)",
 				maxTemplateContentBytes/(1024*1024),
 				float64(len(content))/1024/1024)
 		}
@@ -142,7 +145,7 @@ var MailTemplateCreate = common.Shortcut{
 
 		resp, err := createTemplate(runtime, mailboxID, payload)
 		if err != nil {
-			return fmt.Errorf("create template failed: %w", err)
+			return mailDecorateProblemMessage(err, "create template failed")
 		}
 		tpl, _ := extractTemplatePayload(resp)
 		out := map[string]interface{}{
@@ -173,12 +176,12 @@ func resolveTemplateContent(runtime *common.RuntimeContext) (content, sourcePath
 	}
 	f, err := runtime.FileIO().Open(path)
 	if err != nil {
-		return "", path, output.ErrValidation("open --template-content-file %s: %v", path, err)
+		return "", path, mailValidationParamError("--template-content-file", "open --template-content-file %s: %v", path, err).WithCause(mailInputStatError(err))
 	}
 	defer f.Close()
 	buf, err := io.ReadAll(f)
 	if err != nil {
-		return "", path, output.ErrValidation("read --template-content-file %s: %v", path, err)
+		return "", path, mailValidationParamError("--template-content-file", "read --template-content-file %s: %v", path, err).WithCause(err)
 	}
 	return string(buf), path, nil
 }

--- a/shortcuts/mail/mail_template_update.go
+++ b/shortcuts/mail/mail_template_update.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -93,13 +92,17 @@ var MailTemplateUpdate = common.Shortcut{
 			return err
 		}
 		if runtime.Str("template-id") == "" {
-			return output.ErrValidation("--template-id is required (or use --print-patch-template to print the patch skeleton)")
+			return mailValidationParamError("--template-id", "--template-id is required (or use --print-patch-template to print the patch skeleton)")
 		}
 		if runtime.Str("set-template-content") != "" && runtime.Str("set-template-content-file") != "" {
-			return output.ErrValidation("--set-template-content and --set-template-content-file are mutually exclusive")
+			return mailValidationError("--set-template-content and --set-template-content-file are mutually exclusive").
+				WithParams(
+					mailInvalidParam("--set-template-content", "mutually exclusive with --set-template-content-file"),
+					mailInvalidParam("--set-template-content-file", "mutually exclusive with --set-template-content"),
+				)
 		}
 		if name := runtime.Str("set-name"); name != "" && len([]rune(name)) > 100 {
-			return output.ErrValidation("--set-name must be at most 100 characters")
+			return mailValidationParamError("--set-name", "--set-name must be at most 100 characters")
 		}
 		return nil
 	},
@@ -171,16 +174,16 @@ var MailTemplateUpdate = common.Shortcut{
 		if pf := strings.TrimSpace(runtime.Str("patch-file")); pf != "" {
 			f, err := runtime.FileIO().Open(pf)
 			if err != nil {
-				return output.ErrValidation("open --patch-file %s: %v", pf, err)
+				return mailValidationParamError("--patch-file", "open --patch-file %s: %v", pf, err).WithCause(mailInputStatError(err))
 			}
 			buf, readErr := io.ReadAll(f)
 			f.Close()
 			if readErr != nil {
-				return output.ErrValidation("read --patch-file %s: %v", pf, readErr)
+				return mailValidationParamError("--patch-file", "read --patch-file %s: %v", pf, readErr).WithCause(readErr)
 			}
 			var patch templatePatchFile
 			if err := json.Unmarshal(buf, &patch); err != nil {
-				return output.ErrValidation("parse --patch-file %s: %v", pf, err)
+				return mailValidationParamError("--patch-file", "parse --patch-file %s: %v", pf, err).WithCause(err)
 			}
 			if patch.TemplateContent != nil {
 				contentChanged = true
@@ -198,7 +201,7 @@ var MailTemplateUpdate = common.Shortcut{
 			tpl.TemplateContent = wrapTemplateContentIfNeeded(tpl.TemplateContent, tpl.IsPlainTextMode)
 		}
 		if int64(len(tpl.TemplateContent)) > maxTemplateContentBytes {
-			return output.ErrValidation("template content exceeds %d MB (got %.1f MB)",
+			return mailFailedPreconditionError("template content exceeds %d MB (got %.1f MB)",
 				maxTemplateContentBytes/(1024*1024),
 				float64(len(tpl.TemplateContent))/1024/1024)
 		}
@@ -278,7 +281,7 @@ var MailTemplateUpdate = common.Shortcut{
 
 		resp, err := updateTemplate(runtime, mailboxID, tid, tpl)
 		if err != nil {
-			return fmt.Errorf("update template failed: %w", err)
+			return mailDecorateProblemMessage(err, "update template failed")
 		}
 		updated, _ := extractTemplatePayload(resp)
 		out := map[string]interface{}{
@@ -312,12 +315,12 @@ func resolveTemplateUpdateContent(runtime *common.RuntimeContext) (content, sour
 	}
 	f, err := runtime.FileIO().Open(path)
 	if err != nil {
-		return "", path, output.ErrValidation("open --set-template-content-file %s: %v", path, err)
+		return "", path, mailValidationParamError("--set-template-content-file", "open --set-template-content-file %s: %v", path, err).WithCause(mailInputStatError(err))
 	}
 	defer f.Close()
 	buf, err := io.ReadAll(f)
 	if err != nil {
-		return "", path, output.ErrValidation("read --set-template-content-file %s: %v", path, err)
+		return "", path, mailValidationParamError("--set-template-content-file", "read --set-template-content-file %s: %v", path, err).WithCause(err)
 	}
 	return string(buf), path, nil
 }

--- a/shortcuts/mail/mail_thread.go
+++ b/shortcuts/mail/mail_thread.go
@@ -5,7 +5,6 @@ package mail
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strconv"
 
@@ -88,9 +87,9 @@ var MailThread = common.Shortcut{
 		if runtime.Bool("include-spam-trash") {
 			params["include_spam_trash"] = true
 		}
-		listData, err := runtime.CallAPI("GET", mailboxPath(mailboxID, "threads", threadID), params, nil)
+		listData, err := runtime.CallAPITyped("GET", mailboxPath(mailboxID, "threads", threadID), params, nil)
 		if err != nil {
-			return fmt.Errorf("failed to get thread: %w", err)
+			return mailDecorateProblemMessage(err, "failed to get thread")
 		}
 		// New API: data.thread.messages[]; fallback to old API: data.items[].message
 		var items []interface{}

--- a/shortcuts/mail/mail_triage.go
+++ b/shortcuts/mail/mail_triage.go
@@ -4,7 +4,6 @@
 package mail
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
@@ -140,7 +141,7 @@ var MailTriage = common.Shortcut{
 		outFormat := runtime.Str("format")
 		query := runtime.Str("query")
 		if query != "" {
-			if err := common.RejectDangerousChars("--query", query); err != nil {
+			if err := common.RejectDangerousCharsTyped("--query", query); err != nil {
 				return err
 			}
 		}
@@ -421,9 +422,9 @@ func parseTriageFilter(filterStr string) (triageFilter, error) {
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&filter); err != nil {
 		if hint := triageFilterUnknownFieldHint(err.Error()); hint != "" {
-			return triageFilter{}, output.ErrValidation("invalid --filter: %s", hint)
+			return triageFilter{}, mailValidationParamError("--filter", "invalid --filter: %s", hint)
 		}
-		return triageFilter{}, output.ErrValidation("invalid --filter: %s", err)
+		return triageFilter{}, mailValidationParamError("--filter", "invalid --filter: %s", err)
 	}
 	return filter, nil
 }
@@ -942,16 +943,16 @@ func resolveTriagePath(parsed triagePageToken, query string, filter triageFilter
 	switch parsed.Path {
 	case "search":
 		if !paramWantsSearch && (strings.TrimSpace(query) != "" || len(triageQueryFilterFields(filter)) > 0) {
-			return false, fmt.Errorf("--page-token has search: prefix but current --query/--filter parameters indicate list path; remove conflicting parameters or use the correct token")
+			return false, mailValidationParamError("--page-token", "--page-token has search: prefix but current --query/--filter parameters indicate list path; remove conflicting parameters or use the correct token")
 		}
 		return true, nil
 	case "list":
 		if paramWantsSearch {
-			return false, fmt.Errorf("--page-token has list: prefix but --query or --filter contains search-only fields (e.g. from/to/subject); these parameters would be silently ignored — remove them or use a search: token")
+			return false, mailValidationParamError("--page-token", "--page-token has list: prefix but --query or --filter contains search-only fields (e.g. from/to/subject); these parameters would be silently ignored; remove them or use a search: token")
 		}
 		return false, nil
 	default:
-		return false, fmt.Errorf("invalid --page-token: must start with 'search:' or 'list:' prefix (token was obtained from a previous mail +triage response)")
+		return false, mailValidationParamError("--page-token", "invalid --page-token: must start with 'search:' or 'list:' prefix (token was obtained from a previous mail +triage response)")
 	}
 }
 
@@ -978,15 +979,15 @@ func parseTriagePageToken(token string) (triagePageToken, error) {
 	}
 	idx := strings.IndexByte(token, ':')
 	if idx < 0 {
-		return triagePageToken{}, fmt.Errorf("invalid --page-token: must start with 'search:' or 'list:' prefix (token was obtained from a previous mail +triage response)")
+		return triagePageToken{}, mailValidationParamError("--page-token", "invalid --page-token: must start with 'search:' or 'list:' prefix (token was obtained from a previous mail +triage response)")
 	}
 	path := token[:idx]
 	raw := token[idx+1:]
 	if path != "search" && path != "list" {
-		return triagePageToken{}, fmt.Errorf("invalid --page-token: must start with 'search:' or 'list:' prefix, got %q", path)
+		return triagePageToken{}, mailValidationParamError("--page-token", "invalid --page-token: must start with 'search:' or 'list:' prefix, got %q", path)
 	}
 	if raw == "" {
-		return triagePageToken{}, fmt.Errorf("invalid --page-token: token value is empty after '%s:' prefix", path)
+		return triagePageToken{}, mailValidationParamError("--page-token", "invalid --page-token: token value is empty after '%s:' prefix", path)
 	}
 	return triagePageToken{Path: path, RawToken: raw}, nil
 }
@@ -1108,24 +1109,18 @@ func doJSONAPI(runtime *common.RuntimeContext, req *larkcore.ApiReq, action stri
 	var lastErr error
 	for attempt := 0; attempt <= triageAPIRetries; attempt++ {
 		apiResp, err := runtime.DoAPI(req)
-		if err == nil {
-			var result interface{}
-			dec := json.NewDecoder(bytes.NewReader(apiResp.RawBody))
-			dec.UseNumber()
-			if err := dec.Decode(&result); err != nil {
-				return nil, output.Errorf(output.ExitAPI, "api_error", "%s: response parse error: %s", action, err)
+		if err != nil {
+			lastErr = mailDecorateProblemMessage(client.WrapDoAPIError(err), "%s", action)
+			if attempt == triageAPIRetries {
+				return nil, lastErr
 			}
-			data, handleErr := common.HandleApiResult(result, nil, action)
+		} else {
+			data, handleErr := runtime.ClassifyAPIResponse(apiResp)
 			if handleErr == nil {
 				return data, nil
 			}
-			lastErr = handleErr
-			if !shouldRetryTriageAPIError(handleErr) || attempt == triageAPIRetries {
-				return nil, handleErr
-			}
-		} else {
-			lastErr = output.Errorf(output.ExitAPI, "api_error", "%s: %s", action, err)
-			if attempt == triageAPIRetries {
+			lastErr = mailDecorateProblemMessage(handleErr, "%s", action)
+			if !shouldRetryTriageAPIError(lastErr) || attempt == triageAPIRetries {
 				return nil, lastErr
 			}
 		}
@@ -1135,11 +1130,11 @@ func doJSONAPI(runtime *common.RuntimeContext, req *larkcore.ApiReq, action stri
 }
 
 func shouldRetryTriageAPIError(err error) bool {
-	exitErr, ok := err.(*output.ExitError)
-	if !ok || exitErr.Detail == nil {
+	p, ok := errs.ProblemOf(err)
+	if !ok {
 		return false
 	}
-	return exitErr.Detail.Type == "rate_limit" || exitErr.Code == output.ExitNetwork
+	return p.Subtype == errs.SubtypeRateLimit || p.Category == errs.CategoryNetwork
 }
 
 func toQueryParams(params map[string]interface{}) larkcore.QueryParams {

--- a/shortcuts/mail/mail_triage_test.go
+++ b/shortcuts/mail/mail_triage_test.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -117,6 +119,36 @@ func TestBuildSearchParamsSystemLabelAsFolder(t *testing.T) {
 	}
 	if filterBody["label"] != nil {
 		t.Fatalf("expected label to be absent, got %#v", filterBody["label"])
+	}
+}
+
+func TestMailTriageRejectsDangerousQueryWithTypedValidation(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	err := runMountedMailShortcut(t, MailTriage, []string{
+		"+triage", "--as", "user", "--query", "bad\x01",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected dangerous --query to return an error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T: %v", err, err)
+	}
+	if p.Category != errs.CategoryValidation {
+		t.Errorf("category = %q, want %q", p.Category, errs.CategoryValidation)
+	}
+	if p.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype = %q, want %q", p.Subtype, errs.SubtypeInvalidArgument)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	if validationErr.Param != "--query" {
+		t.Errorf("param = %q, want --query", validationErr.Param)
+	}
+	if !strings.Contains(p.Message, "control character") {
+		t.Errorf("message should mention control character, got: %s", p.Message)
 	}
 }
 
@@ -704,6 +736,43 @@ func TestFormatAddressFallbackToAddress(t *testing.T) {
 	got := formatAddress(map[string]interface{}{"address": "bob@b.com"})
 	if got != "bob@b.com" {
 		t.Fatalf("got %q", got)
+	}
+}
+
+func TestShouldRetryTriageAPIError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "rate limit",
+			err:  errs.NewAPIError(errs.SubtypeRateLimit, "too many requests"),
+			want: true,
+		},
+		{
+			name: "network",
+			err:  errs.NewNetworkError(errs.SubtypeNetworkTransport, "dial timeout"),
+			want: true,
+		},
+		{
+			name: "validation",
+			err:  errs.NewValidationError(errs.SubtypeInvalidArgument, "bad query"),
+			want: false,
+		},
+		{
+			name: "plain",
+			err:  assertErr("legacy plain error"),
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldRetryTriageAPIError(tc.err); got != tc.want {
+				t.Fatalf("shouldRetryTriageAPIError() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/shortcuts/mail/mail_watch.go
+++ b/shortcuts/mail/mail_watch.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,6 +22,8 @@ import (
 
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
@@ -187,7 +188,7 @@ var MailWatch = common.Shortcut{
 		switch outFormat {
 		case "json", "data", "":
 		default:
-			return output.ErrValidation("invalid --format %q: must be json or data", outFormat)
+			return mailValidationParamError("--format", "invalid --format %q: must be json or data", outFormat)
 		}
 		msgFormat := runtime.Str("msg-format")
 		outputDir := runtime.Str("output-dir")
@@ -196,18 +197,18 @@ var MailWatch = common.Shortcut{
 			// literal relative path (creating a directory named "~"), which is
 			// confusing. This also covers ~user/path forms.
 			if strings.HasPrefix(outputDir, "~") {
-				return output.ErrValidation("--output-dir does not support ~ expansion; use a relative path like ./output instead")
+				return mailValidationParamError("--output-dir", "--output-dir does not support ~ expansion; use a relative path like ./output instead")
 			}
 			// Enforce CWD containment: reject absolute paths, path traversal,
 			// and symlink escapes. SafeOutputPath returns a resolved absolute path
 			// under CWD, preventing writes to arbitrary system directories.
 			safePath, err := validate.SafeOutputPath(outputDir)
 			if err != nil {
-				return err
+				return mailValidationParamError("--output-dir", "invalid --output-dir %q: %v", outputDir, err).WithCause(err)
 			}
 			outputDir = safePath
 			if err := vfs.MkdirAll(outputDir, 0700); err != nil {
-				return fmt.Errorf("cannot create output directory %q: %w", outputDir, err)
+				return mailFileIOError("cannot create output directory %q: %v", err, outputDir, err)
 			}
 		}
 		labelIDsInput := runtime.Str("label-ids")
@@ -246,7 +247,7 @@ var MailWatch = common.Shortcut{
 
 		// Step 1: subscribe mailbox events (required before WebSocket pushes mail events)
 		info(fmt.Sprintf("Subscribing mailbox events for: %s", mailbox))
-		_, err = runtime.CallAPI("POST", mailboxPath(mailbox, "event", "subscribe"), nil, map[string]interface{}{"event_type": 1})
+		_, err = runtime.CallAPITyped("POST", mailboxPath(mailbox, "event", "subscribe"), nil, map[string]interface{}{"event_type": 1})
 		if err != nil {
 			return wrapWatchSubscribeError(err)
 		}
@@ -256,7 +257,7 @@ var MailWatch = common.Shortcut{
 		var unsubErr error
 		unsubscribe := func() error {
 			unsubOnce.Do(func() {
-				_, unsubErr = runtime.CallAPI("POST", mailboxPath(mailbox, "event", "unsubscribe"), nil, map[string]interface{}{"event_type": 1})
+				_, unsubErr = runtime.CallAPITyped("POST", mailboxPath(mailbox, "event", "unsubscribe"), nil, map[string]interface{}{"event_type": 1})
 			})
 			return unsubErr
 		}
@@ -485,7 +486,7 @@ var MailWatch = common.Shortcut{
 				if watchCtx.Err() != nil {
 					return nil
 				}
-				return output.ErrNetwork("WebSocket connection failed: %v", err)
+				return errs.NewNetworkError(errs.SubtypeNetworkTransport, "WebSocket connection failed: %v", err).WithCause(err)
 			}
 			return nil
 		}
@@ -508,7 +509,7 @@ func parseJSONArrayFlag(input, flagName string) ([]string, error) {
 	}
 	var values []string
 	if err := json.Unmarshal([]byte(trimmed), &values); err != nil {
-		return nil, output.ErrValidation("invalid --%s: expected JSON array of strings, e.g. [\"INBOX\",\"SENT\"]", flagName)
+		return nil, mailValidationParamError("--"+flagName, "invalid --%s: expected JSON array of strings, e.g. [\"INBOX\",\"SENT\"]", flagName).WithCause(err)
 	}
 	out := make([]string, 0, len(values))
 	for _, value := range values {
@@ -713,18 +714,12 @@ func fetchMessageForWatch(runtime *common.RuntimeContext, mailbox, messageID, fo
 		QueryParams: queryParams,
 	})
 	if err != nil {
+		return nil, client.WrapDoAPIError(err)
+	}
+	data, err := runtime.ClassifyAPIResponse(apiResp)
+	if err != nil {
 		return nil, err
 	}
-
-	var result map[string]interface{}
-	if err := json.Unmarshal(apiResp.RawBody, &result); err != nil {
-		return nil, err
-	}
-	if code, _ := result["code"].(float64); code != 0 {
-		msg, _ := result["msg"].(string)
-		return nil, fmt.Errorf("[%.0f] %s", code, msg)
-	}
-	data, _ := result["data"].(map[string]interface{})
 	msg, _ := data["message"].(map[string]interface{})
 	if msg == nil {
 		return data, nil
@@ -748,29 +743,40 @@ func wrapWatchSubscribeError(err error) error {
 		return nil
 	}
 	hint := "ensure the app has scope mail:event and the event mail.user_mailbox.event.message_received_v1 is enabled"
-	if exitErr, ok := err.(*output.ExitError); ok && exitErr.Detail != nil {
-		msg := "subscribe mailbox events failed: " + exitErr.Detail.Message
-		if exitErr.Detail.Hint != "" {
-			hint = exitErr.Detail.Hint + "; " + hint
+	if p, ok := errs.ProblemOf(err); ok {
+		p.Message = "subscribe mailbox events failed: " + p.Message
+		if strings.TrimSpace(p.Hint) != "" {
+			p.Hint = p.Hint + "; " + hint
+		} else {
+			p.Hint = hint
 		}
-		return output.ErrWithHint(exitErr.Code, exitErr.Detail.Type, msg, hint)
+		return err
 	}
-	return output.ErrWithHint(output.ExitAPI, "api_error", fmt.Sprintf("subscribe mailbox events failed: %v", err), hint)
+	return errs.NewAPIError(errs.SubtypeUnknown, "subscribe mailbox events failed: %v", err).WithHint("%s", hint).WithCause(err)
 }
 
 // enhanceProfileError wraps a profile API error with actionable hints.
 // Permission errors get a scope-specific hint; other errors (network, 5xx)
 // are reported as-is so diagnostics aren't misleading.
 func enhanceProfileError(err error) error {
-	var exitErr *output.ExitError
-	if errors.As(err, &exitErr) && exitErr.Detail != nil {
-		errType := exitErr.Detail.Type
-		lower := strings.ToLower(exitErr.Detail.Message)
-		if errType == "permission" || errType == "missing_scope" ||
-			strings.Contains(lower, "permission") || strings.Contains(lower, "scope") {
-			return output.ErrWithHint(output.ExitAuth, "missing_scope",
-				"unable to resolve mailbox address: "+exitErr.Detail.Message,
-				"run `lark-cli auth login --scope \"mail:user_mailbox:readonly\"` to grant mailbox profile access")
+	if p, ok := errs.ProblemOf(err); ok {
+		lower := strings.ToLower(p.Message)
+		if p.Category == errs.CategoryAuthorization {
+			p.Message = "unable to resolve mailbox address: " + p.Message
+			p.Hint = "run `lark-cli auth login --scope \"mail:user_mailbox:readonly\"` to grant mailbox profile access"
+			return err
+		}
+		if strings.Contains(lower, "permission") || strings.Contains(lower, "scope") {
+			permErr := errs.NewPermissionError(errs.SubtypeMissingScope, "unable to resolve mailbox address: %s", p.Message).
+				WithHint("run `lark-cli auth login --scope \"mail:user_mailbox:readonly\"` to grant mailbox profile access").
+				WithCause(err)
+			if p.Code != 0 {
+				permErr = permErr.WithCode(p.Code)
+			}
+			if p.LogID != "" {
+				permErr = permErr.WithLogID(p.LogID)
+			}
+			return permErr
 		}
 	}
 	// Preserve original error (and its exit code) for non-permission failures.

--- a/shortcuts/mail/mail_watch_test.go
+++ b/shortcuts/mail/mail_watch_test.go
@@ -8,16 +8,19 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/core"
-	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/vfs"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
 )
@@ -218,6 +221,72 @@ func TestMailWatchDryRunEventFormatWithLabelFilterFetchesMessage(t *testing.T) {
 	}
 	if got := apis[2].Params["format"]; got != "metadata" {
 		t.Fatalf("unexpected fetch format: %#v", got)
+	}
+}
+
+func TestMailWatchOutputDirRejectsUnsafePathTyped(t *testing.T) {
+	chdirTemp(t)
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+
+	err := runMountedMailShortcut(t, MailWatch, []string{
+		"+watch",
+		"--output-dir", "../escape",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected unsafe output-dir error")
+	}
+
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T: %v", err, err)
+	}
+	if validationErr.Param != "--output-dir" {
+		t.Fatalf("param = %q, want --output-dir", validationErr.Param)
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if p.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("subtype = %q, want %q", p.Subtype, errs.SubtypeInvalidArgument)
+	}
+}
+
+func TestMailWatchOutputDirMkdirFailureTyped(t *testing.T) {
+	chdirTemp(t)
+	mkdirErr := errors.New("mkdir denied")
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	oldFS := vfs.DefaultFS
+	vfs.DefaultFS = failingMkdirFS{OsFs: vfs.OsFs{}, err: mkdirErr}
+	t.Cleanup(func() { vfs.DefaultFS = oldFS })
+
+	err := runMountedMailShortcut(t, MailWatch, []string{
+		"+watch",
+		"--output-dir", "watch-output",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected mkdir error")
+	}
+
+	var internalErr *errs.InternalError
+	if !errors.As(err, &internalErr) {
+		t.Fatalf("expected internal error, got %T: %v", err, err)
+	}
+	if !errors.Is(err, mkdirErr) {
+		t.Fatalf("cause not preserved: %v", err)
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if p.Subtype != errs.SubtypeFileIO {
+		t.Fatalf("subtype = %q, want %q", p.Subtype, errs.SubtypeFileIO)
+	}
+	if strings.Contains(p.Message, "%!(") {
+		t.Fatalf("message contains fmt extra marker: %q", p.Message)
+	}
+	if !strings.Contains(p.Message, "cannot create output directory") || !strings.Contains(p.Message, "mkdir denied") {
+		t.Fatalf("message missing context: %q", p.Message)
 	}
 }
 
@@ -523,24 +592,93 @@ func TestWrapWatchSubscribeErrorPlain(t *testing.T) {
 	}
 }
 
-func TestWrapWatchSubscribeErrorExitError(t *testing.T) {
-	exitErr := &output.ExitError{
-		Code: output.ExitAPI,
-		Detail: &output.ErrDetail{
-			Type:    "api_error",
-			Message: "permission denied",
-			Hint:    "check app permissions",
-		},
-	}
-	err := wrapWatchSubscribeError(exitErr)
+func TestWrapWatchSubscribeErrorTypedProblem(t *testing.T) {
+	apiErr := errs.NewAPIError(errs.SubtypePermissionDenied, "permission denied").
+		WithHint("check app permissions")
+	err := wrapWatchSubscribeError(apiErr)
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "subscribe mailbox events failed") {
-		t.Fatalf("unexpected message: %v", err)
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
 	}
-	if !strings.Contains(err.Error(), "permission denied") {
-		t.Fatalf("original message missing: %v", err)
+	if !strings.Contains(p.Message, "subscribe mailbox events failed") {
+		t.Fatalf("unexpected message: %v", p.Message)
+	}
+	if !strings.Contains(p.Message, "permission denied") {
+		t.Fatalf("original message missing: %v", p.Message)
+	}
+	if !strings.Contains(p.Hint, "check app permissions") {
+		t.Fatalf("original hint missing: %v", p.Hint)
+	}
+}
+
+func TestWrapWatchSubscribeErrorTypedProblemAddsMissingHint(t *testing.T) {
+	apiErr := errs.NewAPIError(errs.SubtypePermissionDenied, "permission denied")
+
+	err := wrapWatchSubscribeError(apiErr)
+
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if !strings.Contains(p.Hint, "mail:event") {
+		t.Fatalf("scope hint missing: %q", p.Hint)
+	}
+}
+
+func TestEnhanceProfileErrorAuthorization(t *testing.T) {
+	original := errs.NewPermissionError(errs.SubtypeMissingScope, "missing scope")
+
+	err := enhanceProfileError(original)
+
+	if err != original {
+		t.Fatalf("authorization error should be updated in place")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if !strings.Contains(p.Message, "unable to resolve mailbox address") {
+		t.Fatalf("message missing mailbox context: %q", p.Message)
+	}
+	if !strings.Contains(p.Hint, "mail:user_mailbox:readonly") {
+		t.Fatalf("profile scope hint missing: %q", p.Hint)
+	}
+}
+
+func TestEnhanceProfileErrorPermissionMessagePromotesToMissingScope(t *testing.T) {
+	original := errs.NewAPIError(errs.SubtypeUnknown, "scope denied").
+		WithCode(99991679).
+		WithLogID("logid-profile")
+
+	err := enhanceProfileError(original)
+
+	var permissionErr *errs.PermissionError
+	if !errors.As(err, &permissionErr) {
+		t.Fatalf("expected permission error, got %T", err)
+	}
+	if !errors.Is(err, original) {
+		t.Fatalf("original error not preserved as cause: %v", err)
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if p.Subtype != errs.SubtypeMissingScope {
+		t.Fatalf("subtype = %q, want %q", p.Subtype, errs.SubtypeMissingScope)
+	}
+	if p.Code != 99991679 || p.LogID != "logid-profile" {
+		t.Fatalf("code/logid not preserved: %+v", p)
+	}
+}
+
+func TestEnhanceProfileErrorPreservesNonPermissionError(t *testing.T) {
+	original := errs.NewNetworkError(errs.SubtypeNetworkTransport, "dial timeout")
+
+	if got := enhanceProfileError(original); got != original {
+		t.Fatalf("non-permission errors should pass through, got %T", got)
 	}
 }
 
@@ -686,6 +824,15 @@ func assertErr(msg string) error {
 type testErr struct{ msg string }
 
 func (e *testErr) Error() string { return e.msg }
+
+type failingMkdirFS struct {
+	vfs.OsFs
+	err error
+}
+
+func (f failingMkdirFS) MkdirAll(string, fs.FileMode) error {
+	return f.err
+}
 
 type watchDryRunPayload struct {
 	API []struct {

--- a/shortcuts/mail/signature/provider.go
+++ b/shortcuts/mail/signature/provider.go
@@ -5,9 +5,9 @@ package signature
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/url"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -27,19 +27,19 @@ func ListAll(runtime *common.RuntimeContext, mailboxID string) (*GetSignaturesRe
 		return cached, nil
 	}
 
-	data, err := runtime.CallAPI("GET", signaturesPath(mailboxID), nil, nil)
+	data, err := runtime.CallAPITyped("GET", signaturesPath(mailboxID), nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("get signatures: %w", err)
+		return nil, err
 	}
 
 	raw, err := json.Marshal(data)
 	if err != nil {
-		return nil, fmt.Errorf("get signatures: marshal response: %w", err)
+		return nil, errs.NewInternalError(errs.SubtypeSDKError, "get signatures: marshal response: %v", err).WithCause(err)
 	}
 
 	var resp GetSignaturesResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {
-		return nil, fmt.Errorf("get signatures: unmarshal response: %w", err)
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse, "get signatures: unmarshal response: %v", err).WithCause(err)
 	}
 
 	processCache[mailboxID] = &resp
@@ -66,5 +66,5 @@ func Get(runtime *common.RuntimeContext, mailboxID, signatureID string) (*Signat
 			return &resp.Signatures[i], nil
 		}
 	}
-	return nil, fmt.Errorf("signature not found: %s", signatureID)
+	return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "signature not found: %s", signatureID)
 }

--- a/shortcuts/mail/signature_compose.go
+++ b/shortcuts/mail/signature_compose.go
@@ -5,7 +5,6 @@ package mail
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -13,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
 	"github.com/larksuite/cli/shortcuts/mail/emlbuilder"
@@ -33,8 +32,6 @@ type signatureResult struct {
 	Images          []draftpkg.SignatureImage
 }
 
-// resolveSignature fetches, interpolates, and downloads images for a signature.
-// Returns nil if signatureID is empty.
 // resolveSignature fetches, interpolates, and downloads images for a signature.
 // fromEmail is the --from address (may be an alias); used to match the correct
 // sender identity for template interpolation. Pass "" to use the primary address.
@@ -62,7 +59,7 @@ func resolveSignature(ctx context.Context, runtime *common.RuntimeContext, mailb
 		}
 		data, ct, err := downloadSignatureImage(runtime, img.DownloadURL, img.ImageName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to download signature image %s: %w", img.ImageName, err)
+			return nil, mailDecorateProblemMessage(err, "failed to download signature image %s", img.ImageName)
 		}
 		images = append(images, draftpkg.SignatureImage{
 			CID:         img.CID,
@@ -110,13 +107,12 @@ func addSignatureImagesToBuilder(bld emlbuilder.Builder, sig *signatureResult) e
 	return bld
 }
 
-// resolveSenderInfo fetches senderName and senderEmail via the send_as API.
 // resolveSenderInfo fetches send_as addresses and returns the name/email
 // for signature interpolation. If fromEmail is non-empty, it matches
 // that address in the sendable list (for alias/send_as scenarios);
 // otherwise falls back to the first (primary) address.
 func resolveSenderInfo(runtime *common.RuntimeContext, mailboxID, fromEmail string) (name, email string) {
-	data, err := runtime.CallAPI("GET", mailboxPath(mailboxID, "settings", "send_as"), nil, nil)
+	data, err := runtime.CallAPITyped("GET", mailboxPath(mailboxID, "settings", "send_as"), nil, nil)
 	if err != nil {
 		return "", ""
 	}
@@ -155,45 +151,54 @@ func resolveSenderInfo(runtime *common.RuntimeContext, mailboxID, fromEmail stri
 func downloadSignatureImage(runtime *common.RuntimeContext, downloadURL, filename string) ([]byte, string, error) {
 	u, err := url.Parse(downloadURL)
 	if err != nil {
-		return nil, "", fmt.Errorf("signature image download: invalid URL: %w", err)
+		return nil, "", mailInvalidResponseError("signature image download: invalid URL: %v", err).WithCause(err)
 	}
 	if u.Scheme != "https" {
-		return nil, "", fmt.Errorf("signature image download: URL must use https (got %q)", u.Scheme)
+		return nil, "", mailInvalidResponseError("signature image download: URL must use https (got %q)", u.Scheme)
 	}
 	if u.Host == "" {
-		return nil, "", fmt.Errorf("signature image download: URL has no host")
+		return nil, "", mailInvalidResponseError("signature image download: URL has no host")
 	}
 
 	httpClient, err := runtime.Factory.HttpClient()
 	if err != nil {
-		return nil, "", fmt.Errorf("signature image download: %w", err)
+		return nil, "", errs.NewInternalError(errs.SubtypeSDKError, "signature image download: %v", err).WithCause(err)
 	}
 	ctx, cancel := context.WithTimeout(runtime.Ctx(), 30*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
-		return nil, "", fmt.Errorf("signature image download: %w", err)
+		return nil, "", errs.NewInternalError(errs.SubtypeSDKError, "signature image download: %v", err).WithCause(err)
 	}
 	// Do NOT send Authorization: the download URL is pre-signed.
 
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, "", fmt.Errorf("signature image download: %w", err)
+		return nil, "", errs.NewNetworkError(errs.SubtypeNetworkTransport, "signature image download: %v", err).WithCause(err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, "", fmt.Errorf("signature image download: HTTP %d: %s", resp.StatusCode, string(body))
+		if resp.StatusCode >= 500 {
+			return nil, "", errs.NewNetworkError(errs.SubtypeNetworkServer, "signature image download: HTTP %d: %s", resp.StatusCode, string(body)).
+				WithCode(resp.StatusCode).
+				WithRetryable()
+		}
+		subtype := errs.SubtypeUnknown
+		if resp.StatusCode == http.StatusNotFound {
+			subtype = errs.SubtypeNotFound
+		}
+		return nil, "", errs.NewAPIError(subtype, "signature image download: HTTP %d: %s", resp.StatusCode, string(body)).WithCode(resp.StatusCode)
 	}
 
 	const maxSize = 10 * 1024 * 1024
 	data, err := io.ReadAll(io.LimitReader(resp.Body, maxSize+1))
 	if err != nil {
-		return nil, "", fmt.Errorf("signature image download: read body: %w", err)
+		return nil, "", errs.NewNetworkError(errs.SubtypeNetworkTransport, "signature image download: read body: %v", err).WithCause(err)
 	}
 	if len(data) > maxSize {
-		return nil, "", fmt.Errorf("signature image download: file exceeds 10MB limit")
+		return nil, "", mailFailedPreconditionError("signature image download: file exceeds 10MB limit")
 	}
 
 	ct := resp.Header.Get("Content-Type")
@@ -242,7 +247,11 @@ func signatureCIDs(sig *signatureResult) []string {
 // validateSignatureWithPlainText returns an error if both --plain-text and --signature-id are set.
 func validateSignatureWithPlainText(plainText bool, signatureID string) error {
 	if plainText && signatureID != "" {
-		return output.ErrValidation("--plain-text and --signature-id are mutually exclusive: signatures require HTML mode")
+		return mailValidationError("--plain-text and --signature-id are mutually exclusive: signatures require HTML mode").
+			WithParams(
+				mailInvalidParam("--plain-text", "mutually exclusive with --signature-id"),
+				mailInvalidParam("--signature-id", "requires HTML mode"),
+			)
 	}
 	return nil
 }

--- a/shortcuts/mail/signature_compose_test.go
+++ b/shortcuts/mail/signature_compose_test.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+)
+
+func TestDownloadSignatureImageRejectsInvalidURLs(t *testing.T) {
+	rt := newDownloadRuntime(t, &http.Client{})
+
+	cases := []struct {
+		name string
+		url  string
+	}{
+		{name: "invalid", url: "https://[::1"},
+		{name: "http", url: "http://example.com/sig.png"},
+		{name: "no host", url: "https:///sig.png"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := downloadSignatureImage(rt, tc.url, "sig.png")
+			var internalErr *errs.InternalError
+			if !errors.As(err, &internalErr) {
+				t.Fatalf("expected internal error, got %T (%v)", err, err)
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("expected typed problem, got %T", err)
+			}
+			if p.Subtype != errs.SubtypeInvalidResponse {
+				t.Fatalf("subtype = %q, want %q", p.Subtype, errs.SubtypeInvalidResponse)
+			}
+		})
+	}
+}
+
+func TestDownloadSignatureImageHTTPErrorClassification(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		statusCode int
+		wantType   any
+		wantSub    errs.Subtype
+		retryable  bool
+	}{
+		{
+			name:       "server",
+			statusCode: http.StatusInternalServerError,
+			wantType:   (*errs.NetworkError)(nil),
+			wantSub:    errs.SubtypeNetworkServer,
+			retryable:  true,
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			wantType:   (*errs.APIError)(nil),
+			wantSub:    errs.SubtypeNotFound,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "download failed", tc.statusCode)
+			}))
+			t.Cleanup(srv.Close)
+			rt := newDownloadRuntime(t, srv.Client())
+
+			_, _, err := downloadSignatureImage(rt, srv.URL+"/sig.png", "sig.png")
+			switch tc.wantType.(type) {
+			case *errs.NetworkError:
+				var networkErr *errs.NetworkError
+				if !errors.As(err, &networkErr) {
+					t.Fatalf("expected network error, got %T (%v)", err, err)
+				}
+			case *errs.APIError:
+				var apiErr *errs.APIError
+				if !errors.As(err, &apiErr) {
+					t.Fatalf("expected API error, got %T (%v)", err, err)
+				}
+			}
+			p, ok := errs.ProblemOf(err)
+			if !ok {
+				t.Fatalf("expected typed problem, got %T", err)
+			}
+			if p.Code != tc.statusCode {
+				t.Fatalf("code = %d, want %d", p.Code, tc.statusCode)
+			}
+			if p.Subtype != tc.wantSub {
+				t.Fatalf("subtype = %q, want %q", p.Subtype, tc.wantSub)
+			}
+			if p.Retryable != tc.retryable {
+				t.Fatalf("retryable = %v, want %v", p.Retryable, tc.retryable)
+			}
+		})
+	}
+}
+
+func TestDownloadSignatureImageReadAndSizeErrors(t *testing.T) {
+	readErr := errors.New("socket closed")
+	rt := newDownloadRuntime(t, &http.Client{
+		Transport: signatureRoundTripper(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       signatureErrorBody{err: readErr},
+				Request:    req,
+			}, nil
+		}),
+	})
+
+	_, _, err := downloadSignatureImage(rt, "https://example.com/sig.png", "sig.png")
+	var networkErr *errs.NetworkError
+	if !errors.As(err, &networkErr) {
+		t.Fatalf("expected network error, got %T (%v)", err, err)
+	}
+	if !errors.Is(err, readErr) {
+		t.Fatalf("read cause not preserved: %v", err)
+	}
+
+	rt = newDownloadRuntime(t, &http.Client{
+		Transport: signatureRoundTripper(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       &bodyFileTestFile{remaining: 10*1024*1024 + 1},
+				Request:    req,
+			}, nil
+		}),
+	})
+
+	_, _, err = downloadSignatureImage(rt, "https://example.com/huge.png", "huge.png")
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T (%v)", err, err)
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T", err)
+	}
+	if p.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("subtype = %q, want %q", p.Subtype, errs.SubtypeFailedPrecondition)
+	}
+}
+
+func TestDownloadSignatureImageSuccessUsesFilenameContentType(t *testing.T) {
+	rt := newDownloadRuntime(t, &http.Client{
+		Transport: signatureRoundTripper(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("gif-data")),
+				Request:    req,
+			}, nil
+		}),
+	})
+
+	data, contentType, err := downloadSignatureImage(rt, "https://example.com/sig.gif", "sig.gif")
+	if err != nil {
+		t.Fatalf("downloadSignatureImage failed: %v", err)
+	}
+	if string(data) != "gif-data" {
+		t.Fatalf("data = %q", string(data))
+	}
+	if contentType != "image/gif" {
+		t.Fatalf("content type = %q, want image/gif", contentType)
+	}
+}
+
+func TestValidateSignatureWithPlainTextTypedError(t *testing.T) {
+	err := validateSignatureWithPlainText(true, "sig_123")
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T (%v)", err, err)
+	}
+	if len(validationErr.Params) != 2 {
+		t.Fatalf("params = %#v, want two conflicting params", validationErr.Params)
+	}
+	if validationErr.Params[0].Name != "--plain-text" || validationErr.Params[1].Name != "--signature-id" {
+		t.Fatalf("unexpected params: %#v", validationErr.Params)
+	}
+}
+
+type signatureRoundTripper func(*http.Request) (*http.Response, error)
+
+func (rt signatureRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return rt(req)
+}
+
+type signatureErrorBody struct {
+	err error
+}
+
+func (b signatureErrorBody) Read([]byte) (int, error) {
+	return 0, b.err
+}
+
+func (b signatureErrorBody) Close() error {
+	return nil
+}

--- a/shortcuts/mail/template_compose.go
+++ b/shortcuts/mail/template_compose.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
 	"github.com/larksuite/cli/shortcuts/mail/emlbuilder"
@@ -222,7 +222,7 @@ func validateTemplateID(tid string) error {
 		return nil
 	}
 	if _, err := strconv.ParseInt(tid, 10, 64); err != nil {
-		return output.ErrValidation("--template-id must be a decimal integer string")
+		return mailValidationParamError("--template-id", "--template-id must be a decimal integer string")
 	}
 	return nil
 }
@@ -264,7 +264,7 @@ func joinTemplateAddresses(addrs []templateMailAddr) string {
 func generateTemplateCID() (string, error) {
 	id, err := uuid.NewRandom()
 	if err != nil {
-		return "", fmt.Errorf("failed to generate CID: %w", err)
+		return "", errs.NewInternalError(errs.SubtypeSDKError, "failed to generate CID: %v", err).WithCause(err)
 	}
 	return id.String(), nil
 }
@@ -276,23 +276,23 @@ func generateTemplateCID() (string, error) {
 func uploadToDriveForTemplate(ctx context.Context, runtime *common.RuntimeContext, path string) (fileKey string, size int64, err error) {
 	info, err := runtime.FileIO().Stat(path)
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to stat %s: %w", path, err)
+		return "", 0, mailInputStatError(err)
 	}
 	size = info.Size()
 	if size > MaxLargeAttachmentSize {
-		return "", size, fmt.Errorf("attachment %s (%.1f GB) exceeds the %.0f GB single file limit",
+		return "", size, mailFailedPreconditionError("attachment %s (%.1f GB) exceeds the %.0f GB single file limit",
 			filepath.Base(path), float64(size)/1024/1024/1024, float64(MaxLargeAttachmentSize)/1024/1024/1024)
 	}
 	name := filepath.Base(path)
 	if err := filecheck.CheckBlockedExtension(name); err != nil {
-		return "", size, err
+		return "", size, mailValidationError("%v", err).WithCause(err)
 	}
 	userOpenId := runtime.UserOpenId()
 	if userOpenId == "" {
-		return "", size, fmt.Errorf("template attachment upload requires user identity (--as user)")
+		return "", size, mailFailedPreconditionError("template attachment upload requires user identity (--as user)")
 	}
 	if size <= common.MaxDriveMediaUploadSinglePartSize {
-		fileKey, err = common.UploadDriveMediaAll(runtime, common.DriveMediaUploadAllConfig{
+		fileKey, err = common.UploadDriveMediaAllTyped(runtime, common.DriveMediaUploadAllConfig{
 			FilePath:   path,
 			FileName:   name,
 			FileSize:   size,
@@ -300,7 +300,7 @@ func uploadToDriveForTemplate(ctx context.Context, runtime *common.RuntimeContex
 			ParentNode: &userOpenId,
 		})
 	} else {
-		fileKey, err = common.UploadDriveMediaMultipart(runtime, common.DriveMediaMultipartUploadConfig{
+		fileKey, err = common.UploadDriveMediaMultipartTyped(runtime, common.DriveMediaMultipartUploadConfig{
 			FilePath:   path,
 			FileName:   name,
 			FileSize:   size,
@@ -309,7 +309,7 @@ func uploadToDriveForTemplate(ctx context.Context, runtime *common.RuntimeContex
 		})
 	}
 	if err != nil {
-		return "", size, fmt.Errorf("upload %s to Drive failed: %w", name, err)
+		return "", size, mailDecorateProblemMessage(err, "upload %s to Drive failed", name)
 	}
 	return fileKey, size, nil
 }
@@ -404,7 +404,7 @@ func (b *templateAttachmentBuilder) append(fileKey, filename, cid string, isInli
 // self-healing via the LARGE switch inside append().
 func (b *templateAttachmentBuilder) finalize() error {
 	if b.rawBodyInlineSmall > maxTemplateBodyInlineSmallBytes {
-		return fmt.Errorf("template body + inline images exceed %d MB (got %.1f MB); "+
+		return mailFailedPreconditionError("template body + inline images exceed %d MB (got %.1f MB); "+
 			"reduce inline image size or count — inline images cannot be promoted to LARGE",
 			maxTemplateBodyInlineSmallBytes/(1024*1024),
 			float64(b.rawBodyInlineSmall)/1024/1024)
@@ -511,9 +511,9 @@ func replaceImgSrcOnce(html, rawSrc, newSrc string) string {
 // fetchTemplate GETs a single template (full fields) for --template-id
 // composition and update patch workflows.
 func fetchTemplate(runtime *common.RuntimeContext, mailboxID, templateID string) (*templatePayload, error) {
-	data, err := runtime.CallAPI("GET", templateMailboxPath(mailboxID, templateID), nil, nil)
+	data, err := runtime.CallAPITyped("GET", templateMailboxPath(mailboxID, templateID), nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("fetch template %s failed: %w", templateID, err)
+		return nil, mailDecorateProblemMessage(err, "fetch template %s failed", templateID)
 	}
 	return extractTemplatePayload(data)
 }
@@ -526,29 +526,29 @@ func extractTemplatePayload(data map[string]interface{}) (*templatePayload, erro
 		raw = t
 	}
 	if raw == nil {
-		return nil, fmt.Errorf("API response missing template body")
+		return nil, mailInvalidResponseError("API response missing template body")
 	}
 	buf, err := json.Marshal(raw)
 	if err != nil {
-		return nil, fmt.Errorf("re-encode template payload failed: %w", err)
+		return nil, errs.NewInternalError(errs.SubtypeSDKError, "re-encode template payload failed: %v", err).WithCause(err)
 	}
 	var out templatePayload
 	if err := json.Unmarshal(buf, &out); err != nil {
-		return nil, fmt.Errorf("decode template payload failed: %w", err)
+		return nil, mailInvalidResponseError("decode template payload failed: %v", err).WithCause(err)
 	}
 	return &out, nil
 }
 
 // createTemplate POSTs a new template.
 func createTemplate(runtime *common.RuntimeContext, mailboxID string, tpl *templatePayload) (map[string]interface{}, error) {
-	return runtime.CallAPI("POST", templateMailboxPath(mailboxID), nil, map[string]interface{}{
+	return runtime.CallAPITyped("POST", templateMailboxPath(mailboxID), nil, map[string]interface{}{
 		"template": tpl,
 	})
 }
 
 // updateTemplate PUTs a full-replace update.
 func updateTemplate(runtime *common.RuntimeContext, mailboxID, templateID string, tpl *templatePayload) (map[string]interface{}, error) {
-	return runtime.CallAPI("PUT", templateMailboxPath(mailboxID, templateID), nil, map[string]interface{}{
+	return runtime.CallAPITyped("PUT", templateMailboxPath(mailboxID, templateID), nil, map[string]interface{}{
 		"template": tpl,
 	})
 }
@@ -889,9 +889,9 @@ func fetchTemplateAttachmentURLs(
 		}
 		apiURL := templateMailboxPath(mailboxID, templateID) + "/attachments/download_url?" + strings.Join(parts, "&")
 
-		data, err := runtime.CallAPI("GET", apiURL, nil, nil)
+		data, err := runtime.CallAPITyped("GET", apiURL, nil, nil)
 		if err != nil {
-			return nil, warnings, fmt.Errorf("template attachments/download_url (template_id=%s): %w", templateID, err)
+			return nil, warnings, mailDecorateProblemMessage(err, "template attachments/download_url (template_id=%s)", templateID)
 		}
 		if urls, ok := data["download_urls"].([]interface{}); ok {
 			for _, item := range urls {
@@ -976,11 +976,11 @@ func embedTemplateInlineAttachments(
 	for _, ref := range wanted {
 		dlURL, ok := urlMap[ref.FileKey]
 		if !ok || dlURL == "" {
-			return bld, nil, fmt.Errorf("template inline image %q (cid=%s): download URL not returned by server", ref.Filename, ref.CID)
+			return bld, nil, mailInvalidResponseError("template inline image %q (cid=%s): download URL not returned by server", ref.Filename, ref.CID)
 		}
 		bytes, err := downloadAttachmentContent(runtime, dlURL)
 		if err != nil {
-			return bld, nil, fmt.Errorf("template inline image %q (cid=%s): %w", ref.Filename, ref.CID, err)
+			return bld, nil, mailDecorateProblemMessage(err, "template inline image %q (cid=%s)", ref.Filename, ref.CID)
 		}
 		filename := ref.Filename
 		if filename == "" {
@@ -988,7 +988,7 @@ func embedTemplateInlineAttachments(
 		}
 		contentType, err := filecheck.CheckInlineImageFormat(filename, bytes)
 		if err != nil {
-			return bld, nil, fmt.Errorf("template inline image %q (cid=%s): %w", filename, ref.CID, err)
+			return bld, nil, mailValidationError("template inline image %q (cid=%s): %v", filename, ref.CID, err).WithCause(err)
 		}
 		bld = bld.AddInline(bytes, contentType, filename, ref.CID)
 		registered = append(registered, ref.CID)
@@ -1037,11 +1037,11 @@ func embedTemplateSmallAttachments(
 		}
 		dlURL, ok := urlMap[ref.FileKey]
 		if !ok || dlURL == "" {
-			return bld, 0, fmt.Errorf("template attachment %q: download URL not returned by server", ref.Filename)
+			return bld, 0, mailInvalidResponseError("template attachment %q: download URL not returned by server", ref.Filename)
 		}
 		buf, err := downloadAttachmentContent(runtime, dlURL)
 		if err != nil {
-			return bld, 0, fmt.Errorf("template attachment %q: %w", ref.Filename, err)
+			return bld, 0, mailDecorateProblemMessage(err, "template attachment %q", ref.Filename)
 		}
 		filename := ref.Filename
 		if filename == "" {

--- a/shortcuts/register_test.go
+++ b/shortcuts/register_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdmeta"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
@@ -400,17 +401,21 @@ func TestRegisterShortcutsInstallsMailFlagSuggestHook(t *testing.T) {
 
 	// The FlagErrorFunc lookup walks up to the nearest non-nil hook, so
 	// invoking it on the mail parent (or any of its children) must yield
-	// a structured *output.ExitError with type "unknown_flag".
+	// a typed validation problem for the unknown flag.
 	got := mailCmd.FlagErrorFunc()(mailCmd, errors.New("unknown flag: --bogus"))
-	var exitErr *output.ExitError
-	if !errors.As(got, &exitErr) {
-		t.Fatalf("expected *output.ExitError, got %T (%v)", got, got)
+	var validationErr *errs.ValidationError
+	if !errors.As(got, &validationErr) {
+		t.Fatalf("expected *errs.ValidationError, got %T (%v)", got, got)
 	}
-	if exitErr.Detail == nil || exitErr.Detail.Type != "unknown_flag" {
-		t.Fatalf("expected Detail.Type=unknown_flag, got %#v", exitErr.Detail)
+	if validationErr.Param != "--bogus" {
+		t.Fatalf("expected Param=--bogus, got %q", validationErr.Param)
 	}
-	if exitErr.Code != output.ExitAPI {
-		t.Fatalf("expected Code=ExitAPI(%d), got %d", output.ExitAPI, exitErr.Code)
+	problem, ok := errs.ProblemOf(got)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T (%v)", got, got)
+	}
+	if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("expected validation/invalid_argument, got %s/%s", problem.Category, problem.Subtype)
 	}
 }
 


### PR DESCRIPTION
## Summary

`shortcuts/mail` returned many command-facing errors through legacy `output.Err*` / `output.Errorf` / final `fmt.Errorf` paths and legacy API-call envelopes, so consumers had to recover classification from free-form message text. This migrates the mail domain to typed `errs.*` envelopes, giving callers stable `type`, `subtype`, `param` / `params`, `hint`, `retryable`, and `log_id` metadata across validation, API, network, file-I/O, and partial-failure flows. The shared drive-media upload helpers gain additive typed counterparts so mail's attachment uploads emit typed envelopes as well.

## Changes

- Migrate command-facing errors in `shortcuts/mail` from legacy output constructors, common legacy wrappers, and final bare `fmt.Errorf` returns to typed `errs.*` builders
- Convert mail API boundaries from legacy `runtime.CallAPI` / JSON helpers to typed calls or `runtime.ClassifyAPIResponse`, and update mail-specific enrichers to read and preserve `errs.ProblemOf` metadata
- Add `shortcuts/mail/mail_errors.go` with mail-local typed helpers for validation, file I/O, invalid-response, problem-message decoration, and hint enrichment
- Add `UploadDriveMediaAllTyped` / `UploadDriveMediaMultipartTyped` to `shortcuts/common` and deprecate the legacy pair (legacy implementations unchanged); mail's large-attachment and template-attachment uploads consume the typed variants so upload failures carry typed subtype / code / log_id
- Register mail API-code metadata for stable retry/quota hints and keep command-specific guidance in local enrichment paths
- Emit batch draft-send partial failures through `runtime.OutPartialFailure` so successful and failed draft sends stay structured in stdout while the command exits with a typed multi-status signal; account-level fatal classification reads typed category/subtype/code (unregistered not_found codes stay per-draft recoverable)
- Folder/label flags now resolve both IDs and names; `--message-ids` accepts unpadded base64url IDs; attachment and patch-file paths are validated with `SafeInputPath`/`ValidatePath` before reading; unknown-flag errors emit typed validation envelopes with candidate suggestions in `params`
- Update mail tests and fakes to assert typed errors, structured params, typed API metadata preservation, and partial-failure envelopes; add typed upload coverage in `shortcuts/common`
- Enforce typed-only mail errors through golangci path exceptions and the errscontract legacy-envelope / legacy-API-call guards

## Test Plan

- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go test -race ./shortcuts/mail/... ./shortcuts/ ./shortcuts/common/ ./internal/errclass/ ./internal/output/ ./errs/`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main ./shortcuts/mail/... ./shortcuts/common/... ./internal/errclass/...` — 0 issues
- [x] `go run -C lint . ..`
- [x] `go build ./...`

## Related Issues

N/A
