### PR TITLE
fix(core): add LARKSUITE_CLI_FORCE_LOCAL escape hatch for inherited Agent env

### DIFF
--- a/internal/core/notconfigured.go
+++ b/internal/core/notconfigured.go
@@ -52,7 +52,7 @@ const (
 	// the binding workflow" guidance. Always points at --help (never a
 	// ready-to-run bind command) so the AI reads the confirmation
 	// discipline (identity preset, user opt-in) before acting.
-	agentBindHint = "read `lark-cli config bind --help`, then ask the user to confirm intent and identity preset (bot-only or user-default); only after both are confirmed, run `lark-cli config bind`"
+	agentBindHint = "read `lark-cli config bind --help`, then ask the user to confirm intent and identity preset (bot-only or user-default); only after both are confirmed, run `lark-cli config bind`. If this is NOT an Agent job and the Agent context was triggered only by an inherited env var (e.g. HERMES_HOME), set LARKSUITE_CLI_FORCE_LOCAL=1 to use the normal local config instead."
 )
 
 // NotConfiguredError returns the canonical "not configured" error, with a

--- a/internal/core/workspace.go
+++ b/internal/core/workspace.go
@@ -72,6 +72,14 @@ func (w Workspace) IsLocal() bool {
 
 // DetectWorkspaceFromEnv determines the workspace from process environment.
 //
+// Escape hatch: LARKSUITE_CLI_FORCE_LOCAL == "1" forces WorkspaceLocal,
+// overriding every Agent signal below. Agent path variables such as
+// HERMES_HOME / OPENCLAW_HOME are user-facing and get exported into shell
+// profiles, so unrelated automation that merely inherits them would otherwise
+// be misrouted into an Agent context it never opted into (see issue #1405).
+// Setting LARKSUITE_CLI_FORCE_LOCAL=1 in such jobs restores normal local
+// config without unsetting the inherited Agent variables.
+//
 // Detection is signal-based, not credential-based: we look for environment
 // variables that the host Agent itself sets when launching a subprocess.
 // Generic FEISHU_APP_ID / FEISHU_APP_SECRET are intentionally NOT used —
@@ -79,6 +87,8 @@ func (w Workspace) IsLocal() bool {
 // false-positive routing into a Hermes workspace.
 //
 // Priority:
+//  0. LARKSUITE_CLI_FORCE_LOCAL == "1" → WorkspaceLocal (escape hatch,
+//     overrides every signal below; see note above).
 //  1. Any OpenClaw signal → WorkspaceOpenClaw
 //     - OPENCLAW_CLI == "1":  subprocess marker (added 2026-03-09 via
 //     OpenClaw PR #41411). Most precise, but absent on older builds.
@@ -100,6 +110,9 @@ func (w Workspace) IsLocal() bool {
 //     mirrors the OPENCLAW_CLI / HERMES_QUIET style.
 //  4. Otherwise → WorkspaceLocal
 func DetectWorkspaceFromEnv(getenv func(string) string) Workspace {
+	if getenv("LARKSUITE_CLI_FORCE_LOCAL") == "1" {
+		return WorkspaceLocal
+	}
 	if getenv("OPENCLAW_CLI") == "1" ||
 		getenv("OPENCLAW_HOME") != "" ||
 		getenv("OPENCLAW_STATE_DIR") != "" ||

--- a/internal/core/workspace_test.go
+++ b/internal/core/workspace_test.go
@@ -144,6 +144,31 @@ func TestDetectWorkspaceFromEnv(t *testing.T) {
 			env:    map[string]string{"HERMES_HOME": "/Users/me/.hermes", "LARK_CHANNEL": "1"},
 			expect: WorkspaceHermes,
 		},
+		{
+			name:   "LARKSUITE_CLI_FORCE_LOCAL=1 overrides inherited HERMES_HOME → local (issue #1405)",
+			env:    map[string]string{"LARKSUITE_CLI_FORCE_LOCAL": "1", "HERMES_HOME": "/Users/me/.hermes"},
+			expect: WorkspaceLocal,
+		},
+		{
+			name:   "LARKSUITE_CLI_FORCE_LOCAL=1 overrides every Agent signal → local",
+			env:    map[string]string{"LARKSUITE_CLI_FORCE_LOCAL": "1", "OPENCLAW_CLI": "1", "HERMES_GATEWAY_TOKEN": "tok", "LARK_CHANNEL": "1"},
+			expect: WorkspaceLocal,
+		},
+		{
+			name:   "LARKSUITE_CLI_FORCE_LOCAL=true → ignored (strict ==1 check), HERMES_HOME still wins",
+			env:    map[string]string{"LARKSUITE_CLI_FORCE_LOCAL": "true", "HERMES_HOME": "/Users/me/.hermes"},
+			expect: WorkspaceHermes,
+		},
+		{
+			name:   "LARKSUITE_CLI_FORCE_LOCAL=0 → ignored, normal detection applies",
+			env:    map[string]string{"LARKSUITE_CLI_FORCE_LOCAL": "0", "HERMES_HOME": "/Users/me/.hermes"},
+			expect: WorkspaceHermes,
+		},
+		{
+			name:   "LARKSUITE_CLI_FORCE_LOCAL=1 with no Agent signals → local (no-op, still safe)",
+			env:    map[string]string{"LARKSUITE_CLI_FORCE_LOCAL": "1"},
+			expect: WorkspaceLocal,
+		},
 	}
 
 	for _, tt := range tests {

--- a/tests/cli_e2e/config/bind_test.go
+++ b/tests/cli_e2e/config/bind_test.go
@@ -294,7 +294,7 @@ func TestBind_ConfigShow_UnboundWorkspace(t *testing.T) {
 	// wire error.type="config"; CategoryConfig → exit 3.
 	assertStderrError(t, result, 3, "config",
 		"openclaw context detected but lark-cli is not bound to it",
-		"read `lark-cli config bind --help`, then ask the user to confirm intent and identity preset (bot-only or user-default); only after both are confirmed, run `lark-cli config bind`")
+		"read `lark-cli config bind --help`, then ask the user to confirm intent and identity preset (bot-only or user-default); only after both are confirmed, run `lark-cli config bind`. If this is NOT an Agent job and the Agent context was triggered only by an inherited env var (e.g. HERMES_HOME), set LARKSUITE_CLI_FORCE_LOCAL=1 to use the normal local config instead.")
 }
 
 func TestBind_OpenClaw_MissingFile(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #1405.

Agent path variables such as `HERMES_HOME` / `OPENCLAW_HOME` are user-facing and get exported into shell profiles, so they are inherited by **every** child process — not just Agent subprocesses. Any unrelated automation that merely inherits `HERMES_HOME` is routed into the Hermes workspace and refuses to use its valid local `lark-cli` config, failing with:

```json
{ "ok": false, "error": { "type": "config", "subtype": "not_configured",
  "message": "hermes context detected but lark-cli is not bound to it" } }
```

This implements **option 3** from the issue: a documented way to force normal local config mode without unsetting the inherited variable.

## Change

`DetectWorkspaceFromEnv` now honors `LARKSUITE_CLI_FORCE_LOCAL == "1"` as a priority-0 escape hatch that returns `WorkspaceLocal`, overriding every Agent signal. The check uses the same strict `== "1"` convention as `OPENCLAW_CLI` / `HERMES_QUIET` / `LARK_CHANNEL`, and the env-var naming matches the existing `LARKSUITE_CLI_CONFIG_DIR`.

The agent "not bound" hint now mentions the escape hatch so operators who hit the wall can discover it.

```sh
# inherited HERMES_HOME → hijacked into hermes context (the bug)
HERMES_HOME=/some/path lark-cli config show
#   → "hermes context detected but lark-cli is not bound to it"

# escape hatch → back to the normal local config
HERMES_HOME=/some/path LARKSUITE_CLI_FORCE_LOCAL=1 lark-cli config show
#   → uses local ~/.lark-cli config as before
```

## Notes

- The "bind ignores `HERMES_HOME`" part of the issue appears already addressed on `main`: `resolveHermesEnvPath()` (cmd/config/binder.go) already respects `HERMES_HOME`. This PR targets the remaining root cause — false-positive workspace detection.
- Scope is intentionally minimal (the escape hatch). Happy to follow up on a narrower detection model for Hermes (e.g. a subprocess marker like OpenClaw's `OPENCLAW_CLI`, downgrading `HERMES_HOME` to a secondary signal) if maintainers prefer that direction.

## Tests

- New table cases in `workspace_test.go` covering override-of-HERMES_HOME, override-of-all-signals, strict `== "1"` parsing (`true`/`0` ignored), and the no-op case.
- Updated the e2e unbound-workspace hint assertion.
- `go build ./...`, `gofmt`, `go vet`, and `go test ./internal/core/...` + the e2e config suite pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an escape hatch mechanism to force use of local configuration, allowing users to bypass inherited workspace detection settings when needed.

* **Documentation**
  * Enhanced configuration binding guidance with additional instructions for cases where inherited context is triggered and users prefer local configuration.

* **Tests**
  * Added comprehensive test cases validating the override mechanism behavior across multiple configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->