### PR TITLE
docs(lark-base): document signature field (attachment style variant)

### DIFF
--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -174,7 +174,7 @@ PY
 }
 ```
 
-普通附件使用专用 shortcut 上传、下载或移除。签字字段虽然返回 `type:"attachment"`，但 `style.type` 为 `signature` 时单元格只读：向 `attachment` 字段写入或清空前先用 `+field-list` / `+field-get` 核对样式；命中签字字段时不要调用记录写入、`+record-upload-attachment` 或 `+record-remove-attachment`，读取、下载、筛选、lookup 和 workflow 下钻仍按普通附件规则处理。这些写操作会返回成功并把字段放进 `ignored_fields`（`SIGNATURE_READONLY`）；其中上传命令会先上传媒体再被追加接口忽略，不能把成功退出当成签字已写入。created_at, updated_at, created_by, updated_by, auto_number, formula, lookup 类型字段同样只读，误写时会被静默过滤，其余字段正常写入。
+附件使用专用 shortcut 上传、下载或移除。created_at, updated_at, created_by, updated_by, auto_number, formula, lookup 类型字段只读，若误写入单元格会返回 `ignored_fields` 表示这些字段被静默过滤，其余字段正常写入。
 
 ```bash
 # 新增：成功时返回 record_id_list

--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -174,7 +174,7 @@ PY
 }
 ```
 
-附件使用专用 shortcut 上传、下载或移除。created_at, updated_at, created_by, updated_by, auto_number, formula, lookup 类型字段只读，若误写入单元格会返回 `ignored_fields` 表示这些字段被静默过滤，其余字段正常写入。
+普通附件使用专用 shortcut 上传、下载或移除。签字字段虽然返回 `type:"attachment"`，但 `style.type` 为 `signature` 时单元格只读：向 `attachment` 字段写入或清空前先用 `+field-list` / `+field-get` 核对样式；命中签字字段时不要调用记录写入、`+record-upload-attachment` 或 `+record-remove-attachment`，读取、下载、筛选、lookup 和 workflow 下钻仍按普通附件规则处理。这些写操作会返回成功并把字段放进 `ignored_fields`（`SIGNATURE_READONLY`）；其中上传命令会先上传媒体再被追加接口忽略，不能把成功退出当成签字已写入。created_at, updated_at, created_by, updated_by, auto_number, formula, lookup 类型字段同样只读，误写时会被静默过滤，其余字段正常写入。
 
 ```bash
 # 新增：成功时返回 record_id_list

--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -174,7 +174,7 @@ PY
 }
 ```
 
-附件使用专用 shortcut 上传、下载或移除。created_at, updated_at, created_by, updated_by, auto_number, formula, lookup 类型字段只读，若误写入单元格会返回 `ignored_fields` 表示这些字段被静默过滤，其余字段正常写入。
+附件使用专用 shortcut 上传、下载或移除；其中 `style.type` 为 `signature` 的附件字段（签字）单元格只读，写入或上传前先用 `+field-get` 核对样式，规则见 [Field Schema](references/lark-base-field-schema.md) §3.12。created_at, updated_at, created_by, updated_by, auto_number, formula, lookup 类型字段只读，若误写入单元格会返回 `ignored_fields` 表示这些字段被静默过滤，其余字段正常写入。
 
 ```bash
 # 新增：成功时返回 record_id_list

--- a/skills/lark-base/references/lark-base-field-create.md
+++ b/skills/lark-base/references/lark-base-field-create.md
@@ -54,7 +54,7 @@ POST /open-apis/base/v3/bases/:base_token/tables/:table_id/fields
   - `link`：必须有 `link_table`，可选 `bidirectional`、`bidirectional_link_field_name`。
   - `formula`：必须有 `expression`；先读 formula guide，再创建。
   - `lookup`：必须有 `from`、`select`、`where`；先读 lookup guide，再创建。
-  - `attachment`：签字字段没有 `"type":"signature"`，用 `style.type:"signature"` 创建；见 [Field Schema](lark-base-field-schema.md) §3.12。
+  - `attachment`：签字字段没有 `"type":"signature"`，用 `style.type:"signature"` 创建；见 [Field Schema](lark-base-field-schema.md) §3.12。若接口拒绝该 style，停止并报告当前环境尚未支持；不要删掉 `style` 重试，否则会创建普通附件字段。
 
 **正确（base +field-create）**
 

--- a/skills/lark-base/references/lark-base-field-create.md
+++ b/skills/lark-base/references/lark-base-field-create.md
@@ -54,6 +54,7 @@ POST /open-apis/base/v3/bases/:base_token/tables/:table_id/fields
   - `link`：必须有 `link_table`，可选 `bidirectional`、`bidirectional_link_field_name`。
   - `formula`：必须有 `expression`；先读 formula guide，再创建。
   - `lookup`：必须有 `from`、`select`、`where`；先读 lookup guide，再创建。
+  - `attachment`：签字字段没有 `"type":"signature"`，用 `style.type:"signature"` 创建；见 [Field Schema](lark-base-field-schema.md) §3.12。
 
 **正确（base +field-create）**
 

--- a/skills/lark-base/references/lark-base-field-schema.md
+++ b/skills/lark-base/references/lark-base-field-schema.md
@@ -40,7 +40,8 @@
 | `formula` | `type` `name` `expression` | 无 |
 | `lookup` | `type` `name` `from` `select` `where` | `aggregate` |
 | `auto_number` | `type` `name` | `style.rules` |
-| `attachment` / `location` / `checkbox` | `type` `name` | 无 |
+| `attachment` | `type` `name` | `style.type`（`plain` / `signature`） |
+| `location` / `checkbox` | `type` `name` | 无 |
 | `button` | `type` `name` `button_config.title` | 无 |
 
 所有类型都可额外传 `description`；上表的“常见补充字段”只列类型特有配置。
@@ -417,6 +418,14 @@
 ```json
 { "type": "attachment", "name": "附件" }
 ```
+
+签字字段是附件的 `style.type` 变体，没有 `"type":"signature"` 这个顶层类型（不传 `style` 按 `plain`）：
+
+```json
+{ "type": "attachment", "name": "店长确认签字", "style": { "type": "signature" } }
+```
+
+签字单元格**只读**：写入、替换、清空都不生效，签名只能由用户在飞书客户端完成。记录接口和 `+record-upload-attachment` / `+record-remove-attachment` 都不报错，只把该字段放进返回的 `ignored_fields`（`SIGNATURE_READONLY`），别当成成功。读取和下载与普通附件一致。
 
 ```json
 { "type": "location", "name": "位置" }

--- a/skills/lark-base/references/lark-base-field-schema.md
+++ b/skills/lark-base/references/lark-base-field-schema.md
@@ -425,7 +425,7 @@
 { "type": "attachment", "name": "店长确认签字", "style": { "type": "signature" } }
 ```
 
-签字单元格**只读**：写入、替换、清空都不生效，签名只能由用户在飞书客户端完成。记录接口和 `+record-upload-attachment` / `+record-remove-attachment` 都不报错，只把该字段放进返回的 `ignored_fields`（`SIGNATURE_READONLY`），别当成成功。读取和下载与普通附件一致。
+签字单元格**只读**：写入、替换、清空都不生效，签名只能由用户在飞书客户端完成。不要把签字字段放进记录写入，也不要对它调用 `+record-upload-attachment` / `+record-remove-attachment`；这些操作会返回成功并把字段放进 `ignored_fields`（`SIGNATURE_READONLY`），不能当成写入成功。尤其是 `+record-upload-attachment` 会先上传媒体，再由追加接口忽略签字字段，已上传媒体不会自动回滚。读取和下载与普通附件一致。
 
 ```json
 { "type": "location", "name": "位置" }

--- a/skills/lark-base/references/lark-base-field-schema.md
+++ b/skills/lark-base/references/lark-base-field-schema.md
@@ -425,7 +425,7 @@
 { "type": "attachment", "name": "店长确认签字", "style": { "type": "signature" } }
 ```
 
-签字单元格**只读**：写入、替换、清空都不生效，签名只能由用户在飞书客户端完成。不要把签字字段放进记录写入，也不要对它调用 `+record-upload-attachment` / `+record-remove-attachment`；这些操作会返回成功并把字段放进 `ignored_fields`（`SIGNATURE_READONLY`），不能当成写入成功。尤其是 `+record-upload-attachment` 会先上传媒体，再由追加接口忽略签字字段，已上传媒体不会自动回滚。读取和下载与普通附件一致。
+签字单元格**只读**：写入、替换、清空都不生效，签名只能由用户在飞书客户端完成。不要把签字字段放进记录写入，也不要对它调用 `+record-upload-attachment` / `+record-remove-attachment`；这些操作会返回成功并把字段放进 `ignored_fields`（`reason` 为 `SIGNATURE_READONLY`），不能当成写入成功。尤其是 `+record-upload-attachment` 会先上传媒体，再由追加接口忽略签字字段，已上传媒体不会自动回滚。读取和下载与普通附件一致。
 
 ```json
 { "type": "location", "name": "位置" }

--- a/skills/lark-base/references/lark-base-field-update.md
+++ b/skills/lark-base/references/lark-base-field-update.md
@@ -47,7 +47,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
   - 不能把非 `link` 字段改成 `link`，也不能把 `link` 改成非 `link`。
   - 现有 `link` 字段的 `bidirectional` 不能改。
 - 更新 `auto_number.style.rules` 会按新规则更新已有记录的编号；规则结构见 [Field Schema](lark-base-field-schema.md)。
-- 签字字段（`attachment` + `style.type:"signature"`）更新时必须把 `style` 一起写回；漏传会按 `plain` 处理，转成普通附件并移除签字专属的 `signatureExtra`。不要再 `PUT` 回 `signature` 来自动恢复：当前底层 `attachment -> signature` 转换会清空该列的附件值；也不要用"新建字段 + 迁移"，因为签字单元格无法通过 API 写回。若已经误降级，停止后续写操作并报告数据风险；恢复方案必须单独验证后再执行。
+- 签字字段（`attachment` + `style.type:"signature"`）更新时必须把 `style` 一起写回；漏传会按 `plain` 处理，转成普通附件并丢掉签字专属配置。不要再 `PUT` 回 `signature` 来自动恢复：当前底层 `attachment -> signature` 转换会清空该列的附件值；也不要用“新建字段 + 迁移”，因为签字单元格无法通过 API 写回。若已经误降级，停止后续写操作并报告数据风险；恢复方案必须单独验证后再执行。
 
 **推荐更新示例**
 
@@ -75,7 +75,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
 
 1. 先用 `+field-get` 读取当前定义，只改变目标属性，并把需要保留的其他可写配置完整写回。
 2. `formula/lookup` 类型更新前先阅读对应指南。
-3. 如果这次更新会改变字段 `type`，先按下方“字段类型变更规则”判断能否执行。如果不修改 `type`，大多数场景都相对安全。
+3. 如果这次更新会改变字段 `type`，先按下方“字段类型变更规则”判断能否执行。如果不修改 `type`，大多数场景都相对安全；已知例外是签字字段漏传 `style`，`type` 不变也会丢数据，见上方 JSON 值规范。
 
 ## 字段类型变更规则
 

--- a/skills/lark-base/references/lark-base-field-update.md
+++ b/skills/lark-base/references/lark-base-field-update.md
@@ -47,7 +47,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
   - 不能把非 `link` 字段改成 `link`，也不能把 `link` 改成非 `link`。
   - 现有 `link` 字段的 `bidirectional` 不能改。
 - 更新 `auto_number.style.rules` 会按新规则更新已有记录的编号；规则结构见 [Field Schema](lark-base-field-schema.md)。
-- 签字字段（`attachment` + `style.type:"signature"`）更新时必须把 `style` 一起写回；漏传按 `plain` 处理，会静默退化成普通附件。误降级后可再 `PUT` 一次带 `style.type:"signature"` 原地恢复，已有签名值不受影响；这不改 `type`，不属于下方黑名单的类型转换。**不要**用"新建字段 + 迁移"来恢复——签字单元格写不进去，重建会丢掉全部已有签名。
+- 签字字段（`attachment` + `style.type:"signature"`）更新时必须把 `style` 一起写回；漏传会按 `plain` 处理，转成普通附件并移除签字专属的 `signatureExtra`。不要再 `PUT` 回 `signature` 来自动恢复：当前底层 `attachment -> signature` 转换会清空该列的附件值；也不要用"新建字段 + 迁移"，因为签字单元格无法通过 API 写回。若已经误降级，停止后续写操作并报告数据风险；恢复方案必须单独验证后再执行。
 
 **推荐更新示例**
 

--- a/skills/lark-base/references/lark-base-field-update.md
+++ b/skills/lark-base/references/lark-base-field-update.md
@@ -47,6 +47,7 @@ PUT /open-apis/base/v3/bases/:base_token/tables/:table_id/fields/:field_id
   - 不能把非 `link` 字段改成 `link`，也不能把 `link` 改成非 `link`。
   - 现有 `link` 字段的 `bidirectional` 不能改。
 - 更新 `auto_number.style.rules` 会按新规则更新已有记录的编号；规则结构见 [Field Schema](lark-base-field-schema.md)。
+- 签字字段（`attachment` + `style.type:"signature"`）更新时必须把 `style` 一起写回；漏传按 `plain` 处理，会静默退化成普通附件。误降级后可再 `PUT` 一次带 `style.type:"signature"` 原地恢复，已有签名值不受影响；这不改 `type`，不属于下方黑名单的类型转换。**不要**用"新建字段 + 迁移"来恢复——签字单元格写不进去，重建会丢掉全部已有签名。
 
 **推荐更新示例**
 

--- a/skills/lark-base/references/lark-base-form-questions-create.md
+++ b/skills/lark-base/references/lark-base-form-questions-create.md
@@ -123,6 +123,8 @@ lark-cli base +form-questions-create \
 | `number`（评分） | `{"type":"rating","icon":"star","min":1,"max":5}` | icon 可选：`star`/`heart`/`thumbsup`/`fire`/`smile`/`lightning`/`flower`/`number` |
 | `datetime` | `{"format":"yyyy/MM/dd"}` | format 可选：`yyyy/MM/dd`、`yyyy/MM/dd HH:mm`、`MM-dd`、`MM/dd/yyyy`、`dd/MM/yyyy` |
 
+`+form-questions-create` 对签字题目的两种输入当前行为不一致：新建题目会接受 `style.type:"signature"`，但 `use_existing_field` 会拒绝已有签字字段。不要依赖这组不一致行为；需要签字题目时报告当前命令尚未形成稳定支持契约。
+
 ### `visible_rule` 显隐条件
 
 > **仅当用户明确要求为题目设置显隐条件（显示/隐藏逻辑）时，才需要读下面的结构说明；否则忽略本节。**

--- a/skills/lark-base/references/lark-base-form-questions-create.md
+++ b/skills/lark-base/references/lark-base-form-questions-create.md
@@ -123,8 +123,6 @@ lark-cli base +form-questions-create \
 | `number`（评分） | `{"type":"rating","icon":"star","min":1,"max":5}` | icon 可选：`star`/`heart`/`thumbsup`/`fire`/`smile`/`lightning`/`flower`/`number` |
 | `datetime` | `{"format":"yyyy/MM/dd"}` | format 可选：`yyyy/MM/dd`、`yyyy/MM/dd HH:mm`、`MM-dd`、`MM/dd/yyyy`、`dd/MM/yyyy` |
 
-`+form-questions-create` 对签字题目的两种输入当前行为不一致：新建题目会接受 `style.type:"signature"`，但 `use_existing_field` 会拒绝已有签字字段。不要依赖这组不一致行为；需要签字题目时报告当前命令尚未形成稳定支持契约。
-
 ### `visible_rule` 显隐条件
 
 > **仅当用户明确要求为题目设置显隐条件（显示/隐藏逻辑）时，才需要读下面的结构说明；否则忽略本节。**


### PR DESCRIPTION
## What

Documents the new **Signature** field in the `lark-base` skill. Signature is not a top-level field type — it is the **attachment field's `style.type` variant**: `{"type":"attachment","style":{"type":"signature"}}`. Underneath it is `FieldType.Attachment` (17) distinguished only by `FieldUIType=Signature`.

**Signature cells are read-only.** Write, replace and clear are all rejected — there is no "you can clear it but not write it" special case to remember. Nothing errors: the field lands in the response's `ignored_fields` with `reason: SIGNATURE_READONLY`, and the rest of the request goes through. Signing happens in the Lark client.

## Scope: 3 reference files, +13/-2. `SKILL.md` untouched.

A signature field **reports itself as `type: "attachment"`** — `mapAttachmentFieldToOpenAPI` emits `type: attachment` unconditionally, the cell is byte-identical to an attachment cell, and the filter / lookup / workflow paths never consult `isSignatureField`. So every rule already written for `attachment` applies to signature automatically, and restating it in `data-query.md` / `field-lookup.md` / `workflow-schema.md` buys zero behavioural change while creating three places to drift. Those notes were in an earlier revision and have been dropped. For reference, adding the whole `button` field type (#2437) touched exactly one reference file.

What is left is only what the `attachment` rules do **not** already cover:

- **`field-schema.md` §2** — the 速查表 row for `attachment` said supplementary fields were `无`, which is now false.
- **`field-schema.md` §3.12** — the canonical creation payload, plus the read-only cell rule covering all three commands (`+record-*`, `+record-upload-attachment`, `+record-remove-attachment`). `+record-upload-attachment` gets its own sentence: it uploads the media *before* the append call drops the field, and that media is not rolled back, so a clean exit is not evidence the signature landed.
- **`field-create.md`** — `signature` is absent from `AgentFieldType` *and* from the alias map, so `{"type":"signature"}` hard-fails and the natural retry `{"type":"attachment"}` **succeeds as a plain attachment**. Silent wrong outcome, so it needs a pointer at the point of creation.
- **`field-update.md`** — `PUT` is a full overwrite and `style` defaults to `plain`, so omitting it silently downgrades the column while `type` stays `attachment` the whole time. **There is no safe self-service recovery**: re-`PUT`ing `style.type:"signature"` clears the column's attachment values, and recreate-and-migrate cannot work either because signature cells are not writable through the API. The rule is to stop and report the data risk instead. The workflow section's blanket "not changing `type` is relatively safe" now carries this exception — the type-change whitelist below it only governs `type` transitions and never sees this one.

## Notes

- Rebased onto `main` @ `20ef0af8a`. An earlier revision documented the write restriction in `references/lark-base-cell-value.md`; #2529 deleted that file and inlined the CellValue protocol into `SKILL.md`, so the rule now lives in `field-schema.md` §3.12 and this PR deliberately does not touch the `SKILL.md` index.
- **No CLI code change is needed** for this PR to be correct. `validateFieldCreate` does not whitelist field types or style keys — it only checks the formula/lookup guide ack and forwards the JSON verbatim. A separate follow-up could make `+record-upload-attachment` / `+record-remove-attachment` short-circuit on a signature field: both already fetch the field definition and type-check it before touching any media (`shortcuts/base/record_upload_attachment.go:273` and `:320`), so the check has everything it needs at the point where the orphan upload happens today.
- Server side: `bitable-mcp` MR !775 implements the `style.type` mapping and the read-only cell enforcement.
