### PR TITLE
feat(mcp): add 'mcp list' / 'mcp call' general MCP client

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -14,6 +14,7 @@ import (
 	cmdconfig "github.com/larksuite/cli/cmd/config"
 	"github.com/larksuite/cli/cmd/doctor"
 	cmdevent "github.com/larksuite/cli/cmd/event"
+	"github.com/larksuite/cli/cmd/mcp"
 	"github.com/larksuite/cli/cmd/profile"
 	"github.com/larksuite/cli/cmd/schema"
 	"github.com/larksuite/cli/cmd/service"
@@ -156,6 +157,7 @@ func buildInternal(ctx context.Context, inv cmdutil.InvocationContext, opts ...B
 	rootCmd.AddCommand(cmdupdate.NewCmdUpdate(f))
 	rootCmd.AddCommand(cmdevent.NewCmdEvents(f))
 	rootCmd.AddCommand(skill.NewCmdSkill(f))
+	rootCmd.AddCommand(mcp.NewCmdMCP(f))
 	service.RegisterServiceCommandsWithContext(ctx, rootCmd, f)
 	shortcuts.RegisterShortcutsWithContext(ctx, rootCmd, f)
 

--- a/cmd/mcp/call.go
+++ b/cmd/mcp/call.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/output"
+)
+
+type callOptions struct {
+	Factory *cmdutil.Factory
+	URL     string
+	Tool    string
+	Args    string
+	Headers []string
+}
+
+// NewCmdMCPCall builds `mcp call` — JSON-RPC tools/call against --url.
+func NewCmdMCPCall(f *cmdutil.Factory) *cobra.Command {
+	opts := &callOptions{Factory: f}
+	cmd := &cobra.Command{
+		Use:   "call",
+		Short: "Call a tool on an MCP server (tools/call)",
+		Example: `  lark-cli mcp call --url https://example.com/mcp --tool search --args '{"query":"hello"}'
+  lark-cli mcp call --url https://example.com/mcp --tool get_item --args '{"id":1}' --header "Authorization: Bearer $TOKEN"`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCall(cmd.Context(), opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.URL, "url", "", "MCP server URL (https://...)")
+	cmd.Flags().StringVar(&opts.Tool, "tool", "", "tool name to call")
+	cmd.Flags().StringVar(&opts.Args, "args", "{}", "tool arguments as a JSON object")
+	cmd.Flags().StringArrayVar(&opts.Headers, "header", nil, "extra request header \"Key: Value\" (repeatable)")
+	_ = cmd.MarkFlagRequired("url")
+	_ = cmd.MarkFlagRequired("tool")
+	return cmd
+}
+
+func runCall(ctx context.Context, opts *callOptions) error {
+	raw := strings.TrimSpace(opts.Args)
+	if raw == "" {
+		raw = "{}"
+	}
+	var arguments map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &arguments); err != nil {
+		return output.ErrValidation("invalid --args (must be a JSON object): %v", err)
+	}
+
+	headers, err := parseHeaders(opts.Headers)
+	if err != nil {
+		return err
+	}
+	client, err := httpClientFor(ctx, opts.Factory, opts.URL)
+	if err != nil {
+		return err
+	}
+	params := map[string]any{"name": opts.Tool, "arguments": arguments}
+	result, err := jsonRPC(ctx, client, opts.URL, "tools/call", params, headers)
+	if err != nil {
+		return err
+	}
+	output.PrintJson(opts.Factory.IOStreams.Out, map[string]interface{}{"ok": true, "data": result})
+	return nil
+}

--- a/cmd/mcp/client.go
+++ b/cmd/mcp/client.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/validate"
+)
+
+const (
+	mcpBodyLimit  = 4000
+	mcpReadLimit  = 1 << 20 // 1 MiB response cap
+	mcpAcceptType = "application/json, text/event-stream"
+)
+
+// parseHeaders turns repeatable `--header "Key: Value"` flags into an http.Header.
+func parseHeaders(raw []string) (http.Header, error) {
+	h := http.Header{}
+	for _, item := range raw {
+		k, v, ok := strings.Cut(item, ":")
+		if !ok {
+			return nil, output.ErrValidation("invalid --header %q (expected \"Key: Value\")", item)
+		}
+		k = strings.TrimSpace(k)
+		if k == "" {
+			return nil, output.ErrValidation("invalid --header %q (empty key)", item)
+		}
+		h.Add(k, strings.TrimSpace(v))
+	}
+	return h, nil
+}
+
+// httpClientFor validates a user-supplied URL (SSRF guard: rejects localhost /
+// private / link-local / CGNAT hosts and re-checks the IP at dial time to defeat
+// DNS rebinding) and returns an https-only client.
+func httpClientFor(ctx context.Context, f *cmdutil.Factory, rawURL string) (*http.Client, error) {
+	if err := validate.ValidateDownloadSourceURL(ctx, rawURL); err != nil {
+		return nil, output.ErrValidation("invalid --url: %v", err)
+	}
+	base, err := f.HttpClient()
+	if err != nil {
+		return nil, output.ErrNetwork("failed to get HTTP client: %v", err)
+	}
+	return validate.NewDownloadHTTPClient(base, validate.DownloadHTTPClientOptions{AllowHTTP: false}), nil
+}
+
+// jsonRPC performs one JSON-RPC 2.0 request against an arbitrary MCP server and
+// returns the unwrapped `result`. Pure transport + parse — no Lark specifics.
+func jsonRPC(ctx context.Context, client *http.Client, url, method string, params any, headers http.Header) (interface{}, error) {
+	reqBody, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      uuid.NewString(),
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		return nil, output.Errorf(output.ExitInternal, "internal_error", "failed to marshal request: %v", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, output.Errorf(output.ExitInternal, "internal_error", "failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", mcpAcceptType)
+	for k, vs := range headers {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, output.ErrNetwork("MCP transport failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, mcpReadLimit))
+	if err != nil {
+		return nil, output.ErrNetwork("failed to read response: %v", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, output.Errorf(output.ExitAPI, "mcp_error", "MCP HTTP %d: %s", resp.StatusCode, truncate(string(body), mcpBodyLimit))
+	}
+
+	payload, err := decodeJSONRPC(body)
+	if err != nil {
+		return nil, err
+	}
+	if errObj, ok := payload["error"]; ok {
+		return nil, mcpErrorFrom(errObj)
+	}
+	return payload["result"], nil
+}
+
+// decodeJSONRPC parses a JSON-RPC response body. MCP's Streamable HTTP transport
+// may frame the JSON as a Server-Sent Event, so pull it from the last `data:`
+// line when present; otherwise parse the body as plain JSON.
+func decodeJSONRPC(body []byte) (map[string]interface{}, error) {
+	trimmed := bytes.TrimSpace(body)
+	if bytes.HasPrefix(trimmed, []byte("event:")) || bytes.HasPrefix(trimmed, []byte("data:")) {
+		var last []byte
+		for _, line := range bytes.Split(trimmed, []byte("\n")) {
+			line = bytes.TrimSpace(line)
+			if rest, ok := bytes.CutPrefix(line, []byte("data:")); ok {
+				last = bytes.TrimSpace(rest)
+			}
+		}
+		trimmed = last
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(trimmed, &m); err != nil {
+		return nil, output.Errorf(output.ExitAPI, "mcp_error", "MCP returned non-JSON: %s", truncate(string(body), mcpBodyLimit))
+	}
+	return m, nil
+}
+
+// mcpErrorFrom maps a JSON-RPC `error` object to a typed API error.
+func mcpErrorFrom(errObj interface{}) error {
+	if m, ok := errObj.(map[string]interface{}); ok {
+		msg, _ := m["message"].(string)
+		if strings.TrimSpace(msg) == "" {
+			msg = "MCP returned an error response"
+		}
+		return output.Errorf(output.ExitAPI, "mcp_error", "MCP error: %s", msg)
+	}
+	if s, ok := errObj.(string); ok && strings.TrimSpace(s) != "" {
+		return output.Errorf(output.ExitAPI, "mcp_error", "MCP error: %s", s)
+	}
+	return output.Errorf(output.ExitAPI, "mcp_error", "MCP returned an error response")
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/cmd/mcp/client_test.go
+++ b/cmd/mcp/client_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/larksuite/cli/internal/output"
+)
+
+func asExit(t *testing.T, err error) *output.ExitError {
+	t.Helper()
+	var ee *output.ExitError
+	if !errors.As(err, &ee) {
+		t.Fatalf("expected *output.ExitError, got %T: %v", err, err)
+	}
+	return ee
+}
+
+func newServer(t *testing.T, status int, contentType, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+		if contentType != "" {
+			w.Header().Set("Content-Type", contentType)
+		}
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestJSONRPC_ToolsList(t *testing.T) {
+	srv := newServer(t, 200, "application/json",
+		`{"jsonrpc":"2.0","id":"1","result":{"tools":[{"name":"search"},{"name":"get_item"}]}}`)
+
+	got, err := jsonRPC(context.Background(), srv.Client(), srv.URL, "tools/list", map[string]any{}, nil)
+	if err != nil {
+		t.Fatalf("jsonRPC: %v", err)
+	}
+	res, ok := got.(map[string]interface{})
+	if !ok {
+		t.Fatalf("result type = %T, want map", got)
+	}
+	tools, ok := res["tools"].([]interface{})
+	if !ok || len(tools) != 2 {
+		t.Fatalf("tools = %v, want 2 entries", res["tools"])
+	}
+}
+
+func TestJSONRPC_ToolsCall(t *testing.T) {
+	srv := newServer(t, 200, "application/json",
+		`{"jsonrpc":"2.0","id":"1","result":{"content":[{"type":"text","text":"hi"}],"isError":false}}`)
+
+	got, err := jsonRPC(context.Background(), srv.Client(), srv.URL, "tools/call",
+		map[string]any{"name": "search", "arguments": map[string]any{"q": "x"}}, nil)
+	if err != nil {
+		t.Fatalf("jsonRPC: %v", err)
+	}
+	if _, ok := got.(map[string]interface{})["content"]; !ok {
+		t.Fatalf("result missing content: %v", got)
+	}
+}
+
+func TestJSONRPC_SSEFraming(t *testing.T) {
+	// Streamable HTTP may frame the JSON-RPC payload as a Server-Sent Event.
+	body := "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":\"1\",\"result\":{\"ok\":true}}\n\n"
+	srv := newServer(t, 200, "text/event-stream", body)
+
+	got, err := jsonRPC(context.Background(), srv.Client(), srv.URL, "tools/list", map[string]any{}, nil)
+	if err != nil {
+		t.Fatalf("jsonRPC (SSE): %v", err)
+	}
+	if got.(map[string]interface{})["ok"] != true {
+		t.Fatalf("SSE result = %v, want ok:true", got)
+	}
+}
+
+func TestJSONRPC_ErrorPayload(t *testing.T) {
+	srv := newServer(t, 200, "application/json",
+		`{"jsonrpc":"2.0","id":"1","error":{"code":-32601,"message":"Method not found"}}`)
+
+	_, err := jsonRPC(context.Background(), srv.Client(), srv.URL, "tools/list", map[string]any{}, nil)
+	ee := asExit(t, err)
+	if ee.Code != output.ExitAPI {
+		t.Errorf("exit code = %d, want ExitAPI(%d)", ee.Code, output.ExitAPI)
+	}
+	if ee.Detail == nil || ee.Detail.Type != "mcp_error" {
+		t.Errorf("error type = %v, want mcp_error", ee.Detail)
+	}
+}
+
+func TestJSONRPC_HTTPError(t *testing.T) {
+	srv := newServer(t, http.StatusInternalServerError, "text/plain", "boom")
+
+	_, err := jsonRPC(context.Background(), srv.Client(), srv.URL, "tools/list", map[string]any{}, nil)
+	ee := asExit(t, err)
+	if ee.Code != output.ExitAPI {
+		t.Errorf("exit code = %d, want ExitAPI(%d)", ee.Code, output.ExitAPI)
+	}
+}
+
+func TestJSONRPC_NonJSON(t *testing.T) {
+	srv := newServer(t, 200, "application/json", "<html>not json</html>")
+
+	_, err := jsonRPC(context.Background(), srv.Client(), srv.URL, "tools/list", map[string]any{}, nil)
+	if asExit(t, err).Code != output.ExitAPI {
+		t.Errorf("want ExitAPI for non-JSON body")
+	}
+}
+
+func TestParseHeaders(t *testing.T) {
+	h, err := parseHeaders([]string{"Authorization: Bearer abc", "X-Trace:  t1 "})
+	if err != nil {
+		t.Fatalf("parseHeaders: %v", err)
+	}
+	if got := h.Get("Authorization"); got != "Bearer abc" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer abc")
+	}
+	if got := h.Get("X-Trace"); got != "t1" {
+		t.Errorf("X-Trace = %q (whitespace not trimmed)", got)
+	}
+
+	for _, bad := range []string{"no-colon", ": empty-key"} {
+		if _, err := parseHeaders([]string{bad}); err == nil {
+			t.Errorf("parseHeaders(%q) = nil error, want validation error", bad)
+		} else if asExit(t, err).Code != output.ExitValidation {
+			t.Errorf("parseHeaders(%q) wrong exit code", bad)
+		}
+	}
+}
+
+func TestParseHeaders_SentOnWire(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"jsonrpc":"2.0","id":"1","result":{}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	h, _ := parseHeaders([]string{"Authorization: Bearer xyz"})
+	if _, err := jsonRPC(context.Background(), srv.Client(), srv.URL, "tools/list", map[string]any{}, h); err != nil {
+		t.Fatalf("jsonRPC: %v", err)
+	}
+	if gotAuth != "Bearer xyz" {
+		t.Errorf("server saw Authorization = %q, want %q", gotAuth, "Bearer xyz")
+	}
+}

--- a/cmd/mcp/list.go
+++ b/cmd/mcp/list.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/output"
+)
+
+type listOptions struct {
+	Factory *cmdutil.Factory
+	URL     string
+	Headers []string
+}
+
+// NewCmdMCPList builds `mcp list` — JSON-RPC tools/list against --url.
+func NewCmdMCPList(f *cmdutil.Factory) *cobra.Command {
+	opts := &listOptions{Factory: f}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List the tools an MCP server exposes (tools/list)",
+		Example: `  lark-cli mcp list --url https://example.com/mcp
+  lark-cli mcp list --url https://example.com/mcp --header "Authorization: Bearer $TOKEN"`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runList(cmd.Context(), opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.URL, "url", "", "MCP server URL (https://...)")
+	cmd.Flags().StringArrayVar(&opts.Headers, "header", nil, "extra request header \"Key: Value\" (repeatable)")
+	_ = cmd.MarkFlagRequired("url")
+	return cmd
+}
+
+func runList(ctx context.Context, opts *listOptions) error {
+	headers, err := parseHeaders(opts.Headers)
+	if err != nil {
+		return err
+	}
+	client, err := httpClientFor(ctx, opts.Factory, opts.URL)
+	if err != nil {
+		return err
+	}
+	result, err := jsonRPC(ctx, client, opts.URL, "tools/list", map[string]any{}, headers)
+	if err != nil {
+		return err
+	}
+	output.PrintJson(opts.Factory.IOStreams.Out, map[string]interface{}{"ok": true, "data": result})
+	return nil
+}

--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+// Package mcp implements a general Model Context Protocol (MCP) client:
+// `lark-cli mcp list` and `lark-cli mcp call` talk to ANY MCP server over
+// JSON-RPC 2.0 (Streamable HTTP). Unlike the Lark-managed MCP path used by
+// shortcuts, these commands take an arbitrary `--url` and send no Lark-specific
+// auth — auth, if any, is supplied via repeatable `--header "Key: Value"`.
+package mcp
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+)
+
+// NewCmdMCP builds the `mcp` command group.
+func NewCmdMCP(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Call any MCP server over JSON-RPC (tools/list, tools/call)",
+		Long: `Interact with any Model Context Protocol (MCP) server over JSON-RPC 2.0.
+
+These commands target an arbitrary server via --url (https only) and send no
+Lark credentials; pass any auth the server needs with repeatable
+--header "Authorization: Bearer <token>". The raw JSON-RPC result is returned
+under "data" so it can be filtered with --jq downstream.`,
+	}
+	// No Lark login is required to call an external MCP server.
+	cmdutil.DisableAuthCheck(cmd)
+	cmd.AddCommand(NewCmdMCPList(f))
+	cmd.AddCommand(NewCmdMCPCall(f))
+	return cmd
+}


### PR DESCRIPTION
## Summary

Add a general **MCP client** to lark-cli — `mcp list` and `mcp call` talk to **any** Model Context Protocol server over JSON-RPC 2.0 (Streamable HTTP). This complements the existing Lark-*managed* MCP path used internally by shortcuts (`shortcuts/common/mcp_client.go`), which is hardwired to Lark's endpoint and proprietary `X-Lark-MCP-*` headers and cannot reach a third-party server.

## Changes

- New `cmd/mcp` command group:
  - `lark-cli mcp list --url <server>` → JSON-RPC `tools/list`
  - `lark-cli mcp call --url <server> --tool <name> --args '<json>'` → `tools/call`
- Flags: `--url` (required), `--tool` (required for `call`), `--args` (JSON object, default `{}`), repeatable `--header "Key: Value"` for arbitrary server auth. **No Lark credentials are sent** to the external server.
- Security: the user-supplied `--url` is SSRF-guarded via `internal/validate` — https-only, rejects `localhost`/private/link-local/CGNAT hosts, and re-checks the resolved IP at dial time to defeat DNS rebinding.
- Robustness: handles Streamable-HTTP **SSE response framing**; returns the raw JSON-RPC `result` under `data` so it composes with `--jq`.
- Errors: typed `*output.ExitError` throughout (`ErrValidation` / `ErrNetwork` / `Errorf(ExitAPI, …)`); no bare `fmt.Errorf`.
- Placed in `cmd/` (not `shortcuts/`) so it may use `net/http` directly, per the `shortcuts-no-raw-http` forbidigo policy. Registered in `cmd/build.go`.

No new dependencies (reuses `github.com/google/uuid`, `cobra`, and `internal/*`).

## Test Plan

- [x] Unit tests (`go test -race ./cmd/mcp/...`): `httptest`-based table tests covering `tools/list`, `tools/call`, SSE framing, JSON-RPC error payload, HTTP ≥400, non-JSON body, and `--header` parse + on-the-wire delivery.
- [x] Manual local verification: `mcp --help`, `mcp list/call --help`, SSRF rejection of `http://localhost:...`, `--args` JSON validation — all return the correct JSON error envelope.
- [x] `gofmt -l` clean · `go vet` clean · `golangci-lint@v2.1.6 run --new-from-rev=origin/main` → `0 issues` · `go mod tidy` no-op.

## Related Issues

- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `mcp` command group for interacting with MCP servers
  * `mcp list` subcommand lists available tools from a target MCP server
  * `mcp call` subcommand invokes specific tools on a target MCP server
  * Both commands support custom authentication headers and comprehensive error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->