### PR TITLE
fix(event): clarify remote bus blocker recovery

### DIFF
--- a/internal/event/consume/startup.go
+++ b/internal/event/consume/startup.go
@@ -53,8 +53,8 @@ func EnsureBus(ctx context.Context, tr transport.IPC, appID, profileName, domain
 			fmt.Fprintf(errOut, "[event] remote connection check: online_instance_cnt=%d\n", count)
 			if count > 0 {
 				return nil, errs.NewValidationError(errs.SubtypeFailedPrecondition,
-					"another event bus is already connected to this app (%d active connection(s) detected via API); only one bus should run globally to avoid duplicate event delivery", count).
-					WithHint("use `lark-cli event status` to check, or `lark-cli event stop` on the other machine first")
+					"another event bus is already connected to this app (%d remote event connection(s) detected via API); only one bus should run globally to avoid duplicate event delivery", count).
+					WithHint("remote event connection detected; `lark-cli event status` and `lark-cli event stop` only inspect local buses; stop the owner host/process, wait for the platform connection timeout, or use a separate app/profile")
 			}
 		}
 	} else {

--- a/internal/event/consume/startup_guard_test.go
+++ b/internal/event/consume/startup_guard_test.go
@@ -50,8 +50,16 @@ func TestEnsureBus_RemoteBusAlreadyConnectedIsFailedPrecondition(t *testing.T) {
 	if ve.Subtype != errs.SubtypeFailedPrecondition {
 		t.Errorf("subtype = %s, want %s", ve.Subtype, errs.SubtypeFailedPrecondition)
 	}
-	if !strings.Contains(ve.Hint, "event stop") {
-		t.Errorf("hint should point at `event stop`, got: %q", ve.Hint)
+	wantHints := []string{
+		"remote event connection",
+		"`lark-cli event status` and `lark-cli event stop` only inspect local buses",
+		"stop the owner host/process",
+		"wait for the platform connection timeout",
+	}
+	for _, want := range wantHints {
+		if !strings.Contains(ve.Hint, want) {
+			t.Errorf("hint missing %q\ngot: %q", want, ve.Hint)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- clarify that a positive remote event connection preflight is a remote/server-side blocker
- avoid suggesting local-only status/stop as the full recovery path
- point users toward stopping the owner host/process, waiting for platform timeout, or using a separate app/profile

Fixes #1381.

## Tests
- `go test ./internal/event/consume -run TestEnsureBus_RemoteBusAlreadyConnectedIsFailedPrecondition -count=1` (fails before the fix, passes after)
- `go test ./internal/event/consume ./cmd/event -count=1`
- `go test ./internal/event/consume ./cmd/event ./errs -count=1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages when attempting to start a local event bus while a remote connection is already active. The improved guidance provides clearer instructions referencing CLI commands for checking connection status, stopping remote connections, and clarifies how to handle platform connection timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->