### PR TITLE
feat(shortcuts): guard file-input flags against path-like literals

### DIFF
--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -1202,8 +1202,56 @@ func resolveInputFlags(rctx *RuntimeContext, flags []Flag) error {
 			rctx.Cmd.Flags().Set(fl.Name, stripUTF8BOM(string(data)))
 			continue
 		}
+
+		// Bare literal that looks like a file path is almost always a forgotten
+		// "@" (e.g. `--csv data.csv` instead of `--csv @data.csv`). Inputs like
+		// CSV accept any string as valid content, so the slip never surfaces as
+		// a downstream parse error the way malformed JSON would — the filename
+		// gets silently written as a one-cell value. Fail fast with a fix-it
+		// hint; piping via stdin (--flag -) bypasses this check for the rare
+		// case the path-shaped text really is the intended content.
+		if slices.Contains(fl.Input, File) && looksLikePathNotContent(raw) {
+			return ValidationErrorf(
+				"--%s value %q looks like a file path, not inline content; "+
+					"to read that file use --%s @%s, or pass the literal text via stdin with --%s -",
+				fl.Name, raw, fl.Name, raw, fl.Name,
+			).WithParam("--" + fl.Name)
+		}
 	}
 	return nil
+}
+
+// looksLikePathNotContent reports whether a bare flag value (no "@"/"-"/"@@"
+// prefix) is far more likely a file path the caller forgot to prefix with "@"
+// than literal inline content. It is deliberately conservative: a single short
+// line, no embedded comma (real CSV/TSV rows carry delimiters), and a known
+// data or document file extension. The narrow match keeps false positives near
+// zero, and any legitimate value it does trip can be forced through with the
+// existing "@@" escape.
+func looksLikePathNotContent(raw string) bool {
+	s := strings.TrimSpace(raw)
+	if s == "" || len(s) > 255 || strings.ContainsAny(s, "\r\n") {
+		return false
+	}
+	if strings.Contains(s, ",") {
+		return false
+	}
+	lower := strings.ToLower(s)
+	for _, ext := range pathLikeExtensions {
+		if strings.HasSuffix(lower, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// pathLikeExtensions are the file suffixes that, on a bare single-token flag
+// value, signal a forgotten "@" rather than intended inline content.
+var pathLikeExtensions = []string{
+	".csv", ".tsv", ".psv", ".tab",
+	".txt", ".md",
+	".json", ".jsonl", ".ndjson",
+	".xlsx", ".xls", ".dat",
 }
 
 func validateEnumFlags(rctx *RuntimeContext, flags []Flag) error {

--- a/shortcuts/common/runner_input_test.go
+++ b/shortcuts/common/runner_input_test.go
@@ -271,3 +271,118 @@ func TestResolveInputFlags_StripBOMFile(t *testing.T) {
 		t.Errorf("leading BOM not stripped from file, got %q", got)
 	}
 }
+
+func TestResolveInputFlags_FilenameMistakenForContent(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"csv extension", "data.csv"},
+		{"tsv extension", "export.tsv"},
+		{"xlsx extension", "report.xlsx"},
+		{"json extension", "config.json"},
+		{"relative path", "./out/data.csv"},
+		{"uppercase extension", "DATA.CSV"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rctx := newTestRuntimeWithStdin(map[string]string{"csv": c.value}, "")
+			flags := []Flag{{Name: "csv", Input: []string{File, Stdin}}}
+
+			err := resolveInputFlags(rctx, flags)
+			if err == nil {
+				t.Fatalf("expected error for path-like value %q", c.value)
+			}
+			assertValidationParam(t, err, "--csv")
+			if !strings.Contains(err.Error(), "looks like a file path") {
+				t.Errorf("unexpected error: %v", err)
+			}
+			// the hint must point at the @ fix using the original value
+			if !strings.Contains(err.Error(), "@"+c.value) {
+				t.Errorf("error should suggest --csv @%s, got: %v", c.value, err)
+			}
+		})
+	}
+}
+
+func TestResolveInputFlags_ContentNotMistakenForPath(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"multi-cell csv", "a,b\n1,2"},
+		{"single row with commas", "name,age,file.csv"},
+		{"plain text", "hello world"},
+		{"formula", "=SUM(A1:A2)"},
+		{"multiline ending in filename", "line1\nfile.csv"},
+		{"unknown extension", "report.docx-ish"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rctx := newTestRuntimeWithStdin(map[string]string{"csv": c.value}, "")
+			flags := []Flag{{Name: "csv", Input: []string{File, Stdin}}}
+
+			if err := resolveInputFlags(rctx, flags); err != nil {
+				t.Fatalf("unexpected error for content %q: %v", c.value, err)
+			}
+			if got := rctx.Str("csv"); got != c.value {
+				t.Errorf("value should pass through unchanged, got %q", got)
+			}
+		})
+	}
+}
+
+func TestResolveInputFlags_PathLikeContentViaStdin(t *testing.T) {
+	// stdin is the escape hatch for the rare case the literal path-shaped text
+	// is the intended content — the "-" branch returns before the heuristic.
+	rctx := newTestRuntimeWithStdin(map[string]string{"csv": "-"}, "data.csv")
+	flags := []Flag{{Name: "csv", Input: []string{File, Stdin}}}
+
+	if err := resolveInputFlags(rctx, flags); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := rctx.Str("csv"); got != "data.csv" {
+		t.Errorf("expected %q, got %q", "data.csv", got)
+	}
+}
+
+func TestResolveInputFlags_PathCheckSkippedWithoutFileInput(t *testing.T) {
+	// A flag that does not accept @file input must not get the file-path hint —
+	// suggesting "@" would be useless, so the bare value passes through.
+	rctx := newTestRuntimeWithStdin(map[string]string{"name": "data.csv"}, "")
+	flags := []Flag{{Name: "name", Input: []string{Stdin}}} // stdin only, no file
+
+	if err := resolveInputFlags(rctx, flags); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := rctx.Str("name"); got != "data.csv" {
+		t.Errorf("expected pass-through, got %q", got)
+	}
+}
+
+func TestLooksLikePathNotContent(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"data.csv", true},
+		{"  data.csv  ", true},
+		{"./out/report.xlsx", true},
+		{"DATA.CSV", true},
+		{"notes.md", true},
+		{"config.json", true},
+		{"a,b\n1,2", false},    // multi-line
+		{"a,b,c", false},       // has commas
+		{"x,data.csv", false},  // comma guard: a real row, not a bare filename
+		{"hello world", false}, // no extension
+		{"=SUM(A1:A2)", false}, // formula
+		{"", false},
+		{"plain.unknownext", false},
+		{strings.Repeat("a", 256) + ".csv", false}, // too long
+	}
+	for _, c := range cases {
+		if got := looksLikePathNotContent(c.in); got != c.want {
+			t.Errorf("looksLikePathNotContent(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

A bare value like `--csv data.csv` (a forgotten `@` prefix) was silently written as one-cell content. Because CSV accepts any string as valid input, the slip never surfaced as a parse error the way malformed JSON does — the filename landed in the sheet instead of the file's contents.

## How

`resolveInputFlags` now rejects path-shaped literals on any flag that accepts `@file` input, failing fast with a fix-it hint instead of silently writing the filename.

- **Heuristic** (`looksLikePathNotContent`), deliberately conservative to keep false positives near zero: single line, no comma (real CSV/TSV rows carry delimiters), and a known data/document extension (`.csv .tsv .psv .tab .txt .md .json .jsonl .ndjson .xlsx .xls .dat`).
- **Error message** points straight at the fix: use `--flag @file` to read the file, or pipe the literal text via stdin (`--flag -`).
- **Scope**: all file-input flags (csv, markdown, ...) on standalone calls. The `@file`, `@@escape`, and `-` stdin paths are unaffected — they return before the check, so stdin is also the escape hatch for the rare case path-shaped text really is the intended content.

## Test

- New unit tests for the heuristic and the resolve path: path-shaped filenames rejected (`.csv/.tsv/.xlsx/.json`, relative paths, uppercase), real content passed through (multi-cell CSV, comma rows, formulas), stdin escape hatch, and flags without file input skipped.
- `go test ./shortcuts/common/` green; gofmt clean; `go build ./...` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced input validation: The system now detects when a file path is accidentally provided as literal content (e.g., `data.csv`, `./file.json`) and displays a helpful error message guiding you to use the correct `@<path>` syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->