### PR TITLE
feat: simplify proxy plugin warning and gate on tty

### DIFF
--- a/internal/cmdutil/factory_default.go
+++ b/internal/cmdutil/factory_default.go
@@ -100,19 +100,17 @@ func safeRedirectPolicy(req *http.Request, via []*http.Request) error {
 	return nil
 }
 
-// Seams for unit-testing the proxy-warning gate. Production wires them to the
-// real implementations; tests substitute a predicate and a spy to verify the
-// warning fires only on an interactive stderr (see factory_proxy_warn_test.go).
-// StderrIsTerminal is a concrete method (real TTY only) and WarnIfProxied is a
-// package function, so neither is otherwise injectable.
-var (
-	warnIfProxied    = transport.WarnIfProxied
-	stderrIsTerminal = func(s *IOStreams) bool { return s.StderrIsTerminal() }
-)
+// warnIfProxied is a test seam for the proxy-warning gate. Production wires it
+// to transport.WarnIfProxied; tests swap in a spy to count invocations. It is
+// needed because the real function is guarded by an internal sync.Once, so
+// calling it directly would only fire on the first test (see
+// factory_proxy_warn_test.go). The terminal check is the IOStreams
+// .StderrIsTerminal field, which tests set directly.
+var warnIfProxied = transport.WarnIfProxied
 
 func cachedHttpClientFunc(f *Factory) func() (*http.Client, error) {
 	return sync.OnceValues(func() (*http.Client, error) {
-		if stderrIsTerminal(f.IOStreams) {
+		if f.IOStreams.StderrIsTerminal {
 			warnIfProxied(f.IOStreams.ErrOut)
 		}
 
@@ -141,7 +139,7 @@ func cachedLarkClientFunc(f *Factory) func() (*lark.Client, error) {
 			lark.WithLogLevel(larkcore.LogLevelError),
 			lark.WithHeaders(BaseSecurityHeaders()),
 		}
-		if stderrIsTerminal(f.IOStreams) {
+		if f.IOStreams.StderrIsTerminal {
 			warnIfProxied(f.IOStreams.ErrOut)
 		}
 		opts = append(opts, lark.WithHttpClient(&http.Client{

--- a/internal/cmdutil/factory_default.go
+++ b/internal/cmdutil/factory_default.go
@@ -102,7 +102,9 @@ func safeRedirectPolicy(req *http.Request, via []*http.Request) error {
 
 func cachedHttpClientFunc(f *Factory) func() (*http.Client, error) {
 	return sync.OnceValues(func() (*http.Client, error) {
-		transport.WarnIfProxied(f.IOStreams.ErrOut)
+		if f.IOStreams.StderrIsTerminal() {
+			transport.WarnIfProxied(f.IOStreams.ErrOut)
+		}
 
 		var rt http.RoundTripper = transport.Shared()
 		rt = &RetryTransport{Base: rt}
@@ -129,7 +131,9 @@ func cachedLarkClientFunc(f *Factory) func() (*lark.Client, error) {
 			lark.WithLogLevel(larkcore.LogLevelError),
 			lark.WithHeaders(BaseSecurityHeaders()),
 		}
-		transport.WarnIfProxied(f.IOStreams.ErrOut)
+		if f.IOStreams.StderrIsTerminal() {
+			transport.WarnIfProxied(f.IOStreams.ErrOut)
+		}
 		opts = append(opts, lark.WithHttpClient(&http.Client{
 			Transport:     buildSDKTransport(),
 			CheckRedirect: safeRedirectPolicy,

--- a/internal/cmdutil/factory_default.go
+++ b/internal/cmdutil/factory_default.go
@@ -100,10 +100,20 @@ func safeRedirectPolicy(req *http.Request, via []*http.Request) error {
 	return nil
 }
 
+// Seams for unit-testing the proxy-warning gate. Production wires them to the
+// real implementations; tests substitute a predicate and a spy to verify the
+// warning fires only on an interactive stderr (see factory_proxy_warn_test.go).
+// StderrIsTerminal is a concrete method (real TTY only) and WarnIfProxied is a
+// package function, so neither is otherwise injectable.
+var (
+	warnIfProxied    = transport.WarnIfProxied
+	stderrIsTerminal = func(s *IOStreams) bool { return s.StderrIsTerminal() }
+)
+
 func cachedHttpClientFunc(f *Factory) func() (*http.Client, error) {
 	return sync.OnceValues(func() (*http.Client, error) {
-		if f.IOStreams.StderrIsTerminal() {
-			transport.WarnIfProxied(f.IOStreams.ErrOut)
+		if stderrIsTerminal(f.IOStreams) {
+			warnIfProxied(f.IOStreams.ErrOut)
 		}
 
 		var rt http.RoundTripper = transport.Shared()
@@ -131,8 +141,8 @@ func cachedLarkClientFunc(f *Factory) func() (*lark.Client, error) {
 			lark.WithLogLevel(larkcore.LogLevelError),
 			lark.WithHeaders(BaseSecurityHeaders()),
 		}
-		if f.IOStreams.StderrIsTerminal() {
-			transport.WarnIfProxied(f.IOStreams.ErrOut)
+		if stderrIsTerminal(f.IOStreams) {
+			warnIfProxied(f.IOStreams.ErrOut)
 		}
 		opts = append(opts, lark.WithHttpClient(&http.Client{
 			Transport:     buildSDKTransport(),

--- a/internal/cmdutil/factory_proxy_warn_test.go
+++ b/internal/cmdutil/factory_proxy_warn_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package cmdutil
+
+import (
+	"io"
+	"testing"
+
+	_ "github.com/larksuite/cli/extension/credential/env" // registers the env-backed account provider
+	"github.com/larksuite/cli/internal/envvars"
+)
+
+// installProxyWarnSpy swaps the package-level proxy-warning seams for one test:
+// stderrIsTerminal is forced to `terminal`, and warnIfProxied is replaced with a
+// counter. The real implementations are restored on cleanup. Returns a pointer
+// to the call count so the caller can assert how many times the warning fired.
+func installProxyWarnSpy(t *testing.T, terminal bool) *int {
+	t.Helper()
+	prevWarn, prevTTY := warnIfProxied, stderrIsTerminal
+	t.Cleanup(func() {
+		warnIfProxied, stderrIsTerminal = prevWarn, prevTTY
+	})
+	calls := 0
+	warnIfProxied = func(io.Writer) { calls++ }
+	stderrIsTerminal = func(*IOStreams) bool { return terminal }
+	return &calls
+}
+
+var proxyWarnGateCases = []struct {
+	name     string
+	terminal bool
+	want     int
+}{
+	{"terminal stderr warns once", true, 1},
+	{"non-terminal stderr stays silent", false, 0},
+}
+
+// TestCachedHttpClientFunc_ProxyWarnGate verifies the http-client init path
+// invokes WarnIfProxied only when stderr is an interactive terminal.
+func TestCachedHttpClientFunc_ProxyWarnGate(t *testing.T) {
+	for _, tc := range proxyWarnGateCases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := installProxyWarnSpy(t, tc.terminal)
+
+			fn := cachedHttpClientFunc(&Factory{IOStreams: &IOStreams{ErrOut: io.Discard}})
+			if _, err := fn(); err != nil {
+				t.Fatalf("http client init: %v", err)
+			}
+
+			if *calls != tc.want {
+				t.Errorf("WarnIfProxied calls = %d, want %d", *calls, tc.want)
+			}
+		})
+	}
+}
+
+// TestCachedLarkClientFunc_ProxyWarnGate verifies the lark-client init path
+// invokes WarnIfProxied only when stderr is an interactive terminal. The gate
+// runs after ResolveAccount, so an env-backed credential is wired up to let
+// account resolution succeed without network or config files.
+func TestCachedLarkClientFunc_ProxyWarnGate(t *testing.T) {
+	for _, tc := range proxyWarnGateCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(envvars.CliAppID, "env-app")
+			t.Setenv(envvars.CliAppSecret, "env-secret")
+			t.Setenv(envvars.CliDefaultAs, "")
+			t.Setenv(envvars.CliUserAccessToken, "")
+			t.Setenv(envvars.CliTenantAccessToken, "")
+			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+			calls := installProxyWarnSpy(t, tc.terminal)
+
+			f := NewDefault(&IOStreams{ErrOut: io.Discard}, InvocationContext{})
+			if _, err := cachedLarkClientFunc(f)(); err != nil {
+				t.Fatalf("lark client init: %v", err)
+			}
+
+			if *calls != tc.want {
+				t.Errorf("WarnIfProxied calls = %d, want %d", *calls, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cmdutil/factory_proxy_warn_test.go
+++ b/internal/cmdutil/factory_proxy_warn_test.go
@@ -11,19 +11,16 @@ import (
 	"github.com/larksuite/cli/internal/envvars"
 )
 
-// installProxyWarnSpy swaps the package-level proxy-warning seams for one test:
-// stderrIsTerminal is forced to `terminal`, and warnIfProxied is replaced with a
-// counter. The real implementations are restored on cleanup. Returns a pointer
-// to the call count so the caller can assert how many times the warning fired.
-func installProxyWarnSpy(t *testing.T, terminal bool) *int {
+// installProxyWarnSpy replaces warnIfProxied with a counter for one test and
+// restores it on cleanup. Returns a pointer to the call count so the caller can
+// assert how many times the warning fired. The terminal state is controlled via
+// the IOStreams.StderrIsTerminal field, not a seam.
+func installProxyWarnSpy(t *testing.T) *int {
 	t.Helper()
-	prevWarn, prevTTY := warnIfProxied, stderrIsTerminal
-	t.Cleanup(func() {
-		warnIfProxied, stderrIsTerminal = prevWarn, prevTTY
-	})
+	prevWarn := warnIfProxied
+	t.Cleanup(func() { warnIfProxied = prevWarn })
 	calls := 0
 	warnIfProxied = func(io.Writer) { calls++ }
-	stderrIsTerminal = func(*IOStreams) bool { return terminal }
 	return &calls
 }
 
@@ -41,9 +38,11 @@ var proxyWarnGateCases = []struct {
 func TestCachedHttpClientFunc_ProxyWarnGate(t *testing.T) {
 	for _, tc := range proxyWarnGateCases {
 		t.Run(tc.name, func(t *testing.T) {
-			calls := installProxyWarnSpy(t, tc.terminal)
+			calls := installProxyWarnSpy(t)
 
-			fn := cachedHttpClientFunc(&Factory{IOStreams: &IOStreams{ErrOut: io.Discard}})
+			fn := cachedHttpClientFunc(&Factory{IOStreams: &IOStreams{
+				ErrOut: io.Discard, StderrIsTerminal: tc.terminal,
+			}})
 			if _, err := fn(); err != nil {
 				t.Fatalf("http client init: %v", err)
 			}
@@ -69,9 +68,11 @@ func TestCachedLarkClientFunc_ProxyWarnGate(t *testing.T) {
 			t.Setenv(envvars.CliTenantAccessToken, "")
 			t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 
-			calls := installProxyWarnSpy(t, tc.terminal)
+			calls := installProxyWarnSpy(t)
 
-			f := NewDefault(&IOStreams{ErrOut: io.Discard}, InvocationContext{})
+			// normalizeStreams copies the struct (out := *s), so the
+			// StderrIsTerminal field survives into f.IOStreams.
+			f := NewDefault(&IOStreams{ErrOut: io.Discard, StderrIsTerminal: tc.terminal}, InvocationContext{})
 			if _, err := cachedLarkClientFunc(f)(); err != nil {
 				t.Fatalf("lark client init: %v", err)
 			}

--- a/internal/cmdutil/iostreams.go
+++ b/internal/cmdutil/iostreams.go
@@ -18,26 +18,28 @@ type IOStreams struct {
 	Out        io.Writer
 	ErrOut     io.Writer
 	IsTerminal bool
+	// StderrIsTerminal reports whether ErrOut is an interactive terminal.
+	// Advisory warnings written to stderr (e.g. the proxy notice) gate on this
+	// so they stay out of non-interactive output (pipes, CI, agent runs).
+	// Computed once in NewIOStreams, mirroring IsTerminal; tests assign it
+	// directly like cmd/config/bind_test.go does for IsTerminal.
+	StderrIsTerminal bool
 }
 
 // NewIOStreams builds an IOStreams from arbitrary readers/writers.
-// IsTerminal is derived from in's underlying *os.File, if any; non-file
-// readers (bytes.Buffer, strings.Reader, …) yield IsTerminal=false.
+// IsTerminal / StderrIsTerminal are derived from in's / errOut's underlying
+// *os.File, if any; non-file streams (bytes.Buffer, strings.Reader, …) yield
+// false.
 func NewIOStreams(in io.Reader, out, errOut io.Writer) *IOStreams {
 	isTerminal := false
 	if f, ok := in.(*os.File); ok {
 		isTerminal = term.IsTerminal(int(f.Fd()))
 	}
-	return &IOStreams{In: in, Out: out, ErrOut: errOut, IsTerminal: isTerminal}
-}
-
-// StderrIsTerminal reports whether ErrOut is an interactive terminal. Advisory
-// warnings written to stderr (e.g. the proxy notice) gate on this so they stay
-// out of non-interactive output (pipes, CI, agent runs). Buffers (tests) and
-// redirects are not *os.File terminals, so they yield false.
-func (s *IOStreams) StderrIsTerminal() bool {
-	f, ok := s.ErrOut.(*os.File)
-	return ok && term.IsTerminal(int(f.Fd()))
+	stderrIsTerminal := false
+	if f, ok := errOut.(*os.File); ok {
+		stderrIsTerminal = term.IsTerminal(int(f.Fd()))
+	}
+	return &IOStreams{In: in, Out: out, ErrOut: errOut, IsTerminal: isTerminal, StderrIsTerminal: stderrIsTerminal}
 }
 
 // SystemIO creates an IOStreams wired to the process's standard file descriptors.

--- a/internal/cmdutil/iostreams.go
+++ b/internal/cmdutil/iostreams.go
@@ -31,6 +31,15 @@ func NewIOStreams(in io.Reader, out, errOut io.Writer) *IOStreams {
 	return &IOStreams{In: in, Out: out, ErrOut: errOut, IsTerminal: isTerminal}
 }
 
+// StderrIsTerminal reports whether ErrOut is an interactive terminal. Advisory
+// warnings written to stderr (e.g. the proxy notice) gate on this so they stay
+// out of non-interactive output (pipes, CI, agent runs). Buffers (tests) and
+// redirects are not *os.File terminals, so they yield false.
+func (s *IOStreams) StderrIsTerminal() bool {
+	f, ok := s.ErrOut.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
+}
+
 // SystemIO creates an IOStreams wired to the process's standard file descriptors.
 //
 //nolint:forbidigo // entry point for real stdio

--- a/internal/transport/warn.go
+++ b/internal/transport/warn.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-
-	"github.com/larksuite/cli/internal/envvars"
 )
 
 // Proxy environment constants control shared transport proxy behavior.
@@ -79,16 +77,8 @@ func WarnIfProxied(w io.Writer) {
 		// Shared), so its warning and disable instructions take precedence.
 		// Emitting the env-proxy warning here would be misleading: it tells the
 		// user to set LARK_CLI_NO_PROXY=1, which does NOT disable the plugin proxy.
-		if addr, caPath, enabled := proxyPluginStatus(); enabled {
-			fmt.Fprintf(w, "[lark-cli] [WARN] proxy plugin enabled: all requests (including credentials) are forced through %s. To disable, set %s=false or remove %s.\n",
-				redactProxyURL(addr), envvars.CliProxyEnable, Path())
-			if strings.TrimSpace(caPath) != "" {
-				// A custom CA means upstream TLS can be intercepted/inspected by
-				// the proxy (MITM). Surface it so the operator is aware traffic
-				// (including Bearer tokens) is decryptable on this host.
-				fmt.Fprintf(w, "[lark-cli] [WARN] proxy plugin trusts a custom CA (%s); TLS to upstreams can be intercepted/inspected by this proxy.\n",
-					caPath)
-			}
+		if _, _, enabled := proxyPluginStatus(); enabled {
+			fmt.Fprintln(w, "[lark-cli] [WARN] proxy plugin enabled: all requests are forced through proxy.")
 			return
 		}
 		if os.Getenv(EnvNoProxy) != "" {

--- a/internal/transport/warn_test.go
+++ b/internal/transport/warn_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-
-	"github.com/larksuite/cli/internal/envvars"
 )
 
 // TestDetectProxyEnv verifies proxy environment detection priority and empty-state behavior.
@@ -120,9 +118,9 @@ func TestWarnIfProxied_OnlyOnce(t *testing.T) {
 }
 
 // TestWarnIfProxied_ProxyPluginEnabled verifies that when proxy plugin mode is
-// enabled, the warning describes the plugin proxy and the correct disable method
-// (LARKSUITE_CLI_PROXY_ENABLE=false) instead of the misleading LARK_CLI_NO_PROXY
-// instruction — even when env proxy and LARK_CLI_NO_PROXY are also set.
+// enabled, the warning is a single concise line that does not leak the proxy
+// address or give the misleading LARK_CLI_NO_PROXY disable instruction — even
+// when env proxy and LARK_CLI_NO_PROXY are also set.
 func TestWarnIfProxied_ProxyPluginEnabled(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	unsetProxyPluginEnv(t)
@@ -140,51 +138,24 @@ func TestWarnIfProxied_ProxyPluginEnabled(t *testing.T) {
 	WarnIfProxied(&buf)
 	out := buf.String()
 
-	if !strings.Contains(out, "127.0.0.1:3128") {
-		t.Errorf("warning should mention the plugin proxy address, got: %s", out)
+	if !strings.Contains(out, "proxy plugin enabled") {
+		t.Errorf("warning should announce proxy plugin enabled, got: %s", out)
 	}
-	if !strings.Contains(out, envvars.CliProxyEnable) {
-		t.Errorf("warning should mention %s as the disable method, got: %s", envvars.CliProxyEnable, out)
+	// Single line only — no address, CA, or disable hints.
+	if strings.Count(out, "\n") != 1 {
+		t.Errorf("warning must be a single line, got: %s", out)
+	}
+	if strings.Contains(out, "127.0.0.1:3128") || strings.Contains(out, "corp-proxy") {
+		t.Errorf("warning must not leak the proxy address, got: %s", out)
 	}
 	if strings.Contains(out, "Set "+EnvNoProxy+"=1") {
 		t.Errorf("warning must NOT give the misleading %s disable instruction when plugin is enabled, got: %s", EnvNoProxy, out)
 	}
-	// No custom CA configured -> no interception warning.
-	if strings.Contains(out, "custom CA") {
-		t.Errorf("warning should not mention a custom CA when none is configured, got: %s", out)
-	}
-}
-
-// TestWarnIfProxied_ProxyPluginCustomCAWarns verifies that when a custom CA is
-// trusted, the warning surfaces the TLS-interception capability.
-func TestWarnIfProxied_ProxyPluginCustomCAWarns(t *testing.T) {
-	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
-	unsetProxyPluginEnv(t)
-	proxyWarningOnce = sync.Once{}
-
-	old := proxyPluginStatus
-	proxyPluginStatus = func() (string, string, bool) {
-		return "http://127.0.0.1:3128", "/etc/lark/extra_ca.pem", true
-	}
-	t.Cleanup(func() { proxyPluginStatus = old })
-
-	var buf bytes.Buffer
-	WarnIfProxied(&buf)
-	out := buf.String()
-
-	if !strings.Contains(out, "custom CA") {
-		t.Errorf("warning should mention the custom CA, got: %s", out)
-	}
-	if !strings.Contains(out, "/etc/lark/extra_ca.pem") {
-		t.Errorf("warning should include the CA path, got: %s", out)
-	}
-	if !strings.Contains(out, "intercept") {
-		t.Errorf("warning should mention TLS interception, got: %s", out)
-	}
 }
 
 // TestWarnIfProxied_ProxyPluginEnabledRedactsCredentials verifies the plugin
-// warning never leaks credentials embedded in the configured proxy address.
+// warning never leaks credentials embedded in the configured proxy address —
+// the simplified message omits the address entirely.
 func TestWarnIfProxied_ProxyPluginEnabledRedactsCredentials(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
 	unsetProxyPluginEnv(t)
@@ -203,9 +174,6 @@ func TestWarnIfProxied_ProxyPluginEnabledRedactsCredentials(t *testing.T) {
 	}
 	if strings.Contains(out, "user:") {
 		t.Errorf("plugin warning leaked username, got: %s", out)
-	}
-	if !strings.Contains(out, "***@127.0.0.1:3128") {
-		t.Errorf("plugin warning should contain redacted proxy URL, got: %s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

The proxy plugin warning printed two-to-three verbose lines (proxy address, disable instructions, and a custom-CA notice) on every command that built a network client, including non-interactive runs piped to files or consumed by agents. This collapses it to a single concise line and suppresses it entirely when stderr is not a terminal.

## Changes

- Collapse the plugin warning in `internal/transport/warn.go` to one line: `[lark-cli] [WARN] proxy plugin enabled: all requests are forced through proxy.` (drops the address, the `LARKSUITE_CLI_PROXY_ENABLE` disable hint, and the custom-CA line); remove the now-unused `envvars` import
- Add a precomputed `StderrIsTerminal` field to `IOStreams` in `internal/cmdutil/iostreams.go` (computed once in `NewIOStreams`, mirroring the existing `IsTerminal` field)
- Gate both `WarnIfProxied` call sites in `internal/cmdutil/factory_default.go` on `f.IOStreams.StderrIsTerminal` so the notice is silent on pipes / CI / agent runs; introduce a `warnIfProxied` test seam (the real function is guarded by a `sync.Once`)
- Add `internal/cmdutil/factory_proxy_warn_test.go`: verify both client-init paths warn only when stderr is a terminal
- Update `internal/transport/warn_test.go`: assert the single-line message and credential non-leak; drop the obsolete custom-CA assertion test

## Security note

The custom-CA / TLS-MITM line (`...TLS to upstreams can be intercepted/inspected by this proxy`) is **intentionally removed**, not overlooked. Proxy-plugin mode and a custom CA are both operator self-inflicted local configuration (not attacker-controllable), so this was a defense-in-depth awareness line rather than a vulnerability guard. Dropping it is a deliberate noise-vs-signal tradeoff; the remaining one-liner still states that all requests are forced through the proxy.

## Test Plan

- [x] `go build ./...` passed
- [x] `go vet ./internal/transport/ ./internal/cmdutil/` passed
- [x] `go test ./internal/transport/ ./internal/cmdutil/` passed (incl. new `ProxyWarnGate` tests: 4/4)
- [x] manual verification (non-tty): `LARKSUITE_CLI_PROXY_ENABLE=true LARKSUITE_CLI_PROXY_ADDRESS=http://127.0.0.1:8888 lark-cli auth login --domain docs 2>err.txt` — 0 warning lines
- [x] manual verification (tty via pty): `... script -q /dev/null lark-cli auth login --domain docs` — exactly one `proxy plugin enabled` line
- [ ] skipped: local-eval / acceptance-reviewer — change is internal transport/IO plumbing with no shortcut or skill surface; covered by unit tests + manual e2e

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Proxy warnings are now only shown in interactive terminal sessions to reduce log noise.
  * Proxy plugin warning messages are simplified and no longer reveal proxy configuration details.

* **Tests**
  * Added tests to ensure proxy warnings are emitted exactly in interactive terminals and suppressed for non-interactive/redirected output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
