### PR TITLE
fix: add missing CLI headers for git credential helper

### DIFF
--- a/shortcuts/apps/git_credential.go
+++ b/shortcuts/apps/git_credential.go
@@ -17,6 +17,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/google/uuid"
 	larkcore "github.com/larksuite/oapi-sdk-go/v3/core"
 	"github.com/spf13/cobra"
 
@@ -32,6 +33,7 @@ import (
 )
 
 const gitCredentialIssuePath = apiBasePath + "/apps/:app_id/git_info"
+const gitCredentialHelperReportedShortcut = appsService + ":+git-credential-helper"
 
 // gitCredentialIssueHint is the actionable next-step attached to a failed
 // Git-credential issuance. A 5xx is flagged retryable separately at the call site.
@@ -302,7 +304,12 @@ func (i factoryIssuer) Issue(ctx context.Context, appID string, profile gitcred.
 		HttpMethod: http.MethodGet,
 		ApiPath:    issuePath(appID),
 	}
-	resp, err := ac.DoSDKRequest(ctx, req, core.AsUser)
+	ctx = contextWithGitCredentialHelperShortcut(ctx)
+	var opts []larkcore.RequestOptionFunc
+	if optFn := cmdutil.ShortcutHeaderOpts(ctx); optFn != nil {
+		opts = append(opts, optFn)
+	}
+	resp, err := ac.DoSDKRequest(ctx, req, core.AsUser, opts...)
 	data, err := parseIssueCredentialData(resp, err, errclass.ClassifyContext{
 		Brand:    string(cfg.Brand),
 		AppID:    cfg.AppID,
@@ -312,6 +319,13 @@ func (i factoryIssuer) Issue(ctx context.Context, appID string, profile gitcred.
 		return nil, err
 	}
 	return issuedFromData(appID, data)
+}
+
+func contextWithGitCredentialHelperShortcut(ctx context.Context) context.Context {
+	if _, ok := cmdutil.ShortcutNameFromContext(ctx); ok {
+		return ctx
+	}
+	return cmdutil.ContextWithShortcut(ctx, gitCredentialHelperReportedShortcut, uuid.New().String())
 }
 
 func runGitCredentialHelper(ctx context.Context, f *cmdutil.Factory, appID, action string) error {

--- a/shortcuts/apps/git_credential_test.go
+++ b/shortcuts/apps/git_credential_test.go
@@ -825,7 +825,7 @@ func TestRunGitCredentialHelperActions(t *testing.T) {
 func TestFactoryIssuerBranches(t *testing.T) {
 	factory, _, reg := newAppsExecuteFactory(t)
 	expiresAt := time.Now().Add(24 * time.Hour).Unix()
-	reg.Register(&httpmock.Stub{
+	issueStub := &httpmock.Stub{
 		Method: "GET",
 		URL:    "/open-apis/spark/v1/apps/app_xxx/git_info",
 		Body: map[string]interface{}{
@@ -836,13 +836,20 @@ func TestFactoryIssuerBranches(t *testing.T) {
 				"StatusCode": 0,
 			},
 		},
-	})
+	}
+	reg.Register(issueStub)
 	issued, err := (factoryIssuer{f: factory}).Issue(context.Background(), "app_xxx", gitcred.ProfileContext{})
 	if err != nil {
 		t.Fatalf("factory issuer returned error: %v", err)
 	}
 	if issued.PAT != "pat-token" {
 		t.Fatalf("PAT = %q", issued.PAT)
+	}
+	if got := issueStub.CapturedHeaders.Get(cmdutil.HeaderShortcut); got != gitCredentialHelperReportedShortcut {
+		t.Fatalf("%s = %q, want %q", cmdutil.HeaderShortcut, got, gitCredentialHelperReportedShortcut)
+	}
+	if got := issueStub.CapturedHeaders.Get(cmdutil.HeaderExecutionId); got == "" {
+		t.Fatalf("%s header missing", cmdutil.HeaderExecutionId)
 	}
 
 	factory.Config = func() (*core.CliConfig, error) { return nil, errors.New("config failed") }
@@ -877,6 +884,20 @@ func TestFactoryIssuerBranches(t *testing.T) {
 	factory, _, _ = newAppsExecuteFactory(t)
 	if _, err := (factoryIssuer{f: factory}).Issue(context.Background(), "app_xxx", gitcred.ProfileContext{}); err == nil {
 		t.Fatal("factory issuer request error returned nil")
+	}
+}
+
+func TestContextWithGitCredentialHelperShortcutPreservesExistingShortcut(t *testing.T) {
+	ctx := cmdutil.ContextWithShortcut(context.Background(), "apps:+git-credential-init", "exec-existing")
+	got := contextWithGitCredentialHelperShortcut(ctx)
+
+	name, ok := cmdutil.ShortcutNameFromContext(got)
+	if !ok || name != "apps:+git-credential-init" {
+		t.Fatalf("shortcut = %q ok=%v, want existing shortcut", name, ok)
+	}
+	executionID, ok := cmdutil.ExecutionIdFromContext(got)
+	if !ok || executionID != "exec-existing" {
+		t.Fatalf("execution id = %q ok=%v, want existing execution id", executionID, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fix missing standard CLI headers on requests issued by the apps Git credential helper path.

## Changes
- Add a stable shortcut identity for the Git credential helper path.
- Attach standard CLI shortcut headers when the helper requests repository credentials.
- Preserve existing shortcut context when present.
- Add regression coverage for helper header propagation.

## Test Plan
- [x] Unit tests pass
  - `go test -race ./shortcuts/apps -run 'TestFactoryIssuerBranches|TestContextWithGitCredentialHelperShortcutPreservesExistingShortcut' -count=1`
  - `go test -race ./shortcuts/apps -count=1`
- [x] Git credential workflow verified with a real online app
  - `go test -v -count=1 -timeout=5m ./tests/cli_e2e/apps -run 'TestAppsGitCredential'`

## Related Issues
- None