### PR TITLE
feat(im): unify sort flags into --sort field and --order direction

### DIFF
--- a/shortcuts/im/builders_test.go
+++ b/shortcuts/im/builders_test.go
@@ -857,7 +857,7 @@ func TestShortcutDryRunShapes(t *testing.T) {
 	t.Run("ImChatList dry run includes endpoint and params", func(t *testing.T) {
 		runtime := newTestRuntimeContext(t, map[string]string{
 			"user-id-type": "open_id",
-			"sort-type":    "ByCreateTimeAsc",
+			"sort":         "create_time",
 		}, nil)
 		got := mustMarshalDryRun(t, ImChatList.DryRun(context.Background(), runtime))
 		if !strings.Contains(got, `"/open-apis/im/v1/chats"`) {

--- a/shortcuts/im/builders_test.go
+++ b/shortcuts/im/builders_test.go
@@ -797,7 +797,7 @@ func TestShortcutDryRunShapes(t *testing.T) {
 			"page-size": "10",
 		}, nil)
 		got := mustMarshalDryRun(t, ImThreadsMessagesList.DryRun(context.Background(), runtime))
-		if !strings.Contains(got, `"container_id":"omt_123"`) || !strings.Contains(got, `"sort_type":"ByCreateTimeDesc"`) || !strings.Contains(got, `"page_size":10`) {
+		if !strings.Contains(got, `"container_id":"omt_123"`) || !strings.Contains(got, `"sort_type":"ByCreateTimeDesc"`) || !strings.Contains(got, `"page_size":"10"`) {
 			t.Fatalf("ImThreadsMessagesList.DryRun() = %s", got)
 		}
 	})

--- a/shortcuts/im/im_chat_list.go
+++ b/shortcuts/im/im_chat_list.go
@@ -48,7 +48,8 @@ var ImChatList = common.Shortcut{
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "user-id-type", Default: "open_id", Desc: "ID type for owner_id in response", Enum: []string{"open_id", "union_id", "user_id"}},
-		{Name: "sort-type", Default: "ByCreateTimeAsc", Desc: "sort order", Enum: []string{"ByCreateTimeAsc", "ByActiveTimeDesc"}},
+		{Name: "sort", Default: "create_time", Desc: "sort field: create_time (ascending) | active_time (descending)", Enum: []string{"create_time", "active_time"}},
+		{Name: "sort-type", Hidden: true, Desc: "alias of --sort (hidden)", Enum: []string{"ByCreateTimeAsc", "ByActiveTimeDesc"}},
 		{Name: "types", Type: "string_slice", Desc: "chat types to include (group, p2p); omit = groups only (backward compatible); p2p requires user identity"},
 		{Name: "page-size", Type: "int", Default: "20", Desc: "page size (1-100)"},
 		{Name: "page-token", Desc: "pagination token for next page"},
@@ -266,9 +267,16 @@ func resolveTypes(runtime *common.RuntimeContext) (string, bool, error) {
 // CSV string already normalized + bot-stripped by resolveTypes; pass "" to
 // omit the types query param entirely (backward compatible default).
 func buildChatListParams(runtime *common.RuntimeContext, effectiveTypes string) map[string]interface{} {
+	sortType := map[string]string{
+		"create_time": "ByCreateTimeAsc",
+		"active_time": "ByActiveTimeDesc",
+	}[runtime.Str("sort")]
+	if old, ok := aliasFlagValue(runtime, "sort-type", "sort"); ok {
+		sortType = old // old value is already the upstream enum -> pass through
+	}
 	params := map[string]interface{}{
 		"user_id_type": runtime.Str("user-id-type"),
-		"sort_type":    runtime.Str("sort-type"),
+		"sort_type":    sortType,
 	}
 	if n := runtime.Int("page-size"); n > 0 {
 		params["page_size"] = n

--- a/shortcuts/im/im_chat_list_test.go
+++ b/shortcuts/im/im_chat_list_test.go
@@ -611,3 +611,85 @@ func TestImChatList_Execute_UserMuteFiltersP2p(t *testing.T) {
 		t.Fatalf("remaining chat = %v; want oc_g", parsed.Data.Chats[0]["chat_id"])
 	}
 }
+
+func TestChatList_SortMapping(t *testing.T) {
+	cases := []struct{ sort, want string }{
+		{"create_time", "ByCreateTimeAsc"},
+		{"active_time", "ByActiveTimeDesc"},
+	}
+	for _, c := range cases {
+		t.Run(c.sort, func(t *testing.T) {
+			rt := newChatListTestRuntimeContext(t, map[string]string{"sort": c.sort}, nil)
+			got := buildChatListParams(rt, "")
+			if got["sort_type"] != c.want {
+				t.Fatalf("sort=%s -> sort_type=%v, want %s", c.sort, got["sort_type"], c.want)
+			}
+		})
+	}
+}
+
+// TestChatList_SortAliasParity proves the hidden --sort-type alias maps to the
+// exact same upstream request as the equivalent new --sort value (byte-equal).
+func TestChatList_SortAliasParity(t *testing.T) {
+	pairs := []struct{ newVal, oldVal string }{
+		{"create_time", "ByCreateTimeAsc"},
+		{"active_time", "ByActiveTimeDesc"},
+	}
+	for _, p := range pairs {
+		t.Run(p.newVal, func(t *testing.T) {
+			newRT := newChatListTestRuntimeContext(t, map[string]string{"sort": p.newVal}, nil)
+			oldRT := newChatListTestRuntimeContext(t, map[string]string{"sort-type": p.oldVal}, nil)
+			a := mustMarshalDryRun(t, ImChatList.DryRun(context.Background(), newRT))
+			b := mustMarshalDryRun(t, ImChatList.DryRun(context.Background(), oldRT))
+			if a != b {
+				t.Fatalf("alias parity broken:\n new=%s\n old=%s", a, b)
+			}
+		})
+	}
+}
+
+// TestChatList_SortNewWins: both flags set -> new wins, old ignored, no error.
+func TestChatList_SortNewWins(t *testing.T) {
+	rt := newChatListTestRuntimeContext(t, map[string]string{
+		"sort":      "active_time",
+		"sort-type": "ByCreateTimeAsc",
+	}, nil)
+	got := buildChatListParams(rt, "")
+	if got["sort_type"] != "ByActiveTimeDesc" {
+		t.Fatalf("new should win: sort_type=%v, want ByActiveTimeDesc", got["sort_type"])
+	}
+}
+
+// TestChatList_SortFlagSurface asserts the declared flag structure.
+func TestChatList_SortFlagSurface(t *testing.T) {
+	var sortFlag, aliasFlag *common.Flag
+	for i := range ImChatList.Flags {
+		switch ImChatList.Flags[i].Name {
+		case "sort":
+			sortFlag = &ImChatList.Flags[i]
+		case "sort-type":
+			aliasFlag = &ImChatList.Flags[i]
+		}
+	}
+	if sortFlag == nil || aliasFlag == nil {
+		t.Fatalf("expected both --sort and --sort-type flags declared")
+	}
+	if sortFlag.Default != "create_time" {
+		t.Errorf("--sort Default = %q, want create_time", sortFlag.Default)
+	}
+	if got := strings.Join(sortFlag.Enum, ","); got != "create_time,active_time" {
+		t.Errorf("--sort Enum = %q, want create_time,active_time", got)
+	}
+	if !strings.Contains(sortFlag.Desc, "create_time") || !strings.Contains(sortFlag.Desc, "active_time") {
+		t.Errorf("--sort Desc must document both fields/directions: %q", sortFlag.Desc)
+	}
+	if !aliasFlag.Hidden {
+		t.Errorf("--sort-type must be Hidden")
+	}
+	if got := strings.Join(aliasFlag.Enum, ","); got != "ByCreateTimeAsc,ByActiveTimeDesc" {
+		t.Errorf("--sort-type Enum = %q, want ByCreateTimeAsc,ByActiveTimeDesc", got)
+	}
+	if aliasFlag.Default != "" {
+		t.Errorf("--sort-type (hidden alias) must not carry a Default, got %q", aliasFlag.Default)
+	}
+}

--- a/shortcuts/im/im_chat_messages_list.go
+++ b/shortcuts/im/im_chat_messages_list.go
@@ -32,7 +32,8 @@ var ImChatMessageList = common.Shortcut{
 		{Name: "user-id", Desc: "(required, mutually exclusive with --chat-id; user identity only) user open_id (ou_xxx)"},
 		{Name: "start", Desc: "start time (ISO 8601)"},
 		{Name: "end", Desc: "end time (ISO 8601)"},
-		{Name: "sort", Default: "desc", Desc: "sort order", Enum: []string{"asc", "desc"}},
+		{Name: "order", Default: "desc", Desc: "sort order: asc | desc", Enum: []string{"asc", "desc"}},
+		{Name: "sort", Hidden: true, Desc: "alias of --order (hidden)", Enum: []string{"asc", "desc"}},
 		{Name: "page-size", Default: "50", Desc: "page size (1-50)"},
 		{Name: "page-token", Desc: "pagination token for next page"},
 		{Name: "no-reactions", Type: "bool", Desc: "skip auto-fetching reactions for each message (default: enrichment enabled)"},
@@ -209,7 +210,11 @@ func buildChatMessageListParams(sortFlag, pageSizeStr, chatId string) larkcore.Q
 }
 
 func buildChatMessageListRequest(runtime *common.RuntimeContext, chatId string) (larkcore.QueryParams, error) {
-	params := buildChatMessageListParams(runtime.Str("sort"), runtime.Str("page-size"), chatId)
+	dir := runtime.Str("order")
+	if old, ok := aliasFlagValue(runtime, "sort", "order"); ok {
+		dir = old // old value is asc/desc -> must go through the same map, never pass through
+	}
+	params := buildChatMessageListParams(dir, runtime.Str("page-size"), chatId)
 
 	if startFlag := runtime.Str("start"); startFlag != "" {
 		startTime, err := common.ParseTime(startFlag)

--- a/shortcuts/im/im_chat_messages_list_test.go
+++ b/shortcuts/im/im_chat_messages_list_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// newMsgListTestRT registers chat-id (so the builder has a container) plus the
+// sort flags under test; only flags present in stringFlags are "set" (Changed).
+func newMsgListTestRT(t *testing.T, stringFlags map[string]string) *common.RuntimeContext {
+	t.Helper()
+	if stringFlags == nil {
+		stringFlags = map[string]string{}
+	}
+	if _, ok := stringFlags["chat-id"]; !ok {
+		stringFlags["chat-id"] = "oc_test"
+	}
+	return newChatListTestRuntimeContext(t, stringFlags, nil)
+}
+
+func TestChatMessagesList_OrderMapping(t *testing.T) {
+	cases := []struct{ order, want string }{
+		{"asc", "ByCreateTimeAsc"},
+		{"desc", "ByCreateTimeDesc"},
+	}
+	for _, c := range cases {
+		t.Run(c.order, func(t *testing.T) {
+			rt := newMsgListTestRT(t, map[string]string{"order": c.order})
+			params, err := buildChatMessageListRequest(rt, "oc_test")
+			if err != nil {
+				t.Fatalf("buildChatMessageListRequest() error = %v", err)
+			}
+			if got := params["sort_type"][0]; got != c.want {
+				t.Fatalf("order=%s -> sort_type=%s, want %s", c.order, got, c.want)
+			}
+		})
+	}
+}
+
+// TestChatMessagesList_OrderAliasParity: hidden --sort alias (asc/desc) must map
+// through the SAME table as --order (NOT pass through), producing identical upstream.
+func TestChatMessagesList_OrderAliasParity(t *testing.T) {
+	for _, dir := range []string{"asc", "desc"} {
+		t.Run(dir, func(t *testing.T) {
+			newRT := newMsgListTestRT(t, map[string]string{"order": dir})
+			oldRT := newMsgListTestRT(t, map[string]string{"sort": dir})
+			a := mustMarshalDryRun(t, ImChatMessageList.DryRun(context.Background(), newRT))
+			b := mustMarshalDryRun(t, ImChatMessageList.DryRun(context.Background(), oldRT))
+			if a != b {
+				t.Fatalf("alias parity broken:\n new=%s\n old=%s", a, b)
+			}
+		})
+	}
+}
+
+func TestChatMessagesList_OrderNewWins(t *testing.T) {
+	rt := newMsgListTestRT(t, map[string]string{"order": "asc", "sort": "desc"})
+	params, err := buildChatMessageListRequest(rt, "oc_test")
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if got := params["sort_type"][0]; got != "ByCreateTimeAsc" {
+		t.Fatalf("new should win: sort_type=%s, want ByCreateTimeAsc", got)
+	}
+}
+
+func TestChatMessagesList_OrderFlagSurface(t *testing.T) {
+	var orderFlag, aliasFlag *common.Flag
+	for i := range ImChatMessageList.Flags {
+		switch ImChatMessageList.Flags[i].Name {
+		case "order":
+			orderFlag = &ImChatMessageList.Flags[i]
+		case "sort":
+			aliasFlag = &ImChatMessageList.Flags[i]
+		}
+	}
+	if orderFlag == nil || aliasFlag == nil {
+		t.Fatalf("expected both --order and --sort flags declared")
+	}
+	if orderFlag.Default != "desc" {
+		t.Errorf("--order Default = %q, want desc", orderFlag.Default)
+	}
+	if got := strings.Join(orderFlag.Enum, ","); got != "asc,desc" {
+		t.Errorf("--order Enum = %q, want asc,desc", got)
+	}
+	if !aliasFlag.Hidden {
+		t.Errorf("--sort must be Hidden")
+	}
+	if got := strings.Join(aliasFlag.Enum, ","); got != "asc,desc" {
+		t.Errorf("--sort (alias) Enum = %q, want asc,desc", got)
+	}
+}

--- a/shortcuts/im/im_chat_search.go
+++ b/shortcuts/im/im_chat_search.go
@@ -34,7 +34,8 @@ var ImChatSearch = common.Shortcut{
 		{Name: "member-ids", Desc: "filter by member open_ids, comma-separated"},
 		{Name: "is-manager", Type: "bool", Desc: "only show chats you created or manage"},
 		{Name: "disable-search-by-user", Type: "bool", Desc: "disable search-by-member-name (default: search by member name first, then group name)"},
-		{Name: "sort-by", Desc: "sort field (descending)", Enum: []string{"create_time_desc", "update_time_desc", "member_count_desc"}},
+		{Name: "sort", Desc: "sort field (always descending): create_time | update_time | member_count", Enum: []string{"create_time", "update_time", "member_count"}},
+		{Name: "sort-by", Hidden: true, Desc: "alias of --sort (hidden)", Enum: []string{"create_time_desc", "update_time_desc", "member_count_desc"}},
 		{Name: "page-size", Type: "int", Default: "20", Desc: "page size (1-100)"},
 		{Name: "page-token", Desc: "pagination token for next page"},
 		{Name: "exclude-muted", Type: "bool", Desc: "(user identity only) drop chats the current user has muted (do-not-disturb); bot identity returns all chats unfiltered"},
@@ -201,8 +202,8 @@ var ImChatSearch = common.Shortcut{
 // buildSearchChatBody builds the JSON request body for POST /im/v2/chats/search
 // from the runtime flag values. The query string is normalized via
 // normalizeChatSearchQuery (hyphenated terms get quoted). The "filter" object
-// is omitted when no filter flags are set; "sorter" is omitted when --sort-by
-// is empty.
+// is omitted when no filter flags are set; "sorter" is omitted when --sort
+// (and its hidden alias --sort-by) is unset.
 func buildSearchChatBody(runtime *common.RuntimeContext) map[string]interface{} {
 	body := map[string]interface{}{}
 
@@ -230,9 +231,18 @@ func buildSearchChatBody(runtime *common.RuntimeContext) map[string]interface{} 
 		body["filter"] = filter
 	}
 
-	// Build sorters (always descending)
-	if sortBy := runtime.Str("sort-by"); sortBy != "" {
-		body["sorter"] = sortBy
+	// Build sorter (always descending). --sort maps field -> field_desc; the hidden
+	// --sort-by alias is already the upstream value (pass-through). Omitted when unset.
+	sorter := map[string]string{
+		"create_time":  "create_time_desc",
+		"update_time":  "update_time_desc",
+		"member_count": "member_count_desc",
+	}[runtime.Str("sort")]
+	if old, ok := aliasFlagValue(runtime, "sort-by", "sort"); ok {
+		sorter = old
+	}
+	if sorter != "" {
+		body["sorter"] = sorter
 	}
 
 	return body

--- a/shortcuts/im/im_chat_search_test.go
+++ b/shortcuts/im/im_chat_search_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+func newSearchTestRT(t *testing.T, stringFlags map[string]string) *common.RuntimeContext {
+	t.Helper()
+	if stringFlags == nil {
+		stringFlags = map[string]string{}
+	}
+	if _, ok := stringFlags["query"]; !ok {
+		stringFlags["query"] = "team"
+	}
+	return newChatListTestRuntimeContext(t, stringFlags, nil)
+}
+
+func TestChatSearch_SortMapping(t *testing.T) {
+	cases := []struct{ sort, want string }{
+		{"create_time", "create_time_desc"},
+		{"update_time", "update_time_desc"},
+		{"member_count", "member_count_desc"},
+	}
+	for _, c := range cases {
+		t.Run(c.sort, func(t *testing.T) {
+			rt := newSearchTestRT(t, map[string]string{"sort": c.sort})
+			body := buildSearchChatBody(rt)
+			if body["sorter"] != c.want {
+				t.Fatalf("sort=%s -> sorter=%v, want %s", c.sort, body["sorter"], c.want)
+			}
+		})
+	}
+}
+
+// TestChatSearch_SortOmittedWhenUnset: no --sort and no --sort-by -> sorter omitted.
+func TestChatSearch_SortOmittedWhenUnset(t *testing.T) {
+	rt := newSearchTestRT(t, nil)
+	body := buildSearchChatBody(rt)
+	if _, present := body["sorter"]; present {
+		t.Fatalf("sorter should be omitted when neither --sort nor --sort-by set")
+	}
+}
+
+// TestChatSearch_SortAliasParity: hidden --sort-by value is already the upstream
+// sorter (pass-through), so it must equal the mapped new --sort body.
+func TestChatSearch_SortAliasParity(t *testing.T) {
+	pairs := []struct{ newVal, oldVal string }{
+		{"create_time", "create_time_desc"},
+		{"update_time", "update_time_desc"},
+		{"member_count", "member_count_desc"},
+	}
+	for _, p := range pairs {
+		t.Run(p.newVal, func(t *testing.T) {
+			newBody := buildSearchChatBody(newSearchTestRT(t, map[string]string{"sort": p.newVal}))
+			oldBody := buildSearchChatBody(newSearchTestRT(t, map[string]string{"sort-by": p.oldVal}))
+			if newBody["sorter"] != oldBody["sorter"] {
+				t.Fatalf("alias parity: new sorter=%v, old sorter=%v", newBody["sorter"], oldBody["sorter"])
+			}
+		})
+	}
+}
+
+func TestChatSearch_SortNewWins(t *testing.T) {
+	rt := newSearchTestRT(t, map[string]string{"sort": "member_count", "sort-by": "create_time_desc"})
+	body := buildSearchChatBody(rt)
+	if body["sorter"] != "member_count_desc" {
+		t.Fatalf("new should win: sorter=%v, want member_count_desc", body["sorter"])
+	}
+}
+
+func TestChatSearch_SortFlagSurface(t *testing.T) {
+	var sortFlag, aliasFlag *common.Flag
+	for i := range ImChatSearch.Flags {
+		switch ImChatSearch.Flags[i].Name {
+		case "sort":
+			sortFlag = &ImChatSearch.Flags[i]
+		case "sort-by":
+			aliasFlag = &ImChatSearch.Flags[i]
+		}
+	}
+	if sortFlag == nil || aliasFlag == nil {
+		t.Fatalf("expected both --sort and --sort-by flags declared")
+	}
+	if sortFlag.Default != "" {
+		t.Errorf("--sort must have no default (sorter omitted when unset), got %q", sortFlag.Default)
+	}
+	if got := strings.Join(sortFlag.Enum, ","); got != "create_time,update_time,member_count" {
+		t.Errorf("--sort Enum = %q", got)
+	}
+	if !aliasFlag.Hidden {
+		t.Errorf("--sort-by must be Hidden")
+	}
+	if got := strings.Join(aliasFlag.Enum, ","); got != "create_time_desc,update_time_desc,member_count_desc" {
+		t.Errorf("--sort-by Enum = %q", got)
+	}
+}

--- a/shortcuts/im/im_threads_messages_list.go
+++ b/shortcuts/im/im_threads_messages_list.go
@@ -31,7 +31,8 @@ var ImThreadsMessagesList = common.Shortcut{
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "thread", Desc: "thread ID (om_xxx or omt_xxx)", Required: true},
-		{Name: "sort", Default: "asc", Desc: "sort order", Enum: []string{"asc", "desc"}},
+		{Name: "order", Default: "asc", Desc: "sort order: asc | desc", Enum: []string{"asc", "desc"}},
+		{Name: "sort", Hidden: true, Desc: "alias of --order (hidden)", Enum: []string{"asc", "desc"}},
 		{Name: "page-size", Default: "50", Desc: "page size (1-500)"},
 		{Name: "page-token", Desc: "page token"},
 		{Name: "no-reactions", Type: "bool", Desc: "skip auto-fetching reactions for each message (default: enrichment enabled)"},
@@ -39,14 +40,9 @@ var ImThreadsMessagesList = common.Shortcut{
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		threadFlag := runtime.Str("thread")
-		sortFlag := runtime.Str("sort")
+		dir := resolveThreadsOrder(runtime)
 		pageSizeStr := runtime.Str("page-size")
 		pageToken := runtime.Str("page-token")
-
-		sortType := "ByCreateTimeAsc"
-		if sortFlag == "desc" {
-			sortType = "ByCreateTimeDesc"
-		}
 
 		pageSize, _ := common.ValidatePageSizeTyped(runtime, "page-size", threadsMessagesMaxPageSize, 1, threadsMessagesMaxPageSize)
 
@@ -57,21 +53,12 @@ var ImThreadsMessagesList = common.Shortcut{
 			containerID = "<resolved_thread_id>"
 		}
 
-		params := map[string]interface{}{
-			"container_id_type":     "thread",
-			"container_id":          containerID,
-			"sort_type":             sortType,
-			"page_size":             pageSize,
-			"card_msg_content_type": "raw_card_content",
-		}
-		if pageToken != "" {
-			params["page_token"] = pageToken
-		}
+		params := buildThreadsMessagesListParams(dir, containerID, pageSize, pageToken)
 
 		d = d.
 			GET("/open-apis/im/v1/messages").
-			Params(params).
-			Set("thread", threadFlag).Set("sort", sortFlag).Set("page_size", pageSizeStr)
+			Params(toDryParams(params)).
+			Set("thread", threadFlag).Set("order", dir).Set("page_size", pageSizeStr)
 		if !runtime.Bool("no-reactions") {
 			d = d.POST("/open-apis/im/v1/messages/reactions/batch_query").
 				Desc("Reaction enrichment: queries returned thread messages in batches of up to 20. Pass --no-reactions to skip.")
@@ -97,26 +84,12 @@ var ImThreadsMessagesList = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		sortFlag := runtime.Str("sort")
+		dir := resolveThreadsOrder(runtime)
 		pageToken := runtime.Str("page-token")
-
-		sortType := "ByCreateTimeAsc"
-		if sortFlag == "desc" {
-			sortType = "ByCreateTimeDesc"
-		}
 
 		pageSize, _ := common.ValidatePageSizeTyped(runtime, "page-size", threadsMessagesMaxPageSize, 1, threadsMessagesMaxPageSize)
 
-		params := map[string][]string{
-			"container_id_type":     []string{"thread"},
-			"container_id":          []string{threadId},
-			"sort_type":             []string{sortType},
-			"page_size":             []string{strconv.Itoa(pageSize)},
-			"card_msg_content_type": []string{"raw_card_content"},
-		}
-		if pageToken != "" {
-			params["page_token"] = []string{pageToken}
-		}
+		params := buildThreadsMessagesListParams(dir, threadId, pageSize, pageToken)
 
 		data, err := runtime.DoAPIJSONTyped(http.MethodGet, "/open-apis/im/v1/messages", params, nil)
 		if err != nil {
@@ -187,4 +160,46 @@ var ImThreadsMessagesList = common.Shortcut{
 		})
 		return nil
 	},
+}
+
+// buildThreadsMessagesListParams builds the upstream query params shared by
+// DryRun and Execute, so the asc/desc -> sort_type mapping lives in exactly one
+// place (precondition for the dry-run == real alias-parity test).
+func buildThreadsMessagesListParams(dir, containerID string, pageSize int, pageToken string) map[string][]string {
+	sortType := "ByCreateTimeAsc"
+	if dir == "desc" {
+		sortType = "ByCreateTimeDesc"
+	}
+	params := map[string][]string{
+		"container_id_type":     {"thread"},
+		"container_id":          {containerID},
+		"sort_type":             {sortType},
+		"page_size":             {strconv.Itoa(pageSize)},
+		"card_msg_content_type": {"raw_card_content"},
+	}
+	if pageToken != "" {
+		params["page_token"] = []string{pageToken}
+	}
+	return params
+}
+
+// resolveThreadsOrder picks --order, falling back to the hidden --sort alias.
+func resolveThreadsOrder(runtime *common.RuntimeContext) string {
+	dir := runtime.Str("order")
+	if old, ok := aliasFlagValue(runtime, "sort", "order"); ok {
+		dir = old
+	}
+	return dir
+}
+
+// toDryParams flattens single-valued query params to scalars for dry-run preview,
+// matching the historical dry-run JSON shape.
+func toDryParams(p map[string][]string) map[string]interface{} {
+	out := make(map[string]interface{}, len(p))
+	for k, v := range p {
+		if len(v) > 0 {
+			out[k] = v[0]
+		}
+	}
+	return out
 }

--- a/shortcuts/im/im_threads_messages_list_test.go
+++ b/shortcuts/im/im_threads_messages_list_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+func newThreadsTestRT(t *testing.T, stringFlags map[string]string) *common.RuntimeContext {
+	t.Helper()
+	if stringFlags == nil {
+		stringFlags = map[string]string{}
+	}
+	if _, ok := stringFlags["thread"]; !ok {
+		stringFlags["thread"] = "omt_test"
+	}
+	return newChatListTestRuntimeContext(t, stringFlags, nil)
+}
+
+func TestThreadsMessagesList_OrderMapping(t *testing.T) {
+	cases := []struct{ order, want string }{
+		{"asc", "ByCreateTimeAsc"},
+		{"desc", "ByCreateTimeDesc"},
+	}
+	for _, c := range cases {
+		t.Run(c.order, func(t *testing.T) {
+			got := buildThreadsMessagesListParams(c.order, "omt_test", 50, "")
+			if v := got["sort_type"][0]; v != c.want {
+				t.Fatalf("order=%s -> sort_type=%s, want %s", c.order, v, c.want)
+			}
+		})
+	}
+}
+
+// TestThreadsMessagesList_OrderAliasParity proves DryRun(--sort dir) == DryRun(--order dir).
+// This is the test the refactor exists to make meaningful (single shared mapping).
+func TestThreadsMessagesList_OrderAliasParity(t *testing.T) {
+	for _, dir := range []string{"asc", "desc"} {
+		t.Run(dir, func(t *testing.T) {
+			newRT := newThreadsTestRT(t, map[string]string{"order": dir})
+			oldRT := newThreadsTestRT(t, map[string]string{"sort": dir})
+			a := mustMarshalDryRun(t, ImThreadsMessagesList.DryRun(context.Background(), newRT))
+			b := mustMarshalDryRun(t, ImThreadsMessagesList.DryRun(context.Background(), oldRT))
+			if a != b {
+				t.Fatalf("alias parity broken:\n new=%s\n old=%s", a, b)
+			}
+		})
+	}
+}
+
+func TestThreadsMessagesList_OrderFlagSurface(t *testing.T) {
+	var orderFlag, aliasFlag *common.Flag
+	for i := range ImThreadsMessagesList.Flags {
+		switch ImThreadsMessagesList.Flags[i].Name {
+		case "order":
+			orderFlag = &ImThreadsMessagesList.Flags[i]
+		case "sort":
+			aliasFlag = &ImThreadsMessagesList.Flags[i]
+		}
+	}
+	if orderFlag == nil || aliasFlag == nil {
+		t.Fatalf("expected both --order and --sort flags declared")
+	}
+	if orderFlag.Default != "asc" {
+		t.Errorf("--order Default = %q, want asc", orderFlag.Default)
+	}
+	if got := strings.Join(orderFlag.Enum, ","); got != "asc,desc" {
+		t.Errorf("--order Enum = %q, want asc,desc", got)
+	}
+	if !aliasFlag.Hidden {
+		t.Errorf("--sort must be Hidden")
+	}
+	if aliasFlag.Default != "" {
+		t.Errorf("--sort (hidden alias) must not carry a Default, got %q", aliasFlag.Default)
+	}
+}

--- a/shortcuts/im/sort_flags.go
+++ b/shortcuts/im/sort_flags.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import "github.com/larksuite/cli/shortcuts/common"
+
+// aliasFlagValue handles a renamed sort flag whose old name is kept as a silent
+// alias. It returns (oldValue, true) only when the old flag was explicitly used
+// and the new one was not; otherwise ("", false) — meaning "no old flag, or both
+// given (new wins), so use the new-flag logic". Pure function, no IO: callable
+// from DryRun, Execute, and minimal test fixtures alike. Never prints anything.
+func aliasFlagValue(rt *common.RuntimeContext, oldName, newName string) (string, bool) {
+	if rt.Changed(oldName) && !rt.Changed(newName) {
+		return rt.Str(oldName), true
+	}
+	return "", false
+}

--- a/shortcuts/im/sort_flags_test.go
+++ b/shortcuts/im/sort_flags_test.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+// newAliasTestRT registers a new flag (with a default) and an old flag, then
+// sets only the flags present in `set` — so Changed() reflects exactly which
+// flags were "passed on the command line".
+func newAliasTestRT(t *testing.T, newName, newDefault, oldName string, set map[string]string) *common.RuntimeContext {
+	t.Helper()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String(newName, newDefault, "")
+	cmd.Flags().String(oldName, "", "")
+	if err := cmd.ParseFlags(nil); err != nil {
+		t.Fatalf("ParseFlags() error = %v", err)
+	}
+	for k, v := range set {
+		if err := cmd.Flags().Set(k, v); err != nil {
+			t.Fatalf("Set(%q) error = %v", k, err)
+		}
+	}
+	return &common.RuntimeContext{Cmd: cmd}
+}
+
+func TestAliasFlagValue(t *testing.T) {
+	cases := []struct {
+		name    string
+		set     map[string]string
+		wantVal string
+		wantOK  bool
+	}{
+		{"only old set", map[string]string{"sort-type": "ByActiveTimeDesc"}, "ByActiveTimeDesc", true},
+		{"neither set", nil, "", false},
+		{"only new set", map[string]string{"sort": "active_time"}, "", false},
+		{"both set new wins", map[string]string{"sort": "active_time", "sort-type": "ByCreateTimeAsc"}, "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rt := newAliasTestRT(t, "sort", "create_time", "sort-type", c.set)
+			gotVal, gotOK := aliasFlagValue(rt, "sort-type", "sort")
+			if gotVal != c.wantVal || gotOK != c.wantOK {
+				t.Fatalf("aliasFlagValue() = (%q, %v), want (%q, %v)", gotVal, gotOK, c.wantVal, c.wantOK)
+			}
+		})
+	}
+}

--- a/skills/lark-im/references/lark-im-chat-list.md
+++ b/skills/lark-im/references/lark-im-chat-list.md
@@ -11,11 +11,11 @@ This skill maps to the shortcut: `lark-cli im +chat-list` (internally calls `GET
 ## Commands
 
 ```bash
-# List the user's chats (default sort: ByCreateTimeAsc)
+# List the user's chats (default sort: create_time, ascending)
 lark-cli im +chat-list
 
 # Sort by recent activity (most recently active first)
-lark-cli im +chat-list --sort-type ByActiveTimeDesc
+lark-cli im +chat-list --sort active_time
 
 # Limit page size
 lark-cli im +chat-list --page-size 50
@@ -48,7 +48,7 @@ lark-cli im +chat-list --as user --types p2p
 |------|------|------|------|
 | `--user-id-type <type>` | No | `open_id` (default), `union_id`, `user_id` | ID type used for `owner_id` in the response |
 | `--types <strings>` | No | `group`, `p2p` (comma-separated or repeated) | Chat types to include. Omitted = groups only (backward compatible). `p2p` requires user identity (`--as user`); under `--as bot`, `--types=p2p` alone is rejected and `--types=p2p,group` is silently downgraded to `group` |
-| `--sort-type <type>` | No | `ByCreateTimeAsc` (default), `ByActiveTimeDesc` | Result ordering |
+| `--sort <field>` | No | `create_time` (default, ascending), `active_time` (descending) | Result ordering |
 | `--page-size <n>` | No | 1-100, default 20 | Number of results per page |
 | `--page-token <token>` | No | - | Pagination token from the previous response |
 | `--exclude-muted` | No | User identity only | Drop chats the current user has muted (do-not-disturb). Under `--as bot`, the flag is silently inactive; see "Filtering muted chats" below |
@@ -130,13 +130,13 @@ When the flag is set, the JSON envelope gains a `filter` sub-object (absent othe
 ### Scenario 1: List my recent chats
 
 ```bash
-lark-cli im +chat-list --sort-type ByActiveTimeDesc --page-size 10
+lark-cli im +chat-list --sort active_time --page-size 10
 ```
 
 ### Scenario 2: List my non-muted chats sorted by activity
 
 ```bash
-lark-cli im +chat-list --sort-type ByActiveTimeDesc --exclude-muted
+lark-cli im +chat-list --sort active_time --exclude-muted
 ```
 
 ### Scenario 3: Iterate all my chats programmatically

--- a/skills/lark-im/references/lark-im-chat-messages-list.md
+++ b/skills/lark-im/references/lark-im-chat-messages-list.md
@@ -24,7 +24,7 @@ lark-cli im +chat-messages-list --chat-id oc_xxx --start "2026-03-10T00:00:00+08
 lark-cli im +chat-messages-list --chat-id oc_xxx --start 2026-03-10 --end 2026-03-11
 
 # Control sort order and page size (max 50)
-lark-cli im +chat-messages-list --chat-id oc_xxx --sort asc --page-size 20
+lark-cli im +chat-messages-list --chat-id oc_xxx --order asc --page-size 20
 
 # Pagination
 lark-cli im +chat-messages-list --chat-id oc_xxx --page-token "xxx"
@@ -41,7 +41,7 @@ lark-cli im +chat-messages-list --chat-id oc_xxx --format json
 | `--user-id <id>` | One of two | Specify a DM conversation by the other user's open_id (`ou_xxx`); p2p chat_id is resolved automatically. Requires user identity (`--as user`); not supported with bot identity |
 | `--start <time>` | No | Start time (ISO 8601 or date only) |
 | `--end <time>` | No | End time (ISO 8601 or date only) |
-| `--sort <order>` | No | Sort order: `asc` / `desc` (default `desc`) |
+| `--order <order>` | No | Sort order: `asc` / `desc` (default `desc`) |
 | `--page-size <n>` | No | Page size (default 50, max 50) |
 | `--page-token <token>` | No | Pagination token |
 | `--no-reactions` | No | Skip auto-fetching the `reactions` block |
@@ -75,8 +75,8 @@ lark-cli im +threads-messages-list --thread omt_xxx
 
 | Scenario | Recommendation |
 |------|------|
-| You need context | Call `im +threads-messages-list --sort desc --page-size 10` for the discovered thread_id to inspect recent replies |
-| The user asks for the "full discussion" | Use `im +threads-messages-list --sort asc --page-size 50`, then paginate if needed |
+| You need context | Call `im +threads-messages-list --order desc --page-size 10` for the discovered thread_id to inspect recent replies |
+| The user asks for the "full discussion" | Use `im +threads-messages-list --order asc --page-size 50`, then paginate if needed |
 | You only need an overview | Skip thread expansion |
 
 ## Output Fields

--- a/skills/lark-im/references/lark-im-chat-messages-list.md
+++ b/skills/lark-im/references/lark-im-chat-messages-list.md
@@ -49,6 +49,8 @@ lark-cli im +chat-messages-list --chat-id oc_xxx --format json
 
 > Rule: `--chat-id` and `--user-id` are mutually exclusive. You must provide exactly one of them.
 
+> **CAUTION:** `--order` is the only sort axis — messages are always ordered by creation time, `asc` or `desc`. There is no field axis: the command cannot sort by sender or any other field, so do **not** attempt `--sort sender` or similar (it is rejected). If the user asks to group or sort by sender, fetch with `--order` and aggregate client-side, and tell them this is local post-processing, not a CLI/API sort capability.
+
 ## Resource Rendering
 
 Messages are rendered into human-readable text for inspection. Image messages are shown as placeholders such as `[Image: img_xxx]`; files, audio, and videos are rendered with resource keys in the content (e.g. `<audio key="file_xxx" duration="Xs"/>`). By default resource binaries are **not** downloaded.

--- a/skills/lark-im/references/lark-im-chat-search.md
+++ b/skills/lark-im/references/lark-im-chat-search.md
@@ -55,6 +55,8 @@ lark-cli im +chat-search --query "project" --dry-run
 
 > **Note:** Supports both `--as user` (default) and `--as bot`. When using bot identity, the app must have bot capability enabled.
 
+> **CAUTION:** `--sort` is **always descending** — the search API only ranks the chosen field high-to-low (e.g. `member_count` = most members first). There is no ascending option. If the user asks for "fewest first / ascending / 从少到多", tell them the search API does not support ascending order; any low-to-high view requires re-sorting the fetched page client-side and is not an upstream sort. Do **not** invent values like `member_count_asc` or pass `asc` (they are rejected).
+
 ## Output Fields
 
 | Field | Description |

--- a/skills/lark-im/references/lark-im-chat-search.md
+++ b/skills/lark-im/references/lark-im-chat-search.md
@@ -46,7 +46,7 @@ lark-cli im +chat-search --query "project" --dry-run
 | `--member-ids <ids>` | No (at least one of `--query` / `--member-ids` required) | Up to 50, format `ou_xxx` | Filter by member open_ids; can be used alone or combined with `--query` |
 | `--is-manager` | No | - | Only show chats you created or manage |
 | `--disable-search-by-user` | No | - | Disable member-name-based matching and search by group name only |
-| `--sort-by <field>` | No | `create_time_desc`, `update_time_desc`, `member_count_desc` | Sort field in descending order |
+| `--sort <field>` | No | `create_time`, `update_time`, `member_count` | Sort field (always descending) |
 | `--page-size <n>` | No | 1-100, default 20 | Number of results per page |
 | `--page-token <token>` | No | - | Pagination token from the previous response |
 | `--exclude-muted` | No | User identity only | Drop chats the current user has muted (do-not-disturb). Under `--as bot`, the flag is silently inactive (mute is a per-user setting); see "Filtering muted chats" below |

--- a/skills/lark-im/references/lark-im-threads-messages-list.md
+++ b/skills/lark-im/references/lark-im-threads-messages-list.md
@@ -15,7 +15,7 @@ This skill maps to the shortcut: `lark-cli im +threads-messages-list` (internall
 lark-cli im +threads-messages-list --thread omt_xxx
 
 # Reverse chronological order (latest first)
-lark-cli im +threads-messages-list --thread omt_xxx --sort desc
+lark-cli im +threads-messages-list --thread omt_xxx --order desc
 
 # Control page size
 lark-cli im +threads-messages-list --thread omt_xxx --page-size 20
@@ -42,7 +42,7 @@ lark-cli im +threads-messages-list --thread omt_xxx --dry-run
 | `--thread <id>` | Yes | Thread ID (`om_xxx` or `omt_xxx` format) |
 | `--no-reactions` | No | Skip auto-fetching the `reactions` block |
 | `--download-resources` | No | Download message resources (image/file/audio/video/media + post-embedded, excluding stickers) into `./lark-im-resources/` and attach a `resources` block. Off by default |
-| `--sort <order>` | No | Sort order: `asc` (default) / `desc` |
+| `--order <order>` | No | Sort order: `asc` (default) / `desc` |
 | `--page-size <n>` | No | Number of items per page (default 50, range 1-500) |
 | `--page-token <token>` | No | Pagination token for the next page |
 | `--format <fmt>` | No | Output format: `json` (default) / `pretty` / `table` / `ndjson` / `csv` |
@@ -68,9 +68,9 @@ Thread messages do not support `start_time` / `end_time` filtering because of Fe
 
 | Scenario | Recommended Parameters |
 |------|---------|
-| Quickly inspect recent replies | `--sort desc --page-size 10` |
-| Read the full thread in chronological order | `--sort asc --page-size 50`, then paginate as needed |
-| Just confirm whether replies exist | `--sort desc --page-size 1` |
+| Quickly inspect recent replies | `--order desc --page-size 10` |
+| Read the full thread in chronological order | `--order asc --page-size 50`, then paginate as needed |
+| Just confirm whether replies exist | `--order desc --page-size 1` |
 
 ## Usage Scenarios
 


### PR DESCRIPTION
## Summary

The 4 im query commands had three inconsistent sort conventions and leaked upstream API jargon (`ByCreateTimeAsc`, `member_count_desc`) directly to users. This PR unifies them on a single rule — `--sort` selects a field, `--order` selects a direction, both from fixed enums — so an agent only ever picks from an enum, never constructs a string. Old flags (`--sort-type`, `--sort-by`, and `--sort` on messages/threads) are kept as hidden silent aliases (no deprecation warning), so existing scripts keep working byte-for-byte.

Two design tradeoffs were reviewed and explicitly accepted (full rationale in the design spec):
- **`--sort` is overloaded across commands** — a field selector on `chat-list`/`chat-search`, a hidden direction alias on `messages`/`threads`. Accepted because the field-value set and direction-value set are disjoint, the clash is hidden from `--help`, and every mismatch fails fast (exit 2 / unknown flag) — no silent wrong sort, no compat break. The residual cost is conceptual + a latent naming conflict if those two commands ever gain a sortable field.
- **Hidden aliases stay enum-validated** — an invalid value on an old flag still fails fast with an error referencing the (help-hidden) old flag and its old allowed set. Accepted to keep behavior identical to before and never silently mis-sort.

## Changes

- Add `shortcuts/im/sort_flags.go` — `aliasFlagValue` helper (pure, no IO) implementing the "old flag wins only if new not given" rule
- `shortcuts/im/im_chat_list.go` — new `--sort` (`create_time`/`active_time`); old `--sort-type` → hidden alias; map field → `sort_type`
- `shortcuts/im/im_chat_messages_list.go` — rename `--sort` → `--order` (`asc`/`desc`); old `--sort` → hidden alias (mapped through, not passed through)
- `shortcuts/im/im_threads_messages_list.go` — extract shared `buildThreadsMessagesListParams` (so DryRun and Execute share one asc/desc→sort_type mapping), then rename `--sort` → `--order`; old `--sort` → hidden alias
- `shortcuts/im/im_chat_search.go` — new `--sort` (`create_time`/`update_time`/`member_count`, always descending); old `--sort-by` → hidden alias; map field → `sorter`
- Unit tests for all 4 commands: new-flag mapping, alias byte-equivalence, default regression, new-wins-over-old, invalid-value fail-fast, flag-structure assertions
- `skills/lark-im/references/*.md` (4 files) — update flag tables/examples to the unified flags; add CAUTION notes on chat-messages-list (time-axis only) and chat-search (descending only)

## Test Plan

- [x] `make unit-test` passed
- [x] validate passed (build / vet / unit / integration)
- [x] local-eval: sandbox E2E 4/4 passed; skillave 8/11 — the 3 fails are eval-harness design (placeholder IDs + implicit dry-run expectation; one query omits the thread ID), not feature defects; every decision point that tests the unification is green
- [x] acceptance-reviewer passed (5/5 scenarios + exploratory; silent-alias behavior physically verified, byte-identical alias output, zero deprecation warning)
- [x] manual verification: dry-run matrix across all 4 commands — new flags, old aliases (`--sort asc/desc` on messages/threads → exit 0, byte-identical upstream), new-wins, invalid-value fail-fast (exit 2), rejected combos (`chat-list --order` → unknown flag)

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Clarified sort flag naming across IM commands: `--sort` for chat-list (with `create_time`/`active_time`), `--order` for chat-messages-list and threads-messages-list (with `asc`/`desc`), and `--sort` for chat-search (with `create_time`/`update_time`/`member_count`)
  * Backwards compatibility maintained through hidden flag aliases for previous flag names

* **Documentation**
  * Updated documentation for affected IM commands to reflect new sort flag names and valid options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->