### PR TITLE
fix(sheets): translate rich text segment styles

### DIFF
--- a/shortcuts/sheets/lark_sheet_write_cells.go
+++ b/shortcuts/sheets/lark_sheet_write_cells.go
@@ -88,6 +88,7 @@ func cellsSetInput(runtime flagView, token, sheetID, sheetName string) (map[stri
 	if err != nil {
 		return nil, err
 	}
+	normalizeRichTextSegmentStyles(cells)
 	input := map[string]interface{}{
 		"excel_id": token,
 		"range":    strings.TrimSpace(runtime.Str("range")),
@@ -104,6 +105,82 @@ func cellsSetInput(runtime flagView, token, sheetID, sheetName string) (map[stri
 		return nil, err
 	}
 	return input, nil
+}
+
+func normalizeRichTextSegmentStyles(cells []interface{}) {
+	for _, rowValue := range cells {
+		row, ok := rowValue.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, cellValue := range row {
+			cell, ok := cellValue.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			segments, ok := cell["rich_text"].([]interface{})
+			if !ok {
+				continue
+			}
+			for _, segmentValue := range segments {
+				segment, ok := segmentValue.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				style, ok := segment["style"].(map[string]interface{})
+				if !ok {
+					continue
+				}
+				segmentStyle := map[string]interface{}{}
+				if existing, ok := segment["segmentStyle"].(map[string]interface{}); ok {
+					for k, v := range existing {
+						segmentStyle[k] = v
+					}
+				}
+				mergeRichTextStyle(segmentStyle, style)
+				if len(segmentStyle) > 0 {
+					segment["segmentStyle"] = segmentStyle
+				}
+				delete(segment, "style")
+			}
+		}
+	}
+}
+
+func mergeRichTextStyle(segmentStyle map[string]interface{}, style map[string]interface{}) {
+	if v, ok := style["font_color"]; ok {
+		segmentStyle["foreColor"] = v
+	}
+	if v, ok := style["font_size"]; ok {
+		segmentStyle["fontSize"] = v
+	}
+	if v, ok := style["font_weight"].(string); ok {
+		switch v {
+		case "bold":
+			segmentStyle["bold"] = true
+		case "normal":
+			segmentStyle["bold"] = false
+		}
+	}
+	if v, ok := style["font_style"].(string); ok {
+		switch v {
+		case "italic":
+			segmentStyle["italic"] = true
+		case "normal":
+			segmentStyle["italic"] = false
+		}
+	}
+	if v, ok := style["font_line"].(string); ok {
+		switch v {
+		case "line-through":
+			segmentStyle["strikeThrough"] = true
+		case "underline":
+			segmentStyle["underline"] = true
+		case "none":
+			segmentStyle["strikeThrough"] = false
+			segmentStyle["underline"] = false
+		}
+	}
 }
 
 // CellsSetStyle stamps a single style block across every cell in --range.

--- a/shortcuts/sheets/lark_sheet_write_cells_test.go
+++ b/shortcuts/sheets/lark_sheet_write_cells_test.go
@@ -115,6 +115,42 @@ func TestWriteCellsShortcuts_DryRun(t *testing.T) {
 	}
 }
 
+func TestCellsSet_RichTextStyleTranslatedToSegmentStyle(t *testing.T) {
+	t.Parallel()
+
+	body := parseDryRunBody(t, CellsSet, []string{
+		"--url", testURL, "--sheet-id", testSheetID,
+		"--range", "A1",
+		"--cells", `[[{"rich_text":[{"type":"text","text":"OLD","style":{"font_line":"line-through"}},{"type":"text","text":"NEW","style":{"font_color":"#00B050"}}]}]]`,
+	})
+	input := decodeToolInput(t, body, "set_cell_range")
+	cells, _ := input["cells"].([]interface{})
+	row0, _ := cells[0].([]interface{})
+	cell, _ := row0[0].(map[string]interface{})
+	rt, _ := cell["rich_text"].([]interface{})
+	if len(rt) != 2 {
+		t.Fatalf("rich_text len = %d, want 2: %#v", len(rt), cell["rich_text"])
+	}
+
+	oldSeg, _ := rt[0].(map[string]interface{})
+	if _, hasStyle := oldSeg["style"]; hasStyle {
+		t.Fatalf("old segment still has style field: %#v", oldSeg)
+	}
+	oldStyle, _ := oldSeg["segmentStyle"].(map[string]interface{})
+	if oldStyle["strikeThrough"] != true {
+		t.Fatalf("old segment segmentStyle.strikeThrough = %v, want true (segment=%#v)", oldStyle["strikeThrough"], oldSeg)
+	}
+
+	newSeg, _ := rt[1].(map[string]interface{})
+	if _, hasStyle := newSeg["style"]; hasStyle {
+		t.Fatalf("new segment still has style field: %#v", newSeg)
+	}
+	newStyle, _ := newSeg["segmentStyle"].(map[string]interface{})
+	if newStyle["foreColor"] != "#00B050" {
+		t.Fatalf("new segment segmentStyle.foreColor = %v, want #00B050 (segment=%#v)", newStyle["foreColor"], newSeg)
+	}
+}
+
 // TestDropdownSet_CellsShape inspects the 3×1 matrix produced from
 // --range A2:A4 to confirm the data_validation prototype is replicated.
 // Also covers --colors / --highlight emitting the canonical


### PR DESCRIPTION
## Summary
- translate `+cells-set` rich_text segment `style` objects into Sheets `segmentStyle` fields before calling `set_cell_range`
- map font color, font size, bold, italic, underline, and strikethrough segment styles
- add dry-run regression coverage for line-through and font color segment styles

Fixes #1356.

## Tests
- `go test ./shortcuts/sheets -run TestCellsSet_RichTextStyleTranslatedToSegmentStyle -count=1` (fails before the fix, passes after)
- `go test ./shortcuts/sheets -count=1`
- `go test ./cmd ./shortcuts/sheets -count=1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rich text formatting in spreadsheets. Text styling attributes are now properly handled across different format versions, ensuring consistent visual presentation.

* **Tests**
  * Added comprehensive test coverage for rich text style translation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->