### PR TITLE
fix(vfs): reject Windows absolute paths cross-platform

### DIFF
--- a/internal/vfs/localfileio/path.go
+++ b/internal/vfs/localfileio/path.go
@@ -60,11 +60,11 @@ func safePath(raw, flagName string) (string, error) {
 		return "", err
 	}
 
-	path := filepath.Clean(raw)
-
-	if filepath.IsAbs(path) {
+	if isAbsolutePath(raw) {
 		return "", fmt.Errorf("%s must be a relative path within the current directory, got %q (hint: cd to the target directory first, or use a relative path like ./filename)", flagName, raw)
 	}
+
+	path := filepath.Clean(raw)
 
 	cwd, err := vfs.Getwd()
 	if err != nil {
@@ -112,6 +112,21 @@ func resolveNearestAncestor(path string) (string, error) {
 		tail = append([]string{filepath.Base(cur)}, tail...)
 		cur = parent
 	}
+}
+
+func isAbsolutePath(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+	if filepath.IsAbs(path) || strings.HasPrefix(path, "/") || strings.HasPrefix(path, `\`) {
+		return true
+	}
+	if len(path) >= 3 && path[1] == ':' && (path[2] == '/' || path[2] == '\\') {
+		drive := path[0]
+		return ('A' <= drive && drive <= 'Z') || ('a' <= drive && drive <= 'z')
+	}
+	return false
 }
 
 func isUnderDir(child, parent string) bool {

--- a/internal/vfs/localfileio/path_test.go
+++ b/internal/vfs/localfileio/path_test.go
@@ -34,6 +34,10 @@ func TestSafeOutputPath_RejectsPathTraversalAndDangerousInput(t *testing.T) {
 		// ── GIVEN: absolute paths → THEN: rejected ──
 		{"absolute path unix", "/etc/passwd", true},
 		{"absolute path root", "/tmp/evil", true},
+		{"absolute path windows drive", `C:\Users\agent\secret.txt`, true},
+		{"absolute path windows drive slash", "C:/Users/agent/secret.txt", true},
+		{"absolute path windows rooted", `\Users\agent\secret.txt`, true},
+		{"absolute path windows unc", `\\server\share\secret.txt`, true},
 
 		// ── GIVEN: control characters in path → THEN: rejected ──
 		{"null byte", "file\x00.txt", true},

--- a/internal/vfs/localfileio/path_test.go
+++ b/internal/vfs/localfileio/path_test.go
@@ -191,11 +191,23 @@ func TestSafeUploadPath_AllowsTempFileAbsolutePath(t *testing.T) {
 }
 
 func TestSafeUploadPath_RejectsNonTempAbsolutePath(t *testing.T) {
-	// GIVEN: an absolute path outside the temp directory
-	// WHEN / THEN: SafeUploadPath rejects it
-	_, err := SafeInputPath("/etc/passwd")
-	if err == nil {
-		t.Error("expected error for absolute non-temp path, got nil")
+	for _, tt := range []struct {
+		name  string
+		input string
+	}{
+		{"absolute path unix", "/etc/passwd"},
+		{"absolute path windows drive", `C:\Users\agent\secret.txt`},
+		{"absolute path windows drive slash", "C:/Users/agent/secret.txt"},
+		{"absolute path windows rooted", `\Users\agent\secret.txt`},
+		{"absolute path windows unc", `\\server\share\secret.txt`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			// WHEN / THEN: SafeInputPath rejects absolute paths on every platform.
+			_, err := SafeInputPath(tt.input)
+			if err == nil {
+				t.Errorf("expected error for absolute path %q, got nil", tt.input)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Background

Path safety validation is intended to reject absolute paths for user-provided input/output paths. The current check only used `filepath.IsAbs`, which is platform-specific. On Unix/macOS it does not treat Windows-style absolute paths such as `C:\Users\agent\secret.txt`, `C:/Users/agent/secret.txt`, `\Users\agent\secret.txt`, or `\\server\share\secret.txt` as absolute, so those values could pass the initial absolute-path rejection and be interpreted as relative paths.

## Changes

- Add a platform-independent absolute-path detector in `internal/vfs/localfileio.safePath`.
- Reject Unix absolute paths, Windows drive-rooted paths, rooted backslash paths, and UNC paths before cleaning/joining with the current working directory.
- Add regression cases for Windows-style absolute paths in both `SafeOutputPath` and `SafeInputPath`.

## Verification

- Reproduced before fix: `go test -timeout=2m ./internal/vfs/localfileio -run '^TestSafeOutputPath_RejectsPathTraversalAndDangerousInput$'` failed for Windows absolute path cases.
- `go test -count=1 -timeout=2m ./internal/vfs/localfileio -run '^TestSafeOutputPath_RejectsPathTraversalAndDangerousInput$'`: passed
- `go test -count=1 -timeout=2m ./internal/vfs/localfileio -run 'TestSafe(Output|Upload)Path_Rejects'`: passed
- `go test -count=1 -timeout=3m ./internal/vfs/localfileio`: passed
- `go test -count=1 -timeout=4m ./internal/vfs/... ./internal/validate`: passed
- `go test -count=1 -timeout=2m ./shortcuts/im -run '^TestValidateMediaFlagPath$'`: passed
- `gofmt -l internal/vfs/localfileio/path.go internal/vfs/localfileio/path_test.go`: no output
- `git diff --check origin/main...HEAD`: passed

## Risk and rollback

Risk is low and constrained to path validation. The behavior becomes stricter for Windows-style absolute paths on all platforms, matching existing CLI path-safety messaging. Rollback is reverting this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for --output and --file to more reliably reject absolute and Windows drive-qualified paths, including UNC and root-style inputs.
  * Improved handling of whitespace or oddly formatted path inputs so they are correctly treated as invalid when absolute.
  * Clarified error messaging when a provided path is rejected to better guide corrective action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->