### PR TITLE
feat(lark-shared): document relative-path-only file arguments

### DIFF
--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -126,6 +126,7 @@ lark-cli 命令执行后，如果检测到新版本，JSON 输出中会包含 `_
 - **禁止输出密钥**（appSecret、accessToken）到终端明文。
 - **写入/删除操作前必须确认用户意图**。
 - 用 `--dry-run` 预览危险请求。
+- **文件路径只接受相对路径**：`--file`、`--output`、`--output-dir`、`@file` 等路径参数只接受 cwd 下的相对路径，传绝对路径会报 `unsafe file path`。数据输入（`@file`、大 JSON）优先用 stdin 传入，避免路径和转义问题。
 
 ## 高风险操作的审批协议（exit 10）
 


### PR DESCRIPTION
## Summary

lark-cli rejects absolute file paths for path arguments with an `unsafe file path` error, but the lark-shared skill never documented this constraint, so agents repeatedly hit it. This adds a one-line rule under the shared security section so every domain skill inherits the guidance.

## Changes

- Add a relative-path-only rule to the `安全规则` section in `skills/lark-shared/SKILL.md`, covering `--file` / `--output` / `--output-dir` / `@file` and steering large/data input to stdin

## Test Plan

- [x] skipped: `make unit-test` — docs-only change, no Go code touched
- [x] skipped: validate / local-eval / acceptance-reviewer — single-line guidance addition to an existing skill section, no command examples added
- [x] manual verification: reviewed rendered `skills/lark-shared/SKILL.md` — new bullet sits at the end of `## 安全规则`, no structural/frontmatter change

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * New safety guidelines added for path parameters. Path-based arguments now only accept relative paths from the current working directory, with absolute paths resulting in an error. Documentation also recommends using stdin for data input to reduce complexity and potential issues related to path handling and escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->