### PR TITLE
Feat/riscv64 build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
 
 archives:
   - name_template: "lark-cli-{{ .Version }}-{{ .Os }}-{{ .Arch }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ```bash
 make build          # Build (runs fetch_meta first)
-make unit-test      # Required before PR (runs with -race)
+make unit-test      # Required before PR (runs with -race where supported, e.g. amd64/arm64)
 make test           # Full: vet + unit + integration
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ DATE     := $(shell date +%Y-%m-%d)
 LDFLAGS  := -s -w -X $(MODULE)/internal/build.Version=$(VERSION) -X $(MODULE)/internal/build.Date=$(DATE)
 PREFIX   ?= /usr/local
 
+# -race is not supported on linux/riscv64 before Go 1.26.
+RACE_FLAG := $(shell go env GOARCH | grep -qv '^riscv64$$' && echo '-race' || echo '')
+
 .PHONY: all build vet fmt-check test unit-test integration-test examples-build install uninstall clean fetch_meta gitleaks
 
 all: test
@@ -34,7 +37,7 @@ fmt-check:
 
 # ./extension/... keeps the public plugin SDK in the default test matrix.
 unit-test: fetch_meta
-	go test -race -gcflags="all=-N -l" -count=1 \
+	go test $(RACE_FLAG) -gcflags="all=-N -l" -count=1 \
 		./cmd/... ./internal/... ./shortcuts/... ./extension/...
 
 # examples-build keeps the shipped plugin-SDK examples compilable. If this

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "cpu": [
     "x64",
-    "arm64"
+    "arm64",
+    "riscv64"
   ],
   "engines": {
     "node": ">=16"

--- a/scripts/build-pkg-pr-new.sh
+++ b/scripts/build-pkg-pr-new.sh
@@ -33,6 +33,7 @@ build_target darwin arm64
 build_target linux amd64
 build_target darwin amd64
 build_target linux arm64
+build_target linux riscv64
 build_target windows amd64
 build_target windows arm64
 
@@ -55,6 +56,7 @@ const platformMap = {
 const archMap = {
   x64: "amd64",
   arm64: "arm64",
+  riscv64: "riscv64",
 };
 
 const platform = platformMap[process.platform];

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -30,6 +30,7 @@ const PLATFORM_MAP = {
 const ARCH_MAP = {
   x64: "amd64",
   arm64: "arm64",
+  riscv64: "riscv64",
 };
 
 const platform = PLATFORM_MAP[process.platform];


### PR DESCRIPTION
## Summary

Add riscv64 as a supported architecture so the CLI builds and installs
natively on RISC-V hardware.

## Changes

Makefile: make -race flag conditional. Go's race detector is not
available on linux/riscv64 before Go 1.26, so "make unit-test" fails
without this guard.

Release pipeline: add riscv64 to .goreleaser.yml, package.json,
scripts/build-pkg-pr-new.sh, and scripts/install.js.

## Test Plan

Unit tests pass on riscv64 hardware (make unit-test).

Release workflow verified: produced a working lark-cli binary that
runs natively on linux/riscv64.

## Related Issues

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RISC-V 64-bit (riscv64) platform support for builds and package installations.

* **Documentation**
  * Updated build instructions to clarify that race condition testing is conditionally applied based on target architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->