### PR TITLE
docs(skills): clarify Drive-native resource URL guidance

### DIFF
--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -68,6 +68,7 @@ metadata:
 - `base-block` 只负责资源目录管理，包括创建资源、移动到 folder、重命名和删除；具体资源内容仍走 table/dashboard/workflow 命令。
 - 表、字段、视图、workflow、dashboard block 的名称和 ID 必须来自真实返回，不要凭用户口述猜。
 - 存储字段可写；系统字段、`formula`、`lookup` 只读；附件字段走专用 attachment 命令。
+- 写入文本、描述、URL 或富文本相关字段时，如果值是飞书 / Lark Drive-native 资源 URL，遵循 [`lark-shared`](../lark-shared/SKILL.md) 的「资源 URL 写入规则」：默认写原始 URL 字符串；只有用户明确要求自定义显示文本，或字段/API 明确要求结构化 rich link 值时，才构造链接对象。
 - 一次性原始记录查询优先用 `+record-list` / `+record-search` 的 filter/sort；聚合分析优先用 `+data-query`；需要长期显示在表中时，才新增 `formula` / `lookup` 字段。
 - `formula` 适合常规计算、条件判断、文本/日期处理和长期派生指标；`lookup` 适合明确的跨表查找、筛选后取值或聚合引用。
 - 写入、分析、公式、lookup、workflow、dashboard 前，先读取真实结构：表、字段、视图、关联表和 dashboard block 名称都以命令返回为准。

--- a/skills/lark-base/references/lark-base-cell-value.md
+++ b/skills/lark-base/references/lark-base-cell-value.md
@@ -20,6 +20,8 @@
 
 用字符串。URL 字段也传 URL 字符串；普通文本里可以保留 Markdown 风格链接文本，平台会按字段类型处理。
 
+写入飞书 / Lark Drive-native 资源 URL 时，遵循 [`lark-shared`](../../lark-shared/SKILL.md) 的「资源 URL 写入规则」：默认保留原始 URL 字符串，不要默认改成 `[title](url)` 或富链接对象。只有用户明确要求自定义显示文本，或目标字段/API 明确要求结构化 rich link 值时，才使用对应结构。
+
 ```json
 {
     "标题": "Hello",

--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -27,6 +27,8 @@ lark-cli docs +update --api-version v2 --doc "文档URL或token" --command appen
 
 **未读完以上文件就执行相应操作会导致参数选择错误、格式错误或样式不达标。**
 
+> **资源 URL 写入规则：** 文档内容中写入飞书 / Lark Drive-native 资源 URL 时，遵循 [`lark-shared`](../lark-shared/SKILL.md) 的「资源 URL 写入规则」：默认保留原始 URL 字符串，不要默认改成 `[title](url)`，除非用户需要自定义显示文本或目标 API 明确要求结构化链接。
+
 > **格式选择规则（全局）：**
 > - **创建 / 导入场景**（`docs +create`，或 `docs +update --command append/overwrite` 的整段写入）：XML 和 Markdown 都可以。用户提供 `.md` 本地文件、或明确说"导入 Markdown"时，直接用 Markdown；否则默认 XML（可用 callout、grid、checkbox 等富 block）。
 > - **精准编辑场景**（`docs +update` 的 `str_replace` / `block_insert_after` / `block_replace` / `block_delete` / `block_move_after` 等局部精修指令）：优先使用 XML（`--doc-format xml`，即默认值）。XML 能稳定表达 block 结构和样式，局部精修更可控；不要因为 Markdown 更简单就自行切换。

--- a/skills/lark-doc/references/lark-doc-md.md
+++ b/skills/lark-doc/references/lark-doc-md.md
@@ -47,6 +47,10 @@
 
 自行构造 Markdown 内容写入时同理：如字面文本 `a]b` 应写为 `a\]b`，`C:\Users` 应写为 `C:\\Users`。
 
+## 资源 URL 写入
+
+写入飞书 / Lark Drive-native 资源 URL（Docx、Sheets、Base、Wiki、Drive 文件/文件夹、Slides、Minutes 等）时，遵循 [`lark-shared`](../../lark-shared/SKILL.md) 的「资源 URL 写入规则」：默认写原始 URL 字符串，不要默认包装成 `[title](url)`。只有用户明确要求自定义显示文本、目标是外部 URL，或目标字段/API 明确要求结构化链接时，才使用 Markdown 链接或其他 link object。
+
 ## Shell 传参
 - **首选文件传参**：`--content` 支持 `@path/to/file.md`（读文件）和 `-`（读 stdin），彻底绕开 shell 转义；多行、含特殊字符、长文本强烈推荐。字面量以 `@` 开头时用 `@@` 转义（`--pattern` 不支持 `@file`）
 - **默认用单引号 `'...'`**：完全字面量，`$`、`` ` ``、`\`、`>`、`\<b>` 等全部原样保留

--- a/skills/lark-doc/references/lark-doc-xml.md
+++ b/skills/lark-doc/references/lark-doc-xml.md
@@ -32,6 +32,10 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
 | `<button>` | 操作按钮 | `background-color`、`src`，必须包含 `action=OpenLink\|DuplicatePage\|FollowPage` |
 | `<time>` | 提醒 | 必包含 `expire-time`、`notify-time`（毫秒时间戳）、`should-notify=true\|false` |
 
+## 资源 URL 写入
+
+写入飞书 / Lark Drive-native 资源 URL（Docx、Sheets、Base、Wiki、Drive 文件/文件夹、Slides、Minutes 等）时，遵循 [`lark-shared`](../../lark-shared/SKILL.md) 的「资源 URL 写入规则」：默认写原始 URL 文本，不要默认包装成 `<a>`、`<bookmark>` 或 Markdown `[title](url)`。只有用户明确要求自定义显示文本、目标是外部 URL，或需要特定预览/书签结构时，才使用 `<a>` / `<bookmark>` 等结构化链接标签。
+
 ## 文本块通用属性
 - `align` — `"left"`|`"center"`|`"right"`（适用于 p / h1-h9 / li / checkbox）
 - 有序列表项用 `seq="auto"` 自动编号

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -21,6 +21,19 @@ description: "Use when first setting up lark-cli, running auth login, switching 
 lark-cli config init --new
 ```
 
+## 资源 URL 写入规则
+
+当你把链接写入飞书 / Lark 富编辑内容（Docx XML/Markdown、Wiki 文档、Sheets 单元格、Base 文本/描述字段等）时，**Drive-native 资源 URL 默认写成原始 URL 字符串，不要默认改写成 `[title](url)`**。这样编辑器仍有机会识别为原生卡片、预览、引用或 mention。
+
+Drive-native 资源包括：`/doc/`、`/docx/`、`/sheets/`、`/base/`、`/bitable/`、`/wiki/`、`/drive/file/`、`/drive/folder/`、`/slides/`、`/minutes/`、`/mindnote/` 等飞书 / Lark 云空间资源。
+
+例外场景：
+- 用户明确要求自定义显示文本时，可以使用 Markdown 链接、XML `<a>` / `<bookmark>`，或 Sheets/Base 的结构化 rich link 值。
+- 外部 URL、下载 URL、回调 URL、临时分享 URL等非 Drive-native 链接，按目标格式正常处理。
+- API 字段明确要求 `rich_text`、link object、cell link object 或其他结构化链接对象时，按 API schema 构造，不要强行传纯字符串。
+
+无论采用哪种形式，URL 都是 opaque string：不要自行 URL 编码/解码、截断 query、拼接标题或改写域名。
+
 ## 认证
 
 ### 身份类型

--- a/skills/lark-sheets/SKILL.md
+++ b/skills/lark-sheets/SKILL.md
@@ -154,3 +154,5 @@ lark-cli sheets +cells-set --url "..." --sheet-name "Sheet1" --range "A1:B2" --c
 ```
 
 **`@file` 接绝对路径会被拒，且被拒后不要照报错提示做。** `@file` 出于安全只接受 cwd 下的相对路径，传 cwd 之外的绝对路径会被拒。此时报错会建议"先 cd 到目标目录，或改用相对路径"——**两条都不要照做**：cd 过去、或把临时文件写进用户项目目录，都会污染工作目录。正解是改用 stdin（`--<flag> - < 文件`）。
+
+写入飞书 / Lark Drive-native 资源 URL 时，遵循 [`lark-shared`](../lark-shared/SKILL.md) 的「资源 URL 写入规则」：默认写原始 URL 字符串；只有用户明确要求自定义显示文本或目标 API 明确要求富文本链接时，才使用 `rich_text` link object。

--- a/skills/lark-sheets/references/lark-sheets-write-cells.md
+++ b/skills/lark-sheets/references/lark-sheets-write-cells.md
@@ -128,6 +128,8 @@ Step 2: `+cells-set` — range="A2", cells 含 value + cell_styles + border_styl
 
 带显示文本的超链接、@人、@文档这类富内容**必须**走 `+cells-set` 的 `rich_text` 字段（`cells[].rich_text` 数组，每段一个对象、带 `type`），**不能**直接传普通字符串——纯字符串只会被当作纯文本存进单元格。完整字段跑 `lark-cli sheets +cells-set --print-schema --flag-name cells`，常用段类型：
 
+写入飞书 / Lark Drive-native 资源 URL 时，遵循 [`lark-shared`](../../lark-shared/SKILL.md) 的「资源 URL 写入规则」：默认写 `value` 原始 URL 字符串，不要为了标题展示主动改成 `rich_text` link object。只有用户明确要求自定义显示文本，或 API 字段明确要求富文本链接时，才使用 `rich_text`。
+
 - **超链接（带显示文本）**：`{"type":"link","text":"飞书","link":"https://www.feishu.cn"}`。纯 URL 不需要 `rich_text`，直接写普通字符串即可。
 - **@人**：`{"type":"mention","mention_token":"<userId>","notify":false}`。**仅支持同租户用户，单次写入最多 50 人。** `notify` **默认 `true`**（会给被 @ 的人发通知），不想发务必显式传 `false`。
 - **@文档**：同样 `"type":"mention"`，`mention_token` 传文档 token（如 `shtXXX`）。

--- a/skills/lark-wiki/SKILL.md
+++ b/skills/lark-wiki/SKILL.md
@@ -55,6 +55,7 @@ metadata:
 - 处理这类目标时，先解析 `my_library` 对应的真实 `space_id`，再执行 `wiki +move`、`wiki +node-create` 或其他 Wiki 写操作
 - 不要因为缺少显式 `space_id` 就退化成 `drive +move`
 - 如果用户明确说的是 Drive 文件夹、云空间（云盘/云存储）根目录、`我的空间`，才进入 Drive 域处理
+- 在 Wiki 节点或其背后的 Docx 内容中写入飞书 / Lark Drive-native 资源 URL 时，遵循 [`lark-shared`](../lark-shared/SKILL.md) 的「资源 URL 写入规则」：默认写原始 URL 字符串；只有用户明确要求自定义显示文本或目标 API 明确要求结构化链接时才改写成链接对象。
 
 ## Shortcuts（推荐优先使用）
 


### PR DESCRIPTION
## Summary
Clarifies skill guidance for writing Feishu / Lark Drive-native resource URLs into docs, sheets, base fields, and wiki content.

Drive-native URLs should stay as raw URL strings by default so Lark editors and APIs can preserve native resource behavior instead of forcing Markdown-style display text.

## Changes
- Add shared Drive-native resource URL guidance in `lark-shared`.
- Reference the shared rule from doc, sheets, base, and wiki skills.
- Update detailed Markdown/XML/Base cell-value and Sheets write-cells references to keep default behavior consistent across skills.

## Test Plan
- [x] `node scripts/skill-format-check/index.js`
- [x] `git diff --check`
- [x] `make unit-test` blocked locally by Go 1.26 race-test startup `SIGSEGV` across unrelated packages before exercising this docs-only change.

## Related Issues
- Fixes #1298
