### PR TITLE
docs: add Community Integrations section with lark-mcp entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,16 @@ We recommend using the Lark/Feishu bot integrated with this tool as a private co
 
 Please fully understand all usage risks. By using this tool, you are deemed to voluntarily assume all related responsibilities.
 
+## Community Integrations
+
+Tools built by the community that extend lark-cli for specific use cases.
+
+| Tool | Description | Auth boundary | Scope |
+|------|-------------|---------------|-------|
+| [lark-mcp](https://github.com/yyu0310/lark-mcp) | MCP server for Claude Desktop App — wraps lark-cli so Claude can query Lark content directly | lark-cli OAuth token store; zero credentials in MCP config, safe to share | Read-only: wiki spaces, wiki nodes, doc read, IM search |
+
+Want to add your integration? Open an issue or PR with the same four-column format.
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=larksuite/cli&type=Date)](https://star-history.com/#larksuite/cli&Date)


### PR DESCRIPTION
## Summary

Follows up on #1522, where I proposed adding a Community Integrations section and the team suggested a structured metadata format.

Adds a **Community Integrations** section to README.md (before Star History), listing community-built tools that extend lark-cli.

- Single table with four columns: tool, description, auth boundary, data scope
- First entry: [lark-mcp](https://github.com/yyu0310/lark-mcp), an MCP server that wraps lark-cli for Claude Desktop App
- Includes an open invite for others to add their integrations via the same format

The four-column metadata format follows the suggestion in #1522 (Keesan12's comment), making auth boundaries and trust scope explicit at a glance.

## Test plan

- [ ] README renders correctly on GitHub (table displays, links resolve)
- [ ] Section fits naturally between Security and Star History