### PR TITLE
docs: mention markdown for lark-doc read understanding

### DIFF
--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -33,6 +33,7 @@ lark-cli docs +update --api-version v2 --doc "文档URL或token" --command appen
 > **格式选择规则（全局）：**
 > - **创建 / 导入场景**（`docs +create`，或 `docs +update --command append/overwrite` 的整段写入）：XML 和 Markdown 都可以。用户提供 `.md` 本地文件、或明确说"导入 Markdown"时，直接用 Markdown；否则默认 XML（可用 callout、grid、checkbox 等富 block）。
 > - **精准编辑场景**（`docs +update` 的 `str_replace` / `block_insert_after` / `block_replace` / `block_delete` / `block_move_after` 等局部精修指令）：优先使用 XML（`--doc-format xml`，即默认值）。XML 能稳定表达 block 结构和样式，局部精修更可控；不要因为 Markdown 更简单就自行切换。
+> - **读取理解场景**（总结、分析、问答、提取信息、快速浏览）：如果不需要 block ID、资源 token 或精确样式结构，优先使用 Markdown（`--doc-format markdown`），减少结构噪音。
 
 ## 快速决策
 - 用户需要“某个 block 的直达链接 / 锚点链接”时：返回 `文档基础 URL#block_id`。如果当前只有文档 URL 没有 block_id，先用 `docs +fetch --detail with-ids` 拿到目标 block 的 id


### PR DESCRIPTION
## Summary
- add an independent read/understanding scenario to the lark-doc format guidance
- recommend docs +fetch --doc-format markdown for summaries, analysis, QA, extraction, and quick reading when block IDs, resource tokens, and exact styling are not needed
- keep the existing create/import and precise-edit guidance unchanged

## Tests
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined guidance on document format selection: XML remains the default for write operations, while Markdown is used only for importing a local `.md` file or when “导入 Markdown” is explicitly requested.
  * Added a new rule for read-only tasks (summary/analysis/Q&A/info extraction/quick browsing) recommending Markdown (`--doc-format markdown`) to reduce structural noise when block IDs/tokens and precise structured styling aren’t required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->