### PR TITLE
fix: reject out-of-range base pagination flags

### DIFF
--- a/shortcuts/base/base_dryrun_ops_test.go
+++ b/shortcuts/base/base_dryrun_ops_test.go
@@ -22,8 +22,11 @@ func assertDryRunContains(t *testing.T, dr interface{ Format() string }, wants .
 func TestDryRunTableOps(t *testing.T) {
 	ctx := context.Background()
 
-	listRT := newBaseTestRuntime(map[string]string{"base-token": "app_x"}, nil, map[string]int{"offset": -1, "limit": 999})
+	listRT := newBaseTestRuntime(map[string]string{"base-token": "app_x"}, nil, map[string]int{"offset": -1, "limit": 100})
 	assertDryRunContains(t, dryRunTableList(ctx, listRT), "GET /open-apis/base/v3/bases/app_x/tables", "offset=0", "limit=100")
+
+	pageSizeAliasRT := newBaseTestRuntime(map[string]string{"base-token": "app_x"}, nil, map[string]int{"page-size": 40})
+	assertDryRunContains(t, dryRunTableList(ctx, pageSizeAliasRT), "limit=40")
 
 	rt := newBaseTestRuntime(map[string]string{"base-token": "app_x", "table-id": "tbl_1", "name": "Orders"}, nil, nil)
 	assertDryRunContains(t, dryRunTableGet(ctx, rt), "GET /open-apis/base/v3/bases/app_x/tables/tbl_1")
@@ -69,7 +72,7 @@ func TestDryRunFieldOps(t *testing.T) {
 	listRT := newBaseTestRuntime(
 		map[string]string{"base-token": "app_x", "table-id": "tbl_1"},
 		nil,
-		map[string]int{"offset": -2, "limit": 999},
+		map[string]int{"offset": -2, "limit": 200},
 	)
 	assertDryRunContains(t, dryRunFieldList(ctx, listRT), "GET /open-apis/base/v3/bases/app_x/tables/tbl_1/fields", "offset=0", "limit=200")
 
@@ -82,7 +85,7 @@ func TestDryRunFieldOps(t *testing.T) {
 			"keyword":    " open ",
 		},
 		nil,
-		map[string]int{"offset": 3, "limit": 0},
+		map[string]int{"offset": 3, "limit": 30},
 	)
 	assertDryRunContains(t, dryRunFieldGet(ctx, rt), "GET /open-apis/base/v3/bases/app_x/tables/tbl_1/fields/fld_1")
 	assertDryRunContains(t, dryRunFieldCreate(ctx, rt), "POST /open-apis/base/v3/bases/app_x/tables/tbl_1/fields")
@@ -98,7 +101,7 @@ func TestDryRunRecordOps(t *testing.T) {
 		map[string]string{"base-token": "app_x", "table-id": "tbl_1", "view-id": "viw_1"},
 		map[string][]string{"field-id": {"Name", "Age"}},
 		nil,
-		map[string]int{"offset": -3, "limit": 500},
+		map[string]int{"offset": -3, "limit": 200},
 	)
 	assertDryRunContains(t, dryRunRecordList(ctx, listRT), "GET /open-apis/base/v3/bases/app_x/tables/tbl_1/records", "offset=0", "limit=200", "view_id=viw_1", "field_id=Name", "field_id=Age")
 
@@ -179,6 +182,18 @@ func TestDryRunRecordOps(t *testing.T) {
 		`"filter":{"conditions":[["Status","!=","Done"]],"logic":"and"}`,
 		`"sort":[{"desc":true,"field":"Updated At"}]`,
 	)
+
+	searchPageSizeAliasRT := newBaseTestRuntimeWithArrays(
+		map[string]string{
+			"base-token": "app_x",
+			"table-id":   "tbl_1",
+			"keyword":    "Alice",
+		},
+		map[string][]string{"search-field": {"Name"}},
+		nil,
+		map[string]int{"page-size": 25},
+	)
+	assertDryRunContains(t, dryRunRecordSearch(ctx, searchPageSizeAliasRT), `"limit":25`)
 
 	upsertCreateRT := newBaseTestRuntime(
 		map[string]string{"base-token": "app_x", "table-id": "tbl_1", "json": `{"Name":"A"}`},
@@ -332,11 +347,10 @@ func TestDryRunDashboardOps(t *testing.T) {
 			"type":         "bar",
 			"data-config":  `{"table_name":"orders"}`,
 			"user-id-type": "open_id",
-			"page-size":    "50",
 			"page-token":   "pt_1",
 		},
 		nil,
-		nil,
+		map[string]int{"page-size": 50},
 	)
 
 	assertDryRunContains(t, dryRunDashboardList(ctx, rt), "GET /open-apis/base/v3/bases/app_x/dashboards", "page_size=50", "page_token=pt_1")
@@ -358,7 +372,7 @@ func TestDryRunViewOps(t *testing.T) {
 	listRT := newBaseTestRuntime(
 		map[string]string{"base-token": "app_x", "table-id": "tbl_1", "view-id": "viw_1"},
 		nil,
-		map[string]int{"offset": -1, "limit": 500},
+		map[string]int{"offset": -1, "limit": 200},
 	)
 	assertDryRunContains(t, dryRunViewList(ctx, listRT), "GET /open-apis/base/v3/bases/app_x/tables/tbl_1/views", "offset=0", "limit=200")
 	assertDryRunContains(t, dryRunViewGet(ctx, listRT), "GET /open-apis/base/v3/bases/app_x/tables/tbl_1/views/viw_1")

--- a/shortcuts/base/base_form_list.go
+++ b/shortcuts/base/base_form_list.go
@@ -23,11 +23,16 @@ var BaseFormsList = common.Shortcut{
 	Flags: []common.Flag{
 		{Name: "base-token", Desc: "Base token (base_token)", Required: true},
 		{Name: "table-id", Desc: "table ID", Required: true},
-		{Name: "page-size", Type: "int", Default: "100", Desc: "page size per request, max 100"},
+		{Name: "page-size", Type: "int", Default: "100", Desc: "page size per request, range 1-100"},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		_, err := common.ValidatePageSizeTyped(runtime, "page-size", 100, 1, 100)
+		return err
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		return common.NewDryRunAPI().
 			GET("/open-apis/base/v3/bases/:base_token/tables/:table_id/forms").
+			Params(map[string]interface{}{"page_size": runtime.Int("page-size")}).
 			Set("base_token", runtime.Str("base-token")).
 			Set("table_id", runtime.Str("table-id"))
 	},

--- a/shortcuts/base/base_shortcut_helpers.go
+++ b/shortcuts/base/base_shortcut_helpers.go
@@ -27,6 +27,25 @@ func baseTableID(runtime *common.RuntimeContext) string {
 	return strings.TrimSpace(runtime.Str("table-id"))
 }
 
+func pageSizeLimitAliasFlag() common.Flag {
+	return common.Flag{Name: "page-size", Type: "int", Default: "0", Desc: "hidden alias for --limit", Hidden: true}
+}
+
+func getPaginationLimit(runtime *common.RuntimeContext) int {
+	if !runtime.Changed("limit") && runtime.Changed("page-size") {
+		return runtime.Int("page-size")
+	}
+	return runtime.Int("limit")
+}
+
+func validateLimitPageSizeAlias(runtime *common.RuntimeContext) error {
+	if runtime.Changed("limit") && runtime.Changed("page-size") {
+		return common.ValidationErrorf("--limit and --page-size are mutually exclusive; use --limit").
+			WithParam("--page-size")
+	}
+	return nil
+}
+
 func loadJSONInput(pc *parseCtx, raw string, flagName string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {

--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -6,6 +6,7 @@ package base
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
@@ -57,6 +59,26 @@ func newBaseTestRuntimeWithArrays(stringFlags map[string]string, stringArrayFlag
 		_ = cmd.Flags().Set(name, strconv.Itoa(value))
 	}
 	return &common.RuntimeContext{Cmd: cmd, Config: &core.CliConfig{UserOpenId: "ou_test"}}
+}
+
+func assertBasePaginationValidation(t *testing.T, err error, param string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected validation error, got %T: %v", err, err)
+	}
+	if validationErr.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("subtype=%q, want %q", validationErr.Subtype, errs.SubtypeInvalidArgument)
+	}
+	if validationErr.Param != param {
+		t.Fatalf("param=%q, want %s", validationErr.Param, param)
+	}
+	if !strings.Contains(validationErr.Message, "must be between") {
+		t.Fatalf("message=%q, want range limit", validationErr.Message)
+	}
 }
 
 func TestBaseAction(t *testing.T) {
@@ -354,6 +376,85 @@ func TestBaseRecordReadHelpGuidesAgents(t *testing.T) {
 				if !strings.Contains(tips, want) {
 					t.Fatalf("tips missing %q:\n%s", want, tips)
 				}
+			}
+		})
+	}
+}
+
+func TestBasePaginationHelpShowsDefaults(t *testing.T) {
+	tests := []struct {
+		name       string
+		shortcut   common.Shortcut
+		flag       string
+		defaultVal string
+		help       string
+	}{
+		{name: "table list", shortcut: BaseTableList, flag: "limit", defaultVal: "50", help: "pagination size, range 1-100"},
+		{name: "field list", shortcut: BaseFieldList, flag: "limit", defaultVal: "100", help: "pagination size, range 1-200"},
+		{name: "field search options", shortcut: BaseFieldSearchOptions, flag: "limit", defaultVal: "30", help: "pagination size, range 1-200"},
+		{name: "record list", shortcut: BaseRecordList, flag: "limit", defaultVal: "100", help: "pagination size, range 1-200"},
+		{name: "record search", shortcut: BaseRecordSearch, flag: "limit", defaultVal: "10", help: "pagination size, range 1-200"},
+		{name: "view list", shortcut: BaseViewList, flag: "limit", defaultVal: "100", help: "pagination size, range 1-200"},
+		{name: "form list", shortcut: BaseFormsList, flag: "page-size", defaultVal: "100", help: "page size per request, range 1-100"},
+		{name: "workflow list", shortcut: BaseWorkflowList, flag: "page-size", defaultVal: "100", help: "page size per request, range 1-100"},
+		{name: "record history list", shortcut: BaseRecordHistoryList, flag: "page-size", defaultVal: "30", help: "pagination size, range 1-50"},
+		{name: "dashboard list", shortcut: BaseDashboardList, flag: "page-size", defaultVal: "100", help: "page size, range 1-100"},
+		{name: "dashboard block list", shortcut: BaseDashboardBlockList, flag: "page-size", defaultVal: "20", help: "page size, range 1-100"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := &cobra.Command{Use: "base"}
+			tt.shortcut.Mount(parent, &cmdutil.Factory{})
+			cmd := parent.Commands()[0]
+			flag := cmd.Flags().Lookup(tt.flag)
+			if flag == nil {
+				t.Fatalf("flag --%s missing", tt.flag)
+			}
+			if flag.DefValue != tt.defaultVal {
+				t.Fatalf("--%s default=%q, want %q", tt.flag, flag.DefValue, tt.defaultVal)
+			}
+			help := cmd.Flags().FlagUsages()
+			if !strings.Contains(help, tt.help) {
+				t.Fatalf("flag help missing %q:\n%s", tt.help, help)
+			}
+			if !strings.Contains(help, "default "+tt.defaultVal) {
+				t.Fatalf("flag help missing default %s:\n%s", tt.defaultVal, help)
+			}
+			if got := strings.Count(help, "default "+tt.defaultVal); got != 1 {
+				t.Fatalf("flag help default %s count=%d, want 1:\n%s", tt.defaultVal, got, help)
+			}
+		})
+	}
+}
+
+func TestBaseLimitPageSizeAliasIsHidden(t *testing.T) {
+	tests := []struct {
+		name     string
+		shortcut common.Shortcut
+	}{
+		{name: "table list", shortcut: BaseTableList},
+		{name: "field list", shortcut: BaseFieldList},
+		{name: "field search options", shortcut: BaseFieldSearchOptions},
+		{name: "record list", shortcut: BaseRecordList},
+		{name: "record search", shortcut: BaseRecordSearch},
+		{name: "view list", shortcut: BaseViewList},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent := &cobra.Command{Use: "base"}
+			tt.shortcut.Mount(parent, &cmdutil.Factory{})
+			cmd := parent.Commands()[0]
+			flag := cmd.Flags().Lookup("page-size")
+			if flag == nil {
+				t.Fatal("flag --page-size missing")
+			}
+			if !flag.Hidden {
+				t.Fatal("flag --page-size must be hidden")
+			}
+			if strings.Contains(cmd.Flags().FlagUsages(), "--page-size") {
+				t.Fatalf("help should not include hidden --page-size:\n%s", cmd.Flags().FlagUsages())
 			}
 		})
 	}
@@ -1106,6 +1207,184 @@ func TestBaseRecordValidate(t *testing.T) {
 		nil,
 	)); err == nil || !strings.Contains(err.Error(), "--json is mutually exclusive") {
 		t.Fatalf("err=%v", err)
+	}
+}
+
+func TestBasePaginationValidationRejectsOutOfRange(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name     string
+		shortcut common.Shortcut
+		runtime  *common.RuntimeContext
+		param    string
+	}{
+		{
+			name:     "table list",
+			shortcut: BaseTableList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b"}, nil, map[string]int{"limit": 101}),
+			param:    "--limit",
+		},
+		{
+			name:     "field list",
+			shortcut: BaseFieldList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, map[string]int{"limit": 201}),
+			param:    "--limit",
+		},
+		{
+			name:     "field search options",
+			shortcut: BaseFieldSearchOptions,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1", "field-id": "fld_1"}, nil, map[string]int{"limit": 201}),
+			param:    "--limit",
+		},
+		{
+			name:     "view list",
+			shortcut: BaseViewList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, map[string]int{"limit": 201}),
+			param:    "--limit",
+		},
+		{
+			name:     "record list",
+			shortcut: BaseRecordList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, map[string]int{"limit": 0}),
+			param:    "--limit",
+		},
+		{
+			name:     "record search",
+			shortcut: BaseRecordSearch,
+			runtime: newBaseTestRuntimeWithArrays(
+				map[string]string{"base-token": "b", "table-id": "tbl_1", "keyword": "Alice"},
+				map[string][]string{"search-field": {"Name"}},
+				nil,
+				map[string]int{"limit": 201},
+			),
+			param: "--limit",
+		},
+		{
+			name:     "table list page-size alias",
+			shortcut: BaseTableList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b"}, nil, map[string]int{"page-size": 101}),
+			param:    "--page-size",
+		},
+		{
+			name:     "field list page-size alias",
+			shortcut: BaseFieldList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, map[string]int{"page-size": 201}),
+			param:    "--page-size",
+		},
+		{
+			name:     "field search options page-size alias",
+			shortcut: BaseFieldSearchOptions,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1", "field-id": "fld_1"}, nil, map[string]int{"page-size": 201}),
+			param:    "--page-size",
+		},
+		{
+			name:     "view list page-size alias",
+			shortcut: BaseViewList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, map[string]int{"page-size": 201}),
+			param:    "--page-size",
+		},
+		{
+			name:     "record list page-size alias",
+			shortcut: BaseRecordList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, map[string]int{"page-size": 0}),
+			param:    "--page-size",
+		},
+		{
+			name:     "record search page-size alias",
+			shortcut: BaseRecordSearch,
+			runtime: newBaseTestRuntimeWithArrays(
+				map[string]string{"base-token": "b", "table-id": "tbl_1", "keyword": "Alice"},
+				map[string][]string{"search-field": {"Name"}},
+				nil,
+				map[string]int{"page-size": 201},
+			),
+			param: "--page-size",
+		},
+		{
+			name:     "form list",
+			shortcut: BaseFormsList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1"}, nil, map[string]int{"page-size": 101}),
+			param:    "--page-size",
+		},
+		{
+			name:     "workflow list",
+			shortcut: BaseWorkflowList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b"}, nil, map[string]int{"page-size": 101}),
+			param:    "--page-size",
+		},
+		{
+			name:     "record history list",
+			shortcut: BaseRecordHistoryList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "table-id": "tbl_1", "record-id": "rec_1"}, nil, map[string]int{"page-size": 51}),
+			param:    "--page-size",
+		},
+		{
+			name:     "dashboard list",
+			shortcut: BaseDashboardList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "page-size": "101"}, nil, nil),
+			param:    "--page-size",
+		},
+		{
+			name:     "dashboard block list",
+			shortcut: BaseDashboardBlockList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b", "dashboard-id": "dash_1", "page-size": "101"}, nil, nil),
+			param:    "--page-size",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shortcut.Validate == nil {
+				t.Fatalf("%s missing Validate", tt.shortcut.Command)
+			}
+			assertBasePaginationValidation(t, tt.shortcut.Validate(ctx, tt.runtime), tt.param)
+		})
+	}
+}
+
+func TestBaseLimitPageSizeAliasRejectsConflict(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name     string
+		shortcut common.Shortcut
+		runtime  *common.RuntimeContext
+	}{
+		{
+			name:     "table list",
+			shortcut: BaseTableList,
+			runtime:  newBaseTestRuntime(map[string]string{"base-token": "b"}, nil, map[string]int{"limit": 50, "page-size": 50}),
+		},
+		{
+			name:     "record search",
+			shortcut: BaseRecordSearch,
+			runtime: newBaseTestRuntimeWithArrays(
+				map[string]string{"base-token": "b", "table-id": "tbl_1", "keyword": "Alice"},
+				map[string][]string{"search-field": {"Name"}},
+				nil,
+				map[string]int{"limit": 10, "page-size": 10},
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shortcut.Validate == nil {
+				t.Fatalf("%s missing Validate", tt.shortcut.Command)
+			}
+			err := tt.shortcut.Validate(ctx, tt.runtime)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("expected validation error, got %T: %v", err, err)
+			}
+			if validationErr.Param != "--page-size" {
+				t.Fatalf("param=%q, want --page-size", validationErr.Param)
+			}
+			if !strings.Contains(validationErr.Message, "mutually exclusive") {
+				t.Fatalf("message=%q, want mutually exclusive", validationErr.Message)
+			}
+		})
 	}
 }
 

--- a/shortcuts/base/dashboard_block_list.go
+++ b/shortcuts/base/dashboard_block_list.go
@@ -21,18 +21,20 @@ var BaseDashboardBlockList = common.Shortcut{
 	Flags: []common.Flag{
 		baseTokenFlag(true),
 		dashboardIDFlag(true),
-		{Name: "page-size", Desc: "page size, default 20, max 100"},
+		{Name: "page-size", Type: "int", Default: "20", Desc: "page size, range 1-100"},
 		{Name: "page-token", Desc: "pagination token"},
 	},
 	Tips: []string{
 		"lark-cli base +dashboard-block-list --base-token <base_token> --dashboard-id <dashboard_id>",
 		"Use returned block_id and type values for +dashboard-block-get/update/delete/get-data.",
 	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		_, err := common.ValidatePageSizeTyped(runtime, "page-size", 20, 1, 100)
+		return err
+	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		params := map[string]interface{}{}
-		if ps := strings.TrimSpace(runtime.Str("page-size")); ps != "" {
-			params["page_size"] = ps
-		}
+		params["page_size"] = runtime.Int("page-size")
 		if pt := strings.TrimSpace(runtime.Str("page-token")); pt != "" {
 			params["page_token"] = pt
 		}

--- a/shortcuts/base/dashboard_list.go
+++ b/shortcuts/base/dashboard_list.go
@@ -20,17 +20,19 @@ var BaseDashboardList = common.Shortcut{
 	HasFormat:   true,
 	Flags: []common.Flag{
 		baseTokenFlag(true),
-		{Name: "page-size", Desc: "page size, max 100"},
+		{Name: "page-size", Type: "int", Default: "100", Desc: "page size, range 1-100"},
 		{Name: "page-token", Desc: "pagination token"},
 	},
 	Tips: []string{
 		"Use returned dashboard_id values for +dashboard-get, +dashboard-block-list, and +dashboard-block-create.",
 	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		_, err := common.ValidatePageSizeTyped(runtime, "page-size", 100, 1, 100)
+		return err
+	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		params := map[string]interface{}{}
-		if ps := strings.TrimSpace(runtime.Str("page-size")); ps != "" {
-			params["page_size"] = ps
-		}
+		params["page_size"] = runtime.Int("page-size")
 		if pt := strings.TrimSpace(runtime.Str("page-token")); pt != "" {
 			params["page_token"] = pt
 		}

--- a/shortcuts/base/dashboard_ops.go
+++ b/shortcuts/base/dashboard_ops.go
@@ -31,9 +31,7 @@ func dryRunDashboardBase(runtime *common.RuntimeContext) *common.DryRunAPI {
 // dryRunDashboardList returns a DryRunAPI for listing dashboards.
 func dryRunDashboardList(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 	params := map[string]interface{}{}
-	if pageSize := strings.TrimSpace(runtime.Str("page-size")); pageSize != "" {
-		params["page_size"] = pageSize
-	}
+	params["page_size"] = runtime.Int("page-size")
 	if pageToken := strings.TrimSpace(runtime.Str("page-token")); pageToken != "" {
 		params["page_token"] = pageToken
 	}
@@ -82,9 +80,7 @@ func dryRunDashboardDelete(_ context.Context, runtime *common.RuntimeContext) *c
 // dryRunDashboardBlockList returns a DryRunAPI for listing dashboard blocks.
 func dryRunDashboardBlockList(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 	params := map[string]interface{}{}
-	if pageSize := strings.TrimSpace(runtime.Str("page-size")); pageSize != "" {
-		params["page_size"] = pageSize
-	}
+	params["page_size"] = runtime.Int("page-size")
 	if pageToken := strings.TrimSpace(runtime.Str("page-token")); pageToken != "" {
 		params["page_token"] = pageToken
 	}
@@ -171,9 +167,7 @@ func dryRunDashboardBlockDelete(_ context.Context, runtime *common.RuntimeContex
 // executeDashboardList lists all dashboards in a base.
 func executeDashboardList(runtime *common.RuntimeContext) error {
 	params := map[string]interface{}{}
-	if pageSize := strings.TrimSpace(runtime.Str("page-size")); pageSize != "" {
-		params["page_size"] = pageSize
-	}
+	params["page_size"] = runtime.Int("page-size")
 	if pageToken := strings.TrimSpace(runtime.Str("page-token")); pageToken != "" {
 		params["page_token"] = pageToken
 	}
@@ -241,9 +235,7 @@ func executeDashboardDelete(runtime *common.RuntimeContext) error {
 // executeDashboardBlockList lists all blocks in a dashboard.
 func executeDashboardBlockList(runtime *common.RuntimeContext) error {
 	params := map[string]interface{}{}
-	if pageSize := strings.TrimSpace(runtime.Str("page-size")); pageSize != "" {
-		params["page_size"] = pageSize
-	}
+	params["page_size"] = runtime.Int("page-size")
 	if pageToken := strings.TrimSpace(runtime.Str("page-token")); pageToken != "" {
 		params["page_token"] = pageToken
 	}

--- a/shortcuts/base/field_list.go
+++ b/shortcuts/base/field_list.go
@@ -21,6 +21,21 @@ var BaseFieldList = common.Shortcut{
 		tableRefFlag(true),
 		{Name: "offset", Type: "int", Default: "0", Desc: "pagination offset"},
 		{Name: "limit", Type: "int", Default: "100", Desc: "pagination size, range 1-200"},
+		pageSizeLimitAliasFlag(),
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateLimitPageSizeAlias(runtime); err != nil {
+			return err
+		}
+		if _, err := common.ValidatePageSizeTyped(runtime, "limit", 100, 1, 200); err != nil {
+			return err
+		}
+		if runtime.Changed("page-size") {
+			if _, err := common.ValidatePageSizeTyped(runtime, "page-size", 100, 1, 200); err != nil {
+				return err
+			}
+		}
+		return nil
 	},
 	DryRun: dryRunFieldList,
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {

--- a/shortcuts/base/field_ops.go
+++ b/shortcuts/base/field_ops.go
@@ -15,7 +15,7 @@ func dryRunFieldList(_ context.Context, runtime *common.RuntimeContext) *common.
 	if offset < 0 {
 		offset = 0
 	}
-	limit := common.ParseIntBounded(runtime, "limit", 1, 200)
+	limit := getPaginationLimit(runtime)
 	return common.NewDryRunAPI().
 		GET("/open-apis/base/v3/bases/:base_token/tables/:table_id/fields").
 		Params(map[string]interface{}{"offset": offset, "limit": limit}).
@@ -61,12 +61,10 @@ func dryRunFieldDelete(_ context.Context, runtime *common.RuntimeContext) *commo
 }
 
 func dryRunFieldSearchOptions(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+	limit := getPaginationLimit(runtime)
 	params := map[string]interface{}{
 		"offset": runtime.Int("offset"),
-		"limit":  runtime.Int("limit"),
-	}
-	if params["limit"].(int) <= 0 {
-		params["limit"] = 30
+		"limit":  limit,
 	}
 	if keyword := strings.TrimSpace(runtime.Str("keyword")); keyword != "" {
 		params["query"] = keyword
@@ -117,7 +115,7 @@ func executeFieldList(runtime *common.RuntimeContext) error {
 	if offset < 0 {
 		offset = 0
 	}
-	limit := common.ParseIntBounded(runtime, "limit", 1, 200)
+	limit := getPaginationLimit(runtime)
 	fields, total, err := listAllFields(runtime, runtime.Str("base-token"), baseTableID(runtime), offset, limit)
 	if err != nil {
 		return err
@@ -188,12 +186,10 @@ func executeFieldSearchOptions(runtime *common.RuntimeContext) error {
 	baseToken := runtime.Str("base-token")
 	tableIDValue := baseTableID(runtime)
 	fieldRef := runtime.Str("field-id")
+	limit := getPaginationLimit(runtime)
 	params := map[string]interface{}{
 		"offset": runtime.Int("offset"),
-		"limit":  runtime.Int("limit"),
-	}
-	if params["limit"].(int) <= 0 {
-		params["limit"] = 30
+		"limit":  limit,
 	}
 	if keyword := strings.TrimSpace(runtime.Str("keyword")); keyword != "" {
 		params["query"] = keyword

--- a/shortcuts/base/field_search_options.go
+++ b/shortcuts/base/field_search_options.go
@@ -22,11 +22,26 @@ var BaseFieldSearchOptions = common.Shortcut{
 		fieldRefFlag(true),
 		{Name: "keyword", Desc: "keyword for option query"},
 		{Name: "offset", Type: "int", Default: "0", Desc: "pagination offset"},
-		{Name: "limit", Type: "int", Default: "30", Desc: "pagination size, default 30"},
+		{Name: "limit", Type: "int", Default: "30", Desc: "pagination size, range 1-200"},
+		pageSizeLimitAliasFlag(),
 	},
 	Tips: []string{
 		`Example: lark-cli base +field-search-options --base-token <base_token> --table-id <table_id> --field-id "Status" --keyword "Do"`,
 		"Use only for fields with options, such as select or multi-select fields.",
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateLimitPageSizeAlias(runtime); err != nil {
+			return err
+		}
+		if _, err := common.ValidatePageSizeTyped(runtime, "limit", 30, 1, 200); err != nil {
+			return err
+		}
+		if runtime.Changed("page-size") {
+			if _, err := common.ValidatePageSizeTyped(runtime, "page-size", 30, 1, 200); err != nil {
+				return err
+			}
+		}
+		return nil
 	},
 	DryRun: dryRunFieldSearchOptions,
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {

--- a/shortcuts/base/record_history_list.go
+++ b/shortcuts/base/record_history_list.go
@@ -21,11 +21,15 @@ var BaseRecordHistoryList = common.Shortcut{
 		tableRefFlag(true),
 		recordRefFlag(true),
 		{Name: "max-version", Type: "int", Desc: "max version for next page"},
-		{Name: "page-size", Type: "int", Default: "30", Desc: "pagination size, max 50"},
+		{Name: "page-size", Type: "int", Default: "30", Desc: "pagination size, range 1-50"},
 	},
 	Tips: []string{
 		`Example: lark-cli base +record-history-list --base-token <base_token> --table-id <table_id> --record-id <record_id>`,
 		"This reads one record's history only; it is not a table-wide audit scan.",
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		_, err := common.ValidatePageSizeTyped(runtime, "page-size", 30, 1, 50)
+		return err
 	},
 	DryRun: dryRunRecordHistoryList,
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {

--- a/shortcuts/base/record_list.go
+++ b/shortcuts/base/record_list.go
@@ -26,6 +26,7 @@ var BaseRecordList = common.Shortcut{
 		recordSortFlag(),
 		{Name: "offset", Type: "int", Default: "0", Desc: "pagination offset"},
 		{Name: "limit", Type: "int", Default: "100", Desc: "pagination size, range 1-200"},
+		pageSizeLimitAliasFlag(),
 		recordReadFormatFlag(),
 	},
 	Tips: []string{
@@ -44,6 +45,17 @@ var BaseRecordList = common.Shortcut{
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := validateRecordReadFormat(runtime); err != nil {
 			return err
+		}
+		if err := validateLimitPageSizeAlias(runtime); err != nil {
+			return err
+		}
+		if _, err := common.ValidatePageSizeTyped(runtime, "limit", 100, 1, 200); err != nil {
+			return err
+		}
+		if runtime.Changed("page-size") {
+			if _, err := common.ValidatePageSizeTyped(runtime, "page-size", 100, 1, 200); err != nil {
+				return err
+			}
 		}
 		return validateRecordQueryOptions(runtime)
 	},

--- a/shortcuts/base/record_ops.go
+++ b/shortcuts/base/record_ops.go
@@ -207,7 +207,7 @@ func dryRunRecordList(_ context.Context, runtime *common.RuntimeContext) *common
 	if offset < 0 {
 		offset = 0
 	}
-	limit := common.ParseIntBounded(runtime, "limit", 1, 200)
+	limit := getPaginationLimit(runtime)
 	params := url.Values{}
 	params.Set("offset", strconv.Itoa(offset))
 	params.Set("limit", strconv.Itoa(limit))
@@ -304,10 +304,11 @@ func dryRunRecordDelete(_ context.Context, runtime *common.RuntimeContext) *comm
 }
 
 func dryRunRecordHistoryList(_ context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+	pageSize := runtime.Int("page-size")
 	params := map[string]interface{}{
 		"table_id":  baseTableID(runtime),
 		"record_id": runtime.Str("record-id"),
-		"page_size": runtime.Int("page-size"),
+		"page_size": pageSize,
 	}
 	if value := runtime.Int("max-version"); value > 0 {
 		params["max_version"] = value
@@ -386,7 +387,7 @@ func executeRecordList(runtime *common.RuntimeContext) error {
 	if offset < 0 {
 		offset = 0
 	}
-	limit := common.ParseIntBounded(runtime, "limit", 1, 200)
+	limit := getPaginationLimit(runtime)
 	params := map[string]interface{}{"offset": offset, "limit": limit}
 	fields := recordListFields(runtime)
 	if len(fields) > 0 {

--- a/shortcuts/base/record_query.go
+++ b/shortcuts/base/record_query.go
@@ -186,7 +186,7 @@ func recordSearchFlagBody(runtime *common.RuntimeContext) (map[string]interface{
 		offset = 0
 	}
 	body["offset"] = offset
-	body["limit"] = common.ParseIntBounded(runtime, "limit", 1, 200)
+	body["limit"] = getPaginationLimit(runtime)
 	return body, applyRecordQueryToBody(runtime, body)
 }
 
@@ -231,6 +231,17 @@ func validateRecordSearchFlags(runtime *common.RuntimeContext) error {
 	if len(runtime.StrArray("search-field")) == 0 {
 		return baseFlagErrorf("--search-field is required unless --json is used")
 	}
+	if err := validateLimitPageSizeAlias(runtime); err != nil {
+		return err
+	}
+	if _, err := common.ValidatePageSizeTyped(runtime, "limit", 10, 1, 200); err != nil {
+		return err
+	}
+	if runtime.Changed("page-size") {
+		if _, err := common.ValidatePageSizeTyped(runtime, "page-size", 10, 1, 200); err != nil {
+			return err
+		}
+	}
 	return validateRecordQueryOptions(runtime)
 }
 
@@ -240,7 +251,8 @@ func recordSearchHasJSONExclusiveFlagInputs(runtime *common.RuntimeContext) bool
 		len(recordListFields(runtime)) > 0 ||
 		runtime.Str("view-id") != "" ||
 		runtime.Changed("offset") ||
-		runtime.Changed("limit")
+		runtime.Changed("limit") ||
+		runtime.Changed("page-size")
 }
 
 func formatRecordQueryPriorityTip() string {

--- a/shortcuts/base/record_search.go
+++ b/shortcuts/base/record_search.go
@@ -29,6 +29,7 @@ var BaseRecordSearch = common.Shortcut{
 		recordSortFlag(),
 		{Name: "offset", Type: "int", Default: "0", Desc: "pagination offset"},
 		{Name: "limit", Type: "int", Default: "10", Desc: "pagination size, range 1-200"},
+		pageSizeLimitAliasFlag(),
 		recordReadFormatFlag(),
 	},
 	Tips: []string{

--- a/shortcuts/base/table_list.go
+++ b/shortcuts/base/table_list.go
@@ -20,6 +20,21 @@ var BaseTableList = common.Shortcut{
 		baseTokenFlag(true),
 		{Name: "offset", Type: "int", Default: "0", Desc: "pagination offset"},
 		{Name: "limit", Type: "int", Default: "50", Desc: "pagination size, range 1-100"},
+		pageSizeLimitAliasFlag(),
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateLimitPageSizeAlias(runtime); err != nil {
+			return err
+		}
+		if _, err := common.ValidatePageSizeTyped(runtime, "limit", 50, 1, 100); err != nil {
+			return err
+		}
+		if runtime.Changed("page-size") {
+			if _, err := common.ValidatePageSizeTyped(runtime, "page-size", 50, 1, 100); err != nil {
+				return err
+			}
+		}
+		return nil
 	},
 	DryRun: dryRunTableList,
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {

--- a/shortcuts/base/table_ops.go
+++ b/shortcuts/base/table_ops.go
@@ -15,7 +15,7 @@ func dryRunTableList(_ context.Context, runtime *common.RuntimeContext) *common.
 	if offset < 0 {
 		offset = 0
 	}
-	limit := common.ParseIntBounded(runtime, "limit", 1, 100)
+	limit := getPaginationLimit(runtime)
 	return common.NewDryRunAPI().
 		GET("/open-apis/base/v3/bases/:base_token/tables").
 		Params(map[string]interface{}{"offset": offset, "limit": limit}).
@@ -62,7 +62,7 @@ func executeTableList(runtime *common.RuntimeContext) error {
 	if offset < 0 {
 		offset = 0
 	}
-	limit := common.ParseIntBounded(runtime, "limit", 1, 100)
+	limit := getPaginationLimit(runtime)
 	tables, total, err := listAllTables(runtime, runtime.Str("base-token"), offset, limit)
 	if err != nil {
 		return err

--- a/shortcuts/base/view_list.go
+++ b/shortcuts/base/view_list.go
@@ -21,6 +21,21 @@ var BaseViewList = common.Shortcut{
 		tableRefFlag(true),
 		{Name: "offset", Type: "int", Default: "0", Desc: "pagination offset"},
 		{Name: "limit", Type: "int", Default: "100", Desc: "pagination size, range 1-200"},
+		pageSizeLimitAliasFlag(),
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if err := validateLimitPageSizeAlias(runtime); err != nil {
+			return err
+		}
+		if _, err := common.ValidatePageSizeTyped(runtime, "limit", 100, 1, 200); err != nil {
+			return err
+		}
+		if runtime.Changed("page-size") {
+			if _, err := common.ValidatePageSizeTyped(runtime, "page-size", 100, 1, 200); err != nil {
+				return err
+			}
+		}
+		return nil
 	},
 	DryRun: dryRunViewList,
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {

--- a/shortcuts/base/view_ops.go
+++ b/shortcuts/base/view_ops.go
@@ -23,7 +23,7 @@ func dryRunViewList(_ context.Context, runtime *common.RuntimeContext) *common.D
 	if offset < 0 {
 		offset = 0
 	}
-	limit := common.ParseIntBounded(runtime, "limit", 1, 200)
+	limit := getPaginationLimit(runtime)
 	return dryRunViewBase(runtime).
 		GET("/open-apis/base/v3/bases/:base_token/tables/:table_id/views").
 		Params(map[string]interface{}{"offset": offset, "limit": limit})
@@ -154,7 +154,7 @@ func executeViewList(runtime *common.RuntimeContext) error {
 	if offset < 0 {
 		offset = 0
 	}
-	limit := common.ParseIntBounded(runtime, "limit", 1, 200)
+	limit := getPaginationLimit(runtime)
 	views, total, err := listAllViews(runtime, runtime.Str("base-token"), baseTableID(runtime), offset, limit)
 	if err != nil {
 		return err

--- a/shortcuts/base/workflow_list.go
+++ b/shortcuts/base/workflow_list.go
@@ -20,7 +20,7 @@ var BaseWorkflowList = common.Shortcut{
 	Flags: []common.Flag{
 		{Name: "base-token", Desc: "base token", Required: true},
 		{Name: "status", Desc: "filter by status", Enum: []string{"enabled", "disabled"}},
-		{Name: "page-size", Type: "int", Default: "100", Desc: "page size per request, max 100"},
+		{Name: "page-size", Type: "int", Default: "100", Desc: "page size per request, range 1-100"},
 	},
 	Tips: []string{
 		"Returns workflow_id values with wkf prefix; pass those IDs to +workflow-get/enable/disable/update.",
@@ -30,7 +30,8 @@ var BaseWorkflowList = common.Shortcut{
 		if strings.TrimSpace(runtime.Str("base-token")) == "" {
 			return baseFlagErrorf("--base-token must not be blank")
 		}
-		return nil
+		_, err := common.ValidatePageSizeTyped(runtime, "page-size", 100, 1, 100)
+		return err
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		body := map[string]interface{}{

--- a/shortcuts/common/validate.go
+++ b/shortcuts/common/validate.go
@@ -109,8 +109,15 @@ func ExactlyOneTyped(rt *RuntimeContext, flags ...string) error {
 // ValidatePageSizeTyped validates that the named flag (if set) is an integer within [minVal, maxVal].
 // It returns the parsed value (or defaultVal if the flag is empty) and any validation error.
 func ValidatePageSizeTyped(rt *RuntimeContext, flagName string, defaultVal, minVal, maxVal int) (int, error) {
-	s := rt.Str(flagName)
 	param := "--" + flagName
+	if rt.Cmd == nil {
+		return defaultVal, nil
+	}
+	flag := rt.Cmd.Flags().Lookup(flagName)
+	if flag == nil {
+		return defaultVal, nil
+	}
+	s := flag.Value.String()
 	if s == "" {
 		return defaultVal, nil
 	}
@@ -123,18 +130,6 @@ func ValidatePageSizeTyped(rt *RuntimeContext, flagName string, defaultVal, minV
 			WithParam(param)
 	}
 	return n, nil
-}
-
-// ParseIntBounded parses an int flag and clamps it to [min, max].
-func ParseIntBounded(rt *RuntimeContext, name string, min, max int) int {
-	v := rt.Int(name)
-	if v < min {
-		return min
-	}
-	if v > max {
-		return max
-	}
-	return v
 }
 
 // ValidateSafePath ensures path is relative and resolves within the current

--- a/shortcuts/common/validate_test.go
+++ b/shortcuts/common/validate_test.go
@@ -283,18 +283,19 @@ func TestExactlyOne(t *testing.T) {
 	}
 }
 
-func TestParseIntBounded(t *testing.T) {
+func TestValidatePageSizeTyped_IntFlag(t *testing.T) {
 	tests := []struct {
 		name     string
 		val      string
 		min, max int
 		want     int
+		wantErr  bool
 	}{
-		{"within range", "10", 1, 50, 10},
-		{"below min", "0", 1, 50, 1},
-		{"above max", "100", 1, 50, 50},
-		{"at min", "1", 1, 50, 1},
-		{"at max", "50", 1, 50, 50},
+		{"within range", "10", 1, 50, 10, false},
+		{"below min", "0", 1, 50, 0, true},
+		{"above max", "100", 1, 50, 0, true},
+		{"at min", "1", 1, 50, 1, false},
+		{"at max", "50", 1, 50, 50, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -303,9 +304,16 @@ func TestParseIntBounded(t *testing.T) {
 			cmd.ParseFlags(nil)
 			cmd.Flags().Set("page-size", tt.val)
 			rt := &RuntimeContext{Cmd: cmd}
-			got := ParseIntBounded(rt, "page-size", tt.min, tt.max)
+			got, err := ValidatePageSizeTyped(rt, "page-size", 20, tt.min, tt.max)
+			if tt.wantErr {
+				assertValidationParam(t, err, "--page-size")
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidatePageSizeTyped() error = %v", err)
+			}
 			if got != tt.want {
-				t.Errorf("ParseIntBounded() = %d, want %d", got, tt.want)
+				t.Errorf("ValidatePageSizeTyped() = %d, want %d", got, tt.want)
 			}
 		})
 	}

--- a/tests/cli_e2e/base/base_limit_dryrun_test.go
+++ b/tests/cli_e2e/base/base_limit_dryrun_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestBaseListDryRunRejectsOutOfRangeLimit(t *testing.T) {
+	setBaseDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"base", "+table-list",
+			"--base-token", "app_x",
+			"--limit", "101",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+
+	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
+	require.Equal(t, "--limit", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "must be between 1 and 100")
+	require.Empty(t, result.Stdout)
+}
+
+func TestBaseListDryRunAcceptsPageSizeAliasForLimit(t *testing.T) {
+	setBaseDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"base", "+table-list",
+			"--base-token", "app_x",
+			"--page-size", "40",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	require.Equal(t, int64(0), gjson.Get(result.Stdout, "api.0.params.offset").Int(), result.Stdout)
+	require.Equal(t, int64(40), gjson.Get(result.Stdout, "api.0.params.limit").Int(), result.Stdout)
+	require.False(t, gjson.Get(result.Stdout, "api.0.params.page_size").Exists(), result.Stdout)
+}
+
+func TestBaseListDryRunRejectsLimitPageSizeConflict(t *testing.T) {
+	setBaseDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"base", "+table-list",
+			"--base-token", "app_x",
+			"--limit", "20",
+			"--page-size", "40",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 2)
+
+	require.Equal(t, "validation", gjson.Get(result.Stderr, "error.type").String(), result.Stderr)
+	require.Equal(t, "invalid_argument", gjson.Get(result.Stderr, "error.subtype").String(), result.Stderr)
+	require.Equal(t, "--page-size", gjson.Get(result.Stderr, "error.param").String(), result.Stderr)
+	require.Contains(t, gjson.Get(result.Stderr, "error.message").String(), "mutually exclusive")
+	require.Empty(t, result.Stdout)
+}


### PR DESCRIPTION
## Summary
Reject out-of-range Base pagination flags instead of silently clamping or defaulting them. This makes `--limit` and `--page-size` failures explicit and machine-readable for agent callers.

## Changes
- Validate every Base `limit` and `page-size` pagination flag through the typed range helper.
- Remove the silent `ParseIntBounded` clamp path and reuse the existing min/max validation message shape.
- Add Base unit coverage and dry-run E2E coverage for out-of-range pagination errors.

## Test Plan
- [x] Unit tests pass: `make unit-test`
- [x] Manual local verification confirms the `lark-cli base +table-list --limit 101 --dry-run` flow returns a typed validation error via `go test ./tests/cli_e2e/base -run 'DryRun|RejectsOutOfRangeLimit' -count=1`\n\n## Related Issues\n- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pagination flag descriptions now clearly show allowed ranges (e.g., "1-100" instead of "max 100")
  * Enhanced validation with more informative error messages for out-of-range pagination parameters

* **Bug Fixes**
  * Fixed pagination handling consistency across all listing and search commands
  * Improved input validation to ensure proper parameter constraints are enforced

<!-- end of auto-generated comment: release notes by coderabbit.ai -->