### PR TITLE
Validate mail shortcut mailbox IDs before requests

### DIFF
--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -2665,6 +2665,26 @@ func validateBotMailboxNotMe(runtime *common.RuntimeContext) error {
 	return nil
 }
 
+func validateUserMailboxID(flagName, mailboxID string) error {
+	const message = "%s must be \"me\" or a valid email address, for example shared@example.com"
+	if mailboxID == "me" {
+		return nil
+	}
+	if mailboxID == "" || mailboxID != strings.TrimSpace(mailboxID) {
+		return mailValidationParamError(flagName, message, flagName)
+	}
+	if strings.ContainsFunc(mailboxID, func(r rune) bool {
+		return r < 0x20 || r == 0x7f
+	}) {
+		return mailValidationParamError(flagName, message, flagName)
+	}
+	addr, err := netmail.ParseAddress(mailboxID)
+	if err != nil || addr == nil || addr.Name != "" || addr.Address != mailboxID {
+		return mailValidationParamError(flagName, message, flagName)
+	}
+	return nil
+}
+
 // validateMessageIDs parses and validates the existing +messages comma-separated
 // flag format. Unlike splitByComma, it keeps empty entries so "id1,,id2" fails
 // locally. It intentionally does not enforce the server-side single-call limit:

--- a/shortcuts/mail/mail_message.go
+++ b/shortcuts/mail/mail_message.go
@@ -26,7 +26,10 @@ var MailMessage = common.Shortcut{
 		{Name: "print-output-schema", Type: "bool", Desc: "Print output field reference (run this first to learn field names before parsing output)"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		return validateBotMailboxNotMe(runtime)
+		if err := validateBotMailboxNotMe(runtime); err != nil {
+			return err
+		}
+		return validateUserMailboxID("--mailbox", resolveMailboxID(runtime))
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		mailboxID := resolveMailboxID(runtime)

--- a/shortcuts/mail/mail_shortcut_validation_test.go
+++ b/shortcuts/mail/mail_shortcut_validation_test.go
@@ -5,6 +5,7 @@ package mail
 
 import (
 	"encoding/base64"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -32,6 +33,22 @@ func assertValidationError(t *testing.T, err error, wantSubstr string) {
 	}
 	if wantSubstr != "" && !strings.Contains(err.Error(), wantSubstr) {
 		t.Errorf("expected error message to contain %q, got: %v", wantSubstr, err.Error())
+	}
+}
+
+func assertValidationParamError(t *testing.T, err error, wantParam, wantSubstr string) {
+	t.Helper()
+	assertValidationError(t, err, wantSubstr)
+
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if validationErr.Subtype != errs.SubtypeInvalidArgument {
+		t.Errorf("subtype = %q, want %q", validationErr.Subtype, errs.SubtypeInvalidArgument)
+	}
+	if validationErr.Param != wantParam {
+		t.Errorf("param = %q, want %q", validationErr.Param, wantParam)
 	}
 }
 
@@ -207,7 +224,7 @@ func TestValidateUserMailboxID(t *testing.T) {
 	} {
 		t.Run("invalid/"+strings.ReplaceAll(mailboxID, "\n", "\\n"), func(t *testing.T) {
 			err := validateUserMailboxID("--mailbox", mailboxID)
-			assertValidationError(t, err, `--mailbox must be "me" or a valid email address`)
+			assertValidationParamError(t, err, "--mailbox", `--mailbox must be "me" or a valid email address`)
 		})
 	}
 }
@@ -219,7 +236,7 @@ func TestMailMessageInvalidMailboxValidationStopsBeforeHTTP(t *testing.T) {
 			err := runMountedMailShortcut(t, MailMessage, []string{
 				"+message", "--as", "user", "--mailbox", mailboxID, "--message-id", "msg_xxx",
 			}, f, stdout)
-			assertValidationError(t, err, `--mailbox must be "me" or a valid email address`)
+			assertValidationParamError(t, err, "--mailbox", `--mailbox must be "me" or a valid email address`)
 			if stdout.Len() != 0 {
 				t.Fatalf("expected no command output before HTTP, got: %s", stdout.String())
 			}
@@ -234,7 +251,7 @@ func TestMailTriageInvalidMailboxValidationStopsDryRun(t *testing.T) {
 			err := runMountedMailShortcut(t, MailTriage, []string{
 				"+triage", "--as", "user", "--mailbox", mailboxID, "--dry-run",
 			}, f, stdout)
-			assertValidationError(t, err, `--mailbox must be "me" or a valid email address`)
+			assertValidationParamError(t, err, "--mailbox", `--mailbox must be "me" or a valid email address`)
 			if strings.Contains(stdout.String(), "/open-apis/mail/v1/user_mailboxes/") {
 				t.Fatalf("dry-run API output should not be generated, got: %s", stdout.String())
 			}

--- a/shortcuts/mail/mail_shortcut_validation_test.go
+++ b/shortcuts/mail/mail_shortcut_validation_test.go
@@ -181,6 +181,80 @@ func TestMailTriageBotExplicitMailboxPassesValidation(t *testing.T) {
 	assertValidatePasses(t, err)
 }
 
+func TestValidateUserMailboxID(t *testing.T) {
+	for _, mailboxID := range []string{
+		"me",
+		"shared@example.com",
+		"first.last+tag@example.co.uk",
+	} {
+		t.Run("valid/"+mailboxID, func(t *testing.T) {
+			if err := validateUserMailboxID("--mailbox", mailboxID); err != nil {
+				t.Fatalf("expected nil error, got: %v", err)
+			}
+		})
+	}
+
+	for _, mailboxID := range []string{
+		"",
+		"Alice <alice@example.com>",
+		"alice@example.com,bob@example.com",
+		"user/foo",
+		"alice@",
+		"alice@example.com\nx",
+		" ",
+		" me ",
+		"shared@example.com ",
+	} {
+		t.Run("invalid/"+strings.ReplaceAll(mailboxID, "\n", "\\n"), func(t *testing.T) {
+			err := validateUserMailboxID("--mailbox", mailboxID)
+			assertValidationError(t, err, `--mailbox must be "me" or a valid email address`)
+		})
+	}
+}
+
+func TestMailMessageInvalidMailboxValidationStopsBeforeHTTP(t *testing.T) {
+	for _, mailboxID := range []string{"user/foo", " ", " me ", "shared@example.com "} {
+		t.Run(strings.ReplaceAll(mailboxID, " ", "_"), func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			err := runMountedMailShortcut(t, MailMessage, []string{
+				"+message", "--as", "user", "--mailbox", mailboxID, "--message-id", "msg_xxx",
+			}, f, stdout)
+			assertValidationError(t, err, `--mailbox must be "me" or a valid email address`)
+			if stdout.Len() != 0 {
+				t.Fatalf("expected no command output before HTTP, got: %s", stdout.String())
+			}
+		})
+	}
+}
+
+func TestMailTriageInvalidMailboxValidationStopsDryRun(t *testing.T) {
+	for _, mailboxID := range []string{"user/foo", " ", " me ", "shared@example.com "} {
+		t.Run(strings.ReplaceAll(mailboxID, " ", "_"), func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			err := runMountedMailShortcut(t, MailTriage, []string{
+				"+triage", "--as", "user", "--mailbox", mailboxID, "--dry-run",
+			}, f, stdout)
+			assertValidationError(t, err, `--mailbox must be "me" or a valid email address`)
+			if strings.Contains(stdout.String(), "/open-apis/mail/v1/user_mailboxes/") {
+				t.Fatalf("dry-run API output should not be generated, got: %s", stdout.String())
+			}
+		})
+	}
+}
+
+func TestMailTriageValidMailboxDryRunStillGeneratesAPI(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	err := runMountedMailShortcut(t, MailTriage, []string{
+		"+triage", "--as", "user", "--mailbox", "shared@example.com", "--dry-run",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("expected valid mailbox dry-run to pass, got: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "/open-apis/mail/v1/user_mailboxes/shared@example.com/messages") {
+		t.Fatalf("expected dry-run API output for explicit email mailbox, got: %s", stdout.String())
+	}
+}
+
 // --- message_ids validation tests (S2) ---
 
 func validMessageIDForTest(s string) string {

--- a/shortcuts/mail/mail_triage.go
+++ b/shortcuts/mail/mail_triage.go
@@ -66,7 +66,10 @@ var MailTriage = common.Shortcut{
 		{Name: "print-filter-schema", Type: "bool", Desc: "print --filter field reference and exit"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		return validateBotMailboxNotMe(runtime)
+		if err := validateBotMailboxNotMe(runtime); err != nil {
+			return err
+		}
+		return validateUserMailboxID("--mailbox", resolveMailboxID(runtime))
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		mailbox := resolveMailboxID(runtime)


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/35d1f60
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Validate mail +message and +triage mailbox IDs before OAPI calls | passed | 93df9a0 |
| S2 | Synthesize transport contract for larksuite/cli | passed | 69f335b |

## Source specs

- tech-design.md

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Mail shortcuts now validate user mailbox IDs during validation, accepting "me" or a precise email address and rejecting empty, padded, newline/control-char, display-name, comma-separated, or malformed values.
* **Tests**
  * Added validation tests ensuring invalid mailbox inputs fail early and valid mailboxes still produce expected dry-run output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->