### PR TITLE
docs: clarify lark-doc content file paths

### DIFF
--- a/skills/lark-doc/SKILL.md
+++ b/skills/lark-doc/SKILL.md
@@ -33,6 +33,7 @@ lark-cli docs +update --api-version v2 --doc "文档URL或token" --command appen
 > **格式选择规则（全局）：**
 > - **创建 / 导入场景**（`docs +create`，或 `docs +update --command append/overwrite` 的整段写入）：XML 和 Markdown 都可以。用户提供 `.md` 本地文件、或明确说"导入 Markdown"时，直接用 Markdown；否则默认 XML（可用 callout、grid、checkbox 等富 block）。
 > - **精准编辑场景**（`docs +update` 的 `str_replace` / `block_insert_after` / `block_replace` / `block_delete` / `block_move_after` 等局部精修指令）：优先使用 XML（`--doc-format xml`，即默认值）。XML 能稳定表达 block 结构和样式，局部精修更可控；不要因为 Markdown 更简单就自行切换。
+> - **本地文件输入**：`--content @path` 只接受 cwd 内相对路径（如 `@./draft.md`）；绝对路径或逃出 cwd 的路径禁止。用户给绝对路径时，先 `cd` 到文件目录再用 `@./filename`。`@@` 字面量和 `--content -` 行为不变。
 
 ## 快速决策
 - 用户需要“某个 block 的直达链接 / 锚点链接”时：返回 `文档基础 URL#block_id`。如果当前只有文档 URL 没有 block_id，先用 `docs +fetch --detail with-ids` 拿到目标 block 的 id

--- a/skills/lark-doc/references/lark-doc-create.md
+++ b/skills/lark-doc/references/lark-doc-create.md
@@ -11,6 +11,8 @@
 
 > **⚠️ 格式选择规则：** 创建 / 导入场景下 XML 和 Markdown 都可以——用户提供 `.md` 本地文件、或明确说"导入 Markdown"时，直接用 Markdown；没有明确指示时默认 XML（表达能力更强，支持 callout、grid、checkbox 等富 block 类型）。不要在用户没要求的情况下主动从 XML 切到 Markdown，也不要在用户已给出 Markdown 时强行改成 XML。
 
+> **本地文件输入：** `--content @path` 只接受 cwd 内相对路径（如 `@./draft.md`）；用户给绝对路径时，先进入文件目录再用 `@./filename`。
+
 ## 命令
 
 ```bash

--- a/skills/lark-doc/references/lark-doc-update.md
+++ b/skills/lark-doc/references/lark-doc-update.md
@@ -16,6 +16,8 @@
 >
 > **Markdown 局限 & block ID 前提：** Markdown 不携带 block ID，也无样式（颜色、对齐、callout 等）。需要按 block ID 定位（`block_*` 指令的 `--block-id`）时，先 `docs +fetch --api-version v2 --detail with-ids` **配合 `--scope`（`outline` / `range` / `keyword` / `section`）局部获取**目标段落，不要全量 fetch。拿到 block ID 后 `--content` 仍可用 Markdown，只是写入内容不带样式。
 
+> **本地文件输入：** `--content @path` 只接受 cwd 内相对路径（如 `@./file.md`）；用户给绝对路径时，先进入文件目录再用 `@./filename`。
+
 ## 参数
 
 | 参数 | 必填 | 说明 |
@@ -67,7 +69,7 @@ lark-cli docs +update --api-version v2 --doc "<doc_id>" --command str_replace \
   --doc-format markdown --pattern "旧内容" --content "新内容"
 
 # Markdown 模式下支持跨行匹配（--pattern 与 --content 都需要真实换行；"..."/'...' 里的 \n 是字面量）
-# 多行内容推荐 heredoc 或 --content @file.md，避免 shell 转义踩坑
+# 多行内容推荐 heredoc 或本地文件输入，避免 shell 转义踩坑
 lark-cli docs +update --api-version v2 --doc "<doc_id>" --command str_replace \
   --doc-format markdown \
   --pattern "$(printf '## 旧标题\n\n第一段原文\n\n第二段原文')" \


### PR DESCRIPTION
## Summary
Clarify how the `lark-doc` skill should pass local files to `--content`.
The updated guidance tells agents to use cwd-relative `@path` values and to enter the file directory before referencing files provided as absolute paths.

## Changes
- Add a global `lark-doc` note for local `--content @path` handling
- Add matching create and update shortcut guidance for cwd-relative file input
- Replace the older `@file.md` wording in update examples with clearer local file input wording

## Test Plan
- [x] `git diff --check` passed
- [x] Verified the final diff only updates `lark-doc` skill/reference docs
- [x] Manual validation: `docs +create`, `docs +update`, and `docs +fetch` passed with `--content @./draft*.md` for both bot and user identities

## Related Issues
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified local file input path handling: `--content `@path`` accepts only current working directory-relative paths (e.g., `@./filename`), rejecting absolute paths.
  * Added user guidance to change directory first when referencing files with absolute paths, then use `@./filename` syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->