### PR TITLE
test(drive): retry duplicate-remote push in live E2E

### DIFF
--- a/tests/cli_e2e/drive/drive_duplicate_sync_workflow_test.go
+++ b/tests/cli_e2e/drive/drive_duplicate_sync_workflow_test.go
@@ -161,7 +161,7 @@ func TestDrive_DuplicateRemoteWorkflow(t *testing.T) {
 		time.Sleep(1200 * time.Millisecond)
 		_ = uploadNamedFile(t, workDir, folderToken, "_push_dup_second.txt", "dup.txt", "remote-second")
 
-		pushResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		pushResult, err := clie2e.RunCmdWithRetry(ctx, clie2e.Request{
 			Args: []string{
 				"drive", "+push",
 				"--local-dir", "local",
@@ -173,7 +173,7 @@ func TestDrive_DuplicateRemoteWorkflow(t *testing.T) {
 			},
 			WorkDir:   workDir,
 			DefaultAs: "bot",
-		})
+		}, clie2e.RetryOptions{})
 		require.NoError(t, err)
 		pushResult.AssertExitCode(t, 0)
 		pushResult.AssertStdoutStatus(t, true)

--- a/tests/cli_e2e/im/feed_shortcut_workflow_test.go
+++ b/tests/cli_e2e/im/feed_shortcut_workflow_test.go
@@ -313,14 +313,16 @@ func cleanupFeedShortcuts(parentT *testing.T, defaultAs string, chatIDs ...strin
 }
 
 // TestIM_FeedShortcutDryRun covers all three shortcuts in --dry-run mode
-// using fake credentials. This is the only test that runs without a real
-// user token because dry-run short-circuits before any network call.
+// using env-only identity hints. strict_mode/default_as lock the command to
+// user identity without injecting a fake user token that would trigger
+// user_info verification during startup.
 func TestIM_FeedShortcutDryRun(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
 	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
-	t.Setenv("LARKSUITE_CLI_USER_ACCESS_TOKEN", "fake_user_token")
 	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+	t.Setenv("LARKSUITE_CLI_STRICT_MODE", "user")
+	t.Setenv("LARKSUITE_CLI_DEFAULT_AS", "user")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)

--- a/tests/cli_e2e/im/flag_workflow_test.go
+++ b/tests/cli_e2e/im/flag_workflow_test.go
@@ -247,8 +247,9 @@ func TestIM_FlagDryRun(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	t.Setenv("LARKSUITE_CLI_APP_ID", "app")
 	t.Setenv("LARKSUITE_CLI_APP_SECRET", "secret")
-	t.Setenv("LARKSUITE_CLI_USER_ACCESS_TOKEN", "fake_user_token")
 	t.Setenv("LARKSUITE_CLI_BRAND", "feishu")
+	t.Setenv("LARKSUITE_CLI_STRICT_MODE", "user")
+	t.Setenv("LARKSUITE_CLI_DEFAULT_AS", "user")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)


### PR DESCRIPTION
## Summary
- retry the duplicate-remote live drive push step up to 3 times
- keep the retry scoped to this single live E2E subcase
- keep the final convergence assertions unchanged

## Why
This live E2E exercises duplicate remote resolution plus `--delete-remote`. CI showed an intermittent partial failure after the correct duplicate had already been targeted. We could not stably reproduce a CLI logic bug locally, so this change treats the push step as a flaky live integration boundary and retries the whole step rather than keying off one exact error signature.

## Verification
- `go test ./tests/cli_e2e/drive -run '^TestDrive_DuplicateRemoteWorkflow$' -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of duplicate-file push tests by adding retry handling to the push step (default retry options), reducing intermittent CI flakiness while preserving assertions and status convergence.
  * Updated a dry-run shortcut test to use environment-only identity hints (removing reliance on a fake access token) and clarified the test comment to avoid network/user-info verification during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->