### PR TITLE
fix(skills): add single entry skill

### DIFF
--- a/.github/workflows/skill-format-check.yml
+++ b/.github/workflows/skill-format-check.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches: [main]
     paths:
+      - "SKILL.md"
       - "skills/**"
       - "scripts/skill-format-check/**"
       - ".github/workflows/skill-format-check.yml"
   pull_request:
     branches: [main]
     paths:
+      - "SKILL.md"
       - "skills/**"
       - "scripts/skill-format-check/**"
       - ".github/workflows/skill-format-check.yml"
@@ -29,4 +31,6 @@ jobs:
           node-version: '20'
 
       - name: Run Skill Format Check
-        run: node scripts/skill-format-check/index.js
+        run: |
+          node scripts/skill-format-check/index.js .
+          node scripts/skill-format-check/index.js skills

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 
 [中文版](./README.zh.md) | [English](./README.md)
 
-The official [Lark/Feishu](https://www.larksuite.com/) CLI tool, maintained by the [larksuite](https://github.com/larksuite) team — built for humans and AI Agents. Covers core business domains including Messenger, Docs, Base, Sheets, Slides, Calendar, Mail, Tasks, Meetings, Markdown, and more, with 200+ commands and 26 AI Agent [Skills](./skills/).
+The official [Lark/Feishu](https://www.larksuite.com/) CLI tool, maintained by the [larksuite](https://github.com/larksuite) team — built for humans and AI Agents. Covers core business domains including Messenger, Docs, Base, Sheets, Slides, Calendar, Mail, Tasks, Meetings, Markdown, and more, with 200+ commands and one AI Agent entry [Skill](./SKILL.md) that routes to versioned domain docs on demand.
 
 [Install](#installation--quick-start) · [AI Agent Skills](#agent-skills) · [Auth](#authentication) · [Commands](#three-layer-command-system) · [Advanced](#advanced-usage) · [Security](#security--risk-warnings-read-before-use) · [Contributing](#contributing)
 
 ## Why lark-cli?
 
-- **Agent-Native Design** — 24 structured [Skills](./skills/) out of the box, compatible with popular AI tools — Agents can operate Lark with zero extra setup
-- **Wide Coverage** — 18 business domains, 200+ curated commands, 26 AI Agent [Skills](./skills/)
+- **Agent-Native Design** — one concise entry [Skill](./SKILL.md) plus versioned domain docs, compatible with popular AI tools — Agents can operate Lark with zero extra setup
+- **Wide Coverage** — 18 business domains, 200+ curated commands, and on-demand embedded domain guidance
 - **AI-Friendly & Optimized** — Every command is tested with real Agents, featuring concise parameters, smart defaults, and structured output to maximize Agent call success rates
 - **Open Source, Zero Barriers** — MIT license, ready to use, just `npm install`
 - **Up and Running in 3 Minutes** — One-click app creation, interactive login, from install to first API call in just 3 steps
@@ -75,7 +75,7 @@ git clone https://github.com/larksuite/cli.git
 cd cli
 make install
 
-# Install CLI SKILL (required)
+# Install the default CLI skill (required)
 npx skills add larksuite/cli -y -g
 ```
 
@@ -126,32 +126,24 @@ lark-cli auth status
 
 ## Agent Skills
 
-| Skill                           | Description                                                                                                    |
-| ------------------------------- |----------------------------------------------------------------------------------------------------------------|
-| `lark-shared`                   | App config, auth login, identity switching, scope management, security rules (auto-loaded by all other skills) |
-| `lark-calendar`                 | Calendar events (create/update), agenda view, free/busy queries, time suggestions, room finding, RSVP replies  |
-| `lark-im`                       | Send/reply messages, group chat management, message search, upload/download images & files, reactions          |
-| `lark-doc`                      | Create, read, update, search documents (Markdown-based)                                                        |
-| `lark-drive`                    | Upload, download files, manage permissions & comments                                                          |
-| `lark-markdown`                 | Create, fetch, patch, and overwrite Drive-native Markdown files                                                |
-| `lark-sheets`                   | Create, read, write, append, find, export spreadsheets                                                         |
-| `lark-slides`                   | Create and manage presentations, read presentation content, and add or remove slides                          |
-| `lark-base`                     | Tables, fields, records, views, dashboards, data aggregation & analytics                                       |
-| `lark-task`                     | Tasks, task lists, subtasks, reminders, member assignment                                                      |
-| `lark-mail`                     | Browse, search, read emails, send, reply, forward, draft management, watch new mail                            |
-| `lark-contact`                  | Search users by name/email/phone, get user profiles                                                            |
-| `lark-wiki`                     | Knowledge spaces, nodes, documents                                                                             |
-| `lark-event`                    | Real-time event subscriptions (WebSocket), regex routing & agent-friendly format                               |
-| `lark-vc`                       | Search meeting records, query meeting minutes (summary, todos, transcript)                                     |
-| `lark-whiteboard`               | Whiteboard/chart DSL rendering                                                                                 |
-| `lark-minutes`                  | Minutes metadata & AI artifacts (summary, todos, chapters); upload audio/video to create minutes, download media |
-| `lark-openapi-explorer`         | Explore underlying APIs from official docs                                                                     |
-| `lark-skill-maker`              | Custom skill creation framework                                                                                |
-| `lark-attendance`               | Query personal attendance check-in records                                                                     |
-| `lark-approval`                 | Query approval tasks, approve/reject/transfer tasks, cancel and CC instances                                   |
-| `lark-workflow-meeting-summary` | Workflow: meeting minutes aggregation & structured report                                                      |
-| `lark-workflow-standup-report`  | Workflow: agenda & todo summary                                                                                |
-| `lark-okr`                      | Query, create, update OKRs; manage objective & key results, alignments and indicators.                         |
+The repository exposes one default skill, [`lark-suite`](./SKILL.md), so global skill search is not flooded with every Lark domain. Install it with:
+
+```bash
+npx skills add larksuite/cli -y -g
+```
+
+The entry skill routes agents to domain docs embedded in the matching `lark-cli` binary. Agents should read only the domain they need:
+
+```bash
+lark-cli skills read lark-im
+lark-cli skills read lark-doc references/lark-doc-fetch.md
+```
+
+Advanced users who still want to install a nested domain skill directly can opt into deep discovery:
+
+```bash
+npx skills add larksuite/cli --full-depth -s lark-im -y -g
+```
 
 ## Authentication
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,14 +6,14 @@
 
 [中文版](./README.zh.md) | [English](./README.md)
 
-飞书官方 CLI 工具，由 [larksuite](https://github.com/larksuite) 团队维护 — 让人类和 AI Agent 都能在终端中操作飞书。覆盖消息、文档、多维表格、电子表格、幻灯片、日历、邮箱、任务、会议、Markdown 等核心业务域，提供 200+ 命令及 26 个 AI Agent [Skills](./skills/)。
+飞书官方 CLI 工具，由 [larksuite](https://github.com/larksuite) 团队维护 — 让人类和 AI Agent 都能在终端中操作飞书。覆盖消息、文档、多维表格、电子表格、幻灯片、日历、邮箱、任务、会议、Markdown 等核心业务域，提供 200+ 命令和一个 AI Agent 入口 [Skill](./SKILL.md)，按需路由到版本匹配的领域文档。
 
 [安装](#安装与快速开始) · [AI Agent Skills](#agent-skills) · [认证](#认证) · [命令](#三层命令调用) · [进阶用法](#进阶用法) · [安全](#安全与风险提示使用前必读) · [贡献](#贡献)
 
 ## 为什么选 lark-cli？
 
-- **为 Agent 原生设计** — 26 个 [Skills](./skills/) 开箱即用，适配主流 AI 工具，Agent 无需额外适配即可操作飞书
-- **覆盖面广** — 18 大业务域、200+ 精选命令、26 个 AI Agent [Skills](./skills/)
+- **为 Agent 原生设计** — 一个精简入口 [Skill](./SKILL.md) 加版本匹配的领域文档，适配主流 AI 工具，Agent 无需额外适配即可操作飞书
+- **覆盖面广** — 18 大业务域、200+ 精选命令，以及按需读取的内嵌领域指引
 - **AI 友好调优** — 每条命令经过 Agent 实测验证，提供更友好的参数、智能默认值和结构化输出，大幅提升 Agent 调用成功率
 - **开源零门槛** — MIT 协议，开箱即用，`npm install` 即可使用
 - **三分钟上手** — 一键创建应用、交互式登录授权，从安装到第一次 API 调用只需三步
@@ -75,7 +75,7 @@ git clone https://github.com/larksuite/cli.git
 cd cli
 make install
 
-# 安装 CLI SKILL（必需）
+# 安装默认 CLI Skill（必需）
 npx skills add larksuite/cli -y -g
 ```
 
@@ -127,32 +127,24 @@ lark-cli auth status
 
 ## Agent Skills
 
-| Skill                           | 说明                                        |
-| --------------------------------- |-------------------------------------------|
-| `lark-shared`                   | 应用配置、认证登录、身份切换、权限管理、安全规则（所有其他 skill 自动加载） |
-| `lark-calendar`                 | 日历日程（创建/更新）、议程查看、忙闲查询、时间建议、会议室查找、回复邀请       |
-| `lark-im`                       | 发送/回复消息、群聊管理、消息搜索、上传下载图片与文件、表情回复          |
-| `lark-doc`                      | 创建、读取、更新、搜索文档（基于 Markdown）                |
-| `lark-drive`                    | 上传、下载文件，管理权限与评论                           |
-| `lark-markdown`                 | 创建、读取、局部 patch、覆盖更新 Drive 中的原生 Markdown 文件   |
-| `lark-sheets`                   | 创建、读取、写入、追加、查找、导出电子表格                     |
-| `lark-slides`                   | 创建和管理演示文稿、读取演示文稿内容，以及新增或删除幻灯片页面 |
-| `lark-base`                     | 多维表格、字段、记录、视图、仪表盘、数据聚合分析                  |
-| `lark-task`                     | 任务、任务清单、子任务、提醒、成员分配                       |
-| `lark-mail`                     | 浏览、搜索、阅读邮件，发送、回复、转发，草稿管理，监听新邮件            |
-| `lark-contact`                  | 按姓名/邮箱/手机号搜索用户，获取用户信息                     |
-| `lark-wiki`                     | 知识空间、节点、文档                                |
-| `lark-event`                    | 实时事件订阅（WebSocket），支持正则路由与 Agent 友好格式      |
-| `lark-vc`                       | 搜索会议记录、查询会议纪要产物（总结、待办、逐字稿）                |
-| `lark-whiteboard`               | 画板/图表 DSL 渲染                              |
-| `lark-minutes`                  | 妙记元数据与 AI 产物（总结、待办、章节），上传音视频生成妙记，下载音视频文件 |
-| `lark-openapi-explorer`         | 从官方文档探索底层 API                             |
-| `lark-skill-maker`              | 自定义 skill 创建框架                            |
-| `lark-attendance`               | 查询个人考勤打卡记录                                |
-| `lark-approval`                 | 审批任务查询、同意/拒绝/转交审批任务、撤回与抄送审批实例             |
-| `lark-workflow-meeting-summary` | 工作流：会议纪要汇总与结构化报告                          |
-| `lark-workflow-standup-report`  | 工作流：日程待办摘要                                |
-| `lark-okr`                      | 查询、创建、更新 OKR，管理目标、关键结果、对齐、指标和进展记录         |
+仓库默认只暴露一个 [`lark-suite`](./SKILL.md) 入口 Skill，避免全局技能搜索被每个飞书领域刷屏。安装命令：
+
+```bash
+npx skills add larksuite/cli -y -g
+```
+
+入口 Skill 会引导 Agent 按需读取与当前 `lark-cli` 二进制版本匹配的领域文档：
+
+```bash
+lark-cli skills read lark-im
+lark-cli skills read lark-doc references/lark-doc-fetch.md
+```
+
+高级用户如果仍想直接安装嵌套的领域 Skill，可以显式启用深度发现：
+
+```bash
+npx skills add larksuite/cli --full-depth -s lark-im -y -g
+```
 
 ## 认证
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: lark-suite
+version: 1.0.0
+description: "Use lark-cli to operate Lark/Feishu across messaging, docs, drive, sheets, base, calendar, mail, tasks, wiki, meetings, approvals, events, and more. This is the single entry skill; load domain docs only when needed."
+metadata:
+  requires:
+    bins: ["lark-cli"]
+  cliHelp: "lark-cli --help"
+---
+
+# Lark/Feishu CLI
+
+Use `lark-cli` to operate Lark/Feishu resources. This skill is the default entry point and keeps the installed skill list small. Domain-specific details remain available on demand through the CLI-embedded skill content, so agents should load only the domain they need for the current user request.
+
+## Start Here
+
+1. For setup, authentication, identity switching, scope errors, or `_notice` output, read:
+
+   ```bash
+   lark-cli skills read lark-shared
+   ```
+
+2. Pick the domain from the routing table below.
+
+3. Read that domain before choosing flags or payload shapes:
+
+   ```bash
+   lark-cli skills read <domain-skill>
+   ```
+
+4. For detailed reference files mentioned by a domain skill, read them with:
+
+   ```bash
+   lark-cli skills read <domain-skill> references/<file>.md
+   ```
+
+## Domain Routing
+
+| User intent | Read this domain |
+| --- | --- |
+| Configure app credentials, login, switch `--as user` / `--as bot`, fix permission or scope errors | `lark-shared` |
+| Send/reply/search messages, manage chats, download IM resources, reactions, feed shortcuts/groups | `lark-im` |
+| Create/read/edit docs, insert or download doc media, handle docx/wiki document URLs | `lark-doc` |
+| Upload/download/search/move/copy/delete files, import local files, manage Drive metadata/comments/permissions | `lark-drive` |
+| Create/edit native Markdown files stored in Drive, patch/diff Markdown | `lark-markdown` |
+| Create/read/write spreadsheets, formulas, formatting, charts, pivots, filters, images | `lark-sheets` |
+| Work with Base/bitable tables, fields, records, views, forms, dashboards, formulas, permissions | `lark-base` |
+| Create/edit slides and presentation pages | `lark-slides` |
+| Create/search/update calendar events, agenda, free/busy, time suggestions, meeting rooms | `lark-calendar` |
+| Search users and resolve names, emails, phone numbers, or open_id values | `lark-contact` |
+| Browse/search/read/send/reply/forward mail, drafts, folders, labels, rules, attachments | `lark-mail` |
+| Create/update/query tasks, task lists, subtasks, task agents, task attachments | `lark-task` |
+| Manage wiki spaces, members, and node hierarchy | `lark-wiki` |
+| Search past meetings, fetch meeting notes/minutes/transcripts, participant snapshots | `lark-vc` |
+| Join/leave active meetings as an agent, read live meeting events | `lark-vc-agent` |
+| Search/download/upload/update Minutes media or metadata | `lark-minutes` |
+| Query or update OKRs | `lark-okr` |
+| Query approval tasks, approve/reject/transfer/cancel/CC approval instances | `lark-approval` |
+| Query personal attendance check-in records | `lark-attendance` |
+| Subscribe to real-time Lark events via WebSocket / NDJSON streams | `lark-event` |
+| Export or update whiteboards, diagrams, Mermaid/PlantUML/DSL visual content | `lark-whiteboard` |
+| Explore raw OpenAPI endpoints not covered by existing shortcuts | `lark-openapi-explorer` |
+| Build a custom lark-cli skill from repeated API operations | `lark-skill-maker` |
+| Summarize meetings over a date range | `lark-workflow-meeting-summary` |
+| Produce agenda plus task standup summaries | `lark-workflow-standup-report` |
+
+## Command Exploration
+
+```bash
+lark-cli <domain> --help
+lark-cli <domain> +<shortcut> --help
+lark-cli schema <service>.<resource>.<method>
+lark-cli <service> <resource> <method> [flags]
+```
+
+Prefer documented shortcuts (`+<name>`) when a domain skill offers one. Use raw OpenAPI commands only after reading the schema.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,12 +55,12 @@ AI AGENT SKILLS:
     lark-cli pairs with AI agent skills (Claude Code, etc.) that
     teach the agent Lark API patterns, best practices, and workflows.
 
-    Install all skills:
+    Install the default single entry skill:
         npx skills add larksuite/cli -g -y
 
-    Or pick specific domains:
-        npx skills add larksuite/cli -s lark-calendar -y
-        npx skills add larksuite/cli -s lark-im -y
+    Advanced: install legacy domain skills directly:
+        npx skills add larksuite/cli --full-depth -s lark-calendar -y
+        npx skills add larksuite/cli --full-depth -s lark-im -y
 
     Learn more: https://github.com/larksuite/cli#agent-skills
 

--- a/scripts/skill-format-check/README.md
+++ b/scripts/skill-format-check/README.md
@@ -1,6 +1,6 @@
 # Skill Format Check
 
-This directory contains a script to validate the format of `SKILL.md` files located in the `../../skills` directory.
+This directory contains a script to validate root `SKILL.md` files and skill directories such as `../../skills`.
 
 ## Purpose
 
@@ -13,12 +13,13 @@ The `index.js` script ensures that all `SKILL.md` files conform to the standard 
 
 ## Usage
 
-This script is executed automatically via GitHub Actions (`.github/workflows/skill-format-check.yml`) on pull requests and pushes that modify the `skills/` directory.
+This script is executed automatically via GitHub Actions (`.github/workflows/skill-format-check.yml`) on pull requests and pushes that modify the root `SKILL.md`, `skills/`, or this checker.
 
 To run the check manually from the root of the repository, execute:
 
 ```bash
-node scripts/skill-format-check/index.js
+node scripts/skill-format-check/index.js .
+node scripts/skill-format-check/index.js skills
 ```
 
 You can also specify a custom target directory as the first argument:

--- a/scripts/skill-format-check/index.js
+++ b/scripts/skill-format-check/index.js
@@ -22,10 +22,15 @@ function checkSkillFormat() {
 
   let skills;
   try {
-    skills = fs
+    skills = [];
+    if (fs.existsSync(path.join(SKILLS_DIR, 'SKILL.md'))) {
+      skills.push('.');
+    }
+    skills.push(...fs
       .readdirSync(SKILLS_DIR, { withFileTypes: true })
       .filter(entry => entry.isDirectory())
-      .map(entry => entry.name);
+      .filter(entry => fs.existsSync(path.join(SKILLS_DIR, entry.name, 'SKILL.md')))
+      .map(entry => entry.name));
   } catch (err) {
     console.error(`Failed to enumerate skills directory: ${err.message}`);
     process.exit(1);
@@ -40,7 +45,7 @@ function checkSkillFormat() {
         return;
     }
 
-    const skillPath = path.join(SKILLS_DIR, skill);
+    const skillPath = skill === '.' ? SKILLS_DIR : path.join(SKILLS_DIR, skill);
     const skillFile = path.join(skillPath, 'SKILL.md');
 
     if (!fs.existsSync(skillFile)) {

--- a/scripts/skill-format-check/test.sh
+++ b/scripts/skill-format-check/test.sh
@@ -73,6 +73,7 @@ run_negative_test() {
 run_positive_test "good-skill"
 run_positive_test "good-skill-minimal"
 run_positive_test "good-skill-complex"
+run_positive_test "good-root-skill"
 
 # Run negative tests
 run_negative_test "bad-skill"

--- a/scripts/skill-format-check/tests/good-root-skill/SKILL.md
+++ b/scripts/skill-format-check/tests/good-root-skill/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: good-skill
+version: 1.0.0
+description: "This is a properly formatted skill."
+metadata:
+  requires:
+    bins: ["lark-cli"]
+---
+
+# Good Skill
+
+This skill follows all the formatting rules.


### PR DESCRIPTION
## Background

Fixes https://github.com/larksuite/cli/issues/1385.

The repository currently exposes every `skills/lark-*` domain skill by default. In skill pickers/search UIs this floods the global skill list with Lark-specific entries and long domain descriptions, especially for large domains such as IM.

## Changes

- Add a root `lark-suite` `SKILL.md` as the default single entry skill.
- Keep domain-specific guidance in the existing embedded `skills/lark-*` docs and route agents to them through `lark-cli skills read <domain-skill>` only when needed.
- Update README / root help to describe the default single entry skill and document `--full-depth` for users who still want direct nested domain skill discovery.
- Extend the skill format checker and workflow so the root `SKILL.md` is validated alongside `skills/`.

## Verification

- `npx -y skills add . --list --json`: passed — reports `Found 1 skill` and lists `lark-suite`.
- `npx -y skills add . --list --full-depth --json`: passed — nested domain skills such as `lark-im` and `lark-calendar` remain discoverable when explicitly requested.
- `npx -y skills use . --skill lark-suite`: passed — renders the new entry skill.
- `bash scripts/skill-format-check/test.sh`: passed.
- `node scripts/skill-format-check/index.js .`: passed.
- `node scripts/skill-format-check/index.js skills`: passed.
- `go test -count=1 -timeout=3m ./cmd/skill ./internal/skillscheck ./cmd/update`: passed.
- `gofmt -l cmd/root.go internal/skillscheck/sync.go cmd/update/update.go`: no output.
- `git diff --check origin/main...HEAD`: passed.

## Risk and rollback

Default `npx skills add larksuite/cli` now installs the single entry skill instead of every nested domain skill. This intentionally reduces global skill-list noise. Existing domain skills remain in the repository and can still be discovered with `--full-depth` or read via `lark-cli skills read`. Rollback is reverting this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `SKILL.md` documentation with skill metadata and command guidance.
  * Updated README and Chinese README to reflect simplified skill model with single default entry.
  * Enhanced CLI help text with updated installation and discovery instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->