### PR TITLE
chore: release v1.0.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.56] - 2026-06-18
+
+### Features
+
+- **apps**: Add `+session-messages-list` for session turn reply messages (#1402)
+
+### Bug Fixes
+
+- **api**: Align API success envelopes (#1489)
+- **base**: Reject out-of-range pagination flags (#1495)
+
+### Refactor
+
+- Retire legacy error envelopes and enforce typed contract (#1449)
+
+### Documentation
+
+- **skills**: Soften lark-doc style guidance (#1463)
+
+### Build
+
+- Add CI quality gate with semantic review
+
 ## [v1.0.55] - 2026-06-16
 
 ### Features
@@ -1189,6 +1212,7 @@ Bundled AI agent skills for intelligent assistance:
 - Bilingual documentation (English & Chinese).
 - CI/CD pipelines: linting, testing, coverage reporting, and automated releases.
 
+[v1.0.56]: https://github.com/larksuite/cli/releases/tag/v1.0.56
 [v1.0.55]: https://github.com/larksuite/cli/releases/tag/v1.0.55
 [v1.0.54]: https://github.com/larksuite/cli/releases/tag/v1.0.54
 [v1.0.53]: https://github.com/larksuite/cli/releases/tag/v1.0.53

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@larksuite/cli",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "description": "The official CLI for Lark/Feishu open platform",
   "bin": {
     "lark-cli": "scripts/run.js"


### PR DESCRIPTION
## Release v1.0.56

Bumps version `1.0.55` → `1.0.56` and updates the changelog for the 7 commits since the last release.

### Features

- **apps**: Add `+session-messages-list` for session turn reply messages (#1402)

### Bug Fixes

- **api**: Align API success envelopes (#1489)
- **base**: Reject out-of-range pagination flags (#1495)

### Refactor

- Retire legacy error envelopes and enforce typed contract (#1449)

### Documentation

- **skills**: Soften lark-doc style guidance (#1463)

### Build

- Add CI quality gate with semantic review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to v1.0.56

* **Documentation**
  * Release changelog updated with features, bug fixes, refactoring, documentation improvements, and build updates for v1.0.56

<!-- end of auto-generated comment: release notes by coderabbit.ai -->