### PR TITLE
doc: tell users to install skills from local clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ cd cli
 make install
 
 # Install CLI SKILL (required)
-npx skills add larksuite/cli -y -g
+npx skills add ./ -y -g
 ```
 
 #### Configure & Use

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Requires Go `v1.23`+ and Python 3.
 git clone https://github.com/larksuite/cli.git
 cd cli
 make install
+npx skills add ./ -y -g
 
 # Install CLI SKILL (required)
 npx skills add larksuite/cli -y -g


### PR DESCRIPTION

Summary: Update README.md to instruct users to install the CLI SKILL from the local clone instead of from the GitHub repository. If users install from the GitHub repository, they may not get the latest changes that are present in the local clone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README Quick Start instructions to install the CLI skill from the current directory when setting up from source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->