### PR TITLE
feat: fail closed when checksums.txt is missing during install

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -265,10 +265,9 @@ function getExpectedChecksum(archiveName, checksumsDir) {
   const checksumsPath = path.join(dir, "checksums.txt");
 
   if (!fs.existsSync(checksumsPath)) {
-    console.error(
-      "[WARN] checksums.txt not found, skipping checksum verification"
+    throw new Error(
+      "[SECURITY] checksums.txt not found; refusing to install an unverified binary."
     );
-    return null;
   }
 
   const content = fs.readFileSync(checksumsPath, "utf8");

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -285,7 +285,11 @@ function getExpectedChecksum(archiveName, checksumsDir) {
 }
 
 function verifyChecksum(archivePath, expectedHash) {
-  if (expectedHash === null) return;
+  if (typeof expectedHash !== "string" || expectedHash.length === 0) {
+    throw new Error(
+      "[SECURITY] missing expected checksum; refusing to install an unverified binary."
+    );
+  }
 
   // Stream the file to avoid loading the entire archive into memory.
   // Archives can be 10-100MB; streaming keeps RSS constant.

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -131,6 +131,17 @@ describe("verifyChecksum", () => {
       }
     );
   });
+
+  it("verifyChecksum throws [SECURITY] on null/empty expectedHash (fail-closed)", () => {
+    const filePath = makeTmpFile("content");
+    assert.throws(
+      () => verifyChecksum(filePath, null),
+      (err) => {
+        assert.match(err.message, /^\[SECURITY\]/);
+        return true;
+      }
+    );
+  });
 });
 
 describe("assertAllowedHost", () => {

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -134,13 +134,15 @@ describe("verifyChecksum", () => {
 
   it("verifyChecksum throws [SECURITY] on null/empty expectedHash (fail-closed)", () => {
     const filePath = makeTmpFile("content");
-    assert.throws(
-      () => verifyChecksum(filePath, null),
-      (err) => {
-        assert.match(err.message, /^\[SECURITY\]/);
-        return true;
-      }
-    );
+    for (const expectedHash of [null, ""]) {
+      assert.throws(
+        () => verifyChecksum(filePath, expectedHash),
+        (err) => {
+          assert.match(err.message, /^\[SECURITY\]/);
+          return true;
+        }
+      );
+    }
   });
 });
 

--- a/scripts/install.test.js
+++ b/scripts/install.test.js
@@ -52,11 +52,17 @@ describe("getExpectedChecksum", () => {
     );
   });
 
-  it("returns null when checksums.txt does not exist", () => {
+  it("throws [SECURITY] when checksums.txt does not exist (fail-closed)", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "checksum-test-"));
     // No checksums.txt in dir
-    const result = getExpectedChecksum("anything.tar.gz", dir);
-    assert.equal(result, null);
+    assert.throws(
+      () => getExpectedChecksum("anything.tar.gz", dir),
+      (err) => {
+        assert.match(err.message, /^\[SECURITY\]/);
+        assert.match(err.message, /checksums\.txt not found/);
+        return true;
+      }
+    );
   });
 
   it("skips malformed lines and still finds valid entry", () => {


### PR DESCRIPTION
## Summary

The npm `postinstall` (`scripts/install.js`) verifies the downloaded Go binary against the package-shipped `checksums.txt`, but previously **skipped verification entirely when `checksums.txt` was missing** (fail-open) — letting an unverified or tampered binary install silently. This change makes it **fail-closed**: a missing manifest now aborts the install with a clear `[SECURITY]` error and a non-zero exit, so an unverified binary is never copied into place.

## Changes

- `scripts/install.js`: `getExpectedChecksum` now throws `[SECURITY] checksums.txt not found; refusing to install an unverified binary.` when `checksums.txt` is missing (previously logged `[WARN]` and returned `null` to skip verification).
- `scripts/install.js`: `verifyChecksum` now throws `[SECURITY] missing expected checksum; ...` for a non-string/empty expected hash, replacing the silent `if (expectedHash === null) return;` early-return (the second half of the fail-open path).
- `scripts/install.test.js`: updated the missing-manifest case to assert the fail-closed throw; added a regression test for the empty-hash guard.

Normal installs are unaffected: published packages always ship `checksums.txt` (`package.json` `files` includes it and the release workflow enforces its presence before publish). A missing manifest only occurs for tampered or non-standard packages — exactly what fail-closed should reject.

## Test Plan

- [x] `node --test scripts/install.test.js` passed (33/33)
- [x] validate passed (build / vet / unit / integration; zero Go change)
- [x] local-eval: E2E N/A (postinstall script, no CLI E2E), skillave N/A (no shortcut/skill change)
- [x] acceptance-reviewer passed (5/5 cases)
- [x] manual verification: stubbed the download and ran the full `install()` path with no `checksums.txt` — aborted with `[SECURITY]`, exit 1, no binary written to `bin/`; with a valid `checksums.txt` it passed the checksum gate

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened installer security by enforcing strict checksum validation. The installer now refuses to proceed when checksum data is missing or incomplete, preventing installation of unverified or potentially tampered binaries.
* **Tests**
  * Updated checksum verification tests to enforce fail-closed behavior when checksum data is missing and when the expected hash is null or empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->