### PR TITLE
docs: improve lark-markdown skill guidance

### DIFF
--- a/skills/lark-markdown/SKILL.md
+++ b/skills/lark-markdown/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-markdown
-version: 1.2.0
-description: "飞书 Markdown：查看、创建、上传、编辑和比较 Markdown 文件。当用户需要创建或编辑 Markdown 文件、读取、修改、局部 patch 或比较差异时使用。"
+version: 1.2.1
+description: "飞书 Markdown：查看、创建、上传、编辑和比较 Markdown 文件。当用户需要创建或编辑 Markdown 文件、读取、修改、局部 patch 或比较差异时使用。不负责将 Markdown 导入为飞书在线文档，也不负责文件搜索、权限、评论、移动、删除等云空间管理操作。"
 metadata:
   requires:
     bins: ["lark-cli"]
@@ -13,6 +13,8 @@ metadata:
 **CRITICAL — 开始前 MUST 先用 Read 工具读取 [`../lark-shared/SKILL.md`](../lark-shared/SKILL.md)，其中包含认证、权限处理**
 
 ## 快速决策
+
+- 身份：Markdown 文件通常属于用户云空间资源，优先使用 `--as user`。如为自动化场景，或应用已创建并持有目标文件权限，可按场景使用 `--as bot`。首次以 `user` 身份访问前执行 `lark-cli auth login`
 
 - 用户要**上传、创建一个原生 `.md` 文件**，使用 `lark-cli markdown +create`
 - 用户要**比较原生 `.md` 文件的历史版本差异**，或比较远端 Markdown 与本地草稿，使用 `lark-cli markdown +diff`
@@ -34,8 +36,18 @@ metadata:
 - `markdown +patch` 的内部语义是：**先完整下载 Markdown，再本地替换，再整文件覆盖上传**
 - `markdown +patch` 不是服务端原子 patch；它是 CLI 侧编排出来的局部更新能力
 - `markdown +patch` 当前只支持**单组** `--pattern` / `--content`
-- `markdown +patch` 替换后的最终内容**不能为空**；如果替换后整篇 Markdown 变成空字符串，CLI 会直接报错，不会上传空文件
+- `markdown +patch` 替换后的最终内容**不能为空**；CLI 会拒绝上传空文件，因为 Drive 不支持零字节 Markdown，且空文件通常是误操作
 - `--file` 只接受本地 `.md` 文件路径
+
+正则替换时要特别注意 `--pattern` 的转义：
+
+```bash
+# BAD: 未转义正则特殊字符，可能匹配到错误位置
+lark-cli markdown +patch --file-token boxcnxxxx --regex --pattern "version (1.0)" --content "version (2.0)"
+
+# GOOD: 显式转义括号和点号
+lark-cli markdown +patch --file-token boxcnxxxx --regex --pattern "version \\(1\\.0\\)" --content "version (2.0)"
+```
 
 ## Shortcuts（推荐优先使用）
 

--- a/skills/lark-markdown/references/lark-markdown-patch.md
+++ b/skills/lark-markdown/references/lark-markdown-patch.md
@@ -20,6 +20,13 @@ lark-cli markdown +patch \
   --pattern 'hello (.+)' \
   --content 'hi $1'
 
+# 正则 pattern 含特殊字符时要显式转义
+lark-cli markdown +patch \
+  --file-token boxcnxxxx \
+  --regex \
+  --pattern 'version \\(1\\.0\\)' \
+  --content 'version (2.0)'
+
 # 删除匹配内容
 lark-cli markdown +patch \
   --file-token boxcnxxxx \
@@ -63,8 +70,26 @@ lark-cli markdown +patch \
 - `--content` 必须显式传入，但允许为空字符串
 - 未加 `--regex` 时，行为等价于对整份 Markdown 文本执行 `strings.ReplaceAll`
 - 加了 `--regex` 时，行为等价于对整份 Markdown 文本执行 RE2 全量替换；`--content` 里的 `$1`、`${name}` 会按 Go regexp replacement template 解释，字面 `$` 请写成 `$$`
-- 替换后的最终 Markdown 不能为空；如果 patch 结果是空字符串，CLI 会直接报错，不会上传空文件
+- 替换后的最终 Markdown 不能为空；如果 patch 结果是空字符串，CLI 会直接报错，不会上传空文件，因为 Drive 不支持零字节 Markdown，且空文件通常是误操作
 - `0` 命中时命令仍然成功返回，但不会上传新版本
+
+## Good / Bad
+
+```bash
+# BAD: pattern 含正则特殊字符但未转义，容易匹配错误位置
+lark-cli markdown +patch \
+  --file-token boxcnxxxx \
+  --regex \
+  --pattern 'version (1.0)' \
+  --content 'version (2.0)'
+
+# GOOD: 显式转义括号和点号
+lark-cli markdown +patch \
+  --file-token boxcnxxxx \
+  --regex \
+  --pattern 'version \\(1\\.0\\)' \
+  --content 'version (2.0)'
+```
 
 ## 实现边界
 


### PR DESCRIPTION
## Summary
- add explicit in-scope and out-of-scope boundaries to the lark-markdown skill description so routing is clearer for Markdown versus broader Drive and online-document workflows
- clarify markdown identity guidance by prioritizing `--as user`, noting when `--as bot` can still apply, and pointing first-time user access to `lark-cli auth login`
- add regex good/bad examples for `markdown +patch` and explain why empty final content is rejected
- set the skill version to `1.2.1`

## Context
This updates the lark-markdown business-domain skill based on the referenced review points, covering routing boundaries, identity guidance, example completeness, and rationale for constraints.

## Testing
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated skill documentation (v1.2.0 → v1.2.1) with enhanced execution identity guidance (--as user vs --as bot)
  * Added prerequisite: run `lark-cli auth login` before first user access
  * Clarified markdown patch constraints: replaced content must be non-empty, file paths must be local `.md`
  * Added regex escaping guidance with BAD/GOOD pattern examples for special characters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->