### PR TITLE
fix: gate cached meta overlay on version newer than embedded

### DIFF
--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/update"
 )
 
 //go:embed scope_priorities.json scope_overrides.json
@@ -110,7 +111,11 @@ func InitWithBrand(brand core.LarkBrand) {
 			brandChanged := metaErr == nil && meta.Brand != "" && meta.Brand != string(brand)
 
 			if !brandChanged {
-				if cached, err := loadCachedMerged(); err == nil {
+				// Only overlay the cached remote definitions when their version is
+				// strictly newer than the embedded baseline. Versions are not bumped
+				// on every CLI release, so an equal/older cache must not shadow the
+				// freshly shipped embedded commands.
+				if cached, err := loadCachedMerged(); err == nil && update.IsNewer(cached.Version, embeddedVersion) {
 					overlayMergedServices(cached)
 				}
 			}

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/larksuite/cli/internal/core"
+)
+
+// seedCache writes a cache file + meta for service `name` whose `title` field is
+// `marker`, tagged with the given top-level data version and brand.
+func seedCache(t *testing.T, dir, name, marker, version, brand string) {
+	t.Helper()
+	cDir := filepath.Join(dir, "cache")
+	if err := os.MkdirAll(cDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	reg := MergedRegistry{
+		Version: version,
+		Services: []map[string]interface{}{
+			{"name": name, "version": "cache", "title": marker},
+		},
+	}
+	data, _ := json.Marshal(reg)
+	if err := os.WriteFile(filepath.Join(cDir, "remote_meta.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	meta := CacheMeta{LastCheckAt: time.Now().Unix(), Version: version, Brand: brand}
+	mData, _ := json.Marshal(meta)
+	if err := os.WriteFile(filepath.Join(cDir, "remote_meta.meta.json"), mData, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setEmbedded overrides the compiled-in embedded meta for the duration of the test.
+func setEmbedded(t *testing.T, name, marker, version string) {
+	t.Helper()
+	orig := embeddedMetaJSON
+	t.Cleanup(func() { embeddedMetaJSON = orig })
+	reg := MergedRegistry{
+		Version: version,
+		Services: []map[string]interface{}{
+			{"name": name, "version": "embedded", "title": marker},
+		},
+	}
+	embeddedMetaJSON, _ = json.Marshal(reg)
+}
+
+// clearEmbedded removes the compiled-in embedded meta for the duration of the
+// test, so cache-overlay behavior is governed purely by the cache version
+// (embeddedVersion resolves to "" → IsNewer treats any parseable cache as newer).
+// Used by cache-focused tests that must overlay regardless of the ambient
+// fetch_meta-generated meta_data.json version.
+func clearEmbedded(t *testing.T) {
+	t.Helper()
+	orig := embeddedMetaJSON
+	t.Cleanup(func() { embeddedMetaJSON = orig })
+	embeddedMetaJSON = nil
+}
+
+// initWithCache sets up a fresh feishu-brand init with remote on, TTL high so no
+// background refresh fires, embedded data per setEmbedded, and a pre-seeded cache.
+func initWithCache(t *testing.T, embeddedVer, cacheVer string) {
+	t.Helper()
+	// Restore package globals after the test so InitWithBrand's sync.Once and the
+	// merged service map do not leak into order-dependent tests (e.g. registry_test.go's
+	// TestComputeMinimumScopeSet, which relies on a fresh Init). Registered first so it
+	// runs last (LIFO), after t.Setenv reverts and the embedded-meta restore.
+	t.Cleanup(resetInit)
+	tmp := t.TempDir()
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", tmp)
+	t.Setenv("LARKSUITE_CLI_REMOTE_META", "on")
+	t.Setenv("LARKSUITE_CLI_META_TTL", "3600") // recent LastCheckAt + high TTL → no refresh
+	resetInit()
+	setEmbedded(t, "svc", "EMBEDDED", embeddedVer)
+	seedCache(t, tmp, "svc", "CACHE", cacheVer, "feishu")
+	InitWithBrand(core.BrandFeishu)
+}
+
+func titleOf(t *testing.T, name string) string {
+	t.Helper()
+	svc := LoadFromMeta(name)
+	if svc == nil {
+		t.Fatalf("service %q not loaded", name)
+	}
+	return svc["title"].(string)
+}
+
+func TestOverlayGate_EqualVersion_UsesEmbedded(t *testing.T) {
+	initWithCache(t, "1.0.0", "1.0.0")
+	if got := titleOf(t, "svc"); got != "EMBEDDED" {
+		t.Errorf("equal version: got %q, want EMBEDDED (cache must not overlay)", got)
+	}
+}
+
+func TestOverlayGate_OlderCache_UsesEmbedded(t *testing.T) {
+	initWithCache(t, "2.0.0", "1.0.0")
+	if got := titleOf(t, "svc"); got != "EMBEDDED" {
+		t.Errorf("older cache: got %q, want EMBEDDED", got)
+	}
+}
+
+func TestOverlayGate_NewerCache_OverlaysCache(t *testing.T) {
+	initWithCache(t, "1.0.0", "2.0.0")
+	if got := titleOf(t, "svc"); got != "CACHE" {
+		t.Errorf("newer cache: got %q, want CACHE", got)
+	}
+}
+
+func TestOverlayGate_UnparseableCacheVersion_UsesEmbedded(t *testing.T) {
+	initWithCache(t, "1.0.0", "not-a-semver")
+	if got := titleOf(t, "svc"); got != "EMBEDDED" {
+		t.Errorf("unparseable cache version: got %q, want EMBEDDED", got)
+	}
+}
+
+func TestOverlayGate_EmptyEmbedded_OverlaysRealCache(t *testing.T) {
+	// embedded default is "0.0.0"; a real cache version must win so open-source
+	// builds without compiled meta_data.json still get remote data.
+	initWithCache(t, "0.0.0", "1.0.0")
+	if got := titleOf(t, "svc"); got != "CACHE" {
+		t.Errorf("empty-embedded baseline: got %q, want CACHE", got)
+	}
+}

--- a/internal/registry/remote_test.go
+++ b/internal/registry/remote_test.go
@@ -68,9 +68,11 @@ func hasEmbeddedServices() bool {
 }
 
 // testRegistry returns a minimal MergedRegistry with one service.
+// The version is a real semver newer than the embedded baseline ("0.0.0") so
+// cache overlay passes the version gate in InitWithBrand.
 func testRegistry(name string) MergedRegistry {
 	return MergedRegistry{
-		Version: "test-1.0",
+		Version: "1.0.0",
 		Services: []map[string]interface{}{
 			{
 				"name":        name,
@@ -157,6 +159,8 @@ func TestRemoteOff_SkipsRemoteLogic(t *testing.T) {
 
 func TestCacheHit_WithinTTL(t *testing.T) {
 	resetInit()
+	t.Cleanup(resetInit)
+	clearEmbedded(t) // overlay must depend only on the cache version, not the ambient embedded meta
 	tmp := t.TempDir()
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", tmp)
 	t.Setenv("LARKSUITE_CLI_REMOTE_META", "on")
@@ -194,6 +198,8 @@ func TestCacheHit_WithinTTL(t *testing.T) {
 
 func TestNetworkError_SilentDegradation(t *testing.T) {
 	resetInit()
+	t.Cleanup(resetInit)
+	clearEmbedded(t) // overlay must depend only on the cache version, not the ambient embedded meta
 	tmp := t.TempDir()
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", tmp)
 	t.Setenv("LARKSUITE_CLI_REMOTE_META", "on")
@@ -367,8 +373,8 @@ func TestFetchRemoteMerged_200(t *testing.T) {
 	if data == nil {
 		t.Fatal("expected non-nil data")
 	}
-	if reg.Version != "test-1.0" {
-		t.Errorf("expected version test-1.0, got %s", reg.Version)
+	if reg.Version != "1.0.0" {
+		t.Errorf("expected version 1.0.0, got %s", reg.Version)
 	}
 }
 


### PR DESCRIPTION
## Summary

Cached remote meta was overlaid onto the embedded `meta_data.json` unconditionally. Because the embedded data version is not bumped on each CLI release, a cache with the same (or older) version would shadow the freshly shipped embedded command definitions — so after upgrading the CLI, newly bundled commands were never used.

## Changes

- Gate the cache overlay in `InitWithBrand` (`internal/registry/loader.go`) on `update.IsNewer(cached.Version, embeddedVersion)`: only overlay when the cache version is strictly newer than the embedded baseline
- Add `internal/registry/loader_test.go` with unit tests for the gate (equal / older / newer / unparseable / empty-embedded)
- Decouple two cache-overlay regression tests in `internal/registry/remote_test.go` from the ambient embedded version (the CI-fetched `meta_data.json`)

## Test Plan

- [x] `make unit-test` passed (`go test ./internal/registry/`, both real and default embedded meta, deterministic)
- [x] validate passed (build / vet / gofmt clean)
- [ ] local-eval passed — skipped: lite mode, no new E2E and no shortcut/skill change
- [x] acceptance-reviewer passed (3/3 cases)
- [x] manual verification: built the binary, injected a stale cache (`version == embedded`) → injected service absent; bumped cache to a newer version → service overlaid; unparseable version → falls back to embedded, exit 0

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced service metadata loading to ensure cached versions only override embedded definitions when newer. This prevents outdated cached metadata from incorrectly replacing current embedded definitions, maintaining data freshness and accuracy during service initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->