### PR TITLE
feat: support project-level profile binding

### DIFF
--- a/cmd/auth/list.go
+++ b/cmd/auth/list.go
@@ -70,6 +70,9 @@ func authListRun(opts *ListOptions) error {
 	}
 
 	app := multi.CurrentAppConfig(f.Invocation.Profile)
+	if app == nil && f.Invocation.Profile != "" && f.Invocation.ProfileSource == core.ProfileSourceProject {
+		return core.ProjectProfileNotFoundError(f.Invocation.Profile, f.Invocation.ProfileConfigPath, multi.ProfileNames())
+	}
 	if app == nil || len(app.Users) == 0 {
 		if opts.JSON {
 			output.PrintJson(f.IOStreams.Out, map[string]interface{}{

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -59,6 +59,9 @@ func authLogoutRun(opts *LogoutOptions) error {
 	}
 
 	app := multi.CurrentAppConfig(f.Invocation.Profile)
+	if app == nil && f.Invocation.Profile != "" && f.Invocation.ProfileSource == core.ProfileSourceProject {
+		return core.ProjectProfileNotFoundError(f.Invocation.Profile, f.Invocation.ProfileConfigPath, multi.ProfileNames())
+	}
 	if app == nil || len(app.Users) == 0 {
 		if opts.JSON {
 			output.PrintJson(f.IOStreams.Out, map[string]interface{}{

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -6,8 +6,10 @@ package cmd
 import (
 	"errors"
 	"io"
+	"strings"
 
 	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/spf13/pflag"
 )
 
@@ -26,5 +28,71 @@ func BootstrapInvocationContext(args []string) (cmdutil.InvocationContext, error
 	if err := fs.Parse(args); err != nil && !errors.Is(err, pflag.ErrHelp) {
 		return cmdutil.InvocationContext{}, err
 	}
-	return cmdutil.InvocationContext{Profile: globals.Profile}, nil
+	if globals.Profile != "" {
+		return cmdutil.InvocationContext{
+			Profile:       globals.Profile,
+			ProfileSource: core.ProfileSourceCLI,
+		}, nil
+	}
+	if skipProjectProfileLookup(args) {
+		return cmdutil.InvocationContext{ProfileSource: core.ProfileSourceGlobal}, nil
+	}
+	project, err := core.ResolveProjectProfile()
+	if err != nil {
+		return cmdutil.InvocationContext{}, err
+	}
+	if project != nil {
+		return cmdutil.InvocationContext{
+			Profile:           project.Profile,
+			ProfileSource:     core.ProfileSourceProject,
+			ProfileConfigPath: project.Path,
+		}, nil
+	}
+	return cmdutil.InvocationContext{ProfileSource: core.ProfileSourceGlobal}, nil
+}
+
+func skipProjectProfileLookup(args []string) bool {
+	for _, arg := range args {
+		if arg == "-h" || arg == "--help" || arg == "completion" || arg == "__complete" || arg == "__completeNoDesc" {
+			return true
+		}
+	}
+	parts := firstPositionalArgs(args, 2)
+	if len(parts) == 0 {
+		return false
+	}
+	switch parts[0] {
+	case "profile":
+		return len(parts) < 2 || parts[1] != "current"
+	case "config":
+		return len(parts) >= 2 && (parts[1] == "bind" || parts[1] == "init" || parts[1] == "remove")
+	default:
+		return false
+	}
+}
+
+func firstPositionalArgs(args []string, limit int) []string {
+	var out []string
+	skipNext := false
+	for _, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if arg == "--" {
+			break
+		}
+		if arg == "--profile" {
+			skipNext = true
+			continue
+		}
+		if strings.HasPrefix(arg, "--profile=") || strings.HasPrefix(arg, "-") {
+			continue
+		}
+		out = append(out, arg)
+		if len(out) >= limit {
+			return out
+		}
+	}
+	return out
 }

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -3,7 +3,14 @@
 
 package cmd
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+)
 
 func TestBootstrapInvocationContext_ProfileFlag(t *testing.T) {
 	inv, err := BootstrapInvocationContext([]string{"--profile", "target", "auth", "status"})
@@ -68,5 +75,97 @@ func TestBootstrapInvocationContext_HelpWithProfile(t *testing.T) {
 	}
 	if inv.Profile != "target" {
 		t.Fatalf("profile = %q, want %q", inv.Profile, "target")
+	}
+}
+
+func TestBootstrapInvocationContext_ProjectProfile(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0700); err != nil {
+		t.Fatalf("Mkdir(.git): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, core.ProjectConfigFileName), []byte(`{"profile":"bytedance"}`), 0600); err != nil {
+		t.Fatalf("WriteFile(project config): %v", err)
+	}
+	sub := filepath.Join(repo, "sub")
+	if err := os.MkdirAll(sub, 0700); err != nil {
+		t.Fatalf("MkdirAll(sub): %v", err)
+	}
+	cmdutil.TestChdir(t, sub)
+
+	inv, err := BootstrapInvocationContext([]string{"auth", "status"})
+	if err != nil {
+		t.Fatalf("BootstrapInvocationContext() error = %v", err)
+	}
+	if inv.Profile != "bytedance" {
+		t.Fatalf("profile = %q, want bytedance", inv.Profile)
+	}
+	if inv.ProfileSource != core.ProfileSourceProject {
+		t.Fatalf("ProfileSource = %q, want project", inv.ProfileSource)
+	}
+	wantRepo, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(repo): %v", err)
+	}
+	if inv.ProfileConfigPath != filepath.Join(wantRepo, core.ProjectConfigFileName) {
+		t.Fatalf("ProfileConfigPath = %q", inv.ProfileConfigPath)
+	}
+}
+
+func TestBootstrapInvocationContext_ProfileFlagOverridesProjectProfile(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0700); err != nil {
+		t.Fatalf("Mkdir(.git): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, core.ProjectConfigFileName), []byte(`{"profile":"project"}`), 0600); err != nil {
+		t.Fatalf("WriteFile(project config): %v", err)
+	}
+	cmdutil.TestChdir(t, repo)
+
+	inv, err := BootstrapInvocationContext([]string{"--profile", "cli", "auth", "status"})
+	if err != nil {
+		t.Fatalf("BootstrapInvocationContext() error = %v", err)
+	}
+	if inv.Profile != "cli" {
+		t.Fatalf("profile = %q, want cli", inv.Profile)
+	}
+	if inv.ProfileSource != core.ProfileSourceCLI {
+		t.Fatalf("ProfileSource = %q, want cli", inv.ProfileSource)
+	}
+	if inv.ProfileConfigPath != "" {
+		t.Fatalf("ProfileConfigPath = %q, want empty", inv.ProfileConfigPath)
+	}
+}
+
+func TestBootstrapInvocationContext_ProfileBindSkipsMalformedProjectConfig(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0700); err != nil {
+		t.Fatalf("Mkdir(.git): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, core.ProjectConfigFileName), []byte(`{`), 0600); err != nil {
+		t.Fatalf("WriteFile(project config): %v", err)
+	}
+	cmdutil.TestChdir(t, repo)
+
+	inv, err := BootstrapInvocationContext([]string{"profile", "bind", "bytedance"})
+	if err != nil {
+		t.Fatalf("BootstrapInvocationContext() error = %v", err)
+	}
+	if inv.Profile != "" || inv.ProfileSource != core.ProfileSourceGlobal {
+		t.Fatalf("invocation = %#v, want global without profile", inv)
+	}
+}
+
+func TestBootstrapInvocationContext_ProfileCurrentReadsMalformedProjectConfig(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0700); err != nil {
+		t.Fatalf("Mkdir(.git): %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, core.ProjectConfigFileName), []byte(`{`), 0600); err != nil {
+		t.Fatalf("WriteFile(project config): %v", err)
+	}
+	cmdutil.TestChdir(t, repo)
+
+	if _, err := BootstrapInvocationContext([]string{"profile", "current"}); err == nil {
+		t.Fatal("BootstrapInvocationContext() error = nil, want malformed project config error")
 	}
 }

--- a/cmd/config/active_profile.go
+++ b/cmd/config/active_profile.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+)
+
+func noActiveProfileError(f *cmdutil.Factory, multi *core.MultiAppConfig) error {
+	if f.Invocation.Profile != "" && f.Invocation.ProfileSource == core.ProfileSourceProject {
+		return core.ProjectProfileNotFoundError(f.Invocation.Profile, f.Invocation.ProfileConfigPath, multi.ProfileNames())
+	}
+	return errs.NewConfigError(errs.SubtypeNotConfigured, "no active profile").WithHint("run: lark-cli profile list")
+}

--- a/cmd/config/default_as.go
+++ b/cmd/config/default_as.go
@@ -27,7 +27,7 @@ func NewCmdConfigDefaultAs(f *cmdutil.Factory) *cobra.Command {
 
 			app := multi.CurrentAppConfig(f.Invocation.Profile)
 			if app == nil {
-				return core.NoActiveProfileError()
+				return noActiveProfileError(f, multi)
 			}
 
 			if len(args) == 0 {

--- a/cmd/config/show.go
+++ b/cmd/config/show.go
@@ -55,7 +55,7 @@ func configShowRun(opts *ConfigShowOptions) error {
 	}
 	app := config.CurrentAppConfig(f.Invocation.Profile)
 	if app == nil {
-		return errs.NewConfigError(errs.SubtypeNotConfigured, "no active profile").WithHint("run: lark-cli profile list")
+		return noActiveProfileError(f, config)
 	}
 	users := "(no logged-in users)"
 	if len(app.Users) > 0 {

--- a/cmd/config/strict_mode.go
+++ b/cmd/config/strict_mode.go
@@ -45,20 +45,20 @@ explicit user confirmation — never run on your own initiative.`,
 			if reset {
 				app := multi.CurrentAppConfig(f.Invocation.Profile)
 				if app == nil {
-					return core.NoActiveProfileError()
+					return noActiveProfileError(f, multi)
 				}
 				return resetStrictMode(f, multi, app, global, args)
 			}
 			if len(args) == 0 {
 				app := multi.CurrentAppConfig(f.Invocation.Profile)
 				if app == nil {
-					return core.NoActiveProfileError()
+					return noActiveProfileError(f, multi)
 				}
 				return showStrictMode(cmd.Context(), f, multi, app)
 			}
 			app := multi.CurrentAppConfig(f.Invocation.Profile)
 			if !global && app == nil {
-				return core.NoActiveProfileError()
+				return noActiveProfileError(f, multi)
 			}
 			return setStrictMode(f, multi, app, args[0], global)
 		},

--- a/cmd/profile/current.go
+++ b/cmd/profile/current.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package profile
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
+)
+
+type currentProfileOutput struct {
+	Profile string         `json:"profile"`
+	Source  string         `json:"source"`
+	Config  string         `json:"config"`
+	AppID   string         `json:"appId"`
+	Brand   core.LarkBrand `json:"brand"`
+}
+
+// NewCmdProfileCurrent creates the profile current subcommand.
+func NewCmdProfileCurrent(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "current",
+		Short: "Show the effective profile",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return profileCurrentRun(f)
+		},
+	}
+	cmdutil.SetRisk(cmd, "read")
+	return cmd
+}
+
+func profileCurrentRun(f *cmdutil.Factory) error {
+	multi, err := core.LoadOrNotConfigured()
+	if err != nil {
+		return err
+	}
+	app := multi.CurrentAppConfig(f.Invocation.Profile)
+	if app == nil {
+		if f.Invocation.Profile != "" && f.Invocation.ProfileSource == core.ProfileSourceProject {
+			return core.ProjectProfileNotFoundError(f.Invocation.Profile, f.Invocation.ProfileConfigPath, multi.ProfileNames())
+		}
+		return errs.NewConfigError(errs.SubtypeNotConfigured, "no active profile").WithHint("run: lark-cli profile list")
+	}
+
+	source := f.Invocation.ProfileSource
+	if source == "" {
+		source = core.ProfileSourceGlobal
+	}
+	configPath := core.GetConfigPath()
+	if source == core.ProfileSourceProject {
+		configPath = f.Invocation.ProfileConfigPath
+	}
+
+	output.PrintJson(f.IOStreams.Out, currentProfileOutput{
+		Profile: app.ProfileName(),
+		Source:  string(source),
+		Config:  configPath,
+		AppID:   app.AppId,
+		Brand:   app.Brand,
+	})
+	return nil
+}

--- a/cmd/profile/profile.go
+++ b/cmd/profile/profile.go
@@ -21,6 +21,9 @@ func NewCmdProfile(f *cmdutil.Factory) *cobra.Command {
 	})
 
 	cmd.AddCommand(NewCmdProfileList(f))
+	cmd.AddCommand(NewCmdProfileCurrent(f))
+	cmd.AddCommand(NewCmdProfileBind(f))
+	cmd.AddCommand(NewCmdProfileUnbind(f))
 	cmd.AddCommand(NewCmdProfileUse(f))
 	cmd.AddCommand(NewCmdProfileAdd(f))
 	cmd.AddCommand(NewCmdProfileRemove(f))

--- a/cmd/profile/profile_test.go
+++ b/cmd/profile/profile_test.go
@@ -34,6 +34,103 @@ func setupProfileConfigDir(t *testing.T) string {
 	return dir
 }
 
+func saveProfileTestConfig(t *testing.T) {
+	t.Helper()
+	if err := core.SaveMultiAppConfig(&core.MultiAppConfig{
+		CurrentApp: "bytedance",
+		Apps: []core.AppConfig{
+			{Name: "bytedance", AppId: "app_bytedance", AppSecret: core.PlainSecret("secret"), Brand: core.BrandFeishu},
+			{Name: "team-prod", AppId: "app_team", AppSecret: core.PlainSecret("secret"), Brand: core.BrandLark},
+			{Name: "lark-boe", AppId: "app_lark_boe", AppSecret: core.PlainSecret("secret"), Brand: core.BrandLark},
+		},
+	}); err != nil {
+		t.Fatalf("SaveMultiAppConfig() error = %v", err)
+	}
+}
+
+func TestProfileBindRun_WritesProjectConfigAtGitRoot(t *testing.T) {
+	setupProfileConfigDir(t)
+	saveProfileTestConfig(t)
+
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0700); err != nil {
+		t.Fatalf("Mkdir(.git): %v", err)
+	}
+	sub := filepath.Join(repo, "sub")
+	if err := os.MkdirAll(sub, 0700); err != nil {
+		t.Fatalf("MkdirAll(sub): %v", err)
+	}
+	cmdutil.TestChdir(t, sub)
+
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	if err := profileBindRun(f, "app_team"); err != nil {
+		t.Fatalf("profileBindRun() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(repo, core.ProjectConfigFileName))
+	if err != nil {
+		t.Fatalf("ReadFile(project config): %v", err)
+	}
+	var cfg core.ProjectConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("Unmarshal(project config): %v", err)
+	}
+	if cfg.Profile != "team-prod" {
+		t.Fatalf("project profile = %q, want team-prod", cfg.Profile)
+	}
+}
+
+func TestProfileUnbindRun_RemovesNearestProjectConfig(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0700); err != nil {
+		t.Fatalf("Mkdir(.git): %v", err)
+	}
+	path := filepath.Join(repo, core.ProjectConfigFileName)
+	if err := os.WriteFile(path, []byte(`{"profile":"bytedance"}`), 0600); err != nil {
+		t.Fatalf("WriteFile(project config): %v", err)
+	}
+	sub := filepath.Join(repo, "sub")
+	if err := os.MkdirAll(sub, 0700); err != nil {
+		t.Fatalf("MkdirAll(sub): %v", err)
+	}
+	cmdutil.TestChdir(t, sub)
+
+	f, _, _, _ := cmdutil.TestFactory(t, nil)
+	if err := profileUnbindRun(f); err != nil {
+		t.Fatalf("profileUnbindRun() error = %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("project config still exists, Stat err = %v", err)
+	}
+}
+
+func TestProfileCurrentRun_ProjectSource(t *testing.T) {
+	configDir := setupProfileConfigDir(t)
+	saveProfileTestConfig(t)
+	projectPath := filepath.Join(t.TempDir(), core.ProjectConfigFileName)
+
+	f, stdout, _, _ := cmdutil.TestFactory(t, nil)
+	f.Invocation = cmdutil.InvocationContext{
+		Profile:           "team-prod",
+		ProfileSource:     core.ProfileSourceProject,
+		ProfileConfigPath: projectPath,
+	}
+	if err := profileCurrentRun(f); err != nil {
+		t.Fatalf("profileCurrentRun() error = %v", err)
+	}
+
+	var got currentProfileOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal(stdout): %v\nstdout=%s", err, stdout.String())
+	}
+	if got.Profile != "team-prod" || got.Source != "project" || got.Config != projectPath || got.AppID != "app_team" {
+		t.Fatalf("current profile = %#v", got)
+	}
+	if got.Config == filepath.Join(configDir, "config.json") {
+		t.Fatalf("project source should report project config, got global path %q", got.Config)
+	}
+}
+
 func TestProfileAddRun_InvalidExistingConfigReturnsError(t *testing.T) {
 	dir := setupProfileConfigDir(t)
 	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{invalid json"), 0600); err != nil {

--- a/cmd/profile/project_bind.go
+++ b/cmd/profile/project_bind.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package profile
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+// NewCmdProfileBind creates the profile bind subcommand.
+func NewCmdProfileBind(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bind <name>",
+		Short: "Bind the current project to a profile",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return profileBindRun(f, args[0])
+		},
+	}
+	cmdutil.SetRisk(cmd, "write")
+	return cmd
+}
+
+// NewCmdProfileUnbind creates the profile unbind subcommand.
+func NewCmdProfileUnbind(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "unbind",
+		Short: "Remove the current project's profile binding",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return profileUnbindRun(f)
+		},
+	}
+	cmdutil.SetRisk(cmd, "write")
+	return cmd
+}
+
+func profileBindRun(f *cmdutil.Factory, name string) error {
+	name = strings.TrimSpace(name)
+	if err := core.ValidateProfileName(name); err != nil {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "%v", err).WithParam("name").WithCause(err)
+	}
+	multi, err := core.LoadOrNotConfigured()
+	if err != nil {
+		return err
+	}
+	app := multi.FindApp(name)
+	if app == nil {
+		return errs.NewValidationError(errs.SubtypeInvalidArgument, "profile %q not found", name).
+			WithHint("available profiles: %s", formatProfileNameList(multi.ProfileNames())).
+			WithParam("name")
+	}
+	cwd, err := vfs.Getwd()
+	if err != nil {
+		return errs.NewInternalError(errs.SubtypeFileIO, "cannot determine working directory: %v", err).WithCause(err)
+	}
+	path, err := core.ProjectConfigWritePath(cwd)
+	if err != nil {
+		return err
+	}
+	if err := core.SaveProjectConfig(path, app.ProfileName()); err != nil {
+		return err
+	}
+	output.PrintSuccess(f.IOStreams.ErrOut, fmt.Sprintf("Project profile bound to %q", app.ProfileName()))
+	fmt.Fprintf(f.IOStreams.ErrOut, "Config: %s\n", path)
+	return nil
+}
+
+func profileUnbindRun(f *cmdutil.Factory) error {
+	cwd, err := vfs.Getwd()
+	if err != nil {
+		return errs.NewInternalError(errs.SubtypeFileIO, "cannot determine working directory: %v", err).WithCause(err)
+	}
+	path, ok, err := core.FindProjectConfigPath(cwd)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "no project profile binding found").
+			WithHint("run: lark-cli profile bind <name>")
+	}
+	fileRemoved, profileRemoved, err := core.RemoveProjectProfile(path)
+	if err != nil {
+		return err
+	}
+	if !profileRemoved {
+		return errs.NewValidationError(errs.SubtypeFailedPrecondition, "no project profile binding found").
+			WithHint("run: lark-cli profile bind <name>")
+	}
+	output.PrintSuccess(f.IOStreams.ErrOut, "Project profile binding removed")
+	if fileRemoved {
+		fmt.Fprintf(f.IOStreams.ErrOut, "Removed: %s\n", path)
+	} else {
+		fmt.Fprintf(f.IOStreams.ErrOut, "Updated: %s\n", path)
+	}
+	return nil
+}
+
+func formatProfileNameList(names []string) string {
+	if len(names) == 0 {
+		return "(none)"
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -26,7 +26,9 @@ import (
 // All function fields are lazily initialized and cached after first call.
 // In tests, replace any field to stub out external dependencies.
 type InvocationContext struct {
-	Profile string
+	Profile           string
+	ProfileSource     core.ProfileSource
+	ProfileConfigPath string
 }
 
 type Factory struct {

--- a/internal/cmdutil/factory_default.go
+++ b/internal/cmdutil/factory_default.go
@@ -61,10 +61,12 @@ func NewDefault(streams *IOStreams, inv InvocationContext) *Factory {
 	// Phase 2: Credential (sole data source)
 	// Keychain is read via closure so callers can replace f.Keychain after construction.
 	f.Credential = buildCredentialProvider(credentialDeps{
-		Keychain:   func() keychain.KeychainAccess { return f.Keychain },
-		Profile:    inv.Profile,
-		HttpClient: f.HttpClient,
-		ErrOut:     f.IOStreams.ErrOut,
+		Keychain:          func() keychain.KeychainAccess { return f.Keychain },
+		Profile:           inv.Profile,
+		ProfileSource:     inv.ProfileSource,
+		ProfileConfigPath: inv.ProfileConfigPath,
+		HttpClient:        f.HttpClient,
+		ErrOut:            f.IOStreams.ErrOut,
 	})
 
 	// Phase 3: Config derived from Credential via an explicit conversion boundary.
@@ -162,15 +164,17 @@ func buildSDKTransport() http.RoundTripper {
 }
 
 type credentialDeps struct {
-	Keychain   func() keychain.KeychainAccess
-	Profile    string
-	HttpClient func() (*http.Client, error)
-	ErrOut     io.Writer
+	Keychain          func() keychain.KeychainAccess
+	Profile           string
+	ProfileSource     core.ProfileSource
+	ProfileConfigPath string
+	HttpClient        func() (*http.Client, error)
+	ErrOut            io.Writer
 }
 
 func buildCredentialProvider(deps credentialDeps) *credential.CredentialProvider {
 	providers := extcred.Providers()
-	defaultAcct := credential.NewDefaultAccountProvider(deps.Keychain, deps.Profile)
+	defaultAcct := credential.NewDefaultAccountProviderWithSource(deps.Keychain, deps.Profile, deps.ProfileSource, deps.ProfileConfigPath)
 	defaultToken := credential.NewDefaultTokenProvider(defaultAcct, deps.HttpClient, deps.ErrOut)
 	// NOTE: Do not pass deps.ErrOut as warnOut. Credential resolution
 	// happens before the command runs, so any plain-text warning written

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -30,6 +30,15 @@ const (
 // IsBot returns true if the identity is bot.
 func (id Identity) IsBot() bool { return id == AsBot }
 
+// ProfileSource describes where the effective profile selector came from.
+type ProfileSource string
+
+const (
+	ProfileSourceCLI     ProfileSource = "cli"
+	ProfileSourceProject ProfileSource = "project"
+	ProfileSourceGlobal  ProfileSource = "global"
+)
+
 // AppUser is a logged-in user record stored in config.
 type AppUser struct {
 	UserOpenId string `json:"userOpenId"`

--- a/internal/core/project_config.go
+++ b/internal/core/project_config.go
@@ -1,0 +1,200 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/larksuite/cli/internal/validate"
+	"github.com/larksuite/cli/internal/vfs"
+)
+
+// ProjectConfigFileName is the project-local profile binding file.
+const ProjectConfigFileName = ".lark-cli.json"
+
+// ProjectConfig is intentionally small: it stores project preferences, not
+// credentials or login state.
+type ProjectConfig struct {
+	Profile string `json:"profile,omitempty"`
+}
+
+// ProjectProfileBinding is the resolved project profile and its source file.
+type ProjectProfileBinding struct {
+	Profile string
+	Path    string
+}
+
+// ResolveProjectProfile finds and parses the nearest project profile binding.
+func ResolveProjectProfile() (*ProjectProfileBinding, error) {
+	cwd, err := vfs.Getwd()
+	if err != nil {
+		return nil, &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("cannot determine working directory: %v", err)}
+	}
+	return ResolveProjectProfileFrom(cwd)
+}
+
+// ResolveProjectProfileFrom finds and parses the nearest project profile binding
+// from startDir upward. Search stops after the nearest Git root is checked.
+func ResolveProjectProfileFrom(startDir string) (*ProjectProfileBinding, error) {
+	path, ok, err := FindProjectConfigPath(startDir)
+	if err != nil || !ok {
+		return nil, err
+	}
+	cfg, err := LoadProjectConfig(path)
+	if err != nil {
+		return nil, err
+	}
+	return &ProjectProfileBinding{Profile: cfg.Profile, Path: path}, nil
+}
+
+// FindProjectConfigPath returns the nearest .lark-cli.json from startDir upward.
+func FindProjectConfigPath(startDir string) (string, bool, error) {
+	dir := filepath.Clean(startDir)
+	for {
+		path := filepath.Join(dir, ProjectConfigFileName)
+		info, err := vfs.Stat(path)
+		switch {
+		case err == nil && info.IsDir():
+			return "", false, &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("project config %s is a directory", path)}
+		case err == nil:
+			return path, true, nil
+		case !errors.Is(err, os.ErrNotExist):
+			return "", false, &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("cannot inspect project config %s: %v", path, err)}
+		}
+
+		if isGitRoot(dir) {
+			return "", false, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false, nil
+		}
+		dir = parent
+	}
+}
+
+// ProjectConfigWritePath returns where profile bind should write. It updates an
+// existing binding when found; otherwise it writes at the Git root, or cwd when
+// outside a Git repository.
+func ProjectConfigWritePath(startDir string) (string, error) {
+	if path, ok, err := FindProjectConfigPath(startDir); err != nil || ok {
+		return path, err
+	}
+	root := findGitRoot(startDir)
+	if root == "" {
+		root = filepath.Clean(startDir)
+	}
+	return filepath.Join(root, ProjectConfigFileName), nil
+}
+
+// LoadProjectConfig parses a project-local config file.
+func LoadProjectConfig(path string) (*ProjectConfig, error) {
+	data, err := vfs.ReadFile(path)
+	if err != nil {
+		return nil, &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("cannot read project config %s: %v", path, err)}
+	}
+	var cfg ProjectConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("invalid project config %s: %v", path, err)}
+	}
+	cfg.Profile = strings.TrimSpace(cfg.Profile)
+	if cfg.Profile == "" {
+		return nil, &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("project config %s must set profile", path)}
+	}
+	if err := ValidateProfileName(cfg.Profile); err != nil {
+		return nil, &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("invalid project profile in %s: %v", path, err)}
+	}
+	return &cfg, nil
+}
+
+// SaveProjectConfig writes the minimal project profile binding.
+func SaveProjectConfig(path, profile string) error {
+	fields := map[string]json.RawMessage{}
+	if data, err := vfs.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, &fields)
+	}
+	profileJSON, err := json.Marshal(strings.TrimSpace(profile))
+	if err != nil {
+		return &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("failed to marshal project config: %v", err)}
+	}
+	fields["profile"] = profileJSON
+	data, err := json.MarshalIndent(fields, "", "  ")
+	if err != nil {
+		return &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("failed to marshal project config: %v", err)}
+	}
+	return validate.AtomicWrite(path, append(data, '\n'), 0600)
+}
+
+// RemoveProjectProfile removes only the profile binding. If no other fields
+// remain, the project config file is deleted.
+func RemoveProjectProfile(path string) (fileRemoved bool, profileRemoved bool, err error) {
+	data, err := vfs.ReadFile(path)
+	if err != nil {
+		return false, false, &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("cannot read project config %s: %v", path, err)}
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return false, false, &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("invalid project config %s: %v", path, err)}
+	}
+	if _, ok := fields["profile"]; !ok {
+		return false, false, nil
+	}
+	delete(fields, "profile")
+	if len(fields) == 0 {
+		if err := vfs.Remove(path); err != nil {
+			return false, false, &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("failed to remove project config %s: %v", path, err)}
+		}
+		return true, true, nil
+	}
+	next, err := json.MarshalIndent(fields, "", "  ")
+	if err != nil {
+		return false, false, &ConfigError{Code: 3, Type: "config", Message: fmt.Sprintf("failed to marshal project config: %v", err)}
+	}
+	if err := validate.AtomicWrite(path, append(next, '\n'), 0600); err != nil {
+		return false, false, err
+	}
+	return false, true, nil
+}
+
+// ProjectProfileNotFoundError explains that a project binding references a
+// profile that is not present in the user's global profile list.
+func ProjectProfileNotFoundError(profile, path string, names []string) error {
+	hint := "run: lark-cli profile list"
+	if path != "" {
+		hint = fmt.Sprintf("project config: %s; %s", path, hint)
+	}
+	if len(names) > 0 {
+		hint += fmt.Sprintf("; available profiles: %s", formatProfileNames(names))
+	}
+	return &ConfigError{
+		Code:    3,
+		Type:    "config",
+		Message: fmt.Sprintf("profile %q is configured by project but not found", profile),
+		Hint:    hint,
+	}
+}
+
+func isGitRoot(dir string) bool {
+	_, err := vfs.Stat(filepath.Join(dir, ".git"))
+	return err == nil
+}
+
+func findGitRoot(startDir string) string {
+	dir := filepath.Clean(startDir)
+	for {
+		if isGitRoot(dir) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}

--- a/internal/core/project_config_test.go
+++ b/internal/core/project_config_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeProjectConfig(t *testing.T, dir, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, ProjectConfigFileName)
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+	return path
+}
+
+func TestResolveProjectProfileFrom_FindsNearestConfig(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0700); err != nil {
+		t.Fatalf("Mkdir(.git): %v", err)
+	}
+	writeProjectConfig(t, repo, `{"profile":"root"}`)
+	sub := filepath.Join(repo, "sub")
+	if err := os.MkdirAll(sub, 0700); err != nil {
+		t.Fatalf("MkdirAll(sub): %v", err)
+	}
+	subConfig := writeProjectConfig(t, sub, `{"profile":"child"}`)
+
+	got, err := ResolveProjectProfileFrom(filepath.Join(sub, "deep"))
+	if err != nil {
+		t.Fatalf("ResolveProjectProfileFrom() error = %v", err)
+	}
+	if got.Profile != "child" || got.Path != subConfig {
+		t.Fatalf("binding = %#v, want child at %s", got, subConfig)
+	}
+}
+
+func TestFindProjectConfigPath_StopsAtGitRoot(t *testing.T) {
+	parent := t.TempDir()
+	writeProjectConfig(t, parent, `{"profile":"parent"}`)
+	repo := filepath.Join(parent, "repo")
+	sub := filepath.Join(repo, "sub")
+	if err := os.MkdirAll(filepath.Join(repo, ".git"), 0700); err != nil {
+		t.Fatalf("MkdirAll(.git): %v", err)
+	}
+	if err := os.MkdirAll(sub, 0700); err != nil {
+		t.Fatalf("MkdirAll(sub): %v", err)
+	}
+
+	_, ok, err := FindProjectConfigPath(sub)
+	if err != nil {
+		t.Fatalf("FindProjectConfigPath() error = %v", err)
+	}
+	if ok {
+		t.Fatal("FindProjectConfigPath() found config above Git root")
+	}
+}
+
+func TestProjectConfigWritePath_UsesGitRootWhenNoExistingConfig(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repo, ".git"), 0700); err != nil {
+		t.Fatalf("Mkdir(.git): %v", err)
+	}
+	sub := filepath.Join(repo, "a", "b")
+	if err := os.MkdirAll(sub, 0700); err != nil {
+		t.Fatalf("MkdirAll(sub): %v", err)
+	}
+
+	got, err := ProjectConfigWritePath(sub)
+	if err != nil {
+		t.Fatalf("ProjectConfigWritePath() error = %v", err)
+	}
+	want := filepath.Join(repo, ProjectConfigFileName)
+	if got != want {
+		t.Fatalf("ProjectConfigWritePath() = %q, want %q", got, want)
+	}
+}
+
+func TestLoadProjectConfig_InvalidJSONFailsClosed(t *testing.T) {
+	path := writeProjectConfig(t, t.TempDir(), `{`)
+	_, err := LoadProjectConfig(path)
+	if err == nil {
+		t.Fatal("LoadProjectConfig() error = nil, want invalid config error")
+	}
+	var cfgErr *ConfigError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error type = %T, want *ConfigError", err)
+	}
+	if cfgErr.Message == "" {
+		t.Fatal("ConfigError.Message is empty")
+	}
+}
+
+func TestLoadProjectConfig_MissingProfileFailsClosed(t *testing.T) {
+	path := writeProjectConfig(t, t.TempDir(), `{"defaults":{"appId":"cli_x"}}`)
+	_, err := LoadProjectConfig(path)
+	if err == nil {
+		t.Fatal("LoadProjectConfig() error = nil, want missing profile error")
+	}
+}
+
+func TestSaveProjectConfig_PreservesOtherFields(t *testing.T) {
+	path := writeProjectConfig(t, t.TempDir(), `{"defaults":{"appId":"cli_x"}}`)
+	if err := SaveProjectConfig(path, "bytedance"); err != nil {
+		t.Fatalf("SaveProjectConfig() error = %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(project config): %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatalf("Unmarshal(project config): %v", err)
+	}
+	if _, ok := fields["defaults"]; !ok {
+		t.Fatalf("defaults field missing after save: %s", string(data))
+	}
+	var profile string
+	if err := json.Unmarshal(fields["profile"], &profile); err != nil {
+		t.Fatalf("Unmarshal(profile): %v", err)
+	}
+	if profile != "bytedance" {
+		t.Fatalf("profile = %q, want bytedance", profile)
+	}
+}
+
+func TestRemoveProjectProfile_PreservesOtherFields(t *testing.T) {
+	path := writeProjectConfig(t, t.TempDir(), `{"profile":"bytedance","defaults":{"appId":"cli_x"}}`)
+	fileRemoved, profileRemoved, err := RemoveProjectProfile(path)
+	if err != nil {
+		t.Fatalf("RemoveProjectProfile() error = %v", err)
+	}
+	if fileRemoved || !profileRemoved {
+		t.Fatalf("RemoveProjectProfile() = fileRemoved:%v profileRemoved:%v, want file kept and profile removed", fileRemoved, profileRemoved)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(project config): %v", err)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		t.Fatalf("Unmarshal(project config): %v", err)
+	}
+	if _, ok := fields["defaults"]; !ok {
+		t.Fatalf("defaults field missing after profile removal: %s", string(data))
+	}
+	if _, ok := fields["profile"]; ok {
+		t.Fatalf("profile field still present after removal: %s", string(data))
+	}
+	if _, err := LoadProjectConfig(path); err == nil {
+		t.Fatal("LoadProjectConfig() error = nil after profile removal, want missing profile")
+	}
+}
+
+func TestValidateProfileName_AllowsHyphenatedNames(t *testing.T) {
+	for _, name := range []string{"bytedance", "team-prod", "lark-boe"} {
+		if err := ValidateProfileName(name); err != nil {
+			t.Fatalf("ValidateProfileName(%q) error = %v", name, err)
+		}
+	}
+}

--- a/internal/credential/default_provider.go
+++ b/internal/credential/default_provider.go
@@ -61,15 +61,21 @@ func classifyTATResponseCode(code int, oauthErr, errDesc, brand, appID string) e
 
 // DefaultAccountProvider resolves account from config.json via keychain.
 type DefaultAccountProvider struct {
-	keychain func() keychain.KeychainAccess
-	profile  string
+	keychain          func() keychain.KeychainAccess
+	profile           string
+	profileSource     core.ProfileSource
+	profileConfigPath string
 }
 
 func NewDefaultAccountProvider(kc func() keychain.KeychainAccess, profile string) *DefaultAccountProvider {
+	return NewDefaultAccountProviderWithSource(kc, profile, "", "")
+}
+
+func NewDefaultAccountProviderWithSource(kc func() keychain.KeychainAccess, profile string, source core.ProfileSource, configPath string) *DefaultAccountProvider {
 	if kc == nil {
 		kc = keychain.Default
 	}
-	return &DefaultAccountProvider{keychain: kc, profile: profile}
+	return &DefaultAccountProvider{keychain: kc, profile: profile, profileSource: source, profileConfigPath: configPath}
 }
 
 func (p *DefaultAccountProvider) ResolveAccount(ctx context.Context) (*Account, error) {
@@ -77,6 +83,9 @@ func (p *DefaultAccountProvider) ResolveAccount(ctx context.Context) (*Account, 
 	multi, err := core.LoadMultiAppConfig()
 	if err != nil {
 		return nil, core.NotConfiguredError()
+	}
+	if p.profile != "" && p.profileSource == core.ProfileSourceProject && multi.FindApp(p.profile) == nil {
+		return nil, core.ProjectProfileNotFoundError(p.profile, p.profileConfigPath, multi.ProfileNames())
 	}
 
 	cfg, err := core.ResolveConfigFromMulti(multi, p.keychain(), p.profile)

--- a/internal/credential/integration_test.go
+++ b/internal/credential/integration_test.go
@@ -5,6 +5,8 @@ package credential_test
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	extcred "github.com/larksuite/cli/extension/credential"
@@ -79,6 +81,42 @@ type mockDefaultTokenProvider struct {
 
 func (m *mockDefaultTokenProvider) ResolveToken(ctx context.Context, req credential.TokenSpec) (*credential.TokenResult, error) {
 	return &credential.TokenResult{Token: m.token, Scopes: m.scopes}, nil
+}
+
+func TestDefaultAccountProvider_ProjectProfileMissingFailsClosed(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "")
+	t.Setenv(envvars.CliAppSecret, "")
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	if err := core.SaveMultiAppConfig(&core.MultiAppConfig{
+		CurrentApp: "bytedance",
+		Apps: []core.AppConfig{{
+			Name:      "bytedance",
+			AppId:     "cfg_app",
+			AppSecret: core.PlainSecret("cfg_secret"),
+			Brand:     core.BrandFeishu,
+		}},
+	}); err != nil {
+		t.Fatalf("SaveMultiAppConfig: %v", err)
+	}
+
+	defaultAcct := credential.NewDefaultAccountProviderWithSource(
+		func() keychain.KeychainAccess { return &noopKC{} },
+		"missing",
+		core.ProfileSourceProject,
+		"/repo/.lark-cli.json",
+	)
+	_, err := defaultAcct.ResolveAccount(context.Background())
+	if err == nil {
+		t.Fatal("ResolveAccount() error = nil, want project profile not found")
+	}
+	var cfgErr *core.ConfigError
+	if !errors.As(err, &cfgErr) {
+		t.Fatalf("error type = %T, want *core.ConfigError", err)
+	}
+	if !strings.Contains(cfgErr.Message, "configured by project") || !strings.Contains(cfgErr.Hint, "/repo/.lark-cli.json") {
+		t.Fatalf("ConfigError = %#v", cfgErr)
+	}
 }
 
 func TestFullChain_ConfigStrictMode(t *testing.T) {


### PR DESCRIPTION
## Summary
Add project-level profile binding with `.lark-cli.json`, so commands run inside a repository can use the intended profile without passing `--profile` every time.

This keeps the existing precedence model intact: an explicit `--profile` flag still wins over the project binding, and the global current profile remains the fallback when no project binding exists.

## Changes
- Resolve the effective profile from the nearest `.lark-cli.json`, stopping at the Git root.
- Add `profile current` to show the effective profile, source, config path, app ID, and brand.
- Add `profile bind <name>` and `profile unbind` for managing project-level bindings.
- Store only the profile alias in project config; credentials, tokens, users, and app secrets remain in the global config/keychain.
- Preserve unknown fields in `.lark-cli.json` when updating or removing the profile binding, so the file can be extended later.
- Return clearer errors when a project-bound profile does not exist locally.

## Test Plan
- [x] `make build`
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go mod tidy && git diff --exit-code -- go.mod go.sum`
- [x] `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=origin/main`
- [x] `go test ./cmd ./internal/core ./cmd/profile ./cmd/config ./cmd/auth ./internal/credential ./internal/cmdutil`
- [x] Manual binary smoke test for project profile resolution and explicit `--profile` override
- [ ] `make unit-test` is currently blocked by an existing `shortcuts/minutes` failure that also reproduces on clean `origin/main`

The tests cover realistic named profiles and hyphenated aliases such as `bytedance`, `team-prod`, and `lark-boe`.

## Related Issues
- None

---

## 中文说明
这个 PR 增加项目级 profile 绑定能力。项目内存在 `.lark-cli.json` 时，普通命令不需要再显式传 `--profile`，CLI 会自动使用项目绑定的 profile；显式 `--profile` 仍然最高优先级。

项目配置文件只保存 profile 名称，不保存凭证、token、登录用户或 app secret。这样既能解决多租户项目的默认 profile 问题，也不会把机器本地状态写进仓库。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `profile bind`, `profile unbind`, and `profile current` to manage and inspect project-bound profiles stored in `.lark-cli.json`.
  * Added automatic project profile resolution based on local project configuration and CLI profile flags.

* **Bug Fixes**
  * Improved “project profile not found” and “no active profile” errors across auth and config commands, including better hints and project-scoped behavior.

* **Tests**
  * Expanded unit and integration coverage for project profile resolution, flag overrides, malformed config handling, and credential/account resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

