### PR TITLE
chore: add CODEOWNERS for internal/ and new skills domains

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,30 @@
+/internal/ @liangshuo-1
+
+# Last match wins: existing domains below are exempt, only new skills/ entries need review.
+/skills/ @liangshuo-1
+/skills/lark-approval/
+/skills/lark-apps/
+/skills/lark-attendance/
+/skills/lark-base/
+/skills/lark-calendar/
+/skills/lark-contact/
+/skills/lark-doc/
+/skills/lark-drive/
+/skills/lark-event/
+/skills/lark-im/
+/skills/lark-mail/
+/skills/lark-markdown/
+/skills/lark-minutes/
+/skills/lark-okr/
+/skills/lark-openapi-explorer/
+/skills/lark-shared/
+/skills/lark-sheets/
+/skills/lark-skill-maker/
+/skills/lark-slides/
+/skills/lark-task/
+/skills/lark-vc/
+/skills/lark-vc-agent/
+/skills/lark-whiteboard/
+/skills/lark-wiki/
+/skills/lark-workflow-meeting-summary/
+/skills/lark-workflow-standup-report/


### PR DESCRIPTION
## Summary
Require @liangshuo-1's approval for changes under `internal/` and for new business domains under `skills/`.

## Changes
- Add `.github/CODEOWNERS`

## Test Plan
- [x] No code changes; the `main` ruleset already enforces code owner review.

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership configuration to assign review ownership for internal areas and the skills directory, including specific skill subdirectories.

**Note:** This is an internal development update with no impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->