### PR TITLE
feat: docs fetch 支持 lang 参数

### DIFF
--- a/shortcuts/doc/docs_fetch.go
+++ b/shortcuts/doc/docs_fetch.go
@@ -33,7 +33,7 @@ func useV2Fetch(runtime *common.RuntimeContext) bool {
 	if runtime.Str("api-version") == "v2" {
 		return true
 	}
-	for _, name := range []string{"detail", "doc-format", "scope", "revision-id", "start-block-id", "end-block-id", "keyword", "context-before", "context-after", "max-depth"} {
+	for _, name := range []string{"detail", "doc-format", "lang", "scope", "revision-id", "start-block-id", "end-block-id", "keyword", "context-before", "context-after", "max-depth"} {
 		if runtime.Changed(name) {
 			return true
 		}

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -19,6 +19,7 @@ func v2FetchFlags() []common.Flag {
 		{Name: "doc-format", Desc: "content format", Hidden: true, Default: "xml", Enum: []string{"xml", "markdown"}},
 		{Name: "detail", Desc: "export detail level: simple (read-only) | with-ids (block IDs for cross-referencing) | full (all attrs for editing)", Hidden: true, Default: "simple", Enum: []string{"simple", "with-ids", "full"}},
 		{Name: "revision-id", Desc: "document revision (-1 = latest)", Hidden: true, Type: "int", Default: "-1"},
+		{Name: "lang", Desc: "language for user cite names, e.g. zh_cn, en_us, ja_jp"},
 		{Name: "scope", Desc: "partial read scope: outline | range | keyword | section (omit to read whole doc)", Default: "full", Enum: []string{"full", "outline", "range", "keyword", "section"}},
 		{Name: "start-block-id", Desc: "range/section mode: start (anchor) block id"},
 		{Name: "end-block-id", Desc: "range mode: end block id; \"-1\" = to end of document"},
@@ -85,6 +86,9 @@ func buildFetchBody(runtime *common.RuntimeContext) map[string]interface{} {
 	if v := runtime.Int("revision-id"); v > 0 {
 		body["revision_id"] = v
 	}
+	if v := fetchLang(runtime); v != "" {
+		body["lang"] = v
+	}
 
 	detail := runtime.Str("detail")
 	switch detail {
@@ -112,6 +116,16 @@ func buildFetchBody(runtime *common.RuntimeContext) map[string]interface{} {
 	injectDocsScene(runtime, body)
 
 	return body
+}
+
+func fetchLang(runtime *common.RuntimeContext) string {
+	if v := strings.TrimSpace(runtime.Str("lang")); v != "" {
+		return v
+	}
+	if runtime.Config == nil {
+		return ""
+	}
+	return strings.TrimSpace(string(runtime.Lang()))
 }
 
 // buildReadOption 拼装 read_option JSON；full/空模式返回 nil，让服务端走默认全文路径。

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/i18n"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
 )
@@ -58,11 +60,69 @@ func TestBuildFetchBodyOmitsEmptyScene(t *testing.T) {
 	}
 }
 
+func TestBuildFetchBodyIncludesExplicitLang(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchBodyTestRuntime(context.Background())
+	if err := runtime.Cmd.Flags().Set("lang", "en-US"); err != nil {
+		t.Fatalf("set lang: %v", err)
+	}
+
+	body := buildFetchBody(runtime)
+	if got := body["lang"]; got != "en-US" {
+		t.Fatalf("lang = %#v, want %q", got, "en-US")
+	}
+}
+
+func TestBuildFetchBodyUsesRuntimeLangWhenFlagEmpty(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchBodyTestRuntime(context.Background())
+	runtime.Config = &core.CliConfig{Lang: i18n.LangJaJP}
+
+	body := buildFetchBody(runtime)
+	if got := body["lang"]; got != string(i18n.LangJaJP) {
+		t.Fatalf("lang = %#v, want %q", got, i18n.LangJaJP)
+	}
+}
+
+func TestBuildFetchBodyExplicitLangOverridesRuntimeLang(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchBodyTestRuntime(context.Background())
+	runtime.Config = &core.CliConfig{Lang: i18n.LangJaJP}
+	if err := runtime.Cmd.Flags().Set("lang", "en-US"); err != nil {
+		t.Fatalf("set lang: %v", err)
+	}
+
+	body := buildFetchBody(runtime)
+	if got := body["lang"]; got != "en-US" {
+		t.Fatalf("lang = %#v, want explicit flag", got)
+	}
+}
+
+func TestUseV2FetchDetectsLangFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "+fetch"}
+	cmd.Flags().String("api-version", "v1", "")
+	cmd.Flags().String("lang", "", "")
+	if err := cmd.Flags().Set("lang", "en-US"); err != nil {
+		t.Fatalf("set lang: %v", err)
+	}
+	runtime := common.TestNewRuntimeContext(cmd, nil)
+
+	if !useV2Fetch(runtime) {
+		t.Fatal("expected --lang to route to v2 fetch")
+	}
+}
+
 func newFetchBodyTestRuntime(ctx context.Context) *common.RuntimeContext {
 	cmd := &cobra.Command{Use: "+fetch"}
 	cmd.Flags().String("doc-format", "xml", "")
 	cmd.Flags().String("detail", "simple", "")
 	cmd.Flags().Int("revision-id", -1, "")
+	cmd.Flags().String("lang", "", "")
 	cmd.Flags().String("scope", "full", "")
 	cmd.Flags().String("start-block-id", "", "")
 	cmd.Flags().String("end-block-id", "", "")

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -12,6 +12,9 @@ lark-cli docs +fetch --api-version v2 --doc "https://xxx.feishu.cn/docx/Z1Fj...t
 # Markdown 格式
 lark-cli docs +fetch --api-version v2 --doc Z1Fj...tnAc --doc-format markdown
 
+# 指定 <cite type="user"> 的 user-name 语言
+lark-cli docs +fetch --api-version v2 --doc Z1Fj...tnAc --lang en_us
+
 # 带 block ID（用于后续 block 级更新）
 lark-cli docs +fetch --api-version v2 --doc Z1Fj...tnAc --detail with-ids
 
@@ -104,6 +107,7 @@ lark-cli docs +fetch --api-version v2 --doc Z1Fj...tnAc \
 | `--doc-format` | 否 | `xml`（默认）\| `markdown` \| `text` |
 | `--detail` | 否 | `simple`（默认）\| `with-ids` \| `full` |
 | `--revision-id` | 否 | 文档版本号，`-1` = 最新（默认） |
+| `--lang` | 否 | `<cite type="user">` 的 `user-name` 语言偏好，如 `zh_cn` / `en_us` / `ja_jp`；不传时使用当前 profile 语言，仍为空则服务端默认 |
 | `--scope` | 否 | `outline` \| `range` \| `keyword` \| `section`（省略 = 读整篇） |
 | `--start-block-id` | 否 | `range`/`section` 起始/锚点 id（`section` 必填） |
 | `--end-block-id` | 否 | `range` 结束 id；`-1` 表示读到末尾 |


### PR DESCRIPTION
## 背景

PRD: cli docs - cite user 支持返回多语言用户名。

## 改动

- `docs +fetch` v2 增加 `--lang` 参数，支持显式指定用户引用名称语言。
- 构造 fetch body 时，优先使用命令行 `--lang`；未显式传入时回退到 runtime/profile 的语言配置。
- 传入 `--lang` 时自动走 v2 fetch 路由。
- 更新 `lark-doc` skill 文档，补充 `--lang` 用法与参数说明。

## 验证

- `go test ./shortcuts/doc`

## 依赖

后端需要同步支持 ai_edit 到 office_ai_sdk 的 `lang` 透传与用户引用名称处理。
