### PR TITLE
feat: support docs fetch user cite language

### DIFF
--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -265,8 +265,8 @@ func ResolveConfigFromMulti(raw *MultiAppConfig, kc keychain.KeychainAccess, pro
 		AppID:       app.AppId,
 		AppSecret:   secret,
 		Brand:       app.Brand,
-		DefaultAs:   app.DefaultAs,
 		Lang:        app.Lang,
+		DefaultAs:   app.DefaultAs,
 	}
 	if len(app.Users) > 0 {
 		cfg.UserOpenId = app.Users[0].UserOpenId

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -132,6 +132,27 @@ func TestResolveConfigFromMulti_AcceptsPlainSecret(t *testing.T) {
 	}
 }
 
+func TestResolveConfigFromMulti_CarriesLang(t *testing.T) {
+	raw := &MultiAppConfig{
+		Apps: []AppConfig{
+			{
+				AppId:     "cli_abc",
+				AppSecret: PlainSecret("my-secret"),
+				Brand:     BrandFeishu,
+				Lang:      "en",
+			},
+		},
+	}
+
+	cfg, err := ResolveConfigFromMulti(raw, nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Lang != "en" {
+		t.Errorf("Lang = %q, want %q", cfg.Lang, "en")
+	}
+}
+
 func TestResolveConfigFromMulti_MatchingKeychainRefPassesValidation(t *testing.T) {
 	// Keychain ref matches appId, so validation passes.
 	// The subsequent ResolveSecretInput will fail (no real keychain),

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -19,6 +19,7 @@ func v2FetchFlags() []common.Flag {
 	return []common.Flag{
 		{Name: "doc-format", Desc: "output content format; xml keeps DocxXML structure and optional block ids, markdown is plain export", Default: "xml", Enum: []string{"xml", "markdown"}},
 		{Name: "detail", Desc: "detail level; simple for reading, with-ids for block references, full for styles and edit metadata", Default: "simple", Enum: []string{"simple", "with-ids", "full"}},
+		{Name: "lang", Desc: "user cite display language, e.g. en-US, zh-CN, ja-JP"},
 		{Name: "revision-id", Desc: "document revision id; -1 means latest", Type: "int", Default: "-1"},
 		{Name: "scope", Desc: "read scope; full reads whole doc, outline lists headings, section expands from heading anchor, range uses block ids, keyword searches text", Default: "full", Enum: []string{"full", "outline", "range", "keyword", "section"}},
 		{Name: "start-block-id", Desc: "range/section anchor block id; required for section and optional start for range"},
@@ -89,6 +90,9 @@ func buildFetchBody(runtime *common.RuntimeContext) map[string]interface{} {
 	if v := runtime.Int("revision-id"); v > 0 {
 		body["revision_id"] = v
 	}
+	if lang := resolveFetchLang(runtime); lang != "" {
+		body["lang"] = lang
+	}
 
 	detail := effectiveFetchDetail(runtime)
 	switch detail {
@@ -116,6 +120,16 @@ func buildFetchBody(runtime *common.RuntimeContext) map[string]interface{} {
 	injectDocsScene(runtime, body)
 
 	return body
+}
+
+func resolveFetchLang(runtime *common.RuntimeContext) string {
+	if runtime.Changed("lang") {
+		return strings.TrimSpace(runtime.Str("lang"))
+	}
+	if runtime.Config == nil {
+		return ""
+	}
+	return strings.TrimSpace(string(runtime.Config.Lang))
 }
 
 // buildReadOption 拼装 read_option JSON；full/空模式返回 nil，让服务端走默认全文路径。

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
@@ -59,6 +60,47 @@ func TestBuildFetchBodyOmitsEmptyScene(t *testing.T) {
 	body := buildFetchBody(runtime)
 	if _, ok := body["scene"]; ok {
 		t.Fatalf("did not expect empty scene in fetch body: %#v", body)
+	}
+}
+
+func TestBuildFetchBodyIncludesExplicitLang(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchBodyTestRuntime(context.Background())
+	if err := runtime.Cmd.Flags().Set("lang", "en-US"); err != nil {
+		t.Fatalf("set lang: %v", err)
+	}
+
+	body := buildFetchBody(runtime)
+	if got := body["lang"]; got != "en-US" {
+		t.Fatalf("lang = %#v, want %q", got, "en-US")
+	}
+}
+
+func TestBuildFetchBodyUsesRuntimeConfigLang(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchBodyTestRuntime(context.Background())
+	runtime.Config = &core.CliConfig{Lang: "zh_cn"}
+
+	body := buildFetchBody(runtime)
+	if got := body["lang"]; got != "zh_cn" {
+		t.Fatalf("lang = %#v, want %q", got, "zh_cn")
+	}
+}
+
+func TestBuildFetchBodyExplicitBlankLangOmitsLang(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchBodyTestRuntime(context.Background())
+	runtime.Config = &core.CliConfig{Lang: "zh_cn"}
+	if err := runtime.Cmd.Flags().Set("lang", ""); err != nil {
+		t.Fatalf("set lang: %v", err)
+	}
+
+	body := buildFetchBody(runtime)
+	if _, ok := body["lang"]; ok {
+		t.Fatalf("did not expect blank explicit lang in fetch body: %#v", body)
 	}
 }
 
@@ -262,6 +304,7 @@ func newFetchBodyTestRuntime(ctx context.Context) *common.RuntimeContext {
 	cmd := &cobra.Command{Use: "+fetch"}
 	cmd.Flags().String("doc-format", "xml", "")
 	cmd.Flags().String("detail", "simple", "")
+	cmd.Flags().String("lang", "", "")
 	cmd.Flags().Int("revision-id", -1, "")
 	cmd.Flags().String("scope", "full", "")
 	cmd.Flags().String("start-block-id", "", "")
@@ -281,6 +324,7 @@ func newFetchShortcutTestRuntime(t *testing.T, apiVersion string, setFlags map[s
 	cmd.Flags().String("doc", "doxcnFetchDryRun", "")
 	cmd.Flags().String("doc-format", "xml", "")
 	cmd.Flags().String("detail", "simple", "")
+	cmd.Flags().String("lang", "", "")
 	cmd.Flags().Int("revision-id", -1, "")
 	cmd.Flags().String("scope", "full", "")
 	cmd.Flags().String("start-block-id", "", "")


### PR DESCRIPTION
## Summary
This PR adds `--lang` support to `docs +fetch --api-version v2` so callers can request a preferred display language for user cite names in fetched Docx content.
When `--lang` is omitted, the command falls back to the current profile language and omits `lang` entirely when no language preference is configured.

## Changes
- Add the `--lang` flag to the docs v2 fetch shortcut and include it in the OpenAPI fetch request body.
- Resolve the fetch language with explicit flag value first, then profile language, then no request body field.
- Add unit coverage for explicit language, profile language fallback, and explicit blank language behavior.
- Document the new `--lang` option in the `lark-doc` fetch reference.

## Test Plan
- [x] `go test ./shortcuts/doc ./internal/core -run 'TestBuildFetchBody|TestDocsFetch|TestResolveConfigFromMulti_CarriesLang|TestResolveConfigFromMulti_AcceptsPlainSecret' -count=1`
- [x] `go test ./shortcuts/doc ./internal/core ./internal/credential ./cmd/config ./cmd/profile -count=1`
- [x] `git diff --check upstream/main...HEAD`
- [x] Manual validation against a private test document:
  - `docs +fetch --api-version v2 --lang en-US` returns an English user cite display name.
  - `docs +fetch --api-version v2` keeps the default user cite display name.
  - `docs +fetch --api-version v2 --lang xx-YY` succeeds and falls back to the default display name.

## Related Issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--lang` flag to v2 (OpenAPI) documentation fetch operations to control the language used during retrieval.
  * If `--lang` is set, that value is used; if not set, the operation falls back to the existing runtime configuration language; if explicitly set to an empty value, the language is omitted.
* **Bug Fixes**
  * Ensured resolved multi-app configuration preserves the `Lang` value correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->