### PR TITLE
feat(sheets): document link requirement for @document mentions

### DIFF
--- a/shortcuts/sheets/data/flag-schemas.json
+++ b/shortcuts/sheets/data/flag-schemas.json
@@ -454,7 +454,7 @@
                       "type": "object"
                     },
                     "link": {
-                      "description": "超链接地址（仅 type='link' 时必填）",
+                      "description": "超链接地址（type='link' 时必填）；@文档 mention（mention_type 非 0）时也必填，传文档 URL（如搜索结果里的文档链接），否则卡片不可点。@人（mention_type=0）不需要传",
                       "type": "string"
                     },
                     "mention_token": {


### PR DESCRIPTION
## What
Update the `cells` flag schema description: `@document` mentions (`mention_type != 0`) must pass `link` (the doc URL) to render a clickable card; `@user` mentions (`mention_type=0`) don't need it.

## Why
Without `link`, document mentions store a dead token and the cell renders a non-clickable card. The upstream tools-schema now requires `link` for document mentions; this syncs the CLI cells flag schema to match.

## Notes
Schema description only — no Go logic change. Synced from the spec-driven flag-schemas pipeline.