### PR TITLE
feat(sheets): add gridline show/hide shortcuts

### DIFF
--- a/shortcuts/sheets/batch_op_contract_test.go
+++ b/shortcuts/sheets/batch_op_contract_test.go
@@ -178,6 +178,18 @@ func TestBatchOp_BodyMatchesStandalone(t *testing.T) {
 			subInput: `{"sheet-id":"sh1","color":"#FF0000"}`,
 		},
 		{
+			shortcut: "+sheet-show-gridline",
+			sc:       SheetShowGridline,
+			args:     []string{"--sheet-id", "sh1"},
+			subInput: `{"sheet-id":"sh1"}`,
+		},
+		{
+			shortcut: "+sheet-hide-gridline",
+			sc:       SheetHideGridline,
+			args:     []string{"--sheet-id", "sh1"},
+			subInput: `{"sheet-id":"sh1"}`,
+		},
+		{
 			shortcut: "+dropdown-set",
 			sc:       DropdownSet,
 			args:     []string{"--sheet-id", "sh1", "--range", "A2:A4", "--options", `["x","y"]`, "--multiple"},

--- a/shortcuts/sheets/batch_op_dispatch.go
+++ b/shortcuts/sheets/batch_op_dispatch.go
@@ -152,6 +152,12 @@ var batchOpDispatch = map[string]batchOpMapping{
 		return sheetVisibilityInput(fv, t, sid, sn, "unhide")
 	}},
 	"+sheet-set-tab-color": {"modify_workbook_structure", sheetSetTabColorInput},
+	"+sheet-show-gridline": {"modify_workbook_structure", func(fv flagView, t, sid, sn string) (map[string]interface{}, error) {
+		return sheetVisibilityInput(fv, t, sid, sn, "show_gridline")
+	}},
+	"+sheet-hide-gridline": {"modify_workbook_structure", func(fv flagView, t, sid, sn string) (map[string]interface{}, error) {
+		return sheetVisibilityInput(fv, t, sid, sn, "hide_gridline")
+	}},
 
 	// ─── 对象族 CRUD (manage_*_object, operation 区分) ─────────────
 	"+chart-create": {"manage_chart_object", objCreateTranslate(chartSpec)},

--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -413,6 +413,86 @@
       }
     ]
   },
+  "+sheet-hide-gridline": {
+    "risk": "write",
+    "flags": [
+      {
+        "name": "url",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet URL (XOR with `--spreadsheet-token`)"
+      },
+      {
+        "name": "spreadsheet-token",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet token (XOR with `--url`)"
+      },
+      {
+        "name": "sheet-id",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Sheet reference_id (XOR with `--sheet-name`)"
+      },
+      {
+        "name": "sheet-name",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Sheet name (XOR with `--sheet-id`)"
+      },
+      {
+        "name": "dry-run",
+        "kind": "system",
+        "type": "bool",
+        "required": "optional",
+        "desc": ""
+      }
+    ]
+  },
+  "+sheet-show-gridline": {
+    "risk": "write",
+    "flags": [
+      {
+        "name": "url",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet URL (XOR with `--spreadsheet-token`)"
+      },
+      {
+        "name": "spreadsheet-token",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet token (XOR with `--url`)"
+      },
+      {
+        "name": "sheet-id",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Sheet reference_id (XOR with `--sheet-name`)"
+      },
+      {
+        "name": "sheet-name",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Sheet name (XOR with `--sheet-id`)"
+      },
+      {
+        "name": "dry-run",
+        "kind": "system",
+        "type": "bool",
+        "required": "optional",
+        "desc": ""
+      }
+    ]
+  },
   "+workbook-create": {
     "risk": "write",
     "flags": [

--- a/shortcuts/sheets/flag_defs_gen.go
+++ b/shortcuts/sheets/flag_defs_gen.go
@@ -793,6 +793,16 @@ var flagDefs = map[string]commandDef{
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
 		},
 	},
+	"+sheet-hide-gridline": {
+		Risk: "write",
+		Flags: []flagDef{
+			{Name: "url", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet URL (XOR with `--spreadsheet-token`)"},
+			{Name: "spreadsheet-token", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet token (XOR with `--url`)"},
+			{Name: "sheet-id", Kind: "public", Type: "string", Required: "xor", Desc: "Sheet reference_id (XOR with `--sheet-name`)"},
+			{Name: "sheet-name", Kind: "public", Type: "string", Required: "xor", Desc: "Sheet name (XOR with `--sheet-id`)"},
+			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
+		},
+	},
 	"+sheet-info": {
 		Risk: "read",
 		Flags: []flagDef{
@@ -836,6 +846,16 @@ var flagDefs = map[string]commandDef{
 			{Name: "sheet-id", Kind: "public", Type: "string", Required: "xor", Desc: "Sheet reference_id (XOR with `--sheet-name`)"},
 			{Name: "sheet-name", Kind: "public", Type: "string", Required: "xor", Desc: "Sheet name (XOR with `--sheet-id`)"},
 			{Name: "color", Kind: "own", Type: "string", Required: "required", Desc: "Hex color like `#FF0000`; pass empty string `\"\"` to clear"},
+			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
+		},
+	},
+	"+sheet-show-gridline": {
+		Risk: "write",
+		Flags: []flagDef{
+			{Name: "url", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet URL (XOR with `--spreadsheet-token`)"},
+			{Name: "spreadsheet-token", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet token (XOR with `--url`)"},
+			{Name: "sheet-id", Kind: "public", Type: "string", Required: "xor", Desc: "Sheet reference_id (XOR with `--sheet-name`)"},
+			{Name: "sheet-name", Kind: "public", Type: "string", Required: "xor", Desc: "Sheet name (XOR with `--sheet-id`)"},
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
 		},
 	},

--- a/shortcuts/sheets/lark_sheet_workbook.go
+++ b/shortcuts/sheets/lark_sheet_workbook.go
@@ -540,6 +540,18 @@ var SheetSetTabColor = common.Shortcut{
 	},
 }
 
+// SheetShowGridline / SheetHideGridline toggle a sub-sheet's gridline display.
+// Gridline show/hide is the same two-state-via-operation shape as
+// +sheet-hide/+sheet-unhide (no --visible flag), so they reuse
+// newSheetVisibilityShortcut; only the operation enum differs.
+var SheetShowGridline = newSheetVisibilityShortcut(
+	"+sheet-show-gridline", "Show gridlines on a sub-sheet.", "show_gridline",
+)
+
+var SheetHideGridline = newSheetVisibilityShortcut(
+	"+sheet-hide-gridline", "Hide gridlines on a sub-sheet.", "hide_gridline",
+)
+
 // ─── +workbook-create (legacy OAPI, cli_status: cli-only) ────────────
 //
 // Creates a brand-new spreadsheet via POST /sheets/v3/spreadsheets, then

--- a/shortcuts/sheets/lark_sheet_workbook_test.go
+++ b/shortcuts/sheets/lark_sheet_workbook_test.go
@@ -140,6 +140,28 @@ func TestWorkbookShortcuts_DryRun(t *testing.T) {
 				"tab_color": "",
 			},
 		},
+		{
+			name:     "+sheet-show-gridline",
+			sc:       SheetShowGridline,
+			args:     []string{"--url", testURL, "--sheet-id", testSheetID},
+			toolName: "modify_workbook_structure",
+			wantInput: map[string]interface{}{
+				"excel_id":  testToken,
+				"operation": "show_gridline",
+				"sheet_id":  testSheetID,
+			},
+		},
+		{
+			name:     "+sheet-hide-gridline",
+			sc:       SheetHideGridline,
+			args:     []string{"--url", testURL, "--sheet-id", testSheetID},
+			toolName: "modify_workbook_structure",
+			wantInput: map[string]interface{}{
+				"excel_id":  testToken,
+				"operation": "hide_gridline",
+				"sheet_id":  testSheetID,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/shortcuts/sheets/shortcuts.go
+++ b/shortcuts/sheets/shortcuts.go
@@ -38,6 +38,8 @@ func shortcutList() []common.Shortcut {
 		SheetHide,
 		SheetUnhide,
 		SheetSetTabColor,
+		SheetShowGridline,
+		SheetHideGridline,
 		WorkbookCreate,
 		WorkbookExport,
 

--- a/skills/lark-sheets/references/lark-sheets-workbook.md
+++ b/skills/lark-sheets/references/lark-sheets-workbook.md
@@ -41,6 +41,8 @@
 | `+sheet-hide` | write | 工作簿 |
 | `+sheet-unhide` | write | 工作簿 |
 | `+sheet-set-tab-color` | write | 工作簿 |
+| `+sheet-hide-gridline` | write | 工作簿 |
+| `+sheet-show-gridline` | write | 工作簿 |
 | `+workbook-create` | write | 工作簿 |
 | `+workbook-export` | read | 工作簿 |
 
@@ -115,6 +117,18 @@ _公共四件套 · 系统：`--dry-run`_
 | --- | --- | --- | --- |
 | `--color` | string | required | Hex 色值如 `#FF0000`，传空 `""` 清除 |
 
+### `+sheet-hide-gridline`
+
+_公共四件套 · 系统：`--dry-run`_
+
+_仅含公共 / 系统 flag。_
+
+### `+sheet-show-gridline`
+
+_公共四件套 · 系统：`--dry-run`_
+
+_仅含公共 / 系统 flag。_
+
 ### `+workbook-create`
 
 _系统：`--dry-run`_
@@ -188,6 +202,14 @@ lark-cli sheets +sheet-unhide --url "..." --sheet-id "$SID"
 ```bash
 # Hex 色值；传空字符串 "" 清除标签色
 lark-cli sheets +sheet-set-tab-color --url "..." --sheet-id "$SID" --color "#FF0000"
+```
+
+### `+sheet-show-gridline` / `+sheet-hide-gridline`
+
+```bash
+# 切换子表网格线显隐；二态语义在命令名里，无需额外参数（同 +sheet-hide/+sheet-unhide）
+lark-cli sheets +sheet-show-gridline --url "..." --sheet-id "$SID"
+lark-cli sheets +sheet-hide-gridline --url "..." --sheet-id "$SID"
 ```
 
 ### Validate / DryRun / Execute 约束


### PR DESCRIPTION
## What

Add two worksheet-level shortcuts to toggle gridline visibility:

- `+sheet-show-gridline`
- `+sheet-hide-gridline`

Both target the `modify_workbook_structure` tool via the `show_gridline` / `hide_gridline` operations. This mirrors the existing `+sheet-hide` / `+sheet-unhide` two-state pattern — the show/hide intent lives in the operation enum, so no `--visible` flag is needed.

## Changes

- `shortcuts/sheets/lark_sheet_workbook.go`: `sheetGridlineInput` + `newSheetGridlineShortcut` factory + the two shortcuts
- `shortcuts/sheets/shortcuts.go`: registration
- `shortcuts/sheets/batch_op_dispatch.go`: two `+batch-update` sub-op mappings (reusing `sheetGridlineInput`)
- `shortcuts/sheets/data/flag-defs.json` + `flag_defs_gen.go`: flag definitions (four locator flags each, no own flag — same set as `+sheet-hide`)

## Testing

- `go test ./shortcuts/sheets/...` passes; the data-driven batch contract tests (`TestBatchOp_*`) automatically cover the new shortcuts.
- Dry-run confirms the emitted body: `modify_workbook_structure` with `operation: show_gridline` / `hide_gridline` and the sheet selector.

Server-side tool support is delivered separately; the flag-defs / reference docs are normally synced from the spec source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two sheet shortcuts to toggle gridline visibility: show and hide; accepts spreadsheet locators (URL or token) and sheet identifiers (ID or name).
  * Supports a dry-run mode to preview changes before applying.

* **Documentation**
  * Updated docs with flag descriptions and examples for both gridline commands.

* **Tests**
  * Added unit tests and dry-run contract checks covering both new shortcuts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->