### PR TITLE
docs(lark-drive): 明确评论"活跃口径"（is_solved + content_deleted）

### DIFF
--- a/skills/lark-drive/references/lark-drive-list-comments.md
+++ b/skills/lark-drive/references/lark-drive-list-comments.md
@@ -10,6 +10,26 @@
 - 仅当用户明确要求“包含已解决评论”“已解决和未解决都要”“全部历史评论”这类语义时，才传 `--solved-status all`。
 - 是否还有下一页以输出里的 `has_more` 为准；`page_token` 只作为 `has_more=true` 时续跑下一页的游标。
 
+### 活跃评论口径（仅 docx）
+
+默认的 `--solved-status false` 只排除已解决评论。对 docx，评论引用的正文被服务端明确标记为已删除后，API 仍可能返回该条目。用户要统计“活跃评论”或希望结果更接近 UI 默认评论视图时，带 `--need-relation`，并在每页排除 `relation.content_deleted=true`（字段详解见 [`lark-drive-comment-location.md`](lark-drive-comment-location.md)）。
+
+> 本指南的“活跃评论”口径 = `is_solved=false` 且 `relation.content_deleted != true`
+
+```bash
+# 当前页活跃评论：未解决 + 引用内容未明确标记为已删除；保留分页字段。
+lark-cli drive +list-comments \
+  --url "<DOCX_URL>" \
+  --solved-status false \
+  --need-relation \
+  --page-size 100 \
+  -q '.data | .items |= map(select(.relation.content_deleted != true)) | .count = (.items | length)'
+```
+
+这段 `-q` 会保留 `has_more` 和 `page_token`。若 `has_more=true`，继续传 `--page-token`，每页应用同一过滤后再汇总。`relation` 缺失或为 `null` 的条目会被保留，表示“未知或不适用”，不代表已确认引用内容仍存在；该口径通常比只使用 `is_solved=false` 更接近 UI 默认评论视图，但不是 UI 可见性的完整或稳定判定。`--need-relation` 仅对 docx 生效。
+
+一次真实 docx 观测中，45 条评论可拆为 8 条已解决、16 条 `content_deleted=true` 和 21 条符合本口径的活跃评论；该结果是观测示例，不代表 API 字段与所有客户端 UI 状态恒等。
+
 ## 命令
 
 ```bash
@@ -51,6 +71,7 @@ lark-cli drive +list-comments --url "<DOCUMENT_URL>" --solved-status all
 ## 统计口径
 
 - 统计“评论数”或“评论卡片数”：统计 `items` 长度；全量统计时对所有分页返回的 `items` 长度累加。
+- 统计“活跃评论数”（仅 docx，按本指南口径）：使用默认或显式的 `--solved-status false`，带 `--need-relation`，逐页排除 `relation.content_deleted=true` 后累加；不要把已解决评论或明确标记为引用内容已删除的评论计入。
 - 统计“回复数”：统计所有 `item.reply_list.replies` 长度之和，再减去 `items` 长度。
 - 统计“总互动数”：统计所有 `item.reply_list.replies` 长度之和，包含每张评论卡片里的首条评论。
 - 任一 `item.has_more=true` 时，先用 `drive +list-replies --comment-id <id>` 把该卡片的回复拉全，再做回复数或总互动数统计，否则会少算。


### PR DESCRIPTION
## Summary

`drive +list-comments` 默认只查询未解决评论，但这仍会包含 `relation.content_deleted=true` 的条目。对 docx 评论，这类条目表示引用内容已被服务端明确标记为删除；如果直接计入“活跃评论”，统计会偏高。

本 PR 在当前 `+list-comments` 文档中补充 docx 的“活跃评论”口径，并明确它通常更接近 UI 默认评论视图，但不是 UI 可见性的完整或稳定判定。

## Changes

- 在 `skills/lark-drive/references/lark-drive-list-comments.md` 增加“活跃评论口径（仅 docx）”：
  - 口径：`is_solved=false` 且 `relation.content_deleted != true`
  - 使用当前 `drive +list-comments --need-relation` shortcut
  - 提供保留 `has_more` / `page_token` 的可复制 `-q` 过滤命令
  - 明确逐页过滤与汇总，避免只统计第一页
  - 明确 `relation` 缺失或为 `null` 时按“未知或不适用”保留
  - 限定为 docx，并避免把该字段表述为 UI 可见性的充要条件
- 在“统计口径”中补充活跃评论数的计算规则。
- 适配最新 `main`：旧的 `lark-drive-comments-guide.md` 已在 #1898 拆分删除，因此规则迁移到当前评论列表 SSOT，而不是恢复旧文件。

## Test Plan

- [x] `git diff --check upstream/main...HEAD`
- [x] `node scripts/skill-format-check/index.js`
- [x] `bash scripts/check-doc-tokens.sh skills/lark-drive`
- [x] `QUALITY_GATE_CHANGED_FROM=upstream/main make quality-gate`
- [x] `make unit-test`
- [x] `go vet ./...`
- [x] `gofmt -l .` 无输出
- [x] `go mod tidy` 后 `go.mod` / `go.sum` 无变化
- [x] `golangci-lint v2.1.6 --new-from-rev=upstream/main`：0 issues
- [x] 纯文档改动，无代码或依赖变化

## Related Issues

- 背景见 #1111；字段能力由 #1258 提供（`need_relation` / `content_deleted`）
- 当前评论列表 shortcut 由 #1845 引入，评论文档结构由 #1898 更新
- 替代此前 #1114 的 shortcut 方案：当前 `+list-comments` 已暴露 `--need-relation`，本 PR 补足统计口径与过滤示例
