### PR TITLE
feat(mail): apply default send signatures

### DIFF
--- a/shortcuts/mail/mail_lint_writepath_test.go
+++ b/shortcuts/mail/mail_lint_writepath_test.go
@@ -486,6 +486,7 @@ func TestMailSend_WritePathLintAutofixesFontInEML(t *testing.T) {
 		"--to", "alice@example.com",
 		"--subject", "Send",
 		"--body", `<font color="red">payload</font>`,
+		"--no-signature",
 		"--show-lint-details",
 	}, f, stdout)
 	if err != nil {

--- a/shortcuts/mail/mail_request_receipt_integration_test.go
+++ b/shortcuts/mail/mail_request_receipt_integration_test.go
@@ -127,6 +127,7 @@ func TestMailSend_RequestReceiptAddsHeader_Integration(t *testing.T) {
 		"--to", "bob@example.com",
 		"--subject", "hi",
 		"--body", "please confirm",
+		"--no-signature",
 		"--request-receipt",
 		"--confirm-send",
 	}, f, stdout); err != nil {
@@ -153,6 +154,7 @@ func TestMailSend_RequestReceiptNoSender_FailsValidation(t *testing.T) {
 		"--to", "bob@example.com",
 		"--subject", "hi",
 		"--body", "body",
+		"--no-signature",
 		"--request-receipt",
 		"--confirm-send",
 	}, f, stdout)

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -66,6 +66,12 @@ var MailSend = common.Shortcut{
 				Desc("Resolve explicit signature or default send signature.")
 			api = api.GET(mailboxPath(mailboxID, "settings", "send_as")).
 				Desc("Conditionally resolve sender identity for signature template variables.")
+			if aliasMailboxID := mailSendSignatureAliasMailboxID(mailboxID, runtime.Str("from")); aliasMailboxID != "" {
+				api = api.GET(mailboxPath(aliasMailboxID, "settings", "signatures")).
+					Desc("Fallback: resolve default send signature for the alias sender when the owning mailbox usage is absent.")
+				api = api.GET(mailboxPath(aliasMailboxID, "settings", "send_as")).
+					Desc("Fallback: resolve alias sender identity for signature template variables.")
+			}
 		}
 		api = api.
 			POST(mailboxPath(mailboxID, "drafts")).

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -39,7 +39,8 @@ var MailSend = common.Shortcut{
 		{Name: "send-time", Desc: "Scheduled send time as a Unix timestamp in seconds. Must be at least 5 minutes in the future. Use with --confirm-send to schedule the email."},
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's subject/body/to/cc/bcc/attachments are merged with user-supplied flags (user flags win). Requires --as user."},
-		signatureFlag,
+		mailSendSignatureFlag,
+		mailSendNoSignatureFlag,
 		priorityFlag,
 		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag,
 		showLintDetailsFlag},
@@ -52,12 +53,21 @@ var MailSend = common.Shortcut{
 		if confirmSend {
 			desc = "Compose email → save as draft → send draft"
 		}
+		noSignature := runtime.Bool("no-signature")
 		api := common.NewDryRunAPI().Desc(desc)
 		if tid := runtime.Str("template-id"); tid != "" {
 			api = api.GET(templateMailboxPath(mailboxID, tid)).
 				Desc("Fetch template to merge with compose flags (subject/body/to/cc/bcc/attachments).")
 		}
 		api = api.GET(mailboxPath(mailboxID, "profile")).
+			Desc("Resolve mailbox profile and sender address.")
+		if !noSignature {
+			api = api.GET(mailboxPath(mailboxID, "settings", "signatures")).
+				Desc("Resolve explicit signature or default send signature.")
+			api = api.GET(mailboxPath(mailboxID, "settings", "send_as")).
+				Desc("Conditionally resolve sender identity for signature template variables.")
+		}
+		api = api.
 			POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{
 				"raw": "<base64url-EML>",
@@ -98,7 +108,7 @@ var MailSend = common.Shortcut{
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
-		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+		if err := validateMailSendSignatureFlags(runtime); err != nil {
 			return err
 		}
 		// Resolve the body content first (reading --body-file if set) so
@@ -135,6 +145,7 @@ var MailSend = common.Shortcut{
 		inlineFlag := runtime.Str("inline")
 		confirmSend := runtime.Bool("confirm-send")
 		sendTime := runtime.Str("send-time")
+		noSignature := runtime.Bool("no-signature")
 
 		senderEmail := resolveComposeSenderEmail(runtime)
 		signatureID := runtime.Str("signature-id")
@@ -195,7 +206,10 @@ var MailSend = common.Shortcut{
 			}
 		}
 
-		sigResult, err := resolveSignature(ctx, runtime, mailboxID, signatureID, senderEmail)
+		sigResult, err := resolveMailSendComposeSignature(ctx, runtime, mailboxID, senderEmail, mailSendSignatureOptions{
+			SignatureID: signatureID,
+			NoSignature: noSignature,
+		})
 		if err != nil {
 			return err
 		}
@@ -230,10 +244,10 @@ var MailSend = common.Shortcut{
 		// `lint_applied[]` / `original_blocked[]` even on the plain-text path.
 		lintApplied, lintBlocked := emptyLintEnvelopeFields()
 		if plainText {
-			composedTextBody = body
+			composedTextBody = appendMailSendPlainTextSignature(body, sigResult, resolveLang(runtime))
 			bld = bld.TextBody([]byte(composedTextBody))
 		} else if bodyIsHTML(body) || sigResult != nil {
-			// If signature is requested on plain-text body, auto-upgrade to HTML.
+			// Non-plain-text sends can use HTML so signatures keep their rich layout.
 			htmlBody := body
 			if !bodyIsHTML(body) {
 				htmlBody = buildBodyDiv(body, false)

--- a/shortcuts/mail/mail_send_confirm_output_test.go
+++ b/shortcuts/mail/mail_send_confirm_output_test.go
@@ -149,6 +149,7 @@ func TestMailSendConfirmSendOutputsAutomationDisable(t *testing.T) {
 		"--to", "alice@example.com",
 		"--subject", "hello",
 		"--body", "world",
+		"--no-signature",
 		"--confirm-send",
 	}, f, stdout)
 	if err != nil {
@@ -203,6 +204,7 @@ func TestMailSendSaveDraftOutputsReference(t *testing.T) {
 		"--to", "alice@example.com",
 		"--subject", "hello",
 		"--body", "world",
+		"--no-signature",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("save draft failed: %v", err)
@@ -243,6 +245,7 @@ func TestMailSend_WithCalendarEventEmbedded(t *testing.T) {
 		"--to", "alice@example.com",
 		"--subject", "Team Sync",
 		"--body", "<p>Please join us</p>",
+		"--no-signature",
 		"--event-summary", "Team Sync",
 		"--event-start", "2026-05-10T10:00+08:00",
 		"--event-end", "2026-05-10T11:00+08:00",

--- a/shortcuts/mail/mail_send_signature.go
+++ b/shortcuts/mail/mail_send_signature.go
@@ -51,9 +51,20 @@ func resolveMailSendComposeSignature(ctx context.Context, runtime *common.Runtim
 		return resolveSignature(ctx, runtime, mailboxID, signatureID, senderEmail)
 	}
 
+	signatureMailboxID, defaultID, err := selectMailSendDefaultSignature(runtime, mailboxID, senderEmail)
+	if err != nil {
+		return nil, err
+	}
+	if mailSendSignatureIDIsEmpty(defaultID) {
+		return nil, nil
+	}
+	return resolveSignature(ctx, runtime, signatureMailboxID, defaultID, senderEmail)
+}
+
+func selectMailSendDefaultSignature(runtime *common.RuntimeContext, mailboxID, senderEmail string) (string, string, error) {
 	resp, err := signature.ListAll(runtime, mailboxID)
 	if err != nil {
-		return nil, mailAppendProblemHint(
+		return "", "", mailAppendProblemHint(
 			mailDecorateProblemMessage(err, "failed to look up default send signature"),
 			"pass --no-signature to send without a signature",
 		)
@@ -61,13 +72,41 @@ func resolveMailSendComposeSignature(ctx context.Context, runtime *common.Runtim
 
 	defaultID := selectMailSendDefaultSignatureID(resp.Usages, senderEmail)
 	if mailSendSignatureIDIsEmpty(defaultID) {
-		return nil, nil
+		return selectMailSendAliasDefaultSignature(runtime, mailboxID, senderEmail)
 	}
 	if !mailSendSignatureExists(resp.Signatures, defaultID) {
-		return nil, mailValidationError("default send signature %q was configured for %q but was not returned by settings/signatures", defaultID, mailSendSignatureSenderLabel(senderEmail)).
+		return "", "", mailValidationError("default send signature %q was configured for %q but was not returned by settings/signatures", defaultID, mailSendSignatureSenderLabel(senderEmail)).
 			WithHint("run `lark-cli mail +signature` to inspect signatures, or pass --no-signature to send without a signature")
 	}
-	return resolveSignature(ctx, runtime, mailboxID, defaultID, senderEmail)
+	return mailboxID, defaultID, nil
+}
+
+func selectMailSendAliasDefaultSignature(runtime *common.RuntimeContext, mailboxID, senderEmail string) (string, string, error) {
+	aliasMailboxID := mailSendSignatureAliasMailboxID(mailboxID, senderEmail)
+	if aliasMailboxID == "" {
+		return "", "", nil
+	}
+	resp, err := signature.ListAll(runtime, aliasMailboxID)
+	if err != nil {
+		return "", "", nil
+	}
+	defaultID := selectMailSendDefaultSignatureID(resp.Usages, senderEmail)
+	if mailSendSignatureIDIsEmpty(defaultID) {
+		return "", "", nil
+	}
+	if !mailSendSignatureExists(resp.Signatures, defaultID) {
+		return "", "", mailValidationError("default send signature %q was configured for %q but was not returned by settings/signatures", defaultID, mailSendSignatureSenderLabel(senderEmail)).
+			WithHint("run `lark-cli mail +signature` to inspect signatures, or pass --no-signature to send without a signature")
+	}
+	return aliasMailboxID, defaultID, nil
+}
+
+func mailSendSignatureAliasMailboxID(mailboxID, senderEmail string) string {
+	senderEmail = strings.TrimSpace(senderEmail)
+	if senderEmail == "" || strings.EqualFold(strings.TrimSpace(mailboxID), senderEmail) {
+		return ""
+	}
+	return senderEmail
 }
 
 func selectMailSendDefaultSignatureID(usages []signature.SignatureUsage, senderEmail string) string {

--- a/shortcuts/mail/mail_send_signature.go
+++ b/shortcuts/mail/mail_send_signature.go
@@ -269,11 +269,38 @@ func mailSendSignatureImagePlaceholder(lang string) string {
 func mailSendSignatureLooksLikeHTMLFragment(raw string) bool {
 	lower := strings.ToLower(raw)
 	for _, tag := range mailSendSignatureHTMLFragmentTags {
-		if strings.Contains(lower, "<"+tag) || strings.Contains(lower, "</"+tag+">") {
+		if mailSendSignatureContainsHTMLTag(lower, tag) {
 			return true
 		}
 	}
 	return false
+}
+
+func mailSendSignatureContainsHTMLTag(lower, tag string) bool {
+	for _, prefix := range []string{"<" + tag, "</" + tag} {
+		start := 0
+		for {
+			idx := strings.Index(lower[start:], prefix)
+			if idx < 0 {
+				break
+			}
+			end := start + idx + len(prefix)
+			if end >= len(lower) || mailSendSignatureTagBoundary(lower[end]) {
+				return true
+			}
+			start += idx + 1
+		}
+	}
+	return false
+}
+
+func mailSendSignatureTagBoundary(ch byte) bool {
+	switch ch {
+	case ' ', '\t', '\n', '\r', '>', '/', ':':
+		return true
+	default:
+		return false
+	}
 }
 
 var mailSendSignatureHTMLFragmentTags = []string{

--- a/shortcuts/mail/mail_send_signature.go
+++ b/shortcuts/mail/mail_send_signature.go
@@ -178,11 +178,38 @@ func renderMailSendSignatureText(buf *bytes.Buffer, root *xhtml.Node, imagePlace
 			}
 		}
 		if node.Type == xhtml.TextNode {
-			appendMailSendSignatureText(buf, node.Data)
+			appendMailSendSignatureTextNode(buf, node.Data, imagePlaceholder)
 		}
 		if node.FirstChild != nil {
 			stack = append(stack, pendingEntry{node: node, child: node.FirstChild})
 		}
+	}
+}
+
+func appendMailSendSignatureTextNode(buf *bytes.Buffer, raw, imagePlaceholder string) {
+	unescaped := stdhtml.UnescapeString(raw)
+	if !mailSendSignatureLooksLikeHTMLFragment(unescaped) {
+		appendMailSendSignatureText(buf, unescaped)
+		return
+	}
+
+	doc, err := xhtml.Parse(strings.NewReader(unescaped))
+	if err != nil {
+		appendMailSendSignatureText(buf, unescaped)
+		return
+	}
+
+	var nested bytes.Buffer
+	renderMailSendSignatureText(&nested, doc, imagePlaceholder)
+	text := compactMailSendSignaturePlainText(nested.String())
+	if text == "" {
+		return
+	}
+	for i, line := range strings.Split(text, "\n") {
+		if i > 0 {
+			writeMailSendSignatureBreak(buf)
+		}
+		appendMailSendSignatureText(buf, line)
 	}
 }
 
@@ -237,6 +264,20 @@ func mailSendSignatureImagePlaceholder(lang string) string {
 		return "[图片]"
 	}
 	return "[image]"
+}
+
+func mailSendSignatureLooksLikeHTMLFragment(raw string) bool {
+	lower := strings.ToLower(raw)
+	for _, tag := range mailSendSignatureHTMLFragmentTags {
+		if strings.Contains(lower, "<"+tag) || strings.Contains(lower, "</"+tag+">") {
+			return true
+		}
+	}
+	return false
+}
+
+var mailSendSignatureHTMLFragmentTags = []string{
+	"a", "address", "article", "aside", "b", "blockquote", "body", "br", "div", "em", "font", "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "html", "i", "img", "li", "ol", "p", "section", "span", "strong", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "ul",
 }
 
 func mailSendSignatureSkipsText(tag string) bool {

--- a/shortcuts/mail/mail_send_signature.go
+++ b/shortcuts/mail/mail_send_signature.go
@@ -1,0 +1,262 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"bytes"
+	"context"
+	stdhtml "html"
+	"strings"
+
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/larksuite/cli/shortcuts/mail/signature"
+	xhtml "golang.org/x/net/html"
+)
+
+var mailSendSignatureFlag = common.Flag{
+	Name: "signature-id",
+	Desc: "Optional. Signature ID to append. Overrides the default send signature for this email.",
+}
+
+var mailSendNoSignatureFlag = common.Flag{
+	Name: "no-signature",
+	Type: "bool",
+	Desc: "Skip the default send signature for this email.",
+}
+
+type mailSendSignatureOptions struct {
+	SignatureID string
+	NoSignature bool
+}
+
+func validateMailSendSignatureFlags(runtime *common.RuntimeContext) error {
+	if runtime.Bool("no-signature") && strings.TrimSpace(runtime.Str("signature-id")) != "" {
+		return mailValidationError("--signature-id and --no-signature are mutually exclusive").
+			WithParams(
+				mailInvalidParam("--signature-id", "mutually exclusive with --no-signature"),
+				mailInvalidParam("--no-signature", "mutually exclusive with --signature-id"),
+			)
+	}
+	return nil
+}
+
+func resolveMailSendComposeSignature(ctx context.Context, runtime *common.RuntimeContext, mailboxID, senderEmail string, opts mailSendSignatureOptions) (*signatureResult, error) {
+	if opts.NoSignature {
+		return nil, nil
+	}
+
+	signatureID := strings.TrimSpace(opts.SignatureID)
+	if signatureID != "" {
+		return resolveSignature(ctx, runtime, mailboxID, signatureID, senderEmail)
+	}
+
+	resp, err := signature.ListAll(runtime, mailboxID)
+	if err != nil {
+		return nil, mailAppendProblemHint(
+			mailDecorateProblemMessage(err, "failed to look up default send signature"),
+			"pass --no-signature to send without a signature",
+		)
+	}
+
+	defaultID := selectMailSendDefaultSignatureID(resp.Usages, senderEmail)
+	if mailSendSignatureIDIsEmpty(defaultID) {
+		return nil, nil
+	}
+	if !mailSendSignatureExists(resp.Signatures, defaultID) {
+		return nil, mailValidationError("default send signature %q was configured for %q but was not returned by settings/signatures", defaultID, mailSendSignatureSenderLabel(senderEmail)).
+			WithHint("run `lark-cli mail +signature` to inspect signatures, or pass --no-signature to send without a signature")
+	}
+	return resolveSignature(ctx, runtime, mailboxID, defaultID, senderEmail)
+}
+
+func selectMailSendDefaultSignatureID(usages []signature.SignatureUsage, senderEmail string) string {
+	senderEmail = strings.TrimSpace(senderEmail)
+	if senderEmail == "" {
+		if len(usages) != 1 {
+			return ""
+		}
+		return strings.TrimSpace(usages[0].SendMailSignatureID)
+	}
+	for _, usage := range usages {
+		if strings.EqualFold(strings.TrimSpace(usage.EmailAddress), senderEmail) {
+			return strings.TrimSpace(usage.SendMailSignatureID)
+		}
+	}
+	return ""
+}
+
+func mailSendSignatureExists(signatures []signature.Signature, signatureID string) bool {
+	for _, sig := range signatures {
+		if strings.TrimSpace(sig.ID) == signatureID {
+			return true
+		}
+	}
+	return false
+}
+
+func mailSendSignatureIDIsEmpty(signatureID string) bool {
+	signatureID = strings.TrimSpace(signatureID)
+	return signatureID == "" || signatureID == "0"
+}
+
+func mailSendSignatureSenderLabel(senderEmail string) string {
+	if strings.TrimSpace(senderEmail) == "" {
+		return "the resolved sender"
+	}
+	return senderEmail
+}
+
+func appendMailSendPlainTextSignature(body string, sig *signatureResult, lang string) string {
+	if sig == nil {
+		return body
+	}
+	signatureText := renderMailSendSignaturePlainText(sig.RenderedContent, lang)
+	if strings.TrimSpace(signatureText) == "" {
+		return body
+	}
+	body = strings.TrimRight(body, "\r\n")
+	if strings.TrimSpace(body) == "" {
+		return signatureText
+	}
+	return body + "\n\n" + signatureText
+}
+
+func renderMailSendSignaturePlainText(content, lang string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ""
+	}
+	doc, err := xhtml.Parse(strings.NewReader(content))
+	if err != nil {
+		return strings.TrimSpace(stdhtml.UnescapeString(content))
+	}
+	var buf bytes.Buffer
+	renderMailSendSignatureText(&buf, doc, mailSendSignatureImagePlaceholder(lang))
+	return compactMailSendSignaturePlainText(buf.String())
+}
+
+func renderMailSendSignatureText(buf *bytes.Buffer, root *xhtml.Node, imagePlaceholder string) {
+	if root == nil {
+		return
+	}
+
+	type pendingEntry struct {
+		node  *xhtml.Node
+		child *xhtml.Node
+	}
+	stack := []pendingEntry{{node: root, child: root.FirstChild}}
+
+	for len(stack) > 0 {
+		top := &stack[len(stack)-1]
+		if top.child == nil {
+			if mailSendSignatureBlockNode(top.node) {
+				writeMailSendSignatureBreak(buf)
+			}
+			stack = stack[:len(stack)-1]
+			continue
+		}
+
+		node := top.child
+		top.child = node.NextSibling
+
+		if node.Type == xhtml.ElementNode {
+			tag := strings.ToLower(node.Data)
+			if mailSendSignatureSkipsText(tag) {
+				continue
+			}
+			switch tag {
+			case "br":
+				writeMailSendSignatureBreak(buf)
+				continue
+			case "img":
+				appendMailSendSignatureText(buf, imagePlaceholder)
+				continue
+			}
+			if mailSendSignatureBlockTag(tag) {
+				writeMailSendSignatureBreak(buf)
+			}
+		}
+		if node.Type == xhtml.TextNode {
+			appendMailSendSignatureText(buf, node.Data)
+		}
+		if node.FirstChild != nil {
+			stack = append(stack, pendingEntry{node: node, child: node.FirstChild})
+		}
+	}
+}
+
+func appendMailSendSignatureText(buf *bytes.Buffer, raw string) {
+	parts := strings.Fields(stdhtml.UnescapeString(raw))
+	if len(parts) == 0 {
+		return
+	}
+	text := strings.Join(parts, " ")
+	if buf.Len() > 0 {
+		last := buf.Bytes()[buf.Len()-1]
+		if last != '\n' && last != ' ' {
+			buf.WriteByte(' ')
+		}
+	}
+	buf.WriteString(text)
+}
+
+func writeMailSendSignatureBreak(buf *bytes.Buffer) {
+	for buf.Len() > 0 {
+		last := buf.Bytes()[buf.Len()-1]
+		if last != ' ' && last != '\t' && last != '\r' {
+			break
+		}
+		buf.Truncate(buf.Len() - 1)
+	}
+	if buf.Len() == 0 {
+		return
+	}
+	if buf.Bytes()[buf.Len()-1] != '\n' {
+		buf.WriteByte('\n')
+	}
+}
+
+func compactMailSendSignaturePlainText(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+func mailSendSignatureImagePlaceholder(lang string) string {
+	if strings.HasPrefix(strings.ToLower(lang), "zh") {
+		return "[图片]"
+	}
+	return "[image]"
+}
+
+func mailSendSignatureSkipsText(tag string) bool {
+	switch tag {
+	case "head", "script", "style", "title", "meta", "link", "noscript":
+		return true
+	default:
+		return false
+	}
+}
+
+func mailSendSignatureBlockNode(node *xhtml.Node) bool {
+	return node != nil && node.Type == xhtml.ElementNode && mailSendSignatureBlockTag(strings.ToLower(node.Data))
+}
+
+func mailSendSignatureBlockTag(tag string) bool {
+	switch tag {
+	case "address", "article", "aside", "blockquote", "dd", "div", "dl", "dt", "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr", "li", "main", "nav", "ol", "p", "pre", "section", "table", "tbody", "tfoot", "thead", "tr", "ul":
+		return true
+	default:
+		return false
+	}
+}

--- a/shortcuts/mail/mail_send_signature.go
+++ b/shortcuts/mail/mail_send_signature.go
@@ -226,7 +226,10 @@ func renderMailSendSignatureText(buf *bytes.Buffer, root *xhtml.Node, imagePlace
 }
 
 func appendMailSendSignatureTextNode(buf *bytes.Buffer, raw, imagePlaceholder string) {
-	unescaped := stdhtml.UnescapeString(raw)
+	// xhtml.Parse already unescapes HTML entities in text nodes, so raw is
+	// already in its final form. Calling UnescapeString again would corrupt
+	// double-encoded content (e.g. &amp;amp; → &amp; instead of staying as-is).
+	unescaped := raw
 	if !mailSendSignatureLooksLikeHTMLFragment(unescaped) {
 		appendMailSendSignatureText(buf, unescaped)
 		return
@@ -253,7 +256,10 @@ func appendMailSendSignatureTextNode(buf *bytes.Buffer, raw, imagePlaceholder st
 }
 
 func appendMailSendSignatureText(buf *bytes.Buffer, raw string) {
-	parts := strings.Fields(stdhtml.UnescapeString(raw))
+	// Callers (appendMailSendSignatureTextNode and renderMailSendSignatureText)
+	// already pass fully-unescaped text; UnescapeString here would be a redundant
+	// second pass and could corrupt double-encoded entities.
+	parts := strings.Fields(raw)
 	if len(parts) == 0 {
 		return
 	}

--- a/shortcuts/mail/mail_send_signature_test.go
+++ b/shortcuts/mail/mail_send_signature_test.go
@@ -46,6 +46,21 @@ func TestAppendMailSendPlainTextSignatureRendersHTML(t *testing.T) {
 	}
 }
 
+func TestAppendMailSendPlainTextSignatureRendersEscapedHTML(t *testing.T) {
+	got := appendMailSendPlainTextSignature("Hello", &signatureResult{
+		ID:              "sig_plain_escaped",
+		RenderedContent: `<div>Owner&lt;div style=&#34;white-space: nowrap;&#34;&gt;Kind&lt;br&gt;&lt;img src=&#34;cid:logo&#34;&gt;&lt;/div&gt;</div>`,
+	}, "zh_cn")
+
+	want := "Hello\n\nOwner\nKind\n[图片]"
+	if got != want {
+		t.Fatalf("escaped plain-text signature body = %q, want %q", got, want)
+	}
+	if strings.Contains(got, "<div") || strings.Contains(got, "<img") {
+		t.Fatalf("escaped HTML tags must not leak into plain-text body: %q", got)
+	}
+}
+
 func TestValidateMailSendSignatureFlagsRejectsNoSignatureConflict(t *testing.T) {
 	f, stdout, _, _ := mailShortcutTestFactory(t)
 	err := runMountedMailShortcut(t, MailSend, []string{

--- a/shortcuts/mail/mail_send_signature_test.go
+++ b/shortcuts/mail/mail_send_signature_test.go
@@ -1,0 +1,447 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/larksuite/cli/shortcuts/mail/signature"
+)
+
+func TestSelectMailSendDefaultSignatureID(t *testing.T) {
+	usages := []signature.SignatureUsage{
+		{EmailAddress: "owner@example.com", SendMailSignatureID: "sig_owner"},
+		{EmailAddress: "alias@example.com", SendMailSignatureID: " sig_alias "},
+	}
+
+	if got := selectMailSendDefaultSignatureID(usages, "ALIAS@example.com"); got != "sig_alias" {
+		t.Fatalf("alias match = %q, want sig_alias", got)
+	}
+	if got := selectMailSendDefaultSignatureID(usages, "nobody@example.com"); got != "" {
+		t.Fatalf("no match = %q, want empty", got)
+	}
+	if got := selectMailSendDefaultSignatureID([]signature.SignatureUsage{{SendMailSignatureID: "sig_single"}}, ""); got != "sig_single" {
+		t.Fatalf("single fallback = %q, want sig_single", got)
+	}
+	if got := selectMailSendDefaultSignatureID(usages, ""); got != "" {
+		t.Fatalf("multiple fallback = %q, want empty", got)
+	}
+}
+
+func TestAppendMailSendPlainTextSignatureRendersHTML(t *testing.T) {
+	got := appendMailSendPlainTextSignature("Hello\n", &signatureResult{
+		ID:              "sig_plain",
+		RenderedContent: `<div>Kind<br><b>Alice</b><img src="cid:logo"></div>`,
+	}, "en_us")
+
+	want := "Hello\n\nKind\nAlice [image]"
+	if got != want {
+		t.Fatalf("plain-text signature body = %q, want %q", got, want)
+	}
+}
+
+func TestValidateMailSendSignatureFlagsRejectsNoSignatureConflict(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "world",
+		"--signature-id", "sig_123",
+		"--no-signature",
+	}, f, stdout)
+
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T (%v)", err, err)
+	}
+	if len(validationErr.Params) != 2 {
+		t.Fatalf("params = %#v, want signature/no-signature conflict", validationErr.Params)
+	}
+}
+
+func TestMailSendDefaultSignatureUsesAliasSender(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	createStub := registerMailSendSignatureScenario(t, reg, mailSendSignatureScenario{
+		MailboxID:      "sig_default_alias_box",
+		DefaultEmail:   "owner@example.com",
+		DefaultSigID:   "sig_owner",
+		SignatureHTML:  `<p>Owner Signature</p>`,
+		AliasEmail:     "alias@example.com",
+		AliasSigID:     "sig_alias",
+		AliasSignature: `<p>Alias Signature</p>`,
+	})
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", "sig_default_alias_box",
+		"--from", "alias@example.com",
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "<p>Hello</p>",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	raw := decodeCapturedRawEML(t, createStub.CapturedBody)
+	if !strings.Contains(raw, "Alias Signature") {
+		t.Fatalf("expected alias signature in EML:\n%s", raw)
+	}
+	if strings.Contains(raw, "Owner Signature") {
+		t.Fatalf("default owner signature should not be used for alias sender:\n%s", raw)
+	}
+}
+
+func TestMailSendExplicitSignatureOverridesDefault(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	createStub := registerMailSendSignatureScenario(t, reg, mailSendSignatureScenario{
+		MailboxID:     "sig_explicit_box",
+		DefaultEmail:  "owner@example.com",
+		DefaultSigID:  "sig_default",
+		SignatureHTML: `<p>Default Signature</p>`,
+		ExtraSignatures: []signature.Signature{
+			{ID: "sig_explicit", Name: "Explicit", SignatureType: signature.SignatureTypeUser, Content: `<p>Explicit Signature</p>`},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", "sig_explicit_box",
+		"--from", "owner@example.com",
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "<p>Hello</p>",
+		"--signature-id", "sig_explicit",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	raw := decodeCapturedRawEML(t, createStub.CapturedBody)
+	if !strings.Contains(raw, "Explicit Signature") {
+		t.Fatalf("expected explicit signature in EML:\n%s", raw)
+	}
+	if strings.Contains(raw, "Default Signature") {
+		t.Fatalf("explicit signature should override default signature:\n%s", raw)
+	}
+}
+
+func TestMailSendNoSignatureSkipsSignatureAPIs(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	createStub := registerMailSendDraftCreate(reg, "sig_no_signature_box")
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", "sig_no_signature_box",
+		"--from", "owner@example.com",
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "<p>Hello</p>",
+		"--no-signature",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+	raw := decodeCapturedRawEML(t, createStub.CapturedBody)
+	if strings.Contains(raw, "lark-mail-signature") {
+		t.Fatalf("signature block should be absent when --no-signature is set:\n%s", raw)
+	}
+}
+
+func TestMailSendPlainTextExplicitSignatureAppendsText(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	createStub := registerMailSendSignatureScenario(t, reg, mailSendSignatureScenario{
+		MailboxID:     "sig_plain_text_box",
+		DefaultEmail:  "owner@example.com",
+		DefaultSigID:  "sig_default",
+		SignatureHTML: `<div>Default</div>`,
+		ExtraSignatures: []signature.Signature{
+			{ID: "sig_text", Name: "Text", SignatureType: signature.SignatureTypeUser, Content: `<div>Kind<br><b>Alice</b></div>`},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", "sig_plain_text_box",
+		"--from", "owner@example.com",
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "Hello",
+		"--plain-text",
+		"--signature-id", "sig_text",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	raw := decodeCapturedRawEML(t, createStub.CapturedBody)
+	if !strings.Contains(raw, "Content-Type: text/plain") {
+		t.Fatalf("expected text/plain EML:\n%s", raw)
+	}
+	if strings.Contains(raw, "Content-Type: text/html") {
+		t.Fatalf("plain-text signature must not upgrade to HTML:\n%s", raw)
+	}
+	if !strings.Contains(raw, "Hello\n\nKind\nAlice") {
+		t.Fatalf("expected plain-text signature appended after body:\n%s", raw)
+	}
+}
+
+func TestMailSendDefaultSignatureLookupFailureHintsNoSignature(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/sig_lookup_failure_box/settings/signatures",
+		Body: map[string]interface{}{
+			"code": 999,
+			"msg":  "signature service unavailable",
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", "sig_lookup_failure_box",
+		"--from", "owner@example.com",
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "<p>Hello</p>",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected lookup failure")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T (%v)", err, err)
+	}
+	if !strings.Contains(p.Message, "failed to look up default send signature") {
+		t.Fatalf("message = %q, want default lookup prefix", p.Message)
+	}
+	if !strings.Contains(p.Hint, "--no-signature") {
+		t.Fatalf("hint = %q, want --no-signature", p.Hint)
+	}
+}
+
+func TestMailSendDefaultSignatureMissingTargetHintsUser(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/sig_missing_target_box/settings/signatures",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"signatures": []interface{}{},
+				"usages": []interface{}{
+					map[string]interface{}{
+						"email_address":          "owner@example.com",
+						"send_mail_signature_id": "sig_missing",
+						"reply_signature_id":     "0",
+					},
+				},
+			},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", "sig_missing_target_box",
+		"--from", "owner@example.com",
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "<p>Hello</p>",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected missing signature validation error")
+	}
+	p, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed problem, got %T (%v)", err, err)
+	}
+	if !strings.Contains(p.Message, "default send signature") {
+		t.Fatalf("message = %q, want default send signature", p.Message)
+	}
+	if !strings.Contains(p.Hint, "mail +signature") || !strings.Contains(p.Hint, "--no-signature") {
+		t.Fatalf("hint = %q, want mail +signature and --no-signature", p.Hint)
+	}
+}
+
+func TestMailSendSignatureSendAsFailureDegrades(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	createStub := registerMailSendSignatureScenario(t, reg, mailSendSignatureScenario{
+		MailboxID:      "sig_send_as_degrade_box",
+		DefaultEmail:   "owner@example.com",
+		DefaultSigID:   "sig_default",
+		SignatureHTML:  `<p>Default Signature</p>`,
+		SkipSendAsStub: true,
+	})
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", "sig_send_as_degrade_box",
+		"--from", "owner@example.com",
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "<p>Hello</p>",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send should degrade when send_as lookup fails: %v", err)
+	}
+	raw := decodeCapturedRawEML(t, createStub.CapturedBody)
+	if !strings.Contains(raw, "Default Signature") {
+		t.Fatalf("signature should still be appended when send_as fails:\n%s", raw)
+	}
+}
+
+func TestNonSendComposeStillRejectsPlainTextSignatureID(t *testing.T) {
+	cases := []struct {
+		name     string
+		shortcut common.Shortcut
+		args     []string
+	}{
+		{
+			name:     "draft-create",
+			shortcut: MailDraftCreate,
+			args: []string{
+				"+draft-create", "--to", "alice@example.com", "--subject", "s", "--body", "body", "--plain-text", "--signature-id", "sig_123",
+			},
+		},
+		{
+			name:     "reply",
+			shortcut: MailReply,
+			args: []string{
+				"+reply", "--message-id", "msg_001", "--body", "body", "--plain-text", "--signature-id", "sig_123",
+			},
+		},
+		{
+			name:     "reply-all",
+			shortcut: MailReplyAll,
+			args: []string{
+				"+reply-all", "--message-id", "msg_001", "--body", "body", "--plain-text", "--signature-id", "sig_123",
+			},
+		},
+		{
+			name:     "forward",
+			shortcut: MailForward,
+			args: []string{
+				"+forward", "--message-id", "msg_001", "--to", "alice@example.com", "--body", "body", "--plain-text", "--signature-id", "sig_123",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			err := runMountedMailShortcut(t, tc.shortcut, tc.args, f, stdout)
+			assertValidationError(t, err, "--plain-text and --signature-id are mutually exclusive")
+		})
+	}
+}
+
+type mailSendSignatureScenario struct {
+	MailboxID       string
+	DefaultEmail    string
+	DefaultSigID    string
+	SignatureHTML   string
+	AliasEmail      string
+	AliasSigID      string
+	AliasSignature  string
+	ExtraSignatures []signature.Signature
+	SkipSendAsStub  bool
+}
+
+func registerMailSendSignatureScenario(t *testing.T, reg *httpmock.Registry, scenario mailSendSignatureScenario) *httpmock.Stub {
+	t.Helper()
+	signatures := []interface{}{
+		map[string]interface{}{
+			"id":               scenario.DefaultSigID,
+			"name":             "Default",
+			"signature_type":   string(signature.SignatureTypeUser),
+			"signature_device": string(signature.DevicePC),
+			"content":          scenario.SignatureHTML,
+		},
+	}
+	usages := []interface{}{
+		map[string]interface{}{
+			"email_address":          scenario.DefaultEmail,
+			"send_mail_signature_id": scenario.DefaultSigID,
+			"reply_signature_id":     "0",
+		},
+	}
+	if scenario.AliasEmail != "" {
+		signatures = append(signatures, map[string]interface{}{
+			"id":               scenario.AliasSigID,
+			"name":             "Alias",
+			"signature_type":   string(signature.SignatureTypeUser),
+			"signature_device": string(signature.DevicePC),
+			"content":          scenario.AliasSignature,
+		})
+		usages = append(usages, map[string]interface{}{
+			"email_address":          scenario.AliasEmail,
+			"send_mail_signature_id": scenario.AliasSigID,
+			"reply_signature_id":     "0",
+		})
+	}
+	for _, sig := range scenario.ExtraSignatures {
+		signatures = append(signatures, map[string]interface{}{
+			"id":               sig.ID,
+			"name":             sig.Name,
+			"signature_type":   string(sig.SignatureType),
+			"signature_device": string(signature.DevicePC),
+			"content":          sig.Content,
+		})
+	}
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/" + scenario.MailboxID + "/settings/signatures",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"signatures": signatures,
+				"usages":     usages,
+			},
+		},
+	})
+	if !scenario.SkipSendAsStub {
+		registerMailSendSignatureSendAs(reg, scenario.MailboxID, scenario.DefaultEmail, scenario.AliasEmail)
+	}
+	return registerMailSendDraftCreate(reg, scenario.MailboxID)
+}
+
+func registerMailSendSignatureSendAs(reg *httpmock.Registry, mailboxID, defaultEmail, aliasEmail string) {
+	addresses := []interface{}{
+		map[string]interface{}{"name": "Owner", "email_address": defaultEmail},
+	}
+	if aliasEmail != "" {
+		addresses = append(addresses, map[string]interface{}{"name": "Alias", "email_address": aliasEmail})
+	}
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/" + mailboxID + "/settings/send_as",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"sendable_addresses": addresses,
+			},
+		},
+	})
+}
+
+func registerMailSendDraftCreate(reg *httpmock.Registry, mailboxID string) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/" + mailboxID + "/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"draft_id": "draft_" + mailboxID,
+			},
+		},
+	}
+	reg.Register(stub)
+	return stub
+}

--- a/shortcuts/mail/mail_send_signature_test.go
+++ b/shortcuts/mail/mail_send_signature_test.go
@@ -5,6 +5,7 @@ package mail
 
 import (
 	"errors"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -111,6 +112,96 @@ func TestMailSendDefaultSignatureUsesAliasSender(t *testing.T) {
 	}
 	if strings.Contains(raw, "Owner Signature") {
 		t.Fatalf("default owner signature should not be used for alias sender:\n%s", raw)
+	}
+}
+
+func TestMailSendDefaultSignatureFallsBackToAliasMailbox(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	ownerMailbox := "ttt@13.wybanjia.work"
+	aliasEmail := "unsubscribe_test@13.wybanjia.work"
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    mailSendSignatureMockPath(ownerMailbox, "settings", "signatures"),
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"signatures": []interface{}{
+					map[string]interface{}{
+						"id":               "sig_owner",
+						"name":             "Owner",
+						"signature_type":   string(signature.SignatureTypeUser),
+						"signature_device": string(signature.DevicePC),
+						"content":          `<p>Owner Signature</p>`,
+					},
+				},
+				"usages": []interface{}{
+					map[string]interface{}{
+						"email_address":          ownerMailbox,
+						"send_mail_signature_id": "sig_owner",
+						"reply_signature_id":     "0",
+					},
+				},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    mailSendSignatureMockPath(aliasEmail, "settings", "signatures"),
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"signatures": []interface{}{
+					map[string]interface{}{
+						"id":                 "sig_alias",
+						"name":               "Alias",
+						"signature_type":     string(signature.SignatureTypeTenant),
+						"signature_device":   string(signature.DevicePC),
+						"content":            `<p>Alias sender <span data-variable-meta-props='{"id":"B-ENTERPRISE-EMAIL","type":"text"}'>placeholder</span></p>`,
+						"template_json_keys": []interface{}{"B-ENTERPRISE-EMAIL"},
+					},
+				},
+				"usages": []interface{}{
+					map[string]interface{}{
+						"email_address":          aliasEmail,
+						"send_mail_signature_id": "sig_alias",
+						"reply_signature_id":     "0",
+					},
+				},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    mailSendSignatureMockPath(aliasEmail, "settings", "send_as"),
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"sendable_addresses": []interface{}{
+					map[string]interface{}{"name": "Alias", "email_address": aliasEmail},
+				},
+			},
+		},
+	})
+	createStub := registerMailSendDraftCreate(reg, ownerMailbox)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", ownerMailbox,
+		"--from", aliasEmail,
+		"--to", ownerMailbox,
+		"--subject", "hello",
+		"--body", "<p>alias body</p>",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	raw := decodeCapturedRawEML(t, createStub.CapturedBody)
+	if !strings.Contains(raw, "Alias sender") || !strings.Contains(raw, aliasEmail) {
+		t.Fatalf("expected alias signature with alias send_as interpolation in EML:\n%s", raw)
+	}
+	if strings.Contains(raw, "Owner Signature") {
+		t.Fatalf("owner default signature should not be used for alias sender:\n%s", raw)
 	}
 }
 
@@ -412,7 +503,7 @@ func registerMailSendSignatureScenario(t *testing.T, reg *httpmock.Registry, sce
 	}
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/user_mailboxes/" + scenario.MailboxID + "/settings/signatures",
+		URL:    mailSendSignatureMockPath(scenario.MailboxID, "settings", "signatures"),
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -436,7 +527,7 @@ func registerMailSendSignatureSendAs(reg *httpmock.Registry, mailboxID, defaultE
 	}
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
-		URL:    "/user_mailboxes/" + mailboxID + "/settings/send_as",
+		URL:    mailSendSignatureMockPath(mailboxID, "settings", "send_as"),
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -449,7 +540,7 @@ func registerMailSendSignatureSendAs(reg *httpmock.Registry, mailboxID, defaultE
 func registerMailSendDraftCreate(reg *httpmock.Registry, mailboxID string) *httpmock.Stub {
 	stub := &httpmock.Stub{
 		Method: "POST",
-		URL:    "/user_mailboxes/" + mailboxID + "/drafts",
+		URL:    mailSendSignatureMockPath(mailboxID, "drafts"),
 		Body: map[string]interface{}{
 			"code": 0,
 			"data": map[string]interface{}{
@@ -459,4 +550,12 @@ func registerMailSendDraftCreate(reg *httpmock.Registry, mailboxID string) *http
 	}
 	reg.Register(stub)
 	return stub
+}
+
+func mailSendSignatureMockPath(mailboxID string, segments ...string) string {
+	parts := []string{"/user_mailboxes/" + url.PathEscape(mailboxID)}
+	for _, segment := range segments {
+		parts = append(parts, url.PathEscape(segment))
+	}
+	return strings.Join(parts, "/")
 }

--- a/shortcuts/mail/mail_template_shortcut_test.go
+++ b/shortcuts/mail/mail_template_shortcut_test.go
@@ -1041,6 +1041,7 @@ func TestFetchTemplateAttachmentURLs_FailedReasons(t *testing.T) {
 		"--to", "alice@example.com",
 		"--subject", "s",
 		"--body", "<p>b</p>",
+		"--no-signature",
 		"--template-id", "33",
 	}, f, stdout)
 	if err == nil || !strings.Contains(err.Error(), "download URL not returned") {
@@ -1140,6 +1141,7 @@ func TestMailSend_TemplateIDAppliesInlineAndSmall(t *testing.T) {
 		"--to", "alice@example.com",
 		"--subject", "override-subj",
 		"--body", "<p>user body</p>",
+		"--no-signature",
 		"--template-id", "42",
 	}, f, stdout)
 	if err != nil {

--- a/skills/lark-mail/references/lark-mail-send.md
+++ b/skills/lark-mail/references/lark-mail-send.md
@@ -7,6 +7,7 @@
 - 抄送/密送
 - 本地文件附件（`--attach`）
 - 内嵌图片（`--inline`，CID 可用随机字符串）
+- 默认追加当前发件人的发送签名；可用 `--signature-id` 指定签名，或用 `--no-signature` 跳过签名
 
 本 skill 对应 shortcut：`lark-cli mail +send`。
 
@@ -59,6 +60,13 @@ lark-cli mail +send --to alice@example.com --subject '预览图' --body '<img sr
 # 纯文本邮件（仅在内容极简时使用）
 lark-cli mail +send --to alice@example.com --subject '确认' --body '收到，谢谢'
 
+# 使用指定签名；纯文本模式下签名会以 text/plain 追加，不会升级为 HTML
+lark-cli mail +send --to alice@example.com --subject '确认' --body '收到，谢谢' \
+  --plain-text --signature-id sig_123
+
+# 不附加默认签名
+lark-cli mail +send --to alice@example.com --subject '确认' --body '收到，谢谢' --no-signature
+
 # Dry Run（仅打印请求，不执行）
 lark-cli mail +send --to alice@example.com --subject '测试' --body '<p>test</p>' --dry-run
 ```
@@ -75,10 +83,11 @@ lark-cli mail +send --to alice@example.com --subject '测试' --body '<p>test</p
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用。可通过 `accessible_mailboxes` 查询可用邮箱 |
 | `--cc <emails>` | 否 | 抄送邮箱，多个用逗号分隔 |
 | `--bcc <emails>` | 否 | 密送邮箱，多个用逗号分隔 |
-| `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用 |
+| `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用。若使用默认签名或 `--signature-id`，签名会转为纯文本追加到正文末尾，不会升级为 HTML |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
-| `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到正文末尾。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
+| `--signature-id <id>` | 否 | 签名 ID。显式指定要附加的邮箱签名，并覆盖当前发件人的默认发送签名。运行 `mail +signature` 查看可用签名。不可与 `--no-signature` 同时使用 |
+| `--no-signature` | 否 | 不附加默认签名，也不查询签名和 send_as 设置。不可与 `--signature-id` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
 | `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请（text/calendar）。需同时设置 `--event-start` 和 `--event-end` |
 | `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601，如 `2026-04-20T14:00+08:00`） |
@@ -209,6 +218,9 @@ lark-cli mail user_mailbox.drafts cancel_scheduled_send --params '{"user_mailbox
 - 使用 EML 构建器生成完整 MIME 邮件并 base64url 编码后发送。
 - `--attach` 作为普通附件添加。相对路径。
 - `--inline` 接受 JSON 数组，每项需提供 `cid`（唯一标识符，可用随机十六进制字符串）和 `file_path`（相对路径），作为 inline part 嵌入邮件。
+- 签名规则：未传 `--signature-id` 且未传 `--no-signature` 时，命令会按最终发件人（`--from`，或 `--mailbox`/profile 解析出的地址）读取 `settings/signatures`，选择该地址的 `send_mail_signature_id` 作为默认发送签名。`--signature-id` 显式优先；`--no-signature` 完全跳过签名和 send_as 查询。
+- HTML 邮件沿用飞书签名 HTML 注入和内嵌图片处理；纯文本邮件会把签名 HTML 渲染为文本后追加到 `text/plain` 正文末尾，不会因为签名而改成 HTML 邮件。
+- 如果默认签名查询失败，可加 `--no-signature` 先发送无签名邮件；如果默认签名 ID 已配置但在 `settings/signatures` 中找不到，先运行 `lark-cli mail +signature` 检查签名列表，或使用 `--no-signature` 跳过。
 - **超大附件**：当附件导致 EML 总大小（headers + body + inline images + attachments，base64 编码后）超过 25 MB 时，超出的文件自动通过 `medias/upload_*` API 上传到云端。HTML 邮件插入与飞书客户端一致的下载卡片；纯文本邮件追加包含文件名、大小和下载链接的文本块。单个文件上限 3 GB，总附件数量上限 250 个。
 
 ## 相关命令

--- a/tests/cli_e2e/mail/mail_send_dryrun_test.go
+++ b/tests/cli_e2e/mail/mail_send_dryrun_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestMail_SendDryRunSignatureRequestChain(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantURLs []string
+	}{
+		{
+			name: "default signature lookup",
+			args: []string{
+				"mail", "+send",
+				"--mailbox", "dry_box",
+				"--to", "alice@example.com",
+				"--subject", "Dry",
+				"--body", "<p>Hello</p>",
+				"--dry-run",
+			},
+			wantURLs: []string{
+				"/open-apis/mail/v1/user_mailboxes/dry_box/profile",
+				"/open-apis/mail/v1/user_mailboxes/dry_box/settings/signatures",
+				"/open-apis/mail/v1/user_mailboxes/dry_box/settings/send_as",
+				"/open-apis/mail/v1/user_mailboxes/dry_box/drafts",
+			},
+		},
+		{
+			name: "explicit signature then send",
+			args: []string{
+				"mail", "+send",
+				"--mailbox", "dry_explicit_box",
+				"--to", "alice@example.com",
+				"--subject", "Dry",
+				"--body", "<p>Hello</p>",
+				"--signature-id", "sig_123",
+				"--confirm-send",
+				"--dry-run",
+			},
+			wantURLs: []string{
+				"/open-apis/mail/v1/user_mailboxes/dry_explicit_box/profile",
+				"/open-apis/mail/v1/user_mailboxes/dry_explicit_box/settings/signatures",
+				"/open-apis/mail/v1/user_mailboxes/dry_explicit_box/settings/send_as",
+				"/open-apis/mail/v1/user_mailboxes/dry_explicit_box/drafts",
+				"/open-apis/mail/v1/user_mailboxes/dry_explicit_box/drafts/%3Cdraft_id%3E/send",
+			},
+		},
+		{
+			name: "skip signature",
+			args: []string{
+				"mail", "+send",
+				"--mailbox", "dry_no_sig_box",
+				"--to", "alice@example.com",
+				"--subject", "Dry",
+				"--body", "<p>Hello</p>",
+				"--no-signature",
+				"--dry-run",
+			},
+			wantURLs: []string{
+				"/open-apis/mail/v1/user_mailboxes/dry_no_sig_box/profile",
+				"/open-apis/mail/v1/user_mailboxes/dry_no_sig_box/drafts",
+			},
+		},
+	}
+
+	for _, temp := range tests {
+		tt := temp
+		t.Run(tt.name, func(t *testing.T) {
+			setMailSendDryRunEnv(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			t.Cleanup(cancel)
+
+			result, err := clie2e.RunCmd(ctx, clie2e.Request{
+				Args:      tt.args,
+				DefaultAs: "user",
+			})
+			require.NoError(t, err)
+			result.AssertExitCode(t, 0)
+
+			require.Equal(t, int64(len(tt.wantURLs)), gjson.Get(result.Stdout, "api.#").Int(), "stdout:\n%s", result.Stdout)
+			for i, wantURL := range tt.wantURLs {
+				idx := strconv.Itoa(i)
+				require.Equal(t, wantURL, gjson.Get(result.Stdout, "api."+idx+".url").String(), "stdout:\n%s", result.Stdout)
+				if strings.HasSuffix(wantURL, "/drafts") {
+					require.Equal(t, "<base64url-EML>", gjson.Get(result.Stdout, "api."+idx+".body.raw").String(), "stdout:\n%s", result.Stdout)
+				}
+			}
+			require.Equal(t, "POST", gjson.Get(result.Stdout, "api."+strconv.Itoa(len(tt.wantURLs)-1)+".method").String(), "stdout:\n%s", result.Stdout)
+		})
+	}
+}
+
+func TestMail_SendDryRunRejectsSignatureSkipConflict(t *testing.T) {
+	setMailSendDryRunEnv(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"mail", "+send",
+			"--to", "alice@example.com",
+			"--subject", "Dry",
+			"--body", "Hello",
+			"--signature-id", "sig_123",
+			"--no-signature",
+			"--dry-run",
+		},
+		DefaultAs: "user",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+	require.Contains(t, result.Stdout+result.Stderr, "--signature-id and --no-signature are mutually exclusive")
+}
+
+func setMailSendDryRunEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_APP_ID", "mail_send_dryrun_test")
+	t.Setenv("LARKSUITE_CLI_APP_SECRET", "mail_send_dryrun_secret")
+	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+}

--- a/tests/cli_e2e/mail/mail_send_workflow_test.go
+++ b/tests/cli_e2e/mail/mail_send_workflow_test.go
@@ -116,6 +116,7 @@ func TestMail_SendWorkflowAsUser(t *testing.T) {
 				"--subject", subject,
 				"--body", body,
 				"--plain-text",
+				"--no-signature",
 				"--confirm-send",
 			},
 			DefaultAs: "user",


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/70d8de8
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Implement mail +send default signature behavior | passed | 1864b55 |
| S2 | Synthesize transport contract for larksuite/cli | passed | 7c50b3d |

## Source specs

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --no-signature to skip appending the sender’s signature and --signature-id to choose an explicit signature; signatures remain appended by default. Plain-text sends append a plain-text signature without upgrading to HTML.

* **Documentation**
  * Updated mail send docs with signature behavior, examples, mutual-exclusion rules, and plain-text handling.

* **Tests**
  * Added and updated unit and end-to-end tests and dry-run coverage for signature selection, rendering, validation, and workflow scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->