### PR TITLE
fix(im): return partial mget results in messages search instead of all-or-nothing

### DIFF
--- a/shortcuts/im/im_messages_search.go
+++ b/shortcuts/im/im_messages_search.go
@@ -121,9 +121,8 @@ var ImMessagesSearch = common.Shortcut{
 		}
 
 		// ── Step 2: Batch fetch message details (mget) ──
-		msgItems, err := batchMGetMessages(runtime, messageIds)
-		if err != nil {
-			// Fallback when mget fails: return ID list only
+		msgItems := batchMGetMessages(runtime, messageIds)
+		if len(msgItems) == 0 {
 			outData := map[string]interface{}{
 				"message_ids": messageIds,
 				"total":       len(messageIds),
@@ -444,17 +443,17 @@ func searchMessages(runtime *common.RuntimeContext, req *messagesSearchRequest) 
 	return allItems, lastHasMore, lastPageToken, truncatedByLimit, pageLimit, nil
 }
 
-func batchMGetMessages(runtime *common.RuntimeContext, messageIds []string) ([]interface{}, error) {
+func batchMGetMessages(runtime *common.RuntimeContext, messageIds []string) []interface{} {
 	var items []interface{}
 	for _, batch := range chunkStrings(messageIds, messagesSearchMGetBatchSize) {
 		mgetData, err := runtime.DoAPIJSONTyped(http.MethodGet, buildMGetURL(batch), nil, nil)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		batchItems, _ := mgetData["items"].([]interface{})
 		items = append(items, batchItems...)
 	}
-	return items, nil
+	return items
 }
 
 func batchQueryChatContexts(runtime *common.RuntimeContext, chatIds []string) map[string]map[string]interface{} {

--- a/shortcuts/im/im_messages_search_execute_test.go
+++ b/shortcuts/im/im_messages_search_execute_test.go
@@ -268,3 +268,64 @@ func buildChatContexts(chatIDs []string) []interface{} {
 	}
 	return items
 }
+
+func TestImMessagesSearchMgetPartialResults(t *testing.T) {
+	var mgetCalls int
+
+	runtime := newMessagesSearchRuntime(t, map[string]string{
+		"query": "incident",
+	}, map[string]bool{
+		"page-all": true,
+	}, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case strings.Contains(req.URL.Path, "/open-apis/im/v1/messages/search"):
+			return shortcutJSONResponse(200, map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"items":    buildSearchResultItems(1, 55),
+					"has_more": false,
+				},
+			}), nil
+		case strings.Contains(req.URL.Path, "/open-apis/im/v1/messages/mget"):
+			mgetCalls++
+			if mgetCalls == 1 {
+				return nil, fmt.Errorf("transient mget failure")
+			}
+			ids := req.URL.Query()["message_ids"]
+			return shortcutJSONResponse(200, map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"items": buildMessageDetails(ids),
+				},
+			}), nil
+		case strings.Contains(req.URL.Path, "/open-apis/im/v1/chats/batch_query"):
+			var body struct {
+				ChatIDs []string `json:"chat_ids"`
+			}
+			rawBody, _ := io.ReadAll(req.Body)
+			json.Unmarshal(rawBody, &body)
+			return shortcutJSONResponse(200, map[string]interface{}{
+				"code": 0,
+				"data": map[string]interface{}{
+					"items": buildChatContexts(body.ChatIDs),
+				},
+			}), nil
+		default:
+			return nil, fmt.Errorf("unexpected request: %s", req.URL.String())
+		}
+	}))
+
+	if err := ImMessagesSearch.Execute(context.Background(), runtime); err != nil {
+		t.Fatalf("ImMessagesSearch.Execute() error = %v", err)
+	}
+
+	if mgetCalls != 2 {
+		t.Fatalf("mgetCalls = %d, want 2 (first batch fails, second succeeds)", mgetCalls)
+	}
+
+	outBuf, _ := runtime.Factory.IOStreams.Out.(*bytes.Buffer)
+	output := outBuf.String()
+	if !strings.Contains(output, "5 search result(s)") {
+		t.Fatalf("stdout should contain 5 partial results, got: %s", output)
+	}
+}


### PR DESCRIPTION
## Problem

In `+messages-search`, when the batch mget step fails for any single chunk, **all** message details are discarded and replaced with a bare `message_ids` list. AI agents lose all message content, sender names, and timestamps.

## Root Cause

`batchMGetMessages()` in `shortcuts/im/im_messages_search.go` returns `nil, err` on the first batch failure, and the caller falls back to ID-only output.

With 55 search results split into 2 mget batches (50 + 5), a transient failure on batch 1 loses all 55 messages even though batch 2 would succeed.

## Fix

Change `batchMGetMessages` to best-effort:
- `continue` on batch failure instead of `return nil, err`
- Return partial results (successfully fetched batches)
- When all batches fail â†’ empty slice â†’ existing fallback still applies

Also simplified the function signature from `([]interface{}, error)` to `[]interface{` since errors are no longer propagated.

## Testing

- Added `TestImMessagesSearchMgetPartialResults` â€” 55 IDs in 2 batches, first fails, second succeeds, verifies 5 partial results returned
- All existing tests pass (3/3)
- `go vet` clean
- `gofmt` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IM message search resilience to handle transient API failures gracefully. The search now returns available partial results instead of failing entirely when some message details cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->