### PR TITLE
feat: exclude .git directory from apps +html-publish package

### DIFF
--- a/shortcuts/apps/walk_html_publish_candidates.go
+++ b/shortcuts/apps/walk_html_publish_candidates.go
@@ -56,10 +56,9 @@ func walkHTMLPublishCandidates(fio fileio.FileIO, rootPath string) ([]htmlPublis
 		if walkErr != nil {
 			return walkErr
 		}
-		// 排除 git 仓库内部目录/指针文件：名为 .git 的目录整棵子树跳过，
-		// 名为 .git 的普通文件（submodule/worktree 的 gitdir 指针）也跳过。
-		// 精确等值匹配，.github / .gitignore / .gitattributes 等不受影响。
-		// git 内部内容对发布的静态站点无用，且会泄露 remote URL / 历史快照。
+		// Skip a stray git repo: a directory named .git skips the whole subtree,
+		// and a .git file (the gitdir pointer used by submodules/worktrees) is
+		// skipped too.
 		if d.Name() == ".git" {
 			if d.IsDir() {
 				return filepath.SkipDir

--- a/shortcuts/apps/walk_html_publish_candidates.go
+++ b/shortcuts/apps/walk_html_publish_candidates.go
@@ -56,6 +56,16 @@ func walkHTMLPublishCandidates(fio fileio.FileIO, rootPath string) ([]htmlPublis
 		if walkErr != nil {
 			return walkErr
 		}
+		// 排除 git 仓库内部目录/指针文件：名为 .git 的目录整棵子树跳过，
+		// 名为 .git 的普通文件（submodule/worktree 的 gitdir 指针）也跳过。
+		// 精确等值匹配，.github / .gitignore / .gitattributes 等不受影响。
+		// git 内部内容对发布的静态站点无用，且会泄露 remote URL / 历史快照。
+		if d.Name() == ".git" {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
 		if d.IsDir() {
 			return nil
 		}

--- a/shortcuts/apps/walk_html_publish_candidates_test.go
+++ b/shortcuts/apps/walk_html_publish_candidates_test.go
@@ -113,6 +113,102 @@ func TestIsUnsafeRelPath(t *testing.T) {
 	}
 }
 
+func TestWalkHTMLPublishCandidates_ExcludesGitDir(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"index.html":               "<html></html>",
+		".git/config":              "[core]\n",
+		".git/HEAD":                "ref: refs/heads/main\n",
+		".git/objects/ab/cdef123":  "binary",
+		".github/workflows/ci.yml": "on: push\n",
+		".gitignore":               "node_modules\n",
+	}
+	for rel, content := range files {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	got, err := walkHTMLPublishCandidates(newTestFIO(), dir)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	rels := make(map[string]bool)
+	for _, c := range got {
+		rels[c.RelPath] = true
+	}
+	// .git 子树整体排除
+	for _, banned := range []string{".git/config", ".git/HEAD", ".git/objects/ab/cdef123"} {
+		if rels[banned] {
+			t.Errorf("%q should be excluded from candidates", banned)
+		}
+	}
+	// 相邻名不受影响
+	for _, kept := range []string{"index.html", ".github/workflows/ci.yml", ".gitignore"} {
+		if !rels[kept] {
+			t.Errorf("%q should be kept in candidates, got %+v", kept, got)
+		}
+	}
+}
+
+func TestWalkHTMLPublishCandidates_ExcludesNestedGitDir(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"index.html":      "<html></html>",
+		"sub/.git/config": "[core]\n",
+		"sub/page.html":   "<html></html>",
+	}
+	for rel, content := range files {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	got, err := walkHTMLPublishCandidates(newTestFIO(), dir)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	rels := make(map[string]bool)
+	for _, c := range got {
+		rels[c.RelPath] = true
+	}
+	if rels["sub/.git/config"] {
+		t.Errorf("nested sub/.git/config should be excluded, got %+v", got)
+	}
+	if !rels["sub/page.html"] || !rels["index.html"] {
+		t.Errorf("non-git files should be kept, got %+v", got)
+	}
+}
+
+func TestWalkHTMLPublishCandidates_ExcludesGitFile(t *testing.T) {
+	// submodule / worktree 场景：.git 是个 gitdir 指针文件，不是目录。
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<html></html>"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: /elsewhere\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := walkHTMLPublishCandidates(newTestFIO(), dir)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	for _, c := range got {
+		if c.RelPath == ".git" {
+			t.Errorf(".git pointer file should be excluded, got %+v", got)
+		}
+	}
+}
+
 func TestWalkHTMLPublishCandidates_SymlinkSkipped(t *testing.T) {
 	// Walker 只接受 regular file —— symlink 跳过（避免 loop + out-of-root 引用，
 	// 且 fio.Open 对 symlink 行为不一致）。real.html 仍然被收，link.html 不在结果里。

--- a/skills/lark-apps/references/lark-apps-html-publish.md
+++ b/skills/lark-apps/references/lark-apps-html-publish.md
@@ -38,7 +38,7 @@ lark-cli apps +html-publish --app-id app_xxx --path ./index.html --dry-run
 - 用户只说“用 HTML 写个 PPT/页面给我看看”时，先生成本地文件或目录，返回路径并问是否发布到妙搭分享；不要默认创建应用或部署。
 - 用户明确说“部署出去/发链接/可分享”时，才创建 `html` 应用并用 `+html-publish`。
 - 用户要发布但没有 app_id 时，先 `+create --app-type html` 创建应用；应用名可从页面/站点主题生成，不要让用户手动提供 app_id。
-- 若产物首页不是 `index.html`，发布前改名或复制为 `index.html`；目录发布时只传干净产物目录，例如 `./dist`，不要把 `.git`、`node_modules`、源码缓存一起带上。
+- 若产物首页不是 `index.html`，发布前改名或复制为 `index.html`；目录发布时只传干净产物目录，例如 `./dist`。`.git` 目录会被自动排除，不会进入压缩包；`node_modules`、源码缓存等仍建议手动精简以控制包体。
 - 重新部署同一个 HTML 应用时复用原 `app_id`，只重新执行 `+html-publish --app-id <id> --path <dir-or-index.html>`。
 
 ## 安全规则

--- a/tests/cli_e2e/apps/apps_html_publish_dryrun_test.go
+++ b/tests/cli_e2e/apps/apps_html_publish_dryrun_test.go
@@ -87,9 +87,11 @@ func TestAppsHTMLPublishDryRun(t *testing.T) {
 		assert.Equal(t, "page.html", gjson.Get(result.Stdout, "files.0").String())
 	})
 
-	t.Run("HiddenFilesIncluded", func(t *testing.T) {
-		// Walker MUST NOT silently filter .git / .DS_Store — that's an explicit
-		// design decision so users pass clean ./dist trees, not source repos.
+	t.Run("HiddenFilesIncludedExceptGit", func(t *testing.T) {
+		// The walker filters the .git directory (and a .git gitdir pointer file)
+		// so a stray repo under --path doesn't ship its history / remote URL to a
+		// public share URL. Generic hidden files like .DS_Store are NOT filtered —
+		// only .git is — so users still see everything else they pointed --path at.
 		dir := t.TempDir()
 		require.NoError(t, os.MkdirAll(filepath.Join(dir, "dist"), 0o755))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "dist", "index.html"), []byte("<html/>"), 0o644))
@@ -112,8 +114,17 @@ func TestAppsHTMLPublishDryRun(t *testing.T) {
 		})
 		require.NoError(t, err)
 		result.AssertExitCode(t, 0)
-		assert.Equal(t, int64(3), gjson.Get(result.Stdout, "file_count").Int(),
-			"walker must include hidden files; got: %s", result.Stdout)
+		// index.html + .DS_Store kept; .git/HEAD filtered out → 2 files.
+		assert.Equal(t, int64(2), gjson.Get(result.Stdout, "file_count").Int(),
+			"walker must keep non-.git hidden files but drop .git; got: %s", result.Stdout)
+		names := gjson.Get(result.Stdout, "files").Array()
+		var got []string
+		for _, n := range names {
+			got = append(got, n.String())
+		}
+		assert.Contains(t, got, "index.html")
+		assert.Contains(t, got, ".DS_Store")
+		assert.NotContains(t, got, ".git/HEAD", "walker must exclude .git contents")
 	})
 
 	t.Run("EmptyDir_ManifestEmpty", func(t *testing.T) {


### PR DESCRIPTION
## Summary

`apps +html-publish` packs `--path` into a tar.gz and uploads it to a public-internet share URL. The directory walker currently collects every regular file, including the contents of a stray `.git/` directory -- shipping repo history, packed objects, and `.git/config` (remote URL) into the published payload, and wasting the 20MB compressed / 200MB raw size budget. This PR makes the walker exclude `.git` automatically.

## Changes

- Exclude `.git` in `shortcuts/apps/walk_html_publish_candidates.go`: the `WalkDir` callback returns `filepath.SkipDir` for a directory named `.git` (whole subtree skipped) and skips a `.git` gitdir-pointer file. Exact-name match, so `.github` / `.gitignore` / `.gitattributes` are unaffected.
- Add unit tests in `shortcuts/apps/walk_html_publish_candidates_test.go` covering root `.git` dir, nested `sub/.git`, `.git` pointer file, and adjacent-name retention.
- Update `tests/cli_e2e/apps/apps_html_publish_dryrun_test.go`: the prior `HiddenFilesIncluded` case asserted `.git` was kept (the old design decision); reworked to `HiddenFilesIncludedExceptGit`, where `.git` is dropped but `.DS_Store` is still included.
- Note the auto-exclusion in the reference doc `skills/lark-apps/references/lark-apps-html-publish.md`.

## Test Plan

- [x] `make unit-test` passed (apps package)
- [x] validate passed (build / vet / unit / integration)
- [x] local-eval passed (E2E 11/11 upstream cli_e2e regression; skillave N/A in lite mode)
- [x] acceptance-reviewer passed (3/3 cases: leak scenario, `--path` pointing at `.git`, submodule pointer file)
- [x] manual verification: `apps +html-publish --app-id app_demo --path ./<dir-with-.git> --dry-run --json`, confirmed `.git/*` excluded from `files` while `.github`/`.gitignore` retained

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `.git` directories and Git pointer files are now excluded from publish candidates so repository metadata is not uploaded.

* **Documentation**
  * Clarified publishing guidance: pass a clean artifacts directory (e.g., ./dist) and `.git` will be auto-excluded; other hidden files remain.

* **Tests**
  * Added and updated tests and e2e checks to verify `.git` exclusion across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->