### PR TITLE
docs: document base field default values

### DIFF
--- a/skills/lark-base/references/lark-base-cell-value.md
+++ b/skills/lark-base/references/lark-base-cell-value.md
@@ -16,15 +16,20 @@
 
 ## 2. 各类型 CellValue
 
-### 2.1 text / phone / url
+### 2.1 text
 
-用字符串。URL 字段也传 URL 字符串；普通文本里可以保留 Markdown 风格链接文本，平台会按字段类型处理。
+text 字段的 `style.type` 影响单元格检查逻辑：
+`type=plain` 传 Markdown 格式的字符串。
+`type=url` 传一个带 title 的 Markdown 格式链接，或单独传一个链接。
+`type=phone` 传合法电话号码。
+`type=email` 传合法邮箱字符串。
 
 ```json
 {
-    "标题": "Hello",
+    "标题": "Hello, [lark-cli](https://github.com/larksuite/cli)",
+    "官网": "[官网](https://example.com)",
     "联系电话": "1380000000000",
-    "官网": "https://example.com"
+    "邮箱": "owner@example.com"
 }
 ```
 

--- a/skills/lark-base/references/lark-base-field-create.md
+++ b/skills/lark-base/references/lark-base-field-create.md
@@ -23,12 +23,12 @@ lark-cli base +field-create \
 lark-cli base +field-create \
   --base-token <base_token> \
   --table-id <table_id> \
-  --json '{"name":"状态","type":"select","multiple":false,"options":[{"name":"Todo","hue":"Blue","lightness":"Lighter"},{"name":"Done","hue":"Green","lightness":"Light"}]}'
+  --json '{"name":"状态","type":"select","multiple":false,"default_value":["Todo"],"options":[{"name":"Todo","hue":"Blue","lightness":"Lighter"},{"name":"Done","hue":"Green","lightness":"Light"}]}'
 
 lark-cli base +field-create \
   --base-token <base_token> \
   --table-id <table_id> \
-  --json '{"name":"负责人","type":"user","multiple":false,"description":"用于标记记录的直接负责人；协作约定可参考[团队字段约定](https://example.com/field-spec)"}'
+  --json '{"name":"负责人","type":"user","multiple":false,"default_value":[{"$slot":"current_user"}],"description":"用于标记记录的直接负责人；协作约定可参考[团队字段约定](https://example.com/field-spec)"}'
 ```
 
 ## 参数
@@ -51,6 +51,7 @@ POST /open-apis/base/v3/bases/:base_token/tables/:table_id/fields
 - `--json` 必须是 **JSON 对象**，顶层直接传字段定义，不要再套一层。
 - 顶层最少包含：`name`、`type`。
 - 所有字段类型都支持可选 `description`；支持纯文本，也支持 Markdown 链接，如 `协作约定可参考[团队字段约定](https://example.com/field-spec)`。
+- 需要字段默认值时传 `default_value`，直接使用字段对应 CellValue；`datetime` / `user` 的动态填充用 `$slot`。完整规则见 [lark-base-field-json.md](lark-base-field-json.md)。
 - `type` 不同，必填子字段不同：
   - `select`：`multiple` 控制是否多选，`options` 定义静态选项，`dynamic_options_source` 定义动态选项来源。静态与动态选项配置二选一，不能同时传。
   - `link`：必须有 `link_table`，可选 `bidirectional`、`bidirectional_link_field_name`。
@@ -64,6 +65,7 @@ POST /open-apis/base/v3/bases/:base_token/tables/:table_id/fields
   "name": "状态",
   "type": "select",
   "multiple": false,
+  "default_value": ["Todo"],
   "options": [
     { "name": "Todo", "hue": "Blue", "lightness": "Lighter" },
     { "name": "Done", "hue": "Green", "lightness": "Light" }

--- a/skills/lark-base/references/lark-base-field-json.md
+++ b/skills/lark-base/references/lark-base-field-json.md
@@ -9,6 +9,7 @@
 - `--json` 必须是 JSON 对象。
 - 顶层统一使用：`type` + `name` + 类型特有字段。
 - 所有字段类型都支持可选 `description`；支持纯文本，也支持 Markdown 链接。
+- 字段默认值配置的写法在各字段 fewshot 里；`type=specific_value` 的默认值统一沿用记录写入 CellValue 的格式，复杂值先看 CellValue 格式说明 [lark-base-cell-value.md](lark-base-cell-value.md)。
 - 不要使用旧结构：`field_name`、`property`、`ui_type`、数字枚举 `type`。
 - `+field-update` 使用同样的字段 JSON 结构，但语义是 `PUT`；这是高风险写入操作，建议先 `+field-get` 再按目标状态全量提交，并带 `--yes`。
 - `type=formula` 或 `type=lookup` 创建/更新前，必须先读对应 guide。
@@ -27,12 +28,12 @@
 
 | 类型 | 最小必填字段 | 常见补充字段 |
 |------|--------------|-------------|
-| `text` | `type` `name` | `style.type` |
-| `number` | `type` `name` | `style` |
-| `select` | `type` `name` | `multiple` + `options`，或 `multiple` + `dynamic_options_source` |
-| `datetime` | `type` `name` | `style.format` |
+| `text` | `type` `name` | `style.type` `defaultValue` |
+| `number` | `type` `name` | `style` `defaultValue` |
+| `select` | `type` `name` | `multiple` + `options` + 静态 `defaultValue`，或 `multiple` + `dynamic_options_source` |
+| `datetime` | `type` `name` | `style.format` `defaultValue` |
 | `created_at` / `updated_at` | `type` `name` | `style.format` |
-| `user` / `group_chat` | `type` `name` | `multiple` |
+| `user` / `group_chat` | `type` `name` | `multiple`；仅 `user` 支持 `defaultValue` |
 | `created_by` / `updated_by` | `type` `name` | 无 |
 | `link` | `type` `name` `link_table` | `bidirectional` `bidirectional_link_field_name` |
 | `formula` | `type` `name` `expression` | 无 |
@@ -59,14 +60,17 @@
 
 常用写法：
 
+默认值可以是 Markdown 文本
 ```json
 {
   "type": "text",
   "name": "标题",
-  "description": "主标题字段"
+  "description": "主标题字段",
+  "defaultValue": { "type": "specific_value", "cell_value": "未命名" }
 }
 ```
 
+`style.type=phone` 时默认值是合法电话号码字符串。
 ```json
 {
   "type": "text",
@@ -80,6 +84,16 @@
   "type": "text",
   "name": "官网",
   "style": { "type": "url" }
+}
+```
+
+`style.type=email` 时默认值是合法邮箱字符串。
+```json
+{
+  "type": "text",
+  "name": "邮箱",
+  "style": { "type": "email" },
+  "defaultValue": { "type": "specific_value", "cell_value": "owner@example.com" }
 }
 ```
 
@@ -118,7 +132,8 @@
     "precision": 2,
     "percentage": false,
     "thousands_separator": true
-  }
+  },
+  "defaultValue": { "type": "specific_value", "cell_value": 8 }
 }
 ```
 
@@ -151,7 +166,8 @@
 {
   "type": "number",
   "name": "完成度",
-  "style": { "type": "progress", "percentage": true, "color": "Blue" }
+  "style": { "type": "progress", "percentage": true, "color": "Blue" },
+  "defaultValue": { "type": "specific_value", "cell_value": 0.65 }
 }
 ```
 
@@ -189,12 +205,14 @@
 - `options[].hue` 可用：`Red`、`Orange`、`Yellow`、`Lime`、`Green`、`Turquoise`、`Wathet`、`Blue`、`Carmine`、`Purple`、`Gray` 缺省值为 `Blue`
 - `options[].lightness` 可用：`Lighter`、`Light`、`Standard`、`Dark`、`Darker` 缺省值为 `Lighter`
 - 选项里没有 `id`，只有 `name`。
+- 支持默认值配置：`cell_value` 填选项名数组。
 
 ```json
 {
   "type": "select",
   "name": "状态",
   "multiple": false,
+  "defaultValue": { "type": "specific_value", "cell_value": ["Todo"] },
   "options": [
     { "name": "Todo", "hue": "Blue", "lightness": "Lighter" },
     { "name": "Done", "hue": "Green", "lightness": "Light" }
@@ -213,6 +231,7 @@
 - `dynamic_options_source.field_id` 填来源字段 id 或字段名
 - `dynamic_options_source` 仅创建支持；更新已有字段时不要传
 - 引用选项条件 / 级联筛选条件：这个功能在 Base 前端支持，属于 UI-only 属性，OpenAPI 里不支持，CLI 不能读取、创建或更新；不要根据接口返回缺失判断未配置
+- 动态选项不支持配置 `defaultValue`。
 
 ```json
 {
@@ -229,6 +248,8 @@
 ### 3.4 datetime
 
 手动填写的日期/时间字段。系统时间用 `created_at` / `updated_at`。
+支持默认值配置：`specific_value` 固定时间，或 `record_created_time` 自动填充记录创建时间；固定时间 `cell_value` 用 `YYYY-MM-DD HH:mm:ss` 字符串。
+`datetime + record_created_time` 是创建时自动填充时间到单元格中，后续可修改单元格；`created_at` 系统字段读取底层只读元信息，单元格无法修改。
 
 最小写法：
 
@@ -251,7 +272,16 @@
 {
   "type": "datetime",
   "name": "截止时间",
-  "style": { "format": "yyyy-MM-dd HH:mm" }
+  "style": { "format": "yyyy-MM-dd HH:mm" },
+  "defaultValue": { "type": "specific_value", "cell_value": "2026-03-24 10:00:00" }
+}
+```
+
+```json
+{
+  "type": "datetime",
+  "name": "单元格自动填充创建时刻",
+  "defaultValue": { "type": "record_created_time" }
 }
 ```
 
@@ -279,9 +309,15 @@
 
 默认值 / 约束：
 - `multiple` 默认 `true`
+- `user` 字段支持 `defaultValue` 配置，`group_chat` 字段不支持 `defaultValue` 配置。
 
 ```json
-{ "type": "user", "name": "负责人", "multiple": true }
+{
+  "type": "user",
+  "name": "负责人",
+  "multiple": true,
+  "defaultValue": { "type": "specific_value", "cell_value": [{ "id": "ou_xxx" }] }
+}
 ```
 
 ```json
@@ -488,3 +524,4 @@ Object（对象字段）、Button（按钮字段）、Stage（流程字段）暂
 - `number` 的精度、货币、进度、评分配置都放在 `style` 下，不要写顶层 `precision`。
 - `datetime` 是手动日期字段；系统时间请改用 `created_at` / `updated_at`。
 - `formula` / `lookup` 没读 guide 前不要直接写。
+- 只有 `text`、`number`、`select`、`datetime`、`user` 类型支持 `defaultValue`；清空统一传 `"defaultValue": null`。其他字段类型不支持配置默认值，传入会自动忽略。

--- a/skills/lark-base/references/lark-base-field-json.md
+++ b/skills/lark-base/references/lark-base-field-json.md
@@ -9,7 +9,7 @@
 - `--json` 必须是 JSON 对象。
 - 顶层统一使用：`type` + `name` + 类型特有字段。
 - 所有字段类型都支持可选 `description`；支持纯文本，也支持 Markdown 链接。
-- 字段默认值配置的写法在各字段 fewshot 里；`type=specific_value` 的默认值统一沿用记录写入 CellValue 的格式，复杂值先看 CellValue 格式说明 [lark-base-cell-value.md](lark-base-cell-value.md)。
+- 字段默认值使用 `default_value`，直接传对应 CellValue；支持范围只有 `text`、`number`、静态 `select`、`datetime`、`user`。清空默认值传 `null`；省略表示创建时不设置、更新时不修改。
 - 不要使用旧结构：`field_name`、`property`、`ui_type`、数字枚举 `type`。
 - `+field-update` 使用同样的字段 JSON 结构，但语义是 `PUT`；这是高风险写入操作，建议先 `+field-get` 再按目标状态全量提交，并带 `--yes`。
 - `type=formula` 或 `type=lookup` 创建/更新前，必须先读对应 guide。
@@ -28,12 +28,12 @@
 
 | 类型 | 最小必填字段 | 常见补充字段 |
 |------|--------------|-------------|
-| `text` | `type` `name` | `style.type` `defaultValue` |
-| `number` | `type` `name` | `style` `defaultValue` |
-| `select` | `type` `name` | `multiple` + `options` + 静态 `defaultValue`，或 `multiple` + `dynamic_options_source` |
-| `datetime` | `type` `name` | `style.format` `defaultValue` |
+| `text` | `type` `name` | `style.type` `default_value` |
+| `number` | `type` `name` | `style` `default_value` |
+| `select` | `type` `name` | `multiple` + `options` + 静态 `default_value`，或 `multiple` + `dynamic_options_source` |
+| `datetime` | `type` `name` | `style.format` `default_value` |
 | `created_at` / `updated_at` | `type` `name` | `style.format` |
-| `user` / `group_chat` | `type` `name` | `multiple`；仅 `user` 支持 `defaultValue` |
+| `user` / `group_chat` | `type` `name` | `multiple`；仅 `user` 支持 `default_value` |
 | `created_by` / `updated_by` | `type` `name` | 无 |
 | `link` | `type` `name` `link_table` | `bidirectional` `bidirectional_link_field_name` |
 | `formula` | `type` `name` `expression` | 无 |
@@ -48,13 +48,15 @@
 ### 3.1 text
 
 文本字段；电话、超链接、邮箱、条码也都属于 `text`，通过 `style.type` 区分。
+支持 `default_value`：静态 Markdown 文本字符串；`phone` style 必须是合法电话号码；`url` style 传一个 Markdown 链接或裸 URL；`email` style 必须是合法邮箱字符串，不要传 Markdown 链接或 `mailto:`。
 
 最小写法（默认 `style.type` 为 `plain`）：
 
 ```json
 {
   "type": "text",
-  "name": "标题"
+  "name": "标题",
+  "default_value": "默认标题"
 }
 ```
 
@@ -66,7 +68,7 @@
   "type": "text",
   "name": "标题",
   "description": "主标题字段",
-  "defaultValue": { "type": "specific_value", "cell_value": "未命名" }
+  "default_value": "未命名"
 }
 ```
 
@@ -75,7 +77,8 @@
 {
   "type": "text",
   "name": "联系电话",
-  "style": { "type": "phone" }
+  "style": { "type": "phone" },
+  "default_value": "+8613800000000"
 }
 ```
 
@@ -83,17 +86,17 @@
 {
   "type": "text",
   "name": "官网",
-  "style": { "type": "url" }
+  "style": { "type": "url" },
+  "default_value": "[官网](https://example.com)"
 }
 ```
 
-`style.type=email` 时默认值是合法邮箱字符串。
 ```json
 {
   "type": "text",
   "name": "邮箱",
   "style": { "type": "email" },
-  "defaultValue": { "type": "specific_value", "cell_value": "owner@example.com" }
+  "default_value": "owner@example.com"
 }
 ```
 
@@ -102,13 +105,15 @@
 ### 3.2 number
 
 数字字段；货币、进度、评分都属于 `number`，通过 `style.type` 区分。
+支持 `default_value`：静态 JSON number；所有 number style 都按这个规则写。
 
 最小写法（默认 `style.type` 为 `plain`）：
 
 ```json
 {
   "type": "number",
-  "name": "工时"
+  "name": "工时",
+  "default_value": 8
 }
 ```
 
@@ -133,7 +138,7 @@
     "percentage": false,
     "thousands_separator": true
   },
-  "defaultValue": { "type": "specific_value", "cell_value": 8 }
+  "default_value": 8
 }
 ```
 
@@ -167,7 +172,7 @@
   "type": "number",
   "name": "完成度",
   "style": { "type": "progress", "percentage": true, "color": "Blue" },
-  "defaultValue": { "type": "specific_value", "cell_value": 0.65 }
+  "default_value": 0.65
 }
 ```
 
@@ -196,6 +201,7 @@
 #### 静态选项
 
 支持字段：`multiple`、`options`
+支持 `default_value`：静态选项名数组；即使 `multiple=false` 也写数组，如 `["Todo"]`。
 
 默认值 / 约束：
 - `multiple` 默认 `false`
@@ -205,14 +211,14 @@
 - `options[].hue` 可用：`Red`、`Orange`、`Yellow`、`Lime`、`Green`、`Turquoise`、`Wathet`、`Blue`、`Carmine`、`Purple`、`Gray` 缺省值为 `Blue`
 - `options[].lightness` 可用：`Lighter`、`Light`、`Standard`、`Dark`、`Darker` 缺省值为 `Lighter`
 - 选项里没有 `id`，只有 `name`。
-- 支持默认值配置：`cell_value` 填选项名数组。
+- 支持 `default_value` 配置：填选项名数组。
 
 ```json
 {
   "type": "select",
   "name": "状态",
   "multiple": false,
-  "defaultValue": { "type": "specific_value", "cell_value": ["Todo"] },
+  "default_value": ["Todo"],
   "options": [
     { "name": "Todo", "hue": "Blue", "lightness": "Lighter" },
     { "name": "Done", "hue": "Green", "lightness": "Light" }
@@ -223,6 +229,7 @@
 #### 动态选项
 
 支持字段：`multiple`、`dynamic_options_source`
+动态选项不支持 `default_value`。
 
 默认值 / 约束：
 - `multiple` 默认 `false`
@@ -231,7 +238,7 @@
 - `dynamic_options_source.field_id` 填来源字段 id 或字段名
 - `dynamic_options_source` 仅创建支持；更新已有字段时不要传
 - 引用选项条件 / 级联筛选条件：这个功能在 Base 前端支持，属于 UI-only 属性，OpenAPI 里不支持，CLI 不能读取、创建或更新；不要根据接口返回缺失判断未配置
-- 动态选项不支持配置 `defaultValue`。
+- 动态选项不支持配置 `default_value`。
 
 ```json
 {
@@ -248,15 +255,15 @@
 ### 3.4 datetime
 
 手动填写的日期/时间字段。系统时间用 `created_at` / `updated_at`。
-支持默认值配置：`specific_value` 固定时间，或 `record_created_time` 自动填充记录创建时间；固定时间 `cell_value` 用 `YYYY-MM-DD HH:mm:ss` 字符串。
-`datetime + record_created_time` 是创建时自动填充时间到单元格中，后续可修改单元格；`created_at` 系统字段读取底层只读元信息，单元格无法修改。
+支持 `default_value`：静态时间字符串，或 `{ "$slot": "record_created_time" }`。`datetime + record_created_time` 是自动填充可编辑单元格；`created_at` 是只读创建时间元信息。
 
 最小写法：
 
 ```json
 {
   "type": "datetime",
-  "name": "截止时间"
+  "name": "截止时间",
+  "default_value": "2026-03-24 10:00:00"
 }
 ```
 
@@ -273,15 +280,7 @@
   "type": "datetime",
   "name": "截止时间",
   "style": { "format": "yyyy-MM-dd HH:mm" },
-  "defaultValue": { "type": "specific_value", "cell_value": "2026-03-24 10:00:00" }
-}
-```
-
-```json
-{
-  "type": "datetime",
-  "name": "单元格自动填充创建时刻",
-  "defaultValue": { "type": "record_created_time" }
+  "default_value": { "$slot": "record_created_time" }
 }
 ```
 
@@ -306,17 +305,18 @@
 ### 3.6 user / group_chat
 
 人员字段和群字段都支持 `multiple`。
+`user` 支持 `default_value`：人员 CellValue 数组，元素可用 `{ "id": "ou_xxx" }` 或 `{ "$slot": "current_user" }`；不要猜用户 ID。`group_chat` 不支持默认值。
 
 默认值 / 约束：
 - `multiple` 默认 `true`
-- `user` 字段支持 `defaultValue` 配置，`group_chat` 字段不支持 `defaultValue` 配置。
+- `user` 字段支持 `default_value` 配置，`group_chat` 字段不支持 `default_value` 配置。
 
 ```json
 {
   "type": "user",
   "name": "负责人",
   "multiple": true,
-  "defaultValue": { "type": "specific_value", "cell_value": [{ "id": "ou_xxx" }] }
+  "default_value": [{ "$slot": "current_user" }, { "id": "ou_xxx" }]
 }
 ```
 
@@ -524,4 +524,4 @@ Object（对象字段）、Button（按钮字段）、Stage（流程字段）暂
 - `number` 的精度、货币、进度、评分配置都放在 `style` 下，不要写顶层 `precision`。
 - `datetime` 是手动日期字段；系统时间请改用 `created_at` / `updated_at`。
 - `formula` / `lookup` 没读 guide 前不要直接写。
-- 只有 `text`、`number`、`select`、`datetime`、`user` 类型支持 `defaultValue`；清空统一传 `"defaultValue": null`。其他字段类型不支持配置默认值，传入会自动忽略。
+- 只有 `text`、`number`、静态 `select`、`datetime`、`user` 支持 `default_value`；清空统一传 `"default_value": null`。其他字段类型不要配置默认值。

--- a/skills/lark-base/references/lark-base-field-update.md
+++ b/skills/lark-base/references/lark-base-field-update.md
@@ -11,14 +11,14 @@ lark-cli base +field-update \
   --base-token <base_token> \
   --table-id <table_id> \
   --field-id <field_id> \
-  --json '{"name":"状态","type":"select","multiple":false,"options":[{"name":"Todo","hue":"Blue","lightness":"Lighter"},{"name":"Doing","hue":"Orange","lightness":"Light"},{"name":"Done","hue":"Green","lightness":"Light"}]}' \
+  --json '{"name":"状态","type":"select","multiple":false,"default_value":["Doing"],"options":[{"name":"Todo","hue":"Blue","lightness":"Lighter"},{"name":"Doing","hue":"Orange","lightness":"Light"},{"name":"Done","hue":"Green","lightness":"Light"}]}' \
   --yes
 
 lark-cli base +field-update \
   --base-token <base_token> \
   --table-id <table_id> \
   --field-id <field_id> \
-  --json '{"name":"负责人","type":"user","multiple":false,"description":"用于标记记录的直接负责人"}' \
+  --json '{"name":"负责人","type":"user","multiple":false,"default_value":null,"description":"用于标记记录的直接负责人"}' \
   --yes
 ```
 
@@ -47,6 +47,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
 - `--json` 必须是 **JSON 对象**，顶层直接传字段定义。
 - 更新语义是 `PUT`（全量字段配置更新），不要只传零散片段；至少显式包含 `name`、`type`，并补齐该类型所需关键配置。
 - 所有字段类型都支持可选 `description`；支持纯文本，也支持 Markdown 链接。
+- 需要字段默认值时传 `default_value`，直接使用字段对应 CellValue；传 `null` 清空，省略表示不修改现有默认值。完整规则见 [lark-base-field-json.md](lark-base-field-json.md)。
 - `select` 更新时：`options` 仍按对象数组传，避免混入无效字段。
 - `link` 更新限制：
   - 不能把非 `link` 字段改成 `link`，也不能把 `link` 改成非 `link`。
@@ -59,6 +60,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
   "name": "状态",
   "type": "select",
   "multiple": false,
+  "default_value": ["Doing"],
   "options": [
     { "name": "Todo", "hue": "Blue", "lightness": "Lighter" },
     { "name": "Doing", "hue": "Orange", "lightness": "Light" },


### PR DESCRIPTION
## Summary

- Document `defaultValue` examples in the Base field JSON reference for supported field types.
- Clarify text style CellValue rules for `url`, `phone`, and `email`.
- Add default value support and clearing notes to the existing field JSON guidance.

## Validation

- Parsed JSON examples in `lark-base-field-json.md` and `lark-base-cell-value.md`.
- `git diff --check -- skills/lark-base/references/lark-base-field-json.md skills/lark-base/references/lark-base-cell-value.md`
- `node scripts/skill-format-check/index.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to set and clear default values in field JSON payloads.
  * Expanded examples for text, number, select, datetime, and user fields to show supported default value formats.
  * Updated guidance on which field types support defaults and how to handle special cases like URL, phone, email, and current user values.
  * Standardized field creation and update examples to better match the latest JSON format expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->