### PR TITLE
feat: add mail rule reorder shortcut

### DIFF
--- a/shortcuts/mail/mail_rule_reorder.go
+++ b/shortcuts/mail/mail_rule_reorder.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var MailRuleReorder = common.Shortcut{
+	Service:     "mail",
+	Command:     "+rule-reorder",
+	Description: "Reorder mail rules from a partial rule ID prefix. The CLI lists current rules, appends the remaining IDs in current order, then submits a complete reorder request.",
+	Risk:        "write",
+	Scopes:      []string{"mail:user_mailbox.rule:read", "mail:user_mailbox.rule:write"},
+	AuthTypes:   []string{"user"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "mailbox", Default: "me", Desc: "Mailbox email address or user_mailbox_id (default: me)"},
+		{Name: "rule-id", Type: "string_array", Desc: "Rule ID to move to the front. Repeat to specify the desired prefix order."},
+		{Name: "rule-ids", Desc: `Rule IDs as a JSON array (["r3","r1"]) or comma-separated string (r3,r1). Appended after repeated --rule-id values.`},
+		{Name: "print-output-schema", Type: "bool", Desc: "Print output field reference (run this first to learn field names before parsing output)"},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if runtime.Bool("print-output-schema") {
+			return nil
+		}
+		_, err := parseRuleReorderInput(runtime)
+		return err
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		mailboxID := resolveMailboxID(runtime)
+		requested, _ := parseRuleReorderInput(runtime)
+		return common.NewDryRunAPI().
+			Desc("Reorder mail rules: list current rules → auto-complete full rule_ids → submit reorder").
+			GET(mailboxPath(mailboxID, "rules")).
+			Desc("List current rule order").
+			POST(mailboxPath(mailboxID, "rules", "reorder")).
+			Desc("Submit complete rule order after auto-completion").
+			Body(map[string]interface{}{
+				"rule_ids":           "<auto-completed-after-list>",
+				"requested_rule_ids": requested,
+			})
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if runtime.Bool("print-output-schema") {
+			printRuleReorderOutputSchema(runtime)
+			return nil
+		}
+
+		mailboxID := resolveMailboxID(runtime)
+		requested, err := parseRuleReorderInput(runtime)
+		if err != nil {
+			return err
+		}
+
+		existing, err := fetchRuleIDs(runtime, mailboxID)
+		if err != nil {
+			return mailDecorateProblemMessage(err, "failed to list current mail rules")
+		}
+		finalIDs, appendedIDs, err := mergeRuleIDs(requested, existing)
+		if err != nil {
+			return err
+		}
+
+		if _, err := runtime.DoAPIJSONTyped("POST",
+			mailboxPath(mailboxID, "rules", "reorder"),
+			nil,
+			map[string]interface{}{"rule_ids": finalIDs},
+		); err != nil {
+			return mailDecorateProblemMessage(err, "failed to reorder mail rules")
+		}
+
+		result := map[string]interface{}{
+			"mailbox":            mailboxID,
+			"requested_rule_ids": requested,
+			"appended_rule_ids":  appendedIDs,
+			"final_rule_ids":     finalIDs,
+			"total":              len(finalIDs),
+		}
+		runtime.OutFormat(result, &output.Meta{Count: len(finalIDs)}, func(w io.Writer) {
+			fmt.Fprintf(w, "mailbox: %s\n", mailboxID)
+			fmt.Fprintf(w, "requested_rule_ids: %s\n", strings.Join(requested, ", "))
+			if len(appendedIDs) > 0 {
+				fmt.Fprintf(w, "appended_rule_ids: %s\n", strings.Join(appendedIDs, ", "))
+			} else {
+				fmt.Fprintln(w, "appended_rule_ids: (none)")
+			}
+			fmt.Fprintf(w, "final_rule_ids: %s\n", strings.Join(finalIDs, ", "))
+			fmt.Fprintf(w, "total: %d\n", len(finalIDs))
+		})
+		return nil
+	},
+}
+
+func parseRuleReorderInput(runtime *common.RuntimeContext) ([]string, error) {
+	ids := make([]string, 0, len(runtime.StrArray("rule-id")))
+	for _, id := range runtime.StrArray("rule-id") {
+		trimmed := strings.TrimSpace(id)
+		if trimmed != "" {
+			ids = append(ids, trimmed)
+		}
+	}
+
+	extra, err := parseRuleIDsFlag(runtime.Str("rule-ids"))
+	if err != nil {
+		return nil, err
+	}
+	ids = append(ids, extra...)
+
+	if len(ids) == 0 {
+		return nil, mailValidationError("at least one rule ID is required; pass --rule-id repeatedly or --rule-ids as JSON/CSV")
+	}
+	if duplicate := firstDuplicate(ids); duplicate != "" {
+		return nil, mailValidationError("duplicate rule ID %q is not allowed", duplicate).
+			WithParams(mailInvalidParam("--rule-id/--rule-ids", "duplicate rule ID: "+duplicate))
+	}
+	return ids, nil
+}
+
+func parseRuleIDsFlag(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	if strings.HasPrefix(raw, "[") || strings.Contains(raw, "]") {
+		var ids []string
+		if err := json.Unmarshal([]byte(raw), &ids); err != nil {
+			return nil, mailValidationParamError("--rule-ids", `--rule-ids must be a JSON string array such as ["r3","r1"], or a comma-separated string`).WithCause(err)
+		}
+		return trimNonEmptyRuleIDs(ids), nil
+	}
+
+	parts := strings.Split(raw, ",")
+	return trimNonEmptyRuleIDs(parts), nil
+}
+
+func trimNonEmptyRuleIDs(values []string) []string {
+	ids := make([]string, 0, len(values))
+	for _, value := range values {
+		if id := strings.TrimSpace(value); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func firstDuplicate(ids []string) string {
+	seen := map[string]bool{}
+	for _, id := range ids {
+		if seen[id] {
+			return id
+		}
+		seen[id] = true
+	}
+	return ""
+}
+
+func fetchRuleIDs(runtime *common.RuntimeContext, mailboxID string) ([]string, error) {
+	data, err := runtime.DoAPIJSONTyped("GET", mailboxPath(mailboxID, "rules"), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	items, ok := data["items"].([]interface{})
+	if !ok {
+		if typedItems, ok := data["items"].([]map[string]interface{}); ok {
+			ids := make([]string, 0, len(typedItems))
+			for _, item := range typedItems {
+				if id, _ := item["id"].(string); strings.TrimSpace(id) != "" {
+					ids = append(ids, strings.TrimSpace(id))
+				}
+			}
+			return ids, nil
+		}
+		return nil, mailInvalidResponseError("list mail rules response missing items array")
+	}
+
+	ids := make([]string, 0, len(items))
+	for _, raw := range items {
+		item, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if id, _ := item["id"].(string); strings.TrimSpace(id) != "" {
+			ids = append(ids, strings.TrimSpace(id))
+		}
+	}
+	return ids, nil
+}
+
+func mergeRuleIDs(requested, existing []string) ([]string, []string, error) {
+	if len(existing) == 0 {
+		return nil, nil, mailValidationError("no mail rules found in the mailbox; create rules before reordering")
+	}
+
+	exists := make(map[string]bool, len(existing))
+	for _, id := range existing {
+		exists[id] = true
+	}
+	var missing []string
+	for _, id := range requested {
+		if !exists[id] {
+			missing = append(missing, id)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, nil, mailValidationError("rule ID(s) not found in current mailbox rules: %s; run `lark-cli mail user_mailbox.rules list --params '{\"user_mailbox_id\":\"me\"}'` to inspect current rules", strings.Join(missing, ", "))
+	}
+
+	selected := make(map[string]bool, len(requested))
+	finalIDs := append([]string{}, requested...)
+	for _, id := range requested {
+		selected[id] = true
+	}
+
+	appended := make([]string, 0, len(existing)-len(requested))
+	for _, id := range existing {
+		if selected[id] {
+			continue
+		}
+		finalIDs = append(finalIDs, id)
+		appended = append(appended, id)
+	}
+	return finalIDs, appended, nil
+}
+
+func printRuleReorderOutputSchema(runtime *common.RuntimeContext) {
+	runtime.Out(map[string]interface{}{
+		"_description": "Output field reference for mail +rule-reorder",
+		"fields": map[string]string{
+			"mailbox":            "Mailbox ID used in the operation.",
+			"requested_rule_ids": "Rule IDs explicitly supplied by the user, in requested prefix order.",
+			"appended_rule_ids":  "Remaining current rule IDs appended by the CLI in list response order.",
+			"final_rule_ids":     "Complete rule ID order submitted to user_mailbox.rules.reorder.",
+			"total":              "Number of IDs in final_rule_ids.",
+		},
+	}, nil)
+}

--- a/shortcuts/mail/mail_rule_reorder_test.go
+++ b/shortcuts/mail/mail_rule_reorder_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/zalando/go-keyring"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/httpmock"
@@ -117,9 +118,7 @@ func TestRuleReorderRejectsDuplicateInput(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected duplicate validation error, got nil")
 	}
-	if !strings.Contains(err.Error(), "duplicate rule ID") {
-		t.Fatalf("error = %v, want duplicate rule ID", err)
-	}
+	assertRuleReorderValidationError(t, err, errs.SubtypeInvalidArgument, "--rule-id/--rule-ids")
 }
 
 func TestRuleReorderRejectsMissingRuleID(t *testing.T) {
@@ -136,9 +135,7 @@ func TestRuleReorderRejectsMissingRuleID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected missing rule validation error, got nil")
 	}
-	if !strings.Contains(err.Error(), "not found") || !strings.Contains(err.Error(), "user_mailbox.rules list") {
-		t.Fatalf("error = %v, want not found hint", err)
-	}
+	assertRuleReorderValidationError(t, err, errs.SubtypeInvalidArgument, "")
 }
 
 func TestRuleReorderRejectsEmptyRuleList(t *testing.T) {
@@ -155,9 +152,7 @@ func TestRuleReorderRejectsEmptyRuleList(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected empty rules validation error, got nil")
 	}
-	if !strings.Contains(err.Error(), "no mail rules found") {
-		t.Fatalf("error = %v, want no mail rules found", err)
-	}
+	assertRuleReorderValidationError(t, err, errs.SubtypeInvalidArgument, "")
 }
 
 func TestParseRuleIDsFlagSupportsJSONAndCSV(t *testing.T) {
@@ -216,6 +211,35 @@ func ruleListResponse(ids ...string) map[string]interface{} {
 			"items": items,
 		},
 	}
+}
+
+func assertRuleReorderValidationError(t *testing.T, err error, wantSubtype errs.Subtype, wantParam string) {
+	t.Helper()
+
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("error = %T %v, want typed problem", err, err)
+	}
+	if problem.Category != errs.CategoryValidation {
+		t.Fatalf("problem category = %q, want %q", problem.Category, errs.CategoryValidation)
+	}
+	if problem.Subtype != wantSubtype {
+		t.Fatalf("problem subtype = %q, want %q", problem.Subtype, wantSubtype)
+	}
+	if wantParam == "" {
+		return
+	}
+
+	validationErr, ok := err.(*errs.ValidationError)
+	if !ok {
+		t.Fatalf("error = %T, want *errs.ValidationError", err)
+	}
+	for _, param := range validationErr.Params {
+		if param.Name == wantParam {
+			return
+		}
+	}
+	t.Fatalf("validation params = %#v, want param %q", validationErr.Params, wantParam)
 }
 
 func requestRuleIDsEqual(want []string) func([]byte) bool {

--- a/shortcuts/mail/mail_rule_reorder_test.go
+++ b/shortcuts/mail/mail_rule_reorder_test.go
@@ -6,6 +6,7 @@ package mail
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -230,8 +231,8 @@ func assertRuleReorderValidationError(t *testing.T, err error, wantSubtype errs.
 		return
 	}
 
-	validationErr, ok := err.(*errs.ValidationError)
-	if !ok {
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
 		t.Fatalf("error = %T, want *errs.ValidationError", err)
 	}
 	for _, param := range validationErr.Params {

--- a/shortcuts/mail/mail_rule_reorder_test.go
+++ b/shortcuts/mail/mail_rule_reorder_test.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zalando/go-keyring"
+
+	"github.com/larksuite/cli/internal/auth"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/httpmock"
+)
+
+func mailRuleReorderTestFactory(t *testing.T) (*cmdutil.Factory, *bytes.Buffer, *bytes.Buffer, *httpmock.Registry) {
+	t.Helper()
+	keyring.MockInit()
+	t.Setenv("HOME", t.TempDir())
+
+	cfg := mailTestConfig()
+	token := &auth.StoredUAToken{
+		UserOpenId:       cfg.UserOpenId,
+		AppId:            cfg.AppID,
+		AccessToken:      "test-user-access-token",
+		RefreshToken:     "test-refresh-token",
+		ExpiresAt:        time.Now().Add(1 * time.Hour).UnixMilli(),
+		RefreshExpiresAt: time.Now().Add(24 * time.Hour).UnixMilli(),
+		Scope:            "mail:user_mailbox.rule:read mail:user_mailbox.rule:write",
+		GrantedAt:        time.Now().Add(-1 * time.Hour).UnixMilli(),
+	}
+	if err := auth.SetStoredToken(token); err != nil {
+		t.Fatalf("SetStoredToken() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = auth.RemoveStoredToken(cfg.AppID, cfg.UserOpenId)
+	})
+
+	return cmdutil.TestFactory(t, cfg)
+}
+
+func TestRuleReorderExecuteCompletesPartialOrder(t *testing.T) {
+	f, stdout, _, reg := mailRuleReorderTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/rules",
+		Body:   ruleListResponse("r1", "r2", "r3", "r4"),
+	})
+	reg.Register(&httpmock.Stub{
+		Method:     "POST",
+		URL:        "/user_mailboxes/me/rules/reorder",
+		BodyFilter: requestRuleIDsEqual([]string{"r3", "r1", "r2", "r4"}),
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder", "--rule-id", "r3", "--rule-id", "r1",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	assertStringSliceField(t, data, "requested_rule_ids", []string{"r3", "r1"})
+	assertStringSliceField(t, data, "appended_rule_ids", []string{"r2", "r4"})
+	assertStringSliceField(t, data, "final_rule_ids", []string{"r3", "r1", "r2", "r4"})
+	if got := int(data["total"].(float64)); got != 4 {
+		t.Fatalf("total = %d, want 4", got)
+	}
+	if got := data["mailbox"]; got != "me" {
+		t.Fatalf("mailbox = %v, want me", got)
+	}
+}
+
+func TestRuleReorderExecuteKeepsCompleteInput(t *testing.T) {
+	f, stdout, _, reg := mailRuleReorderTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/rules",
+		Body:   ruleListResponse("r1", "r2", "r3"),
+	})
+	reg.Register(&httpmock.Stub{
+		Method:     "POST",
+		URL:        "/user_mailboxes/me/rules/reorder",
+		BodyFilter: requestRuleIDsEqual([]string{"r3", "r2", "r1"}),
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{},
+		},
+	})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder", "--rule-ids", `["r3","r2","r1"]`,
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	data := decodeShortcutEnvelopeData(t, stdout)
+	assertStringSliceField(t, data, "appended_rule_ids", []string{})
+	assertStringSliceField(t, data, "final_rule_ids", []string{"r3", "r2", "r1"})
+}
+
+func TestRuleReorderRejectsDuplicateInput(t *testing.T) {
+	f, stdout, _, _ := mailRuleReorderTestFactory(t)
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder", "--rule-id", "r1", "--rule-ids", "r2,r1",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected duplicate validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate rule ID") {
+		t.Fatalf("error = %v, want duplicate rule ID", err)
+	}
+}
+
+func TestRuleReorderRejectsMissingRuleID(t *testing.T) {
+	f, stdout, _, reg := mailRuleReorderTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/rules",
+		Body:   ruleListResponse("r1", "r2"),
+	})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder", "--rule-id", "missing",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected missing rule validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") || !strings.Contains(err.Error(), "user_mailbox.rules list") {
+		t.Fatalf("error = %v, want not found hint", err)
+	}
+}
+
+func TestRuleReorderRejectsEmptyRuleList(t *testing.T) {
+	f, stdout, _, reg := mailRuleReorderTestFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/user_mailboxes/me/rules",
+		Body:   ruleListResponse(),
+	})
+
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder", "--rule-id", "r1",
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected empty rules validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no mail rules found") {
+		t.Fatalf("error = %v, want no mail rules found", err)
+	}
+}
+
+func TestParseRuleIDsFlagSupportsJSONAndCSV(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{name: "json", raw: `["r3", " r1 ", ""]`, want: []string{"r3", "r1"}},
+		{name: "csv", raw: "r3, r1,,r2", want: []string{"r3", "r1", "r2"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseRuleIDsFlag(tt.raw)
+			if err != nil {
+				t.Fatalf("parseRuleIDsFlag() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("parseRuleIDsFlag() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRuleReorderDryRunShowsListAndReorder(t *testing.T) {
+	f, stdout, _, _ := mailRuleReorderTestFactory(t)
+	err := runMountedMailShortcut(t, MailRuleReorder, []string{
+		"+rule-reorder", "--rule-ids", "r3,r1", "--dry-run",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("dry-run returned error: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		`"method": "GET"`,
+		`"url": "/open-apis/mail/v1/user_mailboxes/me/rules"`,
+		`"method": "POST"`,
+		`"url": "/open-apis/mail/v1/user_mailboxes/me/rules/reorder"`,
+		`auto-completed-after-list`,
+		`"requested_rule_ids"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q; got %s", want, out)
+		}
+	}
+}
+
+func ruleListResponse(ids ...string) map[string]interface{} {
+	items := make([]map[string]interface{}, 0, len(ids))
+	for _, id := range ids {
+		items = append(items, map[string]interface{}{"id": id})
+	}
+	return map[string]interface{}{
+		"code": 0,
+		"data": map[string]interface{}{
+			"items": items,
+		},
+	}
+}
+
+func requestRuleIDsEqual(want []string) func([]byte) bool {
+	return func(body []byte) bool {
+		var payload struct {
+			RuleIDs []string `json:"rule_ids"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			return false
+		}
+		return reflect.DeepEqual(payload.RuleIDs, want)
+	}
+}
+
+func assertStringSliceField(t *testing.T, data map[string]interface{}, field string, want []string) {
+	t.Helper()
+	raw, ok := data[field].([]interface{})
+	if !ok {
+		t.Fatalf("%s has type %T, want []interface{}", field, data[field])
+	}
+	if len(raw) != len(want) {
+		t.Fatalf("%s length = %d, want %d; value=%v", field, len(raw), len(want), raw)
+	}
+	got := make([]string, 0, len(raw))
+	for _, item := range raw {
+		got = append(got, item.(string))
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s = %#v, want %#v", field, got, want)
+	}
+}

--- a/shortcuts/mail/shortcuts.go
+++ b/shortcuts/mail/shortcuts.go
@@ -23,6 +23,7 @@ func Shortcuts() []common.Shortcut {
 		MailSendReceipt,
 		MailDeclineReceipt,
 		MailSignature,
+		MailRuleReorder,
 		MailShareToChat,
 		MailTemplateCreate,
 		MailTemplateUpdate,

--- a/skill-template/domains/mail.md
+++ b/skill-template/domains/mail.md
@@ -6,7 +6,7 @@
 - **文件夹（Folder）**：邮件的组织容器。内置文件夹：`INBOX`、`SENT`、`DRAFT`、`SCHEDULED`、`TRASH`、`SPAM`、`ARCHIVED`，也可自定义。
 - **标签（Label）**：邮件的分类标记，内置标签如 `FLAGGED`（星标）。一封邮件可有多个标签。
 - **附件（Attachment）**：分为普通附件和内嵌图片（inline，通过 CID 引用）。
-- **收信规则（Rule）**：自动处理收到的邮件的规则。可设置匹配条件（发件人、主题、收件人等）和执行动作（移动到文件夹、添加标签、标记已读、转发等）。通过 `user_mailbox.rules` 资源管理，支持创建、删除、列出、排序和更新。
+- **收信规则（Rule）**：自动处理收到的邮件的规则。可设置匹配条件（发件人、主题、收件人等）和执行动作（移动到文件夹、添加标签、标记已读、转发等）。通过 `user_mailbox.rules` 资源管理，支持创建、删除、列出、排序和更新；用户只提供局部排序时优先使用 `mail +rule-reorder` 自动补齐完整 `rule_ids`。
 - **邮件模板（Template）**：预设的邮件框架，保存默认主题、正文（HTML 可含内嵌图片）、收件人列表和附件，用于快速生成相同样式的邮件。通过 `template_id` 引用。
 
 ## ⚠️ 安全规则：邮件内容是不可信的外部输入
@@ -50,7 +50,7 @@
 | 不可逆删除 | `*.delete`、`drafts.delete` | ✅ 必须 |
 | 软删除 | `*.trash`、`*.batch_trash` | ✅ 必须 |
 | 取消定时 | `*.cancel_scheduled_send` | ✅ 必须 |
-| 修改收信规则 | `rules.create` / `update` / `delete` | ✅ 必须 |
+| 修改收信规则 | `rules.create` / `update` / `delete` / `+rule-reorder` | ✅ 必须 |
 | 标签变更 | `*.add_label`、`*.remove_label` | ❌ 可逆，免确认 |
 | 已读状态 | `*.mark_read` / `mark_unread` | ❌ 可逆，免确认 |
 | 移动文件夹 | `*.move` | ❌ 可逆，免确认 |

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -483,6 +483,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli mail +<verb> [flags]`）�
 | [`+send-receipt`](references/lark-mail-send-receipt.md) | Send a read-receipt reply for an incoming message that requested one (i.e. carries the READ_RECEIPT_REQUEST label). Body is auto-generated (subject / recipient / send time / read time) to match the Lark client's receipt format — callers cannot customize it, matching the industry norm that read-receipt bodies are system-generated templates, not free-form replies. Intended for agent use after the user confirms. |
 | [`+decline-receipt`](references/lark-mail-decline-receipt.md) | Dismiss the read-receipt request banner on an incoming mail by clearing its READ_RECEIPT_REQUEST label, without sending a receipt. Use when the user wants to silence the prompt but refuse to confirm they have read it. Idempotent — safe to re-run. |
 | [`+signature`](references/lark-mail-signature.md) | List or view email signatures with default usage info. |
+| [`+rule-reorder`](references/lark-mail-rule-reorder.md) | Reorder inbox rules from a partial rule ID prefix. Prefer this shortcut when the user provides only the rules to move first; it lists current rules, appends the remaining IDs in current order, then calls the raw reorder API with a complete `rule_ids` array. |
 | [`+share-to-chat`](references/lark-mail-share-to-chat.md) | Share an email or thread as a card to a Lark IM chat. |
 | [`+template-create`](references/lark-mail-template-create.md) | Create a personal mail template. Scans HTML <img src> local paths (reusing draft inline-image detection), uploads inline images and non-inline attachments to Drive, rewrites HTML to cid: references, and POSTs a Template payload to mail.user_mailbox.templates.create. |
 | [`+template-update`](references/lark-mail-template-update.md) | Update an existing mail template. Supports --inspect (read-only projection), --print-patch-template (prints a JSON skeleton for --patch-file), and flat flags (--set-subject / --set-name / etc). Internally it GETs the template, applies the patch, rewrites <img> local paths to cid: refs, and PUTs a full-replace update (no optimistic locking: last-write-wins). |
@@ -566,7 +567,7 @@ lark-cli mail <resource> <method> [flags] # 调用 API
   - `create` — 创建收信规则
   - `delete` — 删除收信规则
   - `list` — 列出收信规则
-  - `reorder` — 对收信规则进行排序
+  - `reorder` — 对收信规则进行排序；需要完整 `rule_ids` 透传时使用。若用户只给出想前置的局部规则顺序，优先用 `mail +rule-reorder` 自动补齐剩余 ID。
   - `update` — 更新收信规则
 
 ### user_mailbox.sent_messages

--- a/skills/lark-mail/references/lark-mail-rule-reorder.md
+++ b/skills/lark-mail/references/lark-mail-rule-reorder.md
@@ -1,0 +1,67 @@
+# Mail Rule Reorder
+
+Use `lark-cli mail +rule-reorder` when the user wants to move one or more inbox rules to the front but only provides a partial rule order.
+
+The raw `mail user_mailbox.rules reorder` API requires a complete `rule_ids` array. This shortcut first lists the current rule order, places the requested IDs first, appends all remaining rule IDs in the current list order, then submits the complete reorder request.
+
+## Command
+
+```bash
+lark-cli mail +rule-reorder \
+  --as user \
+  --mailbox me \
+  --rule-id rule_3 \
+  --rule-id rule_1
+```
+
+Equivalent single-flag forms:
+
+```bash
+lark-cli mail +rule-reorder --as user --rule-ids '["rule_3","rule_1"]'
+lark-cli mail +rule-reorder --as user --rule-ids 'rule_3,rule_1'
+```
+
+## Behavior
+
+- `--mailbox` defaults to `me`.
+- `--rule-id` can be repeated and preserves the exact order provided.
+- `--rule-ids` accepts either a JSON string array or a comma-separated list.
+- Duplicate requested IDs are rejected before any API call.
+- Requested IDs that are not present in the current rule list are rejected after the list call.
+- Empty current rule lists are rejected.
+- The shortcut requires user identity and both rule read/write scopes.
+
+## Dry Run
+
+```bash
+lark-cli mail +rule-reorder --as user --rule-ids 'rule_3,rule_1' --dry-run
+```
+
+Dry-run output shows both calls:
+
+1. `GET /open-apis/mail/v1/user_mailboxes/:user_mailbox_id/rules`
+2. `POST /open-apis/mail/v1/user_mailboxes/:user_mailbox_id/rules/reorder`
+
+The POST body uses `<auto-completed-after-list>` because the final order is only known after the list response.
+
+## Output
+
+Run this before parsing output fields:
+
+```bash
+lark-cli mail +rule-reorder --print-output-schema
+```
+
+Successful output includes:
+
+| Field | Meaning |
+|---|---|
+| `mailbox` | Mailbox ID used in the operation |
+| `requested_rule_ids` | IDs explicitly supplied by the user |
+| `appended_rule_ids` | Remaining rule IDs appended by the CLI |
+| `final_rule_ids` | Complete order submitted to reorder |
+| `total` | Number of IDs in `final_rule_ids` |
+
+## When To Use Raw API Instead
+
+Use `lark-cli mail user_mailbox.rules reorder` only when the caller already has the full rule ID order and wants exact raw API passthrough.


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/4a4792c
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Add mail rule reorder shortcut | passed | b52ce38 |

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `mail +rule-reorder` to reorder inbox rules using a user-provided prefix (auto-completes remaining rule IDs in the current order).
  * Added input validation for empty lists, duplicate rule IDs, and missing rule IDs.
  * Added `--dry-run` to preview the rule list lookup and the exact reorder request payload.

* **Documentation**
  * Documented `+rule-reorder` behavior and clarified `user_mailbox.rules reorder` requiring full `rule_ids`.
  * Updated “must-confirm” operations to include `+rule-reorder`.

* **Tests**
  * Added integration-style tests covering ordering, parsing (JSON/CSV), validation, and dry-run output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->