### PR TITLE
feat: support riscv64 prebuilt binaries in release and install

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - riscv64
 
 archives:
   - name_template: "lark-cli-{{ .Version }}-{{ .Os }}-{{ .Arch }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ```bash
 make build          # Build (runs fetch_meta first)
-make unit-test      # Required before PR (runs with -race)
+make unit-test      # Required before PR (runs with -race where supported, e.g. amd64/arm64)
 make test           # Full: vet + unit + integration
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ DATE     := $(shell date +%Y-%m-%d)
 LDFLAGS  := -s -w -X $(MODULE)/internal/build.Version=$(VERSION) -X $(MODULE)/internal/build.Date=$(DATE)
 PREFIX   ?= /usr/local
 
+# -race is not supported on linux/riscv64 before Go 1.26.
+RACE_FLAG := $(shell go env GOARCH | grep -qv '^riscv64$$' && echo '-race' || echo '')
+
 .PHONY: all build vet fmt-check test unit-test integration-test examples-build install uninstall clean fetch_meta gitleaks
 
 all: test
@@ -34,7 +37,7 @@ fmt-check:
 
 # ./extension/... keeps the public plugin SDK in the default test matrix.
 unit-test: fetch_meta
-	go test -race -gcflags="all=-N -l" -count=1 \
+	go test $(RACE_FLAG) -gcflags="all=-N -l" -count=1 \
 		./cmd/... ./internal/... ./shortcuts/... ./extension/...
 
 # examples-build keeps the shipped plugin-SDK examples compilable. If this

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,12 @@ DATE     := $(shell date +%Y-%m-%d)
 LDFLAGS  := -s -w -X $(MODULE)/internal/build.Version=$(VERSION) -X $(MODULE)/internal/build.Date=$(DATE)
 PREFIX   ?= /usr/local
 
-# -race is not supported on linux/riscv64 before Go 1.26.
-RACE_FLAG := $(shell go env GOARCH | grep -qv '^riscv64$$' && echo '-race' || echo '')
+# The repository's Go 1.23 CI toolchain does not support -race on riscv64.
+# Prefer GOARCH passed to make (for example, `make GOARCH=riscv64 unit-test`)
+# over `go env GOARCH`, because command-line make variables are not visible to
+# $(shell ...).
+TEST_GOARCH := $(or $(GOARCH),$(shell go env GOARCH))
+RACE_FLAG := $(if $(filter riscv64,$(TEST_GOARCH)),,-race)
 
 .PHONY: all build vet fmt-check test unit-test integration-test examples-build install uninstall clean fetch_meta gitleaks
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   ],
   "cpu": [
     "x64",
-    "arm64"
+    "arm64",
+    "riscv64"
   ],
   "engines": {
     "node": ">=16"

--- a/scripts/build-pkg-pr-new.sh
+++ b/scripts/build-pkg-pr-new.sh
@@ -33,6 +33,7 @@ build_target darwin arm64
 build_target linux amd64
 build_target darwin amd64
 build_target linux arm64
+build_target linux riscv64
 build_target windows amd64
 build_target windows arm64
 
@@ -55,6 +56,7 @@ const platformMap = {
 const archMap = {
   x64: "amd64",
   arm64: "arm64",
+  riscv64: "riscv64",
 };
 
 const platform = platformMap[process.platform];

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -30,6 +30,7 @@ const PLATFORM_MAP = {
 const ARCH_MAP = {
   x64: "amd64",
   arm64: "arm64",
+  riscv64: "riscv64",
 };
 
 const platform = PLATFORM_MAP[process.platform];


### PR DESCRIPTION
## Summary

Re-homes #1297 onto a branch in the upstream repo and cherry-picks it onto the current `main`. Original feature by @rockyzhang — the two original commits are preserved; a follow-up commit applies review feedback.

Adds `linux/riscv64` as a supported target so lark-cli builds, releases, and installs natively on RISC-V 64-bit hardware. lark-cli is pure Go built with `CGO_ENABLED=0` and has no architecture-specific code, so riscv64 needs only distribution-list additions — no product code changes.

## Changes

- `.goreleaser.yml`: add `riscv64` to the build `goarch` list. goreleaser v2 auto-skips the invalid `darwin/riscv64` and `windows/riscv64` combos, so no `ignore` rule is needed.
- `package.json`: add `riscv64` to the npm `cpu` list so npm does not reject installation on riscv64 hosts.
- `scripts/install.js`: add `riscv64: "riscv64"` to `ARCH_MAP` so the postinstall binary download resolves `lark-cli-<version>-linux-riscv64.tar.gz`.
- `scripts/build-pkg-pr-new.sh`: build the `linux/riscv64` preview target and map it in the embedded runner's `archMap`.
- `Makefile`, `AGENTS.md` (original commit): make the test `-race` flag architecture-conditional — the Go 1.23 toolchain has no race detector on riscv64.
- `Makefile` (follow-up commit): derive the guard with a make-native `TEST_GOARCH := $(or $(GOARCH),$(shell go env GOARCH))` filter so it also honors `make GOARCH=riscv64 unit-test`, and restore the trailing newline the original commit dropped.

## Test Plan

- [x] validate passed: native `go build ./...`, `GOOS=linux GOARCH=riscv64 CGO_ENABLED=0 go build ./...`, `go vet ./...`, gofmt clean, `node --test scripts/install.test.js` (32/32)
- [x] security code review passed (0 findings)
- [x] manual verification: riscv64 cross-compile produces a valid `UCB RISC-V` statically-linked ELF; `make GOARCH=riscv64 -n unit-test` shows `go test` without `-race` while the default amd64 path keeps `-race`; the full npm install chain (download → SHA-256 → extract → run) was exercised on emulated riscv64 (QEMU + container)
- [ ] `make unit-test`: pre-existing local-load flake, unrelated to this change — `internal/binding` (`TestResolveExecRef_*`) and `internal/selfupdate` (`TestVerifyBinaryLookPath`) time out (~10s) only under the full concurrent `-race` run; each passes in isolation (~2s). This diff touches no Go code, so behavior is identical to `main`; CI is the authoritative gate.
- [ ] skipped: sandbox E2E / skillave — build & release-pipeline config change, no CLI command or shortcut behavior to exercise
- [ ] skipped: acceptance-reviewer — no user-facing UX change

## Related Issues

N/A — re-homes PR #1297 (a PR, not a tracking issue); maintainer can close #1297 on merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added riscv64 support: releases now include a riscv64 binary, runtime selects it on riscv64 platforms, and the installer/downloads recognize riscv64 archives.

* **Build / Packaging**
  * CPU compatibility lists updated to include riscv64 and packaging now produces riscv64 artifacts.

* **Documentation**
  * Clarified unit-test guidance: the Go race detector runs only on platforms that support it (e.g., not on riscv64).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->