### PR TITLE
auth: refresh user tokens earlier and clarify refresh failures

### DIFF
--- a/internal/auth/token_store.go
+++ b/internal/auth/token_store.go
@@ -25,7 +25,8 @@ type StoredUAToken struct {
 	GrantedAt        int64  `json:"grantedAt"` // Unix ms
 }
 
-const refreshAheadMs = 5 * 60 * 1000 // 5 minutes
+// Refresh-ahead assumes normal access token TTL is longer than this window.
+const refreshAheadMs = 60 * 60 * 1000 // 60 minutes
 
 var errStoredTokenCorrupt = errors.New("stored token data is corrupt")
 

--- a/internal/auth/token_store_status_test.go
+++ b/internal/auth/token_store_status_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokenStatusUsesRefreshAheadWindow(t *testing.T) {
+	now := time.Now().UnixMilli()
+	token := &StoredUAToken{
+		ExpiresAt:        now + (61 * time.Minute).Milliseconds(),
+		RefreshExpiresAt: now + (24 * time.Hour).Milliseconds(),
+	}
+	if got := TokenStatus(token); got != "valid" {
+		t.Fatalf("TokenStatus outside refresh window = %q, want valid", got)
+	}
+
+	token.ExpiresAt = now + (59 * time.Minute).Milliseconds()
+	if got := TokenStatus(token); got != "needs_refresh" {
+		t.Fatalf("TokenStatus inside refresh window = %q, want needs_refresh", got)
+	}
+}

--- a/internal/auth/uat_client_refresh_test.go
+++ b/internal/auth/uat_client_refresh_test.go
@@ -320,7 +320,7 @@ func TestRefreshDoesNotOverwriteNewerGeneration(t *testing.T) {
 			newGeneration := *stored
 			newGeneration.AccessToken = "access-login-new"
 			newGeneration.RefreshToken = "refresh-login-new"
-			newGeneration.ExpiresAt = time.Now().Add(time.Hour).UnixMilli()
+			newGeneration.ExpiresAt = time.Now().Add(90 * time.Minute).UnixMilli()
 			newGeneration.RefreshExpiresAt = time.Now().Add(24 * time.Hour).UnixMilli()
 			var calls atomic.Int32
 			client := scriptedRefreshClient(t, []refreshHTTPTestStep{{

--- a/internal/identitydiag/diagnostics.go
+++ b/internal/identitydiag/diagnostics.go
@@ -353,11 +353,9 @@ func diagnoseUser(ctx context.Context, f *cmdutil.Factory, cfg *core.CliConfig, 
 	}
 
 	id.Verified = boolPtr(true)
-	if id.Status == StatusReady {
-		id.Message = "User identity: ready"
-	} else {
-		id.Message = "User identity: needs refresh (server verification succeeded after refresh)"
-	}
+	id.Status = StatusReady
+	id.Available = true
+	id.Message = "User identity: ready"
 	return id
 }
 

--- a/internal/identitydiag/diagnostics_test.go
+++ b/internal/identitydiag/diagnostics_test.go
@@ -92,7 +92,7 @@ func TestDiagnose_VerifyUserIdentity(t *testing.T) {
 		UserOpenId:       cfg.UserOpenId,
 		AccessToken:      "user-access-token",
 		RefreshToken:     "refresh-token",
-		ExpiresAt:        now.Add(time.Hour).UnixMilli(),
+		ExpiresAt:        now.Add(90 * time.Minute).UnixMilli(),
 		RefreshExpiresAt: now.Add(24 * time.Hour).UnixMilli(),
 		GrantedAt:        now.Add(-time.Hour).UnixMilli(),
 		Scope:            "offline_access",
@@ -131,6 +131,75 @@ func TestDiagnose_VerifyUserIdentity(t *testing.T) {
 	}
 	if got.User.OpenID != "ou_user" || got.User.UserName != "tester" {
 		t.Fatalf("user = %#v, want user identity details", got.User)
+	}
+}
+
+func TestDiagnose_VerifyUserIdentityMarksRefreshedTokenReady(t *testing.T) {
+	keyring.MockInit()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	t.Setenv("LARKSUITE_CLI_DATA_DIR", t.TempDir())
+
+	cfg := &core.CliConfig{
+		AppID:      "test-app-user-refresh",
+		AppSecret:  "secret",
+		Brand:      core.BrandFeishu,
+		UserOpenId: "ou_refresh",
+		UserName:   "tester",
+	}
+	now := time.Now()
+	if err := larkauth.SetStoredToken(&larkauth.StoredUAToken{
+		AppId:            cfg.AppID,
+		UserOpenId:       cfg.UserOpenId,
+		AccessToken:      "access-old",
+		RefreshToken:     "refresh-old",
+		ExpiresAt:        now.Add(time.Minute).UnixMilli(),
+		RefreshExpiresAt: now.Add(24 * time.Hour).UnixMilli(),
+		GrantedAt:        now.Add(-time.Hour).UnixMilli(),
+		Scope:            "offline_access",
+	}); err != nil {
+		t.Fatalf("SetStoredToken() error = %v", err)
+	}
+
+	f, _, _, reg := cmdutil.TestFactory(t, cfg)
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodPost,
+		URL:    larkauth.PathOAuthTokenV2,
+		Body: map[string]interface{}{
+			"code":                     0,
+			"access_token":             "access-new",
+			"refresh_token":            "refresh-new",
+			"expires_in":               7200,
+			"refresh_token_expires_in": 86400,
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    "/open-apis/bot/v3/info",
+		Body: map[string]interface{}{
+			"code": 0,
+			"bot":  map[string]interface{}{"open_id": "ou_bot", "app_name": "bot"},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: http.MethodGet,
+		URL:    larkauth.PathUserInfoV1,
+		Body:   map[string]interface{}{"code": 0, "msg": "ok"},
+	})
+
+	got := Diagnose(context.Background(), f, cfg, true)
+	if got.User.Status != StatusReady || !got.User.Available {
+		t.Fatalf("user = %#v, want ready and available after refresh and verification", got.User)
+	}
+	if got.User.Verified == nil || !*got.User.Verified {
+		t.Fatalf("user verified = %v, want true", got.User.Verified)
+	}
+	if got.User.Message != "User identity: ready" {
+		t.Fatalf("user message = %q, want ready", got.User.Message)
+	}
+	stored := larkauth.GetStoredToken(cfg.AppID, cfg.UserOpenId)
+	if stored == nil || stored.AccessToken != "access-new" {
+		t.Fatalf("stored token = %#v, want refreshed access token", stored)
 	}
 }
 
@@ -198,7 +267,7 @@ func TestDiagnose_VerifyUserIdentity_ServerRejects(t *testing.T) {
 		UserOpenId:       cfg.UserOpenId,
 		AccessToken:      "user-access-token",
 		RefreshToken:     "refresh-token",
-		ExpiresAt:        now.Add(time.Hour).UnixMilli(),
+		ExpiresAt:        now.Add(90 * time.Minute).UnixMilli(),
 		RefreshExpiresAt: now.Add(24 * time.Hour).UnixMilli(),
 		GrantedAt:        now.Add(-time.Hour).UnixMilli(),
 		Scope:            "offline_access",


### PR DESCRIPTION
## Summary

Refresh user access tokens earlier and correct identity diagnostics after a successful refresh.

This PR has been rebased and narrowed onto current `main`. The earlier concurrency, refresh-error disposition, token-preservation, and generation-safety changes are now superseded by merged #2135, so the old `uat_client.go` changes were dropped rather than layered onto the hardened refresh flow.

## Changes

- Refresh access tokens within 60 minutes of expiry instead of 5 minutes.
- Document the assumption that normal access-token TTL exceeds the refresh-ahead window.
- After `auth status --verify` refreshes and successfully verifies the user token, report the user identity as `ready` and available.
- Add focused boundary and refresh-plus-verification regression coverage.
- Update existing one-hour "already valid" fixtures to 90 minutes so their intent remains valid under the wider window.

## Test plan

- `go test ./internal/auth ./internal/identitydiag -count=1`
- `go build ./...`
- `git diff --check`

## Related issue

Related to #1404. The destructive/concurrent refresh path is now handled by #2135; this PR retains only the independent proactive-refresh and diagnostic-readiness improvements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved token refresh timing so tokens are refreshed earlier, reducing the risk of expiration during use.
  - Ensured successfully verified user identities consistently appear as ready and available.
  - Improved diagnostics for expiring tokens by refreshing them before verification.

- **Tests**
  - Added coverage for refresh timing and identity verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->