### PR TITLE
fix: write skills state timestamps in local time

### DIFF
--- a/internal/skillscheck/sync.go
+++ b/internal/skillscheck/sync.go
@@ -335,7 +335,7 @@ func SyncSkills(opts SyncOptions) *SyncResult {
 		UpdatedSkills:        plan.ToUpdate,
 		AddedOfficialSkills:  plan.Added,
 		SkippedDeletedSkills: plan.SkippedDeleted,
-		UpdatedAt:            opts.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:            opts.Now().Format(time.RFC3339),
 	}
 	if err := WriteState(state); err != nil {
 		result.Action = "failed"
@@ -428,7 +428,7 @@ func fallbackFullInstall(opts SyncOptions, reason string, official []string) *Sy
 		UpdatedSkills:        official,
 		AddedOfficialSkills:  official,
 		SkippedDeletedSkills: []string{},
-		UpdatedAt:            opts.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:            opts.Now().Format(time.RFC3339),
 	}
 	if writeErr := WriteState(state); writeErr != nil {
 		return &SyncResult{

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -339,7 +339,9 @@ func TestSyncSkills_WritesStateAndDoesNotWriteStamp(t *testing.T) {
 	result := SyncSkills(SyncOptions{
 		Version: "1.0.33",
 		Runner:  runner,
-		Now:     func() time.Time { return time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC) },
+		Now: func() time.Time {
+			return time.Date(2026, 5, 18, 12, 0, 0, 0, time.FixedZone("UTC+8", 8*60*60))
+		},
 	})
 
 	if result.Err != nil {
@@ -361,6 +363,9 @@ func TestSyncSkills_WritesStateAndDoesNotWriteStamp(t *testing.T) {
 	assertStrings(t, state.UpdatedSkills, []string{"lark-calendar", "lark-new"})
 	assertStrings(t, state.AddedOfficialSkills, []string{"lark-new"})
 	assertStrings(t, state.SkippedDeletedSkills, []string{"lark-mail"})
+	if state.UpdatedAt != "2026-05-18T12:00:00+08:00" {
+		t.Errorf("state.UpdatedAt = %q, want local RFC3339 timestamp", state.UpdatedAt)
+	}
 	if _, err := os.Stat(filepath.Join(dir, "skills.stamp")); !os.IsNotExist(err) {
 		t.Fatalf("skills.stamp exists or stat failed with unexpected err: %v", err)
 	}
@@ -584,7 +589,13 @@ func TestSyncSkills_ParseEmptyLocalListsFallBackToFullInstall(t *testing.T) {
 		globalOut:        "Some unrecognized output format\n",
 	}
 
-	result := SyncSkills(SyncOptions{Version: "1.0.33", Runner: runner, Now: time.Now})
+	result := SyncSkills(SyncOptions{
+		Version: "1.0.33",
+		Runner:  runner,
+		Now: func() time.Time {
+			return time.Date(2026, 5, 18, 12, 0, 0, 0, time.FixedZone("UTC-7", -7*60*60))
+		},
+	})
 	if result.Action != "fallback_synced" {
 		t.Fatalf("SyncSkills() action = %q, want fallback_synced", result.Action)
 	}
@@ -593,6 +604,13 @@ func TestSyncSkills_ParseEmptyLocalListsFallBackToFullInstall(t *testing.T) {
 	}
 	if runner.installedAll != 1 {
 		t.Fatalf("installedAll = %d, want 1", runner.installedAll)
+	}
+	state, readable, err := ReadState()
+	if err != nil || !readable {
+		t.Fatalf("ReadState() = (_, %v, %v), want readable", readable, err)
+	}
+	if state.UpdatedAt != "2026-05-18T12:00:00-07:00" {
+		t.Errorf("state.UpdatedAt = %q, want local RFC3339 timestamp", state.UpdatedAt)
 	}
 }
 


### PR DESCRIPTION
## Summary

`lark-cli update` wrote `skills-state.json.updated_at` in UTC even when the
sync ran in a local timezone. This PR preserves the local RFC3339 offset for
both incremental sync and full-install fallback state writes.

## Changes

- Preserve the original `time.Time` offset in `internal/skillscheck/sync.go`
  for incremental sync state writes
- Preserve the original `time.Time` offset in `internal/skillscheck/sync.go`
  for full-install fallback state writes
- Add offset-preservation regression tests in
  `internal/skillscheck/sync_test.go` for `+08:00` and `-07:00`

## Test Plan

- [x] `make unit-test` passed
- [x] validate passed
- [ ] skipped: local-eval passed (lite mode; no shortcut/skill change and no
  applicable sandbox E2E or skillave layer)
- [x] acceptance-reviewer passed (2/2 cases)
- [x] manual verification: `make build`, `./lark-cli update --help`, `go test ./internal/skillscheck -run '^TestSyncSkills_WritesStateAndDoesNotWriteStamp$' -count=1 -v`, `go test ./internal/skillscheck -run '^TestSyncSkills_ParseEmptyLocalListsFallBackToFullInstall$' -count=1 -v`

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed timestamp formatting for skill state updates to properly preserve local timezone information instead of always converting to UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->