### PR TITLE
test(calendar): drop flaky calendar list e2e checks

### DIFF
--- a/tests/cli_e2e/calendar/calendar_manage_calendar_test.go
+++ b/tests/cli_e2e/calendar/calendar_manage_calendar_test.go
@@ -28,17 +28,6 @@ func TestCalendar_ManageCalendar(t *testing.T) {
 	var createdCalendarID string
 	var deletedCalendar bool
 
-	t.Run("list calendars as bot", func(t *testing.T) {
-		result, err := clie2e.RunCmd(ctx, clie2e.Request{
-			Args:      []string{"calendar", "calendars", "list"},
-			DefaultAs: "bot",
-		})
-		require.NoError(t, err)
-		result.AssertExitCode(t, 0)
-		result.AssertStdoutStatus(t, 0)
-		require.NotEmpty(t, gjson.Get(result.Stdout, "data.calendar_list").Array(), "stdout:\n%s", result.Stdout)
-	})
-
 	t.Run("get primary calendar as bot", func(t *testing.T) {
 		primaryCalendarID := getPrimaryCalendarID(t, ctx)
 		require.NotEmpty(t, primaryCalendarID)
@@ -95,13 +84,6 @@ func TestCalendar_ManageCalendar(t *testing.T) {
 		assert.Equal(t, createdCalendarID, gjson.Get(result.Stdout, "data.calendar_id").String())
 		assert.Equal(t, calendarSummary, gjson.Get(result.Stdout, "data.summary").String())
 		assert.Equal(t, calendarDescription, gjson.Get(result.Stdout, "data.description").String())
-	})
-
-	t.Run("find created calendar in list as bot", func(t *testing.T) {
-		require.NotEmpty(t, createdCalendarID)
-		calendar := findCalendarByID(t, ctx, createdCalendarID)
-		assert.Equal(t, createdCalendarID, calendar.Get("calendar_id").String())
-		assert.Equal(t, calendarSummary, calendar.Get("summary").String())
 	})
 
 	t.Run("update calendar as bot", func(t *testing.T) {

--- a/tests/cli_e2e/calendar/coverage.md
+++ b/tests/cli_e2e/calendar/coverage.md
@@ -2,15 +2,15 @@
 
 ## Metrics
 - Denominator: 23 leaf commands
-- Covered: 12
-- Coverage: 52.2%
+- Covered: 11
+- Coverage: 47.8%
 
 ## Summary
 - TestCalendar_ViewAgenda: proves the user shortcut `calendar +agenda`; key `t.Run(...)` proof points are `view today agenda as user`, `view agenda with date range as user`, and `view agenda with pretty format as user`.
 - TestCalendar_PersonalEventWorkflowAsUser: proves a self-contained user event workflow across `calendar calendars primary`, `calendar +create`, `calendar events get`, and `calendar +agenda`; key `t.Run(...)` proof points are `get primary calendar as user`, `create personal event with shortcut as user`, `get created event as user`, and `find created event in agenda as user`.
 - TestCalendar_RSVPWorkflowAsUser: proves the user shortcuts `calendar +freebusy` and `calendar +rsvp`; key `t.Run(...)` proof points are `query freebusy as user`, `reply tentative as user`, `verify tentative freebusy as user`, `reply accept as user`, and `verify accepted freebusy as user`.
 - TestCalendar_CreateEvent: proves `calendar +create`, `calendar events get`, and `calendar events delete`; key `t.Run(...)` proof points are `create event with shortcut as bot`, `verify event created as bot`, and `delete event as bot`.
-- TestCalendar_ManageCalendar: proves `calendar calendars primary`, `calendar calendars create`, `calendar calendars get`, `calendar calendars list`, and `calendar calendars patch`; key `t.Run(...)` proof points are `get primary calendar as bot`, `create calendar as bot`, `get created calendar as bot`, `find created calendar in list as bot`, and `update calendar as bot`.
+- TestCalendar_ManageCalendar: proves `calendar calendars primary`, `calendar calendars create`, `calendar calendars get`, and `calendar calendars patch`; key `t.Run(...)` proof points are `get primary calendar as bot`, `create calendar as bot`, `get created calendar as bot`, and `update calendar as bot`.
 - Cleanup note: `calendar calendars delete` is part of the calendar lifecycle workflow and is counted as covered because the workflow proves the full shared-calendar lifecycle.
 - Blocked area: direct `event.attendees *` APIs, `calendar calendars search`, `calendar events create|instance_view|patch|search`, `calendar freebusys list`, and planning shortcuts `calendar +room-find` / `calendar +suggestion` still need deterministic workflows; the planning shortcuts currently depend on live tenant availability and room inventory, so they remain uncovered.
 
@@ -27,7 +27,7 @@
 | ✓ | calendar calendars create | api | calendar_manage_calendar_test.go::TestCalendar_ManageCalendar/create calendar as bot | `summary`; `description` in `--data` | |
 | ✓ | calendar calendars delete | api | calendar_manage_calendar_test.go::TestCalendar_ManageCalendar/delete calendar as bot | `calendar_id` in `--params` | |
 | ✓ | calendar calendars get | api | calendar_manage_calendar_test.go::TestCalendar_ManageCalendar/get created calendar as bot; calendar_manage_calendar_test.go::TestCalendar_ManageCalendar/verify updated calendar as bot | `calendar_id` in `--params` | |
-| ✓ | calendar calendars list | api | calendar_manage_calendar_test.go::TestCalendar_ManageCalendar/list calendars as bot; calendar_manage_calendar_test.go::TestCalendar_ManageCalendar/find created calendar in list as bot | none | |
+| ✕ | calendar calendars list | api |  | none | removed from the live workflow because tenant history made list latency non-deterministic |
 | ✓ | calendar calendars patch | api | calendar_manage_calendar_test.go::TestCalendar_ManageCalendar/update calendar as bot | `calendar_id` in `--params`; `summary` in `--data` | |
 | ✓ | calendar calendars primary | api | calendar_manage_calendar_test.go::TestCalendar_ManageCalendar/get primary calendar as bot; calendar_personal_event_workflow_test.go::TestCalendar_PersonalEventWorkflowAsUser/get primary calendar as user | none | bot and user primary calendar lookup |
 | ✕ | calendar calendars search | api |  | none | no search workflow yet |

--- a/tests/cli_e2e/calendar/helpers_test.go
+++ b/tests/cli_e2e/calendar/helpers_test.go
@@ -62,47 +62,6 @@ func getCurrentUserOpenIDForCalendar(t *testing.T, ctx context.Context) string {
 	return openID
 }
 
-func findCalendarByID(t *testing.T, ctx context.Context, calendarID string) gjson.Result {
-	t.Helper()
-
-	require.NotEmpty(t, calendarID, "calendar ID is required")
-
-	pageToken := ""
-	seenPageTokens := map[string]struct{}{}
-	for {
-		params := map[string]any{
-			"page_size": 50,
-		}
-		if pageToken != "" {
-			if _, seen := seenPageTokens[pageToken]; seen {
-				t.Fatalf("calendar list pagination loop detected for calendar %q, repeated page_token %q", calendarID, pageToken)
-			}
-			seenPageTokens[pageToken] = struct{}{}
-			params["page_token"] = pageToken
-		}
-
-		result, err := clie2e.RunCmd(ctx, clie2e.Request{
-			Args:      []string{"calendar", "calendars", "list"},
-			DefaultAs: "bot",
-			Params:    params,
-		})
-		require.NoError(t, err)
-		result.AssertExitCode(t, 0)
-		result.AssertStdoutStatus(t, 0)
-
-		calendar := gjson.Get(result.Stdout, `data.calendar_list.#(calendar_id=="`+calendarID+`")`)
-		if calendar.Exists() {
-			return calendar
-		}
-
-		hasMore := gjson.Get(result.Stdout, "data.has_more").Bool()
-		pageToken = gjson.Get(result.Stdout, "data.page_token").String()
-		if !hasMore || pageToken == "" {
-			t.Fatalf("calendar %q not found in listed pages, last stdout:\n%s", calendarID, result.Stdout)
-		}
-	}
-}
-
 func unixSecondsRFC3339(t time.Time) string {
 	return strconv.FormatInt(t.Unix(), 10)
 }


### PR DESCRIPTION
## Summary
- remove the live `calendar calendars list` smoke step from `TestCalendar_ManageCalendar`
- remove the follow-up list scan that searched the created calendar by ID
- update calendar e2e coverage to mark `calendar calendars list` as no longer covered

## Why
`calendar calendars list` has become non-deterministic in the shared test tenant because historical calendar tombstones and tenant data growth make list latency unstable. This PR keeps the create/get/patch/delete lifecycle coverage while removing the step that is repeatedly timing out in CI.

## Verification
- `go test -run ^ ./tests/cli_e2e/calendar`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed intermediate test steps from calendar management workflow to improve test reliability.

* **Documentation**
  * Updated test coverage metrics to reflect current CLI command coverage.

---

*Note: This release contains only internal test and documentation updates with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->