### PR TITLE
fix(im): continue contact batch resolution on transient API failures

### DIFF
--- a/shortcuts/im/convert_lib/helpers.go
+++ b/shortcuts/im/convert_lib/helpers.go
@@ -148,6 +148,13 @@ func ResolveSenderNames(runtime *common.RuntimeContext, messages []map[string]in
 	return nameMap
 }
 
+// maxConsecutiveBatchFailures bounds how many batches in a row may fail before
+// name resolution gives up. A single transient error should not discard the
+// remaining batches, but a run of failures usually signals a systemic problem
+// (expired token, missing scope, downstream outage) where continuing would only
+// fire more doomed requests and add latency, so we break out early.
+const maxConsecutiveBatchFailures = 3
+
 // batchResolveByBasicContact resolves user names via POST /contact/v3/users/basic_batch.
 // This API has lighter permission requirements and works with user identity
 // even when the target user is not in the app's visible range.
@@ -155,6 +162,7 @@ func ResolveSenderNames(runtime *common.RuntimeContext, messages []map[string]in
 // The basic_batch endpoint caps user_ids at 10 per request.
 func batchResolveByBasicContact(runtime *common.RuntimeContext, missingIDs []string, nameMap map[string]string) {
 	const batchSize = 10
+	consecutiveFailures := 0
 	for i := 0; i < len(missingIDs); i += batchSize {
 		end := i + batchSize
 		if end > len(missingIDs) {
@@ -168,8 +176,15 @@ func batchResolveByBasicContact(runtime *common.RuntimeContext, missingIDs []str
 			map[string]interface{}{"user_ids": batch},
 		)
 		if err != nil {
+			consecutiveFailures++
+			fmt.Fprintf(runtime.IO().ErrOut, "warning: contact_basic_batch_resolve_failed: batch %d-%d: %v\n", i, end-1, err)
+			if consecutiveFailures >= maxConsecutiveBatchFailures {
+				fmt.Fprintf(runtime.IO().ErrOut, "warning: contact_basic_batch_resolve_aborted: %d consecutive failures, skipping remaining batches\n", consecutiveFailures)
+				break
+			}
 			continue
 		}
+		consecutiveFailures = 0
 
 		users, _ := data["users"].([]interface{})
 		for _, item := range users {
@@ -185,6 +200,7 @@ func batchResolveByBasicContact(runtime *common.RuntimeContext, missingIDs []str
 
 func batchResolveUsers(runtime *common.RuntimeContext, missingIDs []string, nameMap map[string]string) {
 	const batchSize = 50
+	consecutiveFailures := 0
 	for i := 0; i < len(missingIDs); i += batchSize {
 		end := i + batchSize
 		if end > len(missingIDs) {
@@ -200,8 +216,15 @@ func batchResolveUsers(runtime *common.RuntimeContext, missingIDs []string, name
 
 		data, err := runtime.DoAPIJSONTyped(http.MethodGet, apiURL, nil, nil)
 		if err != nil {
+			consecutiveFailures++
+			fmt.Fprintf(runtime.IO().ErrOut, "warning: contact_batch_resolve_failed: batch %d-%d: %v\n", i, end-1, err)
+			if consecutiveFailures >= maxConsecutiveBatchFailures {
+				fmt.Fprintf(runtime.IO().ErrOut, "warning: contact_batch_resolve_aborted: %d consecutive failures, skipping remaining batches\n", consecutiveFailures)
+				break
+			}
 			continue
 		}
+		consecutiveFailures = 0
 
 		items, _ := data["items"].([]interface{})
 		for _, item := range items {

--- a/shortcuts/im/convert_lib/helpers.go
+++ b/shortcuts/im/convert_lib/helpers.go
@@ -168,7 +168,7 @@ func batchResolveByBasicContact(runtime *common.RuntimeContext, missingIDs []str
 			map[string]interface{}{"user_ids": batch},
 		)
 		if err != nil {
-			break
+			continue
 		}
 
 		users, _ := data["users"].([]interface{})
@@ -200,7 +200,7 @@ func batchResolveUsers(runtime *common.RuntimeContext, missingIDs []string, name
 
 		data, err := runtime.DoAPIJSONTyped(http.MethodGet, apiURL, nil, nil)
 		if err != nil {
-			break
+			continue
 		}
 
 		items, _ := data["items"].([]interface{})

--- a/shortcuts/im/convert_lib/helpers_test.go
+++ b/shortcuts/im/convert_lib/helpers_test.go
@@ -223,6 +223,93 @@ func TestBatchResolveByBasicContactRespectsAPILimit(t *testing.T) {
 	}
 }
 
+func TestBatchResolveByBasicContactContinuesOnFailure(t *testing.T) {
+	callCount := 0
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/open-apis/contact/v3/users/basic_batch") {
+			return nil, fmt.Errorf("unexpected path: %s", req.URL.Path)
+		}
+		callCount++
+		if callCount == 1 {
+			return nil, fmt.Errorf("transient contact api failure")
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return nil, err
+		}
+		userIDs, _ := payload["user_ids"].([]interface{})
+		users := make([]interface{}, 0, len(userIDs))
+		for _, raw := range userIDs {
+			id, _ := raw.(string)
+			users = append(users, map[string]interface{}{
+				"user_id": id,
+				"name":    "name-" + id,
+			})
+		}
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"users": users},
+		}), nil
+	}))
+
+	missingIDs := make([]string, 15)
+	for i := range missingIDs {
+		missingIDs[i] = fmt.Sprintf("ou_%02d", i)
+	}
+	nameMap := map[string]string{}
+	batchResolveByBasicContact(runtime, missingIDs, nameMap)
+
+	if callCount != 2 {
+		t.Fatalf("API call count = %d, want 2 (should continue after first failure)", callCount)
+	}
+	if len(nameMap) != 5 {
+		t.Fatalf("resolved name count = %d, want 5 (second batch should succeed)", len(nameMap))
+	}
+	if nameMap["ou_10"] != "name-ou_10" {
+		t.Fatalf("ou_10 name = %q, want %q", nameMap["ou_10"], "name-ou_10")
+	}
+}
+
+func TestBatchResolveUsersContinuesOnFailure(t *testing.T) {
+	callCount := 0
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/open-apis/contact/v3/users/batch") {
+			return nil, fmt.Errorf("unexpected path: %s", req.URL.Path)
+		}
+		callCount++
+		if callCount == 1 {
+			return nil, fmt.Errorf("transient contact api failure")
+		}
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"open_id": "ou_batch2", "name": "Batch2 User"},
+				},
+			},
+		}), nil
+	}))
+
+	missingIDs := make([]string, 51)
+	for i := range missingIDs {
+		missingIDs[i] = fmt.Sprintf("ou_%02d", i)
+	}
+	missingIDs[50] = "ou_batch2"
+	nameMap := map[string]string{}
+	batchResolveUsers(runtime, missingIDs, nameMap)
+
+	if callCount != 2 {
+		t.Fatalf("API call count = %d, want 2", callCount)
+	}
+	if nameMap["ou_batch2"] != "Batch2 User" {
+		t.Fatalf("ou_batch2 name = %q, want %q", nameMap["ou_batch2"], "Batch2 User")
+	}
+}
+
 func TestResolveSenderNamesAPIFailure(t *testing.T) {
 	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {

--- a/shortcuts/im/convert_lib/helpers_test.go
+++ b/shortcuts/im/convert_lib/helpers_test.go
@@ -310,6 +310,88 @@ func TestBatchResolveUsersContinuesOnFailure(t *testing.T) {
 	}
 }
 
+func TestBatchResolveByBasicContactStopsAfterConsecutiveFailures(t *testing.T) {
+	// A systemic failure (e.g. expired token) makes every batch fail. The
+	// circuit breaker should stop after maxConsecutiveBatchFailures requests
+	// instead of firing one doomed request per batch.
+	callCount := 0
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/open-apis/contact/v3/users/basic_batch") {
+			return nil, fmt.Errorf("unexpected path: %s", req.URL.Path)
+		}
+		callCount++
+		return nil, fmt.Errorf("systemic contact api failure")
+	}))
+
+	// 100 IDs would be 10 batches; the breaker must cap requests well below that.
+	missingIDs := make([]string, 100)
+	for i := range missingIDs {
+		missingIDs[i] = fmt.Sprintf("ou_%03d", i)
+	}
+	nameMap := map[string]string{}
+	batchResolveByBasicContact(runtime, missingIDs, nameMap)
+
+	if callCount != maxConsecutiveBatchFailures {
+		t.Fatalf("API call count = %d, want %d (circuit breaker should stop early)", callCount, maxConsecutiveBatchFailures)
+	}
+	if len(nameMap) != 0 {
+		t.Fatalf("resolved name count = %d, want 0", len(nameMap))
+	}
+}
+
+func TestBatchResolveByBasicContactResetsFailureCountOnSuccess(t *testing.T) {
+	// Failures interleaved with successes must not trip the breaker: the
+	// counter resets on each successful batch, so resolution runs to the end.
+	callCount := 0
+	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if !strings.Contains(req.URL.Path, "/open-apis/contact/v3/users/basic_batch") {
+			return nil, fmt.Errorf("unexpected path: %s", req.URL.Path)
+		}
+		callCount++
+		// Fail every other batch; never 3 in a row.
+		if callCount%2 == 1 {
+			return nil, fmt.Errorf("transient contact api failure")
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return nil, err
+		}
+		userIDs, _ := payload["user_ids"].([]interface{})
+		users := make([]interface{}, 0, len(userIDs))
+		for _, raw := range userIDs {
+			id, _ := raw.(string)
+			users = append(users, map[string]interface{}{
+				"user_id": id,
+				"name":    "name-" + id,
+			})
+		}
+		return convertlibJSONResponse(200, map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"users": users},
+		}), nil
+	}))
+
+	// 60 IDs => 6 batches of 10; failures alternate but never reach the threshold.
+	missingIDs := make([]string, 60)
+	for i := range missingIDs {
+		missingIDs[i] = fmt.Sprintf("ou_%03d", i)
+	}
+	nameMap := map[string]string{}
+	batchResolveByBasicContact(runtime, missingIDs, nameMap)
+
+	if callCount != 6 {
+		t.Fatalf("API call count = %d, want 6 (breaker must not trip on interleaved failures)", callCount)
+	}
+	// Batches 2, 4, 6 succeed -> 30 resolved names.
+	if len(nameMap) != 30 {
+		t.Fatalf("resolved name count = %d, want 30", len(nameMap))
+	}
+}
+
 func TestResolveSenderNamesAPIFailure(t *testing.T) {
 	runtime := newBotConvertlibRuntime(t, convertlibRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		switch {


### PR DESCRIPTION
## Problem

When resolving sender display names in IM messages, a single transient API failure causes **all remaining batches** to be skipped, leaving hundreds of sender names empty.

## Root Cause

`batchResolveByBasicContact()` and `batchResolveUsers()` in `shortcuts/im/convert_lib/helpers.go` use `break` on error â€” stopping the entire loop instead of just skipping the failed batch.

Meanwhile, `batchQueryChatContexts()` in the same codebase already uses a best-effort `continue` pattern.

## Fix

Change `break` â†’ `continue` in both functions so a failed batch only loses its own entries.

| Function | Batch size | Before | After |
|----------|-----------|--------|-------|
| `batchResolveByBasicContact` | 10 | break on error | continue |
| `batchResolveUsers` | 50 | break on error | continue |

## Testing

- Added `TestBatchResolveByBasicContactContinuesOnFailure` â€” first batch fails, second succeeds, verifies partial results
- Added `TestBatchResolveUsersContinuesOnFailure` â€” same pattern for bot identity path
- All existing tests pass (62 tests)
- `go vet` clean
- `gofmt` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Batch name resolution now tolerates transient API failures (continuing to produce partial results), emits warnings on repeated errors, and stops further retries after a small number of consecutive failures; successful responses reset the failure count so processing can resume.

* **Tests**
  * Added tests covering transient-failure handling, circuit-breaker behavior, and reset-on-success scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->