### PR TITLE
feat(docs): add --lang to docs +fetch v2 for cite user display language

### DIFF
--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -89,6 +89,9 @@ func (ctx *RuntimeContext) UserOpenId() string { return ctx.Config.UserOpenId }
 // Lang returns the user's preference as a canonical locale, or "" if unset or
 // unrecognized; callers choose their own fallback.
 func (ctx *RuntimeContext) Lang() i18n.Lang {
+	if ctx.Config == nil {
+		return ""
+	}
 	lang, _ := i18n.Parse(string(ctx.Config.Lang))
 	return lang
 }

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -26,6 +26,7 @@ func v2FetchFlags() []common.Flag {
 		{Name: "context-before", Desc: "range/keyword/section mode: sibling blocks before match", Type: "int", Default: "0"},
 		{Name: "context-after", Desc: "range/keyword/section mode: sibling blocks after match", Type: "int", Default: "0"},
 		{Name: "max-depth", Desc: "outline: heading level cap; range/keyword/section: block subtree depth (-1 = unlimited)", Type: "int", Default: "-1"},
+		{Name: "lang", Desc: "language for <cite type=\"user\"> display names (e.g. zh_cn, en_us, ja_jp); omit to use the runtime user's default language; unsupported/invalid values fall back to a default name server-side"},
 	}
 }
 
@@ -110,8 +111,25 @@ func buildFetchBody(runtime *common.RuntimeContext) map[string]interface{} {
 		body["read_option"] = ro
 	}
 	injectDocsScene(runtime, body)
+	injectLang(runtime, body)
 
 	return body
+}
+
+// injectLang sets body["lang"] for the <cite type="user"> display-name language.
+// Priority: explicit --lang > runtime user's default language (runtime.Lang()).
+// When both are empty, lang is omitted so the server falls back to its default
+// (owner-language / built-in default). The server also tolerates equivalent
+// spellings (case / hyphen / underscore / short code) and falls back to a
+// default name for unsupported or invalid languages.
+func injectLang(runtime *common.RuntimeContext, body map[string]interface{}) {
+	if lang := strings.TrimSpace(runtime.Str("lang")); lang != "" {
+		body["lang"] = lang
+		return
+	}
+	if lang := strings.TrimSpace(string(runtime.Lang())); lang != "" {
+		body["lang"] = lang
+	}
 }
 
 // buildReadOption 拼装 read_option JSON；full/空模式返回 nil，让服务端走默认全文路径。

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -58,6 +58,33 @@ func TestBuildFetchBodyOmitsEmptyScene(t *testing.T) {
 	}
 }
 
+func TestBuildFetchBodyIncludesExplicitLang(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchBodyTestRuntime(context.Background())
+	if err := runtime.Cmd.Flags().Set("lang", "ja_jp"); err != nil {
+		t.Fatalf("set lang flag: %v", err)
+	}
+
+	body := buildFetchBody(runtime)
+	if got := body["lang"]; got != "ja_jp" {
+		t.Fatalf("lang = %#v, want %q", got, "ja_jp")
+	}
+}
+
+func TestBuildFetchBodyOmitsEmptyLang(t *testing.T) {
+	t.Parallel()
+
+	// No --lang and a nil Config (TestNewRuntimeContextWithCtx ... nil) means
+	// runtime.Lang() is empty, so lang must be omitted from the body.
+	runtime := newFetchBodyTestRuntime(context.Background())
+
+	body := buildFetchBody(runtime)
+	if _, ok := body["lang"]; ok {
+		t.Fatalf("did not expect lang in fetch body when unset: %#v", body)
+	}
+}
+
 func newFetchBodyTestRuntime(ctx context.Context) *common.RuntimeContext {
 	cmd := &cobra.Command{Use: "+fetch"}
 	cmd.Flags().String("doc-format", "xml", "")
@@ -70,6 +97,7 @@ func newFetchBodyTestRuntime(ctx context.Context) *common.RuntimeContext {
 	cmd.Flags().Int("context-before", 0, "")
 	cmd.Flags().Int("context-after", 0, "")
 	cmd.Flags().Int("max-depth", -1, "")
+	cmd.Flags().String("lang", "", "")
 	return common.TestNewRuntimeContextWithCtx(ctx, cmd, nil)
 }
 

--- a/skills/lark-doc/references/lark-doc-fetch.md
+++ b/skills/lark-doc/references/lark-doc-fetch.md
@@ -111,6 +111,7 @@ lark-cli docs +fetch --api-version v2 --doc Z1Fj...tnAc \
 | `--context-before` | 否 | 命中前拉几个兄弟块（仅对顶层单元生效，默认 `0`） |
 | `--context-after` | 否 | 命中后拉几个兄弟块（仅对顶层单元生效，默认 `0`） |
 | `--max-depth` | 否 | `outline` = 标题层级上限；其它 = 子树深度（`-1` 不限，默认） |
+| `--lang` | 否 | 控制 `<cite type="user">` 用户名按指定语言返回（如 `zh_cn` / `en_us` / `ja_jp`）；省略时用当前用户默认语言，仍为空则不传；大小写 / 连字符 / 下划线 / short code 等写法服务端尽量兼容，不支持的语言降级默认用户名 |
 | `--format` | 否 | `json`（默认）\| `pretty` |
 
 ## 图片、文件、画板的处理

--- a/skills/lark-doc/references/lark-doc-xml.md
+++ b/skills/lark-doc/references/lark-doc-xml.md
@@ -45,6 +45,7 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
 - `<sheet>` — `<sheet type="blank"></sheet>` 空白；`<sheet sheet-id="SID" token="TOKEN"></sheet>` 复制已有
 - `<task>` — `<task task-id="GUID"></task>`，必传 task-id（任务 guid）
 - `<chat_card>` — `<chat_card chat-id="CHAT_ID"></chat_card>`，必传 chat-id
+- `<sub-page-list>` — `<sub-page-list></sub-page-list>` 子页面列表块；仅 wiki 文档可插入
 - bitable、base_ref、synced_reference、synced_source、okr — 不可创建，仅支持移动
 
 # 四、块级复制与移动
@@ -54,7 +55,7 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
 
 ## 复制（block_copy_insert_after）
 - **基础标签**（块级标签、容器标签、行内组件）：均支持复制
-- **资源块**：仅 img、source、whiteboard、sheet、chat_card 支持复制；task、bitable、base_ref、synced_reference、synced_source、okr 不支持复制
+- **资源块**：仅 img、source、whiteboard、sheet、chat_card、sub-page-list 支持复制；task、bitable、base_ref、synced_reference、synced_source、okr 不支持复制
 
 使用 `docs +update --command block_copy_insert_after --block-id "<锚点>" --src-block-ids "id1,id2"`。
 
@@ -75,6 +76,50 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
      <li>第二项</li>
    </ul>
    ```
+
+## 用户名写入规则
+
+### 核心原则
+
+- 当从 IM 消息、日历、审批、任务等来源获取到用户的 `open_id` 时，写入文档**必须**使用 `<cite type="user" user-id="open_id">` 标签，而非纯文本名字。这样文档中会渲染为可点击的 @人。
+- 当只有用户名字而没有 `open_id` 时，**必须**先通过 `lark-cli contact +search-user --query "名字" --as user` 反查 `open_id`，再使用 `<cite type="user">` 标签写入。
+
+### 各场景覆盖
+
+以下场景中出现的用户名**必须**使用 `<cite type="user">` 标签：
+
+| 场景 | 必须使用 cite 的字段 | 说明 |
+|------|---------------------|------|
+| 普通消息 | `sender.id`、`mentions[].id` | 消息发送者和被 @ 的人 |
+| 消息表情 (reactions) | `reactions[].details[].operator.operator_id` | 点赞/表情的操作者 |
+| 卡片消息 (interactive) | 卡片内容中引用的用户 | 如卡片中 @ 的人 |
+| 系统消息 | 消息文本中的用户名 | 如「XXX invited YYY to the chat」中的 XXX 和 YYY |
+| 合并转发 (merge_forward) | 转发内容中的用户名 | 转发内容为纯文本，需先通过 `lark-contact +search-user` 反查 `open_id` |
+
+### 典型示例
+
+将 IM 群聊消息写入文档时：
+
+```xml
+<!-- 消息发送者 + @ 人 -->
+<p><cite type="user" user-id="ou_xxx"></cite>：@<cite type="user" user-id="ou_yyy"></cite> 你好</p>
+
+<!-- 表情操作者 -->
+<p>👍 <cite type="user" user-id="ou_xxx"></cite></p>
+
+<!-- 系统消息 -->
+<p><cite type="user" user-id="ou_xxx"></cite> invited <cite type="user" user-id="ou_yyy"></cite> to the chat.</p>
+```
+
+### 名字反查 open_id
+
+当数据源只提供纯文本名字（如合并转发消息、系统消息文本）时，使用 `lark-contact` 反查：
+
+```bash
+lark-cli contact +search-user --query "张三" --as user
+```
+
+从返回结果中匹配部门信息确认正确用户，取 `open_id` 后写入 `<cite type="user" user-id="open_id">` 标签。
 
 
 ## 表格扩展
@@ -166,4 +211,5 @@ p, h1-h9, ul, ol, li, table, thead, tbody, tr, th, td, blockquote, pre, code, hr
 
 <task task-id="TASK_GUID"></task>
 <chat_card chat-id="CHAT_ID"></chat_card>
+<sub-page-list></sub-page-list>
 ```

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -53,6 +53,29 @@ When using bot identity (`--as bot`) to fetch messages (e.g. `+chat-messages-lis
 
 The four message-pulling shortcuts (`+messages-mget`, `+chat-messages-list`, `+messages-search`, `+threads-messages-list`) automatically attach a `reactions` block and (for edited messages) `update_time` to each returned message — no separate `im.reactions.batch_query` call is needed. Pass `--no-reactions` to opt out. For the full contract (output shape, the `im:message.reactions:read` scope requirement, and the "missing field ≠ fetch failure" data rules), read [`references/lark-im-message-enrichment.md`](references/lark-im-message-enrichment.md).
 
+### Writing Messages to Lark Documents
+
+When writing IM messages into a Lark document (via `lark-doc`), you **must** preserve user identities using `<cite type="user" user-id="open_id">` tags instead of plain text names. This ensures names render as clickable @mentions in the document.
+
+**Fields that carry open_id and must be preserved:**
+
+| Message field | Path | Usage |
+|--------------|------|-------|
+| Sender | `sender.id` | `<cite type="user" user-id="ou_xxx"></cite>` |
+| Mentions | `mentions[].id` | `<cite type="user" user-id="ou_xxx"></cite>` |
+| Reaction operators | `reactions[].details[].operator.operator_id` | `<cite type="user" user-id="ou_xxx"></cite>` |
+| Card-referenced users | Card content | `<cite type="user" user-id="ou_xxx"></cite>` |
+
+**When only plain text names are available** (e.g. system messages like "XXX invited YYY", or merge_forward content), resolve open_id first:
+
+```bash
+lark-cli contact +search-user --query "Name" --as user
+```
+
+Match by department to confirm the correct user, then use the `open_id` in the cite tag.
+
+For full rules, see [`lark-doc-xml.md`](../lark-doc/references/lark-doc-xml.md) → 用户名写入规则.
+
 ### Card Messages (Interactive)
 
 Card messages (`interactive` type) are not yet supported for compact conversion in event subscriptions. The raw event data will be returned instead, with a hint printed to stderr.


### PR DESCRIPTION
## What

Adds a `--lang` flag to `docs +fetch` v2 (OpenAPI path) so `<cite type="user">` display names are returned in the requested language.

- `v2FetchFlags()`: new `--lang` flag (e.g. `zh_cn` / `en_us` / `ja_jp`)
- `buildFetchBody()`: injects `body["lang"]` with priority **explicit `--lang` > `runtime.Lang()` (user default) > omit**
- `RuntimeContext.Lang()`: now nil-`Config` safe
- lark-doc skill fetch reference: documents `--lang`
- Tests: explicit lang + omitted-when-unset

Maps to OpenAPI request field `OpenDocsAIFetchDocumentRequest.Lang` (api.json="lang", field-id 8, already on master). Backend passthrough (ai_edit + office_ai_sdk) tracked separately.

## Verify

```
docs +fetch --api-version v2 --doc <token> --lang ja_jp --dry-run   # body carries "lang":"ja_jp"
docs +fetch --api-version v2 --doc <token> --dry-run                 # falls back to runtime user lang, or omits
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hidden CLI `--lang` option to control citation display language for document fetches (e.g., zh_cn, en_us, ja_jp); when omitted, the user's configured language is used.

* **Bug Fixes**
  * Improved handling when a user's language preference is unset so language resolution falls back sensibly.

* **Documentation**
  * Docs updated with `--lang` usage, guidance for writing messages to documents, and updated rules/examples for the sub-page-list resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->