### PR TITLE
chore(release): v1.0.48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.48] - 2026-06-04
+
+### Features
+
+- **mail**: Preserve mailbox context in `+triage` output for public mailboxes (#1238)
+- **contact**: Add contact skill domain guidance (#1144)
+
+### Bug Fixes
+
+- **skills**: Use JSON skills list during update (#1251)
+
+### Documentation
+
+- **drive**: Refine lark-drive knowledge organize workflow (#1253)
+- **vc-agent**: Require explicit leave request (#1260)
+- **slides**: Add whiteboard element documentation and improve slide guidance (#1029)
+
 ## [v1.0.47] - 2026-06-03
 
 ### Features
@@ -1009,6 +1026,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.48]: https://github.com/larksuite/cli/releases/tag/v1.0.48
 [v1.0.47]: https://github.com/larksuite/cli/releases/tag/v1.0.47
 [v1.0.46]: https://github.com/larksuite/cli/releases/tag/v1.0.46
 [v1.0.45]: https://github.com/larksuite/cli/releases/tag/v1.0.45

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Summary
Release v1.0.48 — bumps the version and adds the changelog entry for the 2 features, 1 fix, and 3 docs changes that landed since v1.0.47.

## Changes
- Bump `package.json` version `1.0.47` → `1.0.48`
- Add `CHANGELOG.md` entry for v1.0.48 covering all 6 commits since the `v1.0.47` tag, and the corresponding release-link reference

## Test Plan
- [x] Docs-only / version bump — no code changes; existing CI applies
- [ ] Tag `v1.0.48` and publish release after merge so the changelog link resolves

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.0.48 with new features, bug fixes, and documentation updates documented in changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->