### PR TITLE
feat: append default mail signatures on send

### DIFF
--- a/shortcuts/mail/draft/htmltext.go
+++ b/shortcuts/mail/draft/htmltext.go
@@ -84,6 +84,11 @@ func plainTextFromHTML(raw string) string {
 	return strings.Join(out, "\n")
 }
 
+// PlainTextFromHTML produces a conservative plain-text fallback from HTML.
+func PlainTextFromHTML(raw string) string {
+	return plainTextFromHTML(raw)
+}
+
 func bufLastByte(buf *bytes.Buffer) byte {
 	if buf.Len() == 0 {
 		return 0

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -40,6 +40,7 @@ var MailSend = common.Shortcut{
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's subject/body/to/cc/bcc/attachments are merged with user-supplied flags (user flags win). Requires --as user."},
 		signatureFlag,
+		noSignatureFlag,
 		priorityFlag,
 		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag,
 		showLintDetailsFlag},
@@ -58,7 +59,14 @@ var MailSend = common.Shortcut{
 				Desc("Fetch template to merge with compose flags (subject/body/to/cc/bcc/attachments).")
 		}
 		api = api.GET(mailboxPath(mailboxID, "profile")).
-			POST(mailboxPath(mailboxID, "drafts")).
+			Desc("Resolve sender mailbox profile.")
+		if !runtime.Bool("no-signature") {
+			api = api.GET(mailboxPath(mailboxID, "settings", "signatures")).
+				Desc("Resolve explicit or default send signature.").
+				GET(mailboxPath(mailboxID, "settings", "send_as")).
+				Desc("Resolve sender variables for signature template.")
+		}
+		api = api.POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{
 				"raw": "<base64url-EML>",
 				"_preview": map[string]interface{}{
@@ -98,7 +106,7 @@ var MailSend = common.Shortcut{
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
-		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+		if err := validateSignatureOptions(runtime.Str("signature-id"), runtime.Bool("no-signature")); err != nil {
 			return err
 		}
 		// Resolve the body content first (reading --body-file if set) so
@@ -135,6 +143,7 @@ var MailSend = common.Shortcut{
 		inlineFlag := runtime.Str("inline")
 		confirmSend := runtime.Bool("confirm-send")
 		sendTime := runtime.Str("send-time")
+		noSignature := runtime.Bool("no-signature")
 
 		senderEmail := resolveComposeSenderEmail(runtime)
 		signatureID := runtime.Str("signature-id")
@@ -195,7 +204,8 @@ var MailSend = common.Shortcut{
 			}
 		}
 
-		sigResult, err := resolveSignature(ctx, runtime, mailboxID, signatureID, senderEmail)
+		signatureNeedsImages := !plainText && bodyIsHTML(body)
+		sigResult, err := resolveSignatureForSend(ctx, runtime, mailboxID, signatureID, senderEmail, noSignature, signatureNeedsImages)
 		if err != nil {
 			return err
 		}
@@ -230,15 +240,10 @@ var MailSend = common.Shortcut{
 		// `lint_applied[]` / `original_blocked[]` even on the plain-text path.
 		lintApplied, lintBlocked := emptyLintEnvelopeFields()
 		if plainText {
-			composedTextBody = body
+			composedTextBody = appendSignatureToPlainText(body, sigResult)
 			bld = bld.TextBody([]byte(composedTextBody))
-		} else if bodyIsHTML(body) || sigResult != nil {
-			// If signature is requested on plain-text body, auto-upgrade to HTML.
-			htmlBody := body
-			if !bodyIsHTML(body) {
-				htmlBody = buildBodyDiv(body, false)
-			}
-			resolved, refs, resolveErr := draftpkg.ResolveLocalImagePaths(htmlBody)
+		} else if bodyIsHTML(body) {
+			resolved, refs, resolveErr := draftpkg.ResolveLocalImagePaths(body)
 			if resolveErr != nil {
 				return mailValidationError("failed to resolve local image paths: %v", resolveErr).WithCause(resolveErr)
 			}
@@ -275,7 +280,7 @@ var MailSend = common.Shortcut{
 				return err
 			}
 		} else {
-			composedTextBody = body
+			composedTextBody = appendSignatureToPlainText(body, sigResult)
 			bld = bld.TextBody([]byte(composedTextBody))
 		}
 		// Embed template SMALL non-inline attachments via AddAttachment.

--- a/shortcuts/mail/mail_send_signature_test.go
+++ b/shortcuts/mail/mail_send_signature_test.go
@@ -1,0 +1,301 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func TestMailSendDefaultHTMLSignatureAppendsSignature(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+	mailbox := "sig-html@example.com"
+	registerSignatureListStub(reg, mailbox, []map[string]interface{}{
+		{
+			"id":             "sig_default",
+			"signature_type": "USER",
+			"content":        "<div>Best<br>Alice</div>",
+		},
+	}, []map[string]interface{}{
+		{"email_address": mailbox, "send_mail_signature_id": "sig_default"},
+	})
+	registerSendAsStub(reg, mailbox, "Alice", mailbox)
+	draftsStub := registerDraftCreateStub(reg, mailbox)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailbox,
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "<p>Hello</p>",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	eml := mustDecodeRawEMLFromStub(t, draftsStub)
+	if !strings.Contains(eml, `class="lark-mail-signature"`) {
+		t.Fatalf("expected signature wrapper in HTML EML:\n%s", eml)
+	}
+	if !strings.Contains(eml, "Best") || !strings.Contains(eml, "Alice") {
+		t.Fatalf("expected default signature content in EML:\n%s", eml)
+	}
+}
+
+func TestMailSendPlainTextDefaultSignatureKeepsTextPlain(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+	mailbox := "sig-plain@example.com"
+	registerSignatureListStub(reg, mailbox, []map[string]interface{}{
+		{
+			"id":             "sig_plain",
+			"signature_type": "USER",
+			"content":        "<div>Regards<br>Alice</div>",
+			"images": []map[string]interface{}{
+				{"cid": "logo", "image_name": "logo.png", "download_url": "https://example.com/logo.png"},
+			},
+		},
+	}, []map[string]interface{}{
+		{"email_address": mailbox, "send_mail_signature_id": "sig_plain"},
+	})
+	registerSendAsStub(reg, mailbox, "Alice", mailbox)
+	draftsStub := registerDraftCreateStub(reg, mailbox)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailbox,
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "Hello",
+		"--plain-text",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	eml := mustDecodeRawEMLFromStub(t, draftsStub)
+	if !strings.Contains(eml, "Content-Type: text/plain") {
+		t.Fatalf("expected text/plain EML:\n%s", eml)
+	}
+	if strings.Contains(eml, "text/html") || strings.Contains(eml, "lark-mail-signature") {
+		t.Fatalf("plain-text signature should not create HTML body:\n%s", eml)
+	}
+	if !strings.Contains(eml, "Hello") || !strings.Contains(eml, "Regards") || !strings.Contains(eml, "Alice") {
+		t.Fatalf("expected body and text signature in EML:\n%s", eml)
+	}
+}
+
+func TestMailSendNoSignatureSkipsSignatureAPI(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+	mailbox := "sig-skip@example.com"
+	draftsStub := registerDraftCreateStub(reg, mailbox)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailbox,
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "<p>Hello</p>",
+		"--no-signature",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	eml := mustDecodeRawEMLFromStub(t, draftsStub)
+	if strings.Contains(eml, "lark-mail-signature") {
+		t.Fatalf("--no-signature should not append signature:\n%s", eml)
+	}
+}
+
+func TestMailSendExplicitSignatureOverridesDefault(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+	mailbox := "sig-explicit@example.com"
+	registerSignatureListStub(reg, mailbox, []map[string]interface{}{
+		{
+			"id":             "sig_default",
+			"signature_type": "USER",
+			"content":        "<div>Default Signature</div>",
+		},
+		{
+			"id":             "sig_explicit",
+			"signature_type": "TENANT",
+			"content":        "<div>Explicit Signature</div>",
+		},
+	}, []map[string]interface{}{
+		{"email_address": mailbox, "send_mail_signature_id": "sig_default"},
+	})
+	registerSendAsStub(reg, mailbox, "Alice", mailbox)
+	draftsStub := registerDraftCreateStub(reg, mailbox)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailbox,
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "<p>Hello</p>",
+		"--signature-id", "sig_explicit",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	eml := mustDecodeRawEMLFromStub(t, draftsStub)
+	if !strings.Contains(eml, "Explicit Signature") {
+		t.Fatalf("expected explicit signature in EML:\n%s", eml)
+	}
+	if strings.Contains(eml, "Default Signature") {
+		t.Fatalf("explicit signature should override default:\n%s", eml)
+	}
+}
+
+func TestMailSendDefaultSignatureFailureWarnsAndContinues(t *testing.T) {
+	f, stdout, stderr, reg := mailShortcutTestFactoryWithSendScope(t)
+	mailbox := "sig-fail-open@example.com"
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    mailboxPath(mailbox, "settings", "signatures"),
+		Status: 500,
+		Body: map[string]interface{}{
+			"code": 500,
+			"msg":  "signature service unavailable",
+		},
+	})
+	draftsStub := registerDraftCreateStub(reg, mailbox)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailbox,
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "Hello",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send should fail open when default signature API fails: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "warning: failed to resolve default signature") {
+		t.Fatalf("expected default signature warning, got stderr=%q", stderr.String())
+	}
+	eml := mustDecodeRawEMLFromStub(t, draftsStub)
+	if strings.Contains(eml, "lark-mail-signature") {
+		t.Fatalf("failed default signature lookup should not append signature:\n%s", eml)
+	}
+}
+
+func TestMailSendDryRunSignatureAPIs(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactoryWithSendScope(t)
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", "dry-default@example.com",
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "Hello",
+		"--dry-run",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("dry-run failed: %v", err)
+	}
+	got := dryRunURLs(t, stdout.String())
+	assertContainsURL(t, got, "/settings/signatures")
+	assertContainsURL(t, got, "/settings/send_as")
+
+	f, stdout, _, _ = mailShortcutTestFactoryWithSendScope(t)
+	err = runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", "dry-skip@example.com",
+		"--to", "bob@example.com",
+		"--subject", "hello",
+		"--body", "Hello",
+		"--no-signature",
+		"--dry-run",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("dry-run with --no-signature failed: %v", err)
+	}
+	got = dryRunURLs(t, stdout.String())
+	assertNotContainsURL(t, got, "/settings/signatures")
+	assertNotContainsURL(t, got, "/settings/send_as")
+}
+
+func registerSignatureListStub(reg *httpmock.Registry, mailbox string, signatures, usages []map[string]interface{}) {
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    mailboxPath(mailbox, "settings", "signatures"),
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"signatures": signatures,
+				"usages":     usages,
+			},
+		},
+	})
+}
+
+func registerSendAsStub(reg *httpmock.Registry, mailbox, name, email string) {
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    mailboxPath(mailbox, "settings", "send_as"),
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"sendable_addresses": []map[string]interface{}{
+					{"name": name, "email_address": email},
+				},
+			},
+		},
+	})
+}
+
+func registerDraftCreateStub(reg *httpmock.Registry, mailbox string) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    mailboxPath(mailbox, "drafts"),
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"draft_id": "draft_sig_001",
+			},
+		},
+	}
+	reg.Register(stub)
+	return stub
+}
+
+func dryRunURLs(t *testing.T, stdout string) []string {
+	t.Helper()
+	var payload struct {
+		API []struct {
+			URL string `json:"url"`
+		} `json:"api"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &payload); err != nil {
+		t.Fatalf("unmarshal dry-run stdout: %v\nstdout=%s", err, stdout)
+	}
+	urls := make([]string, 0, len(payload.API))
+	for _, call := range payload.API {
+		urls = append(urls, call.URL)
+	}
+	return urls
+}
+
+func assertContainsURL(t *testing.T, urls []string, needle string) {
+	t.Helper()
+	for _, url := range urls {
+		if strings.Contains(url, needle) {
+			return
+		}
+	}
+	t.Fatalf("expected dry-run URL containing %q, got %#v", needle, urls)
+}
+
+func assertNotContainsURL(t *testing.T, urls []string, needle string) {
+	t.Helper()
+	for _, url := range urls {
+		if strings.Contains(url, needle) {
+			t.Fatalf("did not expect dry-run URL containing %q, got %#v", needle, urls)
+		}
+	}
+}

--- a/shortcuts/mail/signature_compose.go
+++ b/shortcuts/mail/signature_compose.go
@@ -5,6 +5,7 @@ package mail
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -22,7 +23,13 @@ import (
 // signatureFlag is the common flag definition for --signature-id, shared by all compose shortcuts.
 var signatureFlag = common.Flag{
 	Name: "signature-id",
-	Desc: "Optional. Signature ID to append after body content. Run `mail +signature` to list available signatures.",
+	Desc: "Optional. Signature ID to append after body content, overriding the default send signature. Run `mail +signature` to list available signatures.",
+}
+
+var noSignatureFlag = common.Flag{
+	Name: "no-signature",
+	Type: "bool",
+	Desc: "Skip appending the default or explicit mail signature for this send.",
 }
 
 // signatureResult holds the pre-processed signature data ready for HTML injection.
@@ -36,6 +43,10 @@ type signatureResult struct {
 // fromEmail is the --from address (may be an alias); used to match the correct
 // sender identity for template interpolation. Pass "" to use the primary address.
 func resolveSignature(ctx context.Context, runtime *common.RuntimeContext, mailboxID, signatureID, fromEmail string) (*signatureResult, error) {
+	return resolveSignatureWithOptions(ctx, runtime, mailboxID, signatureID, fromEmail, true)
+}
+
+func resolveSignatureWithOptions(ctx context.Context, runtime *common.RuntimeContext, mailboxID, signatureID, fromEmail string, includeImages bool) (*signatureResult, error) {
 	if signatureID == "" {
 		return nil, nil
 	}
@@ -53,20 +64,22 @@ func resolveSignature(ctx context.Context, runtime *common.RuntimeContext, mailb
 	// Download signature inline images. The file_key field contains a
 	// direct download URL provided by the mail backend.
 	var images []draftpkg.SignatureImage
-	for _, img := range sig.Images {
-		if img.DownloadURL == "" || img.CID == "" {
-			continue
+	if includeImages {
+		for _, img := range sig.Images {
+			if img.DownloadURL == "" || img.CID == "" {
+				continue
+			}
+			data, ct, err := downloadSignatureImage(runtime, img.DownloadURL, img.ImageName)
+			if err != nil {
+				return nil, mailDecorateProblemMessage(err, "failed to download signature image %s", img.ImageName)
+			}
+			images = append(images, draftpkg.SignatureImage{
+				CID:         img.CID,
+				ContentType: ct,
+				FileName:    img.ImageName,
+				Data:        data,
+			})
 		}
-		data, ct, err := downloadSignatureImage(runtime, img.DownloadURL, img.ImageName)
-		if err != nil {
-			return nil, mailDecorateProblemMessage(err, "failed to download signature image %s", img.ImageName)
-		}
-		images = append(images, draftpkg.SignatureImage{
-			CID:         img.CID,
-			ContentType: ct,
-			FileName:    img.ImageName,
-			Data:        data,
-		})
 	}
 
 	return &signatureResult{
@@ -74,6 +87,101 @@ func resolveSignature(ctx context.Context, runtime *common.RuntimeContext, mailb
 		RenderedContent: rendered,
 		Images:          images,
 	}, nil
+}
+
+func resolveSignatureForSend(ctx context.Context, runtime *common.RuntimeContext, mailboxID, explicitSignatureID, senderEmail string, noSignature, includeImages bool) (*signatureResult, error) {
+	if noSignature {
+		return nil, nil
+	}
+	if explicitSignatureID != "" {
+		return resolveSignatureWithOptions(ctx, runtime, mailboxID, explicitSignatureID, senderEmail, includeImages)
+	}
+
+	resp, err := signature.ListAll(runtime, mailboxID)
+	if err != nil {
+		fmt.Fprintf(runtime.IO().ErrOut, "warning: failed to resolve default signature: %v\n", err)
+		return nil, nil
+	}
+	signatureID := selectDefaultSendSignatureID(resp, senderEmail, mailboxID)
+	if signatureID == "" {
+		return nil, nil
+	}
+	if findUserSignatureByID(resp, signatureID) == nil {
+		return nil, nil
+	}
+	return resolveSignatureWithOptions(ctx, runtime, mailboxID, signatureID, senderEmail, includeImages)
+}
+
+func selectDefaultSendSignatureID(resp *signature.GetSignaturesResponse, senderEmail string, mailboxID string) string {
+	if resp == nil {
+		return ""
+	}
+	senderEmail = strings.TrimSpace(senderEmail)
+	mailboxEmail := strings.TrimSpace(mailboxID)
+	if senderEmail != "" {
+		for _, usage := range resp.Usages {
+			if strings.EqualFold(strings.TrimSpace(usage.EmailAddress), senderEmail) {
+				return normalizeSignatureID(usage.SendMailSignatureID)
+			}
+		}
+	}
+	if senderEmail == "" && mailboxEmail != "" && !strings.EqualFold(mailboxEmail, "me") {
+		for _, usage := range resp.Usages {
+			if strings.EqualFold(strings.TrimSpace(usage.EmailAddress), mailboxEmail) {
+				return normalizeSignatureID(usage.SendMailSignatureID)
+			}
+		}
+	}
+
+	var single string
+	for _, usage := range resp.Usages {
+		if id := normalizeSignatureID(usage.SendMailSignatureID); id != "" {
+			if single != "" {
+				return ""
+			}
+			single = id
+		}
+	}
+	return single
+}
+
+func findUserSignatureByID(resp *signature.GetSignaturesResponse, signatureID string) *signature.Signature {
+	if resp == nil {
+		return nil
+	}
+	signatureID = normalizeSignatureID(signatureID)
+	if signatureID == "" {
+		return nil
+	}
+	for i := range resp.Signatures {
+		if resp.Signatures[i].ID == signatureID && resp.Signatures[i].SignatureType == signature.SignatureTypeUser {
+			return &resp.Signatures[i]
+		}
+	}
+	return nil
+}
+
+func normalizeSignatureID(signatureID string) string {
+	signatureID = strings.TrimSpace(signatureID)
+	if signatureID == "" || signatureID == "0" {
+		return ""
+	}
+	return signatureID
+}
+
+func appendSignatureToPlainText(body string, sig *signatureResult) string {
+	if sig == nil {
+		return body
+	}
+	signatureText := strings.TrimSpace(draftpkg.PlainTextFromHTML(sig.RenderedContent))
+	if signatureText == "" {
+		return body
+	}
+	body = strings.TrimRight(body, "\r\n")
+	if body == "" {
+		return signatureText
+	}
+	return body + "\n\n" + signatureText
 }
 
 // injectSignatureIntoBody inserts signature HTML into the body, placing
@@ -251,6 +359,17 @@ func validateSignatureWithPlainText(plainText bool, signatureID string) error {
 			WithParams(
 				mailInvalidParam("--plain-text", "mutually exclusive with --signature-id"),
 				mailInvalidParam("--signature-id", "requires HTML mode"),
+			)
+	}
+	return nil
+}
+
+func validateSignatureOptions(signatureID string, noSignature bool) error {
+	if signatureID != "" && noSignature {
+		return mailValidationError("--signature-id and --no-signature are mutually exclusive").
+			WithParams(
+				mailInvalidParam("--signature-id", "mutually exclusive with --no-signature"),
+				mailInvalidParam("--no-signature", "mutually exclusive with --signature-id"),
 			)
 	}
 	return nil

--- a/shortcuts/mail/signature_compose_test.go
+++ b/shortcuts/mail/signature_compose_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/mail/signature"
 )
 
 func TestDownloadSignatureImageRejectsInvalidURLs(t *testing.T) {
@@ -185,6 +186,82 @@ func TestValidateSignatureWithPlainTextTypedError(t *testing.T) {
 	}
 	if validationErr.Params[0].Name != "--plain-text" || validationErr.Params[1].Name != "--signature-id" {
 		t.Fatalf("unexpected params: %#v", validationErr.Params)
+	}
+}
+
+func TestValidateSignatureOptionsRejectsNoSignatureWithExplicitID(t *testing.T) {
+	err := validateSignatureOptions("sig_123", true)
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T (%v)", err, err)
+	}
+	if !strings.Contains(validationErr.Error(), "--signature-id and --no-signature are mutually exclusive") {
+		t.Fatalf("unexpected validation message: %v", validationErr)
+	}
+}
+
+func TestSelectDefaultSendSignatureID(t *testing.T) {
+	resp := &signature.GetSignaturesResponse{
+		Usages: []signature.SignatureUsage{
+			{EmailAddress: "primary@example.com", SendMailSignatureID: "sig_primary"},
+			{EmailAddress: "alias@example.com", SendMailSignatureID: "sig_alias"},
+		},
+	}
+
+	if got := selectDefaultSendSignatureID(resp, "ALIAS@example.com", "me"); got != "sig_alias" {
+		t.Fatalf("alias match = %q, want sig_alias", got)
+	}
+	if got := selectDefaultSendSignatureID(resp, "", "primary@example.com"); got != "sig_primary" {
+		t.Fatalf("mailbox match = %q, want sig_primary", got)
+	}
+
+	resp = &signature.GetSignaturesResponse{
+		Usages: []signature.SignatureUsage{
+			{EmailAddress: "only@example.com", SendMailSignatureID: " sig_only "},
+			{EmailAddress: "none@example.com", SendMailSignatureID: "0"},
+		},
+	}
+	if got := selectDefaultSendSignatureID(resp, "", "me"); got != "sig_only" {
+		t.Fatalf("single usage fallback = %q, want sig_only", got)
+	}
+
+	resp.Usages = append(resp.Usages, signature.SignatureUsage{EmailAddress: "other@example.com", SendMailSignatureID: "sig_other"})
+	if got := selectDefaultSendSignatureID(resp, "", "me"); got != "" {
+		t.Fatalf("ambiguous fallback = %q, want empty", got)
+	}
+}
+
+func TestFindUserSignatureByIDRequiresUserType(t *testing.T) {
+	resp := &signature.GetSignaturesResponse{
+		Signatures: []signature.Signature{
+			{ID: "sig_user", SignatureType: signature.SignatureTypeUser},
+			{ID: "sig_tenant", SignatureType: signature.SignatureTypeTenant},
+			{ID: "sig_missing_type"},
+		},
+	}
+
+	if got := findUserSignatureByID(resp, "sig_user"); got == nil || got.ID != "sig_user" {
+		t.Fatalf("user signature not found: %#v", got)
+	}
+	if got := findUserSignatureByID(resp, "sig_tenant"); got != nil {
+		t.Fatalf("tenant signature should not be auto-selected: %#v", got)
+	}
+	if got := findUserSignatureByID(resp, "sig_missing_type"); got != nil {
+		t.Fatalf("missing signature_type should not be auto-selected: %#v", got)
+	}
+}
+
+func TestAppendSignatureToPlainText(t *testing.T) {
+	sig := &signatureResult{RenderedContent: "<div>Best<br>Alice</div>"}
+	got := appendSignatureToPlainText("hello\r\n", sig)
+	want := "hello\n\nBest\nAlice"
+	if got != want {
+		t.Fatalf("plain text signature = %q, want %q", got, want)
+	}
+
+	imageOnly := &signatureResult{RenderedContent: `<img src="cid:logo">`}
+	if got := appendSignatureToPlainText("hello", imageOnly); got != "hello" {
+		t.Fatalf("image-only signature should not change body, got %q", got)
 	}
 }
 

--- a/skill-template/domains/mail.md
+++ b/skill-template/domains/mail.md
@@ -203,6 +203,8 @@ lark-cli mail +send --mailbox me --from alias@example.com \
 
 不使用公共邮箱或别名时无需指定 `--mailbox`，行为与之前一致。
 
+`+send` 默认会按最终发件人邮箱追加默认个人发信签名。明确不要签名时传 `--no-signature`；需要手动指定签名时传 `--signature-id <id>`，该显式签名会覆盖默认签名。纯文本邮件会追加签名文本并保持 `text/plain`。
+
 ### 发送后确认投递状态
 
 **立即发送（无 `--send-time`）**：邮件发送成功后（收到 `message_id`），**必须**调用 `send_status` API 查询投递状态并向用户报告：

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -473,7 +473,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli mail +<verb> [flags]`）�
 | [`+watch`](references/lark-mail-watch.md) | Watch for incoming mail events via WebSocket (requires scope mail:event and bot event mail.user_mailbox.event.message_received_v1 added). Run with --print-output-schema to see per-format field reference before parsing output. |
 | [`+reply`](references/lark-mail-reply.md) | Reply to a message and save as draft (default). Use --confirm-send to send immediately after user confirmation. Sets Re: subject, In-Reply-To, and References headers automatically. |
 | [`+reply-all`](references/lark-mail-reply-all.md) | Reply to all recipients and save as draft (default). Use --confirm-send to send immediately after user confirmation. Includes all original To and CC automatically. |
-| [`+send`](references/lark-mail-send.md) | Compose a new email and save as draft (default). Use --confirm-send to send immediately after user confirmation. |
+| [`+send`](references/lark-mail-send.md) | Compose a new email and save as draft (default). Appends the sender's default personal signature unless --no-signature is set. Use --confirm-send to send immediately after user confirmation. |
 | [`+draft-create`](references/lark-mail-draft-create.md) | Create a brand-new mail draft from scratch (NOT for reply or forward). For reply drafts use +reply; for forward drafts use +forward. Only use +draft-create when composing a new email with no parent message. |
 | [`+draft-edit`](references/lark-mail-draft-edit.md) | Use when updating an existing mail draft without sending it. Prefer this shortcut over calling raw drafts.get or drafts.update directly, because it performs draft-safe MIME read/patch/write editing while preserving unchanged structure, attachments, and headers where possible. |
 | [`+forward`](references/lark-mail-forward.md) | Forward a message and save as draft (default). Use --confirm-send to send immediately after user confirmation. Original message block included automatically. |
@@ -657,4 +657,3 @@ lark-cli mail <resource> <method> [flags] # 调用 API
 | `user_mailbox.threads.list` | `mail:user_mailbox.message:readonly` |
 | `user_mailbox.threads.modify` | `mail:user_mailbox.message:modify` |
 | `user_mailbox.threads.trash` | `mail:user_mailbox.message:modify` |
-

--- a/skills/lark-mail/references/lark-mail-send.md
+++ b/skills/lark-mail/references/lark-mail-send.md
@@ -7,6 +7,7 @@
 - 抄送/密送
 - 本地文件附件（`--attach`）
 - 内嵌图片（`--inline`，CID 可用随机字符串）
+- 默认追加当前发件人的个人发信签名；明确不要签名时传 `--no-signature`
 
 本 skill 对应 shortcut：`lark-cli mail +send`。
 
@@ -59,6 +60,9 @@ lark-cli mail +send --to alice@example.com --subject '预览图' --body '<img sr
 # 纯文本邮件（仅在内容极简时使用）
 lark-cli mail +send --to alice@example.com --subject '确认' --body '收到，谢谢'
 
+# 不追加默认签名
+lark-cli mail +send --to alice@example.com --subject '确认' --body '收到，谢谢' --no-signature
+
 # Dry Run（仅打印请求，不执行）
 lark-cli mail +send --to alice@example.com --subject '测试' --body '<p>test</p>' --dry-run
 ```
@@ -78,7 +82,8 @@ lark-cli mail +send --to alice@example.com --subject '测试' --body '<p>test</p
 | `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
-| `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到正文末尾。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
+| `--signature-id <id>` | 否 | 显式签名 ID。覆盖默认发信签名并附加到正文末尾。运行 `mail +signature` 查看可用签名；纯文本模式下会把签名 HTML 转成文本后追加 |
+| `--no-signature` | 否 | 不追加默认或显式邮箱签名。与 `--signature-id` 互斥 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
 | `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请（text/calendar）。需同时设置 `--event-start` 和 `--event-end` |
 | `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601，如 `2026-04-20T14:00+08:00`） |
@@ -207,6 +212,7 @@ lark-cli mail user_mailbox.drafts cancel_scheduled_send --params '{"user_mailbox
 ## 实现说明
 
 - 使用 EML 构建器生成完整 MIME 邮件并 base64url 编码后发送。
+- 未传 `--signature-id` 且未传 `--no-signature` 时，命令会按最终发件人邮箱匹配默认个人发信签名；HTML 正文追加客户端兼容签名块，纯文本正文追加签名文本并保持 `text/plain`。
 - `--attach` 作为普通附件添加。相对路径。
 - `--inline` 接受 JSON 数组，每项需提供 `cid`（唯一标识符，可用随机十六进制字符串）和 `file_path`（相对路径），作为 inline part 嵌入邮件。
 - **超大附件**：当附件导致 EML 总大小（headers + body + inline images + attachments，base64 编码后）超过 25 MB 时，超出的文件自动通过 `medias/upload_*` API 上传到云端。HTML 邮件插入与飞书客户端一致的下载卡片；纯文本邮件追加包含文件名、大小和下载链接的文本块。单个文件上限 3 GB，总附件数量上限 250 个。


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/26bb14a
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Enhance mail +send default signature composition | passed | 8003378 |
| S2 | Synthesize transport contract for larksuite/cli | passed | 0d84751 |

## Source specs

- input/tech-design.md

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `+send` shortcut now appends the sender's default signature by default.
  * Added `--no-signature` flag to skip signature appending.
  * Added `--signature-id` flag to explicitly select a specific signature.
  * Plain-text emails preserve `text/plain` format when signatures are appended.

* **Documentation**
  * Updated `+send` shortcut documentation to explain signature behavior and new flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->