### PR TITLE
fix(sheets): add mention_type enum to set_cell_range cells schema

### DIFF
--- a/shortcuts/sheets/data/flag-schemas.json
+++ b/shortcuts/sheets/data/flag-schemas.json
@@ -462,8 +462,21 @@
                       "type": "string"
                     },
                     "mention_type": {
-                      "description": "@提及类型编号（仅 type='mention' 时可选）",
-                      "type": "number"
+                      "description": "@提及类型编号（仅 type='mention' 时可选）。0 或不填=@用户；@文件时按类型取：1=文档 3=电子表格 8=多维表格 11=思维笔记 12=文件 15=旧版幻灯片 16=知识库 22=新版文档 30=幻灯片 38=画板",
+                      "type": "number",
+                      "enum": [
+                        0,
+                        1,
+                        3,
+                        8,
+                        11,
+                        12,
+                        15,
+                        16,
+                        22,
+                        30,
+                        38
+                      ]
                     },
                     "notify": {
                       "description": "是否发送通知（仅 type='mention' 时可选，默认 true）",

--- a/shortcuts/sheets/lark_sheet_write_cells_test.go
+++ b/shortcuts/sheets/lark_sheet_write_cells_test.go
@@ -4,6 +4,7 @@
 package sheets
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -424,6 +425,44 @@ func TestCellsSet_RequiresJSONArray(t *testing.T) {
 	combined := stdout + stderr + err.Error()
 	if !strings.Contains(combined, `expected type "array"`) && !strings.Contains(combined, "must be a JSON array") {
 		t.Errorf("expected array-type guard; got=%s|%s|%v", stdout, stderr, err)
+	}
+}
+
+// TestCellsSet_RejectsUnsupportedMentionType pins the mention_type enum in
+// data/flag-schemas.json (synced from the upstream tool schema): a rich_text
+// mention whose mention_type is outside MENTION_FILE_TYPE (here 6 = cloud
+// shared folder) is rejected by the schema validator at flag-parse time,
+// before it can reach the server and blow up pb serialization
+// ("mentionFileInfo.fileType: enum value expected").
+func TestCellsSet_RejectsUnsupportedMentionType(t *testing.T) {
+	t.Parallel()
+	cells := `[[{"rich_text":[{"type":"mention","text":"x","mention_type":6,"mention_token":"t"}]}]]`
+	stdout, stderr, err := runShortcutCapturingErr(t, CellsSet, []string{
+		"--url", testURL, "--sheet-id", testSheetID,
+		"--range", "A1", "--cells", cells, "--dry-run",
+	})
+	if err == nil {
+		t.Fatalf("expected validation error; stdout=%s stderr=%s", stdout, stderr)
+	}
+	combined := stdout + stderr + err.Error()
+	if !strings.Contains(combined, "mention_type") || !strings.Contains(combined, "not in enum") {
+		t.Errorf("expected mention_type enum guard; got=%s|%s|%v", stdout, stderr, err)
+	}
+}
+
+// TestCellsSet_AllowsValidMentionTypes confirms the guard lets through a
+// user @mention (mention_type 0) and a render-supported file type (22 = DOCX).
+func TestCellsSet_AllowsValidMentionTypes(t *testing.T) {
+	t.Parallel()
+	for _, mt := range []int{0, 22} {
+		cells := fmt.Sprintf(`[[{"rich_text":[{"type":"mention","text":"x","mention_type":%d,"mention_token":"t"}]}]]`, mt)
+		stdout, stderr, err := runShortcutCapturingErr(t, CellsSet, []string{
+			"--url", testURL, "--sheet-id", testSheetID,
+			"--range", "A1", "--cells", cells, "--dry-run",
+		})
+		if err != nil {
+			t.Errorf("mention_type %d: unexpected error: stdout=%s stderr=%s err=%v", mt, stdout, stderr, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem
A `set_cell_range` rich_text @mention with an unsupported `mention_type` (e.g. `6` = cloud shared folder) was copied verbatim into the `setRangeValues` mutation's `mentionFileInfo.fileType` and failed pb serialization (`mentionFileInfo.fileType: enum value expected`), taking the whole write down. The `--cells` schema declared `mention_type` as a bare `number` with no enum.

## Change
- `shortcuts/sheets/data/flag-schemas.json`: `mention_type` now carries an `enum` — the **render-side** `MENTION_FILE_TYPE` set `[0,1,3,8,11,12,15,16,22,30,38]` (the set `checkIsEmbed` / `MENTION_TO_SUITE` recognize), plus a per-value description. Values that are proto-serializable but absent from this set (`FOLDER=2`, `SHEET_DOC=4`, `CHAT=5`) would survive serialization yet not render — a silent broken mention — so they are excluded too. `0` / omitted = a user @mention. Synced from the upstream tool schema.
- `shortcuts/sheets/lark_sheet_write_cells_test.go`: reject `6`, allow `0` / `22`.

## Verification
`go test ./shortcuts/sheets/` passes.