### PR TITLE
fix: add @file/stdin support to drive +add-comment --content

### DIFF
--- a/shortcuts/drive/drive_add_comment.go
+++ b/shortcuts/drive/drive_add_comment.go
@@ -133,7 +133,7 @@ var DriveAddComment = common.Shortcut{
 	Flags: []common.Flag{
 		{Name: "doc", Desc: "document URL/token, file URL/token, sheet/slides URL, or wiki URL that resolves to doc/docx/file/sheet/slides", Required: true},
 		{Name: "type", Desc: "document type: doc, docx, file, sheet, slides (required when --doc is a bare token; auto-detected for URLs)", Enum: []string{"doc", "docx", "file", "sheet", "slides"}},
-		{Name: "content", Desc: "reply_elements JSON string", Required: true},
+		{Name: "content", Desc: "reply_elements JSON string", Required: true, Input: []string{common.File, common.Stdin}},
 		{Name: "full-comment", Type: "bool", Desc: "create a full-document comment; also the default when no location is provided"},
 		{Name: "selection-with-ellipsis", Desc: "target content locator (plain text or 'start...end')"},
 		{Name: "block-id", Desc: "for docx: anchor block ID; for sheet: <sheetId>!<cell> (e.g. a281f9!D6); for slides: <slide-block-type>!<xml-id> (e.g. shape!bPq)"},


### PR DESCRIPTION
## Summary

Add `@file`/stdin support to `drive +add-comment --content`.

## Why

`reply_elements` is complex JSON that's error-prone to write inline in shell. Other JSON content flags (e.g., sheets `--cells`, `--properties`) already support `@file`/stdin — this makes drive consistent.

## What

- `drive +add-comment --content` now accepts `@file` and `-` (stdin) in addition to inline JSON

## Verification

- `go test ./shortcuts/drive/` — all pass
- `go vet` — clean
- `gofmt` — clean
