### PR TITLE
fix: read release error_logs from data.error_logs in apps +release-get

### DIFF
--- a/shortcuts/apps/apps_release_get.go
+++ b/shortcuts/apps/apps_release_get.go
@@ -57,6 +57,9 @@ var AppsReleaseGet = common.Shortcut{
 		out := data
 		if release, ok := data["release"].(map[string]interface{}); ok {
 			out = release
+			if el, ok := data["error_logs"]; ok {
+				out["error_logs"] = el
+			}
 		}
 		rctx.OutFormat(out, nil, func(w io.Writer) {
 			fmt.Fprintf(w, "release_id: %v\nstatus: %v\ncreated_at: %v\nupdated_at: %v\n",

--- a/shortcuts/apps/apps_release_get_test.go
+++ b/shortcuts/apps/apps_release_get_test.go
@@ -134,13 +134,15 @@ func TestAppsReleaseGetPrettyFailedErrorLogs(t *testing.T) {
 		URL:    "/open-apis/spark/v1/apps/app_x/releases/6",
 		Body: map[string]interface{}{
 			"code": 0, "msg": "",
-			"data": map[string]interface{}{"release": map[string]interface{}{
-				"release_id": "6", "status": "failed",
-				"created_at": "1700000000000", "updated_at": "1700000000050",
+			"data": map[string]interface{}{
+				"release": map[string]interface{}{
+					"release_id": "6", "status": "failed",
+					"created_at": "1700000000000", "updated_at": "1700000000050",
+				},
 				"error_logs": []interface{}{
 					map[string]interface{}{"step": "build", "error_log": "compile error"},
 				},
-			}},
+			},
 		},
 	})
 	if err := AppsReleaseGet.Execute(context.Background(), rctx); err != nil {
@@ -200,17 +202,82 @@ func TestAppsReleaseGetPrettyFailedEmptyLogs(t *testing.T) {
 	reg.Register(&httpmock.Stub{
 		Method: "GET", URL: "/open-apis/spark/v1/apps/app_x/releases/9",
 		Body: map[string]interface{}{"code": 0, "msg": "",
-			"data": map[string]interface{}{"release": map[string]interface{}{
-				"release_id": "9", "status": "failed",
-				"created_at": "1700000000000", "updated_at": "1700000000050",
+			"data": map[string]interface{}{
+				"release": map[string]interface{}{
+					"release_id": "9", "status": "failed",
+					"created_at": "1700000000000", "updated_at": "1700000000050",
+				},
 				"error_logs": []interface{}{},
-			}}},
+			}},
 	})
 	if err := AppsReleaseGet.Execute(context.Background(), rctx); err != nil {
 		t.Fatalf("Execute() = %v", err)
 	}
 	if strings.Contains(stdoutBuf.String(), "compile error") {
 		t.Errorf("empty error_logs must not render row content, got:\n%s", stdoutBuf.String())
+	}
+}
+
+func TestAppsReleaseGetJSONErrorLogsPassthrough(t *testing.T) {
+	rctx, stdoutBuf, reg := newStatusRuntimeContext(t, "app_x", "6")
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/spark/v1/apps/app_x/releases/6",
+		Body: map[string]interface{}{"code": 0, "msg": "",
+			"data": map[string]interface{}{
+				"release": map[string]interface{}{
+					"release_id": "6", "status": "failed",
+					"created_at": "1700000000000", "updated_at": "1700000000050",
+				},
+				"error_logs": []interface{}{
+					map[string]interface{}{"step": "build", "error_log": "compile error"},
+				},
+			}},
+	})
+	if err := AppsReleaseGet.Execute(context.Background(), rctx); err != nil {
+		t.Fatalf("Execute() = %v", err)
+	}
+	var env struct {
+		OK   bool                   `json:"ok"`
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(stdoutBuf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, stdoutBuf.String())
+	}
+	logs, ok := env.Data["error_logs"].([]interface{})
+	if !ok || len(logs) != 1 {
+		t.Fatalf("JSON must passthrough data.error_logs, got: %v", env.Data["error_logs"])
+	}
+	first, _ := logs[0].(map[string]interface{})
+	if first["step"] != "build" || first["error_log"] != "compile error" {
+		t.Errorf("error_logs content mismatch: %v", logs[0])
+	}
+	// flattened release fields must still be present alongside error_logs
+	if env.Data["release_id"] != "6" || env.Data["status"] != "failed" {
+		t.Errorf("flattened release fields missing: %v", env.Data)
+	}
+}
+
+func TestAppsReleaseGetJSONNoErrorLogsKeyWhenAbsent(t *testing.T) {
+	rctx, stdoutBuf, reg := newStatusRuntimeContext(t, "app_x", "5")
+	reg.Register(&httpmock.Stub{
+		Method: "GET", URL: "/open-apis/spark/v1/apps/app_x/releases/5",
+		Body: map[string]interface{}{"code": 0, "msg": "",
+			"data": map[string]interface{}{"release": map[string]interface{}{
+				"release_id": "5", "status": "finished",
+				"created_at": "1700000000000", "updated_at": "1700000000001",
+			}}},
+	})
+	if err := AppsReleaseGet.Execute(context.Background(), rctx); err != nil {
+		t.Fatalf("Execute() = %v", err)
+	}
+	var env struct {
+		Data map[string]interface{} `json:"data"`
+	}
+	if err := json.Unmarshal(stdoutBuf.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal: %v\nraw: %s", err, stdoutBuf.String())
+	}
+	if _, present := env.Data["error_logs"]; present {
+		t.Errorf("error_logs key must be absent when API omits it, got: %v", env.Data)
 	}
 }
 


### PR DESCRIPTION
## Summary

`apps +release-get` read the release error logs from `data.release.error_logs`, but per the interface doc (`app.release/get.yml`) the response places `release` and `error_logs` as two sibling fields under `data`. As a result the default JSON output dropped `data.error_logs` entirely, and the pretty `failed` table was always empty.

## Changes

- `shortcuts/apps/apps_release_get.go`: after unwrapping `data.release` into the flattened output object, graft the sibling `data.error_logs` onto it so both JSON and pretty output surface the real error logs. The flattened-output contract for the release fields is unchanged.
- `shortcuts/apps/apps_release_get_test.go`: correct the failed-release mocks to place `error_logs` as a sibling of `release` (matching the real API), and add JSON-passthrough and no-key-when-absent assertions.

## Test Plan

- [x] `make unit-test` passed (`go test ./shortcuts/apps/ -run TestAppsReleaseGet` → 13/13)
- [x] validate passed (build + vet + unit + integration)
- [ ] skipped: sandbox E2E / skillave — lite mode; command surface unchanged and no existing E2E covers this path
- [x] acceptance-reviewer passed (2/2 scenarios: help, missing-flag, dry-run)
- [x] manual verification: `apps +release-get --help` and `apps +release-get --app-id <id> --release-id <id> --dry-run` — flag validation and identity/error handling confirmed; failed-release error_logs behavior covered by unit tests (a failed release cannot be constructed against a live backend)

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error logs from failed releases are now included in CLI output when provided by the API.
  * JSON output now shows error logs alongside flattened release fields (e.g., release ID and status).
  * When the API omits error logs, the CLI no longer includes an empty error_logs field in JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->