### PR TITLE
feat(docs): add opt-in --emulate fallback for block_move_after/block_copy_insert_after

### DIFF
--- a/shortcuts/doc/docs_update_emulate.go
+++ b/shortcuts/doc/docs_update_emulate.go
@@ -216,6 +216,8 @@ func indexTopLevelBlocks(xml string) []topLevelBlock {
 	return out
 }
 
+// idAttrSet returns the block id(s) carried by an attribute run as a set,
+// or an empty set when the run has no id attribute.
 func idAttrSet(attrs string) map[string]bool {
 	ids := map[string]bool{}
 	if m := emulateBlockIDRE.FindStringSubmatch(attrs); m != nil {
@@ -229,6 +231,8 @@ func idAttrSet(attrs string) map[string]bool {
 // xmlAttrValue call.
 var xmlAttrValueRECache sync.Map // name string -> *regexp.Regexp
 
+// xmlAttrValue returns the value of the named attribute within an attribute
+// run and whether it was present.
 func xmlAttrValue(attrs, name string) (string, bool) {
 	re, ok := xmlAttrValueRECache.Load(name)
 	if !ok {
@@ -242,11 +246,15 @@ func xmlAttrValue(attrs, name string) (string, bool) {
 	return m[1], true
 }
 
+// xmlAttrEscape escapes a raw string for safe inclusion in a double-quoted
+// XML attribute value.
 func xmlAttrEscape(raw string) string {
 	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;")
 	return r.Replace(raw)
 }
 
+// xmlEntityDecode reverses xmlAttrEscape, decoding the XML entities that
+// DocxXML export emits back into their literal characters.
 func xmlEntityDecode(s string) string {
 	r := strings.NewReplacer("&lt;", "<", "&gt;", ">", "&quot;", `"`, "&#39;", "'", "&amp;", "&")
 	return r.Replace(s)
@@ -336,6 +344,8 @@ func buildEmulatedBlockContent(b emulatedBlock) (content, insertedTag string, er
 	return inner, b.tag, nil
 }
 
+// splitSrcBlockIDs splits a comma-separated --src-block-ids value into trimmed,
+// non-empty block ids, preserving order.
 func splitSrcBlockIDs(raw string) []string {
 	var ids []string
 	for _, id := range strings.Split(raw, ",") {

--- a/shortcuts/doc/docs_update_emulate.go
+++ b/shortcuts/doc/docs_update_emulate.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -223,9 +224,18 @@ func idAttrSet(attrs string) map[string]bool {
 	return ids
 }
 
+// xmlAttrValueRECache memoizes the per-attribute-name regex so re-inserting a
+// document with many images does not recompile the same pattern on every
+// xmlAttrValue call.
+var xmlAttrValueRECache sync.Map // name string -> *regexp.Regexp
+
 func xmlAttrValue(attrs, name string) (string, bool) {
-	re := regexp.MustCompile(`(?:^|\s)` + regexp.QuoteMeta(name) + `="([^"]*)"`)
-	m := re.FindStringSubmatch(attrs)
+	re, ok := xmlAttrValueRECache.Load(name)
+	if !ok {
+		re, _ = xmlAttrValueRECache.LoadOrStore(name,
+			regexp.MustCompile(`(?:^|\s)`+regexp.QuoteMeta(name)+`="([^"]*)"`))
+	}
+	m := re.(*regexp.Regexp).FindStringSubmatch(attrs)
 	if m == nil {
 		return "", false
 	}

--- a/shortcuts/doc/docs_update_emulate.go
+++ b/shortcuts/doc/docs_update_emulate.go
@@ -4,6 +4,7 @@
 package doc
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -141,6 +142,87 @@ func indexEmulatedBlocks(xml string) map[string]emulatedBlock {
 	return byID
 }
 
+// topLevelBlock is one direct child of the document root, with the set of
+// id-carrying descendant ids it contains. Used to verify, after the insert,
+// that the rebuilt blocks landed immediately after the anchor — and nothing
+// else (e.g. a concurrent collaborator's edit) is mistaken for our insert.
+type topLevelBlock struct {
+	tag   string
+	start int
+	ids   map[string]bool // ids of this block and every descendant
+}
+
+// indexTopLevelBlocks returns the document's outermost blocks in order. Lark's
+// DocxXML export is flat — top-level blocks are siblings at the root with no
+// wrapping <page>/<body> element — so "top level" means a block that opens
+// while no other block is still open. List containers (<ul>/<ol>) carry no id
+// of their own, so each entry also records the ids in its subtree, which lets
+// the caller decide whether a top-level block is newly inserted (no
+// pre-existing id) or an untouched original.
+func indexTopLevelBlocks(xml string) []topLevelBlock {
+	var out []topLevelBlock
+	depth := 0 // number of currently-open (non-self-closing) blocks
+	var cur *topLevelBlock
+
+	for _, idx := range emulateXMLTagRE.FindAllStringSubmatchIndex(xml, -1) {
+		group := func(n int) string {
+			if idx[2*n] < 0 {
+				return ""
+			}
+			return xml[idx[2*n]:idx[2*n+1]]
+		}
+		closeTag, name, attrs, selfClose := group(1), group(2), group(3), group(4)
+
+		recordID := func() {
+			if cur == nil {
+				return
+			}
+			if m := emulateBlockIDRE.FindStringSubmatch(attrs); m != nil {
+				cur.ids[m[1]] = true
+			}
+		}
+
+		switch {
+		case closeTag == "/":
+			if depth > 0 {
+				depth--
+			}
+			if depth == 0 && cur != nil {
+				// Closing the outermost block: flush it.
+				out = append(out, *cur)
+				cur = nil
+			}
+		case selfClose == "/":
+			if depth == 0 {
+				// A self-closing top-level block (e.g. <img/>).
+				out = append(out, topLevelBlock{tag: name, start: idx[0], ids: idAttrSet(attrs)})
+			} else {
+				recordID()
+			}
+		default:
+			if depth == 0 {
+				cur = &topLevelBlock{tag: name, start: idx[0], ids: idAttrSet(attrs)}
+			} else {
+				recordID()
+			}
+			depth++
+		}
+	}
+	// Flush any unclosed trailing block (defensive; well-formed XML closes all).
+	if cur != nil {
+		out = append(out, *cur)
+	}
+	return out
+}
+
+func idAttrSet(attrs string) map[string]bool {
+	ids := map[string]bool{}
+	if m := emulateBlockIDRE.FindStringSubmatch(attrs); m != nil {
+		ids[m[1]] = true
+	}
+	return ids
+}
+
 func xmlAttrValue(attrs, name string) (string, bool) {
 	re := regexp.MustCompile(`(?:^|\s)` + regexp.QuoteMeta(name) + `="([^"]*)"`)
 	m := re.FindStringSubmatch(attrs)
@@ -208,20 +290,30 @@ func sanitizeEmulatedBlockXML(xml string) (string, error) {
 }
 
 // buildEmulatedBlockContent produces the block_insert_after payload for one
-// source block, rejecting block types a text-level rebuild would corrupt.
-func buildEmulatedBlockContent(b emulatedBlock) (string, error) {
+// source block plus the top-level tag the rebuilt block will carry once
+// inserted (used by anchor-scoped verification). It rejects block types a
+// text-level rebuild would corrupt. Rejections name --src-block-ids in Param
+// so the command layer can surface which source block failed.
+func buildEmulatedBlockContent(b emulatedBlock) (content, insertedTag string, err error) {
 	if !emulableBlockTags[b.tag] {
-		return "", errs.NewValidationError(errs.SubtypeFailedPrecondition,
+		return "", "", errs.NewValidationError(errs.SubtypeFailedPrecondition,
 			"cannot emulate move/copy of block %s: <%s> blocks carry server-side tokens or state that a client-side rebuild would corrupt", b.id, b.tag).
+			WithParam("--src-block-ids").
 			WithHint("supported block types: %s; move other block types in the editor instead", strings.Join(emulableBlockTagList, ", "))
 	}
 	inner, err := sanitizeEmulatedBlockXML(b.outer)
 	if err != nil {
-		return "", err
+		// rebuildEmulatedImgTag may reject (missing href); tag the failing flag.
+		var ve *errs.ValidationError
+		if errors.As(err, &ve) && ve.Param == "" {
+			ve.WithParam("--src-block-ids")
+		}
+		return "", "", err
 	}
 	if b.tag == "li" {
 		// A bare li is invalid insert content; wrap it in the nearest ancestor
-		// list type so ordered items stay ordered.
+		// list type so ordered items stay ordered. The inserted top-level block
+		// is therefore the list container, not the li.
 		listTag := "ul"
 		for i := len(b.parents) - 1; i >= 0; i-- {
 			if b.parents[i] == "ul" || b.parents[i] == "ol" {
@@ -229,9 +321,9 @@ func buildEmulatedBlockContent(b emulatedBlock) (string, error) {
 				break
 			}
 		}
-		return fmt.Sprintf("<%s>%s</%s>", listTag, inner, listTag), nil
+		return fmt.Sprintf("<%s>%s</%s>", listTag, inner, listTag), listTag, nil
 	}
-	return inner, nil
+	return inner, b.tag, nil
 }
 
 func splitSrcBlockIDs(raw string) []string {
@@ -304,6 +396,85 @@ func emulateUpdateDoc(runtime *common.RuntimeContext, token, command string, fie
 	return nil
 }
 
+// isNewTopLevelBlock reports whether a post-insert top-level block is one we
+// just inserted: a rebuilt block carries only server-assigned ids that did not
+// exist before (list containers themselves have no id, so an all-new or empty
+// id set both qualify). A block that contains any pre-existing id is an
+// untouched original, not our insert.
+func isNewTopLevelBlock(b topLevelBlock, beforeIDs map[string]bool) bool {
+	for id := range b.ids {
+		if beforeIDs[id] {
+			return false
+		}
+	}
+	return true
+}
+
+// anchorRunStart returns the index in the after-insert top-level slice where
+// our run of runLen rebuilt blocks must begin:
+//   - "-1": document end, so the run occupies the final runLen slots.
+//   - page id (the document_id): document start, so the run starts at index 0.
+//   - a block id: the top-level block whose subtree contains that id; the run
+//     starts right after it.
+//
+// The second return value is false when the anchor cannot be located among the
+// post-insert top-level blocks, which forces the caller to fail conservatively.
+func anchorRunStart(after []topLevelBlock, anchor, docID string, runLen int) (start int, ok bool) {
+	if anchor == "-1" {
+		// Inserted at document end: the rebuilt blocks are the final runLen.
+		start = len(after) - runLen
+		if start < 0 {
+			return 0, false
+		}
+		return start, true
+	}
+	if anchor == docID {
+		return 0, true
+	}
+	for i, b := range after {
+		if b.ids[anchor] {
+			return i + 1, true
+		}
+	}
+	return 0, false
+}
+
+// verifyEmulatedInsert confirms the rebuilt blocks landed contiguously right
+// after the anchor with the expected count and tag sequence, and returns their
+// ids. It is deliberately strict: a plain "any new block id appeared" check
+// would, in a shared document, treat a concurrent collaborator's edit as proof
+// of our insert and green-light deleting the originals. When the run after the
+// anchor does not match expectations it returns an error so the caller keeps
+// the originals (leaving a recoverable duplicate rather than risking data loss).
+func verifyEmulatedInsert(after []topLevelBlock, beforeIDs map[string]bool, anchor, docID string, expectedTags []string, srcList string) ([]string, error) {
+	conservativeFail := func() ([]string, error) {
+		return nil, errs.NewInternalError(errs.SubtypeInvalidResponse,
+			"could not confirm the rebuilt blocks landed after anchor %s; the original blocks %s were NOT deleted", anchor, srcList).
+			WithHint("inspect the document manually: the rebuilt blocks may have been inserted, but verification could not match them anchor-side (e.g. a concurrent edit), so the originals were left in place")
+	}
+
+	start, ok := anchorRunStart(after, anchor, docID, len(expectedTags))
+	if !ok {
+		return conservativeFail()
+	}
+	if start+len(expectedTags) > len(after) {
+		return conservativeFail()
+	}
+
+	var newIDs []string
+	for i, wantTag := range expectedTags {
+		b := after[start+i]
+		if b.tag != wantTag || !isNewTopLevelBlock(b, beforeIDs) {
+			return conservativeFail()
+		}
+		for id := range b.ids {
+			newIDs = append(newIDs, id)
+		}
+	}
+	sort.Strings(newIDs)
+	return newIDs, nil
+}
+
 var emulateSemanticDifferences = []string{
 	"rebuilt blocks were assigned new block ids; the original ids are gone",
 	"comments and #block_id anchor links on the original blocks are not migrated",
@@ -334,18 +505,21 @@ func executeUpdateEmulated(runtime *common.RuntimeContext, ref documentRef, comm
 
 	// Step 2: validate sources and build the rebuilt payload. Every check
 	// happens before the first write so a rejection leaves the document
-	// untouched.
+	// untouched. expectedTags records the top-level tag each rebuilt block
+	// will carry once inserted, used by anchor-scoped verification below.
 	pieces := make([]string, 0, len(srcIDs))
+	expectedTags := make([]string, 0, len(srcIDs))
 	for _, id := range srcIDs {
 		b, ok := blocks[id]
 		if !ok {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "source block %s not found in document %s", id, docID).WithParam("--src-block-ids")
 		}
-		piece, err := buildEmulatedBlockContent(b)
+		piece, insertedTag, err := buildEmulatedBlockContent(b)
 		if err != nil {
 			return err
 		}
 		pieces = append(pieces, piece)
+		expectedTags = append(expectedTags, insertedTag)
 	}
 	if _, ok := blocks[anchor]; !ok && anchor != "-1" && anchor != docID {
 		fmt.Fprintf(errOut, "note: anchor block %s is not in the fetched block index (normal when it is the page id); the server will validate it\n", anchor)
@@ -364,26 +538,25 @@ func executeUpdateEmulated(runtime *common.RuntimeContext, ref documentRef, comm
 		return err
 	}
 
-	// Step 4: re-fetch and confirm new blocks actually appeared before
-	// deleting anything.
+	// Step 4: re-fetch and confirm the rebuilt blocks landed contiguously
+	// right after the anchor — with the expected count and tag sequence —
+	// before deleting anything. Anchor-scoped (not "any new block appeared")
+	// so a concurrent collaborator's edit in a shared document can't be
+	// mistaken for our insert and trigger an erroneous delete.
 	fmt.Fprintf(errOut, "[4/4] Verifying rebuilt blocks\n")
 	_, afterXML, err := emulateFetchDocumentXML(runtime, ref.Token, false)
 	if err != nil {
 		fmt.Fprintf(errOut, "verification fetch failed AFTER the insert: the rebuilt blocks may now exist alongside the originals %s; inspect the document before retrying\n", srcList)
 		return err
 	}
-	afterBlocks := indexEmulatedBlocks(afterXML)
-	var newIDs []string
-	for id, b := range afterBlocks {
-		if _, existed := blocks[id]; !existed {
-			newIDs = append(newIDs, b.id)
-		}
+	beforeIDs := make(map[string]bool, len(blocks))
+	for id := range blocks {
+		beforeIDs[id] = true
 	}
-	sort.Slice(newIDs, func(i, j int) bool { return afterBlocks[newIDs[i]].start < afterBlocks[newIDs[j]].start })
-	if len(newIDs) == 0 {
-		return errs.NewInternalError(errs.SubtypeInvalidResponse,
-			"block_insert_after reported success but the re-fetch shows no new blocks; the original blocks %s were NOT deleted", srcList).
-			WithHint("inspect the document manually before retrying")
+	newIDs, err := verifyEmulatedInsert(indexTopLevelBlocks(afterXML), beforeIDs, anchor, docID, expectedTags, srcList)
+	if err != nil {
+		fmt.Fprintf(errOut, "verification could not match the rebuilt blocks after anchor %s; leaving the originals %s in place\n", anchor, srcList)
+		return err
 	}
 
 	srcDeleted := false

--- a/shortcuts/doc/docs_update_emulate.go
+++ b/shortcuts/doc/docs_update_emulate.go
@@ -1,0 +1,438 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package doc
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// Client-side emulation for block_move_after / block_copy_insert_after.
+//
+// Some server deployments do not read src_block_ids and reject both commands
+// with "requires content or src_block_ids but both were empty"
+// (https://github.com/larksuite/cli/issues/758). --emulate opts into a
+// client-side fallback that reproduces move/copy with the primitives that do
+// work:
+//
+//	fetch source blocks (full detail) → rebuild them after the anchor via
+//	block_insert_after → re-fetch to verify the rebuilt blocks exist →
+//	block_delete the originals (move only)
+//
+// The insert always happens before the delete and every failure stops the
+// flow immediately with the inserted/deleted state reported on stderr, so no
+// path loses the source content.
+//
+// Emulation is NOT semantically identical to the server-side commands:
+//   - rebuilt blocks are assigned new block ids
+//   - comments and #block_id anchor links on the originals are not migrated
+//   - image blocks are re-uploaded from their source URL (file token changes)
+//
+// Block types that carry server-side tokens or state (whiteboard, sheet,
+// bitable, table, synced_reference, ...) are rejected outright: a text-level
+// rebuild would corrupt them, so refusing is the safe behavior.
+
+var emulableBlockTagList = []string{
+	"p", "h1", "h2", "h3", "h4", "h5", "h6", "h7", "h8", "h9",
+	"ul", "ol", "li", "blockquote", "callout", "pre", "img",
+}
+
+var emulableBlockTags = func() map[string]bool {
+	m := make(map[string]bool, len(emulableBlockTagList))
+	for _, tag := range emulableBlockTagList {
+		m[tag] = true
+	}
+	return m
+}()
+
+var (
+	// emulateXMLTagRE tokenizes DocxXML tags: close marker, tag name,
+	// attribute run (quote-aware so '>' inside attribute values is skipped),
+	// self-close marker.
+	emulateXMLTagRE = regexp.MustCompile(`<(/?)([a-zA-Z][\w:-]*)((?:"[^"]*"|'[^']*'|[^>"'])*?)(/?)>`)
+	// emulateBlockIDRE extracts the block id attribute from an attribute run.
+	emulateBlockIDRE = regexp.MustCompile(`(?:^|\s)id="([^"]+)"`)
+	// emulateStripIDRE removes block id attributes before re-insert; the
+	// server assigns fresh ids to rebuilt blocks.
+	emulateStripIDRE = regexp.MustCompile(`\s+id="[^"]*"`)
+	// emulateStripCalloutColorRE removes rgb(...) callout colors: fetch
+	// returns them as rgb triples but the write path only accepts semantic
+	// color names, so they are dropped (the emoji attribute is kept).
+	emulateStripCalloutColorRE = regexp.MustCompile(`\s+(?:background-color|border-color|text-color)="rgb\([^"]*\)"`)
+	// emulateImgTagRE matches an img tag (optionally with a separate close
+	// tag) for href-based rebuilding.
+	emulateImgTagRE = regexp.MustCompile(`<img\b((?:"[^"]*"|'[^']*'|[^>"'])*?)/?>(?:</img>)?`)
+)
+
+// emulatedBlock is one id-carrying block extracted from fetched DocxXML.
+type emulatedBlock struct {
+	id      string
+	tag     string
+	attrs   string
+	outer   string   // full source slice including the tag itself
+	parents []string // ancestor tag names, outermost first
+	start   int      // byte offset in the fetched XML, used for document ordering
+}
+
+// indexEmulatedBlocks scans fetched DocxXML and indexes every block that
+// carries an id attribute, keeping its full subtree slice and ancestor chain.
+func indexEmulatedBlocks(xml string) map[string]emulatedBlock {
+	byID := make(map[string]emulatedBlock)
+	type openTag struct {
+		name    string
+		attrs   string
+		start   int
+		parents []string
+	}
+	var stack []openTag
+
+	finish := func(el openTag, end int) {
+		m := emulateBlockIDRE.FindStringSubmatch(el.attrs)
+		if m == nil {
+			return
+		}
+		byID[m[1]] = emulatedBlock{
+			id:      m[1],
+			tag:     el.name,
+			attrs:   el.attrs,
+			outer:   xml[el.start:end],
+			parents: el.parents,
+			start:   el.start,
+		}
+	}
+
+	stackNames := func() []string {
+		names := make([]string, len(stack))
+		for i, el := range stack {
+			names[i] = el.name
+		}
+		return names
+	}
+
+	for _, idx := range emulateXMLTagRE.FindAllStringSubmatchIndex(xml, -1) {
+		group := func(n int) string {
+			if idx[2*n] < 0 {
+				return ""
+			}
+			return xml[idx[2*n]:idx[2*n+1]]
+		}
+		name := group(2)
+		switch {
+		case group(1) == "/": // close tag: pop to the nearest matching open tag
+			for i := len(stack) - 1; i >= 0; i-- {
+				if stack[i].name == name {
+					finish(stack[i], idx[1])
+					stack = stack[:i] // unclosed children are dropped with the parent
+					break
+				}
+			}
+		case group(4) == "/": // self-closing tag
+			finish(openTag{name: name, attrs: group(3), start: idx[0], parents: stackNames()}, idx[1])
+		default:
+			stack = append(stack, openTag{name: name, attrs: group(3), start: idx[0], parents: stackNames()})
+		}
+	}
+	return byID
+}
+
+func xmlAttrValue(attrs, name string) (string, bool) {
+	re := regexp.MustCompile(`(?:^|\s)` + regexp.QuoteMeta(name) + `="([^"]*)"`)
+	m := re.FindStringSubmatch(attrs)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}
+
+func xmlAttrEscape(raw string) string {
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;")
+	return r.Replace(raw)
+}
+
+func xmlEntityDecode(s string) string {
+	r := strings.NewReplacer("&lt;", "<", "&gt;", ">", "&quot;", `"`, "&#39;", "'", "&amp;", "&")
+	return r.Replace(s)
+}
+
+// rebuildEmulatedImgTag rewrites an img block from its href: the fetched src
+// token / mime / scale attributes cannot be written back, so re-inserting the
+// image is effectively a re-upload from the source URL.
+func rebuildEmulatedImgTag(attrs string) (string, error) {
+	href, ok := xmlAttrValue(attrs, "href")
+	if !ok {
+		href, ok = xmlAttrValue(attrs, "url")
+	}
+	if !ok {
+		return "", errs.NewValidationError(errs.SubtypeFailedPrecondition,
+			"cannot emulate move/copy of an img block without an href/url attribute; the fetched src token cannot be re-inserted").
+			WithHint("re-insert the image manually, or use docs +media-insert with the original file")
+	}
+	var b strings.Builder
+	b.WriteString(`<img href="`)
+	b.WriteString(xmlAttrEscape(xmlEntityDecode(href)))
+	b.WriteString(`"`)
+	for _, name := range []string{"width", "height", "caption", "name"} {
+		if v, ok := xmlAttrValue(attrs, name); ok && v != "" {
+			fmt.Fprintf(&b, ` %s="%s"`, name, v)
+		}
+	}
+	b.WriteString("/>")
+	return b.String(), nil
+}
+
+// sanitizeEmulatedBlockXML turns a fetched block subtree into content the
+// write path accepts: img tags are rebuilt from href, block ids are stripped
+// (the server assigns new ones), and rgb callout colors are dropped.
+func sanitizeEmulatedBlockXML(xml string) (string, error) {
+	var rebuildErr error
+	out := emulateImgTagRE.ReplaceAllStringFunc(xml, func(tag string) string {
+		m := emulateImgTagRE.FindStringSubmatch(tag)
+		rebuilt, err := rebuildEmulatedImgTag(m[1])
+		if err != nil && rebuildErr == nil {
+			rebuildErr = err
+		}
+		return rebuilt
+	})
+	if rebuildErr != nil {
+		return "", rebuildErr
+	}
+	out = emulateStripIDRE.ReplaceAllString(out, "")
+	out = emulateStripCalloutColorRE.ReplaceAllString(out, "")
+	return out, nil
+}
+
+// buildEmulatedBlockContent produces the block_insert_after payload for one
+// source block, rejecting block types a text-level rebuild would corrupt.
+func buildEmulatedBlockContent(b emulatedBlock) (string, error) {
+	if !emulableBlockTags[b.tag] {
+		return "", errs.NewValidationError(errs.SubtypeFailedPrecondition,
+			"cannot emulate move/copy of block %s: <%s> blocks carry server-side tokens or state that a client-side rebuild would corrupt", b.id, b.tag).
+			WithHint("supported block types: %s; move other block types in the editor instead", strings.Join(emulableBlockTagList, ", "))
+	}
+	inner, err := sanitizeEmulatedBlockXML(b.outer)
+	if err != nil {
+		return "", err
+	}
+	if b.tag == "li" {
+		// A bare li is invalid insert content; wrap it in the nearest ancestor
+		// list type so ordered items stay ordered.
+		listTag := "ul"
+		for i := len(b.parents) - 1; i >= 0; i-- {
+			if b.parents[i] == "ul" || b.parents[i] == "ol" {
+				listTag = b.parents[i]
+				break
+			}
+		}
+		return fmt.Sprintf("<%s>%s</%s>", listTag, inner, listTag), nil
+	}
+	return inner, nil
+}
+
+func splitSrcBlockIDs(raw string) []string {
+	var ids []string
+	for _, id := range strings.Split(raw, ",") {
+		if id = strings.TrimSpace(id); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// emulateFetchBody builds the docs_ai fetch request body for the emulation
+// path. The first fetch needs full detail so img blocks carry a rebuildable
+// href; the verification fetch only needs block ids.
+func emulateFetchBody(runtime *common.RuntimeContext, full bool) map[string]interface{} {
+	exportOption := map[string]interface{}{"export_block_id": true}
+	if full {
+		exportOption["export_style_attrs"] = true
+		exportOption["export_cite_extra_data"] = true
+	}
+	body := map[string]interface{}{
+		"format":        "xml",
+		"export_option": exportOption,
+	}
+	injectDocsScene(runtime, body)
+	return body
+}
+
+// emulateFetchDocumentXML fetches the document and returns its id and XML content.
+func emulateFetchDocumentXML(runtime *common.RuntimeContext, token string, full bool) (docID, content string, err error) {
+	apiPath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s/fetch", token)
+	data, err := doDocAPI(runtime, "POST", apiPath, emulateFetchBody(runtime, full))
+	if err != nil {
+		return "", "", err
+	}
+	doc, _ := data["document"].(map[string]interface{})
+	if doc == nil {
+		return "", "", errs.NewInternalError(errs.SubtypeInvalidResponse, "fetch response has no document object")
+	}
+	docID, _ = doc["document_id"].(string)
+	content, _ = doc["content"].(string)
+	return docID, content, nil
+}
+
+// emulateUpdateBody builds a docs_ai update request body for one emulation write.
+func emulateUpdateBody(runtime *common.RuntimeContext, command string, fields map[string]interface{}) map[string]interface{} {
+	body := map[string]interface{}{
+		"format":  "xml",
+		"command": command,
+	}
+	for k, v := range fields {
+		body[k] = v
+	}
+	injectDocsScene(runtime, body)
+	return body
+}
+
+// emulateUpdateDoc issues one write and asserts the service-level result field,
+// which can report a non-success outcome even when the API code is 0.
+func emulateUpdateDoc(runtime *common.RuntimeContext, token, command string, fields map[string]interface{}) error {
+	apiPath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s", token)
+	data, err := doDocAPI(runtime, "PUT", apiPath, emulateUpdateBody(runtime, command, fields))
+	if err != nil {
+		return err
+	}
+	if result, _ := data["result"].(string); result != "success" {
+		return errs.NewInternalError(errs.SubtypeInvalidResponse, "%s returned result=%q, expected \"success\"", command, result)
+	}
+	return nil
+}
+
+var emulateSemanticDifferences = []string{
+	"rebuilt blocks were assigned new block ids; the original ids are gone",
+	"comments and #block_id anchor links on the original blocks are not migrated",
+	"image blocks were re-uploaded from their source URL; file tokens changed",
+}
+
+// executeUpdateEmulated runs the client-side move/copy emulation. Write order
+// is insert → verify → delete so a failure at any step leaves the source
+// content in the document.
+func executeUpdateEmulated(runtime *common.RuntimeContext, ref documentRef, command string) error {
+	isMove := command == "block_move_after"
+	anchor := runtime.Str("block-id")
+	srcIDs := splitSrcBlockIDs(runtime.Str("src-block-ids"))
+	srcList := strings.Join(srcIDs, ",")
+	errOut := runtime.IO().ErrOut
+
+	fmt.Fprintf(errOut, "Emulating %s client-side (--emulate; server-side src_block_ids workaround)\n", command)
+	fmt.Fprintf(errOut, "warning: emulation differs from the server-side command: rebuilt blocks get new block ids; comments and #block_id anchors on the originals are not migrated; image blocks are re-uploaded\n")
+
+	// Step 1: fetch with full detail — img blocks only carry a rebuildable
+	// href at this level.
+	fmt.Fprintf(errOut, "[1/4] Fetching document blocks (full detail)\n")
+	docID, beforeXML, err := emulateFetchDocumentXML(runtime, ref.Token, true)
+	if err != nil {
+		return err
+	}
+	blocks := indexEmulatedBlocks(beforeXML)
+
+	// Step 2: validate sources and build the rebuilt payload. Every check
+	// happens before the first write so a rejection leaves the document
+	// untouched.
+	pieces := make([]string, 0, len(srcIDs))
+	for _, id := range srcIDs {
+		b, ok := blocks[id]
+		if !ok {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "source block %s not found in document %s", id, docID).WithParam("--src-block-ids")
+		}
+		piece, err := buildEmulatedBlockContent(b)
+		if err != nil {
+			return err
+		}
+		pieces = append(pieces, piece)
+	}
+	if _, ok := blocks[anchor]; !ok && anchor != "-1" && anchor != docID {
+		fmt.Fprintf(errOut, "note: anchor block %s is not in the fetched block index (normal when it is the page id); the server will validate it\n", anchor)
+	}
+	content := strings.Join(pieces, "")
+	fmt.Fprintf(errOut, "[2/4] Rebuilt %d source block(s) (%d characters)\n", len(srcIDs), len(content))
+
+	// Step 3: insert the rebuilt blocks at the anchor. The originals are not
+	// touched until this insert is verified.
+	fmt.Fprintf(errOut, "[3/4] Inserting rebuilt blocks after %s\n", anchor)
+	if err := emulateUpdateDoc(runtime, ref.Token, "block_insert_after", map[string]interface{}{
+		"block_id": anchor,
+		"content":  content,
+	}); err != nil {
+		fmt.Fprintf(errOut, "insert failed; the document is unchanged and the original blocks %s are intact\n", srcList)
+		return err
+	}
+
+	// Step 4: re-fetch and confirm new blocks actually appeared before
+	// deleting anything.
+	fmt.Fprintf(errOut, "[4/4] Verifying rebuilt blocks\n")
+	_, afterXML, err := emulateFetchDocumentXML(runtime, ref.Token, false)
+	if err != nil {
+		fmt.Fprintf(errOut, "verification fetch failed AFTER the insert: the rebuilt blocks may now exist alongside the originals %s; inspect the document before retrying\n", srcList)
+		return err
+	}
+	afterBlocks := indexEmulatedBlocks(afterXML)
+	var newIDs []string
+	for id, b := range afterBlocks {
+		if _, existed := blocks[id]; !existed {
+			newIDs = append(newIDs, b.id)
+		}
+	}
+	sort.Slice(newIDs, func(i, j int) bool { return afterBlocks[newIDs[i]].start < afterBlocks[newIDs[j]].start })
+	if len(newIDs) == 0 {
+		return errs.NewInternalError(errs.SubtypeInvalidResponse,
+			"block_insert_after reported success but the re-fetch shows no new blocks; the original blocks %s were NOT deleted", srcList).
+			WithHint("inspect the document manually before retrying")
+	}
+
+	srcDeleted := false
+	if isMove {
+		fmt.Fprintf(errOut, "Deleting original blocks %s\n", srcList)
+		if err := emulateUpdateDoc(runtime, ref.Token, "block_delete", map[string]interface{}{
+			"block_id": srcList,
+		}); err != nil {
+			fmt.Fprintf(errOut, "delete failed AFTER a verified insert: the document now contains BOTH the originals (%s) and the rebuilt blocks (%s); delete one set manually\n", srcList, strings.Join(newIDs, ","))
+			return err
+		}
+		srcDeleted = true
+	}
+
+	runtime.OutRaw(map[string]interface{}{
+		"result":               "success",
+		"emulated":             true,
+		"command":              command,
+		"document_id":          docID,
+		"anchor_block_id":      anchor,
+		"src_block_ids":        srcIDs,
+		"src_blocks_deleted":   srcDeleted,
+		"new_block_ids":        newIDs,
+		"semantic_differences": emulateSemanticDifferences,
+	}, nil)
+	return nil
+}
+
+// dryRunUpdateEmulated describes the multi-call emulation plan without
+// touching the document. The insert content placeholder stands in for the
+// rebuilt blocks, which only exist after the first fetch.
+func dryRunUpdateEmulated(runtime *common.RuntimeContext, ref documentRef, command string) *common.DryRunAPI {
+	fetchPath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s/fetch", ref.Token)
+	updatePath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s", ref.Token)
+	anchor := runtime.Str("block-id")
+	srcBlockIDs := runtime.Str("src-block-ids")
+
+	d := common.NewDryRunAPI().
+		Desc(fmt.Sprintf("client-side %s emulation: fetch source blocks → rebuild after anchor → verify → delete originals (move only)", command)).
+		POST(fetchPath).Desc("[1] fetch source blocks (full detail)").Body(emulateFetchBody(runtime, true)).
+		PUT(updatePath).Desc("[2] insert rebuilt blocks after the anchor").Body(emulateUpdateBody(runtime, "block_insert_after", map[string]interface{}{
+		"block_id": anchor,
+		"content":  "<rebuilt source blocks>",
+	})).
+		POST(fetchPath).Desc("[3] verify the rebuilt blocks exist").Body(emulateFetchBody(runtime, false))
+	if command == "block_move_after" {
+		d.PUT(updatePath).Desc("[4] delete the original blocks").Body(emulateUpdateBody(runtime, "block_delete", map[string]interface{}{
+			"block_id": srcBlockIDs,
+		}))
+	}
+	return d.Set("document_id", ref.Token)
+}

--- a/shortcuts/doc/docs_update_emulate_test.go
+++ b/shortcuts/doc/docs_update_emulate_test.go
@@ -1,0 +1,441 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+package doc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+// emulateTestXML is a fetched-document fixture covering every rebuild case:
+// heading, paragraph with entities, ordered-list item, image (href + src
+// token), unsupported whiteboard, callout with rgb colors, and the anchor.
+const emulateTestXML = `<page id="doxcnEmu">` +
+	`<h1 id="blkHead">Title</h1>` +
+	`<p id="blkA">First &amp; second</p>` +
+	`<ol id="blkList"><li id="blkLi">item</li></ol>` +
+	`<img id="blkImg" src="tokimg" href="https://example.com/a.png?x=1&amp;y=2" width="100" height="50"/>` +
+	`<whiteboard id="blkWb" token="wbtok"/>` +
+	`<callout id="blkCall" background-color="rgb(1,2,3)" emoji="bulb"><p id="blkCallP">tip</p></callout>` +
+	`<p id="blkAnchor">anchor</p>` +
+	`</page>`
+
+func TestIndexEmulatedBlocks(t *testing.T) {
+	blocks := indexEmulatedBlocks(emulateTestXML)
+
+	tests := []struct {
+		id          string
+		wantTag     string
+		wantOuter   string
+		wantParents []string
+	}{
+		{id: "blkA", wantTag: "p", wantOuter: `<p id="blkA">First &amp; second</p>`, wantParents: []string{"page"}},
+		{id: "blkLi", wantTag: "li", wantOuter: `<li id="blkLi">item</li>`, wantParents: []string{"page", "ol"}},
+		{id: "blkImg", wantTag: "img", wantParents: []string{"page"}},
+		{id: "blkWb", wantTag: "whiteboard", wantParents: []string{"page"}},
+		{id: "blkList", wantTag: "ol", wantOuter: `<ol id="blkList"><li id="blkLi">item</li></ol>`, wantParents: []string{"page"}},
+	}
+	for _, tt := range tests {
+		b, ok := blocks[tt.id]
+		if !ok {
+			t.Fatalf("block %s not indexed", tt.id)
+		}
+		if b.tag != tt.wantTag {
+			t.Fatalf("block %s tag = %q, want %q", tt.id, b.tag, tt.wantTag)
+		}
+		if tt.wantOuter != "" && b.outer != tt.wantOuter {
+			t.Fatalf("block %s outer = %q, want %q", tt.id, b.outer, tt.wantOuter)
+		}
+		if got := strings.Join(b.parents, ","); got != strings.Join(tt.wantParents, ",") {
+			t.Fatalf("block %s parents = %q, want %q", tt.id, got, strings.Join(tt.wantParents, ","))
+		}
+	}
+	if _, ok := blocks["doxcnEmu"]; !ok {
+		t.Fatal("page block should be indexed by its id")
+	}
+}
+
+func TestBuildEmulatedBlockContent(t *testing.T) {
+	blocks := indexEmulatedBlocks(emulateTestXML)
+
+	tests := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{name: "paragraph keeps entities and drops id", id: "blkA", want: `<p>First &amp; second</p>`},
+		{name: "list item wraps in nearest list type", id: "blkLi", want: `<ol><li>item</li></ol>`},
+		{name: "image rebuilds from href and drops src token", id: "blkImg", want: `<img href="https://example.com/a.png?x=1&amp;y=2" width="100" height="50"/>`},
+		{name: "callout drops rgb colors keeps emoji", id: "blkCall", want: `<callout emoji="bulb"><p>tip</p></callout>`},
+		{name: "list container keeps children", id: "blkList", want: `<ol><li>item</li></ol>`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildEmulatedBlockContent(blocks[tt.id])
+			if err != nil {
+				t.Fatalf("buildEmulatedBlockContent(%s) error: %v", tt.id, err)
+			}
+			if got != tt.want {
+				t.Fatalf("buildEmulatedBlockContent(%s) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildEmulatedBlockContentRejectsUnsupportedType(t *testing.T) {
+	blocks := indexEmulatedBlocks(emulateTestXML)
+
+	_, err := buildEmulatedBlockContent(blocks["blkWb"])
+	if err == nil {
+		t.Fatal("expected error for whiteboard block")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %v", err)
+	}
+	if problem.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("subtype = %q, want %q", problem.Subtype, errs.SubtypeFailedPrecondition)
+	}
+	for _, want := range []string{"blkWb", "<whiteboard>"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestRebuildEmulatedImgTagRequiresHref(t *testing.T) {
+	_, err := rebuildEmulatedImgTag(` src="tok123" width="10"`)
+	if err == nil {
+		t.Fatal("expected error for img without href/url")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed error, got %v", err)
+	}
+	if problem.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("subtype = %q, want %q", problem.Subtype, errs.SubtypeFailedPrecondition)
+	}
+}
+
+// docEmulateOutput decodes the emulation success envelope.
+type docEmulateOutput struct {
+	OK   bool `json:"ok"`
+	Data struct {
+		Result           string   `json:"result"`
+		Emulated         bool     `json:"emulated"`
+		Command          string   `json:"command"`
+		DocumentID       string   `json:"document_id"`
+		AnchorBlockID    string   `json:"anchor_block_id"`
+		SrcBlockIDs      []string `json:"src_block_ids"`
+		SrcBlocksDeleted bool     `json:"src_blocks_deleted"`
+		NewBlockIDs      []string `json:"new_block_ids"`
+	} `json:"data"`
+}
+
+func decodeDocEmulateOutput(t *testing.T, stdout *bytes.Buffer) docEmulateOutput {
+	t.Helper()
+	var out docEmulateOutput
+	if err := json.Unmarshal(stdout.Bytes(), &out); err != nil {
+		t.Fatalf("decode emulate output: %v; output=%s", err, stdout.String())
+	}
+	return out
+}
+
+func registerEmulateFetchStub(reg *httpmock.Registry, docID, content string) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/docs_ai/v1/documents/" + docID + "/fetch",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"document": map[string]interface{}{
+					"document_id": docID,
+					"content":     content,
+				},
+			},
+		},
+	}
+	reg.Register(stub)
+	return stub
+}
+
+// emulateUpdateRequestBody mirrors the docs_ai update request fields the
+// emulation writes.
+type emulateUpdateRequestBody struct {
+	Command string `json:"command"`
+	BlockID string `json:"block_id"`
+	Content string `json:"content"`
+}
+
+func decodeEmulateUpdateBody(t *testing.T, stub *httpmock.Stub) emulateUpdateRequestBody {
+	t.Helper()
+	var body emulateUpdateRequestBody
+	if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+		t.Fatalf("decode captured update body: %v; body=%s", err, stub.CapturedBody)
+	}
+	return body
+}
+
+func registerEmulateUpdateStub(reg *httpmock.Registry, docID, command string) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method: "PUT",
+		URL:    "/open-apis/docs_ai/v1/documents/" + docID,
+		BodyFilter: func(body []byte) bool {
+			return strings.Contains(string(body), `"command":"`+command+`"`)
+		},
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"result": "success"},
+		},
+	}
+	reg.Register(stub)
+	return stub
+}
+
+func TestDocsUpdateEmulatedMoveViaExecute(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-emulate-move"))
+
+	afterXML := strings.Replace(emulateTestXML,
+		`<p id="blkAnchor">anchor</p>`,
+		`<p id="blkAnchor">anchor</p><p id="blkNew">First &amp; second</p>`, 1)
+
+	registerEmulateFetchStub(reg, "doxcnEmu", emulateTestXML)
+	insertStub := registerEmulateUpdateStub(reg, "doxcnEmu", "block_insert_after")
+	registerEmulateFetchStub(reg, "doxcnEmu", afterXML)
+	deleteStub := registerEmulateUpdateStub(reg, "doxcnEmu", "block_delete")
+
+	err := mountAndRunDocs(t, DocsUpdate, []string{
+		"+update",
+		"--doc", "doxcnEmu",
+		"--command", "block_move_after",
+		"--block-id", "blkAnchor",
+		"--src-block-ids", "blkA",
+		"--emulate",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	insertBody := decodeEmulateUpdateBody(t, insertStub)
+	if insertBody.Content != `<p>First &amp; second</p>` {
+		t.Fatalf("insert content = %q, want rebuilt paragraph without the source id", insertBody.Content)
+	}
+	if insertBody.BlockID != "blkAnchor" {
+		t.Fatalf("insert block_id = %q, want %q", insertBody.BlockID, "blkAnchor")
+	}
+	if deleteBody := decodeEmulateUpdateBody(t, deleteStub); deleteBody.BlockID != "blkA" {
+		t.Fatalf("delete block_id = %q, want %q", deleteBody.BlockID, "blkA")
+	}
+
+	out := decodeDocEmulateOutput(t, stdout)
+	if !out.OK || out.Data.Result != "success" || !out.Data.Emulated {
+		t.Fatalf("unexpected output envelope: %s", stdout.String())
+	}
+	if !out.Data.SrcBlocksDeleted {
+		t.Fatal("move should delete the source blocks")
+	}
+	if len(out.Data.NewBlockIDs) != 1 || out.Data.NewBlockIDs[0] != "blkNew" {
+		t.Fatalf("new_block_ids = %v, want [blkNew]", out.Data.NewBlockIDs)
+	}
+}
+
+func TestDocsUpdateEmulatedCopyKeepsOriginals(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-emulate-copy"))
+
+	afterXML := strings.Replace(emulateTestXML,
+		`<p id="blkAnchor">anchor</p>`,
+		`<p id="blkAnchor">anchor</p><ol id="blkNewList"><li id="blkNewLi">item</li></ol>`, 1)
+
+	registerEmulateFetchStub(reg, "doxcnEmu", emulateTestXML)
+	insertStub := registerEmulateUpdateStub(reg, "doxcnEmu", "block_insert_after")
+	registerEmulateFetchStub(reg, "doxcnEmu", afterXML)
+	// No block_delete stub: copy must not delete anything; Registry.Verify in
+	// TestFactory cleanup fails the test on any unexpected call.
+
+	err := mountAndRunDocs(t, DocsUpdate, []string{
+		"+update",
+		"--doc", "doxcnEmu",
+		"--command", "block_copy_insert_after",
+		"--block-id", "blkAnchor",
+		"--src-block-ids", "blkLi",
+		"--emulate",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	// The rebuilt list item must be wrapped in its original ordered-list type.
+	if insertBody := decodeEmulateUpdateBody(t, insertStub); insertBody.Content != "<ol><li>item</li></ol>" {
+		t.Fatalf("insert content = %q, want wrapped list item", insertBody.Content)
+	}
+
+	out := decodeDocEmulateOutput(t, stdout)
+	if !out.OK || !out.Data.Emulated || out.Data.Command != "block_copy_insert_after" {
+		t.Fatalf("unexpected output envelope: %s", stdout.String())
+	}
+	if out.Data.SrcBlocksDeleted {
+		t.Fatal("copy must not delete the source blocks")
+	}
+	if len(out.Data.NewBlockIDs) != 2 {
+		t.Fatalf("new_block_ids = %v, want the two rebuilt list ids", out.Data.NewBlockIDs)
+	}
+}
+
+func TestDocsUpdateEmulatedRejectsUnsupportedTypeBeforeWriting(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-emulate-reject"))
+
+	// Only the initial fetch is stubbed: the unsupported block must be
+	// rejected before any write request is issued.
+	registerEmulateFetchStub(reg, "doxcnEmu", emulateTestXML)
+
+	err := mountAndRunDocs(t, DocsUpdate, []string{
+		"+update",
+		"--doc", "doxcnEmu",
+		"--command", "block_move_after",
+		"--block-id", "blkAnchor",
+		"--src-block-ids", "blkA,blkWb",
+		"--emulate",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected unsupported-type error")
+	}
+	for _, want := range []string{"blkWb", "<whiteboard>"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestDocsUpdateEmulatedStopsWhenInsertNotVisible(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-emulate-verify"))
+
+	registerEmulateFetchStub(reg, "doxcnEmu", emulateTestXML)
+	registerEmulateUpdateStub(reg, "doxcnEmu", "block_insert_after")
+	// The verification fetch returns the unchanged document: no new block ids.
+	registerEmulateFetchStub(reg, "doxcnEmu", emulateTestXML)
+	// No block_delete stub: the originals must never be deleted on a failed
+	// verification.
+
+	err := mountAndRunDocs(t, DocsUpdate, []string{
+		"+update",
+		"--doc", "doxcnEmu",
+		"--command", "block_move_after",
+		"--block-id", "blkAnchor",
+		"--src-block-ids", "blkA",
+		"--emulate",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected verification error")
+	}
+	if !strings.Contains(err.Error(), "NOT deleted") {
+		t.Fatalf("error should state the originals were kept: %v", err)
+	}
+}
+
+func TestDocsUpdateEmulateValidation(t *testing.T) {
+	tests := []struct {
+		name     string
+		setFlags map[string]string
+		want     string
+	}{
+		{
+			name:     "rejects non move/copy command",
+			setFlags: map[string]string{"command": "append", "content": "<p>x</p>", "emulate": "true"},
+			want:     "--emulate only applies to block_move_after and block_copy_insert_after",
+		},
+		{
+			name: "rejects explicit revision id",
+			setFlags: map[string]string{
+				"command": "block_move_after", "block-id": "blkAnchor",
+				"src-block-ids": "blkA", "emulate": "true", "revision-id": "7", "content": "",
+			},
+			want: "--revision-id is not supported with --emulate",
+		},
+		{
+			name: "rejects duplicate source ids",
+			setFlags: map[string]string{
+				"command": "block_move_after", "block-id": "blkAnchor",
+				"src-block-ids": "blkA,blkA", "emulate": "true", "content": "",
+			},
+			want: "duplicate block id blkA",
+		},
+		{
+			name: "rejects empty source id list",
+			setFlags: map[string]string{
+				"command": "block_copy_insert_after", "block-id": "blkAnchor",
+				"src-block-ids": ",", "emulate": "true",
+			},
+			want: "contains no block ids",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runtime := newUpdateShortcutTestRuntime(t, "", tt.setFlags)
+			err := validateUpdateV2(context.Background(), runtime)
+			if err == nil {
+				t.Fatal("expected validation error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error missing %q: %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func TestDocsUpdateEmulatedDryRun(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   string
+		wantCalls int
+	}{
+		{name: "move plans fetch insert verify delete", command: "block_move_after", wantCalls: 4},
+		{name: "copy plans fetch insert verify", command: "block_copy_insert_after", wantCalls: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			runtime := newUpdateShortcutTestRuntime(t, "", map[string]string{
+				"command": tt.command, "block-id": "blkAnchor",
+				"src-block-ids": "blkA,blkB", "emulate": "true", "content": "",
+			})
+			if err := validateUpdateV2(context.Background(), runtime); err != nil {
+				t.Fatalf("validateUpdateV2() error = %v", err)
+			}
+
+			dry := decodeDocDryRun(t, DocsUpdate.DryRun(context.Background(), runtime))
+			if len(dry.API) != tt.wantCalls {
+				t.Fatalf("expected %d dry-run API calls, got %d", tt.wantCalls, len(dry.API))
+			}
+			if got, want := dry.API[0].URL, "/open-apis/docs_ai/v1/documents/doxcnUpdateDryRun/fetch"; got != want {
+				t.Fatalf("first dry-run URL = %q, want %q", got, want)
+			}
+			if got, want := dry.API[1].Body["command"], "block_insert_after"; got != want {
+				t.Fatalf("insert command = %#v, want %q", got, want)
+			}
+			if tt.command == "block_move_after" {
+				if got, want := dry.API[3].Body["command"], "block_delete"; got != want {
+					t.Fatalf("delete command = %#v, want %q", got, want)
+				}
+				if got, want := dry.API[3].Body["block_id"], "blkA,blkB"; got != want {
+					t.Fatalf("delete block_id = %#v, want %q", got, want)
+				}
+			}
+		})
+	}
+}

--- a/shortcuts/doc/docs_update_emulate_test.go
+++ b/shortcuts/doc/docs_update_emulate_test.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"strings"
 	"testing"
 
@@ -426,22 +425,10 @@ func TestDocsUpdateEmulateValidation(t *testing.T) {
 
 			runtime := newUpdateShortcutTestRuntime(t, "", tt.setFlags)
 			err := validateUpdateV2(context.Background(), runtime)
-			if err == nil {
-				t.Fatal("expected validation error")
-			}
 
-			// Primary assertions: typed error metadata (category/subtype/param),
-			// not message text — error-path tests must pin the envelope.
-			if p, ok := errs.ProblemOf(err); !ok || p.Subtype != errs.SubtypeInvalidArgument {
-				t.Fatalf("expected subtype %s, got %T: %v", errs.SubtypeInvalidArgument, err, err)
-			}
-			var ve *errs.ValidationError
-			if !errors.As(err, &ve) {
-				t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
-			}
-			if ve.Param != tt.wantParam {
-				t.Fatalf("param = %q, want %q", ve.Param, tt.wantParam)
-			}
+			// Primary: pin the typed envelope (category/subtype/param) via the
+			// package's shared contract helper, not message text.
+			assertValidationContract(t, err, errs.SubtypeInvalidArgument, tt.wantParam)
 
 			// Secondary: the human-facing message still names the problem.
 			if !strings.Contains(err.Error(), tt.want) {

--- a/shortcuts/doc/docs_update_emulate_test.go
+++ b/shortcuts/doc/docs_update_emulate_test.go
@@ -17,15 +17,15 @@ import (
 // emulateTestXML is a fetched-document fixture covering every rebuild case:
 // heading, paragraph with entities, ordered-list item, image (href + src
 // token), unsupported whiteboard, callout with rgb colors, and the anchor.
-const emulateTestXML = `<page id="doxcnEmu">` +
-	`<h1 id="blkHead">Title</h1>` +
+// Lark's DocxXML export is flat (top-level blocks are siblings with no
+// wrapping <page>/<body> element), so the fixture mirrors that.
+const emulateTestXML = `<h1 id="blkHead">Title</h1>` +
 	`<p id="blkA">First &amp; second</p>` +
 	`<ol id="blkList"><li id="blkLi">item</li></ol>` +
 	`<img id="blkImg" src="tokimg" href="https://example.com/a.png?x=1&amp;y=2" width="100" height="50"/>` +
 	`<whiteboard id="blkWb" token="wbtok"/>` +
 	`<callout id="blkCall" background-color="rgb(1,2,3)" emoji="bulb"><p id="blkCallP">tip</p></callout>` +
-	`<p id="blkAnchor">anchor</p>` +
-	`</page>`
+	`<p id="blkAnchor">anchor</p>`
 
 func TestIndexEmulatedBlocks(t *testing.T) {
 	blocks := indexEmulatedBlocks(emulateTestXML)
@@ -36,11 +36,11 @@ func TestIndexEmulatedBlocks(t *testing.T) {
 		wantOuter   string
 		wantParents []string
 	}{
-		{id: "blkA", wantTag: "p", wantOuter: `<p id="blkA">First &amp; second</p>`, wantParents: []string{"page"}},
-		{id: "blkLi", wantTag: "li", wantOuter: `<li id="blkLi">item</li>`, wantParents: []string{"page", "ol"}},
-		{id: "blkImg", wantTag: "img", wantParents: []string{"page"}},
-		{id: "blkWb", wantTag: "whiteboard", wantParents: []string{"page"}},
-		{id: "blkList", wantTag: "ol", wantOuter: `<ol id="blkList"><li id="blkLi">item</li></ol>`, wantParents: []string{"page"}},
+		{id: "blkA", wantTag: "p", wantOuter: `<p id="blkA">First &amp; second</p>`, wantParents: []string{}},
+		{id: "blkLi", wantTag: "li", wantOuter: `<li id="blkLi">item</li>`, wantParents: []string{"ol"}},
+		{id: "blkImg", wantTag: "img", wantParents: []string{}},
+		{id: "blkWb", wantTag: "whiteboard", wantParents: []string{}},
+		{id: "blkList", wantTag: "ol", wantOuter: `<ol id="blkList"><li id="blkLi">item</li></ol>`, wantParents: []string{}},
 	}
 	for _, tt := range tests {
 		b, ok := blocks[tt.id]
@@ -57,33 +57,34 @@ func TestIndexEmulatedBlocks(t *testing.T) {
 			t.Fatalf("block %s parents = %q, want %q", tt.id, got, strings.Join(tt.wantParents, ","))
 		}
 	}
-	if _, ok := blocks["doxcnEmu"]; !ok {
-		t.Fatal("page block should be indexed by its id")
-	}
 }
 
 func TestBuildEmulatedBlockContent(t *testing.T) {
 	blocks := indexEmulatedBlocks(emulateTestXML)
 
 	tests := []struct {
-		name string
-		id   string
-		want string
+		name            string
+		id              string
+		want            string
+		wantInsertedTag string
 	}{
-		{name: "paragraph keeps entities and drops id", id: "blkA", want: `<p>First &amp; second</p>`},
-		{name: "list item wraps in nearest list type", id: "blkLi", want: `<ol><li>item</li></ol>`},
-		{name: "image rebuilds from href and drops src token", id: "blkImg", want: `<img href="https://example.com/a.png?x=1&amp;y=2" width="100" height="50"/>`},
-		{name: "callout drops rgb colors keeps emoji", id: "blkCall", want: `<callout emoji="bulb"><p>tip</p></callout>`},
-		{name: "list container keeps children", id: "blkList", want: `<ol><li>item</li></ol>`},
+		{name: "paragraph keeps entities and drops id", id: "blkA", want: `<p>First &amp; second</p>`, wantInsertedTag: "p"},
+		{name: "list item wraps in nearest list type", id: "blkLi", want: `<ol><li>item</li></ol>`, wantInsertedTag: "ol"},
+		{name: "image rebuilds from href and drops src token", id: "blkImg", want: `<img href="https://example.com/a.png?x=1&amp;y=2" width="100" height="50"/>`, wantInsertedTag: "img"},
+		{name: "callout drops rgb colors keeps emoji", id: "blkCall", want: `<callout emoji="bulb"><p>tip</p></callout>`, wantInsertedTag: "callout"},
+		{name: "list container keeps children", id: "blkList", want: `<ol><li>item</li></ol>`, wantInsertedTag: "ol"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildEmulatedBlockContent(blocks[tt.id])
+			got, insertedTag, err := buildEmulatedBlockContent(blocks[tt.id])
 			if err != nil {
 				t.Fatalf("buildEmulatedBlockContent(%s) error: %v", tt.id, err)
 			}
 			if got != tt.want {
-				t.Fatalf("buildEmulatedBlockContent(%s) = %q, want %q", tt.id, got, tt.want)
+				t.Fatalf("buildEmulatedBlockContent(%s) content = %q, want %q", tt.id, got, tt.want)
+			}
+			if insertedTag != tt.wantInsertedTag {
+				t.Fatalf("buildEmulatedBlockContent(%s) insertedTag = %q, want %q", tt.id, insertedTag, tt.wantInsertedTag)
 			}
 		})
 	}
@@ -92,21 +93,26 @@ func TestBuildEmulatedBlockContent(t *testing.T) {
 func TestBuildEmulatedBlockContentRejectsUnsupportedType(t *testing.T) {
 	blocks := indexEmulatedBlocks(emulateTestXML)
 
-	_, err := buildEmulatedBlockContent(blocks["blkWb"])
-	if err == nil {
-		t.Fatal("expected error for whiteboard block")
-	}
-	problem, ok := errs.ProblemOf(err)
-	if !ok {
-		t.Fatalf("expected typed error, got %v", err)
-	}
-	if problem.Subtype != errs.SubtypeFailedPrecondition {
-		t.Fatalf("subtype = %q, want %q", problem.Subtype, errs.SubtypeFailedPrecondition)
-	}
+	_, _, err := buildEmulatedBlockContent(blocks["blkWb"])
+	// Typed validation contract: failed_precondition naming --src-block-ids so
+	// the command layer knows which flag carried the offending source block.
+	assertValidationContract(t, err, errs.SubtypeFailedPrecondition, "--src-block-ids")
 	for _, want := range []string{"blkWb", "<whiteboard>"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error missing %q: %v", want, err)
 		}
+	}
+}
+
+func TestBuildEmulatedBlockContentRejectsImgWithoutHref(t *testing.T) {
+	// An img source block with no href/url cannot be re-inserted; the rejection
+	// must surface as a typed validation fault naming --src-block-ids.
+	blocks := indexEmulatedBlocks(`<img id="blkNoHref" src="tok123" width="10"/>`)
+
+	_, _, err := buildEmulatedBlockContent(blocks["blkNoHref"])
+	assertValidationContract(t, err, errs.SubtypeFailedPrecondition, "--src-block-ids")
+	if !strings.Contains(err.Error(), "href") {
+		t.Fatalf("error should mention the missing href: %v", err)
 	}
 }
 
@@ -437,5 +443,205 @@ func TestDocsUpdateEmulatedDryRun(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestIndexTopLevelBlocks(t *testing.T) {
+	got := indexTopLevelBlocks(emulateTestXML)
+
+	type want struct {
+		tag string
+		ids []string
+	}
+	wants := []want{
+		{tag: "h1", ids: []string{"blkHead"}},
+		{tag: "p", ids: []string{"blkA"}},
+		{tag: "ol", ids: []string{"blkLi"}}, // list container has no id; its li does
+		{tag: "img", ids: []string{"blkImg"}},
+		{tag: "whiteboard", ids: []string{"blkWb"}},
+		{tag: "callout", ids: []string{"blkCall", "blkCallP"}}, // block + nested child
+		{tag: "p", ids: []string{"blkAnchor"}},
+	}
+	if len(got) != len(wants) {
+		t.Fatalf("top-level block count = %d, want %d (%+v)", len(got), len(wants), got)
+	}
+	for i, w := range wants {
+		if got[i].tag != w.tag {
+			t.Fatalf("block[%d] tag = %q, want %q", i, got[i].tag, w.tag)
+		}
+		for _, id := range w.ids {
+			if !got[i].ids[id] {
+				t.Fatalf("block[%d] (%s) missing id %q; ids=%v", i, w.tag, id, got[i].ids)
+			}
+		}
+	}
+}
+
+func TestVerifyEmulatedInsert(t *testing.T) {
+	beforeIDs := map[string]bool{"blkAnchor": true, "blkOld": true}
+	// after: anchor, then a freshly inserted paragraph, then a pre-existing block.
+	after := []topLevelBlock{
+		{tag: "p", ids: map[string]bool{"blkAnchor": true}},
+		{tag: "p", ids: map[string]bool{"blkNew": true}},
+		{tag: "p", ids: map[string]bool{"blkOld": true}},
+	}
+
+	t.Run("matches contiguous run after anchor", func(t *testing.T) {
+		newIDs, err := verifyEmulatedInsert(after, beforeIDs, "blkAnchor", "doxcnEmu", []string{"p"}, "blkSrc")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(newIDs) != 1 || newIDs[0] != "blkNew" {
+			t.Fatalf("newIDs = %v, want [blkNew]", newIDs)
+		}
+	})
+
+	t.Run("rejects tag mismatch", func(t *testing.T) {
+		_, err := verifyEmulatedInsert(after, beforeIDs, "blkAnchor", "doxcnEmu", []string{"h1"}, "blkSrc")
+		if err == nil {
+			t.Fatal("expected conservative failure on tag mismatch")
+		}
+	})
+
+	t.Run("rejects when the next block is a pre-existing original", func(t *testing.T) {
+		// A concurrent edit could leave a pre-existing block right after the
+		// anchor; that is not our insert, so verification must fail.
+		concurrent := []topLevelBlock{
+			{tag: "p", ids: map[string]bool{"blkAnchor": true}},
+			{tag: "p", ids: map[string]bool{"blkOld": true}},
+		}
+		_, err := verifyEmulatedInsert(concurrent, beforeIDs, "blkAnchor", "doxcnEmu", []string{"p"}, "blkSrc")
+		if err == nil {
+			t.Fatal("expected conservative failure: the block after the anchor is a pre-existing original")
+		}
+	})
+
+	t.Run("rejects when anchor is missing", func(t *testing.T) {
+		_, err := verifyEmulatedInsert(after, beforeIDs, "blkGone", "doxcnEmu", []string{"p"}, "blkSrc")
+		if err == nil {
+			t.Fatal("expected conservative failure when anchor cannot be located")
+		}
+	})
+
+	t.Run("page id anchor inserts at document start", func(t *testing.T) {
+		atStart := []topLevelBlock{
+			{tag: "p", ids: map[string]bool{"blkNew": true}},
+			{tag: "p", ids: map[string]bool{"blkAnchor": true}},
+		}
+		newIDs, err := verifyEmulatedInsert(atStart, beforeIDs, "doxcnEmu", "doxcnEmu", []string{"p"}, "blkSrc")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(newIDs) != 1 || newIDs[0] != "blkNew" {
+			t.Fatalf("newIDs = %v, want [blkNew]", newIDs)
+		}
+	})
+
+	t.Run("-1 anchor matches the final inserted block at document end", func(t *testing.T) {
+		atEnd := []topLevelBlock{
+			{tag: "p", ids: map[string]bool{"blkOld": true}},
+			{tag: "img", ids: map[string]bool{"blkNew": true}},
+		}
+		newIDs, err := verifyEmulatedInsert(atEnd, beforeIDs, "-1", "doxcnEmu", []string{"img"}, "blkSrc")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(newIDs) != 1 || newIDs[0] != "blkNew" {
+			t.Fatalf("newIDs = %v, want [blkNew]", newIDs)
+		}
+	})
+
+	t.Run("-1 anchor rejects when the last block is a pre-existing original", func(t *testing.T) {
+		// Our insert at -1 did not land last (e.g. concurrent edit appended);
+		// the final block is a pre-existing original, so do not delete.
+		atEnd := []topLevelBlock{
+			{tag: "img", ids: map[string]bool{"blkNew": true}},
+			{tag: "p", ids: map[string]bool{"blkOld": true}},
+		}
+		_, err := verifyEmulatedInsert(atEnd, beforeIDs, "-1", "doxcnEmu", []string{"img"}, "blkSrc")
+		if err == nil {
+			t.Fatal("expected conservative failure: the final block is a pre-existing original")
+		}
+	})
+}
+
+// TestDocsUpdateEmulatedRejectsConcurrentEditAtAnchor is the regression guard
+// for the data-loss bug a naive "any new block id appeared" check invited: a
+// collaborator adds an unrelated block elsewhere, but our insert did NOT land
+// after the anchor. The old check would have seen *a* new id and deleted the
+// originals; anchor-scoped verification must refuse and keep them.
+func TestDocsUpdateEmulatedRejectsConcurrentEditAtAnchor(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-emulate-concurrent"))
+
+	// Verification fetch: a brand-new block appeared, but at the document top —
+	// nowhere near the anchor. (Simulates a concurrent collaborator edit while
+	// our own insert is, say, lost or delayed.)
+	afterXML := strings.Replace(emulateTestXML,
+		`<h1 id="blkHead">Title</h1>`,
+		`<p id="blkConcurrent">someone else typed this</p><h1 id="blkHead">Title</h1>`, 1)
+
+	registerEmulateFetchStub(reg, "doxcnEmu", emulateTestXML)
+	registerEmulateUpdateStub(reg, "doxcnEmu", "block_insert_after")
+	registerEmulateFetchStub(reg, "doxcnEmu", afterXML)
+	// No block_delete stub: the originals must survive.
+
+	err := mountAndRunDocs(t, DocsUpdate, []string{
+		"+update",
+		"--doc", "doxcnEmu",
+		"--command", "block_move_after",
+		"--block-id", "blkAnchor",
+		"--src-block-ids", "blkA",
+		"--emulate",
+		"--as", "bot",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected conservative verification failure, not a false success")
+	}
+	if !strings.Contains(err.Error(), "NOT deleted") {
+		t.Fatalf("error should state the originals were kept: %v", err)
+	}
+}
+
+// TestDocsUpdateEmulatedMoveSucceedsDespiteConcurrentEditElsewhere proves the
+// strict check is not over-eager: a concurrent edit far from the anchor does
+// not block a legitimate insert that did land contiguously after the anchor.
+func TestDocsUpdateEmulatedMoveSucceedsDespiteConcurrentEditElsewhere(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-emulate-concurrent-ok"))
+
+	// after: our rebuilt block lands right after the anchor AND an unrelated
+	// new block appears at the top from a concurrent edit.
+	afterXML := strings.Replace(emulateTestXML,
+		`<p id="blkAnchor">anchor</p>`,
+		`<p id="blkAnchor">anchor</p><p id="blkNew">First &amp; second</p>`, 1)
+	afterXML = strings.Replace(afterXML,
+		`<h1 id="blkHead">Title</h1>`,
+		`<p id="blkConcurrent">unrelated</p><h1 id="blkHead">Title</h1>`, 1)
+
+	registerEmulateFetchStub(reg, "doxcnEmu", emulateTestXML)
+	registerEmulateUpdateStub(reg, "doxcnEmu", "block_insert_after")
+	registerEmulateFetchStub(reg, "doxcnEmu", afterXML)
+	registerEmulateUpdateStub(reg, "doxcnEmu", "block_delete")
+
+	err := mountAndRunDocs(t, DocsUpdate, []string{
+		"+update",
+		"--doc", "doxcnEmu",
+		"--command", "block_move_after",
+		"--block-id", "blkAnchor",
+		"--src-block-ids", "blkA",
+		"--emulate",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	out := decodeDocEmulateOutput(t, stdout)
+	if !out.Data.SrcBlocksDeleted {
+		t.Fatal("move should delete the source blocks once anchor-scoped verification passes")
+	}
+	// Only the anchor-adjacent rebuilt block counts as ours; the concurrent
+	// block must not be reported as a new block id.
+	if len(out.Data.NewBlockIDs) != 1 || out.Data.NewBlockIDs[0] != "blkNew" {
+		t.Fatalf("new_block_ids = %v, want [blkNew] (concurrent edit excluded)", out.Data.NewBlockIDs)
 	}
 }

--- a/shortcuts/doc/docs_update_emulate_test.go
+++ b/shortcuts/doc/docs_update_emulate_test.go
@@ -28,6 +28,8 @@ const emulateTestXML = `<h1 id="blkHead">Title</h1>` +
 	`<callout id="blkCall" background-color="rgb(1,2,3)" emoji="bulb"><p id="blkCallP">tip</p></callout>` +
 	`<p id="blkAnchor">anchor</p>`
 
+// TestIndexEmulatedBlocks checks that indexEmulatedBlocks maps every fetched
+// block id to its tag and attribute run across the fixture document.
 func TestIndexEmulatedBlocks(t *testing.T) {
 	blocks := indexEmulatedBlocks(emulateTestXML)
 
@@ -60,6 +62,8 @@ func TestIndexEmulatedBlocks(t *testing.T) {
 	}
 }
 
+// TestBuildEmulatedBlockContent verifies the rebuild rules that turn each
+// supported fetched block into the content re-inserted after the anchor.
 func TestBuildEmulatedBlockContent(t *testing.T) {
 	blocks := indexEmulatedBlocks(emulateTestXML)
 
@@ -91,6 +95,8 @@ func TestBuildEmulatedBlockContent(t *testing.T) {
 	}
 }
 
+// TestBuildEmulatedBlockContentRejectsUnsupportedType asserts that block types
+// carrying server-side state are rejected with a failed_precondition error.
 func TestBuildEmulatedBlockContentRejectsUnsupportedType(t *testing.T) {
 	blocks := indexEmulatedBlocks(emulateTestXML)
 
@@ -105,6 +111,8 @@ func TestBuildEmulatedBlockContentRejectsUnsupportedType(t *testing.T) {
 	}
 }
 
+// TestBuildEmulatedBlockContentRejectsImgWithoutHref asserts that an img block
+// without a rebuildable href is rejected rather than silently dropped.
 func TestBuildEmulatedBlockContentRejectsImgWithoutHref(t *testing.T) {
 	// An img source block with no href/url cannot be re-inserted; the rejection
 	// must surface as a typed validation fault naming --src-block-ids.
@@ -117,6 +125,8 @@ func TestBuildEmulatedBlockContentRejectsImgWithoutHref(t *testing.T) {
 	}
 }
 
+// TestRebuildEmulatedImgTagRequiresHref verifies rebuildEmulatedImgTag fails
+// when the source img tag has no href to re-upload from.
 func TestRebuildEmulatedImgTagRequiresHref(t *testing.T) {
 	_, err := rebuildEmulatedImgTag(` src="tok123" width="10"`)
 	if err == nil {
@@ -146,6 +156,8 @@ type docEmulateOutput struct {
 	} `json:"data"`
 }
 
+// decodeDocEmulateOutput unmarshals the JSON success envelope an emulation run
+// writes to stdout, failing the test on malformed output.
 func decodeDocEmulateOutput(t *testing.T, stdout *bytes.Buffer) docEmulateOutput {
 	t.Helper()
 	var out docEmulateOutput
@@ -155,6 +167,8 @@ func decodeDocEmulateOutput(t *testing.T, stdout *bytes.Buffer) docEmulateOutput
 	return out
 }
 
+// registerEmulateFetchStub registers an httpmock stub that answers the
+// docs_ai fetch call with the given document content.
 func registerEmulateFetchStub(reg *httpmock.Registry, docID, content string) *httpmock.Stub {
 	stub := &httpmock.Stub{
 		Method: "POST",
@@ -181,6 +195,8 @@ type emulateUpdateRequestBody struct {
 	Content string `json:"content"`
 }
 
+// decodeEmulateUpdateBody unmarshals the update request body a stub captured so
+// tests can assert the command and block ids the emulation wrote.
 func decodeEmulateUpdateBody(t *testing.T, stub *httpmock.Stub) emulateUpdateRequestBody {
 	t.Helper()
 	var body emulateUpdateRequestBody
@@ -190,6 +206,8 @@ func decodeEmulateUpdateBody(t *testing.T, stub *httpmock.Stub) emulateUpdateReq
 	return body
 }
 
+// registerEmulateUpdateStub registers an httpmock stub that matches the
+// emulation's update call for the given command and returns a success result.
 func registerEmulateUpdateStub(reg *httpmock.Registry, docID, command string) *httpmock.Stub {
 	stub := &httpmock.Stub{
 		Method: "PUT",
@@ -206,6 +224,8 @@ func registerEmulateUpdateStub(reg *httpmock.Registry, docID, command string) *h
 	return stub
 }
 
+// TestDocsUpdateEmulatedMoveViaExecute drives a full move through execute:
+// fetch, insert after the anchor, verify, then delete the originals.
 func TestDocsUpdateEmulatedMoveViaExecute(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-emulate-move"))
 
@@ -254,6 +274,8 @@ func TestDocsUpdateEmulatedMoveViaExecute(t *testing.T) {
 	}
 }
 
+// TestDocsUpdateEmulatedCopyKeepsOriginals verifies a copy inserts the rebuilt
+// blocks but issues no delete, leaving the source blocks in place.
 func TestDocsUpdateEmulatedCopyKeepsOriginals(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-emulate-copy"))
 
@@ -297,6 +319,8 @@ func TestDocsUpdateEmulatedCopyKeepsOriginals(t *testing.T) {
 	}
 }
 
+// TestDocsUpdateEmulatedRejectsUnsupportedTypeBeforeWriting asserts an
+// unsupported source block aborts the run before any insert or delete write.
 func TestDocsUpdateEmulatedRejectsUnsupportedTypeBeforeWriting(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-emulate-reject"))
 
@@ -323,6 +347,8 @@ func TestDocsUpdateEmulatedRejectsUnsupportedTypeBeforeWriting(t *testing.T) {
 	}
 }
 
+// TestDocsUpdateEmulatedStopsWhenInsertNotVisible asserts that a failed
+// post-insert verification halts the move and keeps the originals undeleted.
 func TestDocsUpdateEmulatedStopsWhenInsertNotVisible(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-emulate-verify"))
 
@@ -350,6 +376,8 @@ func TestDocsUpdateEmulatedStopsWhenInsertNotVisible(t *testing.T) {
 	}
 }
 
+// TestDocsUpdateEmulateValidation checks that validateUpdateV2 rejects invalid
+// --emulate flag combinations with the expected typed validation metadata.
 func TestDocsUpdateEmulateValidation(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -423,6 +451,8 @@ func TestDocsUpdateEmulateValidation(t *testing.T) {
 	}
 }
 
+// TestDocsUpdateEmulatedDryRun verifies the dry-run plan lists the expected
+// fetch/insert/verify/delete call sequence for move and copy.
 func TestDocsUpdateEmulatedDryRun(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -467,6 +497,8 @@ func TestDocsUpdateEmulatedDryRun(t *testing.T) {
 	}
 }
 
+// TestIndexTopLevelBlocks checks that indexTopLevelBlocks returns the ordered
+// top-level blocks with their tags and ids, including nested callout children.
 func TestIndexTopLevelBlocks(t *testing.T) {
 	got := indexTopLevelBlocks(emulateTestXML)
 
@@ -498,6 +530,8 @@ func TestIndexTopLevelBlocks(t *testing.T) {
 	}
 }
 
+// TestVerifyEmulatedInsert checks that verifyEmulatedInsert confirms the
+// rebuilt blocks appear within the anchor-scoped run before delete is allowed.
 func TestVerifyEmulatedInsert(t *testing.T) {
 	beforeIDs := map[string]bool{"blkAnchor": true, "blkOld": true}
 	// after: anchor, then a freshly inserted paragraph, then a pre-existing block.

--- a/shortcuts/doc/docs_update_emulate_test.go
+++ b/shortcuts/doc/docs_update_emulate_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -351,14 +352,16 @@ func TestDocsUpdateEmulatedStopsWhenInsertNotVisible(t *testing.T) {
 
 func TestDocsUpdateEmulateValidation(t *testing.T) {
 	tests := []struct {
-		name     string
-		setFlags map[string]string
-		want     string
+		name      string
+		setFlags  map[string]string
+		wantParam string
+		want      string
 	}{
 		{
-			name:     "rejects non move/copy command",
-			setFlags: map[string]string{"command": "append", "content": "<p>x</p>", "emulate": "true"},
-			want:     "--emulate only applies to block_move_after and block_copy_insert_after",
+			name:      "rejects non move/copy command",
+			setFlags:  map[string]string{"command": "append", "content": "<p>x</p>", "emulate": "true"},
+			wantParam: "--emulate",
+			want:      "--emulate only applies to block_move_after and block_copy_insert_after",
 		},
 		{
 			name: "rejects explicit revision id",
@@ -366,7 +369,8 @@ func TestDocsUpdateEmulateValidation(t *testing.T) {
 				"command": "block_move_after", "block-id": "blkAnchor",
 				"src-block-ids": "blkA", "emulate": "true", "revision-id": "7", "content": "",
 			},
-			want: "--revision-id is not supported with --emulate",
+			wantParam: "--revision-id",
+			want:      "--revision-id is not supported with --emulate",
 		},
 		{
 			name: "rejects duplicate source ids",
@@ -374,7 +378,8 @@ func TestDocsUpdateEmulateValidation(t *testing.T) {
 				"command": "block_move_after", "block-id": "blkAnchor",
 				"src-block-ids": "blkA,blkA", "emulate": "true", "content": "",
 			},
-			want: "duplicate block id blkA",
+			wantParam: "--src-block-ids",
+			want:      "duplicate block id blkA",
 		},
 		{
 			name: "rejects empty source id list",
@@ -382,7 +387,8 @@ func TestDocsUpdateEmulateValidation(t *testing.T) {
 				"command": "block_copy_insert_after", "block-id": "blkAnchor",
 				"src-block-ids": ",", "emulate": "true",
 			},
-			want: "contains no block ids",
+			wantParam: "--src-block-ids",
+			want:      "contains no block ids",
 		},
 	}
 
@@ -395,6 +401,21 @@ func TestDocsUpdateEmulateValidation(t *testing.T) {
 			if err == nil {
 				t.Fatal("expected validation error")
 			}
+
+			// Primary assertions: typed error metadata (category/subtype/param),
+			// not message text — error-path tests must pin the envelope.
+			if p, ok := errs.ProblemOf(err); !ok || p.Subtype != errs.SubtypeInvalidArgument {
+				t.Fatalf("expected subtype %s, got %T: %v", errs.SubtypeInvalidArgument, err, err)
+			}
+			var ve *errs.ValidationError
+			if !errors.As(err, &ve) {
+				t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+			}
+			if ve.Param != tt.wantParam {
+				t.Fatalf("param = %q, want %q", ve.Param, tt.wantParam)
+			}
+
+			// Secondary: the human-facing message still names the problem.
 			if !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("error missing %q: %v", tt.want, err)
 			}

--- a/shortcuts/doc/docs_update_test.go
+++ b/shortcuts/doc/docs_update_test.go
@@ -116,6 +116,7 @@ func newUpdateShortcutTestRuntime(t *testing.T, apiVersion string, setFlags map[
 	cmd.Flags().String("pattern", "", "")
 	cmd.Flags().String("block-id", "", "")
 	cmd.Flags().String("src-block-ids", "", "")
+	cmd.Flags().Bool("emulate", false, "")
 	cmd.Flags().String("mode", "", "")
 	cmd.Flags().String("markdown", "", "")
 	cmd.Flags().String("selection-with-ellipsis", "", "")

--- a/shortcuts/doc/docs_update_v2.go
+++ b/shortcuts/doc/docs_update_v2.go
@@ -31,6 +31,7 @@ func v2UpdateFlags() []common.Flag {
 		{Name: "pattern", Desc: "str_replace match pattern; XML mode is inline text, Markdown mode can match multiline text"},
 		{Name: "block-id", Desc: "target block ID(s) for block operations (comma-separated for batch delete); -1 means document end where supported"},
 		{Name: "src-block-ids", Desc: "comma-separated source block ids for block_copy_insert_after and block_move_after"},
+		{Name: "emulate", Type: "bool", Default: "false", Desc: "block_copy_insert_after/block_move_after only: client-side fallback for servers that reject src_block_ids (fetch source blocks, rebuild after --block-id, verify, then delete originals for move); rebuilt blocks get new ids, comments/#block_id anchors are not migrated, images are re-uploaded; supports p/h1-h9/ul/ol/li/blockquote/callout/pre/img blocks only"},
 		{Name: "revision-id", Desc: "base revision id; -1 means latest", Type: "int", Default: "-1"},
 	}
 }
@@ -107,12 +108,42 @@ func validateUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--command append requires --content").WithParam("--content")
 		}
 	}
+	if runtime.Bool("emulate") {
+		return validateUpdateEmulate(runtime, cmd, srcBlockIDs)
+	}
+	return nil
+}
+
+// validateUpdateEmulate checks the extra constraints of the --emulate
+// client-side fallback path. It runs after the per-command checks above, so
+// --block-id and --src-block-ids presence is already guaranteed.
+func validateUpdateEmulate(runtime *common.RuntimeContext, cmd, srcBlockIDs string) error {
+	if cmd != "block_move_after" && cmd != "block_copy_insert_after" {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--emulate only applies to block_move_after and block_copy_insert_after, got --command %s", cmd).WithParam("--emulate")
+	}
+	if v := runtime.Int("revision-id"); v != -1 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--revision-id is not supported with --emulate: the emulation issues multiple writes and always targets the latest revision").WithParam("--revision-id")
+	}
+	ids := splitSrcBlockIDs(srcBlockIDs)
+	if len(ids) == 0 {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "--src-block-ids contains no block ids").WithParam("--src-block-ids")
+	}
+	seen := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		if seen[id] {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--src-block-ids contains duplicate block id %s", id).WithParam("--src-block-ids")
+		}
+		seen[id] = true
+	}
 	return nil
 }
 
 func dryRunUpdateV2(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 	// Validate has already accepted --doc; parseDocumentRef cannot fail here.
 	ref, _ := parseDocumentRef(runtime.Str("doc"))
+	if runtime.Bool("emulate") {
+		return dryRunUpdateEmulated(runtime, ref, runtime.Str("command"))
+	}
 	body := buildUpdateBody(runtime)
 	apiPath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s", ref.Token)
 	return common.NewDryRunAPI().
@@ -124,6 +155,11 @@ func dryRunUpdateV2(_ context.Context, runtime *common.RuntimeContext) *common.D
 
 func executeUpdateV2(_ context.Context, runtime *common.RuntimeContext) error {
 	ref, _ := parseDocumentRef(runtime.Str("doc"))
+
+	if runtime.Bool("emulate") {
+		// Validate has already restricted --emulate to move/copy commands.
+		return executeUpdateEmulated(runtime, ref, runtime.Str("command"))
+	}
 
 	apiPath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s", ref.Token)
 	body := buildUpdateBody(runtime)

--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -161,6 +161,8 @@ lark-cli docs +update --api-version v2 --doc "<doc_id>" --command block_move_aft
   --src-block-ids "block_a,block_b"
 ```
 
+> **`--emulate` 客户端兜底**：若服务端报 `requires content or src_block_ids but both were empty`（服务端未读取 `src_block_ids` 的已知问题），可在 `block_move_after` / `block_copy_insert_after` 上追加 `--emulate`，由 CLI 客户端模拟完成（先取源块重建并插入锚点之后，验证成功后才删除原块，move 专属；失败立即停止，不会丢内容）。注意语义差异：重建块的 block_id 会变化，原块上的评论与 `#block_id` 锚点链接不会迁移，img 相当于重新上传。仅支持 `p`/`h1`-`h9`/`ul`/`ol`/`li`/`blockquote`/`callout`/`pre`/`img`，含服务端状态的块类型（whiteboard / sheet / bitable / table 等）会被拒绝。
+
 ## 返回值
 
 ```json

--- a/tests/cli_e2e/docs/docs_update_dryrun_test.go
+++ b/tests/cli_e2e/docs/docs_update_dryrun_test.go
@@ -77,6 +77,32 @@ func TestDocs_DryRunDefaultsToV2OpenAPI(t *testing.T) {
 			},
 			wantURL: "/open-apis/docs_ai/v1/documents/doxcnDryRunE2E",
 		},
+		{
+			name: "block_move_after emulate",
+			args: []string{
+				"docs", "+update",
+				"--doc", "doxcnDryRunE2E",
+				"--command", "block_move_after",
+				"--block-id", "blkAnchor",
+				"--src-block-ids", "blkA,blkB",
+				"--emulate",
+				"--dry-run",
+			},
+			wantURL: "/open-apis/docs_ai/v1/documents/doxcnDryRunE2E/fetch",
+		},
+		{
+			name: "block_copy_insert_after emulate",
+			args: []string{
+				"docs", "+update",
+				"--doc", "doxcnDryRunE2E",
+				"--command", "block_copy_insert_after",
+				"--block-id", "blkAnchor",
+				"--src-block-ids", "blkA",
+				"--emulate",
+				"--dry-run",
+			},
+			wantURL: "/open-apis/docs_ai/v1/documents/doxcnDryRunE2E/fetch",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

On some server deployments (reproduced on a JP-tenant Lark international workspace, see #758), `docs +update --command block_move_after` / `block_copy_insert_after` fail with `command 'block_move_after' requires content or src_block_ids but both were empty` even though the CLI sends `src_block_ids` correctly — the server side does not read the field. This PR adds an opt-in `--emulate` flag that reproduces move/copy semantics client-side with the primitives that do work, so agents are not blocked while the server bug persists. Default behavior is completely unchanged; without `--emulate` both commands still send the same single request as today.

## Changes

- Add `--emulate` (bool, default false) to `docs +update`, valid only with `block_move_after` / `block_copy_insert_after`. When set, the command runs a client-side orchestration: fetch source blocks (full detail) → rebuild them after `--block-id` via `block_insert_after` → re-fetch to verify the rebuilt blocks exist → `block_delete` the originals (move only). Insert always precedes delete and any failure stops immediately with the inserted/deleted state reported on stderr, so no path loses source content (`shortcuts/doc/docs_update_emulate.go`).
- Supported block types: `p`, `h1`–`h9`, `ul`, `ol`, `li` (re-wrapped in its original list type), `blockquote`, `callout` (rgb colors dropped, emoji kept), `pre`, `img` (rebuilt from `href`, effectively a re-upload). Block types carrying server-side tokens or state (`whiteboard`, `sheet`, `bitable`, `table`, `synced_reference`, …) are rejected with a typed `failed_precondition` error before any write.
- The emulation is not semantically identical to the server-side command and says so explicitly — in the flag help, in a stderr warning on every run, and in a `semantic_differences` field of the success envelope: rebuilt blocks get new block ids, comments and `#block_id` anchors on the originals are not migrated, and image file tokens change.
- `--emulate` rejects a non-default `--revision-id` (the orchestration issues multiple writes against the latest revision) and duplicate ids in `--src-block-ids`.
- `--dry-run --emulate` prints the multi-call plan (fetch → insert → verify-fetch → delete for move; three calls for copy).
- Unit tests for the XML block indexer / rebuild rules and httpmock-based orchestration tests (move, copy keeps originals, unsupported type rejected before any write, verification failure keeps originals); dry-run E2E cases for both commands.
- Note the fallback (and its semantic differences) in the `lark-doc-update.md` skill reference so agents discover it next to the move/copy documentation.

## Test Plan

- [x] `make unit-test` (full `-race` suite green)
- [x] `go vet ./...`
- [x] `gofmt -l .` (no output)
- [x] `go mod tidy` (no go.mod/go.sum changes)
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main` (0 issues)
- [x] `LARK_CLI_BIN=$PWD/lark-cli go test ./tests/cli_e2e/docs/ -run TestDocs_DryRunDefaultsToV2OpenAPI`
- [x] Live verification on a scratch docx in the affected JP tenant:
  - without `--emulate`: unchanged behavior — the server still does not perform the move (observed both the #758 hard error and, on a later run, `result: "failed"` with degrade warning "Instruction produced no document changes"; either way `src_block_ids` is not honored)
  - `--emulate` single paragraph move, multi-block move (`p` + `li`), `img` move to `-1` (re-uploaded, new src token), copy keeping the original
  - `table` source block rejected with `failed_precondition` before any write

## Related Issues

- #758 (server-side reproduction evidence in the issue comments; this PR is the client-side opt-in workaround until the server fix lands)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--emulate` flag for `block_move_after` and `block_copy_insert_after` as a client-side fallback when servers reject requests due to missing `src_block_ids`, including dry-run and execute support.
  * Emulation rebuilds eligible blocks, inserts after the anchor, verifies the insertion is visible/contiguous, and deletes originals only for move (conservatively aborts on verification failures).

* **Documentation**
  * Updated `docs +update` guidance with behavior notes and limitations (block-id changes, link/comment behavior, image handling, supported block types, stop-on-failure).

* **Tests**
  * Added extensive unit, dry-run, and end-to-end coverage, including validation, error paths, and concurrency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->