### PR TITLE
docs(fetch): default --doc-format to markdown

### DIFF
--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -17,7 +17,7 @@ import (
 // v2FetchFlags returns the flag definitions for the v2 (OpenAPI) fetch path.
 func v2FetchFlags() []common.Flag {
 	return []common.Flag{
-		{Name: "doc-format", Desc: "output content format; xml keeps DocxXML structure and optional block ids, markdown is plain export", Default: "xml", Enum: []string{"xml", "markdown"}},
+		{Name: "doc-format", Desc: "output content format; xml keeps DocxXML structure and optional block ids, markdown is plain export", Default: "markdown", Enum: []string{"xml", "markdown"}},
 		{Name: "detail", Desc: "detail level; simple for reading, with-ids for block references, full for styles and edit metadata", Default: "simple", Enum: []string{"simple", "with-ids", "full"}},
 		{Name: "revision-id", Desc: "document revision id; -1 means latest", Type: "int", Default: "-1"},
 		{Name: "scope", Desc: "read scope; full reads whole doc, outline lists headings, section expands from heading anchor, range uses block ids, keyword searches text", Default: "full", Enum: []string{"full", "outline", "range", "keyword", "section"}},
@@ -147,14 +147,25 @@ func buildReadOption(runtime *common.RuntimeContext) map[string]interface{} {
 }
 
 // validateFetchDetail 非 xml 格式（markdown）不承载 block_id 与样式属性，拒绝 with-ids/full。
+// When --detail with-ids or --detail full is used without an explicit --doc-format,
+// auto-upgrade the format to xml since block ids and style attributes are only
+// available in XML output. This preserves backward compatibility after the default
+// format changed from xml to markdown.
 func validateFetchDetail(runtime *common.RuntimeContext) error {
 	format := strings.TrimSpace(runtime.Str("doc-format"))
 	detail := strings.TrimSpace(runtime.Str("detail"))
-	if format == "" || format == "xml" {
-		return nil
-	}
 	if detail == "with-ids" || detail == "full" {
-		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--detail %s is only supported with --doc-format xml; %s output has no block ids, use --detail simple or switch to --doc-format xml", detail, format).WithParam("--detail")
+		// If the user didn't explicitly set --doc-format, upgrade to xml since
+		// markdown cannot carry block ids or style attributes.
+		if format == "" || format == "markdown" {
+			if !runtime.Cmd.Flags().Changed("doc-format") {
+				if err := runtime.Cmd.Flags().Set("doc-format", "xml"); err != nil {
+					return err
+				}
+			} else if format == "markdown" {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--detail %s is only supported with --doc-format xml; %s output has no block ids, use --detail simple or switch to --doc-format xml", detail, format).WithParam("--detail")
+			}
+		}
 	}
 	return nil
 }

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -75,8 +75,71 @@ func TestDocsFetchDryRunDefaultsToV2Endpoint(t *testing.T) {
 	if got, want := dry.API[0].URL, "/open-apis/docs_ai/v1/documents/doxcnFetchDryRun/fetch"; got != want {
 		t.Fatalf("dry-run URL = %q, want %q", got, want)
 	}
-	if got, want := dry.API[0].Body["format"], "xml"; got != want {
+	if got, want := dry.API[0].Body["format"], "markdown"; got != want {
 		t.Fatalf("dry-run format = %#v, want %q", got, want)
+	}
+}
+
+func TestDocsFetchDetailWithIdsAutoUpgradesFormatToXml(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		setFlags map[string]string
+		wantFmt  string
+		wantErr  bool
+	}{
+		{
+			name:     "with-ids without explicit doc-format auto-upgrades to xml",
+			setFlags: map[string]string{"detail": "with-ids"},
+			wantFmt:  "xml",
+		},
+		{
+			name:     "full without explicit doc-format auto-upgrades to xml",
+			setFlags: map[string]string{"detail": "full"},
+			wantFmt:  "xml",
+		},
+		{
+			name:     "with-ids with explicit xml stays xml",
+			setFlags: map[string]string{"detail": "with-ids", "doc-format": "xml"},
+			wantFmt:  "xml",
+		},
+		{
+			name:     "with-ids with explicit markdown errors",
+			setFlags: map[string]string{"detail": "with-ids", "doc-format": "markdown"},
+			wantErr:  true,
+		},
+		{
+			name:     "simple detail keeps markdown default",
+			setFlags: map[string]string{"detail": "simple"},
+			wantFmt:  "markdown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runtime := newFetchShortcutTestRuntime(t, "", tt.setFlags)
+			err := validateFetchV2(context.Background(), runtime)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected validation error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateFetchV2() error = %v", err)
+			}
+			if got := runtime.Str("doc-format"); got != tt.wantFmt {
+				t.Fatalf("doc-format = %q, want %q", got, tt.wantFmt)
+			}
+
+			dry := decodeDocDryRun(t, DocsFetch.DryRun(context.Background(), runtime))
+			if got := dry.API[0].Body["format"]; got != tt.wantFmt {
+				t.Fatalf("dry-run format = %#v, want %q", got, tt.wantFmt)
+			}
+		})
 	}
 }
 

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -5,6 +5,7 @@ package doc
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -137,17 +138,45 @@ func TestDocsFetchRejectsLegacyFlags(t *testing.T) {
 
 func newFetchBodyTestRuntime(ctx context.Context) *common.RuntimeContext {
 	cmd := &cobra.Command{Use: "+fetch"}
-	cmd.Flags().String("doc-format", "xml", "")
-	cmd.Flags().String("detail", "simple", "")
-	cmd.Flags().Int("revision-id", -1, "")
-	cmd.Flags().String("scope", "full", "")
-	cmd.Flags().String("start-block-id", "", "")
-	cmd.Flags().String("end-block-id", "", "")
-	cmd.Flags().String("keyword", "", "")
-	cmd.Flags().Int("context-before", 0, "")
-	cmd.Flags().Int("context-after", 0, "")
-	cmd.Flags().Int("max-depth", -1, "")
+	cmd.Flags().String("doc-format", fetchDefault("doc-format"), "")
+	cmd.Flags().String("detail", fetchDefault("detail"), "")
+	cmd.Flags().Int("revision-id", fetchDefaultInt("revision-id"), "")
+	cmd.Flags().String("scope", fetchDefault("scope"), "")
+	cmd.Flags().String("start-block-id", fetchDefault("start-block-id"), "")
+	cmd.Flags().String("end-block-id", fetchDefault("end-block-id"), "")
+	cmd.Flags().String("keyword", fetchDefault("keyword"), "")
+	cmd.Flags().Int("context-before", fetchDefaultInt("context-before"), "")
+	cmd.Flags().Int("context-after", fetchDefaultInt("context-after"), "")
+	cmd.Flags().Int("max-depth", fetchDefaultInt("max-depth"), "")
 	return common.TestNewRuntimeContextWithCtx(ctx, cmd, nil)
+}
+
+// fetchDefault returns the declared default for a flag from the real
+// v2FetchFlags definition so tests don't hardcode a stale default.
+// It panics if the flag is not found, since a missing flag indicates
+// a test setup error rather than a runtime condition.
+func fetchDefault(name string) string {
+	for _, fl := range v2FetchFlags() {
+		if fl.Name == name {
+			return fl.Default
+		}
+	}
+	panic(fmt.Sprintf("fetchDefault: flag %q not found in v2FetchFlags", name))
+}
+
+// fetchDefaultInt returns the declared default for an int flag from
+// v2FetchFlags, parsed as an int. It panics if the flag is not found
+// or its default cannot be parsed as an int.
+func fetchDefaultInt(name string) int {
+	s := fetchDefault(name)
+	if s == "" {
+		return 0
+	}
+	var d int
+	if _, err := fmt.Sscanf(s, "%d", &d); err != nil {
+		panic(fmt.Sprintf("fetchDefaultInt: flag %q default %q is not an int", name, s))
+	}
+	return d
 }
 
 func newFetchShortcutTestRuntime(t *testing.T, apiVersion string, setFlags map[string]string) *common.RuntimeContext {
@@ -156,16 +185,16 @@ func newFetchShortcutTestRuntime(t *testing.T, apiVersion string, setFlags map[s
 	cmd := &cobra.Command{Use: "+fetch"}
 	cmd.Flags().String("api-version", "", "")
 	cmd.Flags().String("doc", "doxcnFetchDryRun", "")
-	cmd.Flags().String("doc-format", "xml", "")
-	cmd.Flags().String("detail", "simple", "")
-	cmd.Flags().Int("revision-id", -1, "")
-	cmd.Flags().String("scope", "full", "")
-	cmd.Flags().String("start-block-id", "", "")
-	cmd.Flags().String("end-block-id", "", "")
-	cmd.Flags().String("keyword", "", "")
-	cmd.Flags().Int("context-before", 0, "")
-	cmd.Flags().Int("context-after", 0, "")
-	cmd.Flags().Int("max-depth", -1, "")
+	cmd.Flags().String("doc-format", fetchDefault("doc-format"), "")
+	cmd.Flags().String("detail", fetchDefault("detail"), "")
+	cmd.Flags().Int("revision-id", fetchDefaultInt("revision-id"), "")
+	cmd.Flags().String("scope", fetchDefault("scope"), "")
+	cmd.Flags().String("start-block-id", fetchDefault("start-block-id"), "")
+	cmd.Flags().String("end-block-id", fetchDefault("end-block-id"), "")
+	cmd.Flags().String("keyword", fetchDefault("keyword"), "")
+	cmd.Flags().Int("context-before", fetchDefaultInt("context-before"), "")
+	cmd.Flags().Int("context-after", fetchDefaultInt("context-after"), "")
+	cmd.Flags().Int("max-depth", fetchDefaultInt("max-depth"), "")
 	cmd.Flags().String("offset", "", "")
 	cmd.Flags().String("limit", "", "")
 	if apiVersion != "" {


### PR DESCRIPTION

LLMs are the primary consumer of docs +fetch. Markdown renders the
same semantic content with substantially fewer tokens than the
DocxXML default, which cuts context-window bloat in the common
case. XML is still available via --doc-format xml for block-id
workflows.

When --detail with-ids or --detail full is used without an explicit
--doc-format, auto-upgrade the format to xml since block ids and
style attributes are only available in XML output. This preserves
backward compatibility after the default format changed from xml
to markdown.

Closes #1423.

Co-authored-by: TraeCli (Doubao-Seed-Dogfooding) <trae@bytedance.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/larksuite/cli/pull/1424).
* __->__ #1424
* #1428