### PR TITLE
feat: append default mail send signatures

### DIFF
--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -40,6 +40,7 @@ var MailSend = common.Shortcut{
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's subject/body/to/cc/bcc/attachments are merged with user-supplied flags (user flags win). Requires --as user."},
 		signatureFlag,
+		noSignatureFlag,
 		priorityFlag,
 		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag,
 		showLintDetailsFlag},
@@ -57,8 +58,12 @@ var MailSend = common.Shortcut{
 			api = api.GET(templateMailboxPath(mailboxID, tid)).
 				Desc("Fetch template to merge with compose flags (subject/body/to/cc/bcc/attachments).")
 		}
-		api = api.GET(mailboxPath(mailboxID, "profile")).
-			POST(mailboxPath(mailboxID, "drafts")).
+		api = api.GET(mailboxPath(mailboxID, "profile"))
+		if !runtime.Bool("no-signature") {
+			api = api.GET(mailboxPath(mailboxID, "settings", "signatures")).
+				Desc("Fetch signatures to resolve --signature-id or the default send signature.")
+		}
+		api = api.POST(mailboxPath(mailboxID, "drafts")).
 			Body(map[string]interface{}{
 				"raw": "<base64url-EML>",
 				"_preview": map[string]interface{}{
@@ -98,8 +103,12 @@ var MailSend = common.Shortcut{
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
-		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
-			return err
+		if runtime.Bool("no-signature") && runtime.Str("signature-id") != "" {
+			return mailValidationError("--no-signature and --signature-id are mutually exclusive").
+				WithParams(
+					mailInvalidParam("--no-signature", "mutually exclusive with --signature-id"),
+					mailInvalidParam("--signature-id", "mutually exclusive with --no-signature"),
+				)
 		}
 		// Resolve the body content first (reading --body-file if set) so
 		// inline / HTML checks see the actual body. This makes the
@@ -195,7 +204,23 @@ var MailSend = common.Shortcut{
 			}
 		}
 
-		sigResult, err := resolveSignature(ctx, runtime, mailboxID, signatureID, senderEmail)
+		if runtime.Bool("no-signature") {
+			signatureID = ""
+		} else if signatureID == "" {
+			defaultSignatureID, sigErr := resolveDefaultSendSignatureID(runtime, mailboxID, senderEmail)
+			if sigErr != nil {
+				fmt.Fprintf(runtime.IO().ErrOut, "warning: default signature lookup failed: %v\n", sigErr)
+			} else {
+				signatureID = defaultSignatureID
+			}
+		}
+
+		var sigResult *signatureResult
+		if plainText {
+			sigResult, err = resolveSignatureTextOnly(ctx, runtime, mailboxID, signatureID, senderEmail)
+		} else {
+			sigResult, err = resolveSignature(ctx, runtime, mailboxID, signatureID, senderEmail)
+		}
 		if err != nil {
 			return err
 		}
@@ -230,7 +255,7 @@ var MailSend = common.Shortcut{
 		// `lint_applied[]` / `original_blocked[]` even on the plain-text path.
 		lintApplied, lintBlocked := emptyLintEnvelopeFields()
 		if plainText {
-			composedTextBody = body
+			composedTextBody = appendPlainTextSignature(body, sigResult)
 			bld = bld.TextBody([]byte(composedTextBody))
 		} else if bodyIsHTML(body) || sigResult != nil {
 			// If signature is requested on plain-text body, auto-upgrade to HTML.

--- a/shortcuts/mail/mail_send_signature_test.go
+++ b/shortcuts/mail/mail_send_signature_test.go
@@ -1,0 +1,294 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/larksuite/cli/shortcuts/mail/signature"
+)
+
+func TestDefaultSendSignatureIDFromUsages(t *testing.T) {
+	usages := []signature.SignatureUsage{
+		{EmailAddress: "primary@example.com", SendMailSignatureID: "0"},
+		{EmailAddress: "alias@example.com", SendMailSignatureID: "sig_alias"},
+		{EmailAddress: "shared@example.com", SendMailSignatureID: "sig_shared"},
+	}
+
+	if got := defaultSendSignatureIDFromUsages(usages, "ALIAS@example.com", "primary@example.com"); got != "sig_alias" {
+		t.Fatalf("default signature ID = %q, want sig_alias", got)
+	}
+	if got := defaultSendSignatureIDFromUsages(usages, "missing@example.com", "shared@example.com"); got != "sig_shared" {
+		t.Fatalf("fallback default signature ID = %q, want sig_shared", got)
+	}
+	if got := defaultSendSignatureIDFromUsages(usages, "primary@example.com", "shared@example.com"); got != "" {
+		t.Fatalf("zero default signature ID = %q, want empty", got)
+	}
+}
+
+func TestAppendPlainTextSignature(t *testing.T) {
+	sig := &signatureResult{
+		ID:              "sig_text",
+		RenderedContent: `<p>Regards,<br><a href="https://example.com">Alice</a><img src="cid:x"></p>`,
+	}
+
+	got := appendPlainTextSignature("hello\n", sig)
+	want := "hello\n\nRegards,\nAlice (https://example.com)"
+	if got != want {
+		t.Fatalf("plain text signature:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestMailSendDefaultSignatureHitAppendsHTML(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+	mailboxID := "mb-default-hit"
+	registerSignatureListMock(reg, mailboxID, signatureListBody("sig_default", "sender@example.com", "sig_default", `<p>Default Sig</p>`))
+	draftStub := registerDraftCreateForMailbox(reg, mailboxID)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--from", "sender@example.com",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>body</p>",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	eml := mustDecodeRawEMLFromStub(t, draftStub)
+	if !strings.Contains(eml, "Default Sig") {
+		t.Fatalf("default signature not appended in EML:\n%s", eml)
+	}
+}
+
+func TestMailSendDefaultSignatureZeroDoesNotAppend(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+	mailboxID := "mb-default-zero"
+	registerSignatureListMock(reg, mailboxID, signatureListBody("sig_default", "sender@example.com", "0", `<p>Default Sig</p>`))
+	draftStub := registerDraftCreateForMailbox(reg, mailboxID)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--from", "sender@example.com",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>body</p>",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send failed: %v", err)
+	}
+
+	eml := mustDecodeRawEMLFromStub(t, draftStub)
+	if strings.Contains(eml, "Default Sig") {
+		t.Fatalf("zero default signature should not append signature:\n%s", eml)
+	}
+}
+
+func TestMailSendDefaultSignatureLookupFailureDowngrades(t *testing.T) {
+	f, stdout, stderr, reg := mailShortcutTestFactoryWithSendScope(t)
+	mailboxID := "mb-default-fail"
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/" + mailboxID + "/settings/signatures",
+		Body: map[string]interface{}{
+			"code": 999,
+			"msg":  "temporary signature failure",
+		},
+	})
+	draftStub := registerDraftCreateForMailbox(reg, mailboxID)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--from", "sender@example.com",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>body</p>",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send should downgrade default-signature failure: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "warning: default signature lookup failed") {
+		t.Fatalf("expected default signature warning, stderr=%q", stderr.String())
+	}
+	_ = mustDecodeRawEMLFromStub(t, draftStub)
+}
+
+func TestMailSendNoSignatureSkipsDefaultLookup(t *testing.T) {
+	f, stdout, stderr, reg := mailShortcutTestFactoryWithSendScope(t)
+	mailboxID := "mb-no-signature"
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/" + mailboxID + "/settings/signatures",
+		Body: map[string]interface{}{
+			"code": 999,
+			"msg":  "should not be called",
+		},
+	})
+	draftStub := registerDraftCreateForMailbox(reg, mailboxID)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--from", "sender@example.com",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "<p>body</p>",
+		"--no-signature",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("send with --no-signature failed: %v", err)
+	}
+	if strings.Contains(stderr.String(), "default signature lookup failed") {
+		t.Fatalf("--no-signature should skip lookup warning, stderr=%q", stderr.String())
+	}
+	eml := mustDecodeRawEMLFromStub(t, draftStub)
+	if strings.Contains(eml, "Default Sig") {
+		t.Fatalf("--no-signature should not append signature:\n%s", eml)
+	}
+}
+
+func TestMailSendPlainTextSignatureStaysText(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactoryWithSendScope(t)
+	mailboxID := "mb-plain-text-signature"
+	registerSignatureListMock(reg, mailboxID, signatureListBody("sig_text", "sender@example.com", "sig_text", `<p>Regards,<br>Alice</p>`))
+	draftStub := registerDraftCreateForMailbox(reg, mailboxID)
+
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--mailbox", mailboxID,
+		"--from", "sender@example.com",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "plain body",
+		"--plain-text",
+		"--signature-id", "sig_text",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("plain-text send with signature failed: %v", err)
+	}
+
+	eml := mustDecodeRawEMLFromStub(t, draftStub)
+	if !strings.Contains(eml, "text/plain") {
+		t.Fatalf("plain-text signature send should stay text/plain:\n%s", eml)
+	}
+	if strings.Contains(eml, "text/html") {
+		t.Fatalf("plain-text signature send should not add html part:\n%s", eml)
+	}
+	if !strings.Contains(eml, "plain body") || !strings.Contains(eml, "Regards,") || !strings.Contains(eml, "Alice") {
+		t.Fatalf("plain-text signature not present in EML:\n%s", eml)
+	}
+}
+
+func TestMailSendNoSignatureConflictsWithSignatureID(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactoryWithSendScope(t)
+	err := runMountedMailShortcut(t, MailSend, []string{
+		"+send",
+		"--to", "alice@example.com",
+		"--subject", "hello",
+		"--body", "body",
+		"--signature-id", "sig_123",
+		"--no-signature",
+	}, f, stdout)
+	assertValidationError(t, err, "--no-signature and --signature-id")
+}
+
+func TestNonSendComposeShortcutsStillRejectPlainTextSignature(t *testing.T) {
+	cases := []struct {
+		name     string
+		shortcut common.Shortcut
+		args     []string
+	}{
+		{
+			name:     "draft-create",
+			shortcut: MailDraftCreate,
+			args: []string{
+				"+draft-create", "--to", "alice@example.com", "--subject", "hello", "--body", "body",
+				"--plain-text", "--signature-id", "sig_123",
+			},
+		},
+		{
+			name:     "reply",
+			shortcut: MailReply,
+			args: []string{
+				"+reply", "--message-id", "msg_123", "--body", "body",
+				"--plain-text", "--signature-id", "sig_123",
+			},
+		},
+		{
+			name:     "reply-all",
+			shortcut: MailReplyAll,
+			args: []string{
+				"+reply-all", "--message-id", "msg_123", "--body", "body",
+				"--plain-text", "--signature-id", "sig_123",
+			},
+		},
+		{
+			name:     "forward",
+			shortcut: MailForward,
+			args: []string{
+				"+forward", "--message-id", "msg_123", "--to", "alice@example.com", "--body", "body",
+				"--plain-text", "--signature-id", "sig_123",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			err := runMountedMailShortcut(t, tc.shortcut, tc.args, f, stdout)
+			assertValidationError(t, err, "--plain-text and --signature-id")
+		})
+	}
+}
+
+func registerSignatureListMock(reg *httpmock.Registry, mailboxID string, body map[string]interface{}) {
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/" + mailboxID + "/settings/signatures",
+		Body:   body,
+	})
+}
+
+func registerDraftCreateForMailbox(reg *httpmock.Registry, mailboxID string) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/" + mailboxID + "/drafts",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"draft_id": "draft_" + mailboxID},
+		},
+	}
+	reg.Register(stub)
+	return stub
+}
+
+func signatureListBody(signatureID, usageEmail, usageSignatureID, content string) map[string]interface{} {
+	return map[string]interface{}{
+		"code": 0,
+		"data": map[string]interface{}{
+			"signatures": []map[string]interface{}{
+				{
+					"id":             signatureID,
+					"name":           "Default",
+					"signature_type": "USER",
+					"content":        content,
+				},
+			},
+			"usages": []map[string]interface{}{
+				{
+					"email_address":          usageEmail,
+					"send_mail_signature_id": usageSignatureID,
+					"reply_signature_id":     "0",
+				},
+			},
+		},
+	}
+}

--- a/shortcuts/mail/mail_send_signature_test.go
+++ b/shortcuts/mail/mail_send_signature_test.go
@@ -124,14 +124,6 @@ func TestMailSendDefaultSignatureLookupFailureDowngrades(t *testing.T) {
 func TestMailSendNoSignatureSkipsDefaultLookup(t *testing.T) {
 	f, stdout, stderr, reg := mailShortcutTestFactoryWithSendScope(t)
 	mailboxID := "mb-no-signature"
-	reg.Register(&httpmock.Stub{
-		Method: "GET",
-		URL:    "/user_mailboxes/" + mailboxID + "/settings/signatures",
-		Body: map[string]interface{}{
-			"code": 999,
-			"msg":  "should not be called",
-		},
-	})
 	draftStub := registerDraftCreateForMailbox(reg, mailboxID)
 
 	err := runMountedMailShortcut(t, MailSend, []string{

--- a/shortcuts/mail/signature_compose.go
+++ b/shortcuts/mail/signature_compose.go
@@ -19,6 +19,7 @@ import (
 	"github.com/larksuite/cli/shortcuts/mail/emlbuilder"
 	"github.com/larksuite/cli/shortcuts/mail/signature"
 	nethtml "golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 // signatureFlag is the common flag definition for --signature-id, shared by all compose shortcuts.
@@ -160,8 +161,9 @@ func appendPlainTextSignature(textBody string, sig *signatureResult) string {
 
 func signatureHTMLToPlainText(htmlText string) string {
 	nodes, err := nethtml.ParseFragment(strings.NewReader(htmlText), &nethtml.Node{
-		Type: nethtml.ElementNode,
-		Data: "div",
+		Type:     nethtml.ElementNode,
+		DataAtom: atom.Body,
+		Data:     "body",
 	})
 	if err != nil {
 		return strings.TrimSpace(stdhtml.UnescapeString(htmlText))

--- a/shortcuts/mail/signature_compose.go
+++ b/shortcuts/mail/signature_compose.go
@@ -5,6 +5,7 @@ package mail
 
 import (
 	"context"
+	stdhtml "html"
 	"io"
 	"net/http"
 	"net/url"
@@ -17,12 +18,20 @@ import (
 	draftpkg "github.com/larksuite/cli/shortcuts/mail/draft"
 	"github.com/larksuite/cli/shortcuts/mail/emlbuilder"
 	"github.com/larksuite/cli/shortcuts/mail/signature"
+	nethtml "golang.org/x/net/html"
 )
 
 // signatureFlag is the common flag definition for --signature-id, shared by all compose shortcuts.
 var signatureFlag = common.Flag{
 	Name: "signature-id",
 	Desc: "Optional. Signature ID to append after body content. Run `mail +signature` to list available signatures.",
+}
+
+// noSignatureFlag is send-only: skip automatic default signature lookup and injection.
+var noSignatureFlag = common.Flag{
+	Name: "no-signature",
+	Type: "bool",
+	Desc: "Skip auto-appending the default send signature.",
 }
 
 // signatureResult holds the pre-processed signature data ready for HTML injection.
@@ -36,6 +45,14 @@ type signatureResult struct {
 // fromEmail is the --from address (may be an alias); used to match the correct
 // sender identity for template interpolation. Pass "" to use the primary address.
 func resolveSignature(ctx context.Context, runtime *common.RuntimeContext, mailboxID, signatureID, fromEmail string) (*signatureResult, error) {
+	return resolveSignatureWithImages(ctx, runtime, mailboxID, signatureID, fromEmail, true)
+}
+
+func resolveSignatureTextOnly(ctx context.Context, runtime *common.RuntimeContext, mailboxID, signatureID, fromEmail string) (*signatureResult, error) {
+	return resolveSignatureWithImages(ctx, runtime, mailboxID, signatureID, fromEmail, false)
+}
+
+func resolveSignatureWithImages(ctx context.Context, runtime *common.RuntimeContext, mailboxID, signatureID, fromEmail string, includeImages bool) (*signatureResult, error) {
 	if signatureID == "" {
 		return nil, nil
 	}
@@ -53,20 +70,22 @@ func resolveSignature(ctx context.Context, runtime *common.RuntimeContext, mailb
 	// Download signature inline images. The file_key field contains a
 	// direct download URL provided by the mail backend.
 	var images []draftpkg.SignatureImage
-	for _, img := range sig.Images {
-		if img.DownloadURL == "" || img.CID == "" {
-			continue
+	if includeImages {
+		for _, img := range sig.Images {
+			if img.DownloadURL == "" || img.CID == "" {
+				continue
+			}
+			data, ct, err := downloadSignatureImage(runtime, img.DownloadURL, img.ImageName)
+			if err != nil {
+				return nil, mailDecorateProblemMessage(err, "failed to download signature image %s", img.ImageName)
+			}
+			images = append(images, draftpkg.SignatureImage{
+				CID:         img.CID,
+				ContentType: ct,
+				FileName:    img.ImageName,
+				Data:        data,
+			})
 		}
-		data, ct, err := downloadSignatureImage(runtime, img.DownloadURL, img.ImageName)
-		if err != nil {
-			return nil, mailDecorateProblemMessage(err, "failed to download signature image %s", img.ImageName)
-		}
-		images = append(images, draftpkg.SignatureImage{
-			CID:         img.CID,
-			ContentType: ct,
-			FileName:    img.ImageName,
-			Data:        data,
-		})
 	}
 
 	return &signatureResult{
@@ -74,6 +93,38 @@ func resolveSignature(ctx context.Context, runtime *common.RuntimeContext, mailb
 		RenderedContent: rendered,
 		Images:          images,
 	}, nil
+}
+
+func resolveDefaultSendSignatureID(runtime *common.RuntimeContext, mailboxID, senderEmail string) (string, error) {
+	resp, err := signature.ListAll(runtime, mailboxID)
+	if err != nil {
+		return "", err
+	}
+	candidates := []string{senderEmail}
+	if mailboxID != "" && mailboxID != "me" {
+		candidates = append(candidates, mailboxID)
+	}
+	return defaultSendSignatureIDFromUsages(resp.Usages, candidates...), nil
+}
+
+func defaultSendSignatureIDFromUsages(usages []signature.SignatureUsage, candidates ...string) string {
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		for _, usage := range usages {
+			if !strings.EqualFold(strings.TrimSpace(usage.EmailAddress), candidate) {
+				continue
+			}
+			id := strings.TrimSpace(usage.SendMailSignatureID)
+			if id == "" || id == "0" {
+				return ""
+			}
+			return id
+		}
+	}
+	return ""
 }
 
 // injectSignatureIntoBody inserts signature HTML into the body, placing
@@ -90,6 +141,134 @@ func injectSignatureIntoBody(bodyHTML string, sig *signatureResult) string {
 	}
 	sigBlock := draftpkg.SignatureSpacing() + draftpkg.BuildSignatureHTML(sig.ID, sig.RenderedContent)
 	return draftpkg.PlaceSignatureBeforeSystemTail(bodyHTML, sigBlock)
+}
+
+func appendPlainTextSignature(textBody string, sig *signatureResult) string {
+	if sig == nil {
+		return textBody
+	}
+	sigText := strings.TrimSpace(signatureHTMLToPlainText(sig.RenderedContent))
+	if sigText == "" {
+		return textBody
+	}
+	body := strings.TrimRight(textBody, " \t\r\n")
+	if body == "" {
+		return sigText
+	}
+	return body + "\n\n" + sigText
+}
+
+func signatureHTMLToPlainText(htmlText string) string {
+	nodes, err := nethtml.ParseFragment(strings.NewReader(htmlText), &nethtml.Node{
+		Type: nethtml.ElementNode,
+		Data: "div",
+	})
+	if err != nil {
+		return strings.TrimSpace(stdhtml.UnescapeString(htmlText))
+	}
+	var b strings.Builder
+	for _, n := range nodes {
+		appendHTMLNodeText(&b, n)
+	}
+	return normalizePlainSignatureText(b.String())
+}
+
+func appendHTMLNodeText(b *strings.Builder, n *nethtml.Node) {
+	switch n.Type {
+	case nethtml.TextNode:
+		writePlainTextWords(b, stdhtml.UnescapeString(n.Data))
+	case nethtml.ElementNode:
+		switch strings.ToLower(n.Data) {
+		case "br":
+			writePlainTextNewline(b)
+			return
+		case "img":
+			return
+		case "a":
+			var child strings.Builder
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				appendHTMLNodeText(&child, c)
+			}
+			label := strings.TrimSpace(normalizePlainSignatureText(child.String()))
+			href := attrValue(n, "href")
+			if href != "" && label != "" && href != label {
+				writePlainTextWords(b, label+" ("+href+")")
+			} else if label != "" {
+				writePlainTextWords(b, label)
+			} else if href != "" {
+				writePlainTextWords(b, href)
+			}
+			return
+		case "p", "div", "section", "article", "header", "footer", "blockquote", "tr", "table", "ul", "ol":
+			writePlainTextNewline(b)
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				appendHTMLNodeText(b, c)
+			}
+			writePlainTextNewline(b)
+			return
+		case "li":
+			writePlainTextNewline(b)
+			writePlainTextWords(b, "-")
+			for c := n.FirstChild; c != nil; c = c.NextSibling {
+				appendHTMLNodeText(b, c)
+			}
+			writePlainTextNewline(b)
+			return
+		}
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		appendHTMLNodeText(b, c)
+	}
+}
+
+func writePlainTextWords(b *strings.Builder, text string) {
+	words := strings.Join(strings.Fields(text), " ")
+	if words == "" {
+		return
+	}
+	current := b.String()
+	if current != "" && !strings.HasSuffix(current, " ") && !strings.HasSuffix(current, "\n") {
+		b.WriteByte(' ')
+	}
+	b.WriteString(words)
+}
+
+func writePlainTextNewline(b *strings.Builder) {
+	current := b.String()
+	if current == "" || strings.HasSuffix(current, "\n") {
+		return
+	}
+	b.WriteByte('\n')
+}
+
+func normalizePlainSignatureText(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+	lines := strings.Split(text, "\n")
+	out := make([]string, 0, len(lines))
+	blank := false
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			if len(out) > 0 && !blank {
+				out = append(out, "")
+				blank = true
+			}
+			continue
+		}
+		out = append(out, line)
+		blank = false
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+func attrValue(n *nethtml.Node, key string) string {
+	for _, attr := range n.Attr {
+		if strings.EqualFold(attr.Key, key) {
+			return strings.TrimSpace(attr.Val)
+		}
+	}
+	return ""
 }
 
 // addSignatureImagesToBuilder adds signature inline images to the EML builder.

--- a/shortcuts/mail/signature_compose.go
+++ b/shortcuts/mail/signature_compose.go
@@ -102,6 +102,11 @@ func resolveDefaultSendSignatureID(runtime *common.RuntimeContext, mailboxID, se
 		return "", err
 	}
 	candidates := []string{senderEmail}
+	if strings.TrimSpace(senderEmail) == "" {
+		if _, resolvedEmail := resolveSenderInfo(runtime, mailboxID, ""); resolvedEmail != "" {
+			candidates = append(candidates, resolvedEmail)
+		}
+	}
 	if mailboxID != "" && mailboxID != "me" {
 		candidates = append(candidates, mailboxID)
 	}
@@ -185,6 +190,8 @@ func appendHTMLNodeText(b *strings.Builder, n *nethtml.Node) {
 			writePlainTextNewline(b)
 			return
 		case "img":
+			return
+		case "script", "style", "head", "template", "noscript":
 			return
 		case "a":
 			var child strings.Builder

--- a/skills/lark-mail/references/lark-mail-send.md
+++ b/skills/lark-mail/references/lark-mail-send.md
@@ -7,6 +7,7 @@
 - 抄送/密送
 - 本地文件附件（`--attach`）
 - 内嵌图片（`--inline`，CID 可用随机字符串）
+- 自动追加当前发件地址的新邮件默认签名（可用 `--no-signature` 跳过）
 
 本 skill 对应 shortcut：`lark-cli mail +send`。
 
@@ -59,6 +60,9 @@ lark-cli mail +send --to alice@example.com --subject '预览图' --body '<img sr
 # 纯文本邮件（仅在内容极简时使用）
 lark-cli mail +send --to alice@example.com --subject '确认' --body '收到，谢谢'
 
+# 跳过默认签名
+lark-cli mail +send --to alice@example.com --subject '确认' --body '收到，谢谢' --no-signature
+
 # Dry Run（仅打印请求，不执行）
 lark-cli mail +send --to alice@example.com --subject '测试' --body '<p>test</p>' --dry-run
 ```
@@ -75,10 +79,11 @@ lark-cli mail +send --to alice@example.com --subject '测试' --body '<p>test</p
 | `--mailbox <email>` | 否 | 邮箱地址，指定草稿所属的邮箱（默认回退到 `--from`，再回退到 `me`）。当发件人（`--from`）与邮箱不同时使用。可通过 `accessible_mailboxes` 查询可用邮箱 |
 | `--cc <emails>` | 否 | 抄送邮箱，多个用逗号分隔 |
 | `--bcc <emails>` | 否 | 密送邮箱，多个用逗号分隔 |
-| `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用 |
+| `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用。若追加签名，签名会转换为纯文本 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
-| `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到正文末尾。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
+| `--signature-id <id>` | 否 | 签名 ID。显式附加该签名到正文末尾。运行 `mail +signature` 查看可用签名。不可与 `--no-signature` 同时使用 |
+| `--no-signature` | 否 | 跳过自动追加当前发件地址的新邮件默认签名。不可与 `--signature-id` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
 | `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请（text/calendar）。需同时设置 `--event-start` 和 `--event-end` |
 | `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601，如 `2026-04-20T14:00+08:00`） |
@@ -207,6 +212,8 @@ lark-cli mail user_mailbox.drafts cancel_scheduled_send --params '{"user_mailbox
 ## 实现说明
 
 - 使用 EML 构建器生成完整 MIME 邮件并 base64url 编码后发送。
+- 未传 `--signature-id` 且未传 `--no-signature` 时，`+send` 会读取当前发件地址的新邮件默认签名并追加到正文末尾；读取默认签名失败时会降级为无签名并继续创建草稿/发送。
+- `--plain-text` 模式下仍保持 text/plain，签名 HTML 会转换为可读纯文本后追加。
 - `--attach` 作为普通附件添加。相对路径。
 - `--inline` 接受 JSON 数组，每项需提供 `cid`（唯一标识符，可用随机十六进制字符串）和 `file_path`（相对路径），作为 inline part 嵌入邮件。
 - **超大附件**：当附件导致 EML 总大小（headers + body + inline images + attachments，base64 编码后）超过 25 MB 时，超出的文件自动通过 `medias/upload_*` API 上传到云端。HTML 邮件插入与飞书客户端一致的下载卡片；纯文本邮件追加包含文件名、大小和下载链接的文本块。单个文件上限 3 GB，总附件数量上限 250 个。

--- a/skills/lark-mail/references/lark-mail-signature.md
+++ b/skills/lark-mail/references/lark-mail-signature.md
@@ -87,12 +87,15 @@ lark-cli mail +signature --from shared@example.com
 
 ## 与 compose shortcut 配合
 
-获取签名 ID 后，可在发送/回复/转发时附加签名：
+`mail +send` 默认会自动追加当前发件地址的新邮件默认签名；如需跳过，传 `--no-signature`。获取签名 ID 后，也可在发送/回复/转发时显式附加签名：
 
 ```bash
 # 查看签名列表获取 ID
 lark-cli mail +signature
 
-# 在发送邮件时附加签名
+# 在发送邮件时显式附加签名（覆盖默认签名选择）
 lark-cli mail +send --to alice@example.com --subject '你好' --body '<p>内容</p>' --signature-id <签名ID>
+
+# 发送邮件时跳过默认签名
+lark-cli mail +send --to alice@example.com --subject '你好' --body '<p>内容</p>' --no-signature
 ```


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/eb56b12
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Add default signature auto-append to mail +send | passed | 4a2436a |
| S2 | Synthesize transport contract for larksuite/cli | passed | 03ea6e7 |

## Source specs

- tech-design.md

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--no-signature` to skip automatic signature appending when sending mail.
  * Sender default signature is auto-appended on send; plain-text mode appends a plain-text signature.

* **Improvements**
  * Signature lookup failures downgrade to a warning (do not block send).
  * Enforced mutual exclusivity between `--no-signature` and `--signature-id`.

* **Documentation**
  * Updated mail send/signature docs with flag details and default behavior.

* **Tests**
  * Added tests for default signature selection, plain-text appending, lookup warnings, and flag validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->