### PR TITLE
fix(sheets): reject cond-format attrs whose shape mismatches rule_type

### DIFF
--- a/shortcuts/sheets/lark_sheet_object_crud.go
+++ b/shortcuts/sheets/lark_sheet_object_crud.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/larksuite/cli/internal/output"
@@ -58,6 +59,12 @@ type objectCRUDSpec struct {
 	// against data/flag-schemas.json in objectCreateInput /
 	// objectUpdateInput via validatePropertiesAgainstSchema.
 	validateUpdateInput func(input map[string]interface{}) error
+	// validateCreateInput is the create-path twin of validateUpdateInput:
+	// it runs after enhanceCreateInput to enforce cross-field rules JSON
+	// Schema can't express (e.g. cond-format's attrs shape must match the
+	// sibling rule_type — see validateCondFormatAttrs). Same scope notes
+	// as validateUpdateInput apply.
+	validateCreateInput func(input map[string]interface{}) error
 	// allowEmptySheetSelectorOnCreate, when true, makes the *create*
 	// shortcut accept empty --sheet-id / --sheet-name (backend then picks
 	// the placement target — e.g. manage_pivot_table_object auto-creates
@@ -192,6 +199,11 @@ func objectCreateInput(runtime flagView, token, sheetID, sheetName string, spec 
 	}
 	if err := validateInputAgainstSchema(runtime, input); err != nil {
 		return nil, err
+	}
+	if spec.validateCreateInput != nil {
+		if err := spec.validateCreateInput(input); err != nil {
+			return nil, err
+		}
 	}
 	return input, nil
 }
@@ -481,12 +493,118 @@ var condFormatEnhance = func(rt flagView, input map[string]interface{}) {
 }
 
 var condFormatSpec = objectCRUDSpec{
-	commandPrefix:      "+cond-format",
-	toolName:           "manage_conditional_format_object",
-	idFlag:             "rule-id",
-	idField:            "conditional_format_id",
-	enhanceCreateInput: condFormatEnhance,
-	enhanceUpdateInput: condFormatEnhance,
+	commandPrefix:       "+cond-format",
+	toolName:            "manage_conditional_format_object",
+	idFlag:              "rule-id",
+	idField:             "conditional_format_id",
+	enhanceCreateInput:  condFormatEnhance,
+	enhanceUpdateInput:  condFormatEnhance,
+	validateCreateInput: validateCondFormatAttrs,
+	validateUpdateInput: validateCondFormatAttrs,
+}
+
+// condFormatAttrsRequired maps each conditional-format rule_type to the
+// keys every properties.attrs entry must carry for that rule. It mirrors
+// the per-rule attrs contract the tool's manage_conditional_format_object
+// converter reads (byted-sheet ai-tools manage-conditional-format-object.ts):
+// that converter maps each attrs entry *blindly by rule_type*, so a
+// colorScale rule fed cellIs-shaped attrs ({compare_type,value}) silently
+// yields a color-less color-scale segment — dirty data that crashes the
+// frontend on snapshot deserialization (the 5005 "can't open" report this
+// validator was added for).
+//
+// JSON Schema can't catch this: properties.attrs.items is a oneOf over all
+// nine shapes, and the validator accepts an entry as soon as *any* branch
+// matches — blind to the sibling rule_type. {compare_type,value} matches
+// the cellIs branch regardless of whether rule_type says colorScale.
+//
+// Rule types absent from the map (duplicateValues, uniqueValues,
+// containsBlanks, notContainsBlanks) carry no attrs, so nothing to check.
+// Counts (dataBar==2, colorScale 2–3, iconSet ordering) stay the tool's
+// job — it already rejects those with actionable messages; the gap this
+// closes is per-entry *shape*, which the tool does not check.
+var condFormatAttrsRequired = map[string][]string{
+	"cellIs":       {"compare_type", "value"},
+	"containsText": {"compare_type", "text"},
+	"timePeriod":   {"operator", "time_period"},
+	"dataBar":      {"color", "value_type"},
+	"colorScale":   {"value_type", "color"},
+	"rank":         {"is_bottom", "value_type"},
+	"aboveAverage": {"operator"},
+	"expression":   {"formula"},
+	"iconSet":      {"icon_type", "value_type", "operator"},
+}
+
+// validateCondFormatAttrs enforces that every properties.attrs entry
+// matches the shape required by the sibling properties.rule_type. Shared
+// by create and update. On update, rule_type may be omitted (the caller is
+// editing style only and the existing rule's type governs the attrs shape,
+// which the CLI can't see); in that case validation is deferred to the
+// server. Missing/empty attrs is likewise left to the tool, which already
+// reports "attrs are required for rule_type: X" clearly.
+func validateCondFormatAttrs(input map[string]interface{}) error {
+	props, _ := input["properties"].(map[string]interface{})
+	if props == nil {
+		return nil
+	}
+	ruleType, _ := props["rule_type"].(string)
+	ruleType = strings.TrimSpace(ruleType)
+	if ruleType == "" {
+		return nil
+	}
+	required, ok := condFormatAttrsRequired[ruleType]
+	if !ok {
+		return nil
+	}
+	attrs, ok := props["attrs"].([]interface{})
+	if !ok {
+		// Missing attrs, or a non-array shape the schema check already
+		// flagged — nothing for this cross-field rule to add.
+		return nil
+	}
+	for i, entryRaw := range attrs {
+		entry, ok := entryRaw.(map[string]interface{})
+		if !ok {
+			continue // schema validation owns per-entry type errors.
+		}
+		for _, key := range required {
+			if v, has := entry[key]; !has || condAttrIsBlank(v) {
+				return common.FlagErrorf(
+					"--properties: attrs[%d] is missing %q, which rule_type %q requires on every entry (expected keys %s; got %s). "+
+						"A common cause is reusing another rule's attrs shape — e.g. cellIs-style {compare_type,value} under a colorScale rule, which writes a color-less segment that breaks the sheet on open.",
+					i, key, ruleType, strings.Join(required, "+"), condAttrPresentKeys(entry))
+			}
+		}
+	}
+	return nil
+}
+
+// condAttrIsBlank treats a present-but-empty string (after trimming) as
+// missing. The crash-causing case is an empty `color`, but an empty value
+// for any required key is never meaningful in these branches, so the rule
+// is uniform. Non-string values (numbers, booleans) count as present.
+func condAttrIsBlank(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	if s, ok := v.(string); ok {
+		return strings.TrimSpace(s) == ""
+	}
+	return false
+}
+
+// condAttrPresentKeys lists the keys actually present on an attrs entry,
+// sorted, for the "got ..." half of the error message.
+func condAttrPresentKeys(entry map[string]interface{}) string {
+	if len(entry) == 0 {
+		return "{}"
+	}
+	keys := make([]string, 0, len(entry))
+	for k := range entry {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return "{" + strings.Join(keys, ",") + "}"
 }
 var CondFormatCreate = newObjectCreateShortcut(condFormatSpec)
 var CondFormatUpdate = newObjectUpdateShortcut(condFormatSpec)

--- a/shortcuts/sheets/lark_sheet_object_crud_test.go
+++ b/shortcuts/sheets/lark_sheet_object_crud_test.go
@@ -4,6 +4,8 @@
 package sheets
 
 import (
+	"encoding/json"
+	"sort"
 	"strings"
 	"testing"
 
@@ -691,6 +693,102 @@ func TestCondFormatAttrs_ShapeMatchesRuleType(t *testing.T) {
 				t.Fatalf("expected acceptance (dry-run); got err=%v stderr=%s", err, stderr)
 			}
 		})
+	}
+}
+
+// TestCondFormatAttrsRequired_MatchesSchemaOneOf guards against drift
+// between the hand-maintained condFormatAttrsRequired table (the source
+// validateCondFormatAttrs enforces) and the embedded flag-schemas.json
+// attrs oneOf (the authoritative shape contract synced from the spec
+// repo). The cross-field validator only works if its per-rule_type
+// required keys mirror the schema branches; if a future schema sync adds
+// or drops a required key on any branch without updating the table, the
+// CLI would silently under- or over-validate. They share no compile-time
+// link, so this test is the only thing pinning them together.
+//
+// The schema oneOf branches are NOT labeled by rule_type (that's the whole
+// point — rule_type is a sibling field the per-entry oneOf can't see), so
+// we can't match branch→rule_type. We instead compare the *multiset* of
+// required-key sets: every branch's required array must appear as some
+// table entry's value and vice versa. This catches any added/dropped
+// required key (real drift); it tolerates only a relabeling between two
+// branches that happen to share an identical required set (dataBar and
+// colorScale both require {color,value_type}), which is harmless here.
+func TestCondFormatAttrsRequired_MatchesSchemaOneOf(t *testing.T) {
+	t.Parallel()
+
+	// multiset key: required keys sorted + joined, so order within a
+	// branch's required array doesn't matter.
+	keyOf := func(req []string) string {
+		s := append([]string(nil), req...)
+		sort.Strings(s)
+		return strings.Join(s, "+")
+	}
+
+	tableMS := map[string]int{}
+	for _, req := range condFormatAttrsRequired {
+		tableMS[keyOf(req)]++
+	}
+
+	schemaMS := func(t *testing.T, command string) map[string]int {
+		idx, err := loadFlagSchemas()
+		if err != nil {
+			t.Fatalf("loadFlagSchemas: %v", err)
+		}
+		raw, ok := idx.Flags[command]["properties"]
+		if !ok {
+			t.Fatalf("no embedded schema for %s --properties", command)
+		}
+		var schema map[string]interface{}
+		if err := json.Unmarshal(raw, &schema); err != nil {
+			t.Fatalf("unmarshal %s properties schema: %v", command, err)
+		}
+		dig := func(m map[string]interface{}, key string) map[string]interface{} {
+			next, _ := m[key].(map[string]interface{})
+			if next == nil {
+				t.Fatalf("%s: missing %q while navigating to attrs oneOf", command, key)
+			}
+			return next
+		}
+		attrs := dig(dig(schema, "properties"), "attrs")
+		items := dig(attrs, "items")
+		oneOf, ok := items["oneOf"].([]interface{})
+		if !ok || len(oneOf) == 0 {
+			t.Fatalf("%s: attrs.items.oneOf is missing or empty", command)
+		}
+		ms := map[string]int{}
+		for i, branchRaw := range oneOf {
+			branch, ok := branchRaw.(map[string]interface{})
+			if !ok {
+				t.Fatalf("%s: oneOf[%d] is not an object", command, i)
+			}
+			reqRaw, _ := branch["required"].([]interface{})
+			req := make([]string, 0, len(reqRaw))
+			for _, r := range reqRaw {
+				if s, ok := r.(string); ok {
+					req = append(req, s)
+				}
+			}
+			ms[keyOf(req)]++
+		}
+		return ms
+	}
+
+	for _, command := range []string{"+cond-format-create", "+cond-format-update"} {
+		got := schemaMS(t, command)
+		if len(got) != len(tableMS) {
+			t.Errorf("%s: schema oneOf has %d distinct required-sets, table has %d", command, len(got), len(tableMS))
+		}
+		for k, n := range tableMS {
+			if got[k] != n {
+				t.Errorf("%s: required-set %q appears %d× in schema but %d× in condFormatAttrsRequired — table drifted from schema; re-sync the table", command, k, got[k], n)
+			}
+		}
+		for k, n := range got {
+			if tableMS[k] != n {
+				t.Errorf("%s: schema branch with required-set %q (×%d) has no matching condFormatAttrsRequired entry — add it to the table", command, k, n)
+			}
+		}
 	}
 }
 

--- a/shortcuts/sheets/lark_sheet_object_crud_test.go
+++ b/shortcuts/sheets/lark_sheet_object_crud_test.go
@@ -202,7 +202,7 @@ func TestObjectCRUDShortcuts_DryRun(t *testing.T) {
 			args: []string{
 				"--url", testURL, "--sheet-id", testSheetID,
 				"--rule-id", "ruleA",
-				"--properties", `{"attrs":[{"operator":"greaterThan","value":"100"}],"style":{"back_color":"#FFD7D7"}}`,
+				"--properties", `{"attrs":[{"compare_type":"greaterThan","value":"100"}],"style":{"back_color":"#FFD7D7"}}`,
 				"--rule-type", "cellIs",
 				"--ranges", `["A1:A100"]`,
 			},
@@ -214,7 +214,7 @@ func TestObjectCRUDShortcuts_DryRun(t *testing.T) {
 				"conditional_format_id": "ruleA",
 				"properties": map[string]interface{}{
 					"rule_type": "cellIs",
-					"attrs":     []interface{}{map[string]interface{}{"operator": "greaterThan", "value": "100"}},
+					"attrs":     []interface{}{map[string]interface{}{"compare_type": "greaterThan", "value": "100"}},
 					"style":     map[string]interface{}{"back_color": "#FFD7D7"},
 					"ranges":    []interface{}{"A1:A100"},
 				},
@@ -611,6 +611,86 @@ func TestSparklineUpdate_MissingSparklineID(t *testing.T) {
 	}
 	if !strings.Contains(combined, "+sparkline-list") {
 		t.Errorf("expected error to point at +sparkline-list; got=%s|%v", stderr, err)
+	}
+}
+
+// TestCondFormatAttrs_ShapeMatchesRuleType regresses the cross-field
+// guard that rejects attrs whose shape doesn't match the sibling
+// rule_type — the gap behind the "缺 color 的 colorScale 脏数据导致表格
+// 打不开" report: a colorScale rule fed cellIs-shaped attrs
+// ({compare_type,value}, no color) passed both the CLI's per-entry oneOf
+// schema check and the tool, writing a color-less segment that crashed
+// the frontend on open. The check covers create and update symmetrically.
+func TestCondFormatAttrs_ShapeMatchesRuleType(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name    string
+		sc      common.Shortcut
+		args    []string
+		wantErr bool
+		wantMsg string // substring expected in the error, when wantErr
+	}{
+		{
+			name: "colorScale fed cellIs-shaped attrs (missing color) is rejected",
+			sc:   CondFormatCreate,
+			args: []string{
+				"--url", testURL, "--sheet-id", testSheetID,
+				"--rule-type", "colorScale", "--ranges", `["C1:C10"]`,
+				"--properties", `{"style":{},"attrs":[{"compare_type":"greaterThan","value":"0"},{"compare_type":"lessThan","value":"100"}]}`, "--dry-run",
+			},
+			wantErr: true,
+			wantMsg: "colorScale",
+		},
+		{
+			name: "colorScale with empty color string is rejected",
+			sc:   CondFormatCreate,
+			args: []string{
+				"--url", testURL, "--sheet-id", testSheetID,
+				"--rule-type", "colorScale", "--ranges", `["C1:C10"]`,
+				"--properties", `{"style":{},"attrs":[{"value_type":"minValue","color":""},{"value_type":"maxValue","color":"#FF0000"}]}`, "--dry-run",
+			},
+			wantErr: true,
+			wantMsg: `"color"`,
+		},
+		{
+			name: "well-formed colorScale attrs pass",
+			sc:   CondFormatCreate,
+			args: []string{
+				"--url", testURL, "--sheet-id", testSheetID,
+				"--rule-type", "colorScale", "--ranges", `["C1:C10"]`,
+				"--properties", `{"style":{},"attrs":[{"value_type":"minValue","color":"#FFFFFF"},{"value_type":"maxValue","color":"#FF0000"}]}`, "--dry-run",
+			},
+			wantErr: false,
+		},
+		{
+			name: "update path is guarded too (colorScale + cellIs attrs)",
+			sc:   CondFormatUpdate,
+			args: []string{
+				"--url", testURL, "--sheet-id", testSheetID, "--rule-id", "ruleA",
+				"--rule-type", "colorScale", "--ranges", `["C1:C10"]`,
+				"--properties", `{"style":{},"attrs":[{"compare_type":"greaterThan","value":"0"}]}`, "--dry-run",
+			},
+			wantErr: true,
+			wantMsg: "colorScale",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, stderr, err := runShortcutCapturingErr(t, tt.sc, tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected rejection; stderr=%s", stderr)
+				}
+				if combined := stderr + err.Error(); tt.wantMsg != "" && !strings.Contains(combined, tt.wantMsg) {
+					t.Errorf("expected error to mention %q; got=%s|%v", tt.wantMsg, stderr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected acceptance (dry-run); got err=%v stderr=%s", err, stderr)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

A conditional-format rule created with `--rule-type colorScale` but **cellIs-shaped attrs** (`{compare_type, value}`, no `color`) was accepted by the CLI and written through to the server, producing a color-less color-scale segment. That dirty data crashes the frontend on snapshot deserialization, so the spreadsheet can **no longer be opened** (5005 error). Reported from a real user ticket where AI-driven `lark-cli sheets +cond-format-create` wrote such a rule.

Repro:
```bash
lark-cli sheets +cond-format-create \
  --spreadsheet-token <token> --sheet-name "Sheet1" \
  --rule-type colorScale --ranges '["C1:C10"]' \
  --properties '{"style":{},"attrs":[{"compare_type":"greaterThan","value":"0"},{"compare_type":"lessThan","value":"100"}]}'
#  → before: ok:true, writes a colorScale rule with empty color (dirty)
#  → after:  rejected CLI-side with an actionable error
```

## Root cause

The per-entry schema check can't catch this: `properties.attrs.items` is a `oneOf` over all nine attr shapes and passes as soon as *any* branch matches, blind to the sibling `rule_type` — `{compare_type, value}` matches the cellIs branch even when `rule_type` says `colorScale`. The tool side maps attrs blindly by `rule_type` and only validates dataBar count / iconSet ordering, so the malformed shape reaches the data layer untouched.

## Fix

Add a cross-field validator `validateCondFormatAttrs`, wired into both create and update via a new `objectCRUDSpec.validateCreateInput` hook (twin of the existing `validateUpdateInput`). For each `rule_type` it enforces the keys every `attrs` entry must carry — the table mirrors the tool's converter contract (`manage_conditional_format_object`) — and treats an empty required string (notably `color`) as missing.

Deliberately left to the server, to avoid false rejections:
- Rule types that take no attrs (`duplicateValues` / `uniqueValues` / `containsBlanks` / `notContainsBlanks`).
- Updates that omit `rule_type` (the existing rule's type governs the attrs shape, which the CLI can't see).

Counts (dataBar == 2, colorScale 2–3, iconSet ordering) remain the tool's job — it already rejects those with actionable messages; the gap this closes is per-entry **shape**.

## Scope

- `shortcuts/sheets/lark_sheet_object_crud.go` — new hook + validator + `rule_type → required attrs keys` table.
- `shortcuts/sheets/lark_sheet_object_crud_test.go` — new `TestCondFormatAttrs_ShapeMatchesRuleType` (reject mismatched shape / empty color, accept well-formed, guard update path); corrected one existing dry-run fixture that used the internal `operator` key instead of the AI-input `compare_type`.

## Verification

- `go test ./shortcuts/sheets/` — all green except the pre-existing, unrelated `TestFlagDefsGen_MatchesJSON` generator-drift failure (fails on a clean tree too).
- `go vet ./shortcuts/sheets/` clean.
- Verified end-to-end against a built binary: repro command now rejected with the actionable message; a well-formed colorScale rule still passes through (dry-run).