### PR TITLE
fix(im): detect concrete audio file_type for mp3/wav/m4a/aac/amr/wma

### DIFF
--- a/shortcuts/im/helpers.go
+++ b/shortcuts/im/helpers.go
@@ -1033,6 +1033,18 @@ func detectIMFileType(filePath string) string {
 	switch ext {
 	case ".opus", ".ogg":
 		return "opus"
+	case ".mp3":
+		return "mp3"
+	case ".wav":
+		return "wav"
+	case ".m4a":
+		return "m4a"
+	case ".aac":
+		return "aac"
+	case ".amr":
+		return "amr"
+	case ".wma":
+		return "wma"
 	case ".mp4", ".mov", ".avi", ".mkv", ".webm":
 		return "mp4"
 	case ".pdf":

--- a/shortcuts/im/helpers_test.go
+++ b/shortcuts/im/helpers_test.go
@@ -33,6 +33,13 @@ func TestDetectIMFileType(t *testing.T) {
 	}{
 		{name: "opus", path: "voice.opus", want: "opus"},
 		{name: "ogg", path: "voice.ogg", want: "opus"},
+		{name: "mp3", path: "song.mp3", want: "mp3"},
+		{name: "mp3 uppercase", path: "song.MP3", want: "mp3"},
+		{name: "wav", path: "audio.wav", want: "wav"},
+		{name: "m4a", path: "audio.m4a", want: "m4a"},
+		{name: "aac", path: "audio.aac", want: "aac"},
+		{name: "amr", path: "voice.amr", want: "amr"},
+		{name: "wma", path: "audio.wma", want: "wma"},
 		{name: "video uppercase", path: "movie.MP4", want: "mp4"},
 		{name: "document", path: "report.docx", want: "doc"},
 		{name: "sheet", path: "data.csv", want: "xls"},


### PR DESCRIPTION
## Problem

When sending audio files via `im message send --audio song.mp3`, the CLI returns error **230055** (`file_type does not match message type`).

## Root Cause

`detectIMFileType()` in `shortcuts/im/helpers.go` had no cases for common audio extensions (.mp3, .wav, .m4a, .aac, .amr, .wma). These fell through to the default branch which returns `stream`, but the Feishu IM API expects a concrete file type like `mp3`.

## Fix

Add explicit `switch` cases for 6 common audio formats:

| Extension | file_type |
|-----------|-----------|
| .mp3 | mp3 |
| .wav | wav |
| .m4a | m4a |
| .aac | aac |
| .amr | amr |
| .wma | wma |

## Testing

- Added 7 new test cases to `TestDetectIMFileType` (including uppercase .MP3)
- All 15 test cases pass
- `go vet` clean
- `gofmt` clean

Closes #1247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio file format support expanded to recognize MP3, WAV, M4A, AAC, AMR, and WMA files.

* **Tests**
  * Added test coverage for new audio format detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->