### PR TITLE
fix(binding): skip unix mode audit on windows

### DIFF
--- a/internal/binding/audit.go
+++ b/internal/binding/audit.go
@@ -131,31 +131,3 @@ func requireInTrustedDirs(effectivePath string, trustedDirs []string, label stri
 	}
 	return fmt.Errorf("%s: path %q is not inside any trusted directory", label, effectivePath)
 }
-
-// auditFilePermissions rejects world/group-writable modes (always) and
-// world/group-readable modes (unless allowReadableByOthers is true, which
-// exec commands typically need for their usual 755 mode).
-func auditFilePermissions(effectivePath string, allowReadableByOthers bool, label string) error {
-	info, err := vfs.Stat(effectivePath)
-	if err != nil {
-		return fmt.Errorf("%s: cannot stat %q: %w", label, effectivePath, err)
-	}
-	mode := info.Mode().Perm()
-
-	if mode&0o002 != 0 {
-		return fmt.Errorf("%s: path %q is world-writable (mode %04o)", label, effectivePath, mode)
-	}
-	if mode&0o020 != 0 {
-		return fmt.Errorf("%s: path %q is group-writable (mode %04o)", label, effectivePath, mode)
-	}
-	if allowReadableByOthers {
-		return nil
-	}
-	if mode&0o004 != 0 {
-		return fmt.Errorf("%s: path %q is world-readable (mode %04o)", label, effectivePath, mode)
-	}
-	if mode&0o040 != 0 {
-		return fmt.Errorf("%s: path %q is group-readable (mode %04o)", label, effectivePath, mode)
-	}
-	return nil
-}

--- a/internal/binding/audit_unix.go
+++ b/internal/binding/audit_unix.go
@@ -29,3 +29,31 @@ func checkOwnerUID(path, label string) error {
 	}
 	return nil
 }
+
+// auditFilePermissions rejects world/group-writable modes (always) and
+// world/group-readable modes (unless allowReadableByOthers is true, which
+// exec commands typically need for their usual 755 mode).
+func auditFilePermissions(effectivePath string, allowReadableByOthers bool, label string) error {
+	info, err := vfs.Stat(effectivePath)
+	if err != nil {
+		return fmt.Errorf("%s: cannot stat %q: %w", label, effectivePath, err)
+	}
+	mode := info.Mode().Perm()
+
+	if mode&0o002 != 0 {
+		return fmt.Errorf("%s: path %q is world-writable (mode %04o)", label, effectivePath, mode)
+	}
+	if mode&0o020 != 0 {
+		return fmt.Errorf("%s: path %q is group-writable (mode %04o)", label, effectivePath, mode)
+	}
+	if allowReadableByOthers {
+		return nil
+	}
+	if mode&0o004 != 0 {
+		return fmt.Errorf("%s: path %q is world-readable (mode %04o)", label, effectivePath, mode)
+	}
+	if mode&0o040 != 0 {
+		return fmt.Errorf("%s: path %q is group-readable (mode %04o)", label, effectivePath, mode)
+	}
+	return nil
+}

--- a/internal/binding/audit_windows.go
+++ b/internal/binding/audit_windows.go
@@ -5,7 +5,22 @@
 
 package binding
 
+import (
+	"fmt"
+
+	"github.com/larksuite/cli/internal/vfs"
+)
+
 // checkOwnerUID is a no-op on Windows where Unix UID semantics don't apply.
 func checkOwnerUID(path, label string) error {
+	return nil
+}
+
+// auditFilePermissions skips POSIX permission-bit auditing on Windows because
+// Go synthesizes mode bits from file attributes rather than NTFS ACLs.
+func auditFilePermissions(effectivePath string, allowReadableByOthers bool, label string) error {
+	if _, err := vfs.Stat(effectivePath); err != nil {
+		return fmt.Errorf("%s: cannot stat %q: %w", label, effectivePath, err)
+	}
 	return nil
 }

--- a/internal/binding/audit_windows_test.go
+++ b/internal/binding/audit_windows_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package binding
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAssertSecurePath_WindowsIgnoresSyntheticUnixPermissionBits(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "secrets-getter.cmd")
+	if err := os.WriteFile(p, []byte("@echo off\r\n"), 0o600); err != nil {
+		t.Fatalf("write temp command: %v", err)
+	}
+
+	got, err := AssertSecurePath(AuditParams{
+		TargetPath:            p,
+		Label:                 "exec provider command",
+		AllowInsecurePath:     false,
+		AllowReadableByOthers: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error for Windows synthetic mode bits: %v", err)
+	}
+	if got != p {
+		t.Errorf("got %q, want %q", got, p)
+	}
+}


### PR DESCRIPTION
## Summary
Fix Windows exec provider binding failures caused by treating synthesized POSIX mode bits as real NTFS permissions. On Windows, Go reports writable regular files as mode 0666 based on file attributes, which made secure exec providers fail the world-writable audit even when the file was not broadly writable by ACL.

## Changes
- Keep the existing absolute path, non-directory, trusted directory, and symlink checks for secure paths.
- Skip the Unix group/world permission-bit audit on Windows, where those bits do not represent ACL permissions.
- Add a regression test for the Windows synthetic 0666 mode case reported by `lark-channel-bridge` exec provider wrappers.
- Trade-off: on Windows the inapplicable POSIX mode audit is skipped, while absolute-path, non-directory, symlink, and trusted-dir checks still run; real NTFS ACL auditing can be a follow-up enhancement.

## Test Plan
- [x] Unit tests pass: `GOTOOLCHAIN=go1.23.12 make unit-test`
- [x] Targeted secure-path tests: `go test ./internal/binding -run TestAssertSecurePath -count=1`
- [x] Related packages: `go test ./internal/binding ./internal/transport -count=1`
- [x] Race check: `go test -race ./internal/binding -count=1`
- [x] Windows compile check, including the Windows-only regression test: `GOOS=windows GOARCH=amd64 go test -c ./internal/binding -o /tmp/larksuite-cli-binding.test.exe`
- [x] Static checks: `go vet ./...`, `gofmt -l .`, `git diff --check`
- [x] Lint on this branch diff: `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --new-from-rev=upstream/main`
- [ ] Manual Windows CLI flow was not run locally; this change is covered by secure-path unit tests and Windows test binary compilation.

## Related Issues
- Fixes #1475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file permission validation on Windows to skip POSIX permission mode checks, which don't apply to Windows filesystems. Windows now only verifies file accessibility.
  * Unix systems continue to enforce strict permission validation for secure file access.

* **Tests**
  * Added test coverage for Windows file permission handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

