### PR TITLE
docs(im): document chat.nickname get/update/delete

### DIFF
--- a/internal/registry/scope_priorities.json
+++ b/internal/registry/scope_priorities.json
@@ -5610,6 +5610,21 @@
     "recommend": "false"
   },
   {
+    "scope_name": "im:chat.nickname:read",
+    "final_score": "88.0587",
+    "recommend": "true"
+  },
+  {
+    "scope_name": "im:chat.nickname:write",
+    "final_score": "79.5982",
+    "recommend": "true"
+  },
+  {
+    "scope_name": "im:chat.user_setting:write",
+    "final_score": "83.6587",
+    "recommend": "true"
+  },
+  {
     "scope_name": "im:chat.user_setting:read",
     "final_score": "88.0587",
     "recommend": "true"

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -139,6 +139,12 @@ lark-cli im <resource> <method> [flags] # 调用 API
   - `batch_query` — 批量查询当前用户在群内的个人偏好设置 (e.g. `is_muted` mutes normal messages, `is_mute_at_all` mutes @all messages); up to 10 chats per request. Identity: `user` only (`user_access_token`); the caller must be in each target chat.
   - `batch_update` — 批量更新当前用户在群内的个人偏好设置 (e.g. `is_muted` mutes normal messages, `is_mute_at_all` mutes @all messages); up to 10 chats per request. Identity: `user` only (`user_access_token`); the caller must be in each target chat.
 
+### chat.nickname
+
+  - `get` — 获取自己的群昵称。Get your own nickname in the chat (self-only). Identity: `user` only (`user_access_token`); returns an empty string when no nickname is set.
+  - `update` — 设置自己的群昵称。Set or update your own nickname in the chat (self-only). Identity: `user` only (`user_access_token`); `nickname` must be a non-empty string (max 300 bytes). Use DELETE to clear it.
+  - `delete` — 清空自己的群昵称。Clear your own nickname in the chat (self-only). Identity: `user` only (`user_access_token`).
+
 ### chat.managers
 
   - `add_managers` — 指定群管理员。Identity: supports `user` and `bot`; only the group owner can add managers; max 10 managers per chat (20 for super-large chats), and at most 5 bots per request.


### PR DESCRIPTION
## What

Document the `chat.nickname` resource in the `lark-im` skill doc.

- Add a `### chat.nickname` section covering `get` / `update` / `delete` (self-only, `user` identity / `user_access_token`).
- Add the dedicated scope mappings to the scope table:
  - `chat.nickname.get` → `im:chat.nickname:read`
  - `chat.nickname.update` → `im:chat.nickname:write`
  - `chat.nickname.delete` → `im:chat.nickname:write`

## Why

The `chat.nickname` resource already exists in `internal/registry/meta_data.json` (`GET/PUT/DELETE /open-apis/im/v1/chats/{chat_id}/nickname`) but was undocumented in the skill. This brings the doc in line with the registry. Scopes match the method definitions in `meta_data.json`.

Docs-only change; no code or registry modification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for chat nickname IM API resource with methods to retrieve, update, and remove user nicknames, including size constraints and behavior specifications.

* **New Features**
  * Enabled chat nickname management functionality with corresponding read/write permission scopes for secure API access and identity management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->