### PR TITLE
feat(sheets): resolve wiki URLs to the backing spreadsheet for --url

### DIFF
--- a/shortcuts/sheets/execute_paths_test.go
+++ b/shortcuts/sheets/execute_paths_test.go
@@ -63,6 +63,66 @@ func TestExecute_WorkbookInfo_ToolError(t *testing.T) {
 	}
 }
 
+// TestExecute_WikiURLResolvesToSheet covers the two-step wiki path: a /wiki/
+// URL is resolved via get_node to its spreadsheet obj_token, which then feeds
+// the tool invoke. The tool stub is keyed on the resolved obj_token, so the
+// test would fail if the node_token were used unresolved.
+func TestExecute_WikiURLResolvesToSheet(t *testing.T) {
+	t.Parallel()
+	getNode := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":  "sheet",
+					"obj_token": testToken,
+				},
+			},
+		},
+	}
+	tool := toolOutputStub(testToken, "read", `{"sheets":[{"sheet_id":"sh1","title":"Sheet1","index":0}]}`)
+	out, err := runShortcutWithStubs(t, WorkbookInfo,
+		[]string{"--url", "https://example.feishu.cn/wiki/wikTestNODE"}, getNode, tool)
+	if err != nil {
+		t.Fatalf("execute failed: %v\nout=%s", err, out)
+	}
+	data := decodeEnvelopeData(t, out)
+	if sheets, _ := data["sheets"].([]interface{}); len(sheets) != 1 {
+		t.Fatalf("sheets len = %d, want 1; out=%s", len(sheets), out)
+	}
+}
+
+// TestExecute_WikiURLWrongObjType rejects a wiki node that resolves to a
+// non-spreadsheet obj_type before any tool invoke.
+func TestExecute_WikiURLWrongObjType(t *testing.T) {
+	t.Parallel()
+	getNode := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":  "docx",
+					"obj_token": "docABC",
+				},
+			},
+		},
+	}
+	out, err := runShortcutWithStubs(t, WorkbookInfo,
+		[]string{"--url", "https://example.feishu.cn/wiki/wikTestNODE"}, getNode)
+	if err == nil {
+		t.Fatalf("want error for non-sheet wiki node; out=%s", out)
+	}
+	if !strings.Contains(err.Error(), "obj_type") {
+		t.Fatalf("error = %v, want mention of obj_type", err)
+	}
+}
+
 // TestExecute_SheetMove_LookupsIndex covers the two-step path: SheetMove
 // when only --sheet-name is given (and --source-index omitted) first
 // reads the workbook structure to derive sheet_id + source_index, then

--- a/shortcuts/sheets/execute_paths_test.go
+++ b/shortcuts/sheets/execute_paths_test.go
@@ -121,6 +121,37 @@ func TestExecute_WikiURLWrongObjType(t *testing.T) {
 	if !strings.Contains(err.Error(), "obj_type") {
 		t.Fatalf("error = %v, want mention of obj_type", err)
 	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("wrong-obj_type error = %T, want *errs.ValidationError", err)
+	}
+}
+
+// TestExecute_WikiURLIncompleteNode treats an incomplete get_node response
+// (missing obj_type/obj_token) as an internal/server error, not a user --url
+// validation error.
+func TestExecute_WikiURLIncompleteNode(t *testing.T) {
+	t.Parallel()
+	getNode := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{},
+			},
+		},
+	}
+	_, err := runShortcutWithStubs(t, WorkbookInfo,
+		[]string{"--url", "https://example.feishu.cn/wiki/wikTestNODE"}, getNode)
+	if err == nil {
+		t.Fatal("want error for incomplete get_node node data")
+	}
+	var ve *errs.ValidationError
+	if errors.As(err, &ve) {
+		t.Fatalf("incomplete-data error classified as validation (%v); want internal", err)
+	}
 }
 
 // TestExecute_SheetMove_LookupsIndex covers the two-step path: SheetMove

--- a/shortcuts/sheets/helpers.go
+++ b/shortcuts/sheets/helpers.go
@@ -49,29 +49,132 @@ func sheetsInputStatError(flag string, err error) error {
 	return wrapped
 }
 
-// resolveSpreadsheetToken applies the public --url / --spreadsheet-token XOR
-// pair shared by every sheets canonical shortcut and returns the resolved
-// token. Network-free, safe to call from Validate and DryRun.
-func resolveSpreadsheetToken(runtime *common.RuntimeContext) (string, error) {
+// spreadsheetRef classification: a --url / --spreadsheet-token input names a
+// spreadsheet either directly (a /sheets/ URL or raw token) or indirectly via a
+// wiki node that must be resolved to its backing spreadsheet at Execute time.
+const (
+	spreadsheetRefSheet = "sheet"
+	spreadsheetRefWiki  = "wiki"
+)
+
+// spreadsheetRef is a parsed --url / --spreadsheet-token input. A wiki ref holds
+// the still-unresolved wiki node_token; resolveSpreadsheetTokenExec turns it
+// into the real spreadsheet token at Execute time.
+type spreadsheetRef struct {
+	Kind  string // spreadsheetRefSheet | spreadsheetRefWiki
+	Token string
+}
+
+// parseSpreadsheetRef applies the public --url / --spreadsheet-token XOR pair and
+// classifies the input. Network-free, safe to call from Validate and DryRun.
+//
+// Recognized --url shapes:
+//   - https://.../sheets/<token>        → {sheet, token}
+//   - https://.../spreadsheets/<token>  → {sheet, token}
+//   - https://.../wiki/<node_token>     → {wiki, node_token}  (resolved at Execute)
+//
+// A raw --spreadsheet-token is always treated as a spreadsheet token; wiki nodes
+// only ever arrive as a /wiki/ URL.
+func parseSpreadsheetRef(runtime *common.RuntimeContext) (spreadsheetRef, error) {
 	if err := common.ExactlyOneTyped(runtime, "url", "spreadsheet-token"); err != nil {
-		return "", err
+		return spreadsheetRef{}, err
 	}
 	if token := strings.TrimSpace(runtime.Str("spreadsheet-token")); token != "" {
 		if err := validate.RejectControlChars(token, "spreadsheet-token"); err != nil {
-			return "", sheetsValidationCauseForFlag("spreadsheet-token", err)
+			return spreadsheetRef{}, sheetsValidationCauseForFlag("spreadsheet-token", err)
 		}
-		return token, nil
+		return spreadsheetRef{Kind: spreadsheetRefSheet, Token: token}, nil
 	}
 
 	url := strings.TrimSpace(runtime.Str("url"))
+	if node := tokenAfterURLPrefix(url, "/wiki/"); node != "" {
+		if err := validate.RejectControlChars(node, "url"); err != nil {
+			return spreadsheetRef{}, sheetsValidationCauseForFlag("url", err)
+		}
+		return spreadsheetRef{Kind: spreadsheetRefWiki, Token: node}, nil
+	}
 	token := extractSpreadsheetToken(url)
 	if token == "" || token == url {
-		return "", sheetsValidationForFlag("url", "--url must be a spreadsheet URL like https://.../sheets/<token>")
+		return spreadsheetRef{}, sheetsValidationForFlag("url", "--url must be a spreadsheet URL like https://.../sheets/<token> or a wiki URL like https://.../wiki/<token>")
 	}
 	if err := validate.RejectControlChars(token, "url"); err != nil {
-		return "", sheetsValidationCauseForFlag("url", err)
+		return spreadsheetRef{}, sheetsValidationCauseForFlag("url", err)
 	}
-	return token, nil
+	return spreadsheetRef{Kind: spreadsheetRefSheet, Token: token}, nil
+}
+
+// tokenAfterURLPrefix returns the path segment following the first occurrence of
+// prefix in input, stopping at the next /?# boundary. Returns "" when prefix is
+// absent or the following segment is empty. Substring-based to match
+// extractSpreadsheetToken's lenient, host-agnostic parsing.
+func tokenAfterURLPrefix(input, prefix string) string {
+	idx := strings.Index(input, prefix)
+	if idx < 0 {
+		return ""
+	}
+	token := input[idx+len(prefix):]
+	if j := strings.IndexAny(token, "/?#"); j >= 0 {
+		token = token[:j]
+	}
+	return strings.TrimSpace(token)
+}
+
+// resolveSpreadsheetToken applies the public --url / --spreadsheet-token XOR pair
+// and returns the resolved token. Network-free, safe to call from Validate and
+// DryRun.
+//
+// A /wiki/ URL yields the still-unresolved wiki node_token: turning it into the
+// backing spreadsheet token needs a get_node call, which only Execute may make.
+// Validate/DryRun only need a non-empty, control-char-clean token, so the
+// node_token passes through unchanged here; Execute paths call
+// resolveSpreadsheetTokenExec instead.
+func resolveSpreadsheetToken(runtime *common.RuntimeContext) (string, error) {
+	ref, err := parseSpreadsheetRef(runtime)
+	if err != nil {
+		return "", err
+	}
+	return ref.Token, nil
+}
+
+// resolveSpreadsheetTokenExec is the Execute-time counterpart of
+// resolveSpreadsheetToken: it additionally resolves a /wiki/ URL's node_token to
+// the backing spreadsheet token via wiki get_node, verifying obj_type=sheet.
+// Non-wiki inputs make no API call. Use this from every sheets Execute hook and
+// keep resolveSpreadsheetToken in Validate/DryRun so those stay network-free.
+func resolveSpreadsheetTokenExec(runtime *common.RuntimeContext) (string, error) {
+	ref, err := parseSpreadsheetRef(runtime)
+	if err != nil {
+		return "", err
+	}
+	if ref.Kind != spreadsheetRefWiki {
+		return ref.Token, nil
+	}
+	return resolveWikiNodeToSpreadsheetToken(runtime, ref.Token)
+}
+
+// resolveWikiNodeToSpreadsheetToken resolves a wiki node_token to the spreadsheet
+// obj_token it points at, erroring when the node is not a spreadsheet. The
+// wiki:node:read scope is only needed on this path, so it is enforced here rather
+// than declared unconditionally on every sheets shortcut.
+func resolveWikiNodeToSpreadsheetToken(runtime *common.RuntimeContext, nodeToken string) (string, error) {
+	if err := runtime.EnsureScopes([]string{"wiki:node:read"}); err != nil {
+		return "", err
+	}
+	data, err := runtime.CallAPI("GET", "/open-apis/wiki/v2/spaces/get_node",
+		map[string]interface{}{"token": nodeToken}, nil)
+	if err != nil {
+		return "", err
+	}
+	node := common.GetMap(data, "node")
+	objType := common.GetString(node, "obj_type")
+	objToken := common.GetString(node, "obj_token")
+	if objType == "" || objToken == "" {
+		return "", sheetsValidationForFlag("url", "wiki node %q returned incomplete data from get_node", nodeToken)
+	}
+	if objType != "sheet" {
+		return "", sheetsValidationForFlag("url", "wiki URL resolves to obj_type=%q, but a spreadsheet (obj_type=sheet) is required", objType)
+	}
+	return objToken, nil
 }
 
 // extractSpreadsheetToken pulls the token segment out of a /sheets/<token>

--- a/shortcuts/sheets/helpers.go
+++ b/shortcuts/sheets/helpers.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	neturl "net/url"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
@@ -86,37 +87,56 @@ func parseSpreadsheetRef(runtime *common.RuntimeContext) (spreadsheetRef, error)
 		return spreadsheetRef{Kind: spreadsheetRefSheet, Token: token}, nil
 	}
 
-	url := strings.TrimSpace(runtime.Str("url"))
-	if node := tokenAfterURLPrefix(url, "/wiki/"); node != "" {
-		if err := validate.RejectControlChars(node, "url"); err != nil {
-			return spreadsheetRef{}, sheetsValidationCauseForFlag("url", err)
-		}
-		return spreadsheetRef{Kind: spreadsheetRefWiki, Token: node}, nil
-	}
-	token := extractSpreadsheetToken(url)
-	if token == "" || token == url {
+	rawURL := strings.TrimSpace(runtime.Str("url"))
+	token, kind, ok := spreadsheetURLToken(rawURL)
+	if !ok {
 		return spreadsheetRef{}, sheetsValidationForFlag("url", "--url must be a spreadsheet URL like https://.../sheets/<token> or a wiki URL like https://.../wiki/<token>")
 	}
 	if err := validate.RejectControlChars(token, "url"); err != nil {
 		return spreadsheetRef{}, sheetsValidationCauseForFlag("url", err)
 	}
-	return spreadsheetRef{Kind: spreadsheetRefSheet, Token: token}, nil
+	return spreadsheetRef{Kind: kind, Token: token}, nil
 }
 
-// tokenAfterURLPrefix returns the path segment following the first occurrence of
-// prefix in input, stopping at the next /?# boundary. Returns "" when prefix is
-// absent or the following segment is empty. Substring-based to match
-// extractSpreadsheetToken's lenient, host-agnostic parsing.
-func tokenAfterURLPrefix(input, prefix string) string {
-	idx := strings.Index(input, prefix)
-	if idx < 0 {
-		return ""
+// spreadsheetURLToken extracts the token and its kind from a Lark URL, matching
+// only on the URL *path* segment (parsed via net/url). A /wiki/ or /sheets/ that
+// appears only in the query or fragment (e.g. a redirect or anchor param) never
+// hijacks classification. Returns ok=false when no known prefix heads the path.
+func spreadsheetURLToken(rawURL string) (token, kind string, ok bool) {
+	u, err := neturl.Parse(rawURL)
+	if err != nil || u.Path == "" {
+		return "", "", false
 	}
-	token := input[idx+len(prefix):]
-	if j := strings.IndexAny(token, "/?#"); j >= 0 {
-		token = token[:j]
+	for _, m := range []struct {
+		prefix string
+		kind   string
+	}{
+		{"/sheets/", spreadsheetRefSheet},
+		{"/spreadsheets/", spreadsheetRefSheet},
+		{"/wiki/", spreadsheetRefWiki},
+	} {
+		if seg, found := pathSegmentAfter(u.Path, m.prefix); found {
+			return seg, m.kind, true
+		}
 	}
-	return strings.TrimSpace(token)
+	return "", "", false
+}
+
+// pathSegmentAfter returns the first path segment after prefix when path begins
+// with prefix, else ("", false).
+func pathSegmentAfter(path, prefix string) (string, bool) {
+	if !strings.HasPrefix(path, prefix) {
+		return "", false
+	}
+	rest := path[len(prefix):]
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		rest = rest[:i]
+	}
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		return "", false
+	}
+	return rest, true
 }
 
 // resolveSpreadsheetToken applies the public --url / --spreadsheet-token XOR pair
@@ -160,7 +180,7 @@ func resolveWikiNodeToSpreadsheetToken(runtime *common.RuntimeContext, nodeToken
 	if err := runtime.EnsureScopes([]string{"wiki:node:read"}); err != nil {
 		return "", err
 	}
-	data, err := runtime.CallAPI("GET", "/open-apis/wiki/v2/spaces/get_node",
+	data, err := runtime.CallAPITyped("GET", "/open-apis/wiki/v2/spaces/get_node",
 		map[string]interface{}{"token": nodeToken}, nil)
 	if err != nil {
 		return "", err
@@ -169,29 +189,12 @@ func resolveWikiNodeToSpreadsheetToken(runtime *common.RuntimeContext, nodeToken
 	objType := common.GetString(node, "obj_type")
 	objToken := common.GetString(node, "obj_token")
 	if objType == "" || objToken == "" {
-		return "", sheetsValidationForFlag("url", "wiki node %q returned incomplete data from get_node", nodeToken)
+		return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki get_node returned incomplete node data for %q", nodeToken)
 	}
 	if objType != "sheet" {
 		return "", sheetsValidationForFlag("url", "wiki URL resolves to obj_type=%q, but a spreadsheet (obj_type=sheet) is required", objType)
 	}
 	return objToken, nil
-}
-
-// extractSpreadsheetToken pulls the token segment out of a /sheets/<token>
-// or /spreadsheets/<token> URL. Returns the input unchanged when no known
-// prefix is present (callers must check token != originalInput).
-func extractSpreadsheetToken(input string) string {
-	input = strings.TrimSpace(input)
-	for _, prefix := range []string{"/sheets/", "/spreadsheets/"} {
-		if idx := strings.Index(input, prefix); idx >= 0 {
-			token := input[idx+len(prefix):]
-			if idx2 := strings.IndexAny(token, "/?#"); idx2 >= 0 {
-				token = token[:idx2]
-			}
-			return token
-		}
-	}
-	return input
 }
 
 // resolveSheetSelector validates the --sheet-id / --sheet-name XOR and

--- a/shortcuts/sheets/helpers_test.go
+++ b/shortcuts/sheets/helpers_test.go
@@ -268,3 +268,51 @@ const (
 	testSheetID  = "shtSubA"
 	testSheetID2 = "shtSubB"
 )
+
+// TestParseSpreadsheetRef locks the network-free classification of
+// --url / --spreadsheet-token into a sheet token vs an (unresolved) wiki
+// node_token. The wiki node is resolved later, at Execute time only.
+func TestParseSpreadsheetRef(t *testing.T) {
+	t.Parallel()
+	mk := func(url, tok string) *common.RuntimeContext {
+		cmd := &cobra.Command{Use: "sheets"}
+		cmd.Flags().String("url", url, "")
+		cmd.Flags().String("spreadsheet-token", tok, "")
+		return common.TestNewRuntimeContext(cmd, testConfig(t))
+	}
+	cases := []struct {
+		name      string
+		url       string
+		tok       string
+		wantKind  string
+		wantToken string
+		wantErr   bool
+	}{
+		{name: "sheets url", url: "https://x.feishu.cn/sheets/shtABC", wantKind: spreadsheetRefSheet, wantToken: "shtABC"},
+		{name: "spreadsheets url", url: "https://x.feishu.cn/spreadsheets/shtABC", wantKind: spreadsheetRefSheet, wantToken: "shtABC"},
+		{name: "wiki url", url: "https://x.feishu.cn/wiki/wikDEF", wantKind: spreadsheetRefWiki, wantToken: "wikDEF"},
+		{name: "wiki url with query", url: "https://x.feishu.cn/wiki/wikDEF?sheet=xxxxxx", wantKind: spreadsheetRefWiki, wantToken: "wikDEF"},
+		{name: "raw token", tok: "shtRAW", wantKind: spreadsheetRefSheet, wantToken: "shtRAW"},
+		{name: "docx url unsupported", url: "https://x.feishu.cn/docx/docABC", wantErr: true},
+		{name: "neither provided", wantErr: true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ref, err := parseSpreadsheetRef(mk(tc.url, tc.tok))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got ref=%+v", ref)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ref.Kind != tc.wantKind || ref.Token != tc.wantToken {
+				t.Fatalf("ref = %+v, want {Kind:%s Token:%s}", ref, tc.wantKind, tc.wantToken)
+			}
+		})
+	}
+}

--- a/shortcuts/sheets/helpers_test.go
+++ b/shortcuts/sheets/helpers_test.go
@@ -293,6 +293,8 @@ func TestParseSpreadsheetRef(t *testing.T) {
 		{name: "wiki url", url: "https://x.feishu.cn/wiki/wikDEF", wantKind: spreadsheetRefWiki, wantToken: "wikDEF"},
 		{name: "wiki url with query", url: "https://x.feishu.cn/wiki/wikDEF?sheet=xxxxxx", wantKind: spreadsheetRefWiki, wantToken: "wikDEF"},
 		{name: "raw token", tok: "shtRAW", wantKind: spreadsheetRefSheet, wantToken: "shtRAW"},
+		{name: "sheets url with /wiki/ in query stays sheet", url: "https://x.feishu.cn/sheets/shtABC?from=/wiki/wikX", wantKind: spreadsheetRefSheet, wantToken: "shtABC"},
+		{name: "sheets url with /wiki/ in fragment stays sheet", url: "https://x.feishu.cn/sheets/shtABC#/wiki/wikX", wantKind: spreadsheetRefSheet, wantToken: "shtABC"},
 		{name: "docx url unsupported", url: "https://x.feishu.cn/docx/docABC", wantErr: true},
 		{name: "neither provided", wantErr: true},
 	}

--- a/shortcuts/sheets/lark_sheet_batch_update.go
+++ b/shortcuts/sheets/lark_sheet_batch_update.go
@@ -67,7 +67,7 @@ var BatchUpdate = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "batch_update", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -180,7 +180,7 @@ var CellsBatchSetStyle = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "batch_update", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -270,7 +270,7 @@ var CellsBatchClear = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "batch_update", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -350,7 +350,7 @@ var DropdownUpdate = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "batch_update", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -396,7 +396,7 @@ var DropdownDelete = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "batch_update", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/sheets/lark_sheet_object_crud.go
+++ b/shortcuts/sheets/lark_sheet_object_crud.go
@@ -155,7 +155,7 @@ func newObjectCreateShortcut(spec objectCRUDSpec) common.Shortcut {
 			return dr
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			token, err := resolveSpreadsheetToken(runtime)
+			token, err := resolveSpreadsheetTokenExec(runtime)
 			if err != nil {
 				return err
 			}
@@ -244,7 +244,7 @@ func newObjectUpdateShortcut(spec objectCRUDSpec) common.Shortcut {
 			return invokeToolDryRun(token, ToolKindWrite, spec.toolName, input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			token, err := resolveSpreadsheetToken(runtime)
+			token, err := resolveSpreadsheetTokenExec(runtime)
 			if err != nil {
 				return err
 			}
@@ -328,7 +328,7 @@ func newObjectDeleteShortcut(spec objectCRUDSpec) common.Shortcut {
 			return invokeToolDryRun(token, ToolKindWrite, spec.toolName, input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			token, err := resolveSpreadsheetToken(runtime)
+			token, err := resolveSpreadsheetTokenExec(runtime)
 			if err != nil {
 				return err
 			}
@@ -876,7 +876,7 @@ func newFloatImageWriteShortcut(command, description, op string, withIDFlag, isH
 			return invokeToolDryRun(token, ToolKindWrite, "manage_float_image_object", input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			token, err := resolveSpreadsheetToken(runtime)
+			token, err := resolveSpreadsheetTokenExec(runtime)
 			if err != nil {
 				return err
 			}
@@ -1026,7 +1026,7 @@ var FilterCreate = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "manage_filter_object", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -1101,7 +1101,7 @@ var FilterUpdate = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "manage_filter_object", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -1169,7 +1169,7 @@ var FilterDelete = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "manage_filter_object", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/sheets/lark_sheet_object_list.go
+++ b/shortcuts/sheets/lark_sheet_object_list.go
@@ -57,7 +57,7 @@ func newObjectListShortcut(spec objectListSpec) common.Shortcut {
 			return invokeToolDryRun(token, ToolKindRead, spec.toolName, objectListInput(runtime, token, sheetID, sheetName, spec))
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			token, err := resolveSpreadsheetToken(runtime)
+			token, err := resolveSpreadsheetTokenExec(runtime)
 			if err != nil {
 				return err
 			}

--- a/shortcuts/sheets/lark_sheet_range_operations.go
+++ b/shortcuts/sheets/lark_sheet_range_operations.go
@@ -45,7 +45,7 @@ var CellsClear = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "clear_cell_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -163,7 +163,7 @@ func newMergeShortcut(command, desc, op string, withMergeType bool) common.Short
 			return invokeToolDryRun(token, ToolKindWrite, "merge_cells", input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			token, err := resolveSpreadsheetToken(runtime)
+			token, err := resolveSpreadsheetTokenExec(runtime)
 			if err != nil {
 				return err
 			}
@@ -239,7 +239,7 @@ var RowsResize = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "resize_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -279,7 +279,7 @@ var ColsResize = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "resize_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -451,7 +451,7 @@ var RangeFill = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "transform_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -490,7 +490,7 @@ var RangeSort = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "transform_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/sheets/lark_sheet_read_data.go
+++ b/shortcuts/sheets/lark_sheet_read_data.go
@@ -57,7 +57,7 @@ var CellsGet = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindRead, "get_cell_ranges", cellsGetInput(runtime, token, sheetID, sheetName))
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -150,7 +150,7 @@ var CsvGet = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindRead, "get_range_as_csv", csvGetInput(runtime, token, sheetID, sheetName))
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -269,7 +269,7 @@ var DropdownGet = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindRead, "get_cell_ranges", dropdownGetInput(runtime, token, sheetID, sheetName))
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/sheets/lark_sheet_search_replace.go
+++ b/shortcuts/sheets/lark_sheet_search_replace.go
@@ -46,7 +46,7 @@ var CellsSearch = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindRead, "search_data", searchInput(runtime, token, sheetID, sheetName))
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -122,7 +122,7 @@ var CellsReplace = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "replace_data", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/sheets/lark_sheet_sheet_structure.go
+++ b/shortcuts/sheets/lark_sheet_sheet_structure.go
@@ -51,7 +51,7 @@ var SheetInfo = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindRead, "get_sheet_structure", sheetInfoInput(runtime, token, sheetID, sheetName))
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -136,7 +136,7 @@ var DimInsert = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -211,7 +211,7 @@ var DimDelete = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -300,7 +300,7 @@ var DimFreeze = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -395,7 +395,7 @@ func newDimRangeOpShortcut(command, desc, op, risk string) common.Shortcut {
 			return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			token, err := resolveSpreadsheetToken(runtime)
+			token, err := resolveSpreadsheetTokenExec(runtime)
 			if err != nil {
 				return err
 			}
@@ -439,7 +439,7 @@ func newDimGroupShortcut(command, desc, op string) common.Shortcut {
 			return invokeToolDryRun(token, ToolKindWrite, "modify_sheet_structure", input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			token, err := resolveSpreadsheetToken(runtime)
+			token, err := resolveSpreadsheetTokenExec(runtime)
 			if err != nil {
 				return err
 			}
@@ -593,7 +593,7 @@ var DimMove = common.Shortcut{
 			Set("spreadsheet_token", token)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/sheets/lark_sheet_table_io.go
+++ b/shortcuts/sheets/lark_sheet_table_io.go
@@ -68,7 +68,7 @@ var TablePut = common.Shortcut{
 		return tablePutDryRun(runtime)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -1136,7 +1136,7 @@ var TableGet = common.Shortcut{
 		return dry
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}

--- a/shortcuts/sheets/lark_sheet_workbook.go
+++ b/shortcuts/sheets/lark_sheet_workbook.go
@@ -54,7 +54,7 @@ var WorkbookInfo = common.Shortcut{
 		})
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -99,7 +99,7 @@ var SheetCreate = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -221,7 +221,7 @@ var SheetDelete = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -263,7 +263,7 @@ var SheetRename = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -333,7 +333,7 @@ var SheetMove = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -405,7 +405,7 @@ var SheetCopy = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -478,7 +478,7 @@ func newSheetVisibilityShortcut(command, desc, op string) common.Shortcut {
 			return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 		},
 		Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-			token, err := resolveSpreadsheetToken(runtime)
+			token, err := resolveSpreadsheetTokenExec(runtime)
 			if err != nil {
 				return err
 			}
@@ -518,7 +518,7 @@ var SheetSetTabColor = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "modify_workbook_structure", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -1526,6 +1526,12 @@ var WorkbookExport = common.Shortcut{
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		p, err := workbookExportParams(runtime)
 		if err != nil {
+			return err
+		}
+		// workbookExportParams resolves --url network-free (DryRun shares it); a
+		// /wiki/ URL carries a node_token that needs the get_node step only
+		// Execute may take, so re-resolve the token here.
+		if p.Token, err = resolveSpreadsheetTokenExec(runtime); err != nil {
 			return err
 		}
 		applyWorkbookOutputPath(&p, runtime.FileIO(), runtime.Str("output-path"))

--- a/shortcuts/sheets/lark_sheet_write_cells.go
+++ b/shortcuts/sheets/lark_sheet_write_cells.go
@@ -56,7 +56,7 @@ var CellsSet = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "set_cell_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ var CellsSetStyle = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "set_cell_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -240,7 +240,7 @@ var CsvPut = common.Shortcut{
 		return dr
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -417,7 +417,7 @@ var DropdownSet = common.Shortcut{
 		return invokeToolDryRun(token, ToolKindWrite, "set_cell_range", input)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
@@ -804,7 +804,7 @@ var CellsSetImage = common.Shortcut{
 			Body(setCellBody)
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}

--- a/skills/lark-sheets/SKILL.md
+++ b/skills/lark-sheets/SKILL.md
@@ -107,8 +107,8 @@ metadata:
 **公共四件套** = `--url` / `--spreadsheet-token` / `--sheet-id` / `--sheet-name`，分成两组 XOR，**每组都必须给且只能给一个**（XOR = 二选一必填，不是"可选"）：
 
 1. **spreadsheet 定位（必填）**：`--url` 与 `--spreadsheet-token` 二选一，**必须给其中之一**。两个都不给 → 校验报错 `specify at least one of --url or --spreadsheet-token`；两个都给 → 互斥冲突。
-   - **`--url` 只解析 `/sheets/` 与 `/spreadsheets/` 两种链接**（从路径里抽出 token；也可以直接把裸 token 传给 `--spreadsheet-token`）。其它形态的链接不会被解析成表格 token。
-   - ⚠️ **`/wiki/` 知识库链接不能直接当表格定位用**：wiki 链接背后可能是电子表格，也可能是文档 / 多维表格等其它类型，`--url` **不会**自动把 wiki token 解析成 spreadsheet token，直接传会失败。必须先把它解析成真实文档 token —— `lark-cli wiki +node-get --node-token "<wiki 链接或 token>"`，确认返回的 `obj_type` 为 `sheet` 后，取其 `obj_token` 作为 `--spreadsheet-token` 传入（解析细节见 [`../lark-wiki/SKILL.md`](../lark-wiki/SKILL.md)）。
+   - **`--url` 解析 `/sheets/`、`/spreadsheets/` 与 `/wiki/` 三种链接**（从路径里抽出 token；也可以直接把裸 token 传给 `--spreadsheet-token`）。其它形态的链接不会被解析成表格 token。
+   - **`/wiki/` 知识库链接可直接传 `--url`**：会自动定位到链接背后的电子表格；若该链接背后不是电子表格（而是文档 / 多维表格等），则报错。
    - **例外**：`+workbook-create`（新建表 + 可选写入数据）与 `+workbook-import`（把本地文件导入为新表）都产出一张**还不存在**的表格，**不接受任何 spreadsheet / sheet 定位 flag**——`+workbook-create` 只有 `--title` / `--folder-token` / `--values` / `--styles` / `--sheets`，`+workbook-import` 只有 `--file`（必填）/ `--folder-token` / `--name`。
 2. **sheet 定位（公共四件套 shortcut 必填）**：`--sheet-id` 与 `--sheet-name` 二选一，**必须给其中之一**。两个都不给 → 校验报错 `specify at least one of --sheet-id or --sheet-name`。
    - ⚠️ **不确定 sheet 名时禁止直接猜 `Sheet1`**：除非用户对话明确说出 sheet 名 / id，或上下文（之前的工具调用 / URL 锚点 `?sheet=xxx`）已经出现过具体值，否则**第一步先调 `+workbook-info --url "..."`**（或 `--spreadsheet-token`）拿 `sheets[].sheet_id` / `sheets[].title` 列表再选。中文环境下子表常叫"数据" / "Sheet"（无数字）/ "工作表 1" / 业务名，猜 `Sheet1` 大概率撞 `sheet not found`，比先查多耗一次失败调用 + 重试。
@@ -118,7 +118,7 @@ metadata:
 
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
-| `--url` | string | 二选一必填（与 `--spreadsheet-token`） | spreadsheet URL |
+| `--url` | string | 二选一必填（与 `--spreadsheet-token`） | spreadsheet 或 wiki URL |
 | `--spreadsheet-token` | string | 二选一必填（与 `--url`） | spreadsheet token |
 | `--sheet-id` | string | 二选一必填（与 `--sheet-name`；仅公共四件套 shortcut） | 工作表 reference_id |
 | `--sheet-name` | string | 二选一必填（与 `--sheet-id`；仅公共四件套 shortcut） | 工作表名称 |


### PR DESCRIPTION
## 解决的问题

`lark-cli sheets` 的 `--url` 此前只识别 `/sheets/`（和 `/spreadsheets/`）链接。wiki 里的电子表格链接 `https://.../wiki/<node_token>` 会被拒绝（`--url must be a spreadsheet URL`），因为 wiki 的 `node_token` 不是 spreadsheet token——要拿到真正的表格 token 必须调一次 wiki `get_node`，而 `resolveSpreadsheetToken` 是 network-free 的（Validate/DryRun 共用，DryRun 不能联网）。

## 改动机制

照搬仓库里 slides / doc / drive 已有的「两阶段解析」：

- **parse（network-free）** `parseSpreadsheetRef`：把 `--url` / `--spreadsheet-token` 分类成 sheet token 或（未解析的）wiki node_token。
- **resolve（仅 Execute 联网）** `resolveSpreadsheetTokenExec`：wiki 时调 `get_node` 校验 `obj_type=sheet`，返回 `obj_token`；`wiki:node:read` scope 只在这条路径上 `EnsureScopes`，非 wiki 调用零影响。
- `resolveSpreadsheetToken` 保持 network-free 供 Validate/DryRun，wiki URL 放行 node_token。

47 处 Execute（含 `+batch-update`、`+workbook-export`）切到 Exec 版；Validate/DryRun 保持 network-free 版。

## 改动范围

13 文件，+273/-56，纯 `shortcuts/sheets/` 内 CLI 层逻辑。**不改 tool schema**——CLI 把解析后的 spreadsheet token 作为 `excel_id` 传给 tool，服务端契约不变，不涉及 base / sheet-skill-spec。

## 验证

- **单测**：`TestParseSpreadsheetRef`（7 case URL 分类）+ 2 个 wiki `get_node` e2e（httpmock）。
- **线上端到端**（真实 wiki 电子表格）：read `+workbook-info` / `+cells-get` / `+csv-get` / `+chart-list`，write `+sheet-create` / `+sheet-rename` / `+csv-put`（写入读回一致），全部 `ok`。
- 全仓 `go build` + `go vet` 通过。

## 备注

- `--url` 的 flag 描述（提示支持 wiki）按本仓规约走上游事实源 → sync，不在本 PR 手改 `data/flag-defs.json`，后续单独同步。
- DryRun 对 wiki URL 仍显示 node_token 作 `excel_id` 占位（execute 时才解析为真实 token）；如需精确预览可后续迭代。
