### PR TITLE
fix(drive): use docs secure label read scope

### DIFF
--- a/shortcuts/drive/drive_secure_label.go
+++ b/shortcuts/drive/drive_secure_label.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	secureLabelReadScope   = "drive:file.meta.sec_label.read_only"
+	secureLabelReadScope   = "docs:secure_label:readonly"
 	secureLabelUpdateScope = "docs:secure_label:write_only"
 )
 

--- a/shortcuts/drive/drive_secure_label_test.go
+++ b/shortcuts/drive/drive_secure_label_test.go
@@ -12,6 +12,17 @@ import (
 	"github.com/larksuite/cli/internal/httpmock"
 )
 
+func TestDriveSecureLabelScopes(t *testing.T) {
+	t.Parallel()
+
+	if len(DriveSecureLabelList.Scopes) != 1 || DriveSecureLabelList.Scopes[0] != "docs:secure_label:readonly" {
+		t.Fatalf("list scopes = %v, want docs:secure_label:readonly", DriveSecureLabelList.Scopes)
+	}
+	if len(DriveSecureLabelUpdate.Scopes) != 1 || DriveSecureLabelUpdate.Scopes[0] != "docs:secure_label:write_only" {
+		t.Fatalf("update scopes = %v, want docs:secure_label:write_only", DriveSecureLabelUpdate.Scopes)
+	}
+}
+
 func TestDriveSecureLabelList_DryRun(t *testing.T) {
 	t.Parallel()
 	f, stdout, _, _ := cmdutil.TestFactory(t, driveTestConfig())


### PR DESCRIPTION

  ## Summary
  Update the Drive secure label list shortcut to request the correct read scope, `docs:secure_label:readonly`, so auth scope checks match the secure label API requirement.

  ## Changes
  - Replace the secure label list read scope with `docs:secure_label:readonly`
  - Add a unit test to pin the secure label list/update shortcut scopes

  ## Test Plan
  - [x] Unit tests pass
  - [x] Manual local verification confirms the `lark-cli drive +secure-label-list` flow works as expected

  Not run locally.

  ## Related Issues
  - None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated permission scopes for secure label operations.

* **Tests**
  * Added verification tests for secure label permission scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->