### PR TITLE
fix: clarify --block-id supports comma-separated batch delete in help text

### DIFF
--- a/shortcuts/doc/docs_update_v2.go
+++ b/shortcuts/doc/docs_update_v2.go
@@ -24,11 +24,11 @@ var validCommandsV2 = map[string]bool{
 // v2UpdateFlags returns the flag definitions for the v2 (OpenAPI) update path.
 func v2UpdateFlags() []common.Flag {
 	return []common.Flag{
-		{Name: "command", Desc: "operation; requirements: str_replace(--pattern), block_delete(--block-id), block_insert_after/block_replace(--block-id,--content), block_copy_insert_after/block_move_after(--block-id,--src-block-ids), overwrite/append(--content)", Enum: validCommandsV2Keys()},
+		{Name: "command", Desc: "operation; requirements: str_replace(--pattern), block_delete(--block-id, comma-separated for batch), block_insert_after/block_replace(--block-id,--content), block_copy_insert_after/block_move_after(--block-id,--src-block-ids), overwrite/append(--content)", Enum: validCommandsV2Keys()},
 		{Name: "doc-format", Desc: "content format for --content; xml is default for precise rich edits, markdown for user-provided Markdown or plain append/overwrite", Default: "xml", Enum: []string{"xml", "markdown"}},
 		{Name: "content", Desc: "replacement or inserted content; XML by default or Markdown when --doc-format markdown; empty with str_replace deletes match. " + docsContentSkillHelp + "; use --help for the latest command flags", Input: []string{common.File, common.Stdin}},
 		{Name: "pattern", Desc: "str_replace match pattern; XML mode is inline text, Markdown mode can match multiline text"},
-		{Name: "block-id", Desc: "target anchor/block id for block operations; -1 means document end where supported"},
+		{Name: "block-id", Desc: "target block ID(s) for block operations (comma-separated for batch delete); -1 means document end where supported"},
 		{Name: "src-block-ids", Desc: "comma-separated source block ids for block_copy_insert_after and block_move_after"},
 		{Name: "revision-id", Desc: "base revision id; -1 means latest", Type: "int", Default: "-1"},
 	}

--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -26,7 +26,7 @@
 | `--doc-format` | 否 | 内容格式：`xml`（默认，始终优先使用）\| `markdown`（仅用户明确要求时） |
 | `--content` | 视指令 | 写入内容（`str_replace` 传空字符串可实现删除） |
 | `--pattern` | 视指令 | 匹配文本（str_replace） |
-| `--block-id` | 视指令 | 目标 block ID（block_* 操作）,-1 表示末尾 |
+| `--block-id` | 视指令 | 目标 block ID（block_* 操作），逗号分隔可批量删除，-1 表示末尾 |
 | `--src-block-ids` | 视指令 | 源 block ID（逗号分隔），用于 block_copy_insert_after / block_move_after |
 | `--revision-id` | 否 | 基准版本号，-1 = 最新（默认 `-1`） |
 
@@ -116,8 +116,9 @@ lark-cli docs +update --api-version v2 --doc "<doc_id>" --command block_replace 
 ### block_delete — 删除指定 block
 
 ```bash
+# 删除多个块时用逗号 "," 分隔
 lark-cli docs +update --api-version v2 --doc "<doc_id>" --command block_delete \
-  --block-id "目标 block_id"
+  --block-id "block_id_1,block_id_2,block_id_3"
 ```
 
 ### overwrite — 全文覆盖

--- a/tests/cli_e2e/docs/docs_update_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_update_dryrun_test.go
@@ -66,6 +66,17 @@ func TestDocs_DryRunDefaultsToV2OpenAPI(t *testing.T) {
 			},
 			wantURL: "/open-apis/docs_ai/v1/documents/doxcnDryRunE2E",
 		},
+		{
+			name: "block_delete batch",
+			args: []string{
+				"docs", "+update",
+				"--doc", "doxcnDryRunE2E",
+				"--command", "block_delete",
+				"--block-id", "blkA,blkB,blkC",
+				"--dry-run",
+			},
+			wantURL: "/open-apis/docs_ai/v1/documents/doxcnDryRunE2E",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

The `--block-id` flag actually supports comma-separated multiple IDs for batch deletion (e.g. `--block-id "id1,id2,id3"`), but the CLI `--help` text described it as a singular "target anchor/block id", causing AI agents to assume only single values are accepted.

## Changes

- **`shortcuts/doc/docs_update_v2.go`**: Update `--block-id` Desc to mention comma-separated batch support; update `--command` Desc for `block_delete` to note batch capability
- **`skills/lark-doc/references/lark-doc-update.md`**: Update parameter table and `block_delete` example to show batch usage
- **`tests/cli_e2e/docs/docs_update_dryrun_test.go`**: Add dry-run E2E test for batch `block_delete`

## Test Plan

- [x] `go test ./shortcuts/doc/...` — all unit tests pass
- [x] `go test ./tests/cli_e2e/docs/ -run TestDocs_DryRunDefaultsToV2OpenAPI/block_delete_batch` — new dry-run E2E test passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI help for the docs update command with explicit per-command parameter requirements (which commands need block ID and/or content), reworded to “target block ID(s)”, added comma-separated batch block-ID guidance, and reiterated `-1` end-of-document semantics; updated examples to show batch block deletion usage.

* **Tests**
  * Added end-to-end dry-run test coverage for the batch block deletion workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->