### PR TITLE
docs: add lark-drive permission governance workflow

### DIFF
--- a/skills/lark-drive/SKILL.md
+++ b/skills/lark-drive/SKILL.md
@@ -18,6 +18,7 @@ metadata:
 
 ## 快速决策
 
+- 用户要**检查 / 治理文档权限、公开范围、链接分享、外部访问、复制下载权限、密级标签、owner 转移**，或要“权限风险报告、收紧权限、申请查看 / 编辑权限、转移 / 批量转移 owner”，必须先阅读 [`references/lark-drive-workflow.md`](references/lark-drive-workflow.md)，再按其中 `Workflow Registry` 进入 [`permission_governance`](references/lark-drive-workflow-permission-governance.md) workflow。
 - 用户要**整理云盘 / 文件夹 / 文档库 / 知识库 / 个人文档库**，或要“盘点目录结构、找出未归档/临时/重复/空目录、生成整理方案”，必须先阅读 [`references/lark-drive-workflow-knowledge-organize.md`](references/lark-drive-workflow-knowledge-organize.md)。默认只生成方案；创建目录、移动资源、申请权限都必须单独确认。
 - 用户要**搜文档 / Wiki / 电子表格 / 多维表格 / 云空间（云盘/云存储）对象**，优先使用 `lark-cli drive +search`。自然语言里"最近我编辑过的"、"我创建的"（→ `--mine`，实为 owner 语义）、"最近一周我打开过的 xxx"、"某人 owner 的 docx" 等直接映射到扁平 flag，避免手写嵌套 JSON。
 - 用户要**根据文档评论定位正文位置**，例如 根据评论 review 文档、根据评论内容回看文档、区分多处相同引用文本时，对于 docx 类型（`file_type=docx`）的文档支持通过 `need_relation=true` 返回评论位置，其他类型暂不支持，具体用法需要先阅读 [`references/lark-drive-comment-location.md`](references/lark-drive-comment-location.md) 了解。

--- a/skills/lark-drive/references/lark-drive-workflow-permission-governance-commands.md
+++ b/skills/lark-drive/references/lark-drive-workflow-permission-governance-commands.md
@@ -1,0 +1,168 @@
+# 权限治理 Command Patterns
+
+本文只提供 `permission_governance` workflow 的具体 `lark-cli` 命令样例。只有进入对应 state 且需要拼装命令时才读取本文；命令可用范围仍以 [`lark-drive-workflow-permission-governance.md`](lark-drive-workflow-permission-governance.md) 的 `Command Map` 为准。
+
+## 目录
+
+- `目标解析`
+- `目标发现`
+- `事实读取`
+- `写前确认与执行`
+
+## 目标解析
+
+```bash
+lark-cli drive +inspect --url '<url>' --as user --format json
+```
+
+`/wiki/space/<space_id>` URL 是 Wiki space 范围，不要用 `drive +inspect` 当作单文档解析；直接提取 `space_id` 后进入 `DISCOVER_TARGETS`。
+
+## 目标发现
+
+发现 Wiki space / node 下目标：
+
+```bash
+lark-cli wiki +node-list \
+  --space-id '<space_id>' --page-size 50 \
+  --page-all --page-limit 0 \
+  --as user --format json
+
+lark-cli wiki +node-list \
+  --space-id '<space_id>' --parent-node-token '<node_token>' --page-size 50 \
+  --page-all --page-limit 0 \
+  --as user --format json
+
+lark-cli wiki +node-list \
+  --space-id '<space_id>' --page-token '<PAGE_TOKEN>' --page-size 50 \
+  --as user --format json
+```
+
+解析返回时使用 `data.nodes`，不要读取顶层 `items`。`--page-limit 0` 表示当前层分页不设页数上限；`--page-all` 只覆盖当前 `space-id` / `parent-node-token` 范围内的分页，不会递归子节点。节点 `has_child=true` 时，必须继续以该节点的 `node_token` 作为 `--parent-node-token` 递归读取。
+
+发现 Drive folder 下目标：
+
+```bash
+lark-cli drive files list \
+  --params '{"folder_token":"<folder_token>","page_size":200}' \
+  --as user --format json
+
+lark-cli drive files list \
+  --params '{"folder_token":"<folder_token>","page_size":200,"page_token":"<PAGE_TOKEN>"}' \
+  --as user --format json
+```
+
+## 事实读取
+
+读取 metadata：
+
+```bash
+lark-cli drive metas batch_query \
+  --data '{"request_docs":[{"doc_token":"<token>","doc_type":"<type>"}],"with_url":true}' \
+  --as user --format json
+```
+
+读取 public permission：
+
+```bash
+lark-cli drive permission.public get \
+  --params '{"token":"<token>","type":"<type>"}' \
+  --as user --format json
+```
+
+按需读取访问统计：
+
+```bash
+lark-cli drive file.statistics get \
+  --params '{"file_token":"<token>","file_type":"<type>"}' \
+  --as user --format json
+```
+
+按需读取最近访问记录：
+
+```bash
+lark-cli drive file.view_records list \
+  --params '{"file_token":"<token>","file_type":"<type>","page_size":50}' \
+  --as user --format json
+```
+
+## 写前确认与执行
+
+patch 前检查 manage-public permission：
+
+```bash
+lark-cli drive permission.members auth \
+  --params '{"token":"<token>","type":"<type>","action":"manage_public"}' \
+  --as user --format json
+```
+
+patch 前读取当前 schema：
+
+```bash
+lark-cli schema drive.permission.public.patch --format json
+```
+
+只 patch 当前 schema 支持的字段；对 Wiki 目标，必须省略 schema 明确标注为 Wiki 不支持的字段。
+
+显式确认后 patch public permission：
+
+```bash
+lark-cli drive permission.public patch \
+  --params '{"token":"<token>","type":"<type>"}' \
+  --data '{"link_share_entity":"closed","external_access":false}' \
+  --as user --yes --format json
+```
+
+显式确认后申请访问权限：
+
+```bash
+lark-cli drive +apply-permission \
+  --token '<url>' \
+  --perm view --remark '<reason>' --as user --format json
+
+lark-cli drive +apply-permission \
+  --token '<bare-token>' --type '<type>' \
+  --perm view --remark '<reason>' --as user --format json
+```
+
+owner 转移前读取当前 schema：
+
+```bash
+lark-cli schema drive.permission.members.transfer_owner --format json
+```
+
+显式确认后转移 owner：
+
+```bash
+lark-cli drive permission.members transfer_owner \
+  --params '{"token":"<token>","type":"<type>","need_notification":true,"remove_old_owner":false,"old_owner_perm":"full_access","stay_put":true}' \
+  --data '{"member_id":"<new_owner_open_id>","member_type":"openid"}' \
+  --as user --yes --format json
+```
+
+`member_type` 只能使用当前 schema 支持的值：`email`、`openid`、`userid`、`appid`。如果用户只给姓名，必须先解析为明确身份或要求用户补充；不要猜测 `member_id`。批量 owner 转移必须逐个目标顺序执行。
+
+secure label 写前枚举可用标签：
+
+```bash
+lark-cli drive +secure-label-list \
+  --page-size 10 --lang zh \
+  --as user --format json
+
+lark-cli drive +secure-label-list \
+  --page-size 10 --page-token '<PAGE_TOKEN>' --lang zh \
+  --as user --format json
+```
+
+当用户给出的是标签名称、密级文案或不确定的 label ID 时，必须先枚举并解析为 `label-id`；写入确认里展示目标标签名称和 ID。找不到唯一标签时，停止并让用户选择，不要猜测。
+
+显式确认后更新 secure label：
+
+```bash
+lark-cli drive +secure-label-update \
+  --token '<url>' \
+  --label-id '<label-id>' --as user --format json
+
+lark-cli drive +secure-label-update \
+  --token '<bare-token>' --type '<type>' \
+  --label-id '<label-id>' --as user --format json
+```

--- a/skills/lark-drive/references/lark-drive-workflow-permission-governance-outputs.md
+++ b/skills/lark-drive/references/lark-drive-workflow-permission-governance-outputs.md
@@ -1,0 +1,424 @@
+# 权限治理输出模板
+
+本文只提供 `permission_governance` workflow 的用户可见输出模板。默认先给简短摘要；只有用户要求完整表格、需要写入确认，或结果大到需要结构化展示时才读取本文。
+
+## 目录
+
+- `输出策略`
+- `Semantic Rendering`
+- `定位与治理动作`
+- `单目标公开性判断`
+- `多目标明确列表诊断`
+- `审计摘要`
+- `容器安全诊断报告摘要`
+- `可操作风险清单`
+- `治理选择交互`
+- `权限设置清单`
+- `访问复核清单`
+- `整改 dry-run`
+- `批量权限申请确认`
+- `owner 转移确认`
+- `确认请求`
+- `最终摘要`
+
+## 输出策略
+
+- 单目标默认输出审计摘要。
+- 多目标明确列表默认输出逐目标诊断摘要；不要因为目标数大于 1 就套用容器递归发现报告。
+- 用户可见结论默认跟随用户当前语言。用户用中文提问时输出中文，用户用英文提问时输出英文；混合语言时跟随主要语言。
+- 单目标公开性判断默认输出业务表达，不直接展示 `link_share_entity`、`external_access_entity`、`external_access` 等底层字段名；只有用户要求 raw evidence、排障，或完整清单 / artifact 场景才展示底层字段。
+- 中文用户可见输出中，`permission_public` / `public permission` 默认译为“文档公共访问和协作权限设置”；可在摘要里简称“公共访问与协作设置”。它在官方语义中包含链接分享、对外分享、协作者管理、复制内容、创建副本、打印、下载和评论；具体可判断字段以当前 CLI schema 和实际响应为准。只有命令名、schema 字段、raw evidence、排障信息和完整 artifact 字段名保留英文原文。
+- 容器目标默认输出安全诊断报告摘要：一句话结论、覆盖情况、风险分级、优先处理对象、建议下一步和剩余限制。
+- 容器目标不要把风险按数量机械排序；外部公开、允许对外分享、缺失密级标签优先于复制 / 下载 / 评论这类依赖策略的候选项。
+- 用户没有提供明确 policy 时，使用“候选风险 / 待复核 / 待策略确认”，不要写“违规 / 已泄露 / 已外部访问”。
+- 容器安全诊断里不要把 `external_access=true` / `external_access_entity=open` 简写成“高风险”或“外部泄露”；用户可见说法应为“允许对外分享，需 owner 复核；这不等于已经存在外部协作者”。
+- 风险对象展示按规模渐进披露：1-10 个全部展示；11-30 个展示全部高优先级待复核对象，中 / 低优先级只做分组摘要；31-100 个按高优先级待复核分组展示 Top 5 和数量；100+ 个只展示分组统计和 Top 样例。
+- 当摘要未展示全部风险对象时，必须明确“完整清单包含 <count> 条”，并提供生成 Markdown / CSV / 飞书文档风险清单或整改 dry-run 的下一步。
+- 只要发现需要处理的对象，最终回复必须给出可执行下一步 CTA。不能因为默认只读，就只报告风险后结束。
+- 完整风险清单是后续治理选择的输入；Markdown / CSV / 飞书文档报告必须使用同一套字段和稳定 `risk_id`。
+- 写入前必须使用确认模板；权限申请、文档公共访问和协作权限设置修改、owner 转移、密级标签更新分别确认。
+- 最终回复必须包含已完成事项、验证结果和剩余限制；异步权限申请审批不能表述为已完成授权。
+
+## Semantic Rendering
+
+面向用户的主结论优先渲染 `per_target_permission_assessment` 中的语义状态，并使用用户当前语言；底层字段名只在 raw evidence、排障或完整清单中保留。下表给出字段值到业务表达的标准映射；其他语言应表达同等业务含义。
+
+字段来源边界：下表同时覆盖官方 OpenAPI 语义和当前 / 未来 CLI schema。只有实际响应或当前 schema 返回的字段和值，才可渲染为确定状态；当前 installed CLI 未返回的字段（例如 `copy_entity`、`manage_collaborator_entity`、`external_access_entity`）或未出现的枚举值，只能在 raw response / schema 实际出现时使用，缺失时必须按 unknown / unsupported 处理，不要臆造。
+
+| Raw field / value | Semantic State | 中文说法 | English phrasing |
+|-------------------|----------------|----------|------------------|
+| `link_share_entity=anyone_readable` | `link_access=public_readable` | 互联网上获得链接的任何人可阅读 | Anyone on the internet with the link can read |
+| `link_share_entity=anyone_editable` | `link_access=public_editable` | 互联网上获得链接的任何人可编辑 | Anyone on the internet with the link can edit |
+| `link_share_entity=partner_tenant_readable` | `link_access=partner_readable` | 关联组织内知道链接可读 | People in partner tenants with the link can read |
+| `link_share_entity=partner_tenant_editable` | `link_access=partner_editable` | 关联组织内知道链接可编辑 | People in partner tenants with the link can edit |
+| `link_share_entity=tenant_readable` | `link_access=tenant_readable` | 公司内知道链接可读 | People in the tenant with the link can read |
+| `link_share_entity=tenant_editable` | `link_access=tenant_editable` | 公司内知道链接可编辑 | People in the tenant with the link can edit |
+| link sharing empty / disabled | `link_access=closed` | 未开启链接分享 | Link sharing is disabled |
+| `external_access_entity=open` or `external_access=true` | `external_sharing=open` | 允许分享到组织外；不等于已经存在外部协作者 | External sharing is open; this does not mean external collaborators already exist |
+| `external_access_entity=allow_share_partner_tenant` | `external_sharing=partner_only` | 仅允许分享到关联组织 | Sharing is allowed only with partner tenants |
+| `external_access_entity=closed` or `external_access=false` | `external_sharing=closed` | 当前不允许分享到组织外 | External sharing is disabled |
+| `invite_external=true` | `external_invitation=enabled` | 当前允许邀请外部用户 | Inviting external users is enabled |
+| `invite_external=false` | `external_invitation=disabled` | 当前不允许邀请外部用户 | Inviting external users is disabled |
+| `share_entity=anyone` | `collaborator_org_scope=all_viewers_or_editors` | 所有可阅读或可编辑者可查看、添加、移除协作者 | All viewers or editors can view, add, and remove collaborators |
+| `share_entity=same_tenant` | `collaborator_org_scope=tenant_viewers_or_editors` | 组织内可阅读或可编辑者可查看、添加、移除协作者 | Tenant viewers or editors can view, add, and remove collaborators |
+| `manage_collaborator_entity=collaborator_can_view` | `collaborator_permission_scope=viewer` | 拥有可阅读权限的协作者可查看、添加、移除协作者 | Collaborators with view permission can view, add, and remove collaborators |
+| `manage_collaborator_entity=collaborator_can_edit` | `collaborator_permission_scope=editor` | 拥有可编辑权限的协作者可查看、添加、移除协作者 | Collaborators with edit permission can view, add, and remove collaborators |
+| `manage_collaborator_entity=collaborator_full_access` | `collaborator_permission_scope=full_access` | 拥有可管理权限的协作者可查看、添加、移除协作者 | Collaborators with full-access permission can view, add, and remove collaborators |
+| `copy_entity=anyone_can_view` | `copy_scope=viewer` | 拥有可阅读权限的用户可复制内容 | Users with view permission can copy content |
+| `copy_entity=anyone_can_edit` | `copy_scope=editor` | 拥有可编辑权限的用户可复制内容 | Users with edit permission can copy content |
+| `copy_entity=only_full_access` | `copy_scope=full_access` | 仅拥有可管理权限的协作者可复制内容 | Only collaborators with full-access permission can copy content |
+| `security_entity=anyone_can_view` | `security_scope=viewer` | 拥有可阅读权限的用户可创建副本、打印、下载 | Users with view permission can create copies, print, and download |
+| `security_entity=anyone_can_edit` | `security_scope=editor` | 拥有可编辑权限的用户可创建副本、打印、下载 | Users with edit permission can create copies, print, and download |
+| `security_entity=only_full_access` | `security_scope=full_access` | 仅拥有可管理权限的用户可创建副本、打印、下载 | Only users with full-access permission can create copies, print, and download |
+| `comment_entity=anyone_can_view` | `comment_scope=viewer` | 拥有可阅读权限的用户可评论 | Users with view permission can comment |
+| `comment_entity=anyone_can_edit` | `comment_scope=editor` | 拥有可编辑权限的用户可评论 | Users with edit permission can comment |
+| `lock_switch=true` | `lock_state=locked_not_inheriting` | 已限制权限，不再继承父级页面权限 | The node is locked and no longer inherits parent-page permissions |
+| `lock_switch=false` | `lock_state=not_locked_or_inheriting` | 未限制权限，可能继承父级页面权限 | The node is not locked and may inherit parent-page permissions |
+| field absent / unsupported | `<state>=unknown` | 当前 schema 未返回，无法判断 | The current schema did not return this field, so it is unknown |
+| `check_scope=current_public_permission_only` | `check_scope=current_public_permission_only` | 本次判断的是当前文档公共访问和协作权限设置，不是协作者名单或历史权限变更审计 | This check covers current public access and collaboration settings, not collaborator-list or historical permission-change auditing |
+| `sec_label_name` missing | `sec_label=missing` | 缺少密级标签 | Security label is missing |
+
+## 定位与治理动作
+
+风险对象必须能让用户直接定位和处理：
+
+- 摘要中的每个优先处理对象必须包含 `risk_id`、`path/title`、`URL`、`type`、owner、sec_label、风险原因、关键证据和建议动作。
+- 完整清单、访问复核清单、整改 dry-run 和写入确认都必须包含 URL。缺少 URL 时，展示 token / node_token，并说明 URL 未能获取。
+- 同名文档、shortcut 或副本必须用 path + URL 区分；不要只输出 title。
+- 完整风险清单中的每条记录必须有稳定 `risk_id`，格式为 `PG-001`、`PG-002`。`risk_id` 在同一次诊断和后续 dry-run / 确认 / 验证中保持不变。
+- 即使摘要只展示 Top 样例，也必须给样例分配稳定 `risk_id`；不能输出无法选择的标题列表。
+- 建议动作必须和风险类型绑定：互联网公开链接优先建议关闭链接分享或收紧为组织内；允许对外分享优先建议 owner 复核或关闭对外分享；缺少密级标签优先建议补齐密级；复制 / 下载 / 评论范围只在用户 policy 明确时建议收紧。
+- 写入动作只能作为下一步选项或确认请求出现。不要在诊断摘要里暗示已经执行缩权。
+
+## 单目标公开性判断
+
+当 `intent=public_exposure_check` 且 `target_scope=single_resource` 时，使用此模板。默认渲染 `target_count=1` 的 `per_target_permission_assessment`，跟随用户当前语言，不直接展示底层字段名；用户要求 raw evidence 时，再追加字段证据。
+
+中文模板：
+
+```text
+结论：<不是对外公开 / 存在互联网公开链接 / 允许对外分享>。
+
+目标：<title>
+URL：<url-or-token-if-url-unavailable>
+类型：<type>
+
+当前链接访问范围：<render link_access>
+对外分享：<render external_sharing>
+外部邀请：<render external_invitation or omit if unknown because field is absent>
+协作者管理（组织维度）：<render collaborator_org_scope>
+协作者管理（权限维度）：<render collaborator_permission_scope or omit if unknown because field is absent>
+复制内容：<render copy_scope or omit if unknown because field is absent>
+创建副本 / 打印 / 下载：<render security_scope>
+评论：<render comment_scope>
+Wiki 继承限制：<render lock_state or omit if unknown because field is absent>
+
+检查边界：<render check_scope>
+```
+
+English template:
+
+```text
+Conclusion: <Not publicly accessible on the internet / A public internet link is enabled / External sharing is enabled>.
+
+Target: <title>
+URL: <url-or-token-if-url-unavailable>
+Type: <type>
+
+Current link access: <render link_access>
+External sharing: <render external_sharing>
+External invitations: <render external_invitation or omit if unknown because field is absent>
+Collaborator management by tenant: <render collaborator_org_scope>
+Collaborator management by permission: <render collaborator_permission_scope or omit if unknown because field is absent>
+Copy content: <render copy_scope or omit if unknown because field is absent>
+Create copies / print / download: <render security_scope>
+Comments: <render comment_scope>
+Wiki inheritance lock: <render lock_state or omit if unknown because field is absent>
+
+Check boundary: <render check_scope>
+```
+
+Raw evidence, only when requested:
+
+```text
+Evidence fields:
+- link_share_entity=<value>
+- external_access_entity=<value>
+- external_access=<value>
+- invite_external=<value>
+- share_entity=<value>
+- manage_collaborator_entity=<value>
+- copy_entity=<value>
+- security_entity=<value>
+- comment_entity=<value>
+- lock_switch=<value>
+```
+
+## 多目标明确列表诊断
+
+当 `target_scope=explicit_list` 时，使用此模板。该场景不执行容器递归发现；对用户提供的每个 URL / token 逐个生成 `per_target_permission_assessment`，再按风险分组聚合。权限语义和单目标、容器诊断完全复用，不新增判断模型。
+
+```text
+已完成只读权限诊断，没有做任何权限修改。
+
+一句话结论：<N> 个目标中，<risk_count> 个存在待复核权限风险；<internet_public_count> 个存在互联网公开链接候选，<external_access_count> 个允许对外分享，<unknown_count> 个无法完整判断。
+
+覆盖情况：
+- 用户提供目标：<input_target_count>；成功解析：<resolved_count>
+- 成功读取文档公共访问和协作权限设置：<permission_checked_count>；读取失败 / 不支持 / 无权限：<failed_or_unsupported_count>
+
+逐目标结果（1-10 个目标默认全部展示；超过 10 个时按 `摘要清单展开规则` 展示，并提示生成完整风险清单）：
+
+- <risk_id-or-item_id> <path-or-title> (<type>)
+  URL: <url-or-token-if-url-unavailable>
+  结论：<not_public / public_link_enabled / external_sharing_enabled / policy_review / unknown>
+  关键权限：<render link_access>; <render external_sharing>; <render security_scope>; <render comment_scope>
+  密级：<sec_label_name-or-missing-or-unknown>
+  待复核原因：<risk reason or none>
+  建议动作：<recommended action or no action>
+
+分组摘要：
+- 互联网公开链接候选：<count>；允许对外分享：<count>；公司内链接可访问 / 可编辑：<count>
+- 复制 / 下载 / 打印 / 评论待策略确认：<count>；无法判断：<count and reason summary>
+
+建议下一步：
+- 处理明确的 <risk_id>，先生成只读 dry-run。
+- 生成完整风险清单 artifact，后续可按 `risk_id`、风险分组、URL 或 `selected=true` 选择治理范围；只看权限设置时改用 `权限设置清单`。
+```
+
+## 摘要清单展开规则
+
+容器安全诊断的摘要必须兼顾可读性和可治理性。不要用固定 Top N 代替可处理清单。
+
+| 风险对象数 | 摘要默认展示 | 必须提供的下一步 |
+|------------|--------------|------------------|
+| `0` | 只展示覆盖情况、未覆盖能力和剩余限制 | 如需更细审计，可生成权限设置清单 |
+| `1-10` | 展示全部风险对象 | 可直接按 `risk_id` 生成 dry-run 或写入确认 |
+| `11-30` | 展示全部高优先级待复核对象；中 / 低优先级做分组摘要 | 生成完整风险清单 artifact，或按风险分组生成 dry-run |
+| `31-100` | 每个高优先级待复核分组展示 Top 5，附未展示数量 | 生成 Markdown / CSV / 飞书文档完整风险清单 |
+| `100+` | 只展示分组统计、Top 样例和覆盖限制，不内联长表 | 强烈建议生成结构化风险清单后再选择治理范围 |
+
+高优先级待复核对象包括：互联网公开链接、允许对外分享、允许对外分享且缺少 / 低于 policy 密级标签、公司内可编辑链接。协作者管理范围较宽默认归入中优先级待复核；只有用户 policy 明确要求严格协作者管理时才提升优先级。复制 / 下载 / 打印、评论范围在用户未提供明确 policy 时归入“待策略确认”，不要挤占高优先级清单。
+
+摘要中的每个待复核对象必须包含 `risk_id`、path/title、URL、type、owner、sec_label、风险原因、关键证据和建议动作。对同一底层文档的多个 Wiki 入口或 shortcut，必须用 URL 区分；如果建议合并治理，在建议动作里说明它们指向同一底层对象。
+
+## 审计摘要
+
+```text
+目标：<title> (<type>)
+URL：<url-or-token-if-url-unavailable>
+结论：<合规 / 待确认风险 / 无法完整判断>
+证据：
+- link_share_entity=<value>
+- external_access_entity=<value>
+- external_access=<value>
+- invite_external=<value>
+- share_entity=<value>
+- manage_collaborator_entity=<value>
+- copy_entity=<value>
+- security_entity=<value>
+- comment_entity=<value>
+- lock_switch=<value>
+- sec_label_name=<value-or-missing>
+限制：<unsupported_checks or none>
+建议动作：<read-only next step or proposed remediation>
+```
+
+## 容器安全诊断报告摘要
+
+```text
+已完成只读安全诊断，没有做任何权限修改。
+
+一句话结论：<未发现互联网公开链接 / 存在互联网公开链接候选风险>；<external_access_count> 个文档允许对外分享，<missing_label_count> 个文档缺少密级标签。建议优先复核 <top_priority_group_or_paths>。
+
+覆盖情况：
+- 当前身份可见目标：<visible_count>
+- 已成功检查文档公共访问和协作权限设置：<permission_checked_count>
+- 读取失败 / 已删除 / 无权限：<failed_count>
+- 未覆盖能力：<collaborator_list / inheritance / audit_log / view_records / none>
+
+风险分级：
+- 高优先级待复核：<internet_public_count> 个互联网公开链接候选；<external_access_count> 个允许对外分享；其中 <external_without_label_count> 个同时缺少密级标签。
+- 中优先级待复核：<tenant_link_count> 个公司内知道链接可访问 / 可编辑；<wide_share_count> 个协作者管理范围较宽。
+- 待策略确认：<security_count> 个复制 / 下载 / 打印范围待复核；<comment_count> 个评论范围待复核。
+- 无法判断：<unsupported_or_unverified_summary>。
+
+分级含义：
+- 互联网公开链接：获得链接的任何人可能访问，最高优先级。
+- 允许对外分享：外部分享能力已开启，需 owner 复核；不等于已经存在外部协作者。
+- 公司内链接可访问：不是对外公开，但组织内扩散范围较宽。
+- 复制 / 下载 / 打印 / 评论：是否需要收紧取决于业务 policy 和文档密级。
+
+高优先级待复核清单：
+> 按 `摘要清单展开规则` 展示。每个对象必须包含 `risk_id` 和 URL；缺少 URL 时展示 token / node_token 和原因。若没有高优先级对象，只展示中优先级或待策略确认分组摘要。
+
+- <risk_id> <path-or-title> (<type>)
+  URL: <url-or-token-if-url-unavailable>
+  Owner: <owner-or-unknown>
+  密级：<sec_label_name-or-missing-or-unknown>
+  待复核原因：<why high priority>
+  证据：<short user-language evidence, e.g. 对外分享=已开启；链接分享=未开启互联网公开链接>
+  建议动作：<recommended action>
+
+未完全展开：
+- 完整风险清单包含 <risk_manifest_count> 条；本摘要已展示 <shown_count> 条，未展示 <hidden_count> 条。
+- 未展示分组：<risk_group=count summary or none>
+
+建议下一步：
+- 生成完整风险清单 artifact，包含 `risk_id`、URL、owner、密级、证据字段、建议动作和 `selected` 列。
+- 基于 risk_id、风险分组、owner、路径、URL 或 artifact 中 `selected=true` 的行生成只读整改 dry-run。
+- 只针对最高优先级目标进入写入确认流程，例如关闭互联网公开链接或收紧对外分享；写入前仍需二次确认。
+- 按 owner / 密级生成复核清单。
+- 继续读取访问记录，判断低活跃高暴露。
+
+剩余限制：
+- <do not claim collaborator-list verification if unsupported>
+- <external_access_entity=open or external_access=true only means sharing outside is allowed, not that external collaborators exist>
+- <missing view_records / DLP / AI index status / audit log limitations>
+```
+
+## 可操作风险清单
+
+完整风险清单用于让用户选择后续治理范围。Markdown / CSV / 飞书文档报告都必须包含以下字段；如果某种格式无法完整展示嵌套证据，使用短文本摘要，保留 `risk_id` 和 URL。
+
+```text
+范围：<explicit_list / wiki_space / wiki_node / drive_folder> <name-or-id>
+生成时间：<timestamp>
+用途：用户可按 risk_id、priority、risk_group、owner、path、URL 或 selected=true 选择治理对象。
+
+| risk_id | priority | Path | URL | Type | Owner | sec_label | risk_group | evidence | recommended_action | current_setting | target_setting | selected | decision | status | skip_reason |
+|---------|----------|------|-----|------|-------|-----------|------------|----------|--------------------|-----------------|----------------|----------|----------|--------|-------------|
+| PG-001 | P1 | <path> | <url-or-token> | <type> | <owner-or-unknown> | <sec-label-or-missing> | <risk_group> | <short evidence> | <recommended-action> | <field=value> | <field=value-or-owner-review> | false | undecided | pending | <none-or-reason> |
+```
+
+字段规则：
+
+- `risk_id` 按 priority、risk_group、normalized path、URL、canonical token / node_token 稳定排序生成；URL 缺失时必须使用 token / node_token 作为 tie-breaker。同名、同路径、shortcut 或多个 Wiki 入口不能只靠 path 生成编号；同一次诊断中不得重复。
+- `priority` 使用 `P0`、`P1`、`P2`、`PolicyReview`、`Unknown`；面向用户展示时可译为“最高优先级 / 高优先级待复核 / 中优先级待复核 / 待策略确认 / 无法判断”。
+- `selected` 默认 `false`；用户可在 CSV / 飞书文档表格中改为 `true`，或在聊天中直接说 “处理 PG-001、PG-003”。
+- `decision` 表示用户决策：`undecided`、`keep`、`dry_run`、`confirm_write`、`skip`。
+- `status` 表示执行状态：`pending`、`dry_run_ready`、`confirmed`、`executed`、`verified`、`failed`、`skipped`。
+- `target_setting` 是建议目标状态，不代表已执行；没有明确 policy 时只能写 owner review / policy review。
+
+## 治理选择交互
+
+用户基于完整风险清单继续治理时，Agent 必须先解析选择范围，再生成只读 dry-run：
+
+```text
+可接受的用户选择：
+- 处理 PG-001、PG-003、PG-008，把互联网公开链接关闭。
+- 先处理所有 risk_group=internet_public_link，不处理 external_access_only。
+- 把 CSV / 飞书文档里 selected=true 的行生成整改 dry-run。
+- PG-003 先跳过，只处理 PG-001。
+
+Agent 必须回复：
+- 已选择对象数：<count>
+- 选择来源：<risk_id list / risk_group / selected=true / URL / path>
+- 将执行的下一步：生成 dry-run；不执行写入
+- 需要跳过或重新确认的对象：<missing risk_id / unsupported / changed_since_report / no manage_public>
+```
+
+如果用户选择来自旧报告或外部 artifact，生成 dry-run 前必须对所选目标重新读取当前权限。当前设置和报告快照不一致时，标记为 `changed_since_report`，不要直接沿用旧字段执行。
+
+## 权限设置清单
+
+```text
+范围：<explicit_list / wiki_space / wiki_node / drive_folder> <name-or-id>
+
+| Path | URL | Type | link_share_entity | external_access_entity / external_access | invite_external | share_entity | manage_collaborator_entity | copy_entity | security_entity | comment_entity | lock_switch | sec_label_name | 建议动作 | 限制 |
+|------|-----|------|-------------------|------------------------------------------|-----------------|--------------|----------------------------|-------------|-----------------|----------------|-------------|----------------|----------|------|
+| <path> | <url-or-token> | <type> | <value> | <value> | <value-or-unknown> | <value> | <value-or-unknown> | <value-or-unknown> | <value> | <value> | <value-or-unknown> | <value-or-missing> | <recommended-action> | <unsupported-or-none> |
+```
+
+## 访问复核清单
+
+```text
+范围：<wiki_space / wiki_node / drive_folder / explicit_list> <name-or-id>
+复核对象数：<count>
+
+| Owner | Path | URL | Type | 密级 | 风险标签 | 当前权限摘要 | 最近访问证据 | 建议动作 |
+|-------|------|-----|------|------|----------|--------------|--------------|----------|
+| <owner-or-unknown> | <path> | <url-or-token> | <type> | <sec-label-or-missing> | <labels> | <link/external/share/security/comment> | <uv/pv/last_view_or_unknown> | <keep / tighten / owner review / unsupported> |
+
+限制：<unsupported_checks / discovery_blockers / none>
+```
+
+## 整改 dry-run
+
+```text
+将生成整改计划，不执行写入：
+- 范围：<scope>
+- 选择来源：<risk_id list / risk_group / selected=true artifact / URL list>
+- 候选目标数：<count>
+- 计划执行命令：<command family>
+- 重新读取：已对所选目标重新读取当前权限；changed_since_report=<count>
+- 字段变更：
+  - <risk_id> <path> (<url-or-token>): <field> <old> -> <new>
+- 跳过项：<unsupported / no manage_public / unsupported type / missing policy>
+- 验证方式：执行后重新读取 <元数据 / 文档公共访问和协作权限设置>
+- 有限回滚范围：<文档公共访问和协作权限设置快照字段 / 不适用>
+
+请确认是否进入写入确认。
+```
+
+## 批量权限申请确认
+
+```text
+将逐个发起 <view / edit> 权限申请：
+- 候选目标数：<count>
+- 命令类型：drive +apply-permission
+- 风险：write；每个请求都会通知 owner
+- 执行方式：按候选列表顺序逐个调用，失败项会单独记录
+
+候选示例：
+- <risk_id> <title> (<type>, <url-or-token>)：<reason>
+
+请确认是否对上述候选目标发起权限申请。
+```
+
+## owner 转移确认
+
+```text
+将逐个转移 owner：
+- 候选目标数：<count>
+- 命令类型：drive permission.members transfer_owner
+- 风险：high-risk-write；会改变文档 owner，可能影响原 owner 权限和文档所在位置
+- 新 owner 映射：<same_new_owner / per_target_new_owner>
+- 全局新 owner：<member_id> (<member_type>)；仅当所有候选目标的新 owner 相同时展示，否则省略
+- 通知新 owner：<need_notification>
+- 原 owner 权限：<remove_old_owner=true / old_owner_perm>
+- 个人空间位置：<stay_put>
+- 执行方式：按候选列表顺序逐个调用，失败项会单独记录
+- 验证方式：执行后重新读取 metadata owner；metadata 不支持的类型标记为 partial
+- 回滚边界：不做自动回滚；如需恢复 owner，必须另起一次反向 owner 转移确认
+
+候选示例：
+- <risk_id> <title> (<type>, <url-or-token>)：当前 owner=<owner-or-unknown> -> 新 owner=<member_id> (<member_type>)
+
+请确认是否对上述候选目标转移 owner。
+```
+
+## 确认请求
+
+```text
+将执行 <operation>：
+- 目标：<risk_id> <title> (<type>, <url-or-token>)
+- 命令类型：<command family>
+- 风险：<risk_level>
+- 字段变更：
+  - <field>: <old> -> <new>
+- 验证方式：执行后重新读取 <元数据 / 文档公共访问和协作权限设置>
+- 有限回滚材料：<文档公共访问和协作权限设置快照 / 不适用>
+
+请确认是否执行。
+```
+
+## 最终摘要
+
+```text
+已完成：<read checks / writes>
+验证：<fresh read result or async permission-request approval note>
+清单状态：<risk_id status updates / not applicable>
+回滚材料：<文档公共访问和协作权限设置快照 / 不适用>
+剩余限制：<unsupported_checks / partial facts / approvals>
+```

--- a/skills/lark-drive/references/lark-drive-workflow-permission-governance.md
+++ b/skills/lark-drive/references/lark-drive-workflow-permission-governance.md
@@ -1,0 +1,207 @@
+# lark-drive 权限治理 Workflow
+
+Workflow id: `permission_governance`
+
+Risk / Structure: `R2` / `S2`
+
+本文实现已注册的权限治理 workflow。执行前必须先读取 [`lark-drive-workflow.md`](lark-drive-workflow.md) 和 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md)，并遵循共享执行协议、Artifact Contract、Workflow Loading、认证和写入确认规则。
+
+## 适用范围
+
+当用户要求检查或治理 Drive / Docs / Wiki 资产访问权限时，使用本 workflow。典型意图包括：
+
+- 单资源公开性、外部访问、公司内链接、分享 / 复制 / 下载 / 评论设置检查。
+- 多资源、Wiki space / node、Drive folder 或个人文档库的权限风险诊断和权限设置清单。
+- 访问复核、低活跃高暴露、权限申请、owner 转移、密级标签调整、AI Agent / RAG 前置权限治理。
+- 只读整改 dry-run，或经确认后的权限收紧 / 权限申请 / owner 转移 / 密级标签更新。
+
+目标可以是明确 URL / token、小规模明确列表、Wiki space / Wiki node 或 Drive folder。容器范围必须先只读 `DISCOVER_TARGETS` 并产出覆盖摘要；这里的"所有文档"只表示当前身份在确认范围内可枚举到的文档。任何写入都必须再次确认。
+
+单目标轻量路径：用户只问“是否对外公开 / 外部可访问 / 公司内链接可见”且目标是单个明确 URL / token 时，设置 `intent=public_exposure_check`、`target_scope=single_resource`，走 `PARSE_INTENT -> TARGET_INSPECT -> FACT_READ -> RISK_ASSESS -> DONE`。该路径是 `target_count=1` 的轻量输出模式，不是独立判断逻辑；不执行 `DISCOVER_TARGETS`、不生成 `risk_manifest` / `risk_id`，只输出结论、权限含义、检查边界和必要下一步。
+
+## Target Set Evaluation
+
+本 workflow 不按“单篇 / 多篇 / 容器”复制权限判断逻辑。所有范围先归一为 target set，再对每个可审计目标生成 `per_target_permission_assessment`，最后按目标数量和风险分组聚合输出。
+
+| target_scope | Target Collection | Output Mode |
+|--------------|-------------------|-------------|
+| `single_resource` | 直接解析一个 URL / token | `target_count=1` 时轻量渲染；不生成 `risk_manifest` |
+| `explicit_list` | 用户给出的多个 URL / token 逐个 inspect / normalize | 逐目标渲染摘要；需要后续治理时生成稳定 `risk_id` |
+| `wiki_space` / `wiki_node` / `drive_folder` | 先只读递归发现，再归一化为 `discovered_targets` | 输出覆盖情况、风险分组、可定位待复核对象和 artifact / dry-run CTA |
+
+特殊的是目标收集和输出聚合，不是权限语义。`link_access`、`external_sharing`、`copy_scope`、`security_scope`、`comment_scope`、`sec_label`、`check_scope` 等语义字段必须在单目标、多目标明确列表和容器发现目标之间复用。
+
+## 非目标
+
+本 workflow 不处理：
+
+- 目录组织、迁移、归档或清理；这类需求应使用知识整理 workflow。
+- 内容审查、过期内容判断或知识质量评分。
+- backup owner 补充、部门 / 项目负责人绑定、协作者创建 / 撤销、成员列表审计；本 workflow 只支持把 owner 转移给每个目标明确指定的新 owner，不建模 backup owner 或负责人绑定关系。
+- 文件夹自身公开权限审计或修复。`drive permission.public get` / `patch` 不支持 `type=folder`；必须记录到 `unsupported_checks`，然后继续读取文件夹下其他支持的文档事实。
+- 当前身份无法枚举到的不可见文档的完整发现；只能处理已发现目标，或用户显式提供的 URL / token。
+- 未按范围确认的批量写入。
+
+不要声称已完成协作者列表验证：当前 CLI surface 没有 `permission.members list` shortcut。
+
+## Progressive Load Map
+
+本表只规定每个 state 需要加载的额外上下文；命令可用范围以 `Command Map` 为准。需要拼装具体 `lark-cli` 命令时，再按需读取 [`lark-drive-workflow-permission-governance-commands.md`](lark-drive-workflow-permission-governance-commands.md)。
+
+| State | Required Reference |
+|-------|--------------------|
+| `PARSE_INTENT` | 本文件、[`lark-drive-workflow.md`](lark-drive-workflow.md)、[`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) |
+| `TARGET_INSPECT` | [`lark-drive-inspect.md`](lark-drive-inspect.md) |
+| `DISCOVER_TARGETS` | 容器范围时读取 [`../../lark-wiki/references/lark-wiki-node-list.md`](../../lark-wiki/references/lark-wiki-node-list.md) 或 [`lark-drive-files-list.md`](lark-drive-files-list.md) |
+| `FACT_READ` | `lark-cli schema drive.metas.batch_query`；涉及公开权限时再读取 `lark-cli schema drive.permission.public.get`；涉及活跃度、访问复核或生命周期判断时再读取 `lark-cli schema drive.file.statistics.get` 和 `lark-cli schema drive.file.view_records.list` |
+| `RISK_ASSESS` | 本文件的 `Risk Classification` |
+| `EXEC_CONFIRM` | 只为用户选择的动作读取 [`lark-drive-apply-permission.md`](lark-drive-apply-permission.md)、[`lark-drive-secure-label.md`](lark-drive-secure-label.md)，或 `lark-cli schema drive.permission.public.patch` / `lark-cli schema drive.permission.members.transfer_owner`；需要确认模板时读取 [`lark-drive-workflow-permission-governance-outputs.md`](lark-drive-workflow-permission-governance-outputs.md) |
+| `EXECUTE` | 复用 `EXEC_CONFIRM` 已加载且已确认的写命令上下文 |
+| `VERIFY` | 复用 `FACT_READ` 阶段使用的 read schemas |
+
+## Runtime State Extension
+
+本 workflow 在共享 `Artifact Contract` 基础上扩展以下字段组：
+
+| Group | Fields | Meaning |
+|-------|--------|---------|
+| Scope | `intent`, `target_scope`, `targets`, `discovered_targets`, `coverage_summary`, `discovery_blockers` | 记录用户意图、确认范围、直接目标、容器发现目标和未覆盖范围 |
+| Facts | `metadata_facts`, `public_permission_facts`, `activity_facts`, `manage_public_auth` | 记录 metadata、公共访问与协作权限、访问证据，以及写前 `manage_public` 校验 |
+| Assessment | `per_target_permission_assessments`, `risk_findings`, `unsupported_checks` | 记录逐目标语义判断、带 `risk_id` / URL / owner / sec_label / evidence / action 的风险发现，以及无法执行的检查 |
+| Governance | `risk_manifest`, `selected_risk_items`, `access_review_items`, `permission_request_candidates`, `owner_transfer_candidates` | 支持用户按 `risk_id`、风险分组、owner、路径、URL 或 artifact `selected=true` 选择治理范围，并记录 owner 转移候选 |
+| Execution | `remediation_plan`, `owner_transfer_plan`, `public_permission_snapshots` | 记录 dry-run / 已确认整改计划、owner 转移计划、字段 diff、验证方式和 public-permission 有限回滚快照 |
+
+## Execution State Machine
+
+| State | Protocol Step | Agent MUST Do | User-Facing Output | wait_for_user | Next State |
+|-------|---------------|---------------|--------------------|---------------|------------|
+| `PARSE_INTENT` | `route` / `scope` | 解析 intent、target scope、desired policy，以及只读审计、单目标公开性判断、权限申请、owner 转移还是修复模式；单目标公开性判断设置 `intent=public_exposure_check`、`target_scope=single_resource` | 范围确认；如果缺少目标、新 owner 或期望动作，只问一个澄清问题 | 缺少 target / new owner / action，或容器范围需要用户确认时为 `true` | `TARGET_INSPECT` |
+| `TARGET_INSPECT` | `scope` | 解析单资源、明确列表、Wiki space / node、Drive folder；保留原始 URL、scope type、canonical token/type | 目标范围表，包含 scope、title/type/token status | 除非解析失败，否则为 `false` | `DISCOVER_TARGETS` or `FACT_READ` |
+| `DISCOVER_TARGETS` | `scope` / `read` | 对 Wiki space / node 或 Drive folder 递归只读枚举，归一化为 `discovered_targets`；记录 `discovery_blockers` | 发现进度和覆盖摘要；不展示内部 cursor/token，除非用户要求 | 除非发现范围无法确认或全部被阻断，否则为 `false` | `FACT_READ` |
+| `FACT_READ` | `read` | 对直接目标或 `discovered_targets` 执行 `drive metas batch_query`；对支持的非 folder 目标执行 `drive permission.public get`；当 `intent=public_exposure_check` 且 `target_scope=single_resource` 时，可复用 `drive +inspect` 返回的 title / URL / type，只补读文档公共访问和协作权限设置；在用户要求活跃度 / 访问复核 / 生命周期判断时读取访问统计和访问记录 | 权限事实摘要、coverage summary、activity facts 和 unsupported checks | 除非所有目标都被 auth 阻断，否则为 `false` | `RISK_ASSESS` |
+| `RISK_ASSESS` | `assess/plan` | 对每个可审计目标生成 `per_target_permission_assessment` 并分类证据；如用户提供 policy，则对照 policy；`public_exposure_check + single_resource` 只渲染单目标结论，不生成 `risk_id`；owner 转移路径生成 `owner_transfer_candidates` / `owner_transfer_plan`；治理路径构建可定位风险清单、访问复核清单、dry-run 整改计划或候选修复计划，完整清单必须生成稳定 `risk_id` | 带 priority、URL、risk_id、owner、sec_label 的 findings、confidence、review items、建议动作和下一步 CTA；单目标公开性判断只输出结论和关键字段 | 治理路径为 `true`，单目标公开性判断为 `false` | `EXEC_CONFIRM` or `DONE` |
+| `EXEC_CONFIRM` | `confirm` | 展示准确写入范围、command family、target count、risk、verification method | 确认请求 | `true` | `EXECUTE` or `DONE` |
+| `EXECUTE` | `execute` | 只执行 `Command Map` 中已确认的写入 | 进度 / 结果摘要 | 除非被阻断，否则为 `false` | `VERIFY` |
+| `VERIFY` | `verify` | 重新执行支持的读取，并与目标状态对比 | 验证表和剩余缺口 | `false` | `DONE` |
+| `DONE` | `done` | 停止 | 最终回复，包含完成事项、验证结果和剩余风险 | `false` | End |
+
+## Command Map
+
+本 workflow 只能使用以下 command families：
+
+| State | Allowed Command Families | Purpose |
+|-------|--------------------------|---------|
+| `TARGET_INSPECT` | `drive +inspect` | 解析 URL、type、canonical token、title 和 wiki unwrap data |
+| `DISCOVER_TARGETS` | `wiki +node-list` | 递归发现 Wiki space / node 下当前身份可见的节点 |
+| `DISCOVER_TARGETS` | `drive files list` | 递归发现 Drive folder 下当前身份可见的文件和子文件夹 |
+| `FACT_READ` | `drive metas batch_query` | 读取 title、URL、owner 和 secure-label metadata |
+| `FACT_READ` | `drive permission.public get` | 读取支持类型的文档公共访问和协作权限设置，包括链接分享、对外分享、协作者管理、复制内容、创建副本、打印、下载和评论 |
+| `FACT_READ` | `drive file.statistics get` | 在用户要求活跃度、闲置暴露、生命周期或访问复核时读取文件访问统计 |
+| `FACT_READ` | `drive file.view_records list` | 在用户要求最近访问人、访问复核或低活跃证据时读取访问记录 |
+| `EXEC_CONFIRM` | `drive +secure-label-list` | 提议 label update 前解析可用 secure-label IDs |
+| `EXEC_CONFIRM` | `drive permission.members auth` | 文档公共访问和协作权限设置修改前检查 `action=manage_public` |
+| `EXEC_CONFIRM` | `lark-cli schema drive.permission.members.transfer_owner` | owner 转移前读取当前字段、支持类型和高风险写入门禁 |
+| `EXECUTE` | `drive +apply-permission` | 向 owner 提交 view/edit access request；只允许单目标、小列表或已明确确认的候选列表逐个执行 |
+| `EXECUTE` | `drive permission.public patch` | 修改已确认的 public/link settings；必须传 `--yes` |
+| `EXECUTE` | `drive permission.members transfer_owner` | 转移已确认目标的 owner；必须传 `--yes` |
+| `EXECUTE` | `drive +secure-label-update` | 设置已确认的 secure-label ID |
+| `VERIFY` | `drive metas batch_query`, `drive permission.public get` | 验证支持的 metadata，包括 owner、secure-label 和文档公共访问与协作权限设置变更；权限申请只能表述为已发起 |
+
+## Command Patterns
+
+本入口不内联命令样例。需要拼装具体 `lark-cli` 命令时，按当前 state 读取 [`lark-drive-workflow-permission-governance-commands.md`](lark-drive-workflow-permission-governance-commands.md)。命令是否允许执行仍以 `Command Map` 和写入规则为准。
+
+## Discovery Rules
+
+容器范围只能先做只读发现和覆盖摘要，不能在发现阶段执行权限申请、权限 patch 或密级更新。
+
+通用规则：
+
+1. "所有文档"只表示当前身份在确认范围内可枚举到的文档。不可见、无权限、API 不返回或工具预算不足的部分必须进入 `discovery_blockers` 或 `unsupported_checks`。
+2. 发现阶段必须生成稳定 `path`。不要只保存 title；同名文档必须能通过 path 或 token 区分。
+3. 只把 `drive.permission.public.get` 当前 schema 支持的类型加入公开权限可审计目标。已知支持包括 `doc`、`sheet`、`file`、`wiki`、`bitable`、`docx`、`mindnote`、`minutes`、`slides`；未来新增类型以运行时 schema 为准。
+4. `minutes` 只能作为 `partial_public_permission` 目标：可读取 / 修改公开权限和 owner 转移能力以运行时 schema 为准，但 `drive metas batch_query` 当前不支持 `minutes`，URL、owner、密级等 metadata 可能进入 `unsupported_checks`。
+5. `folder` 只作为递归容器，不执行 `permission.public get` / `patch`。如果用户明确要求 owner 转移且 schema 支持 `folder`，必须按 owner-transfer 写入规则单独确认。`shortcut`、`catalog` 或缺少 stable token/type 的条目必须记录为 unsupported，除非后续 API 明确解析出支持目标。
+6. 对大范围目标输出进度时，只展示已扫描容器数、已发现目标数、已审计目标数、剩余队列或 blocker；不要默认展示内部 page token / cursor。
+
+Wiki space / node 发现：
+
+1. `/wiki/space/<space_id>` 直接解析为 `target_scope=wiki_space`。不要因为 `drive +inspect` 对该 URL 返回 not found 就停止。
+2. 用 `wiki +node-list --space-id <space_id>` 读取根节点；当节点 `has_child=true` 时，用该节点的 `node_token` 继续递归读取子节点。
+3. Wiki 节点必须同时保留 `node_token`、`obj_token` 和 `obj_type`。权限读取优先用 `type=wiki` + `node_token` 表达 Wiki 节点权限；元数据补充可使用 `obj_type` + `obj_token`。
+4. 如果节点只有 `obj_token` / `obj_type`，但无法确认 Wiki 节点权限 token，保留该目标为 partial，并在 `unsupported_checks` 中说明只能读取底层对象或无法完整判断 Wiki 节点权限。
+
+Drive folder 发现：
+
+1. `/drive/folder/<folder_token>` 解析为 `target_scope=drive_folder`。文件夹自身公开权限不支持；继续枚举其子文档。
+2. 按 [`lark-drive-files-list.md`](lark-drive-files-list.md) 递归处理 `data.files`、`has_more` 和 `next_page_token`。不要把第一页数量当作完整范围。
+3. 只对返回项中的 `folder` 继续递归；对子文档按 `type + token` 归一化为 `discovered_targets`。
+4. 如果某个目录分页失败、无 continuation token、权限不足或 API 报错，只阻断该目录分支，并在 `discovery_blockers` 中记录；继续处理其他可枚举分支。
+
+## Fact Read Rules
+
+1. `drive metas batch_query` 单次最多 200 个 `request_docs`；当 `targets` 或 `discovered_targets` 超过 200 个时，必须分批读取并合并结果。
+2. `drive permission.public get` 没有批量读取接口；对支持目标逐个读取。单个目标失败时记录 `unsupported_checks` 或 `partial`，不要阻断其他目标。
+3. 对 Wiki 发现目标，公开权限读取优先使用 `type=wiki` + `node_token`；metadata 可使用 `obj_type` + `obj_token` 补充 title、owner、URL 和 `sec_label_name`。
+4. 当 intent 是 `list_permission_settings` 时，只输出权限设置清单和覆盖限制，不主动生成修复计划。
+5. 单目标、多目标明确列表和容器发现目标都必须复用同一套逐目标事实读取与语义归一逻辑；差异只体现在目标来源、coverage summary 和输出聚合。
+6. `permission_public` 用户可见含义是“文档公共访问和协作权限设置”，语义以官方 OpenAPI 字段说明为准，同时兼容当前 CLI schema 返回的字段：优先使用 `external_access_entity`，缺失时才用 `external_access` boolean 映射为 `open` / `closed`；`manage_collaborator_entity`、`copy_entity`、`lock_switch` 等字段缺失时标记为 unknown，不要伪造；未识别字段保留在 raw evidence / partial note 中。
+7. `drive file.statistics get` 和 `drive file.view_records list` 只在用户要求最近访问、活跃度、闲置暴露、访问复核，或用户提供的 policy 明确依赖活跃度时执行；不要为普通权限审计默认读取访问记录。
+8. 访问统计 / 访问记录当前只对 `doc`、`docx`、`sheet`、`bitable`、`mindnote`、`wiki`、`file` 作为支持类型处理。其他类型必须进入 `unsupported_checks`，不能推断活跃度。
+9. `view_records` 是访问证据，不是权限列表。没有返回访问记录只能表述为“未获得最近访问证据”或“低活跃候选”，不能表述为“无人有权限”。
+
+## Risk Classification
+
+风险标签只能作为 evidence labels。除非用户提供明确 policy，否则不要表述为绝对违规、已泄露或已外部访问。
+
+默认优先级面向用户决策，而不是制造告警感：
+
+- `P0`：`link_share_entity=anyone_readable/anyone_editable`，互联网公开链接候选风险。
+- `P1`：`external_access_entity=open` / `external_access=true`、关联组织访问、公司内链接可编辑，或外部分享且缺少 / 低于 policy 密级标签。
+- `P2`：公司内知道链接可读、协作者管理范围较宽。
+- `PolicyReview`：复制、创建副本、打印、下载、评论等依赖 policy 的设置；没有明确 policy 时不要称为高风险。
+- `Unknown`：读取失败、已删除、无权限、API 不支持、协作者名单 / 继承链 / DLP / AI 索引 / 审计日志未覆盖。
+
+每个可审计目标都必须先归一化为 `per_target_permission_assessment`，再按 [`lark-drive-workflow-permission-governance-outputs.md`](lark-drive-workflow-permission-governance-outputs.md) 的 `Semantic Rendering` 渲染。`public_exposure_check` 只是 `target_count=1` 的轻量渲染模式；它和多目标、容器诊断复用同一套语义字段与风险分类。该判断只覆盖当前文档公共访问和协作权限设置，不审计协作者名单、历史权限变更、完整继承链或审计日志。
+
+`AI 检索暴露候选风险` 只是基于权限和标签的代理标签。除非另有工具明确返回索引状态，否则不要声称某个文档已经被 Agent、Copilot 或 RAG 索引。
+
+## 写入规则
+
+- 文档公共访问和协作权限设置修改（`drive permission.public patch`）属于高风险写入。请求确认前，必须展示 target title、token、current setting、desired setting 和准确 field changes。
+- 如果 `manage_public_auth.auth_result=false`，禁止 patch。告诉用户需要具备 manage-public 权限的用户，或由 owner 操作。
+- `drive permission.public get` 只用于 `drive +inspect` 或 `DISCOVER_TARGETS` 可解析且运行时 schema 支持的目标类型；类型集合不要硬编码，执行时以 `lark-cli schema drive.permission.public.get` 为准。
+- 不要 patch 已解析类型不支持的字段。对于 wiki 目标，必须省略 schema 明确标注为 wiki 不支持的字段。
+- 不要在同一个写入确认中合并密级标签更新和文档公共访问与协作权限设置修改；必须分别确认。
+- `drive +apply-permission` 默认不批量执行；每次调用都会向 owner 发送通知。
+- `permission_request_candidates` 可以来自用户直接提供的目标、明确列表或容器发现目标；只要能构造 token、type、权限类型和申请理由，就可以进入候选。不要因为目标不在 `discovered_targets` 中而拒绝单目标 / 小列表权限申请。
+- 容器范围内的"统一申请权限"必须先产出 `permission_request_candidates`。未展示候选目标、数量、权限类型和 owner 通知影响前，禁止调用 `drive +apply-permission`。
+- 用户显式确认批量权限申请后，也必须逐个目标顺序调用 `drive +apply-permission`，并在结果中区分已发起申请、失败、无法构造申请请求和未发现目标。
+- `drive permission.members transfer_owner` 属于 owner 转移高风险写入。必须先确认目标、当前 owner、新 owner 的 `member_id` / `member_type`、`need_notification`、`remove_old_owner`、`old_owner_perm`、`stay_put`、执行顺序和验证方式；不能只凭姓名猜测新 owner。
+- owner 转移没有 `permission.members auth` 的等价 precheck。执行前只能用 schema 和当前 metadata 做计划，执行后必须用 `drive metas batch_query` fresh read 验证 owner；metadata 不支持的类型必须把验证标记为 partial。
+- 批量 owner 转移必须逐个顺序执行；失败项进入结果清单，不要重复执行已成功目标。`remove_old_owner=true` 或 `old_owner_perm` 降权必须单独在确认中高亮。
+- 用户要求“生成整改方案 / dry-run / 先看看会改什么”时，只生成 `remediation_plan`，不执行任何写命令。dry-run 必须包含 target count、field changes、跳过原因、验证方式和有限回滚范围。
+- 用户基于完整风险清单选择对象时，必须先解析 `risk_id`、风险分组、URL 或 artifact 中 `selected=true` 的行，生成 `selected_risk_items`。无法匹配到当前 `risk_manifest` 的选择必须要求用户重新确认或重新读取清单。
+- 针对 `selected_risk_items` 生成 dry-run 前，必须重新读取所选目标的 `drive permission.public get`；如果当前设置和清单快照不同，标记为 `changed_since_report` 并跳过或要求用户确认更新后的计划。
+- 执行 `drive permission.public patch` 前，必须把当前 `public_permission_facts` 中会被改动的字段保存为 `public_permission_snapshots`。该快照只用于文档公共访问和协作权限设置字段的有限回滚说明，不覆盖协作者、owner、继承权限或密级标签。
+- 如果用户要求批量收紧权限，必须按风险分层和目标顺序逐个执行；失败项进入结果清单，不要因为单个失败而重复执行已成功目标。
+- 遇到 secure-label downgrade error `1063013` 时，停止重试，并告诉用户需要在文档 UI 中完成审批。
+
+## 未来扩展边界
+
+以下能力已有部分 CLI surface 或用户价值，但不要在当前 workflow 中作为可执行分支直接调用：
+
+- `drive permission.members create` 可创建协作者权限，但当前 workflow 不做协作者 grant / update / revoke；未来需要单独定义授权对象解析、最小权限、确认模板和验证方式。
+- backup owner、部门 / 项目负责人绑定没有当前 workflow 可执行写入面；如用户要落地为 owner 转移，必须先给出明确目标和新 owner，并走本 workflow 的 owner-transfer 确认。
+- `wiki +member-list` 可作为 Wiki space 成员治理的读侧事实来源；当前 workflow 只治理文档 / 节点 / 文件夹下可发现文档的权限，不做 space member governance。
+- 当前 CLI 没有 `permission.members list`、完整继承链、DLP 扫描、AI 索引状态、审计日志和跨平台权限事实。遇到这些需求必须记录为 `unsupported_checks` 或建议新增独立 workflow。
+
+## 输出策略
+
+- 默认 summary-first：单目标输出简短审计摘要；多目标明确列表输出逐目标摘要；容器目标输出安全诊断报告摘要，不堆叠字段计数。
+- 单目标 `public_exposure_check` 按 outputs 的 `Semantic Rendering` 渲染 `per_target_permission_assessment`，输出用户语言结论和检查边界；默认不展示底层字段名、风险清单或整改 CTA。
+- 容器安全诊断必须包含一句话结论、覆盖情况、风险分级、可定位待复核对象、建议下一步和剩余限制。
+- 待复核对象必须包含稳定 `risk_id`、path/title、URL、type、owner、sec_label、风险原因、证据和建议动作；缺少 URL 时展示 token / node_token 和原因。
+- 容器摘要按规模渐进披露，不能固定 Top N；未完全展开时必须说明完整清单总数，并给出生成 artifact / dry-run / owner 复核清单等 CTA。
+- 面向用户优先使用业务语言和“候选风险 / 待复核 / 待策略确认”；底层字段只作为证据。完整模板按需读取 [`lark-drive-workflow-permission-governance-outputs.md`](lark-drive-workflow-permission-governance-outputs.md)。
+- 不要默认创建文件、飞书文档或长表格；最终回复必须包含已完成事项、验证结果和剩余限制。异步权限申请审批只能表述为“已发起申请”。

--- a/skills/lark-drive/references/lark-drive-workflow.md
+++ b/skills/lark-drive/references/lark-drive-workflow.md
@@ -1,0 +1,130 @@
+# lark-drive Workflow 总框架
+
+本文是 `lark-drive` workflow 总框架的运行协议和注册表。它面向 AI Agent 执行，只负责路由已纳入本总框架的 workflow。
+
+`Workflow Registry` 是本总框架的唯一注册来源。未命中 registry 的请求必须按“未注册 workflow 处理”执行，不要按已有 workflow 类推扩展。
+
+## 必读上下文
+
+执行本总框架内的 workflow 前，必须先阅读 [`../../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
+
+下游 reference 只能按需逐步加载。不要因为命中本总框架，就预加载所有 workflow 文件或相关 skill。
+
+## 能力边界
+
+`lark-drive` workflow 总框架以 `lark-drive` 作为 Drive / Docs / Wiki 资产编排的总入口。其他领域 skill 只有在已纳入本总框架的 workflow 明确需要时，才作为辅助能力加载。
+
+| Layer | Owns | Must Not Own |
+|-------|------|--------------|
+| `lark-drive/SKILL.md` | 用户意图到具体 workflow entry 的短路由 | 长流程逻辑、未注册场景 |
+| `lark-drive-workflow.md` | 共享运行协议、Artifact Contract、Workflow Registry、加载规则 | 非运行时背景说明、宽泛路线图、场景专项执行细节 |
+| Registered workflow file | 场景范围、状态机、Command Map、确认门槛、验证规则 | 其他场景、隐藏写入、未被 CLI/API 支持的能力声明 |
+
+## 执行协议
+
+每个已纳入本总框架的 workflow 必须遵循同一条执行骨架：
+
+```text
+route -> scope -> read -> assess/plan -> confirm -> execute -> verify -> done
+```
+
+运行规则：
+
+1. 在读取或写入资产前，先把用户意图解析到唯一一个已纳入本总框架的 workflow。
+2. 在昂贵读取或写入规划前，先解析并确认 `target_scope`。
+3. 事实必须来自可执行 CLI 命令或被引用 skill；不要只凭目录结构推断治理结论。
+4. 无法执行的检查必须记录到 `unsupported_checks`，不能静默省略。
+5. 写入前必须产出计划。每一次写入都需要用户对准确范围和 command family 显式确认。
+6. CLI/API 支持验证时，写入后必须用 fresh read 验证。
+7. 结束时进入 `done`，返回已完成事项、验证结果和剩余限制。不要把尚未完成的外部审批描述成已完成。
+
+## Artifact Contract
+
+每个已纳入本总框架的 workflow 必须维护以下内部字段：
+
+| Field | Meaning |
+|-------|---------|
+| `workflow_id` | 本总框架注册的 workflow 名称，例如 `permission_governance` |
+| `current_state` | 当前 workflow 状态 |
+| `target_scope` | 已确认的目标范围和用户原始输入 |
+| `identity` | 当前身份和执行视角，通常为 `user` |
+| `facts` | 从 CLI 读取或引用 skill 获取的证据 |
+| `plan_items` | 候选动作；每项包含 command family、target、risk、verification method |
+| `unsupported_checks` | 因 CLI/API 覆盖、目标类型、认证或范围限制而无法执行的检查 |
+| `partial` | 结果是否不完整，以及不完整原因 |
+| `execution_results` | 已确认写入的执行结果 |
+| `verification_results` | fresh read 验证结果，或明确的异步审批限制 |
+
+用户可见输出默认使用简洁 chat summary。只有在用户要求、结果过大不适合聊天展示，或当前 workflow 明确要求共享产物时，才创建本地文件或飞书文档。
+
+## Workflow Entry Contract
+
+每个已纳入本总框架的 workflow entry file 必须让 Agent 能直接判断和执行：
+
+- 何时进入该 workflow，以及哪些需求不属于该 workflow；
+- 如何映射到共享执行骨架的 state machine；
+- 当前 state 需要按需加载哪些 reference；
+- 哪些 command family 可用，以及读写风险边界；
+- 写入前如何确认，写入后如何验证；
+- 最终回复必须包含哪些字段，或使用哪些 output templates。
+
+每个纳入本总框架的 workflow 默认从一个独立 reference 文件开始。只有当写入、回滚或验证流程复杂到影响可读性时，才继续拆 phase 文件。
+
+## Risk / Structure Gate
+
+每个纳入本总框架的 workflow 都必须同时声明 `Risk Level` 和 `Structure Level`。风险等级决定安全门槛；结构等级决定文件拆分。高风险写入不等于必须拆 phase。
+
+Risk Level：
+
+| Level | Meaning | Runtime Requirement |
+|-------|---------|---------------------|
+| `R0` | read-only：只读发现、分析、报告 | 记录事实来源、`unsupported_checks` 和 `partial` 原因 |
+| `R1` | low-risk write：创建草稿、生成临时产物等低风险写入 | 写前说明范围，写后返回结果链接或标识 |
+| `R2` | high-risk write：权限变更、批量移动、标签修改等高风险写入 | 写前计划、准确 diff、用户显式确认、fresh read 验证 |
+| `R3` | destructive / recovery-sensitive write：删除、自动归档、双向同步、rollback cleanup | 恢复边界、执行日志、分批策略、失败停止条件和单独确认 |
+
+Structure Level：
+
+| Level | File Shape | When To Use |
+|-------|------------|-------------|
+| `S1` | compact entry only | 只读、轻量审计、简单计划，无复杂写入 |
+| `S2` | entry + optional `commands` / `outputs` / `artifacts` references | 有命令样例、输出模板、少量高风险写入，但状态链可集中表达 |
+| `S3` | entry + phase files + optional shared references | 多阶段写入、复杂验证、恢复 / rollback、长任务或分批执行 |
+
+升级规则：
+
+1. 新 workflow 默认从 `S1` 开始。
+2. Entry file 超过约 300 行时，优先拆 `commands`、`outputs` 或 `artifacts` reference。
+3. 只有执行、验证、恢复或 rollback 状态链复杂到影响可读性时，才升级到 `S3` phase files。
+4. 垂直业务包优先作为已有 workflow 的 recipe / policy / template，不默认新增独立 workflow。
+5. 已有样板：`permission_governance` 是 `R2/S2`；已发布的独立 `knowledge_organize` 是 `R2-R3/S3`，当前不作为本总框架 registry entry。
+
+## 加载与拆分边界
+
+- 每个纳入本总框架的场景默认只保留一个紧凑 workflow entry file。
+- 不为未注册或未来场景创建占位 reference / registry entry。
+- 只有 workflow 已经具备可执行规则时，才允许作为本总框架 workflow 出现在 `SKILL.md` 并加入 `Workflow Registry`。
+- 多文件 phase 拆分只用于执行、回滚或验证流程复杂到影响可读性的 `S3` 场景。
+
+## Workflow Registry
+
+| Workflow | Status | Risk | Structure | Entry File | Trigger |
+|----------|--------|------|-----------|------------|---------|
+| `permission_governance` | Registered | `R2` | `S2` | [`lark-drive-workflow-permission-governance.md`](lark-drive-workflow-permission-governance.md) | 权限审计、公开链接/外部访问、复制/下载/评论/分享设置、权限申请、owner 转移 / 批量 owner 转移、密级标签调整 |
+
+## Workflow Loading
+
+当用户意图匹配到本总框架已注册 workflow 时：
+
+1. 先读取本总框架文件。
+2. 只读取 `Workflow Registry` 中命中的 entry file。
+3. 按该 workflow 的 progressive load map 继续加载额外 reference。
+4. 除非用户改变意图，或当前 workflow 明确路由到其他 workflow，否则不要读取其他 workflow 文件。
+
+## 未注册 workflow 处理
+
+`Workflow Registry` 是本总框架的唯一注册来源。用户请求未列入 registry 的 workflow 或组合型治理场景时：
+
+1. 明确说明该需求暂无纳入本总框架的 `lark-drive` workflow。
+2. 只在不新增本总框架 workflow 行为的前提下，将请求收窄为现有 skill / CLI 可执行的原子操作。
+3. 不要类比本总框架任何已注册 workflow 新增 state machine、artifact shape、风险分类、写入行为或验证结论。


### PR DESCRIPTION
## Summary

Add and refine the registered `permission_governance` workflow for `lark-drive` so AI agents can audit, report, and govern Drive / Docs / Wiki permission risks with explicit capability boundaries and write-safety gates. This update also aligns owner-transfer routing, public-permission semantic rendering, and user-facing output templates with the current CLI schema and official OpenAPI terminology.

## Changes

- Register permission governance routing for owner transfer and batch owner transfer from `SKILL.md` through the workflow registry.
- Refine permission governance runtime rules for single-target, explicit-list, and container permission diagnostics without duplicating logic.
- Improve semantic rendering for document public access and collaboration settings, including current-schema vs official-field boundaries.
- Clarify confirmation and final-summary wording so asynchronous permission-request approval is not confused with owner transfer.
- Add command and output guidance for owner transfer, secure-label preflight, stable risk IDs, URL-backed risk lists, and actionable governance reports.

## Test Plan

- [x] `node scripts/skill-format-check/index.js` passed
- [x] `bash scripts/check-doc-tokens.sh skills/lark-drive` passed
- [x] `bash scripts/check-skill-wire-vocab.sh` passed
- [x] `git diff --check -- skills/lark-drive/SKILL.md skills/lark-drive/references/lark-drive-workflow.md skills/lark-drive/references/lark-drive-workflow-permission-governance.md skills/lark-drive/references/lark-drive-workflow-permission-governance-outputs.md skills/lark-drive/references/lark-drive-workflow-permission-governance-commands.md` passed
- [x] Manual CLI schema validation:
  - `lark-cli schema drive.permission.public.get --format json`
  - `lark-cli schema drive.permission.members.transfer_owner --format json`
- [ ] GitHub Actions tests and lint pass after push

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a permission-governance workflow to audit and manage document permissions, sharing scope, external access, copy/download rights, owner transfers, security labels, and generate permission-risk reports with actionable remediation and confirmation steps.

* **Documentation**
  * Added comprehensive docs and templates: workflow protocols, step-by-step procedures, CLI command examples, output/ rendering rules, risk/report formats, dry-run/confirmation flows, bulk operation and owner-transfer guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->