### PR TITLE
fix: pin fetch_meta.py output to utf-8 encoding

### DIFF
--- a/scripts/fetch_meta.py
+++ b/scripts/fetch_meta.py
@@ -89,7 +89,7 @@ def main():
     count = len(data.get("services", []))
     print(f"fetch-meta: OK, {count} services from remote API", file=sys.stderr)
 
-    with open(OUT_PATH, "w", encoding="utf-8") as fp:
+    with open(OUT_PATH, "w", encoding="utf-8", newline="\n") as fp:
         json.dump(data, fp, ensure_ascii=False, indent=2)
         fp.write("\n")
 

--- a/scripts/fetch_meta.py
+++ b/scripts/fetch_meta.py
@@ -89,7 +89,7 @@ def main():
     count = len(data.get("services", []))
     print(f"fetch-meta: OK, {count} services from remote API", file=sys.stderr)
 
-    with open(OUT_PATH, "w") as fp:
+    with open(OUT_PATH, "w", encoding="utf-8") as fp:
         json.dump(data, fp, ensure_ascii=False, indent=2)
         fp.write("\n")
 


### PR DESCRIPTION
Pin the output file to UTF-8 when writing `meta_data.json`.

`open()` without `encoding=` follows the host locale, so `json.dump(ensure_ascii=False)` wrote Chinese metadata in the system encoding — GBK/mojibake on Chinese Windows, and a crash under cp1252/ascii locales. The read path already pins `encoding="utf-8"`; this aligns the write to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata file writing to consistently use UTF-8 encoding and normalize line endings, ensuring reliable processing across different system environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->