### PR TITLE
feat(mail): add LMSReplyType header to emlbuilder and reply/forward shortcuts

### DIFF
--- a/shortcuts/mail/emlbuilder/builder.go
+++ b/shortcuts/mail/emlbuilder/builder.go
@@ -59,6 +59,9 @@ import (
 // MaxEMLSize is the maximum allowed raw EML size in bytes.
 const MaxEMLSize = 25 * 1024 * 1024 // 25 MB
 
+// lmsReplyTypeHeaderKey is the Lark internal header that carries the reply/forward type.
+const lmsReplyTypeHeaderKey = "X-LMS-Reply-Type"
+
 // readFile reads the named file and returns its contents via FileIO.
 func readFile(fio fileio.FileIO, path string) ([]byte, error) {
 	f, err := fio.Open(path)
@@ -389,6 +392,24 @@ func (b Builder) LMSReplyToMessageID(id string) Builder {
 	}
 	b.lmsReplyToMessageID = id
 	return b
+}
+
+// LMSReplyType sets the reply/forward type header (X-LMS-Reply-Type).
+// Accepted values are "REPLY" and "FORWARD".
+// Used together with LMSReplyToMessageID so the server can mark the original
+// message as replied-to or forwarded.
+// Returns an error builder if t contains CR or LF.
+func (b Builder) LMSReplyType(t string) Builder {
+	if b.err != nil {
+		return b
+	}
+	if err := validateHeaderValue(t); err != nil {
+		b.err = err
+		return b
+	}
+	cp := b.copySlices()
+	cp.extraHeaders = append(cp.extraHeaders, [2]string{lmsReplyTypeHeaderKey, t})
+	return cp
 }
 
 // References sets the References header value verbatim.

--- a/shortcuts/mail/mail_forward.go
+++ b/shortcuts/mail/mail_forward.go
@@ -229,6 +229,7 @@ var MailForward = common.Shortcut{
 		}
 		if messageId != "" {
 			bld = bld.LMSReplyToMessageID(messageId)
+			bld = bld.LMSReplyType("FORWARD")
 		}
 		useHTML := !plainText && (bodyIsHTML(body) || bodyIsHTML(orig.bodyRaw) || sigResult != nil)
 		if strings.TrimSpace(inlineFlag) != "" && !useHTML {

--- a/shortcuts/mail/mail_reply.go
+++ b/shortcuts/mail/mail_reply.go
@@ -239,6 +239,7 @@ var MailReply = common.Shortcut{
 		}
 		if messageId != "" {
 			bld = bld.LMSReplyToMessageID(messageId)
+			bld = bld.LMSReplyType("REPLY")
 		}
 		var autoResolvedPaths []string
 		var composedHTMLBody string

--- a/shortcuts/mail/mail_reply_all.go
+++ b/shortcuts/mail/mail_reply_all.go
@@ -248,6 +248,7 @@ var MailReplyAll = common.Shortcut{
 		}
 		if messageId != "" {
 			bld = bld.LMSReplyToMessageID(messageId)
+			bld = bld.LMSReplyType("REPLY")
 		}
 		var autoResolvedPaths []string
 		var composedHTMLBody string


### PR DESCRIPTION
Generated by the harness-coding skill (recovery run — original attempt crashed before MR open).

- **Branch**: feat/095af0d
- **Target**: main

> The commits below were produced by a prior coding run on this branch. The current resume run regenerated the sprint plan from tech-specs and confirmed those commits already implement the work (sprint status `skipped:already_implemented`). Any sprint with status `passed` in the table below represents work this resume run added on top.

## Commits on branch (ahead of main)

| Commit | Subject |
|--------|---------|
| ab059d9e | feat(mail): add LMSReplyType header to emlbuilder and reply/forward shortcuts |

## This resume run

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S4 | Add LMSReplyType header to emlbuilder and all three reply/forward shortcuts | passed | ab059d9e |

## Source specs

(see tech-design.md — local path omitted per output policy)

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email reply, reply-all, and forward operations now include message-type metadata headers that explicitly identify the operation type. This enhancement improves message identification, routing, and handling within the email system, ensuring that replied and forwarded messages are correctly processed and categorized throughout your email workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->