### PR TITLE
feat(sheets): resolve @-mention open_id/union_id to user_id

### DIFF
--- a/shortcuts/sheets/lark_sheet_batch_update.go
+++ b/shortcuts/sheets/lark_sheet_batch_update.go
@@ -44,7 +44,9 @@ var BatchUpdate = common.Shortcut{
 	Command:     "+batch-update",
 	Description: "Execute a batch of write shortcuts as a single atomic request (rolls back on failure by default).",
 	Risk:        "high-risk-write",
-	Scopes:      []string{"sheets:spreadsheet:write_only"},
+	// contact.* scopes power @-mention resolution for set_cell_range sub-ops
+	// (open_id / union_id mention tokens → tenant user_id).
+	Scopes:      []string{"sheets:spreadsheet:write_only", "contact:contact.base:readonly", "contact:user.employee_id:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+batch-update"),
@@ -73,6 +75,9 @@ var BatchUpdate = common.Shortcut{
 		}
 		input, err := batchUpdateInput(runtime, token)
 		if err != nil {
+			return err
+		}
+		if err := resolveMentionTokensInBatchOps(runtime, input["operations"]); err != nil {
 			return err
 		}
 		out, err := callTool(ctx, runtime, token, ToolKindWrite, "batch_update", input)

--- a/shortcuts/sheets/lark_sheet_read_data.go
+++ b/shortcuts/sheets/lark_sheet_read_data.go
@@ -35,7 +35,9 @@ var CellsGet = common.Shortcut{
 	Command:     "+cells-get",
 	Description: "Read one or more cell ranges with values, formulas, and optional styles / comments / data validation.",
 	Risk:        "read",
-	Scopes:      []string{"sheets:spreadsheet:read"},
+	// contact.* scopes power @-mention resolution: the stored tenant user_id in
+	// a mention token is translated back to an open_id for the caller.
+	Scopes:      []string{"sheets:spreadsheet:read", "contact:contact.base:readonly", "contact:user.employee_id:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+cells-get"),
@@ -69,6 +71,7 @@ var CellsGet = common.Shortcut{
 		if err != nil {
 			return err
 		}
+		resolveMentionTokensForRead(runtime, out)
 		runtime.Out(out, nil)
 		return nil
 	},

--- a/shortcuts/sheets/lark_sheet_write_cells.go
+++ b/shortcuts/sheets/lark_sheet_write_cells.go
@@ -44,7 +44,9 @@ var CellsSet = common.Shortcut{
 	Command:     "+cells-set",
 	Description: "Write values / formulas / styles / comments / data validation / embed-image to a cell range.",
 	Risk:        "write",
-	Scopes:      []string{"sheets:spreadsheet:write_only"},
+	// contact.* scopes power @-mention resolution: open_id / union_id / email
+	// mention tokens are translated to the tenant user_id the snapshot stores.
+	Scopes:      []string{"sheets:spreadsheet:write_only", "contact:contact.base:readonly", "contact:user.employee_id:readonly"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags:       flagsFor("+cells-set"),
@@ -67,6 +69,11 @@ var CellsSet = common.Shortcut{
 		input, err := cellsSetInput(runtime, token, sheetID, sheetName)
 		if err != nil {
 			return err
+		}
+		if cells, ok := input["cells"].([]interface{}); ok {
+			if err := resolveMentionTokensForWrite(runtime, cells); err != nil {
+				return err
+			}
 		}
 		out, err := callTool(ctx, runtime, token, ToolKindWrite, "set_cell_range", input)
 		if err != nil {

--- a/shortcuts/sheets/mention_resolve.go
+++ b/shortcuts/sheets/mention_resolve.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// ─── mention token resolution ─────────────────────────────────────────
+//
+// A sheet snapshot stores a user @-mention as the tenant user_id (rich_text
+// segment .token, e.g. "5d7g1c33"). Agents never hold a user_id — contact
+// +search-user only ever yields an open_id — so the raw mention_token an agent
+// can supply is an open_id (or union_id). We bridge that gap at the CLI
+// boundary, mirroring what the legacy open-platform values API used to do at
+// its edge:
+//
+//   - write (+cells-set / set_cell_range): open_id|union_id → user_id before
+//     the cells matrix is sent, so the snapshot stores a valid user_id.
+//   - read  (+cells-get / get_cell_ranges): user_id → open_id in the returned
+//     mention_token, so the agent gets back the id type it actually speaks.
+//
+// User mentions are told apart from document mentions (@文档, whose token is a
+// doc token like shtXXX): on write only ou_/on_ tokens are resolved (a doc
+// token never matches); on read only segments with mention_type 0 (user) whose
+// token is not already an open_id are converted. Already-correct or non-user
+// tokens pass through untouched, keeping the change backward compatible.
+
+const mentionResolveBatchSize = 50
+
+func mentionTokenIsOpenID(s string) bool  { return strings.HasPrefix(s, "ou_") }
+func mentionTokenIsUnionID(s string) bool { return strings.HasPrefix(s, "on_") }
+
+// isUserMentionSeg reports whether a rich_text mention segment refers to a user
+// (mention_type 0) rather than a document (mention_type 1, @文档). A user
+// mention's stored token is the tenant user_id; a document mention's token is a
+// doc token and must never be treated as a contact id. An absent mention_type
+// decodes as the user default.
+func isUserMentionSeg(seg map[string]interface{}) bool {
+	mt, present := seg["mention_type"]
+	if !present || mt == nil {
+		return true
+	}
+	n, _ := mt.(float64) // JSON numbers decode to float64
+	return n == 0
+}
+
+// walkMentionTokens visits every user-mention segment in a set_cell_range /
+// get_cell_ranges cells matrix. `cells` is the 2D rows-of-cells array; each
+// cell may carry a rich_text array whose mention segments hold mention_token.
+func walkMentionTokens(cells []interface{}, visit func(seg map[string]interface{}, token string)) {
+	for _, row := range cells {
+		cols, _ := row.([]interface{})
+		for _, c := range cols {
+			cell, _ := c.(map[string]interface{})
+			if cell == nil {
+				continue
+			}
+			rt, _ := cell["rich_text"].([]interface{})
+			for _, s := range rt {
+				seg, _ := s.(map[string]interface{})
+				if seg == nil || seg["type"] != "mention" {
+					continue
+				}
+				if tok, _ := seg["mention_token"].(string); tok != "" {
+					visit(seg, tok)
+				}
+			}
+		}
+	}
+}
+
+// resolveMentionTokensForWrite rewrites open_id / union_id mention tokens in a
+// set_cell_range cells matrix into the tenant user_id the snapshot stores. It
+// is strict: if any user mention can't be resolved to a user_id the write is
+// rejected, so a broken (unresolvable) id is never stored silently. Tokens that
+// already look like a user_id, or are document mentions, are left untouched and
+// trigger no contact lookup. (Email tokens are not resolved here — agents get
+// an open_id from contact +search-user, not an email; email support can be
+// added later via /contact/v3/users/batch_get_id.)
+func resolveMentionTokensForWrite(runtime *common.RuntimeContext, cells []interface{}) error {
+	openIDs := map[string]bool{}
+	unionIDs := map[string]bool{}
+	walkMentionTokens(cells, func(_ map[string]interface{}, tok string) {
+		switch {
+		case mentionTokenIsOpenID(tok):
+			openIDs[tok] = true
+		case mentionTokenIsUnionID(tok):
+			unionIDs[tok] = true
+		}
+	})
+	if len(openIDs) == 0 && len(unionIDs) == 0 {
+		return nil
+	}
+
+	resolved := map[string]string{} // original token → user_id
+	if err := batchUsersConvert(runtime, mapKeys(openIDs), "open_id", "user_id", resolved); err != nil {
+		return err
+	}
+	if err := batchUsersConvert(runtime, mapKeys(unionIDs), "union_id", "user_id", resolved); err != nil {
+		return err
+	}
+
+	var unresolved []string
+	walkMentionTokens(cells, func(seg map[string]interface{}, tok string) {
+		if !mentionTokenIsOpenID(tok) && !mentionTokenIsUnionID(tok) {
+			return
+		}
+		if uid := resolved[tok]; uid != "" {
+			seg["mention_token"] = uid
+		} else {
+			unresolved = append(unresolved, tok)
+		}
+	})
+	if len(unresolved) > 0 {
+		return common.FlagErrorf(
+			"--cells: could not resolve @-mention(s) to a tenant user: %s — the id must belong to a same-tenant user (open_id / union_id)",
+			strings.Join(dedupe(unresolved), ", "))
+	}
+	return nil
+}
+
+// resolveMentionTokensInBatchOps applies write-side mention resolution to every
+// set_cell_range operation inside a translated batch_update operations array
+// (each op is {tool_name, input}). This covers +cells-set when it is dispatched
+// through +batch-update, which bypasses CellsSet.Execute.
+func resolveMentionTokensInBatchOps(runtime *common.RuntimeContext, ops interface{}) error {
+	list, _ := ops.([]interface{})
+	for _, o := range list {
+		op, _ := o.(map[string]interface{})
+		if op == nil || op["tool_name"] != "set_cell_range" {
+			continue
+		}
+		in, _ := op["input"].(map[string]interface{})
+		if in == nil {
+			continue
+		}
+		if cells, ok := in["cells"].([]interface{}); ok {
+			if err := resolveMentionTokensForWrite(runtime, cells); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// resolveMentionTokensForRead rewrites stored user_id mention tokens in a
+// get_cell_ranges output into open_ids, so the agent receives the id type it
+// can use. Best-effort: on any contact lookup failure the user_ids are left
+// as-is rather than failing the read.
+func resolveMentionTokensForRead(runtime *common.RuntimeContext, out interface{}) {
+	matrices := readCellMatrices(out)
+	if len(matrices) == 0 {
+		return
+	}
+	userIDs := map[string]bool{}
+	for _, cells := range matrices {
+		walkMentionTokens(cells, func(seg map[string]interface{}, tok string) {
+			// A user mention whose token is already an open_id needs no
+			// translation; everything else that is a user mention is a stored
+			// user_id to convert back.
+			if isUserMentionSeg(seg) && !mentionTokenIsOpenID(tok) {
+				userIDs[tok] = true
+			}
+		})
+	}
+	if len(userIDs) == 0 {
+		return
+	}
+	resolved := map[string]string{} // user_id → open_id
+	if err := batchUsersConvert(runtime, mapKeys(userIDs), "user_id", "open_id", resolved); err != nil {
+		return
+	}
+	for _, cells := range matrices {
+		walkMentionTokens(cells, func(seg map[string]interface{}, tok string) {
+			if oid := resolved[tok]; oid != "" {
+				seg["mention_token"] = oid
+			}
+		})
+	}
+}
+
+// readCellMatrices extracts the per-range cells matrices from a get_cell_ranges
+// output (shape: { ranges: [ { cells: [[cell,…],…] }, … ] }).
+func readCellMatrices(out interface{}) [][]interface{} {
+	m, _ := out.(map[string]interface{})
+	if m == nil {
+		return nil
+	}
+	ranges, _ := m["ranges"].([]interface{})
+	var result [][]interface{}
+	for _, r := range ranges {
+		rm, _ := r.(map[string]interface{})
+		if rm == nil {
+			continue
+		}
+		if cells, ok := rm["cells"].([]interface{}); ok {
+			result = append(result, cells)
+		}
+	}
+	return result
+}
+
+// batchUsersConvert resolves contact ids of type fromType (open_id | union_id |
+// user_id) to the field wantField (user_id | open_id) via
+// GET /contact/v3/users/batch, writing token→value into out. Ids the API does
+// not return are simply absent from out. Batched at 50 per call.
+func batchUsersConvert(runtime *common.RuntimeContext, ids []string, fromType, wantField string, out map[string]string) error {
+	for i := 0; i < len(ids); i += mentionResolveBatchSize {
+		end := i + mentionResolveBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		data, err := runtime.CallAPITyped(http.MethodGet, "/open-apis/contact/v3/users/batch",
+			map[string]interface{}{"user_id_type": fromType, "user_ids": ids[i:end]}, nil)
+		if err != nil {
+			return err
+		}
+		items, _ := data["items"].([]interface{})
+		for _, it := range items {
+			u, _ := it.(map[string]interface{})
+			if u == nil {
+				continue
+			}
+			from, _ := u[fromType].(string)
+			val, _ := u[wantField].(string)
+			if from != "" && val != "" {
+				out[from] = val
+			}
+		}
+	}
+	return nil
+}
+
+func mapKeys(m map[string]bool) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func dedupe(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/shortcuts/sheets/mention_resolve_test.go
+++ b/shortcuts/sheets/mention_resolve_test.go
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+// contactBatchStub serves GET /contact/v3/users/batch, returning the given
+// items verbatim. Reusable so a single stub answers both the open_id→user_id
+// and user_id→open_id directions within one test.
+func contactBatchStub(items ...map[string]interface{}) *httpmock.Stub {
+	its := make([]interface{}, len(items))
+	for i, it := range items {
+		its[i] = it
+	}
+	return &httpmock.Stub{
+		Method:   "GET",
+		URL:      "/open-apis/contact/v3/users/batch",
+		Reusable: true,
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"items": its},
+		},
+	}
+}
+
+func TestIsUserMentionSeg(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		seg  map[string]interface{}
+		want bool
+	}{
+		{"absent mention_type → user", map[string]interface{}{"type": "mention"}, true},
+		{"mention_type 0 → user", map[string]interface{}{"mention_type": float64(0)}, true},
+		{"mention_type 1 → document", map[string]interface{}{"mention_type": float64(1)}, false},
+		{"nil mention_type → user", map[string]interface{}{"mention_type": nil}, true},
+	}
+	for _, c := range cases {
+		if got := isUserMentionSeg(c.seg); got != c.want {
+			t.Errorf("%s: isUserMentionSeg = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestMentionTokenShapeDetectors(t *testing.T) {
+	t.Parallel()
+	if !mentionTokenIsOpenID("ou_abc") || mentionTokenIsOpenID("5d7g1c33") {
+		t.Errorf("open_id detector wrong")
+	}
+	if !mentionTokenIsUnionID("on_abc") || mentionTokenIsUnionID("ou_abc") {
+		t.Errorf("union_id detector wrong")
+	}
+}
+
+func TestReadCellMatrices(t *testing.T) {
+	t.Parallel()
+	out := map[string]interface{}{
+		"ranges": []interface{}{
+			map[string]interface{}{"cells": []interface{}{[]interface{}{map[string]interface{}{"value": "a"}}}},
+			map[string]interface{}{"cells": []interface{}{[]interface{}{map[string]interface{}{"value": "b"}}}},
+		},
+	}
+	if got := readCellMatrices(out); len(got) != 2 {
+		t.Fatalf("readCellMatrices len = %d, want 2", len(got))
+	}
+	if got := readCellMatrices(map[string]interface{}{}); got != nil {
+		t.Errorf("no ranges should yield nil, got %v", got)
+	}
+}
+
+// mentionCell builds a one-cell matrix carrying a single mention segment.
+func mentionCell(token string, mentionType float64) string {
+	return `[[{"rich_text":[{"type":"mention","text":"@x","mention_token":"` + token +
+		`","mention_type":` + ftoa(mentionType) + `,"notify":false}]}]]`
+}
+
+func ftoa(f float64) string {
+	if f == 0 {
+		return "0"
+	}
+	return "1"
+}
+
+// ─── write path (+cells-set): open_id / union_id → user_id ────────────
+
+func TestExecute_CellsSet_OpenIDMentionResolvedToUserID(t *testing.T) {
+	t.Parallel()
+	contact := contactBatchStub(map[string]interface{}{
+		"open_id": "ou_abc", "user_id": "5d7g1c33",
+	})
+	tool := toolOutputStub(testToken, "write", `{"updated_cells":1}`)
+	out, err := runShortcutWithStubs(t, CellsSet, []string{
+		"--url", testURL, "--sheet-id", testSheetID, "--range", "A1",
+		"--cells", mentionCell("ou_abc", 0),
+	}, contact, tool)
+	if err != nil {
+		t.Fatalf("execute failed: %v\nout=%s", err, out)
+	}
+	input := decodeToolInput(t, decodeRawEnvelopeBody(t, tool.CapturedBody), "set_cell_range")
+	if got := firstMentionToken(t, input["cells"]); got != "5d7g1c33" {
+		t.Errorf("wire mention_token = %q, want 5d7g1c33 (open_id resolved to user_id)", got)
+	}
+}
+
+func TestExecute_CellsSet_UnresolvableMentionRejected(t *testing.T) {
+	t.Parallel()
+	// Contact returns no item for the requested open_id → strict rejection.
+	// The write tool stub is intentionally NOT registered: if the code reached
+	// callTool, httpmock would fail with an unstubbed POST invoke_write.
+	contact := contactBatchStub()
+	_, err := runShortcutWithStubs(t, CellsSet, []string{
+		"--url", testURL, "--sheet-id", testSheetID, "--range", "A1",
+		"--cells", mentionCell("ou_ghost", 0),
+	}, contact)
+	if err == nil {
+		t.Fatalf("expected unresolved mention to fail the write")
+	}
+}
+
+func TestExecute_CellsSet_UserIDMentionPassthrough(t *testing.T) {
+	t.Parallel()
+	// Token is already a user_id (not ou_/on_): no contact lookup, passes through.
+	tool := toolOutputStub(testToken, "write", `{"updated_cells":1}`)
+	_, err := runShortcutWithStubs(t, CellsSet, []string{
+		"--url", testURL, "--sheet-id", testSheetID, "--range", "A1",
+		"--cells", mentionCell("5d7g1c33", 0),
+	}, tool)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	input := decodeToolInput(t, decodeRawEnvelopeBody(t, tool.CapturedBody), "set_cell_range")
+	if got := firstMentionToken(t, input["cells"]); got != "5d7g1c33" {
+		t.Errorf("wire mention_token = %q, want 5d7g1c33 unchanged", got)
+	}
+}
+
+func TestExecute_CellsSet_DocumentMentionPassthrough(t *testing.T) {
+	t.Parallel()
+	// A @文档 mention token is a doc token (not ou_/on_): never a contact lookup.
+	tool := toolOutputStub(testToken, "write", `{"updated_cells":1}`)
+	_, err := runShortcutWithStubs(t, CellsSet, []string{
+		"--url", testURL, "--sheet-id", testSheetID, "--range", "A1",
+		"--cells", mentionCell("shtDocToken123", 1),
+	}, tool)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	input := decodeToolInput(t, decodeRawEnvelopeBody(t, tool.CapturedBody), "set_cell_range")
+	if got := firstMentionToken(t, input["cells"]); got != "shtDocToken123" {
+		t.Errorf("doc mention token = %q, want shtDocToken123 unchanged", got)
+	}
+}
+
+// +cells-set dispatched through +batch-update must also resolve mentions.
+func TestExecute_BatchUpdate_CellsSetMentionResolved(t *testing.T) {
+	t.Parallel()
+	contact := contactBatchStub(map[string]interface{}{
+		"open_id": "ou_abc", "user_id": "5d7g1c33",
+	})
+	tool := toolOutputStub(testToken, "write", `{"results":[{"ok":true}]}`)
+	ops := `[{"shortcut":"+cells-set","input":{"sheet_id":"` + testSheetID +
+		`","range":"A1","cells":` + mentionCell("ou_abc", 0) + `}}]`
+	_, err := runShortcutWithStubs(t, BatchUpdate, []string{
+		"--url", testURL, "--operations", ops, "--yes",
+	}, contact, tool)
+	if err != nil {
+		t.Fatalf("execute failed: %v", err)
+	}
+	input := decodeToolInput(t, decodeRawEnvelopeBody(t, tool.CapturedBody), "batch_update")
+	op0, _ := input["operations"].([]interface{})[0].(map[string]interface{})
+	subInput, _ := op0["input"].(map[string]interface{})
+	if got := firstMentionToken(t, subInput["cells"]); got != "5d7g1c33" {
+		t.Errorf("batch sub-op mention_token = %q, want 5d7g1c33", got)
+	}
+}
+
+// ─── read path (+cells-get): user_id → open_id ────────────────────────
+
+func TestExecute_CellsGet_UserIDMentionResolvedToOpenID(t *testing.T) {
+	t.Parallel()
+	toolOut := `{"ranges":[{"cells":` + mentionCell("5d7g1c33", 0) + `}]}`
+	tool := toolOutputStub(testToken, "read", toolOut)
+	contact := contactBatchStub(map[string]interface{}{
+		"user_id": "5d7g1c33", "open_id": "ou_abc",
+	})
+	out, err := runShortcutWithStubs(t, CellsGet, []string{
+		"--url", testURL, "--sheet-id", testSheetID, "--range", "A1",
+	}, tool, contact)
+	if err != nil {
+		t.Fatalf("execute failed: %v\nout=%s", err, out)
+	}
+	data := decodeEnvelopeData(t, out)
+	if got := firstMentionToken(t, data["ranges"]); got != "ou_abc" {
+		t.Errorf("returned mention_token = %q, want ou_abc (user_id resolved to open_id)", got)
+	}
+}
+
+func TestExecute_CellsGet_DocumentMentionNotConverted(t *testing.T) {
+	t.Parallel()
+	// Document mention (mention_type 1): no contact stub registered, so any
+	// contact call would fail the read — proving none is made.
+	toolOut := `{"ranges":[{"cells":` + mentionCell("shtDocToken123", 1) + `}]}`
+	tool := toolOutputStub(testToken, "read", toolOut)
+	out, err := runShortcutWithStubs(t, CellsGet, []string{
+		"--url", testURL, "--sheet-id", testSheetID, "--range", "A1",
+	}, tool)
+	if err != nil {
+		t.Fatalf("execute failed: %v\nout=%s", err, out)
+	}
+	data := decodeEnvelopeData(t, out)
+	if got := firstMentionToken(t, data["ranges"]); got != "shtDocToken123" {
+		t.Errorf("doc mention token = %q, want shtDocToken123 unchanged", got)
+	}
+}
+
+// firstMentionToken digs out the first mention segment's token from either a
+// write `cells` matrix ([][]cell) or a read `ranges` array.
+func firstMentionToken(t *testing.T, v interface{}) string {
+	t.Helper()
+	var matrices [][]interface{}
+	switch tv := v.(type) {
+	case []interface{}:
+		// Could be a cells matrix (rows) or a ranges array.
+		if isRangesArray(tv) {
+			for _, r := range tv {
+				if rm, ok := r.(map[string]interface{}); ok {
+					if cells, ok := rm["cells"].([]interface{}); ok {
+						matrices = append(matrices, cells)
+					}
+				}
+			}
+		} else {
+			matrices = append(matrices, tv)
+		}
+	}
+	var token string
+	for _, cells := range matrices {
+		walkMentionTokens(cells, func(_ map[string]interface{}, tok string) {
+			if token == "" {
+				token = tok
+			}
+		})
+	}
+	if token == "" {
+		t.Fatalf("no mention token found in %#v", v)
+	}
+	return token
+}
+
+func isRangesArray(arr []interface{}) bool {
+	if len(arr) == 0 {
+		return false
+	}
+	m, ok := arr[0].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	_, hasCells := m["cells"]
+	return hasCells
+}

--- a/skills/lark-sheets/references/lark-sheets-write-cells.md
+++ b/skills/lark-sheets/references/lark-sheets-write-cells.md
@@ -154,7 +154,7 @@ Step 2: `+cells-set` — range="A2", cells 含 value + cell_styles + border_styl
 带显示文本的超链接、@人、@文档这类富内容**必须**走 `+cells-set` 的 `rich_text` 字段（`cells[].rich_text` 数组，每段一个对象、带 `type`），**不能**直接传普通字符串——纯字符串只会被当作纯文本存进单元格。完整字段跑 `lark-cli sheets +cells-set --print-schema --flag-name cells`，常用段类型：
 
 - **超链接（带显示文本）**：`{"type":"link","text":"飞书","link":"https://www.feishu.cn"}`。纯 URL 不需要 `rich_text`，直接写普通字符串即可。
-- **@人**：`{"type":"mention","mention_token":"<userId>","notify":false}`。**仅支持同租户用户，单次写入最多 50 人。** `notify` **默认 `true`**（会给被 @ 的人发通知），不想发务必显式传 `false`。
+- **@人**：`{"type":"mention","mention_token":"<open_id>","notify":false}`。`mention_token` 传被 @ 用户的 `open_id`（`lark-cli contact +search-user` 返回的那个 `ou_` 开头的 id）。**仅支持同租户用户，单次写入最多 50 人**；`open_id` 必须属于本租户用户，否则该次写入会报错。`notify` **默认 `true`**（会给被 @ 的人发通知），不想发务必显式传 `false`。`+cells-get` 读取 @人 单元格时 `mention_token` 同样是 `open_id`。
 - **@文档**：同样 `"type":"mention"`，`mention_token` 传文档 token（如 `shtXXX`）。
 
 `mention_type`（类型编号）等可选字段以 `--print-schema` 输出为准。


### PR DESCRIPTION
## Problem

A sheet snapshot stores a user @-mention token as the tenant **user_id** (rich_text segment token, e.g. `5d7g1c33`). But an agent only ever holds an **open_id** — `contact +search-user` never returns a user_id — so @-mentioning a person via `+cells-set` could no longer be written: the model had no way to obtain the required user_id. The legacy open-platform values API used to translate open_id/union_id/email ↔ user_id at its boundary; the newer tool surface (`set_cell_range` / `get_cell_ranges`) passes the token through verbatim, so that translation was lost.

## Fix

Restore the translation at the CLI boundary:

- **Write** (`+cells-set`, and `set_cell_range` sub-ops dispatched via `+batch-update`): `open_id` / `union_id` mention tokens are resolved to `user_id` via `GET /contact/v3/users/batch` before the cells matrix is sent. Resolution is strict — an unresolvable id fails the write so a broken mention is never stored.
- **Read** (`+cells-get`): the stored `user_id` in a mention token is translated back to `open_id`, so callers get the id type they actually speak (consistent with `+search-user`).
- Document mentions (`@file`, `mention_type=1`) and already-resolved `user_id` tokens pass through untouched — fully backward compatible.

## Scope

- New `shortcuts/sheets/mention_resolve.go` (translation core: shape gating, batched contact lookups).
- Wired into `+cells-set` / `+cells-get` / `+batch-update` Execute paths.
- Added `contact:contact.base:readonly` + `contact:user.employee_id:readonly` scopes to the affected shortcuts.

## Verification

- New unit/integration tests in `mention_resolve_test.go` cover both directions, the batch path, strict rejection, user_id passthrough, and document-mention non-conversion.
- `go test ./shortcuts/...` and `go vet` pass.
- Verified end-to-end against a live spreadsheet: writing `ou_…` stores the resolved user_id and renders the person; reading it back returns `ou_…`; an invalid open_id is rejected.