### PR TITLE
fix: validate drive import folder target

### DIFF
--- a/shortcuts/drive/drive_import.go
+++ b/shortcuts/drive/drive_import.go
@@ -25,7 +25,8 @@ var DriveImport = common.Shortcut{
 		"docs:document.media:upload",
 		"docs:document:import",
 	},
-	AuthTypes: []string{"user", "bot"},
+	ConditionalScopes: []string{"wiki:node:retrieve"},
+	AuthTypes:         []string{"user", "bot"},
 	Flags: []common.Flag{
 		{Name: "file", Desc: "local file path (e.g. .docx, .xlsx, .md, .base, .pptx; large files auto use multipart upload; .base is capped at 20MB, .pptx at 500MB)", Required: true},
 		{Name: "type", Desc: "target document type (docx, sheet, bitable, slides)", Required: true},
@@ -61,6 +62,7 @@ var DriveImport = common.Shortcut{
 		dry := common.NewDryRunAPI()
 		dry.Desc("Upload file (single-part or multipart) -> create import task -> poll status")
 
+		appendDriveImportFolderTokenWikiCheckDryRun(dry, spec)
 		appendDriveImportUploadDryRun(dry, spec, fileSize)
 
 		dry.POST("/open-apis/drive/v1/import_tasks").
@@ -85,6 +87,9 @@ var DriveImport = common.Shortcut{
 			TargetToken: runtime.Str("target-token"),
 		}
 		if _, err := preflightDriveImportFile(runtime.FileIO(), &spec); err != nil {
+			return err
+		}
+		if err := rejectDriveImportWikiFolderToken(runtime, spec.FolderToken); err != nil {
 			return err
 		}
 

--- a/shortcuts/drive/drive_import_common.go
+++ b/shortcuts/drive/drive_import_common.go
@@ -257,6 +257,46 @@ func validateDriveImportSpec(spec driveImportSpec) error {
 	return nil
 }
 
+func appendDriveImportFolderTokenWikiCheckDryRun(dry *common.DryRunAPI, spec driveImportSpec) {
+	folderToken := strings.TrimSpace(spec.FolderToken)
+	if folderToken == "" {
+		return
+	}
+
+	dry.GET("/open-apis/wiki/v2/spaces/get_node").
+		Desc("[0] Validate whether --folder-token is a wiki node").
+		Params(map[string]interface{}{"token": folderToken})
+}
+
+func rejectDriveImportWikiFolderToken(runtime *common.RuntimeContext, folderToken string) error {
+	folderToken = strings.TrimSpace(folderToken)
+	if folderToken == "" {
+		return nil
+	}
+
+	data, err := runtime.CallAPITyped(
+		"GET",
+		"/open-apis/wiki/v2/spaces/get_node",
+		map[string]interface{}{"token": folderToken},
+		nil,
+	)
+	if err == nil {
+		node := common.GetMap(data, "node")
+		if len(node) == 0 {
+			return nil
+		}
+
+		return errs.NewValidationError(
+			errs.SubtypeInvalidArgument,
+			"--folder-token only supports Drive folder tokens, but the provided token resolves to a wiki node",
+		).
+			WithParam("--folder-token").
+			WithHint("Pass a Drive folder token, or omit --folder-token to import into the Drive root folder. Wiki node tokens are not accepted as import mount folders.")
+	}
+
+	return nil
+}
+
 // driveImportStatus captures the backend fields needed to decide whether the
 // import can be surfaced immediately or requires a follow-up poll.
 type driveImportStatus struct {

--- a/shortcuts/drive/drive_import_common_test.go
+++ b/shortcuts/drive/drive_import_common_test.go
@@ -5,10 +5,12 @@ package drive
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/httpmock"
 )
@@ -273,6 +275,134 @@ func TestDriveImportTimeoutReturnsFollowUpCommand(t *testing.T) {
 	}
 	if bytes.Contains(stdout.Bytes(), []byte(`"permission_grant"`)) {
 		t.Fatalf("stdout should not include permission_grant before import is ready: %s", stdout.String())
+	}
+}
+
+func TestDriveImportRejectsWikiFolderToken(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"node_token": "wikcnImportTarget",
+					"obj_type":   "docx",
+					"obj_token":  "docxImportTarget",
+					"title":      "Wiki Import Target",
+				},
+			},
+		},
+	})
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.WriteFile("notes.md", []byte("# Hi"), 0644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	err := mountAndRunDrive(t, DriveImport, []string{
+		"+import",
+		"--file", "notes.md",
+		"--type", "docx",
+		"--folder-token", "wikcnImportTarget",
+		"--as", "user",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected wiki folder-token validation error, got nil")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected *errs.ValidationError, got %T (%v)", err, err)
+	}
+	if validationErr.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("subtype = %q, want %q", validationErr.Subtype, errs.SubtypeInvalidArgument)
+	}
+	if validationErr.Param != "--folder-token" {
+		t.Fatalf("param = %q, want --folder-token", validationErr.Param)
+	}
+	wantMessage := "--folder-token only supports Drive folder tokens, but the provided token resolves to a wiki node"
+	if validationErr.Message != wantMessage {
+		t.Fatalf("message = %q, want %q", validationErr.Message, wantMessage)
+	}
+	for _, disallowed := range []string{"node_token=", "obj_type=", "Wiki Import Target"} {
+		if strings.Contains(validationErr.Message, disallowed) {
+			t.Fatalf("message = %q, must not contain %q", validationErr.Message, disallowed)
+		}
+	}
+	if !strings.Contains(validationErr.Hint, "Drive folder token") {
+		t.Fatalf("hint = %q, want Drive folder token guidance", validationErr.Hint)
+	}
+}
+
+func TestDriveImportContinuesWhenFolderTokenDoesNotResolveAsWiki(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, driveTestConfig())
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 1310001,
+			"msg":  "node not found",
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/medias/upload_all",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"file_token": "file_import_media"},
+		},
+	})
+	createStub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/drive/v1/import_tasks",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"ticket": "tk_import_folder"},
+		},
+	}
+	reg.Register(createStub)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/drive/v1/import_tasks/tk_import_folder",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"result": map[string]interface{}{
+					"type":       "docx",
+					"job_status": 0,
+					"token":      "docx_imported",
+				},
+			},
+		},
+	})
+
+	tmpDir := t.TempDir()
+	withDriveWorkingDir(t, tmpDir)
+	if err := os.WriteFile("notes.md", []byte("# Hi"), 0644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	err := mountAndRunDrive(t, DriveImport, []string{
+		"+import",
+		"--file", "notes.md",
+		"--type", "docx",
+		"--folder-token", "fldcnImportTarget",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data := decodeDriveEnvelope(t, stdout)
+	if got := data["token"]; got != "docx_imported" {
+		t.Fatalf("token = %#v, want docx_imported", got)
+	}
+	body := decodeCapturedJSONBody(t, createStub)
+	point, _ := body["point"].(map[string]interface{})
+	if got := point["mount_key"]; got != "fldcnImportTarget" {
+		t.Fatalf("import mount_key = %#v, want fldcnImportTarget", got)
 	}
 }
 

--- a/shortcuts/drive/drive_import_test.go
+++ b/shortcuts/drive/drive_import_test.go
@@ -114,16 +114,20 @@ func TestDriveImportDryRunUsesExtensionlessDefaultName(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal dry run json: %v", err)
 	}
-	if len(got.API) != 3 {
-		t.Fatalf("expected 3 API calls, got %d", len(got.API))
+	if len(got.API) != 4 {
+		t.Fatalf("expected 4 API calls, got %d", len(got.API))
 	}
 
-	uploadName, _ := got.API[0].Body["file_name"].(string)
+	if got.API[0].Body != nil {
+		t.Fatalf("wiki probe should not have a request body, got %#v", got.API[0].Body)
+	}
+
+	uploadName, _ := got.API[1].Body["file_name"].(string)
 	if uploadName != "base-import.xlsx" {
 		t.Fatalf("upload file_name = %q, want %q", uploadName, "base-import.xlsx")
 	}
 
-	importName, _ := got.API[1].Body["file_name"].(string)
+	importName, _ := got.API[2].Body["file_name"].(string)
 	if importName != "base-import" {
 		t.Fatalf("import task file_name = %q, want %q", importName, "base-import")
 	}

--- a/tests/cli_e2e/drive/drive_import_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_import_dryrun_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package drive
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestDriveImportDryRunFolderTokenWikiProbe(t *testing.T) {
+	setDriveDryRunConfigEnv(t)
+
+	workDir := t.TempDir()
+	if err := os.WriteFile(workDir+"/notes.md", []byte("# dry run\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+import",
+			"--file", "notes.md",
+			"--type", "docx",
+			"--folder-token", "fldcnImportDryRunTarget",
+			"--dry-run",
+		},
+		WorkDir:   workDir,
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	if got := gjson.Get(out, "api.0.method").String(); got != "GET" {
+		t.Fatalf("api.0.method = %q, want GET\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.0.url").String(); got != "/open-apis/wiki/v2/spaces/get_node" {
+		t.Fatalf("api.0.url = %q, want wiki get_node\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.0.params.token").String(); got != "fldcnImportDryRunTarget" {
+		t.Fatalf("api.0.params.token = %q, want fldcnImportDryRunTarget\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.1.url").String(); got != "/open-apis/drive/v1/medias/upload_all" {
+		t.Fatalf("api.1.url = %q, want upload_all\nstdout:\n%s", got, out)
+	}
+	if got := gjson.Get(out, "api.2.body.point.mount_key").String(); got != "fldcnImportDryRunTarget" {
+		t.Fatalf("api.2.body.point.mount_key = %q, want fldcnImportDryRunTarget\nstdout:\n%s", got, out)
+	}
+}


### PR DESCRIPTION
## Summary
Add preflight validation for `drive +import --folder-token` so the CLI verifies whether the provided target token resolves as a Wiki node before uploading import media. This keeps import target handling explicit and guides users to provide a Drive folder token.

## Changes
- Use `wiki.spaces.get_node` when `drive +import --folder-token` is provided to verify whether the token is a Wiki node.
- Return a typed validation error on `--folder-token` when the target resolves as a Wiki node.
- Surface the validation step in dry-run output and declare `wiki:node:retrieve` as a conditional scope.
- Add unit coverage for Wiki-node validation and normal folder-token import flow, plus dry-run E2E coverage for the validation request shape.

## Test Plan
- [x] `make unit-test`
- [x] `go vet ./...`
- [x] `gofmt -l .` produced no output
- [x] `go mod tidy` produced no `go.mod` / `go.sum` diff
- [x] `GOTOOLCHAIN=go1.25.9 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main` (`0 issues`)
- [x] `go test ./shortcuts/drive -run 'TestDriveImport(RejectsWikiFolderToken|ContinuesWhenFolderTokenDoesNotResolveAsWiki|DryRunUsesExtensionlessDefaultName)'`
- [x] `LARK_CLI_BIN=/tmp/lark-cli-import-wiki-check go test ./tests/cli_e2e/drive -run TestDriveImportDryRunFolderTokenWikiProbe`
- [x] Live validation in the agreed Drive/Wiki test locations: created a temporary Wiki node and Drive folder; verified the Wiki node target returns `validation/invalid_argument`, verified a Drive folder target imports docx successfully, and cleaned up all temporary resources.

## Related Issues
- None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drive import now performs a wiki “probe” when `--folder-token` is provided, to distinguish wiki nodes from Drive folder tokens.

* **Bug Fixes**
  * In execution mode, wiki node tokens passed via `--folder-token` are now rejected with a validation error and guidance to omit `--folder-token` for Drive root imports.
  * In both dry-run and execution, `--folder-token` is validated via the wiki probe; if it doesn’t resolve to a wiki node, the import continues as a Drive folder token.

* **Tests**
  * Added unit and e2e coverage for the wiki probe behavior and updated dry-run expectations for the extra API call.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->