### PR TITLE
docs(im): document chat.user_setting batch_query/batch_update

### DIFF
--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -134,6 +134,11 @@ lark-cli im <resource> <method> [flags] # 调用 API
   - `delete` — 将用户或机器人移出群聊。Identity: supports `user` and `bot`; only group owner, admin, or creator bot can remove others; max 50 users or 5 bots per request.
   - `get` — 获取群成员列表。Identity: supports `user` and `bot`; the caller must be in the target chat and must belong to the same tenant for internal chats.
 
+### chat.user_setting
+
+  - `batch_query` — 批量查询当前用户在群内的个人偏好设置 (e.g. `is_muted` mutes normal messages, `is_mute_at_all` mutes @all messages); up to 10 chats per request. Identity: `user` only (`user_access_token`); the caller must be in each target chat.
+  - `batch_update` — 批量更新当前用户在群内的个人偏好设置 (e.g. `is_muted` mutes normal messages, `is_mute_at_all` mutes @all messages); up to 10 chats per request. Identity: `user` only (`user_access_token`); the caller must be in each target chat.
+
 ### chat.managers
 
   - `add_managers` — 指定群管理员。Identity: supports `user` and `bot`; only the group owner can add managers; max 10 managers per chat (20 for super-large chats), and at most 5 bots per request.
@@ -196,6 +201,8 @@ lark-cli im <resource> <method> [flags] # 调用 API
 | `chat.members.create` | `im:chat.members:write_only` |
 | `chat.members.delete` | `im:chat.members:write_only` |
 | `chat.members.get` | `im:chat.members:read` |
+| `chat.user_setting.batch_query` | `im:chat.user_setting:read` |
+| `chat.user_setting.batch_update` | `im:chat.user_setting:write` |
 | `chat.managers.add_managers` | `im:chat.managers:write_only` |
 | `chat.managers.delete_managers` | `im:chat.managers:write_only` |
 | `chat.moderation.get` | `im:chat.moderation:read` |


### PR DESCRIPTION
## What

Document the `chat.user_setting` resource in the lark-im skill, exposing `batch_query` / `batch_update` via the generic `lark-cli im <resource> <method>` gateway.

Per-user in-chat mute preferences:
- `is_muted` — mute normal messages
- `is_mute_at_all` — mute @all messages

User identity only (`user_access_token`); caller must be in each target chat; up to 10 chats per call.

## Changes

- New `### chat.user_setting` entry under API Resources (`batch_query`, `batch_update`).
- Permission table: `batch_query` → `im:chat.user_setting:read`, `batch_update` → `im:chat.user_setting:write`.

Docs only; no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch query and batch update operations for chat user settings. These new user-scoped operations enable developers to efficiently query and update user settings across multiple chats simultaneously. Each request supports processing up to 10 chats and includes enforced permission scopes to ensure secure and granular access control for all operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->