### PR TITLE
fix(vfs): reject blank local paths

### DIFF
--- a/internal/validate/path_test.go
+++ b/internal/validate/path_test.go
@@ -26,6 +26,10 @@ func TestSafeOutputPath_RejectsPathTraversalAndDangerousInput(t *testing.T) {
 		{"unicode normal", "报告.xlsx", false},
 		{"dot-dot resolves to cwd", "subdir/..", false},
 
+		// ── GIVEN: empty or blank paths → THEN: rejected ──
+		{"empty path", "", true},
+		{"blank path", "   ", true},
+
 		// ── GIVEN: path traversal via .. → THEN: rejected ──
 		{"dot-dot escape", "../../.ssh/authorized_keys", true},
 		{"dot-dot mid path", "subdir/../../etc/passwd", true},

--- a/internal/vfs/localfileio/path.go
+++ b/internal/vfs/localfileio/path.go
@@ -60,6 +60,10 @@ func safePath(raw, flagName string) (string, error) {
 		return "", err
 	}
 
+	if strings.TrimSpace(raw) == "" {
+		return "", fmt.Errorf("%s must not be empty", flagName)
+	}
+
 	if isAbsolutePath(raw) {
 		return "", fmt.Errorf("%s must be a relative path within the current directory, got %q (hint: cd to the target directory first, or use a relative path like ./filename)", flagName, raw)
 	}

--- a/internal/vfs/localfileio/path_test.go
+++ b/internal/vfs/localfileio/path_test.go
@@ -26,6 +26,10 @@ func TestSafeOutputPath_RejectsPathTraversalAndDangerousInput(t *testing.T) {
 		{"unicode normal", "报告.xlsx", false},
 		{"dot-dot resolves to cwd", "subdir/..", false},
 
+		// ── GIVEN: empty or blank paths → THEN: rejected ──
+		{"empty path", "", true},
+		{"blank path", "   ", true},
+
 		// ── GIVEN: path traversal via .. → THEN: rejected ──
 		{"dot-dot escape", "../../.ssh/authorized_keys", true},
 		{"dot-dot mid path", "subdir/../../etc/passwd", true},


### PR DESCRIPTION
## Summary
- reject empty or whitespace-only values in shared local file path validation
- prevent blank --file/--output values from being normalized to the current directory
- add regression coverage for localfileio and validate wrappers

## Validation
- env GOCACHE=/private/tmp/cli-gocache go test ./internal/vfs/localfileio ./internal/validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path validation to properly reject empty and whitespace-only file paths in file operations. These invalid inputs are now correctly caught and prevented from processing, effectively eliminating edge cases that could potentially cause errors. This improves application stability and ensures more reliable and robust file handling across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->