### PR TITLE
fix: preserve local timezone in skill sync state

### DIFF
--- a/internal/skillscheck/sync.go
+++ b/internal/skillscheck/sync.go
@@ -335,7 +335,7 @@ func SyncSkills(opts SyncOptions) *SyncResult {
 		UpdatedSkills:        plan.ToUpdate,
 		AddedOfficialSkills:  plan.Added,
 		SkippedDeletedSkills: plan.SkippedDeleted,
-		UpdatedAt:            opts.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:            opts.Now().Format(time.RFC3339),
 	}
 	if err := WriteState(state); err != nil {
 		result.Action = "failed"
@@ -428,7 +428,7 @@ func fallbackFullInstall(opts SyncOptions, reason string, official []string) *Sy
 		UpdatedSkills:        official,
 		AddedOfficialSkills:  official,
 		SkippedDeletedSkills: []string{},
-		UpdatedAt:            opts.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:            opts.Now().Format(time.RFC3339),
 	}
 	if writeErr := WriteState(state); writeErr != nil {
 		return &SyncResult{

--- a/internal/skillscheck/sync_test.go
+++ b/internal/skillscheck/sync_test.go
@@ -322,6 +322,7 @@ func (f *fakeSkillsRunner) InstallAllSkills() *selfupdate.NpmResult {
 func TestSyncSkills_WritesStateAndDoesNotWriteStamp(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", dir)
+	localZone := time.FixedZone("UTC+8", 8*60*60)
 	if err := WriteState(SkillsState{
 		Version:        "1.0.30",
 		OfficialSkills: []string{"lark-calendar", "lark-mail"},
@@ -339,7 +340,7 @@ func TestSyncSkills_WritesStateAndDoesNotWriteStamp(t *testing.T) {
 	result := SyncSkills(SyncOptions{
 		Version: "1.0.33",
 		Runner:  runner,
-		Now:     func() time.Time { return time.Date(2026, 5, 18, 12, 0, 0, 0, time.UTC) },
+		Now:     func() time.Time { return time.Date(2026, 5, 18, 20, 0, 0, 0, localZone) },
 	})
 
 	if result.Err != nil {
@@ -361,6 +362,9 @@ func TestSyncSkills_WritesStateAndDoesNotWriteStamp(t *testing.T) {
 	assertStrings(t, state.UpdatedSkills, []string{"lark-calendar", "lark-new"})
 	assertStrings(t, state.AddedOfficialSkills, []string{"lark-new"})
 	assertStrings(t, state.SkippedDeletedSkills, []string{"lark-mail"})
+	if state.UpdatedAt != "2026-05-18T20:00:00+08:00" {
+		t.Fatalf("UpdatedAt = %q, want local RFC3339 timestamp with offset preserved", state.UpdatedAt)
+	}
 	if _, err := os.Stat(filepath.Join(dir, "skills.stamp")); !os.IsNotExist(err) {
 		t.Fatalf("skills.stamp exists or stat failed with unexpected err: %v", err)
 	}


### PR DESCRIPTION
## Summary
Preserve the local timezone offset when `lark-cli update` syncs skills and writes `skills-state.json`. This keeps the existing RFC3339 format while avoiding UTC normalization.

## Changes
- Update `internal/skillscheck` to write `UpdatedAt` with the provided local offset instead of forcing UTC
- Add a regression test that injects a non-UTC clock and asserts the saved timestamp preserves `+08:00`

## Test Plan
- [x] Unit tests pass
- [x] Manual local verification confirms the `lark-cli update` flow remains unchanged from the user perspective
- [x] `go test ./internal/skillscheck`
- [x] `bash /Users/bytedance/.codex/plugins/cache/lark-cli-harness-codex-marketplace/lark-cli-harness/0.6.6/skills/dev-verify/scripts/validate.sh`
- [x] `LARKSUITE_CLI_CONFIG_DIR=/Users/bytedance/.lark-cli ./lark-cli update --help`
- [x] `go test ./internal/skillscheck -run TestSyncSkills_WritesStateAndDoesNotWriteStamp -count=1`

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed timestamp formatting in skills check to preserve local timezone information instead of converting all times to UTC, ensuring timestamps display with the correct timezone offset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->