### PR TITLE
feat: clear recommend.allow scope auto-approve overrides

### DIFF
--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -231,14 +231,9 @@ func TestLoadAutoApproveSet(t *testing.T) {
 		t.Fatal("expected non-empty auto-approve set")
 	}
 
-	// From scope_overrides.json allow list
-	if !aaSet["calendar:calendar.event:create"] {
-		t.Error("expected calendar:calendar.event:create in auto-approve set (from allow list)")
-	}
-
-	// Verify allow list entries are present
+	// From scope_priorities.json recommend=="true"
 	if !aaSet["sheets:spreadsheet:read"] {
-		t.Error("expected sheets:spreadsheet:read in auto-approve set (from allow list)")
+		t.Error("expected sheets:spreadsheet:read in auto-approve set (recommend=true in priorities)")
 	}
 
 	t.Logf("Auto-approve set has %d scopes", len(aaSet))
@@ -257,16 +252,10 @@ func TestLoadPlatformAutoApproveSet(t *testing.T) {
 
 func TestLoadOverrideAutoApproveAllow(t *testing.T) {
 	allowSet := LoadOverrideAutoApproveAllow()
-	if len(allowSet) == 0 {
-		t.Fatal("expected non-empty override allow set")
-	}
-
-	// Known entries from scope_overrides.json
-	if !allowSet["calendar:calendar.event:create"] {
-		t.Error("expected calendar:calendar.event:create in allow set")
-	}
-	if !allowSet["mail:event"] {
-		t.Error("expected mail:event in allow set")
+	// recommend.allow in scope_overrides.json is intentionally empty:
+	// no scopes are special-cased into the auto-approve set anymore.
+	if len(allowSet) != 0 {
+		t.Errorf("expected empty override allow set, got %d entries", len(allowSet))
 	}
 }
 
@@ -277,9 +266,9 @@ func TestLoadOverrideAutoApproveDeny(t *testing.T) {
 }
 
 func TestIsAutoApproveScope(t *testing.T) {
-	// Known auto-approve scope (in allow list)
-	if !IsAutoApproveScope("calendar:calendar.event:create") {
-		t.Error("expected calendar:calendar.event:create to be auto-approve")
+	// Known auto-approve scope (recommend=true in scope_priorities.json)
+	if !IsAutoApproveScope("sheets:spreadsheet:read") {
+		t.Error("expected sheets:spreadsheet:read to be auto-approve")
 	}
 
 	// Completely unknown scope
@@ -290,9 +279,8 @@ func TestIsAutoApproveScope(t *testing.T) {
 
 func TestFilterAutoApproveScopes(t *testing.T) {
 	scopes := []string{
-		"calendar:calendar.event:create", // auto-approve (in allow list)
-		"zzz:unknown:scope",              // not in auto-approve
-		"sheets:spreadsheet:read",        // auto-approve (in allow list)
+		"sheets:spreadsheet:read", // auto-approve (recommend=true in priorities)
+		"zzz:unknown:scope",       // not in auto-approve
 	}
 
 	result := FilterAutoApproveScopes(scopes)
@@ -300,10 +288,10 @@ func TestFilterAutoApproveScopes(t *testing.T) {
 		t.Fatal("expected at least 1 auto-approve scope in result")
 	}
 
-	// Check that calendar:calendar.event:create is included
+	// Check that sheets:spreadsheet:read is included
 	found := false
 	for _, s := range result {
-		if s == "calendar:calendar.event:create" {
+		if s == "sheets:spreadsheet:read" {
 			found = true
 		}
 		// Ensure unknown scopes are not included
@@ -312,7 +300,7 @@ func TestFilterAutoApproveScopes(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Error("expected calendar:calendar.event:create in result")
+		t.Error("expected sheets:spreadsheet:read in result")
 	}
 }
 

--- a/internal/registry/scope_overrides.json
+++ b/internal/registry/scope_overrides.json
@@ -12,25 +12,7 @@
     "vc:meeting.meetingevent:read": 75
   },
   "recommend": {
-    "allow": [
-      "calendar:calendar.event:create",
-      "calendar:calendar.event:delete",
-      "calendar:calendar.event:read",
-      "calendar:calendar.event:update",
-      "calendar:calendar.free_busy:read",
-      "calendar:calendar:create",
-      "calendar:calendar:delete",
-      "calendar:calendar:read",
-      "calendar:calendar:update",
-      "contact:user.basic_profile:readonly",
-      "mail:event",
-      "mail:user_mailbox.mail_contact:read",
-      "mail:user_mailbox.mail_contact:write",
-      "mail:user_mailbox.message.address:read",
-      "mail:user_mailbox.message.body:read",
-      "mail:user_mailbox.message.subject:read",
-      "mail:user_mailbox.message:readonly"
-    ],
+    "allow": [],
     "deny": [
       "im:chat",
       "im:message.send_as_user"


### PR DESCRIPTION
## Summary

The `recommend.allow` list in `internal/registry/scope_overrides.json` special-cased a fixed set of calendar/contact/mail scopes into the auto-approve set, on top of the platform recommendations carried by `scope_priorities.json`. Per the decision to stop special-casing scopes, this clears the list entirely.

## Changes

- Empty the `recommend.allow` array in `scope_overrides.json`. The auto-approve set now reflects only `recommend=true` scopes from `scope_priorities.json` (minus the `recommend.deny` removals); the previously special-cased calendar/contact/mail scopes are no longer auto-approved.
- Update `registry_test.go` to use a `recommend=true` scope (`sheets:spreadsheet:read`) as the auto-approve sample, and assert the override allow set is now empty.

## Test Plan

- [x] Unit tests pass (`go test ./internal/registry/...`)
- [x] `go build ./...` succeeds
- [x] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated auto-approval behavior tests to align with new scope override rules

* **Chores**
  * Cleared auto-approval override allow-list configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->