### PR TITLE
feat: append default signature for mail send

### DIFF
--- a/shortcuts/mail/mail_lint_writepath_test.go
+++ b/shortcuts/mail/mail_lint_writepath_test.go
@@ -487,6 +487,7 @@ func TestMailSend_WritePathLintAutofixesFontInEML(t *testing.T) {
 		"--subject", "Send",
 		"--body", `<font color="red">payload</font>`,
 		"--show-lint-details",
+		"--no-signature",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("send failed: %v", err)

--- a/shortcuts/mail/mail_request_receipt_integration_test.go
+++ b/shortcuts/mail/mail_request_receipt_integration_test.go
@@ -129,6 +129,7 @@ func TestMailSend_RequestReceiptAddsHeader_Integration(t *testing.T) {
 		"--body", "please confirm",
 		"--request-receipt",
 		"--confirm-send",
+		"--no-signature",
 	}, f, stdout); err != nil {
 		t.Fatalf("send failed: %v", err)
 	}

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -104,7 +104,7 @@ var MailSend = common.Shortcut{
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
-		if err := validateSignatureFlags(runtime.Str("signature-id"), runtime.Bool("no-signature")); err != nil {
+		if err := validateSignatureFlags(runtime.Str("signature-id"), runtime.Changed("signature-id"), runtime.Bool("no-signature")); err != nil {
 			return err
 		}
 		// Resolve the body content first (reading --body-file if set) so

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -32,7 +32,7 @@ var MailSend = common.Shortcut{
 		{Name: "mailbox", Desc: "Mailbox email address that owns the draft (default: falls back to --from, then me). Use this when the sender (--from) differs from the mailbox, e.g. sending via an alias or send_as address."},
 		{Name: "cc", Desc: "CC email address(es), comma-separated"},
 		{Name: "bcc", Desc: "BCC email address(es), comma-separated"},
-		{Name: "plain-text", Type: "bool", Desc: "Force plain-text mode, ignoring HTML auto-detection. Cannot be used with --inline."},
+		{Name: "plain-text", Type: "bool", Desc: "Force plain-text mode, ignoring HTML auto-detection. Cannot be used with --inline. Signatures are appended as visible text in plain-text output."},
 		{Name: "attach", Desc: "Attachment file path(s), comma-separated (relative path only)"},
 		{Name: "inline", Desc: "Inline images as a JSON array. Each entry: {\"cid\":\"<unique-id>\",\"file_path\":\"<relative-path>\"}. All file_path values must be relative paths. Cannot be used with --plain-text. CID images are embedded via <img src=\"cid:...\"> in the HTML body. CID is a unique identifier, e.g. a random hex string like \"a1b2c3d4e5f6a7b8c9d0\"."},
 		{Name: "confirm-send", Type: "bool", Desc: "Send the email immediately instead of saving as draft. Only use after the user has explicitly confirmed recipients and content."},
@@ -40,6 +40,7 @@ var MailSend = common.Shortcut{
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's subject/body/to/cc/bcc/attachments are merged with user-supplied flags (user flags win). Requires --as user."},
 		signatureFlag,
+		noSignatureFlag,
 		priorityFlag,
 		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag,
 		showLintDetailsFlag},
@@ -58,7 +59,12 @@ var MailSend = common.Shortcut{
 				Desc("Fetch template to merge with compose flags (subject/body/to/cc/bcc/attachments).")
 		}
 		api = api.GET(mailboxPath(mailboxID, "profile")).
-			POST(mailboxPath(mailboxID, "drafts")).
+			Desc("Resolve sender address for default signature matching and message headers.")
+		if !runtime.Bool("no-signature") {
+			api = api.GET(mailboxPath(mailboxID, "settings", "signatures")).
+				Desc("Fetch explicit or sender-matched default signature.")
+		}
+		api = api.POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{
 				"raw": "<base64url-EML>",
 				"_preview": map[string]interface{}{
@@ -98,7 +104,7 @@ var MailSend = common.Shortcut{
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
-		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+		if err := validateSignatureFlags(runtime.Str("signature-id"), runtime.Bool("no-signature")); err != nil {
 			return err
 		}
 		// Resolve the body content first (reading --body-file if set) so
@@ -138,6 +144,7 @@ var MailSend = common.Shortcut{
 
 		senderEmail := resolveComposeSenderEmail(runtime)
 		signatureID := runtime.Str("signature-id")
+		noSignature := runtime.Bool("no-signature")
 		priority, err := parsePriority(runtime.Str("priority"))
 		if err != nil {
 			return err
@@ -195,11 +202,6 @@ var MailSend = common.Shortcut{
 			}
 		}
 
-		sigResult, err := resolveSignature(ctx, runtime, mailboxID, signatureID, senderEmail)
-		if err != nil {
-			return err
-		}
-
 		bld := emlbuilder.New().WithFileIO(runtime.FileIO()).
 			Subject(subject).
 			ToAddrs(parseNetAddrs(to))
@@ -207,6 +209,11 @@ var MailSend = common.Shortcut{
 			bld = bld.From("", senderEmail)
 		}
 		if err := requireSenderForRequestReceipt(runtime, senderEmail); err != nil {
+			return err
+		}
+
+		sigResult, sigImages, err := resolveComposeSignature(runtime, mailboxID, signatureID, senderEmail, noSignature)
+		if err != nil {
 			return err
 		}
 		if runtime.Bool("request-receipt") {
@@ -229,15 +236,15 @@ var MailSend = common.Shortcut{
 		// Initialised as empty (non-nil) slices so the envelope always carries
 		// `lint_applied[]` / `original_blocked[]` even on the plain-text path.
 		lintApplied, lintBlocked := emptyLintEnvelopeFields()
-		if plainText {
-			composedTextBody = body
+		if plainText || !bodyIsHTML(body) {
+			composedTextBody = appendPlainTextSignature(body, sigResult)
 			bld = bld.TextBody([]byte(composedTextBody))
-		} else if bodyIsHTML(body) || sigResult != nil {
-			// If signature is requested on plain-text body, auto-upgrade to HTML.
-			htmlBody := body
-			if !bodyIsHTML(body) {
-				htmlBody = buildBodyDiv(body, false)
+		} else {
+			sigResult, err = resolveSignatureImages(runtime, sigResult, sigImages)
+			if err != nil {
+				return err
 			}
+			htmlBody := body
 			resolved, refs, resolveErr := draftpkg.ResolveLocalImagePaths(htmlBody)
 			if resolveErr != nil {
 				return mailValidationError("failed to resolve local image paths: %v", resolveErr).WithCause(resolveErr)
@@ -274,9 +281,6 @@ var MailSend = common.Shortcut{
 			if err := validateInlineCIDs(resolved, allCIDs, nil); err != nil {
 				return err
 			}
-		} else {
-			composedTextBody = body
-			bld = bld.TextBody([]byte(composedTextBody))
 		}
 		// Embed template SMALL non-inline attachments via AddAttachment.
 		// Runs after the body branch so the part list is already set; the

--- a/shortcuts/mail/mail_send_confirm_output_test.go
+++ b/shortcuts/mail/mail_send_confirm_output_test.go
@@ -150,6 +150,7 @@ func TestMailSendConfirmSendOutputsAutomationDisable(t *testing.T) {
 		"--subject", "hello",
 		"--body", "world",
 		"--confirm-send",
+		"--no-signature",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("send failed: %v", err)
@@ -203,6 +204,7 @@ func TestMailSendSaveDraftOutputsReference(t *testing.T) {
 		"--to", "alice@example.com",
 		"--subject", "hello",
 		"--body", "world",
+		"--no-signature",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("save draft failed: %v", err)
@@ -246,6 +248,7 @@ func TestMailSend_WithCalendarEventEmbedded(t *testing.T) {
 		"--event-summary", "Team Sync",
 		"--event-start", "2026-05-10T10:00+08:00",
 		"--event-end", "2026-05-10T11:00+08:00",
+		"--no-signature",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("mail send with calendar failed: %v", err)

--- a/shortcuts/mail/mail_send_signature_test.go
+++ b/shortcuts/mail/mail_send_signature_test.go
@@ -1,0 +1,398 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func registerSignatureListStub(reg *httpmock.Registry, mailboxID string, signatures []interface{}, usages []interface{}) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/" + url.PathEscape(mailboxID) + "/settings/signatures",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"signatures": signatures,
+				"usages":     usages,
+			},
+		},
+	}
+	reg.Register(stub)
+	return stub
+}
+
+func registerSendAsStub(reg *httpmock.Registry, mailboxID, email string) {
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/" + url.PathEscape(mailboxID) + "/settings/send_as",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"sendable_addresses": []interface{}{
+					map[string]interface{}{"email_address": email, "name": "Sender Name"},
+				},
+			},
+		},
+	})
+}
+
+func signatureForTest(id, content string, images []interface{}) map[string]interface{} {
+	return map[string]interface{}{
+		"id":             id,
+		"name":           id,
+		"signature_type": "USER",
+		"content":        content,
+		"images":         images,
+	}
+}
+
+func sendDefaultUsageForTest(email, signatureID string) map[string]interface{} {
+	return map[string]interface{}{
+		"email_address":          email,
+		"send_mail_signature_id": signatureID,
+		"reply_signature_id":     "reply-unused",
+	}
+}
+
+func registerDraftCreateStub(reg *httpmock.Registry, mailboxID string) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/" + url.PathEscape(mailboxID) + "/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "draft_001"},
+		},
+	}
+	reg.Register(stub)
+	return stub
+}
+
+func TestMailSendDefaultSignatureHTML(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	mailboxID := "owner-html@example.com"
+	registerSignatureListStub(reg, mailboxID,
+		[]interface{}{
+			signatureForTest("sig_owner", `<p>Owner Sig<img src="cid:sigcid"></p>`, []interface{}{
+				map[string]interface{}{
+					"image_name":   "logo.png",
+					"cid":          "sigcid",
+					"download_url": "https://storage.example.com/sigcid",
+				},
+			}),
+		},
+		[]interface{}{sendDefaultUsageForTest("owner-html@example.com", "sig_owner")},
+	)
+	registerSendAsStub(reg, mailboxID, "owner-html@example.com")
+	reg.Register(&httpmock.Stub{
+		Method:  "GET",
+		URL:     "https://storage.example.com/sigcid",
+		RawBody: []byte{0x89, 'P', 'N', 'G'},
+	})
+	draftStub := registerDraftCreateStub(reg, mailboxID)
+
+	if err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>Body</p>",
+	}, f, stdout); err != nil {
+		t.Fatalf("+send default signature failed: %v", err)
+	}
+	raw := decodeCapturedRawEML(t, draftStub.CapturedBody)
+	for _, want := range []string{`class="lark-mail-signature"`, "Owner Sig", "Content-Id: <sigcid>"} {
+		if !strings.Contains(raw, want) {
+			t.Fatalf("EML missing %q:\n%s", want, raw)
+		}
+	}
+}
+
+func TestMailSendNoSignatureSkipsSignatureLookup(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	mailboxID := "owner-skip@example.com"
+	draftStub := registerDraftCreateStub(reg, mailboxID)
+
+	if err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--from", "owner-skip@example.com",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>Body</p>",
+		"--no-signature",
+	}, f, stdout); err != nil {
+		t.Fatalf("+send --no-signature failed: %v", err)
+	}
+	raw := decodeCapturedRawEML(t, draftStub.CapturedBody)
+	if strings.Contains(raw, "lark-mail-signature") {
+		t.Fatalf("EML should not contain signature:\n%s", raw)
+	}
+	reg.Verify(t)
+}
+
+func TestMailSendExplicitSignatureIgnoresDefault(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	mailboxID := "owner-explicit@example.com"
+	registerSignatureListStub(reg, mailboxID,
+		[]interface{}{
+			signatureForTest("sig_default", "<p>Default Sig</p>", nil),
+			signatureForTest("sig_explicit", "<p>Explicit Sig</p>", nil),
+		},
+		[]interface{}{sendDefaultUsageForTest("owner-explicit@example.com", "sig_default")},
+	)
+	registerSendAsStub(reg, mailboxID, "owner-explicit@example.com")
+	draftStub := registerDraftCreateStub(reg, mailboxID)
+
+	if err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>Body</p>",
+		"--signature-id", "sig_explicit",
+	}, f, stdout); err != nil {
+		t.Fatalf("+send explicit signature failed: %v", err)
+	}
+	raw := decodeCapturedRawEML(t, draftStub.CapturedBody)
+	if !strings.Contains(raw, "Explicit Sig") {
+		t.Fatalf("EML missing explicit signature:\n%s", raw)
+	}
+	if strings.Contains(raw, "Default Sig") {
+		t.Fatalf("EML should not contain default signature:\n%s", raw)
+	}
+}
+
+func TestMailSendDefaultSignatureMatchesAliasSender(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	mailboxID := "owner-alias@example.com"
+	registerSignatureListStub(reg, mailboxID,
+		[]interface{}{
+			signatureForTest("sig_owner", "<p>Owner Sig</p>", nil),
+			signatureForTest("sig_alias", "<p>Alias Sig</p>", nil),
+		},
+		[]interface{}{
+			sendDefaultUsageForTest("owner-alias@example.com", "sig_owner"),
+			sendDefaultUsageForTest("alias@example.com", "sig_alias"),
+		},
+	)
+	registerSendAsStub(reg, mailboxID, "alias@example.com")
+	draftStub := registerDraftCreateStub(reg, mailboxID)
+
+	if err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--from", "alias@example.com",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>Body</p>",
+	}, f, stdout); err != nil {
+		t.Fatalf("+send alias signature failed: %v", err)
+	}
+	raw := decodeCapturedRawEML(t, draftStub.CapturedBody)
+	if !strings.Contains(raw, "Alias Sig") || strings.Contains(raw, "Owner Sig") {
+		t.Fatalf("EML should contain alias signature only:\n%s", raw)
+	}
+}
+
+func TestMailSendNoDefaultSignatureCreatesDraft(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	mailboxID := "owner-nodefault@example.com"
+	registerSignatureListStub(reg, mailboxID,
+		[]interface{}{signatureForTest("sig_other", "<p>Other Sig</p>", nil)},
+		[]interface{}{sendDefaultUsageForTest("owner-nodefault@example.com", "0")},
+	)
+	draftStub := registerDraftCreateStub(reg, mailboxID)
+
+	if err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--from", "owner-nodefault@example.com",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>Body</p>",
+	}, f, stdout); err != nil {
+		t.Fatalf("+send no default signature failed: %v", err)
+	}
+	raw := decodeCapturedRawEML(t, draftStub.CapturedBody)
+	if strings.Contains(raw, "Other Sig") || strings.Contains(raw, "lark-mail-signature") {
+		t.Fatalf("EML should not contain a signature:\n%s", raw)
+	}
+}
+
+func TestMailSendPlainTextSignatureDoesNotDownloadImages(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	mailboxID := "owner-plain@example.com"
+	registerSignatureListStub(reg, mailboxID,
+		[]interface{}{
+			signatureForTest("sig_plain", `<div>Plain Sig</div><img src="cid:sigcid"><script>bad()</script>`, []interface{}{
+				map[string]interface{}{
+					"image_name":   "logo.png",
+					"cid":          "sigcid",
+					"download_url": "https://storage.example.com/should-not-download",
+				},
+			}),
+		},
+		[]interface{}{sendDefaultUsageForTest("owner-plain@example.com", "sig_plain")},
+	)
+	registerSendAsStub(reg, mailboxID, "owner-plain@example.com")
+	draftStub := registerDraftCreateStub(reg, mailboxID)
+
+	if err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "Body",
+		"--plain-text",
+	}, f, stdout); err != nil {
+		t.Fatalf("+send plain-text signature failed: %v", err)
+	}
+	raw := decodeCapturedRawEML(t, draftStub.CapturedBody)
+	for _, want := range []string{"Content-Type: text/plain", "Body", "Plain Sig"} {
+		if !strings.Contains(raw, want) {
+			t.Fatalf("plain EML missing %q:\n%s", want, raw)
+		}
+	}
+	for _, forbidden := range []string{"lark-mail-signature", "Content-ID:", "cid:sigcid", "bad()"} {
+		if strings.Contains(raw, forbidden) {
+			t.Fatalf("plain EML leaked %q:\n%s", forbidden, raw)
+		}
+	}
+}
+
+func TestMailSendSignatureAPIFailureDoesNotCreateDraft(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	mailboxID := "owner-api-fail@example.com"
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/" + url.PathEscape(mailboxID) + "/settings/signatures",
+		Status: 500,
+		Body: map[string]interface{}{
+			"code": 999,
+			"msg":  "boom",
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--from", "owner-api-fail@example.com",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>Body</p>",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected signature API failure")
+	}
+	if strings.Contains(err.Error(), "draft") {
+		t.Fatalf("error should come from signature lookup before draft creation, got: %v", err)
+	}
+}
+
+func TestMailSendExplicitSignatureMissingDoesNotCreateDraft(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	mailboxID := "owner-missing@example.com"
+	registerSignatureListStub(reg, mailboxID,
+		[]interface{}{signatureForTest("sig_other", "<p>Other Sig</p>", nil)},
+		nil,
+	)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--from", "owner-missing@example.com",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>Body</p>",
+		"--signature-id", "sig_missing",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "signature not found") {
+		t.Fatalf("expected signature not found error, got: %v", err)
+	}
+}
+
+func TestMailSendSignatureImageFailureDoesNotCreateDraft(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	mailboxID := "owner-image-fail@example.com"
+	registerSignatureListStub(reg, mailboxID,
+		[]interface{}{
+			signatureForTest("sig_img", `<p>Sig <img src="cid:sigcid"></p>`, []interface{}{
+				map[string]interface{}{
+					"image_name":   "logo.png",
+					"cid":          "sigcid",
+					"download_url": "https://storage.example.com/missing-logo",
+				},
+			}),
+		},
+		[]interface{}{sendDefaultUsageForTest("owner-image-fail@example.com", "sig_img")},
+	)
+	registerSendAsStub(reg, mailboxID, "owner-image-fail@example.com")
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "https://storage.example.com/missing-logo",
+		Status: 404,
+		Body:   "missing",
+	})
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>Body</p>",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "failed to download signature image") {
+		t.Fatalf("expected image download error, got: %v", err)
+	}
+}
+
+func TestMailSendSignatureFlagConflictValidation(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "Body",
+		"--signature-id", "sig_1",
+		"--no-signature",
+	}, f, stdout)
+	assertValidationError(t, err, "--signature-id and --no-signature")
+}
+
+func TestMailSendDryRunSignaturePlan(t *testing.T) {
+	runtimeFor := func(args []string) string {
+		f, stdout, _, _ := mailShortcutTestFactory(t)
+		err := runMountedMailShortcut(t, MailSend, append([]string{
+			"+send", "--to", "alice@example.com", "--subject", "hello", "--body", "Body",
+		}, args...), f, stdout)
+		if err != nil {
+			t.Fatalf("dry-run failed: %v", err)
+		}
+		var out map[string]interface{}
+		if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+			t.Fatalf("unmarshal dry-run: %v; stdout=%s", err, stdout.String())
+		}
+		b, _ := json.Marshal(out)
+		return string(b)
+	}
+
+	defaultPlan := runtimeFor([]string{"--dry-run"})
+	if !strings.Contains(defaultPlan, "/settings/signatures") {
+		t.Fatalf("default dry-run missing signatures call: %s", defaultPlan)
+	}
+	explicitPlan := runtimeFor([]string{"--signature-id", "sig_1", "--dry-run"})
+	if !strings.Contains(explicitPlan, "/settings/signatures") {
+		t.Fatalf("explicit dry-run missing signatures call: %s", explicitPlan)
+	}
+	skipPlan := runtimeFor([]string{"--no-signature", "--dry-run"})
+	if strings.Contains(skipPlan, "/settings/signatures") {
+		t.Fatalf("--no-signature dry-run should omit signatures call: %s", skipPlan)
+	}
+}

--- a/shortcuts/mail/mail_send_signature_test.go
+++ b/shortcuts/mail/mail_send_signature_test.go
@@ -366,6 +366,22 @@ func TestMailSendSignatureFlagConflictValidation(t *testing.T) {
 	assertValidationError(t, err, "--signature-id and --no-signature")
 }
 
+func TestMailSendEmptySignatureIDFailsBeforeAPI(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	mailboxID := "owner-empty@example.com"
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--from", "owner-empty@example.com",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>Body</p>",
+		"--signature-id", "",
+	}, f, stdout)
+	assertValidationError(t, err, "--signature-id must not be empty")
+}
+
 func TestMailSendDryRunSignaturePlan(t *testing.T) {
 	runtimeFor := func(args []string) string {
 		f, stdout, _, _ := mailShortcutTestFactory(t)

--- a/shortcuts/mail/mail_template_shortcut_test.go
+++ b/shortcuts/mail/mail_template_shortcut_test.go
@@ -1042,6 +1042,7 @@ func TestFetchTemplateAttachmentURLs_FailedReasons(t *testing.T) {
 		"--subject", "s",
 		"--body", "<p>b</p>",
 		"--template-id", "33",
+		"--no-signature",
 	}, f, stdout)
 	if err == nil || !strings.Contains(err.Error(), "download URL not returned") {
 		t.Errorf("expected download-URL-missing error (with failed_reasons warning), got %v", err)
@@ -1141,6 +1142,7 @@ func TestMailSend_TemplateIDAppliesInlineAndSmall(t *testing.T) {
 		"--subject", "override-subj",
 		"--body", "<p>user body</p>",
 		"--template-id", "42",
+		"--no-signature",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("+send --template-id failed: %v", err)

--- a/shortcuts/mail/signature/plaintext.go
+++ b/shortcuts/mail/signature/plaintext.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package signature
+
+import (
+	"bytes"
+	"strings"
+
+	xhtml "golang.org/x/net/html"
+)
+
+// PlainTextFromHTML returns the visible text of a rendered signature HTML.
+// It uses an explicit stack so malformed or deeply nested signatures cannot
+// overflow the goroutine stack.
+func PlainTextFromHTML(raw string) string {
+	doc, err := xhtml.Parse(strings.NewReader(raw))
+	if err != nil {
+		return strings.TrimSpace(raw)
+	}
+
+	var buf bytes.Buffer
+	type pendingEntry struct {
+		node  *xhtml.Node
+		child *xhtml.Node
+	}
+	stack := []pendingEntry{{node: doc, child: doc.FirstChild}}
+
+	for len(stack) > 0 {
+		top := &stack[len(stack)-1]
+		if top.child == nil {
+			if isBlockBoundary(top.node) && buf.Len() > 0 && lastByte(&buf) != '\n' {
+				buf.WriteByte('\n')
+			}
+			stack = stack[:len(stack)-1]
+			continue
+		}
+
+		n := top.child
+		top.child = top.child.NextSibling
+		if isNonTextTag(n) {
+			continue
+		}
+		if n.Type == xhtml.TextNode {
+			text := collapseWhitespace(n.Data)
+			if text != "" {
+				if last := lastByte(&buf); last != 0 && last != '\n' && last != ' ' {
+					buf.WriteByte(' ')
+				}
+				buf.WriteString(text)
+			}
+		}
+		if isBlockBoundary(n) && buf.Len() > 0 && lastByte(&buf) != '\n' {
+			buf.WriteByte('\n')
+		}
+		if n.FirstChild != nil {
+			stack = append(stack, pendingEntry{node: n, child: n.FirstChild})
+		}
+	}
+
+	lines := strings.Split(buf.String(), "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return strings.Join(out, "\n")
+}
+
+func lastByte(buf *bytes.Buffer) byte {
+	if buf.Len() == 0 {
+		return 0
+	}
+	return buf.Bytes()[buf.Len()-1]
+}
+
+func isNonTextTag(n *xhtml.Node) bool {
+	if n == nil || n.Type != xhtml.ElementNode {
+		return false
+	}
+	switch strings.ToLower(n.Data) {
+	case "head", "meta", "script", "noscript", "style", "link", "title", "img":
+		return true
+	default:
+		return false
+	}
+}
+
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func isBlockBoundary(n *xhtml.Node) bool {
+	if n == nil || n.Type != xhtml.ElementNode {
+		return false
+	}
+	switch strings.ToLower(n.Data) {
+	case "address", "article", "aside", "blockquote", "br", "dd", "div", "dl", "dt",
+		"figcaption", "figure", "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6",
+		"header", "hr", "li", "main", "nav", "ol", "p", "pre", "section", "table", "tr", "ul":
+		return true
+	default:
+		return false
+	}
+}

--- a/shortcuts/mail/signature/plaintext_test.go
+++ b/shortcuts/mail/signature/plaintext_test.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package signature
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPlainTextFromHTML(t *testing.T) {
+	got := PlainTextFromHTML(`<div>Hello <b>Alice</b></div><p>Role<br>Team</p><img src="cid:x"><script>bad()</script><style>.x{}</style>`)
+
+	for _, want := range []string{"Hello Alice", "Role", "Team"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("PlainTextFromHTML missing %q: %q", want, got)
+		}
+	}
+	for _, forbidden := range []string{"cid:x", "bad()", ".x"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("PlainTextFromHTML leaked %q: %q", forbidden, got)
+		}
+	}
+}
+
+func TestPlainTextFromHTMLMalformedFallsBack(t *testing.T) {
+	got := PlainTextFromHTML("<div>hello")
+	if !strings.Contains(got, "hello") {
+		t.Fatalf("PlainTextFromHTML malformed result = %q", got)
+	}
+}

--- a/shortcuts/mail/signature/provider.go
+++ b/shortcuts/mail/signature/provider.go
@@ -6,6 +6,7 @@ package signature
 import (
 	"encoding/json"
 	"net/url"
+	"strings"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -67,4 +68,31 @@ func Get(runtime *common.RuntimeContext, mailboxID, signatureID string) (*Signat
 		}
 	}
 	return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "signature not found: %s", signatureID)
+}
+
+// FindSendDefault returns the new-mail default signature for senderEmail.
+// Empty, "0", unmatched sender, and dangling signature IDs all mean no
+// default signature instead of an API-level error.
+func FindSendDefault(resp *GetSignaturesResponse, senderEmail string) (*Signature, bool) {
+	if resp == nil || strings.TrimSpace(senderEmail) == "" {
+		return nil, false
+	}
+
+	var signatureID string
+	for _, usage := range resp.Usages {
+		if strings.EqualFold(strings.TrimSpace(usage.EmailAddress), strings.TrimSpace(senderEmail)) {
+			signatureID = strings.TrimSpace(usage.SendMailSignatureID)
+			break
+		}
+	}
+	if signatureID == "" || signatureID == "0" {
+		return nil, false
+	}
+
+	for i := range resp.Signatures {
+		if resp.Signatures[i].ID == signatureID {
+			return &resp.Signatures[i], true
+		}
+	}
+	return nil, false
 }

--- a/shortcuts/mail/signature/provider_test.go
+++ b/shortcuts/mail/signature/provider_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package signature
+
+import "testing"
+
+func TestFindSendDefault(t *testing.T) {
+	resp := &GetSignaturesResponse{
+		Signatures: []Signature{
+			{ID: "sig_main", Content: "main"},
+			{ID: "sig_alias", Content: "alias"},
+		},
+		Usages: []SignatureUsage{
+			{EmailAddress: "main@example.com", SendMailSignatureID: "sig_main"},
+			{EmailAddress: "Alias@Example.com", SendMailSignatureID: "sig_alias"},
+			{EmailAddress: "empty@example.com", SendMailSignatureID: ""},
+			{EmailAddress: "zero@example.com", SendMailSignatureID: "0"},
+			{EmailAddress: "dangling@example.com", SendMailSignatureID: "sig_missing"},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		sender    string
+		wantID    string
+		wantFound bool
+	}{
+		{name: "case insensitive match", sender: "alias@example.com", wantID: "sig_alias", wantFound: true},
+		{name: "main match", sender: "MAIN@example.com", wantID: "sig_main", wantFound: true},
+		{name: "empty default", sender: "empty@example.com"},
+		{name: "zero default", sender: "zero@example.com"},
+		{name: "dangling default", sender: "dangling@example.com"},
+		{name: "unknown sender", sender: "other@example.com"},
+		{name: "empty sender", sender: " "},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, found := FindSendDefault(resp, tc.sender)
+			if found != tc.wantFound {
+				t.Fatalf("found = %v, want %v", found, tc.wantFound)
+			}
+			if tc.wantID == "" {
+				if got != nil {
+					t.Fatalf("signature = %#v, want nil", got)
+				}
+				return
+			}
+			if got == nil || got.ID != tc.wantID {
+				t.Fatalf("signature ID = %#v, want %q", got, tc.wantID)
+			}
+		})
+	}
+}

--- a/shortcuts/mail/signature_compose.go
+++ b/shortcuts/mail/signature_compose.go
@@ -25,11 +25,76 @@ var signatureFlag = common.Flag{
 	Desc: "Optional. Signature ID to append after body content. Run `mail +signature` to list available signatures.",
 }
 
+var noSignatureFlag = common.Flag{
+	Name: "no-signature",
+	Type: "bool",
+	Desc: "Skip automatic default signature lookup and send without a signature.",
+}
+
 // signatureResult holds the pre-processed signature data ready for HTML injection.
 type signatureResult struct {
 	ID              string
 	RenderedContent string
 	Images          []draftpkg.SignatureImage
+}
+
+// resolveComposeSignature selects and renders a signature for compose flows.
+// It does not download images; HTML callers opt into image resolution after
+// deciding the final body mode.
+func resolveComposeSignature(runtime *common.RuntimeContext, mailboxID, signatureID, fromEmail string, noSignature bool) (*signatureResult, []signature.SignatureImage, error) {
+	if noSignature {
+		return nil, nil, nil
+	}
+
+	var sig *signature.Signature
+	if signatureID != "" {
+		var err error
+		sig, err = signature.Get(runtime, mailboxID, signatureID)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		resp, err := signature.ListAll(runtime, mailboxID)
+		if err != nil {
+			return nil, nil, err
+		}
+		var ok bool
+		sig, ok = signature.FindSendDefault(resp, fromEmail)
+		if !ok {
+			return nil, nil, nil
+		}
+	}
+
+	lang := resolveLang(runtime)
+	senderName, senderEmail := resolveSenderInfo(runtime, mailboxID, fromEmail)
+	return &signatureResult{
+		ID:              sig.ID,
+		RenderedContent: signature.InterpolateTemplate(sig, lang, senderName, senderEmail),
+	}, sig.Images, nil
+}
+
+func resolveSignatureImages(runtime *common.RuntimeContext, sig *signatureResult, images []signature.SignatureImage) (*signatureResult, error) {
+	if sig == nil {
+		return nil, nil
+	}
+	resolved := *sig
+	resolved.Images = nil
+	for _, img := range images {
+		if img.DownloadURL == "" || img.CID == "" {
+			continue
+		}
+		data, ct, err := downloadSignatureImage(runtime, img.DownloadURL, img.ImageName)
+		if err != nil {
+			return nil, mailDecorateProblemMessage(err, "failed to download signature image %s", img.ImageName)
+		}
+		resolved.Images = append(resolved.Images, draftpkg.SignatureImage{
+			CID:         img.CID,
+			ContentType: ct,
+			FileName:    img.ImageName,
+			Data:        data,
+		})
+	}
+	return &resolved, nil
 }
 
 // resolveSignature fetches, interpolates, and downloads images for a signature.
@@ -229,6 +294,20 @@ func contentTypeFromFilename(name string) string {
 	}
 }
 
+func appendPlainTextSignature(body string, sig *signatureResult) string {
+	if sig == nil {
+		return body
+	}
+	text := signature.PlainTextFromHTML(sig.RenderedContent)
+	if text == "" {
+		return body
+	}
+	if strings.TrimSpace(body) == "" {
+		return text
+	}
+	return strings.TrimRight(body, "\r\n") + "\n\n" + text
+}
+
 // signatureCIDs returns the CID list from a signatureResult, for inline CID validation.
 func signatureCIDs(sig *signatureResult) []string {
 	if sig == nil {
@@ -242,6 +321,17 @@ func signatureCIDs(sig *signatureResult) []string {
 		}
 	}
 	return cids
+}
+
+func validateSignatureFlags(signatureID string, noSignature bool) error {
+	if signatureID != "" && noSignature {
+		return mailValidationError("--signature-id and --no-signature are mutually exclusive").
+			WithParams(
+				mailInvalidParam("--signature-id", "mutually exclusive with --no-signature"),
+				mailInvalidParam("--no-signature", "skip signatures lookup or remove --signature-id"),
+			)
+	}
+	return nil
 }
 
 // validateSignatureWithPlainText returns an error if both --plain-text and --signature-id are set.

--- a/shortcuts/mail/signature_compose.go
+++ b/shortcuts/mail/signature_compose.go
@@ -323,7 +323,10 @@ func signatureCIDs(sig *signatureResult) []string {
 	return cids
 }
 
-func validateSignatureFlags(signatureID string, noSignature bool) error {
+func validateSignatureFlags(signatureID string, signatureIDChanged bool, noSignature bool) error {
+	if signatureIDChanged && strings.TrimSpace(signatureID) == "" {
+		return mailValidationParamError("--signature-id", "--signature-id must not be empty; omit it to use the default signature or pass --no-signature to skip signatures")
+	}
 	if signatureID != "" && noSignature {
 		return mailValidationError("--signature-id and --no-signature are mutually exclusive").
 			WithParams(

--- a/shortcuts/mail/signature_compose_test.go
+++ b/shortcuts/mail/signature_compose_test.go
@@ -174,8 +174,8 @@ func TestDownloadSignatureImageSuccessUsesFilenameContentType(t *testing.T) {
 	}
 }
 
-func TestValidateSignatureWithPlainTextTypedError(t *testing.T) {
-	err := validateSignatureWithPlainText(true, "sig_123")
+func TestValidateSignatureFlagsTypedError(t *testing.T) {
+	err := validateSignatureFlags("sig_123", true)
 	var validationErr *errs.ValidationError
 	if !errors.As(err, &validationErr) {
 		t.Fatalf("expected validation error, got %T (%v)", err, err)
@@ -183,7 +183,7 @@ func TestValidateSignatureWithPlainTextTypedError(t *testing.T) {
 	if len(validationErr.Params) != 2 {
 		t.Fatalf("params = %#v, want two conflicting params", validationErr.Params)
 	}
-	if validationErr.Params[0].Name != "--plain-text" || validationErr.Params[1].Name != "--signature-id" {
+	if validationErr.Params[0].Name != "--signature-id" || validationErr.Params[1].Name != "--no-signature" {
 		t.Fatalf("unexpected params: %#v", validationErr.Params)
 	}
 }

--- a/shortcuts/mail/signature_compose_test.go
+++ b/shortcuts/mail/signature_compose_test.go
@@ -175,7 +175,7 @@ func TestDownloadSignatureImageSuccessUsesFilenameContentType(t *testing.T) {
 }
 
 func TestValidateSignatureFlagsTypedError(t *testing.T) {
-	err := validateSignatureFlags("sig_123", true)
+	err := validateSignatureFlags("sig_123", true, true)
 	var validationErr *errs.ValidationError
 	if !errors.As(err, &validationErr) {
 		t.Fatalf("expected validation error, got %T (%v)", err, err)
@@ -185,6 +185,17 @@ func TestValidateSignatureFlagsTypedError(t *testing.T) {
 	}
 	if validationErr.Params[0].Name != "--signature-id" || validationErr.Params[1].Name != "--no-signature" {
 		t.Fatalf("unexpected params: %#v", validationErr.Params)
+	}
+}
+
+func TestValidateSignatureFlagsRejectsExplicitEmpty(t *testing.T) {
+	err := validateSignatureFlags("", true, false)
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T (%v)", err, err)
+	}
+	if validationErr.Param != "--signature-id" {
+		t.Fatalf("param = %q, want --signature-id", validationErr.Param)
 	}
 }
 

--- a/skill-template/domains/mail.md
+++ b/skill-template/domains/mail.md
@@ -312,11 +312,17 @@ lark-cli mail +send --as user \
 - HTML 支持粗体、列表、链接、段落等富文本排版，收件人阅读体验更好
 - 所有发送类命令（`+send`、`+reply`、`+reply-all`、`+forward`、`+draft-create`）都支持自动检测 HTML，可通过 `--plain-text` 强制纯文本
 - 纯文本仅适用于极简内容（如一句话回复 "收到"）
+- `+send` 默认按实际发件地址追加新邮件默认签名；用户明确说“不要带签名”“不加签名”时必须传 `--no-signature`
+- `+send --plain-text` 命中签名时会追加签名的纯文本表示，不会下载签名图片
 
 ```bash
 # ✅ 推荐：HTML 格式
 lark-cli mail +send --to alice@example.com --subject '周报' \
   --body '<p>本周进展：</p><ul><li>完成 A 模块</li><li>修复 3 个 bug</li></ul>'
+
+# ✅ 用户要求不要签名时
+lark-cli mail +send --to alice@example.com --subject '周报' \
+  --body '<p>本周进展...</p>' --no-signature
 
 # ⚠️ 仅在内容极简时使用纯文本
 lark-cli mail +reply --message-id <id> --body '收到，谢谢'

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -329,11 +329,17 @@ lark-cli mail +send --as user \
 - HTML 支持粗体、列表、链接、段落等富文本排版，收件人阅读体验更好
 - 所有发送类命令（`+send`、`+reply`、`+reply-all`、`+forward`、`+draft-create`）都支持自动检测 HTML，可通过 `--plain-text` 强制纯文本
 - 纯文本仅适用于极简内容（如一句话回复 "收到"）
+- `+send` 默认按实际发件地址追加新邮件默认签名；用户明确说“不要带签名”“不加签名”时必须传 `--no-signature`
+- `+send --plain-text` 命中签名时会追加签名的纯文本表示，不会下载签名图片
 
 ```bash
 # ✅ 推荐：HTML 格式
 lark-cli mail +send --to alice@example.com --subject '周报' \
   --body '<p>本周进展：</p><ul><li>完成 A 模块</li><li>修复 3 个 bug</li></ul>'
+
+# ✅ 用户要求不要签名时
+lark-cli mail +send --to alice@example.com --subject '周报' \
+  --body '<p>本周进展...</p>' --no-signature
 
 # ⚠️ 仅在内容极简时使用纯文本
 lark-cli mail +reply --message-id <id> --body '收到，谢谢'
@@ -657,4 +663,3 @@ lark-cli mail <resource> <method> [flags] # 调用 API
 | `user_mailbox.threads.list` | `mail:user_mailbox.message:readonly` |
 | `user_mailbox.threads.modify` | `mail:user_mailbox.message:modify` |
 | `user_mailbox.threads.trash` | `mail:user_mailbox.message:modify` |
-

--- a/skills/lark-mail/references/lark-mail-send.md
+++ b/skills/lark-mail/references/lark-mail-send.md
@@ -7,6 +7,7 @@
 - 抄送/密送
 - 本地文件附件（`--attach`）
 - 内嵌图片（`--inline`，CID 可用随机字符串）
+- 默认追加当前发件地址的新邮件签名，可用 `--no-signature` 跳过
 
 本 skill 对应 shortcut：`lark-cli mail +send`。
 
@@ -53,6 +54,9 @@ lark-cli mail +send --to alice@example.com --subject '周报' \
 # 保存带附件的草稿
 lark-cli mail +send --to alice@example.com --subject '请查收' --body '<p>见附件</p>' --attach ./report.pdf,./logs.zip
 
+# 保存草稿但不要追加默认签名
+lark-cli mail +send --to alice@example.com --subject '测试' --body '<p>test</p>' --no-signature
+
 # 保存带内嵌图片的草稿（推荐：直接用相对路径，自动解析）
 lark-cli mail +send --to alice@example.com --subject '预览图' --body '<img src="./logo.png" />'
 
@@ -75,10 +79,11 @@ lark-cli mail +send --to alice@example.com --subject '测试' --body '<p>test</p
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用。可通过 `accessible_mailboxes` 查询可用邮箱 |
 | `--cc <emails>` | 否 | 抄送邮箱，多个用逗号分隔 |
 | `--bcc <emails>` | 否 | 密送邮箱，多个用逗号分隔 |
-| `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用 |
+| `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用。若命中默认签名或显式签名，签名 HTML 会转为可见纯文本追加，不下载签名图片 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
-| `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到正文末尾。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
+| `--signature-id <id>` | 否 | 显式签名 ID，优先于默认签名。运行 `mail +signature` 查看可用签名。与 `--no-signature` 互斥；可与 `--plain-text` 共存，纯文本模式下追加签名文本 |
+| `--no-signature` | 否 | 跳过默认签名查询和追加。用户明确要求“不要带签名”“不加签名”时使用。与 `--signature-id` 互斥 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
 | `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请（text/calendar）。需同时设置 `--event-start` 和 `--event-end` |
 | `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601，如 `2026-04-20T14:00+08:00`） |
@@ -88,6 +93,14 @@ lark-cli mail +send --to alice@example.com --subject '测试' --body '<p>test</p
 | `--send-time <timestamp>` | 否 | 定时发送时间，Unix 时间戳（秒）。需至少为当前时间 + 5 分钟。配合 `--confirm-send` 使用可定时发送邮件 |
 | `--request-receipt` | 否 | 请求已读回执（RFC 3798 Message Disposition Notification）。在出站 EML 里写 `Disposition-Notification-To: <sender>` 头。收件人的邮件客户端**可能**弹出提示询问是否回执、可能自动发送、也可能忽略——送达不保证 |
 | `--dry-run` | 否 | 仅打印请求，不执行 |
+
+### 签名规则
+
+- 默认行为：未传 `--signature-id` / `--no-signature` 时，`+send` 会按实际发件地址匹配账号配置的新邮件默认签名并追加。
+- 别名发信：同时使用 `--mailbox owner@example.com --from alias@example.com` 时，默认签名按 `alias@example.com` 匹配。
+- 显式签名：`--signature-id <id>` 优先于默认签名。
+- 跳过签名：用户明确要求不带签名时必须加 `--no-signature`。
+- 无默认签名或默认签名配置为空时，正常创建无签名草稿。
 
 ### 日程邀请约束
 


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/d9f2d23
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Implement default signature handling for mail +send | passed | 36401ba |
| S2 | Synthesize transport contract for larksuite/cli | passed | 9d84544 |

## Source specs

- input/tech-design.md#CLI-larksuite-cli

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --no-signature option to skip default signatures.
  * Default signature selection now matches the actual sender; explicit signature IDs take precedence.
  * Plain-text mode appends signature text (without downloading signature images).

* **Tests**
  * Expanded unit and integration tests covering signature selection, plain-text conversion, image handling, validation conflicts, and dry-run behavior.

* **Documentation**
  * Updated mail composition docs and examples to document signature rules and --no-signature usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->