### PR TITLE
feat: append default mail signatures

### DIFF
--- a/shortcuts/mail/mail_draft_create.go
+++ b/shortcuts/mail/mail_draft_create.go
@@ -56,6 +56,7 @@ var MailDraftCreate = common.Shortcut{
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's subject/body/to/cc/bcc/attachments are merged with user-supplied flags (user flags win). Requires --as user."},
 		signatureFlag,
+		noSignatureFlag,
 		priorityFlag,
 		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag,
 		showLintDetailsFlag,
@@ -92,7 +93,7 @@ var MailDraftCreate = common.Shortcut{
 		if !hasTemplate && strings.TrimSpace(runtime.Str("subject")) == "" {
 			return mailValidationParamError("--subject", "--subject is required; pass the final email subject (or use --template-id)")
 		}
-		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+		if err := validateSignatureFlags(runtime.Bool("no-signature"), runtime.Str("signature-id")); err != nil {
 			return err
 		}
 		if err := validateEventFlags(runtime); err != nil {
@@ -180,7 +181,11 @@ var MailDraftCreate = common.Shortcut{
 		if strings.TrimSpace(input.Body) == "" {
 			return mailValidationParamError("--body", "effective body is empty after applying template; pass --body explicitly")
 		}
-		sigResult, err := resolveSignature(ctx, runtime, mailboxID, runtime.Str("signature-id"), runtime.Str("from"))
+		senderEmail := runtime.Str("from")
+		if senderEmail == "" && runtime.Str("mailbox") != "" && runtime.Str("mailbox") != "me" {
+			senderEmail = runtime.Str("mailbox")
+		}
+		sigResult, err := resolveComposeSignature(ctx, runtime, mailboxID, senderEmail, sigKindSend)
 		if err != nil {
 			return err
 		}
@@ -290,7 +295,7 @@ func buildRawEMLForDraftCreate(
 	var composedHTMLBody string
 	var composedTextBody string
 	if input.PlainText {
-		composedTextBody = input.Body
+		composedTextBody = appendPlainTextSignature(input.Body, sigResult)
 		bld = bld.TextBody([]byte(composedTextBody))
 	} else if bodyIsHTML(input.Body) || sigResult != nil {
 		htmlBody := input.Body
@@ -335,7 +340,7 @@ func buildRawEMLForDraftCreate(
 			return "", lintApplied, lintBlocked, cidErr
 		}
 	} else {
-		composedTextBody = input.Body
+		composedTextBody = appendPlainTextSignature(input.Body, sigResult)
 		bld = bld.TextBody([]byte(composedTextBody))
 	}
 	// Embed template SMALL non-inline attachments via AddAttachment. No-op

--- a/shortcuts/mail/mail_forward.go
+++ b/shortcuts/mail/mail_forward.go
@@ -45,6 +45,7 @@ var MailForward = common.Shortcut{
 		{Name: "subject", Desc: "Optional. Override the auto-generated Fw: subject. When set, the shortcut uses this value verbatim instead of prefixing the original subject."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's body/to/cc/bcc/attachments are merged into the forward draft (template values appended to user flags / forward-derived values; no de-duplication)."},
 		signatureFlag,
+		noSignatureFlag,
 		priorityFlag,
 		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag,
 		showLintDetailsFlag},
@@ -96,7 +97,7 @@ var MailForward = common.Shortcut{
 				return err
 			}
 		}
-		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+		if err := validateSignatureFlags(runtime.Bool("no-signature"), runtime.Str("signature-id")); err != nil {
 			return err
 		}
 		if err := validateEventFlags(runtime); err != nil {
@@ -127,12 +128,7 @@ var MailForward = common.Shortcut{
 			return err
 		}
 
-		signatureID := runtime.Str("signature-id")
 		mailboxID := resolveComposeMailboxID(runtime)
-		sigResult, sigErr := resolveSignature(ctx, runtime, mailboxID, signatureID, runtime.Str("from"))
-		if sigErr != nil {
-			return sigErr
-		}
 		sourceMsg, err := fetchComposeSourceMessage(runtime, mailboxID, messageId)
 		if err != nil {
 			return mailDecorateProblemMessage(err, "failed to fetch original message")
@@ -154,6 +150,10 @@ var MailForward = common.Shortcut{
 		senderEmail := resolvedSender
 		if senderEmail == "" {
 			senderEmail = orig.headTo
+		}
+		sigResult, sigErr := resolveComposeSignature(ctx, runtime, mailboxID, senderEmail, sigKindSend)
+		if sigErr != nil {
+			return sigErr
 		}
 
 		// --template-id merge (§5.5 Q1-Q5).
@@ -310,7 +310,7 @@ var MailForward = common.Shortcut{
 				return err
 			}
 		} else {
-			composedTextBody = buildForwardedMessage(&orig, body)
+			composedTextBody = buildForwardedMessage(&orig, appendPlainTextSignature(body, sigResult))
 			bld = bld.TextBody([]byte(composedTextBody))
 		}
 		// Embed template SMALL non-inline attachments regardless of body mode.

--- a/shortcuts/mail/mail_reply.go
+++ b/shortcuts/mail/mail_reply.go
@@ -42,6 +42,7 @@ var MailReply = common.Shortcut{
 		{Name: "subject", Desc: "Optional. Override the auto-generated Re: subject. When set, the shortcut uses this value verbatim instead of prefixing the original subject."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's body/to/cc/bcc/attachments are appended to the reply-derived values (no de-duplication; see warning in Execute output)."},
 		signatureFlag,
+		noSignatureFlag,
 		priorityFlag,
 		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag,
 		showLintDetailsFlag},
@@ -93,7 +94,7 @@ var MailReply = common.Shortcut{
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
-		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+		if err := validateSignatureFlags(runtime.Bool("no-signature"), runtime.Str("signature-id")); err != nil {
 			return err
 		}
 		if err := validateEventFlags(runtime); err != nil {
@@ -129,12 +130,7 @@ var MailReply = common.Shortcut{
 			return err
 		}
 
-		signatureID := runtime.Str("signature-id")
 		mailboxID := resolveComposeMailboxID(runtime)
-		sigResult, sigErr := resolveSignature(ctx, runtime, mailboxID, signatureID, runtime.Str("from"))
-		if sigErr != nil {
-			return sigErr
-		}
 		sourceMsg, err := fetchComposeSourceMessage(runtime, mailboxID, messageId)
 		if err != nil {
 			return mailDecorateProblemMessage(err, "failed to fetch original message")
@@ -154,6 +150,10 @@ var MailReply = common.Shortcut{
 		senderEmail := resolvedSender
 		if senderEmail == "" {
 			senderEmail = orig.headTo
+		}
+		sigResult, sigErr := resolveComposeSignature(ctx, runtime, mailboxID, senderEmail, sigKindReply)
+		if sigErr != nil {
+			return sigErr
 		}
 
 		replyTo := orig.replyTo
@@ -311,7 +311,7 @@ var MailReply = common.Shortcut{
 				return err
 			}
 		} else {
-			composedTextBody = bodyStr + quoted
+			composedTextBody = appendPlainTextSignature(bodyStr, sigResult) + quoted
 			bld = bld.TextBody([]byte(composedTextBody))
 		}
 		// Embed template SMALL non-inline attachments regardless of body mode.

--- a/shortcuts/mail/mail_reply_all.go
+++ b/shortcuts/mail/mail_reply_all.go
@@ -43,6 +43,7 @@ var MailReplyAll = common.Shortcut{
 		{Name: "subject", Desc: "Optional. Override the auto-generated Re: subject. When set, the shortcut uses this value verbatim instead of prefixing the original subject."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's body/to/cc/bcc/attachments are appended to the reply-derived values (no de-duplication; see warning in Execute output)."},
 		signatureFlag,
+		noSignatureFlag,
 		priorityFlag,
 		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag,
 		showLintDetailsFlag},
@@ -94,7 +95,7 @@ var MailReplyAll = common.Shortcut{
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
-		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+		if err := validateSignatureFlags(runtime.Bool("no-signature"), runtime.Str("signature-id")); err != nil {
 			return err
 		}
 		if err := validateEventFlags(runtime); err != nil {
@@ -131,12 +132,7 @@ var MailReplyAll = common.Shortcut{
 			return err
 		}
 
-		signatureID := runtime.Str("signature-id")
 		mailboxID := resolveComposeMailboxID(runtime)
-		sigResult, sigErr := resolveSignature(ctx, runtime, mailboxID, signatureID, runtime.Str("from"))
-		if sigErr != nil {
-			return sigErr
-		}
 		sourceMsg, err := fetchComposeSourceMessage(runtime, mailboxID, messageId)
 		if err != nil {
 			return mailDecorateProblemMessage(err, "failed to fetch original message")
@@ -156,6 +152,10 @@ var MailReplyAll = common.Shortcut{
 		senderEmail := resolvedSender
 		if senderEmail == "" {
 			senderEmail = orig.headTo
+		}
+		sigResult, sigErr := resolveComposeSignature(ctx, runtime, mailboxID, senderEmail, sigKindReply)
+		if sigErr != nil {
+			return sigErr
 		}
 
 		var removeList []string
@@ -316,7 +316,7 @@ var MailReplyAll = common.Shortcut{
 				return err
 			}
 		} else {
-			composedTextBody = bodyStr + quoted
+			composedTextBody = appendPlainTextSignature(bodyStr, sigResult) + quoted
 			bld = bld.TextBody([]byte(composedTextBody))
 		}
 		// Embed template SMALL non-inline attachments regardless of body mode.

--- a/shortcuts/mail/mail_send.go
+++ b/shortcuts/mail/mail_send.go
@@ -40,6 +40,7 @@ var MailSend = common.Shortcut{
 		{Name: "request-receipt", Type: "bool", Desc: "Request a read receipt (Message Disposition Notification, RFC 3798) addressed to the sender. Recipient mail clients may prompt the user, send automatically, or silently ignore — delivery of a receipt is not guaranteed."},
 		{Name: "template-id", Desc: "Optional. Apply a saved template by ID (decimal integer string) before composing. The template's subject/body/to/cc/bcc/attachments are merged with user-supplied flags (user flags win). Requires --as user."},
 		signatureFlag,
+		noSignatureFlag,
 		priorityFlag,
 		eventSummaryFlag, eventStartFlag, eventEndFlag, eventLocationFlag,
 		showLintDetailsFlag},
@@ -98,7 +99,7 @@ var MailSend = common.Shortcut{
 		if err := validateSendTime(runtime); err != nil {
 			return err
 		}
-		if err := validateSignatureWithPlainText(runtime.Bool("plain-text"), runtime.Str("signature-id")); err != nil {
+		if err := validateSignatureFlags(runtime.Bool("no-signature"), runtime.Str("signature-id")); err != nil {
 			return err
 		}
 		// Resolve the body content first (reading --body-file if set) so
@@ -137,7 +138,6 @@ var MailSend = common.Shortcut{
 		sendTime := runtime.Str("send-time")
 
 		senderEmail := resolveComposeSenderEmail(runtime)
-		signatureID := runtime.Str("signature-id")
 		priority, err := parsePriority(runtime.Str("priority"))
 		if err != nil {
 			return err
@@ -195,7 +195,7 @@ var MailSend = common.Shortcut{
 			}
 		}
 
-		sigResult, err := resolveSignature(ctx, runtime, mailboxID, signatureID, senderEmail)
+		sigResult, err := resolveComposeSignature(ctx, runtime, mailboxID, senderEmail, sigKindSend)
 		if err != nil {
 			return err
 		}
@@ -230,7 +230,7 @@ var MailSend = common.Shortcut{
 		// `lint_applied[]` / `original_blocked[]` even on the plain-text path.
 		lintApplied, lintBlocked := emptyLintEnvelopeFields()
 		if plainText {
-			composedTextBody = body
+			composedTextBody = appendPlainTextSignature(body, sigResult)
 			bld = bld.TextBody([]byte(composedTextBody))
 		} else if bodyIsHTML(body) || sigResult != nil {
 			// If signature is requested on plain-text body, auto-upgrade to HTML.
@@ -275,7 +275,7 @@ var MailSend = common.Shortcut{
 				return err
 			}
 		} else {
-			composedTextBody = body
+			composedTextBody = appendPlainTextSignature(body, sigResult)
 			bld = bld.TextBody([]byte(composedTextBody))
 		}
 		// Embed template SMALL non-inline attachments via AddAttachment.

--- a/shortcuts/mail/signature_compose.go
+++ b/shortcuts/mail/signature_compose.go
@@ -5,10 +5,13 @@ package mail
 
 import (
 	"context"
+	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -25,11 +28,67 @@ var signatureFlag = common.Flag{
 	Desc: "Optional. Signature ID to append after body content. Run `mail +signature` to list available signatures.",
 }
 
+// noSignatureFlag is the common flag definition for --no-signature, shared by all compose shortcuts.
+var noSignatureFlag = common.Flag{
+	Name: "no-signature",
+	Type: "bool",
+	Desc: "Do not append any signature, including the account's default signature.",
+}
+
+type signatureKind int
+
+const (
+	sigKindSend signatureKind = iota
+	sigKindReply
+)
+
 // signatureResult holds the pre-processed signature data ready for HTML injection.
 type signatureResult struct {
 	ID              string
 	RenderedContent string
 	Images          []draftpkg.SignatureImage
+}
+
+// resolveDefaultSignatureID returns the sender address default signature ID.
+// Automatic default lookup is best-effort: failures degrade to no signature.
+func resolveDefaultSignatureID(runtime *common.RuntimeContext, mailboxID, senderEmail string, kind signatureKind) string {
+	resp, err := signature.ListAll(runtime, mailboxID)
+	if err != nil {
+		fmt.Fprintf(runtime.IO().ErrOut, "warning: failed to resolve default mail signature: %v\n", err)
+		return ""
+	}
+	return defaultSignatureIDFromResponse(resp, senderEmail, kind)
+}
+
+func defaultSignatureIDFromResponse(resp *signature.GetSignaturesResponse, senderEmail string, kind signatureKind) string {
+	if resp == nil {
+		return ""
+	}
+	pick := func(u signature.SignatureUsage) string {
+		if kind == sigKindReply {
+			return u.ReplySignatureID
+		}
+		return u.SendMailSignatureID
+	}
+	if senderEmail != "" {
+		for _, u := range resp.Usages {
+			if strings.EqualFold(u.EmailAddress, senderEmail) {
+				return normalizeSigID(pick(u))
+			}
+		}
+	}
+	if len(resp.Usages) > 0 {
+		return normalizeSigID(pick(resp.Usages[0]))
+	}
+	return ""
+}
+
+func normalizeSigID(id string) string {
+	id = strings.TrimSpace(id)
+	if id == "" || id == "0" {
+		return ""
+	}
+	return id
 }
 
 // resolveSignature fetches, interpolates, and downloads images for a signature.
@@ -244,13 +303,66 @@ func signatureCIDs(sig *signatureResult) []string {
 	return cids
 }
 
-// validateSignatureWithPlainText returns an error if both --plain-text and --signature-id are set.
-func validateSignatureWithPlainText(plainText bool, signatureID string) error {
-	if plainText && signatureID != "" {
-		return mailValidationError("--plain-text and --signature-id are mutually exclusive: signatures require HTML mode").
+var (
+	plainTextBlockBoundaryRE = regexp.MustCompile(`(?i)</?(br|div|p|tr)\b[^>]*>`)
+	plainTextImgRE           = regexp.MustCompile(`(?is)<img\b[^>]*>`)
+	plainTextTagRE           = regexp.MustCompile(`(?is)<[^>]+>`)
+	plainTextBlankLinesRE    = regexp.MustCompile(`\n{3,}`)
+)
+
+func signatureToPlainText(renderedHTML string) string {
+	text := plainTextImgRE.ReplaceAllString(renderedHTML, "")
+	text = plainTextBlockBoundaryRE.ReplaceAllString(text, "\n")
+	text = plainTextTagRE.ReplaceAllString(text, "")
+	text = html.UnescapeString(text)
+	text = strings.ReplaceAll(text, "\u00a0", " ")
+	lines := strings.Split(text, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimSpace(lines[i])
+	}
+	text = strings.Join(lines, "\n")
+	text = plainTextBlankLinesRE.ReplaceAllString(text, "\n\n")
+	return strings.TrimSpace(text)
+}
+
+func appendPlainTextSignature(textBody string, sig *signatureResult) string {
+	if sig == nil {
+		return textBody
+	}
+	txt := signatureToPlainText(sig.RenderedContent)
+	if strings.TrimSpace(txt) == "" {
+		return textBody
+	}
+	return strings.TrimRight(textBody, "\n") + "\n\n" + txt
+}
+
+func resolveComposeSignatureID(runtime *common.RuntimeContext, mailboxID, senderEmail string, kind signatureKind) (string, bool) {
+	if runtime.Bool("no-signature") {
+		return "", false
+	}
+	signatureID := runtime.Str("signature-id")
+	if signatureID != "" {
+		return signatureID, false
+	}
+	return resolveDefaultSignatureID(runtime, mailboxID, senderEmail, kind), true
+}
+
+func resolveComposeSignature(ctx context.Context, runtime *common.RuntimeContext, mailboxID, senderEmail string, kind signatureKind) (*signatureResult, error) {
+	signatureID, autoSignature := resolveComposeSignatureID(runtime, mailboxID, senderEmail, kind)
+	sigResult, err := resolveSignature(ctx, runtime, mailboxID, signatureID, senderEmail)
+	if err != nil && autoSignature {
+		fmt.Fprintf(runtime.IO().ErrOut, "warning: failed to append default mail signature: %v\n", err)
+		return nil, nil
+	}
+	return sigResult, err
+}
+
+func validateSignatureFlags(noSig bool, signatureID string) error {
+	if noSig && signatureID != "" {
+		return mailValidationError("--no-signature and --signature-id are mutually exclusive").
 			WithParams(
-				mailInvalidParam("--plain-text", "mutually exclusive with --signature-id"),
-				mailInvalidParam("--signature-id", "requires HTML mode"),
+				mailInvalidParam("--no-signature", "mutually exclusive with --signature-id"),
+				mailInvalidParam("--signature-id", "mutually exclusive with --no-signature"),
 			)
 	}
 	return nil

--- a/shortcuts/mail/signature_compose_test.go
+++ b/shortcuts/mail/signature_compose_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/mail/signature"
 )
 
 func TestDownloadSignatureImageRejectsInvalidURLs(t *testing.T) {
@@ -174,8 +175,43 @@ func TestDownloadSignatureImageSuccessUsesFilenameContentType(t *testing.T) {
 	}
 }
 
-func TestValidateSignatureWithPlainTextTypedError(t *testing.T) {
-	err := validateSignatureWithPlainText(true, "sig_123")
+func TestSignatureToPlainText(t *testing.T) {
+	got := signatureToPlainText(`<div>Best&nbsp;regards,<br>Alice<img src="cid:x"></div><p>Mail &amp; Team</p>`)
+	want := "Best regards,\nAlice\n\nMail & Team"
+	if got != want {
+		t.Fatalf("signatureToPlainText() = %q, want %q", got, want)
+	}
+}
+
+func TestAppendPlainTextSignature(t *testing.T) {
+	got := appendPlainTextSignature("body\n\n", &signatureResult{RenderedContent: "<div>--<br>Alice</div>"})
+	want := "body\n\n--\nAlice"
+	if got != want {
+		t.Fatalf("appendPlainTextSignature() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDefaultSignatureIDMatchesSenderAndFallback(t *testing.T) {
+	resp := &signature.GetSignaturesResponse{
+		Usages: []signature.SignatureUsage{
+			{EmailAddress: "primary@example.com", SendMailSignatureID: "sig_primary", ReplySignatureID: "sig_reply_primary"},
+			{EmailAddress: "Alias@Example.com", SendMailSignatureID: "sig_alias", ReplySignatureID: "sig_reply_alias"},
+		},
+	}
+	if got := defaultSignatureIDFromResponse(resp, "alias@example.com", sigKindSend); got != "sig_alias" {
+		t.Fatalf("alias send default = %q, want sig_alias", got)
+	}
+	if got := defaultSignatureIDFromResponse(resp, "missing@example.com", sigKindReply); got != "sig_reply_primary" {
+		t.Fatalf("fallback reply default = %q, want sig_reply_primary", got)
+	}
+	resp.Usages[0].SendMailSignatureID = "0"
+	if got := defaultSignatureIDFromResponse(resp, "", sigKindSend); got != "" {
+		t.Fatalf("zero default = %q, want empty", got)
+	}
+}
+
+func TestValidateSignatureFlagsTypedError(t *testing.T) {
+	err := validateSignatureFlags(true, "sig_123")
 	var validationErr *errs.ValidationError
 	if !errors.As(err, &validationErr) {
 		t.Fatalf("expected validation error, got %T (%v)", err, err)
@@ -183,7 +219,7 @@ func TestValidateSignatureWithPlainTextTypedError(t *testing.T) {
 	if len(validationErr.Params) != 2 {
 		t.Fatalf("params = %#v, want two conflicting params", validationErr.Params)
 	}
-	if validationErr.Params[0].Name != "--plain-text" || validationErr.Params[1].Name != "--signature-id" {
+	if validationErr.Params[0].Name != "--no-signature" || validationErr.Params[1].Name != "--signature-id" {
 		t.Fatalf("unexpected params: %#v", validationErr.Params)
 	}
 }

--- a/skills/lark-mail/references/lark-mail-draft-create.md
+++ b/skills/lark-mail/references/lark-mail-draft-create.md
@@ -8,6 +8,8 @@
 
 如需修改已有草稿，不要使用此命令，请使用 `lark-cli mail +draft-edit`。
 
+未显式传 `--signature-id` 且未传 `--no-signature` 时，如当前发件地址配置了默认发信签名，命令会自动追加该签名。
+
 **CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [references/lark-mail-html.md](references/lark-mail-html.md)，其中包含邮件书写规范**
 
 ## 安全约束
@@ -55,7 +57,8 @@ lark-cli mail +draft-create --to alice@example.com --subject '测试' --body 'te
 | `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
-| `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到正文末尾。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
+| `--signature-id <id>` | 否 | 签名 ID。显式附加指定邮箱签名到正文末尾，并覆盖账号默认发信签名。运行 `mail +signature` 查看可用签名。HTML 草稿追加 HTML 签名；纯文本草稿会把签名降级为纯文本追加 |
+| `--no-signature` | 否 | 跳过所有签名，包括账号默认发信签名。不可与 `--signature-id` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
 | `--request-receipt` | 否 | 请求已读回执（RFC 3798 Message Disposition Notification）。在草稿 EML 里写 `Disposition-Notification-To: <sender>` 头，发送时生效。收件人的邮件客户端可能弹出提示、自动发送或忽略——送达不保证 |
 | `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请。需同时设置 `--event-start` 和 `--event-end` |

--- a/skills/lark-mail/references/lark-mail-forward.md
+++ b/skills/lark-mail/references/lark-mail-forward.md
@@ -9,6 +9,8 @@
 
 > **默认草稿**：`+forward` 默认保存为草稿，不会立即发送。如需立即发送，添加 `--confirm-send` 参数（仅在用户明确确认后使用）。
 
+未显式传 `--signature-id` 且未传 `--no-signature` 时，如当前发件地址配置了默认发信签名，命令会自动追加该签名。
+
 本 skill 对应 shortcut：`lark-cli mail +forward`。
 
 ## CRITICAL — 发送工作流（必须遵循）
@@ -71,7 +73,8 @@ lark-cli mail +forward --message-id <邮件ID> --to alice@example.com --dry-run
 | `--plain-text` | 否 | 强制纯文本模式，忽略所有 HTML 自动检测。不可与 `--inline` 同时使用 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔，追加在原邮件附件之后。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
-| `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到转发正文与引用块之间。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
+| `--signature-id <id>` | 否 | 签名 ID。显式附加指定邮箱签名到转发正文与引用块之间，并覆盖账号默认发信签名。运行 `mail +signature` 查看可用签名。HTML 转发追加 HTML 签名；纯文本转发会把签名降级为纯文本追加 |
+| `--no-signature` | 否 | 跳过所有签名，包括账号默认发信签名。不可与 `--signature-id` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
 | `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请。需同时设置 `--event-start` 和 `--event-end` |
 | `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601） |

--- a/skills/lark-mail/references/lark-mail-reply-all.md
+++ b/skills/lark-mail/references/lark-mail-reply-all.md
@@ -9,6 +9,8 @@
 
 > **默认草稿**：`+reply-all` 默认保存为草稿，不会立即发送。如需立即发送，添加 `--confirm-send` 参数（仅在用户明确确认后使用）。
 
+未显式传 `--signature-id` 且未传 `--no-signature` 时，如当前发件地址配置了默认回复签名，命令会自动追加该签名。
+
 本 skill 对应 shortcut：`lark-cli mail +reply-all`。
 
 ## CRITICAL — 发送工作流（必须遵循）
@@ -75,7 +77,8 @@ lark-cli mail +reply-all --message-id <邮件ID> --body '测试' --dry-run
 | `--plain-text` | 否 | 强制纯文本模式，忽略所有 HTML 自动检测。不可与 `--inline` 同时使用 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
-| `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到回复正文与引用块之间。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
+| `--signature-id <id>` | 否 | 签名 ID。显式附加指定邮箱签名到回复正文与引用块之间，并覆盖账号默认回复签名。运行 `mail +signature` 查看可用签名。HTML 回复追加 HTML 签名；纯文本回复会把签名降级为纯文本追加 |
+| `--no-signature` | 否 | 跳过所有签名，包括账号默认回复签名。不可与 `--signature-id` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
 | `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请。需同时设置 `--event-start` 和 `--event-end` |
 | `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601） |

--- a/skills/lark-mail/references/lark-mail-reply.md
+++ b/skills/lark-mail/references/lark-mail-reply.md
@@ -9,6 +9,8 @@
 
 > **默认草稿模式**：`+reply` 默认保存为草稿，不会立即发送。如需立即发送，使用 `--confirm-send` 参数（须经用户明确确认）。**优先使用 `+reply` 而不是 `+draft-create` 来创建回复草稿**，因为 `+reply` 会自动处理主题、收件人和会话头。
 
+未显式传 `--signature-id` 且未传 `--no-signature` 时，如当前发件地址配置了默认回复签名，命令会自动追加该签名。
+
 本 skill 对应 shortcut：`lark-cli mail +reply`，内部步骤：
 1. `GET /open-apis/mail/v1/user_mailboxes/me/messages/{message_id}` — 获取原邮件元数据
 2. `GET /open-apis/mail/v1/user_mailboxes/me/profile` — 获取邮箱主地址（`primary_email_address`，填入默认 From 头）
@@ -78,7 +80,8 @@ lark-cli mail +reply --message-id <邮件ID> --body '<p>测试</p>' --dry-run
 | `--plain-text` | 否 | 强制纯文本模式，忽略所有 HTML 自动检测。不可与 `--inline` 同时使用 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
-| `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到回复正文与引用块之间。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
+| `--signature-id <id>` | 否 | 签名 ID。显式附加指定邮箱签名到回复正文与引用块之间，并覆盖账号默认回复签名。运行 `mail +signature` 查看可用签名。HTML 回复追加 HTML 签名；纯文本回复会把签名降级为纯文本追加 |
+| `--no-signature` | 否 | 跳过所有签名，包括账号默认回复签名。不可与 `--signature-id` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
 | `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请。需同时设置 `--event-start` 和 `--event-end` |
 | `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601） |

--- a/skills/lark-mail/references/lark-mail-send.md
+++ b/skills/lark-mail/references/lark-mail-send.md
@@ -10,6 +10,8 @@
 
 本 skill 对应 shortcut：`lark-cli mail +send`。
 
+未显式传 `--signature-id` 且未传 `--no-signature` 时，如当前发件地址配置了默认发信签名，命令会自动追加该签名。
+
 ## CRITICAL — 发送工作流（必须遵循）
 
 **CRITICAL - 编辑邮件内容前 MUST 先用 Read 工具读取 [references/lark-mail-html.md](references/lark-mail-html.md)，其中包含邮件书写规范**
@@ -78,7 +80,8 @@ lark-cli mail +send --to alice@example.com --subject '测试' --body '<p>test</p
 | `--plain-text` | 否 | 强制纯文本模式，忽略 HTML 自动检测。不可与 `--inline` 同时使用 |
 | `--attach <paths>` | 否 | 附件文件路径，多个用逗号分隔。相对路径。当附件导致 EML 总大小超过 25 MB 时，超出部分自动上传为超大附件（HTML 邮件插入下载卡片，纯文本邮件追加下载链接），单个文件上限 3 GB |
 | `--inline <json>` | 否 | 高级用法：手动指定内嵌图片 CID 映射。推荐直接在 `--body` 中使用 `<img src="./path" />`（自动解析）。仅在需要精确控制 CID 命名时使用此参数。格式：`'[{"cid":"mycid","file_path":"./logo.png"}]'`，在 body 中用 `<img src="cid:mycid">` 引用。不可与 `--plain-text` 同时使用 |
-| `--signature-id <id>` | 否 | 签名 ID。附加邮箱签名到正文末尾。运行 `mail +signature` 查看可用签名。不可与 `--plain-text` 同时使用 |
+| `--signature-id <id>` | 否 | 签名 ID。显式附加指定邮箱签名到正文末尾，并覆盖账号默认发信签名。运行 `mail +signature` 查看可用签名。HTML 邮件追加 HTML 签名；纯文本邮件会把签名降级为纯文本追加 |
+| `--no-signature` | 否 | 跳过所有签名，包括账号默认发信签名。不可与 `--signature-id` 同时使用 |
 | `--priority <level>` | 否 | 邮件优先级：`high`、`normal`、`low`。省略或 `normal` 时不设置优先级 |
 | `--event-summary <text>` | 否 | 日程标题。设置此参数即在邮件中嵌入日程邀请（text/calendar）。需同时设置 `--event-start` 和 `--event-end` |
 | `--event-start <time>` | 条件必填 | 日程开始时间（ISO 8601，如 `2026-04-20T14:00+08:00`） |


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/f81fd50
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | lark-cli mail compose 自动追加默认签名 + --no-signature + 纯文本签名降级 | passed | fc24225 |
| S2 | Synthesize transport contract for larksuite/cli | passed | 03ea6e7 |

## Source specs

- tech-design.md#cli-端详细实施

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-signature` flag to draft, forward, reply, reply-all, and send commands to skip all signatures
  * Implemented automatic default signature selection based on sender email when no signature flag is provided

* **Documentation**
  * Updated mail command references to clarify signature behavior, override options, and mutual exclusivity of signature flags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->