### PR TITLE
fix: normalize vc meeting events contract

### DIFF
--- a/shortcuts/vc/vc_meeting_events.go
+++ b/shortcuts/vc/vc_meeting_events.go
@@ -5,6 +5,7 @@ package vc
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -28,6 +30,13 @@ const (
 )
 
 var meetingDisplayLocation = time.FixedZone("UTC+8", 8*60*60)
+
+type meetingEventsView string
+
+const (
+	meetingEventsViewCompact meetingEventsView = "compact"
+	meetingEventsViewRaw     meetingEventsView = "raw"
+)
 
 // toUnixSeconds converts a supported CLI time input into a Unix seconds string.
 func toUnixSeconds(input string, hint ...string) (string, error) {
@@ -48,7 +57,7 @@ var VCMeetingEvents = common.Shortcut{
 	Description: "List bot meeting events by meeting ID",
 	Risk:        "read",
 	Scopes:      []string{"vc:meeting.meetingevent:read"},
-	AuthTypes:   []string{"user", "bot"},
+	AuthTypes:   []string{"bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "meeting-id", Required: true, Desc: "meeting ID to query"},
@@ -57,9 +66,13 @@ var VCMeetingEvents = common.Shortcut{
 		{Name: "page-token", Desc: "page token for the next page"},
 		{Name: "page-size", Default: "20", Desc: "page size, 20-100 (default 20)"},
 		{Name: "page-all", Type: "bool", Desc: "automatically paginate through all available pages"},
+		{Name: "view", Default: string(meetingEventsViewCompact), Desc: "output view: compact or raw"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := validateMeetingEventsMeetingID(runtime.Str("meeting-id")); err != nil {
+			return err
+		}
+		if _, err := meetingEventsOutputView(runtime); err != nil {
 			return err
 		}
 		if _, err := meetingEventsPageSize(runtime); err != nil {
@@ -98,21 +111,39 @@ var VCMeetingEvents = common.Shortcut{
 		if err != nil {
 			return err
 		}
-		events = compactMeetingEvents(events)
-		outData := map[string]interface{}{
-			"events":     events,
-			"has_more":   data["has_more"],
-			"page_token": data["page_token"],
+		if view, err := meetingEventsOutputView(runtime); err != nil {
+			return err
+		} else if view == meetingEventsViewRaw {
+			runtime.Out(data, &output.Meta{Count: len(events)})
+			return nil
 		}
+		events = compactMeetingEvents(events)
+		botInfo, err := runtime.BotInfo()
+		if err != nil {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "fetch bot identity for compact meeting-events output: %v", err).WithParam("--as")
+		}
+		currentRoster, err := fetchMeetingEventsCurrentRoster(runtime)
+		if err != nil {
+			return err
+		}
+		outData := buildNormalizedMeetingEvents(data, events, currentRoster, botInfo)
+		ndjsonData := normalizedMeetingEventRows(outData.Events, map[string]interface{}{
+			"row_type":       "metadata",
+			"meeting":        outData.Meeting,
+			"bot":            outData.Bot,
+			"current_roster": outData.CurrentRoster,
+			"has_more":       outData.HasMore,
+			"page_token":     outData.PageToken,
+		})
 
 		timeline := buildMeetingEventTimeline(events)
-		runtime.OutFormat(outData, &output.Meta{Count: len(events)}, func(w io.Writer) {
-			if len(timeline.entries) == 0 {
-				fmt.Fprintln(w, "No meeting events.")
-				return
-			}
-			io.WriteString(w, renderMeetingEventsPretty(timeline))
-		})
+		if runtime.Format == "ndjson" {
+			runtime.OutFormat(ndjsonData, &output.Meta{Count: len(events)}, func(w io.Writer) {})
+		} else {
+			runtime.OutFormat(outData, &output.Meta{Count: len(events)}, func(w io.Writer) {
+				renderMeetingEventsCompactPretty(w, outData, timeline)
+			})
+		}
 		if runtime.Format == "pretty" && pageToken != "" {
 			fmt.Fprintf(runtime.IO().Out, "\npage_token: %s\n", pageToken)
 			if hasMore {
@@ -121,6 +152,352 @@ var VCMeetingEvents = common.Shortcut{
 		}
 		return nil
 	},
+}
+
+type normalizedMeetingEventsOutput struct {
+	Meeting       normalizedMeeting        `json:"meeting"`
+	Bot           normalizedIdentity       `json:"bot"`
+	CurrentRoster []normalizedIdentity     `json:"current_roster"`
+	Events        []normalizedMeetingEvent `json:"events"`
+	HasMore       bool                     `json:"has_more"`
+	PageToken     string                   `json:"page_token,omitempty"`
+}
+
+type normalizedMeeting struct {
+	ID        string `json:"id,omitempty"`
+	Topic     string `json:"topic,omitempty"`
+	MeetingNo string `json:"meeting_no,omitempty"`
+	StartTime string `json:"start_time,omitempty"`
+	EndTime   string `json:"end_time,omitempty"`
+	Status    string `json:"status"`
+}
+
+type normalizedIdentity struct {
+	ID              string `json:"id,omitempty"`
+	Name            string `json:"name,omitempty"`
+	ParticipantType string `json:"participant_type,omitempty"`
+	Role            string `json:"role,omitempty"`
+	IsSelf          bool   `json:"is_self"`
+	Label           string `json:"label,omitempty"`
+}
+
+type normalizedMeetingEvent struct {
+	EventID   string                 `json:"event_id,omitempty"`
+	EventType string                 `json:"event_type,omitempty"`
+	EventTime string                 `json:"event_time,omitempty"`
+	Summary   string                 `json:"summary,omitempty"`
+	Actors    []normalizedIdentity   `json:"actors,omitempty"`
+	Payload   map[string]interface{} `json:"payload,omitempty"`
+	Raw       map[string]interface{} `json:"raw,omitempty"`
+}
+
+func meetingEventsOutputView(runtime *common.RuntimeContext) (meetingEventsView, error) {
+	view := strings.TrimSpace(runtime.Str("view"))
+	if view == "" {
+		view = string(meetingEventsViewCompact)
+	}
+	switch meetingEventsView(view) {
+	case meetingEventsViewCompact:
+		return meetingEventsViewCompact, nil
+	case meetingEventsViewRaw:
+		if runtime.Format != "" && runtime.Format != "json" {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--view raw only supports --format json").WithParam("--view")
+		}
+		return meetingEventsViewRaw, nil
+	default:
+		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--view must be compact or raw, got %q", view).WithParam("--view")
+	}
+}
+
+func buildNormalizedMeetingEvents(data map[string]interface{}, events []interface{}, currentRoster []interface{}, botInfo *common.BotInfo) normalizedMeetingEventsOutput {
+	normalized := normalizedMeetingEventsOutput{
+		Bot:       normalizeBotIdentity(botInfo),
+		HasMore:   common.GetBool(data, "has_more"),
+		PageToken: common.GetString(data, "page_token"),
+	}
+	for _, raw := range events {
+		event, _ := raw.(map[string]interface{})
+		if event == nil {
+			continue
+		}
+		payload := common.GetMap(event, "payload")
+		if normalized.Meeting.ID == "" {
+			normalized.Meeting = normalizeMeeting(common.GetMap(payload, "meeting"))
+		}
+		normalized.Events = append(normalized.Events, normalizeMeetingEvent(event, normalized.Bot.ID))
+	}
+	normalized.CurrentRoster = normalizeCurrentRoster(currentRoster, normalized.Bot.ID)
+	return normalized
+}
+
+func fetchMeetingEventsCurrentRoster(runtime *common.RuntimeContext) ([]interface{}, error) {
+	meetingID := strings.TrimSpace(runtime.Str("meeting-id"))
+	data, err := runtime.CallAPITyped(http.MethodGet, fmt.Sprintf("/open-apis/vc/v1/meetings/%s", validate.EncodePathSegment(meetingID)),
+		map[string]interface{}{"with_participants": "true", "query_mode": "0"}, nil)
+	if err != nil {
+		return nil, err
+	}
+	if meeting := common.GetMap(data, "meeting"); meeting != nil {
+		if roster := common.GetSlice(meeting, "participants"); len(roster) > 0 {
+			return roster, nil
+		}
+		if roster := common.GetSlice(meeting, "current_roster"); len(roster) > 0 {
+			return roster, nil
+		}
+	}
+	if roster := common.GetSlice(data, "participants"); len(roster) > 0 {
+		return roster, nil
+	}
+	return common.GetSlice(data, "current_roster"), nil
+}
+
+func normalizeBotIdentity(botInfo *common.BotInfo) normalizedIdentity {
+	if botInfo == nil {
+		return normalizedIdentity{ParticipantType: "bot", Role: "bot", IsSelf: true, Label: "bot"}
+	}
+	identity := normalizedIdentity{
+		ID:              botInfo.OpenID,
+		Name:            botInfo.AppName,
+		ParticipantType: "bot",
+		Role:            "bot",
+		IsSelf:          true,
+	}
+	identity.Label = identityLabel(identity)
+	return identity
+}
+
+func normalizeMeeting(meeting map[string]interface{}) normalizedMeeting {
+	out := normalizedMeeting{
+		ID:        common.GetString(meeting, "id"),
+		Topic:     common.GetString(meeting, "topic"),
+		MeetingNo: common.GetString(meeting, "meeting_no"),
+		StartTime: normalizeTimeString(common.GetString(meeting, "start_time")),
+		EndTime:   normalizeTimeString(common.GetString(meeting, "end_time")),
+		Status:    "unknown",
+	}
+	start, hasStart := parseFlexibleTime(out.StartTime)
+	end, hasEnd := parseFlexibleTime(out.EndTime)
+	if hasStart && hasEnd {
+		if end.After(start) {
+			out.Status = "ended"
+		} else {
+			out.Status = "ongoing"
+		}
+	}
+	return out
+}
+
+func normalizeMeetingEvent(event map[string]interface{}, selfID string) normalizedMeetingEvent {
+	payload := common.GetMap(event, "payload")
+	rawCopy := cloneStringMap(event)
+	out := normalizedMeetingEvent{
+		EventID:   common.GetString(event, "event_id"),
+		EventType: meetingEventType(event),
+		EventTime: normalizeTimeString(common.GetString(event, "event_time")),
+		Summary:   meetingEventSummary(event),
+		Payload:   payload,
+		Raw:       rawCopy,
+	}
+	out.Actors = eventActors(out.EventType, payload, selfID)
+	return out
+}
+
+func normalizeCurrentRoster(rawRoster []interface{}, selfID string) []normalizedIdentity {
+	roster := make([]normalizedIdentity, 0, len(rawRoster))
+	for _, raw := range rawRoster {
+		item, _ := raw.(map[string]interface{})
+		if item == nil {
+			continue
+		}
+		participant := item
+		if nested := common.GetMap(item, "participant"); nested != nil {
+			participant = nested
+		}
+		roster = append(roster, normalizeParticipant(participant, selfID))
+	}
+	return roster
+}
+
+func eventActors(eventType string, payload map[string]interface{}, selfID string) []normalizedIdentity {
+	var actors []normalizedIdentity
+	addFromItems := func(key, participantKey string) {
+		for _, raw := range common.GetSlice(payload, key) {
+			item, _ := raw.(map[string]interface{})
+			if item == nil {
+				continue
+			}
+			if participant := common.GetMap(item, participantKey); participant != nil {
+				actors = append(actors, normalizeParticipant(participant, selfID))
+			}
+		}
+	}
+	switch eventType {
+	case "participant_joined":
+		addFromItems("participant_joined_items", "participant")
+	case "participant_left":
+		addFromItems("participant_left_items", "participant")
+	case "transcript_received":
+		addFromItems("transcript_received_items", "speaker")
+	case "chat_received":
+		addFromItems("chat_received_items", "operator")
+	case "magic_share_started":
+		addFromItems("magic_share_started_items", "operator")
+	case "magic_share_ended":
+		addFromItems("magic_share_ended_items", "operator")
+	}
+	return actors
+}
+
+func normalizeParticipant(participant map[string]interface{}, selfID string) normalizedIdentity {
+	identity := normalizedIdentity{
+		ID:              common.GetString(participant, "id"),
+		Name:            common.GetString(participant, "user_name"),
+		ParticipantType: normalizeParticipantType(participant),
+		Role:            normalizeRole(participant),
+	}
+	if identity.ID != "" && selfID != "" && identity.ID == selfID {
+		identity.IsSelf = true
+		if identity.ParticipantType == "" || identity.ParticipantType == "human" {
+			identity.ParticipantType = "bot"
+		}
+		if identity.Role == "" || identity.Role == "participant" {
+			identity.Role = "bot"
+		}
+	}
+	if identity.ParticipantType == "" {
+		identity.ParticipantType = "human"
+	}
+	if identity.Role == "" {
+		identity.Role = "participant"
+	}
+	identity.Label = identityLabel(identity)
+	return identity
+}
+
+func normalizeParticipantType(participant map[string]interface{}) string {
+	raw := strings.ToLower(strings.TrimSpace(firstNonEmptyString(participant, "participant_type", "user_type", "type")))
+	switch raw {
+	case "1", "user", "human":
+		return "human"
+	case "2", "bot", "app":
+		return "bot"
+	case "":
+		return ""
+	default:
+		return raw
+	}
+}
+
+func normalizeRole(participant map[string]interface{}) string {
+	raw := strings.ToLower(strings.TrimSpace(firstNonEmptyString(participant, "role", "participant_role")))
+	switch raw {
+	case "1", "host":
+		return "host"
+	case "2", "co_host", "cohost":
+		return "co_host"
+	case "3", "participant", "attendee":
+		return "participant"
+	case "4", "bot", "app":
+		return "bot"
+	case "":
+		return ""
+	default:
+		return raw
+	}
+}
+
+func firstNonEmptyString(values map[string]interface{}, keys ...string) string {
+	for _, key := range keys {
+		if value := common.GetString(values, key); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func identityLabel(identity normalizedIdentity) string {
+	name := identity.Name
+	if name == "" {
+		name = identity.ID
+	}
+	if name == "" {
+		name = "unknown"
+	}
+	var tags []string
+	if identity.ParticipantType != "" {
+		tags = append(tags, identity.ParticipantType)
+	}
+	if identity.Role != "" && identity.Role != identity.ParticipantType {
+		tags = append(tags, identity.Role)
+	}
+	if identity.IsSelf {
+		tags = append(tags, "self")
+	}
+	if len(tags) == 0 {
+		return name
+	}
+	return fmt.Sprintf("%s [%s]", name, strings.Join(tags, ","))
+}
+
+func normalizeTimeString(raw string) string {
+	if parsed, ok := parseFlexibleTime(raw); ok {
+		return parsed.UTC().Format(time.RFC3339)
+	}
+	return strings.TrimSpace(raw)
+}
+
+func cloneStringMap(in map[string]interface{}) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	raw, err := json.Marshal(in)
+	if err != nil {
+		return in
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return in
+	}
+	return out
+}
+
+func normalizedMeetingEventRows(events []normalizedMeetingEvent, metadata map[string]interface{}) []interface{} {
+	rows := make([]interface{}, 0, len(events)+1)
+	for _, event := range events {
+		row := map[string]interface{}{
+			"row_type":   "event",
+			"event_id":   event.EventID,
+			"event_type": event.EventType,
+			"event_time": event.EventTime,
+			"summary":    event.Summary,
+			"actors":     event.Actors,
+			"payload":    event.Payload,
+			"raw":        event.Raw,
+		}
+		rows = append(rows, row)
+	}
+	if metadata != nil {
+		rows = append(rows, metadata)
+	}
+	return rows
+}
+
+func renderMeetingEventsCompactPretty(w io.Writer, data normalizedMeetingEventsOutput, timeline meetingTimeline) {
+	if data.Bot.Label != "" {
+		fmt.Fprintf(w, "应用身份：%s\n", escapePrettyText(data.Bot.Label))
+	}
+	if len(data.CurrentRoster) > 0 {
+		fmt.Fprintln(w, "当前名单：")
+		for _, participant := range data.CurrentRoster {
+			fmt.Fprintf(w, "- %s\n", escapePrettyText(participant.Label))
+		}
+		fmt.Fprintln(w)
+	}
+	if len(timeline.entries) == 0 {
+		fmt.Fprintln(w, "No meeting events.")
+		return
+	}
+	io.WriteString(w, renderMeetingEventsPretty(timeline))
 }
 
 func meetingEventsPageSize(runtime *common.RuntimeContext) (int, error) {

--- a/shortcuts/vc/vc_meeting_events.go
+++ b/shortcuts/vc/vc_meeting_events.go
@@ -16,6 +16,7 @@ import (
 	"unicode"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -50,14 +51,14 @@ func toUnixSeconds(input string, hint ...string) (string, error) {
 	return ts, nil
 }
 
-// VCMeetingEvents lists bot meeting events for a meeting.
+// VCMeetingEvents lists meeting events for a meeting.
 var VCMeetingEvents = common.Shortcut{
 	Service:     "vc",
 	Command:     "+meeting-events",
-	Description: "List bot meeting events by meeting ID",
+	Description: "List meeting events by meeting ID",
 	Risk:        "read",
 	Scopes:      []string{"vc:meeting.meetingevent:read"},
-	AuthTypes:   []string{"bot"},
+	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "meeting-id", Required: true, Desc: "meeting ID to query"},
@@ -118,19 +119,19 @@ var VCMeetingEvents = common.Shortcut{
 			return nil
 		}
 		events = compactMeetingEvents(events)
-		botInfo, err := runtime.BotInfo()
+		identity, err := meetingEventsCurrentIdentity(runtime)
 		if err != nil {
-			return errs.NewValidationError(errs.SubtypeInvalidArgument, "fetch bot identity for compact meeting-events output: %v", err).WithParam("--as")
+			return err
 		}
 		currentRoster, err := fetchMeetingEventsCurrentRoster(runtime)
 		if err != nil {
 			return err
 		}
-		outData := buildNormalizedMeetingEvents(data, events, currentRoster, botInfo)
+		outData := buildNormalizedMeetingEvents(data, events, currentRoster, identity)
 		ndjsonData := normalizedMeetingEventRows(outData.Events, map[string]interface{}{
 			"row_type":       "metadata",
 			"meeting":        outData.Meeting,
-			"bot":            outData.Bot,
+			"identity":       outData.Identity,
 			"current_roster": outData.CurrentRoster,
 			"has_more":       outData.HasMore,
 			"page_token":     outData.PageToken,
@@ -156,7 +157,7 @@ var VCMeetingEvents = common.Shortcut{
 
 type normalizedMeetingEventsOutput struct {
 	Meeting       normalizedMeeting        `json:"meeting"`
-	Bot           normalizedIdentity       `json:"bot"`
+	Identity      normalizedIdentity       `json:"identity"`
 	CurrentRoster []normalizedIdentity     `json:"current_roster"`
 	Events        []normalizedMeetingEvent `json:"events"`
 	HasMore       bool                     `json:"has_more"`
@@ -209,9 +210,9 @@ func meetingEventsOutputView(runtime *common.RuntimeContext) (meetingEventsView,
 	}
 }
 
-func buildNormalizedMeetingEvents(data map[string]interface{}, events []interface{}, currentRoster []interface{}, botInfo *common.BotInfo) normalizedMeetingEventsOutput {
+func buildNormalizedMeetingEvents(data map[string]interface{}, events []interface{}, currentRoster []interface{}, identity normalizedIdentity) normalizedMeetingEventsOutput {
 	normalized := normalizedMeetingEventsOutput{
-		Bot:       normalizeBotIdentity(botInfo),
+		Identity:  identity,
 		HasMore:   common.GetBool(data, "has_more"),
 		PageToken: common.GetString(data, "page_token"),
 	}
@@ -224,10 +225,33 @@ func buildNormalizedMeetingEvents(data map[string]interface{}, events []interfac
 		if normalized.Meeting.ID == "" {
 			normalized.Meeting = normalizeMeeting(common.GetMap(payload, "meeting"))
 		}
-		normalized.Events = append(normalized.Events, normalizeMeetingEvent(event, normalized.Bot.ID))
+		normalized.Events = append(normalized.Events, normalizeMeetingEvent(event, normalized.Identity))
 	}
-	normalized.CurrentRoster = normalizeCurrentRoster(currentRoster, normalized.Bot.ID)
+	normalized.CurrentRoster = normalizeCurrentRoster(currentRoster, normalized.Identity)
 	return normalized
+}
+
+func meetingEventsCurrentIdentity(runtime *common.RuntimeContext) (normalizedIdentity, error) {
+	if runtime.As() == core.AsBot {
+		botInfo, err := runtime.BotInfo()
+		if err != nil {
+			return normalizedIdentity{}, errs.NewValidationError(errs.SubtypeInvalidArgument, "fetch bot identity for compact meeting-events output: %v", err).WithParam("--as")
+		}
+		return normalizeBotIdentity(botInfo), nil
+	}
+	userOpenID := strings.TrimSpace(runtime.UserOpenId())
+	if userOpenID == "" {
+		return normalizedIdentity{}, errs.NewValidationError(errs.SubtypeFailedPrecondition, "current user open_id is unavailable for compact meeting-events output").WithParam("--as")
+	}
+	identity := normalizedIdentity{
+		ID:              userOpenID,
+		Name:            strings.TrimSpace(runtime.Config.UserName),
+		ParticipantType: "human",
+		Role:            "user",
+		IsSelf:          true,
+	}
+	identity.Label = identityLabel(identity)
+	return identity, nil
 }
 
 func fetchMeetingEventsCurrentRoster(runtime *common.RuntimeContext) ([]interface{}, error) {
@@ -287,7 +311,7 @@ func normalizeMeeting(meeting map[string]interface{}) normalizedMeeting {
 	return out
 }
 
-func normalizeMeetingEvent(event map[string]interface{}, selfID string) normalizedMeetingEvent {
+func normalizeMeetingEvent(event map[string]interface{}, selfIdentity normalizedIdentity) normalizedMeetingEvent {
 	payload := common.GetMap(event, "payload")
 	rawCopy := cloneStringMap(event)
 	out := normalizedMeetingEvent{
@@ -298,11 +322,11 @@ func normalizeMeetingEvent(event map[string]interface{}, selfID string) normaliz
 		Payload:   payload,
 		Raw:       rawCopy,
 	}
-	out.Actors = eventActors(out.EventType, payload, selfID)
+	out.Actors = eventActors(out.EventType, payload, selfIdentity)
 	return out
 }
 
-func normalizeCurrentRoster(rawRoster []interface{}, selfID string) []normalizedIdentity {
+func normalizeCurrentRoster(rawRoster []interface{}, selfIdentity normalizedIdentity) []normalizedIdentity {
 	roster := make([]normalizedIdentity, 0, len(rawRoster))
 	for _, raw := range rawRoster {
 		item, _ := raw.(map[string]interface{})
@@ -313,12 +337,12 @@ func normalizeCurrentRoster(rawRoster []interface{}, selfID string) []normalized
 		if nested := common.GetMap(item, "participant"); nested != nil {
 			participant = nested
 		}
-		roster = append(roster, normalizeParticipant(participant, selfID))
+		roster = append(roster, normalizeParticipant(participant, selfIdentity))
 	}
 	return roster
 }
 
-func eventActors(eventType string, payload map[string]interface{}, selfID string) []normalizedIdentity {
+func eventActors(eventType string, payload map[string]interface{}, selfIdentity normalizedIdentity) []normalizedIdentity {
 	var actors []normalizedIdentity
 	addFromItems := func(key, participantKey string) {
 		for _, raw := range common.GetSlice(payload, key) {
@@ -327,7 +351,7 @@ func eventActors(eventType string, payload map[string]interface{}, selfID string
 				continue
 			}
 			if participant := common.GetMap(item, participantKey); participant != nil {
-				actors = append(actors, normalizeParticipant(participant, selfID))
+				actors = append(actors, normalizeParticipant(participant, selfIdentity))
 			}
 		}
 	}
@@ -348,19 +372,19 @@ func eventActors(eventType string, payload map[string]interface{}, selfID string
 	return actors
 }
 
-func normalizeParticipant(participant map[string]interface{}, selfID string) normalizedIdentity {
+func normalizeParticipant(participant map[string]interface{}, selfIdentity normalizedIdentity) normalizedIdentity {
 	identity := normalizedIdentity{
 		ID:              common.GetString(participant, "id"),
 		Name:            common.GetString(participant, "user_name"),
 		ParticipantType: normalizeParticipantType(participant),
 		Role:            normalizeRole(participant),
 	}
-	if identity.ID != "" && selfID != "" && identity.ID == selfID {
+	if identity.ID != "" && selfIdentity.ID != "" && identity.ID == selfIdentity.ID {
 		identity.IsSelf = true
-		if identity.ParticipantType == "" || identity.ParticipantType == "human" {
+		if selfIdentity.ParticipantType == "bot" && (identity.ParticipantType == "" || identity.ParticipantType == "human") {
 			identity.ParticipantType = "bot"
 		}
-		if identity.Role == "" || identity.Role == "participant" {
+		if selfIdentity.Role == "bot" && (identity.Role == "" || identity.Role == "participant") {
 			identity.Role = "bot"
 		}
 	}
@@ -483,8 +507,8 @@ func normalizedMeetingEventRows(events []normalizedMeetingEvent, metadata map[st
 }
 
 func renderMeetingEventsCompactPretty(w io.Writer, data normalizedMeetingEventsOutput, timeline meetingTimeline) {
-	if data.Bot.Label != "" {
-		fmt.Fprintf(w, "应用身份：%s\n", escapePrettyText(data.Bot.Label))
+	if data.Identity.Label != "" {
+		fmt.Fprintf(w, "当前身份：%s\n", escapePrettyText(data.Identity.Label))
 	}
 	if len(data.CurrentRoster) > 0 {
 		fmt.Fprintln(w, "当前名单：")

--- a/shortcuts/vc/vc_meeting_events.go
+++ b/shortcuts/vc/vc_meeting_events.go
@@ -32,13 +32,6 @@ const (
 
 var meetingDisplayLocation = time.FixedZone("UTC+8", 8*60*60)
 
-type meetingEventsView string
-
-const (
-	meetingEventsViewCompact meetingEventsView = "compact"
-	meetingEventsViewRaw     meetingEventsView = "raw"
-)
-
 // toUnixSeconds converts a supported CLI time input into a Unix seconds string.
 func toUnixSeconds(input string, hint ...string) (string, error) {
 	ts, err := common.ParseTime(input, hint...)
@@ -67,13 +60,9 @@ var VCMeetingEvents = common.Shortcut{
 		{Name: "page-token", Desc: "page token for the next page"},
 		{Name: "page-size", Default: "20", Desc: "page size, 20-100 (default 20)"},
 		{Name: "page-all", Type: "bool", Desc: "automatically paginate through all available pages"},
-		{Name: "view", Default: string(meetingEventsViewCompact), Desc: "output view: compact or raw"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if err := validateMeetingEventsMeetingID(runtime.Str("meeting-id")); err != nil {
-			return err
-		}
-		if _, err := meetingEventsOutputView(runtime); err != nil {
 			return err
 		}
 		if _, err := meetingEventsPageSize(runtime); err != nil {
@@ -111,12 +100,6 @@ var VCMeetingEvents = common.Shortcut{
 		data, events, hasMore, pageToken, err := fetchMeetingEvents(ctx, runtime, startTime, endTime)
 		if err != nil {
 			return err
-		}
-		if view, err := meetingEventsOutputView(runtime); err != nil {
-			return err
-		} else if view == meetingEventsViewRaw {
-			runtime.Out(data, &output.Meta{Count: len(events)})
-			return nil
 		}
 		events = compactMeetingEvents(events)
 		identity, err := meetingEventsCurrentIdentity(runtime)
@@ -190,24 +173,6 @@ type normalizedMeetingEvent struct {
 	Actors    []normalizedIdentity   `json:"actors,omitempty"`
 	Payload   map[string]interface{} `json:"payload,omitempty"`
 	Raw       map[string]interface{} `json:"raw,omitempty"`
-}
-
-func meetingEventsOutputView(runtime *common.RuntimeContext) (meetingEventsView, error) {
-	view := strings.TrimSpace(runtime.Str("view"))
-	if view == "" {
-		view = string(meetingEventsViewCompact)
-	}
-	switch meetingEventsView(view) {
-	case meetingEventsViewCompact:
-		return meetingEventsViewCompact, nil
-	case meetingEventsViewRaw:
-		if runtime.Format != "" && runtime.Format != "json" {
-			return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--view raw only supports --format json").WithParam("--view")
-		}
-		return meetingEventsViewRaw, nil
-	default:
-		return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "--view must be compact or raw, got %q", view).WithParam("--view")
-	}
 }
 
 func buildNormalizedMeetingEvents(data map[string]interface{}, events []interface{}, currentRoster []interface{}, identity normalizedIdentity) normalizedMeetingEventsOutput {

--- a/shortcuts/vc/vc_meeting_events_test.go
+++ b/shortcuts/vc/vc_meeting_events_test.go
@@ -509,7 +509,7 @@ func TestMeetingEvents_ExecuteJSON_PageAll(t *testing.T) {
 
 	out := strings.ReplaceAll(stdout.String(), " ", "")
 	out = strings.ReplaceAll(out, "\n", "")
-	if count := strings.Count(out, `"id":"event-1"`); count != 2 {
+	if count := strings.Count(out, `"summary":"participantbot_001(DemoBot)joined"`); count != 2 {
 		t.Fatalf("expected 2 aggregated events, got %d: %s", count, stdout.String())
 	}
 	if !strings.Contains(out, `"has_more":false`) {

--- a/shortcuts/vc/vc_meeting_events_test.go
+++ b/shortcuts/vc/vc_meeting_events_test.go
@@ -27,7 +27,6 @@ func newMeetingEventsRuntime() *common.RuntimeContext {
 	cmd.Flags().String("page-token", "", "")
 	cmd.Flags().String("page-size", "", "")
 	cmd.Flags().Bool("page-all", false, "")
-	cmd.Flags().String("view", "compact", "")
 	return common.TestNewRuntimeContext(cmd, defaultConfig())
 }
 
@@ -592,39 +591,6 @@ func TestMeetingEvents_ExecuteJSON_UserIdentitySkipsBotInfo(t *testing.T) {
 	}
 }
 
-func TestMeetingEvents_ExecuteRawJSONSkipsBotInfo(t *testing.T) {
-	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
-	reg.Register(meetingEventsStub([]interface{}{participantJoinedEvent()}, true, "1710000000000000000"))
-
-	err := mountAndRun(t, VCMeetingEvents, []string{
-		"+meeting-events",
-		"--meeting-id", "7628568141510692381",
-		"--format", "json",
-		"--view", "raw",
-		"--as", "bot",
-	}, f, stdout)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	reg.Verify(t)
-
-	out := strings.ReplaceAll(stdout.String(), " ", "")
-	out = strings.ReplaceAll(out, "\n", "")
-	for _, want := range []string{
-		`"events":[`,
-		`"event_type":"participant_joined"`,
-		`"has_more":true`,
-		`"page_token":"1710000000000000000"`,
-	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("raw json output missing %q: %s", want, stdout.String())
-		}
-	}
-	if strings.Contains(out, `"current_roster"`) || strings.Contains(out, `"identity":{`) || strings.Contains(out, `"bot":{`) {
-		t.Fatalf("raw json should preserve legacy events envelope without normalized fields: %s", stdout.String())
-	}
-}
-
 func TestMeetingEvents_ExecuteNDJSONIncludesMetadataRow(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
 	reg.Register(meetingEventsStub([]interface{}{participantJoinedEvent()}, true, "1710000000000000000"))
@@ -661,25 +627,6 @@ func TestMeetingEvents_ExecuteNDJSONIncludesMetadataRow(t *testing.T) {
 		if !strings.Contains(lines[1], want) {
 			t.Fatalf("metadata ndjson row missing %q: %s", want, lines[1])
 		}
-	}
-}
-
-func TestMeetingEvents_Validation_RawRejectsPretty(t *testing.T) {
-	runtime := newMeetingEventsRuntime()
-	mustSetMeetingEventsFlag(t, runtime, "meeting-id", "7628568141510692381")
-	mustSetMeetingEventsFlag(t, runtime, "view", "raw")
-	runtime.Format = "pretty"
-
-	err := VCMeetingEvents.Validate(context.Background(), runtime)
-	if err == nil {
-		t.Fatal("expected validation error for raw pretty")
-	}
-	var ve *errs.ValidationError
-	if !errors.As(err, &ve) {
-		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
-	}
-	if ve.Param != "--view" {
-		t.Errorf("Param = %q, want %q", ve.Param, "--view")
 	}
 }
 

--- a/shortcuts/vc/vc_meeting_events_test.go
+++ b/shortcuts/vc/vc_meeting_events_test.go
@@ -540,7 +540,7 @@ func TestMeetingEvents_ExecuteJSON(t *testing.T) {
 	out := strings.ReplaceAll(stdout.String(), " ", "")
 	out = strings.ReplaceAll(out, "\n", "")
 	for _, want := range []string{
-		`"bot":{"id":"bot_001","name":"DemoBot","participant_type":"bot","role":"bot","is_self":true,"label":"DemoBot[bot,self]"}`,
+		`"identity":{"id":"bot_001","name":"DemoBot","participant_type":"bot","role":"bot","is_self":true,"label":"DemoBot[bot,self]"}`,
 		`"current_roster":[`,
 		`"role":"host"`,
 		`"is_self":true`,
@@ -553,6 +553,41 @@ func TestMeetingEvents_ExecuteJSON(t *testing.T) {
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("json output missing %q: %s", want, stdout.String())
+		}
+	}
+}
+
+func TestMeetingEvents_ExecuteJSON_UserIdentitySkipsBotInfo(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(meetingEventsStub([]interface{}{participantJoinedEvent()}, false, ""))
+	reg.Register(meetingDetailRosterStub([]interface{}{
+		map[string]interface{}{"id": "ou_testuser", "user_name": "Current User", "participant_type": "1", "role": "1"},
+		map[string]interface{}{"id": "u1", "user_name": "Alice", "participant_type": "1", "role": "1"},
+	}))
+
+	err := mountAndRun(t, VCMeetingEvents, []string{
+		"+meeting-events",
+		"--meeting-id", "7628568141510692381",
+		"--format", "json",
+		"--as", "user",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	reg.Verify(t)
+
+	out := strings.ReplaceAll(stdout.String(), " ", "")
+	out = strings.ReplaceAll(out, "\n", "")
+	for _, want := range []string{
+		`"identity":{"id":"ou_testuser","participant_type":"human","role":"user","is_self":true,"label":"ou_testuser[human,user,self]"}`,
+		`"current_roster":[`,
+		`"id":"ou_testuser"`,
+		`"is_self":true`,
+		`"event_type":"participant_joined"`,
+		`"has_more":false`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("user json output missing %q: %s", want, stdout.String())
 		}
 	}
 }
@@ -585,7 +620,7 @@ func TestMeetingEvents_ExecuteRawJSONSkipsBotInfo(t *testing.T) {
 			t.Fatalf("raw json output missing %q: %s", want, stdout.String())
 		}
 	}
-	if strings.Contains(out, `"current_roster"`) || strings.Contains(out, `"bot":`) {
+	if strings.Contains(out, `"current_roster"`) || strings.Contains(out, `"identity":{`) || strings.Contains(out, `"bot":{`) {
 		t.Fatalf("raw json should preserve legacy events envelope without normalized fields: %s", stdout.String())
 	}
 }
@@ -620,6 +655,7 @@ func TestMeetingEvents_ExecuteNDJSONIncludesMetadataRow(t *testing.T) {
 		`"row_type":"metadata"`,
 		`"has_more":true`,
 		`"page_token":"1710000000000000000"`,
+		`"identity":`,
 		`"current_roster":[`,
 	} {
 		if !strings.Contains(lines[1], want) {
@@ -703,7 +739,7 @@ func TestMeetingEvents_ExecutePretty(t *testing.T) {
 
 	out := stdout.String()
 	for _, want := range []string{
-		"应用身份：Demo Bot [bot,self]",
+		"当前身份：Demo Bot [bot,self]",
 		"当前名单：",
 		"- Demo Bot [bot,self]",
 		"- Alice [human,host]",

--- a/shortcuts/vc/vc_meeting_events_test.go
+++ b/shortcuts/vc/vc_meeting_events_test.go
@@ -509,7 +509,7 @@ func TestMeetingEvents_ExecuteJSON_PageAll(t *testing.T) {
 
 	out := strings.ReplaceAll(stdout.String(), " ", "")
 	out = strings.ReplaceAll(out, "\n", "")
-	if count := strings.Count(out, `"event_type":"participant_joined"`); count != 2 {
+	if count := strings.Count(out, `"id":"event-1"`); count != 2 {
 		t.Fatalf("expected 2 aggregated events, got %d: %s", count, stdout.String())
 	}
 	if !strings.Contains(out, `"has_more":false`) {

--- a/shortcuts/vc/vc_meeting_events_test.go
+++ b/shortcuts/vc/vc_meeting_events_test.go
@@ -546,7 +546,7 @@ func TestMeetingEvents_ExecuteJSON(t *testing.T) {
 		`"is_self":true`,
 		`"event_type":"participant_joined"`,
 		`"actors":[`,
-		`"start_time":"2026-04-17T07:55:00Z"`,
+		`"start_time":"2026-04-17T06:35:00Z"`,
 		`"has_more":true`,
 		`"page_token":"1710000000000000000"`,
 		`"events":[`,

--- a/shortcuts/vc/vc_meeting_events_test.go
+++ b/shortcuts/vc/vc_meeting_events_test.go
@@ -27,6 +27,7 @@ func newMeetingEventsRuntime() *common.RuntimeContext {
 	cmd.Flags().String("page-token", "", "")
 	cmd.Flags().String("page-size", "", "")
 	cmd.Flags().Bool("page-all", false, "")
+	cmd.Flags().String("view", "compact", "")
 	return common.TestNewRuntimeContext(cmd, defaultConfig())
 }
 
@@ -54,6 +55,38 @@ func meetingEventsStub(events []interface{}, hasMore bool, pageToken string) *ht
 	}
 }
 
+func botInfoStub() *httpmock.Stub {
+	return &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/bot/v3/info",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"bot": map[string]interface{}{
+				"open_id":  "bot_001",
+				"app_name": "Demo Bot",
+			},
+		},
+	}
+}
+
+func meetingDetailRosterStub(roster []interface{}) *httpmock.Stub {
+	return &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/vc/v1/meetings/7628568141510692381",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"meeting": map[string]interface{}{
+					"id":           "7628568141510692381",
+					"participants": roster,
+				},
+			},
+		},
+	}
+}
+
 func participantJoinedEvent() map[string]interface{} {
 	return map[string]interface{}{
 		"event_id":   "event-1",
@@ -71,8 +104,10 @@ func participantJoinedEvent() map[string]interface{} {
 			"participant_joined_items": []interface{}{
 				map[string]interface{}{
 					"participant": map[string]interface{}{
-						"id":        "bot_001",
-						"user_name": "Demo Bot",
+						"id":               "bot_001",
+						"user_name":        "Demo Bot",
+						"participant_type": "2",
+						"role":             "4",
 					},
 					"join_time": "2026-04-17T08:00:00Z",
 				},
@@ -414,7 +449,7 @@ func TestMeetingEvents_DryRun(t *testing.T) {
 		"--start", "1710000000",
 		"--end", "1710003600",
 		"--dry-run",
-		"--as", "user",
+		"--as", "bot",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -442,7 +477,7 @@ func TestMeetingEvents_DryRun_PageAllUsesMaxLimit(t *testing.T) {
 		"--meeting-id", "7628568141510692381",
 		"--page-all",
 		"--dry-run",
-		"--as", "user",
+		"--as", "bot",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -457,13 +492,15 @@ func TestMeetingEvents_ExecuteJSON_PageAll(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
 	reg.Register(meetingEventsStub([]interface{}{participantJoinedEvent()}, true, "pt_2"))
 	reg.Register(meetingEventsStub([]interface{}{participantJoinedEvent()}, false, ""))
+	reg.Register(botInfoStub())
+	reg.Register(meetingDetailRosterStub(nil))
 
 	err := mountAndRun(t, VCMeetingEvents, []string{
 		"+meeting-events",
 		"--meeting-id", "7628568141510692381",
 		"--format", "json",
 		"--page-all",
-		"--as", "user",
+		"--as", "bot",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -483,12 +520,17 @@ func TestMeetingEvents_ExecuteJSON_PageAll(t *testing.T) {
 func TestMeetingEvents_ExecuteJSON(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
 	reg.Register(meetingEventsStub([]interface{}{participantJoinedEvent()}, true, "1710000000000000000"))
+	reg.Register(botInfoStub())
+	reg.Register(meetingDetailRosterStub([]interface{}{
+		map[string]interface{}{"id": "bot_001", "user_name": "Demo Bot", "participant_type": "2", "role": "4"},
+		map[string]interface{}{"id": "u1", "user_name": "Alice", "participant_type": "1", "role": "1"},
+	}))
 
 	err := mountAndRun(t, VCMeetingEvents, []string{
 		"+meeting-events",
 		"--meeting-id", "7628568141510692381",
 		"--format", "json",
-		"--as", "user",
+		"--as", "bot",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -498,7 +540,13 @@ func TestMeetingEvents_ExecuteJSON(t *testing.T) {
 	out := strings.ReplaceAll(stdout.String(), " ", "")
 	out = strings.ReplaceAll(out, "\n", "")
 	for _, want := range []string{
+		`"bot":{"id":"bot_001","name":"DemoBot","participant_type":"bot","role":"bot","is_self":true,"label":"DemoBot[bot,self]"}`,
+		`"current_roster":[`,
+		`"role":"host"`,
+		`"is_self":true`,
 		`"event_type":"participant_joined"`,
+		`"actors":[`,
+		`"start_time":"2026-04-17T07:55:00Z"`,
 		`"has_more":true`,
 		`"page_token":"1710000000000000000"`,
 		`"events":[`,
@@ -509,15 +557,107 @@ func TestMeetingEvents_ExecuteJSON(t *testing.T) {
 	}
 }
 
-func TestMeetingEvents_ExecuteJSON_PrunesEmptySlices(t *testing.T) {
+func TestMeetingEvents_ExecuteRawJSONSkipsBotInfo(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
-	reg.Register(meetingEventsStub([]interface{}{chatReceivedEvent()}, false, ""))
+	reg.Register(meetingEventsStub([]interface{}{participantJoinedEvent()}, true, "1710000000000000000"))
 
 	err := mountAndRun(t, VCMeetingEvents, []string{
 		"+meeting-events",
 		"--meeting-id", "7628568141510692381",
 		"--format", "json",
-		"--as", "user",
+		"--view", "raw",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	reg.Verify(t)
+
+	out := strings.ReplaceAll(stdout.String(), " ", "")
+	out = strings.ReplaceAll(out, "\n", "")
+	for _, want := range []string{
+		`"events":[`,
+		`"event_type":"participant_joined"`,
+		`"has_more":true`,
+		`"page_token":"1710000000000000000"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("raw json output missing %q: %s", want, stdout.String())
+		}
+	}
+	if strings.Contains(out, `"current_roster"`) || strings.Contains(out, `"bot":`) {
+		t.Fatalf("raw json should preserve legacy events envelope without normalized fields: %s", stdout.String())
+	}
+}
+
+func TestMeetingEvents_ExecuteNDJSONIncludesMetadataRow(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(meetingEventsStub([]interface{}{participantJoinedEvent()}, true, "1710000000000000000"))
+	reg.Register(botInfoStub())
+	reg.Register(meetingDetailRosterStub([]interface{}{
+		map[string]interface{}{"id": "bot_001", "user_name": "Demo Bot", "participant_type": "2", "role": "4"},
+	}))
+
+	err := mountAndRun(t, VCMeetingEvents, []string{
+		"+meeting-events",
+		"--meeting-id", "7628568141510692381",
+		"--format", "ndjson",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	reg.Verify(t)
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("ndjson lines = %d, want 2: %s", len(lines), stdout.String())
+	}
+	if !strings.Contains(lines[0], `"row_type":"event"`) || !strings.Contains(lines[0], `"event_type":"participant_joined"`) {
+		t.Fatalf("first ndjson row should be event: %s", lines[0])
+	}
+	for _, want := range []string{
+		`"row_type":"metadata"`,
+		`"has_more":true`,
+		`"page_token":"1710000000000000000"`,
+		`"current_roster":[`,
+	} {
+		if !strings.Contains(lines[1], want) {
+			t.Fatalf("metadata ndjson row missing %q: %s", want, lines[1])
+		}
+	}
+}
+
+func TestMeetingEvents_Validation_RawRejectsPretty(t *testing.T) {
+	runtime := newMeetingEventsRuntime()
+	mustSetMeetingEventsFlag(t, runtime, "meeting-id", "7628568141510692381")
+	mustSetMeetingEventsFlag(t, runtime, "view", "raw")
+	runtime.Format = "pretty"
+
+	err := VCMeetingEvents.Validate(context.Background(), runtime)
+	if err == nil {
+		t.Fatal("expected validation error for raw pretty")
+	}
+	var ve *errs.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected *errs.ValidationError, got %T: %v", err, err)
+	}
+	if ve.Param != "--view" {
+		t.Errorf("Param = %q, want %q", ve.Param, "--view")
+	}
+}
+
+func TestMeetingEvents_ExecuteJSON_PrunesEmptySlices(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
+	reg.Register(meetingEventsStub([]interface{}{chatReceivedEvent()}, false, ""))
+	reg.Register(botInfoStub())
+	reg.Register(meetingDetailRosterStub(nil))
+
+	err := mountAndRun(t, VCMeetingEvents, []string{
+		"+meeting-events",
+		"--meeting-id", "7628568141510692381",
+		"--format", "json",
+		"--as", "bot",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -544,12 +684,17 @@ func TestMeetingEvents_ExecuteJSON_PrunesEmptySlices(t *testing.T) {
 func TestMeetingEvents_ExecutePretty(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
 	reg.Register(meetingEventsStub([]interface{}{participantJoinedEventOngoing(), multiChatReceivedEvent(), magicShareStartedEvent()}, true, "1710000000000000000"))
+	reg.Register(botInfoStub())
+	reg.Register(meetingDetailRosterStub([]interface{}{
+		map[string]interface{}{"id": "bot_001", "user_name": "Demo Bot", "participant_type": "2", "role": "4"},
+		map[string]interface{}{"id": "u1", "user_name": "Alice", "participant_type": "1", "role": "1"},
+	}))
 
 	err := mountAndRun(t, VCMeetingEvents, []string{
 		"+meeting-events",
 		"--meeting-id", "7628568141510692381",
 		"--format", "pretty",
-		"--as", "user",
+		"--as", "bot",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -558,6 +703,10 @@ func TestMeetingEvents_ExecutePretty(t *testing.T) {
 
 	out := stdout.String()
 	for _, want := range []string{
+		"应用身份：Demo Bot [bot,self]",
+		"当前名单：",
+		"- Demo Bot [bot,self]",
+		"- Alice [human,host]",
 		"会议主题：项目例会",
 		"会议时间：2026-04-17 15:15:00（进行中）",
 		"Demo Bot(bot_001) 加入了会议",
@@ -582,12 +731,14 @@ func TestMeetingEvents_ExecutePretty(t *testing.T) {
 func TestMeetingEvents_ExecutePretty_PrintsPageTokenWithoutHasMore(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
 	reg.Register(meetingEventsStub([]interface{}{participantJoinedEventOngoing()}, false, "pt_last"))
+	reg.Register(botInfoStub())
+	reg.Register(meetingDetailRosterStub(nil))
 
 	err := mountAndRun(t, VCMeetingEvents, []string{
 		"+meeting-events",
 		"--meeting-id", "7628568141510692381",
 		"--format", "pretty",
-		"--as", "user",
+		"--as", "bot",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -606,12 +757,14 @@ func TestMeetingEvents_ExecutePretty_PrintsPageTokenWithoutHasMore(t *testing.T)
 func TestMeetingEvents_ExecuteEmpty(t *testing.T) {
 	f, stdout, _, reg := cmdutil.TestFactory(t, defaultConfig())
 	reg.Register(meetingEventsStub(nil, false, ""))
+	reg.Register(botInfoStub())
+	reg.Register(meetingDetailRosterStub(nil))
 
 	err := mountAndRun(t, VCMeetingEvents, []string{
 		"+meeting-events",
 		"--meeting-id", "7628568141510692381",
 		"--format", "pretty",
-		"--as", "user",
+		"--as", "bot",
 	}, f, stdout)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/skills/lark-vc-agent/SKILL.md
+++ b/skills/lark-vc-agent/SKILL.md
@@ -118,14 +118,14 @@ lark-cli vc +notes --meeting-ids "$MID"
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
 ```
 
 如果只是回答当前登录用户所在会议发生了什么，先用用户身份发现候选会议；读取事件仍需要应用机器人视角：
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
 ```
 
 ## Shortcuts

--- a/skills/lark-vc-agent/SKILL.md
+++ b/skills/lark-vc-agent/SKILL.md
@@ -45,11 +45,11 @@ metadata:
 
 | 场景 | 使用身份 | 关键规则 |
 | ---- | -------- | -------- |
-| 查询当前登录用户正在参加的会议 | `--as user` | 不传 `--user-id`；只用于发现候选会议；读取会中事件时切到应用身份，并确保应用机器人已在会中或曾参会 |
+| 查询当前登录用户正在参加的会议 | `--as user` | 不传 `--user-id`；拿到的 `meeting_id` 后续继续用 `--as user` 读事件 |
 | 查询目标用户且应用机器人也在会中的会议 | `--as bot --user-id <user_open_id>` | `--user-id` 必须是 `ou_...`；拿到的 `meeting_id` 后续继续用 `--as bot` 读事件 |
 | 用户明确要求应用机器人入会/旁听/代参会 | `--as bot` | 这是写操作，会真实产生入会记录；返回的 `meeting.id` 后续继续用 `--as bot` |
 
-硬规则：`+meeting-events` 是应用机器人视角的事件读取契约，后续统一用 `--as bot`。如果 `meeting_id` 来自用户身份发现，必须先确认应用机器人也在会中或按用户确认执行入会，否则事件读取会失败或不可见。
+硬规则：`meeting_id` 从哪种身份路径拿到，后续 `+meeting-events` 就沿用哪种身份，除非用户明确要求切换场景（例如从“仅查询我当前会”改成“让应用机器人入会旁听”）。
 
 ## 核心场景
 
@@ -66,19 +66,19 @@ metadata:
 
 1. 用户要看"会议里正在发生什么"（参会人加入/离开、聊天、转写、屏幕共享）时，用 `+meeting-events`。
 2. 输入是 **`meeting_id`**（长数字 ID），不是 9 位会议号。
-3. 不依赖默认身份。`+meeting-events` 必须显式使用 `--as bot`；`meeting_id` 来自用户身份发现时，只能作为候选输入，读取前必须确认应用机器人也在会中或曾参会。
+3. 不依赖默认身份。`meeting_id` 来自用户身份发现时，继续用 `--as user`；来自应用身份发现或 `+meeting-join` 时，继续用 `--as bot`。身份不一致会导致空结果或权限错误。
 4. **不能做会后复盘**，**不能替代参会人快照查询**。如果会议已结束：
    - 先用 `lark-cli vc +notes --meeting-ids <meeting.id>` 获取会议产物信息。
    - 再根据 `note_display_type`、`note_id`、`minute_token` 和用户意图，按 [`lark-vc`](../lark-vc/SKILL.md) 的产物决策读取正文、逐字稿或妙记。
    - 想看参会人快照：用 `vc meeting get --with-participants`（见 [`lark-vc`](../lark-vc/SKILL.md)）
 5. **默认必须使用** **`--page-all`**，除非用户明确要求“只查一页”，或确实需要控制返回体大小。
-6. 默认 `--view compact` 输出 normalized 契约：`meeting`、`bot`、`current_roster`、`events`、`has_more`、`page_token`，参会人含 `participant_type`、`role`、`is_self` 和可读 `label`。需要兼容旧事件包时用 `--view raw --format json`，raw 不支持 pretty/ndjson。
-7. 输出格式默认优先 `--format pretty`（时间线更易读，并带应用身份与当前名单标签）；需要结构化处理时用 `--format json`；需要流式消费事件时用 `--format ndjson`。
+6. 默认 `--view compact` 输出 normalized 契约：`meeting`、`identity`、`current_roster`、`events`、`has_more`、`page_token`，参会人含 `participant_type`、`role`、`is_self` 和可读 `label`。需要兼容旧事件包时用 `--view raw --format json`，raw 不支持 pretty/ndjson。
+7. 输出格式默认优先 `--format pretty`（时间线更易读，并带当前身份与当前名单标签）；需要结构化处理时用 `--format json`；需要流式消费事件时用 `--format ndjson`。
 8. **必须识别分页信号**：只要响应里出现 `has_more=true`、pretty 里的 `more available`，或返回了非空 `page_token`，就不能把当前结果当作完整事件流；默认应继续分页，或明确告诉用户当前只是部分结果。
 9. 保留响应里的 `page_token`，下次增量拉取直接续，不要从头再拉。
 10. **只要你是基于** **`+meeting-events`** **来回答一场正在进行中的会议内容，就不能直接复用旧结果。** 无论用户是在问“现在/刚刚/最新”的状态，还是让你“总结一下这个会议讲什么”，都必须先重新拉一次当前事件流，确认拿到的是最新信息，再基于最新结果回答。只有在用户明确要求基于某次历史快照继续分析时，才可以复用旧结果。
-11. 用户直接问“这个会议讲了什么 / 现在讲到哪了”且上下文没有明确 `meeting_id` 时，先发现当前会议；如果需要应用机器人读取事件，必须使用应用身份发现或先让应用机器人入会。若返回多个会议，展示候选并让用户选择。
-12. 用户直接提供 **9 位会议号** 并询问会中事件/会议内容时，默认把它当作 active meeting 的筛选条件：先查 active meetings 并匹配 `meeting_no == <9位会议号>`；匹配到唯一会议后取长数字 `meeting_id`，再用 `--as bot` 查事件。只有用户明确要求“入会 / 让应用机器人旁听 / 代我参会”时才改用 `+meeting-join`。
+11. 用户直接问“这个会议讲了什么 / 现在讲到哪了”且上下文没有明确 `meeting_id` 时，先用用户身份发现当前会议；如果用户明确要求应用机器人视角，或上下文已经是应用机器人参会流程，再用应用身份发现。若返回多个会议，展示候选并让用户选择。
+12. 用户直接提供 **9 位会议号** 并询问会中事件/会议内容时，默认把它当作 active meeting 的筛选条件：先按当前身份查 active meetings，并在返回里匹配 `meeting_no == <9位会议号>`；匹配到唯一会议后取长数字 `meeting_id`，再用同一身份查事件。只有用户明确要求“入会 / 让应用机器人旁听 / 代我参会”时才改用 `+meeting-join`。
 
 ### 3. 离开会议（写操作）
 
@@ -90,7 +90,7 @@ metadata:
 ### 4. 获取当前可用的进行中会议 ID（读操作）
 
 1. `+meeting-list-active` 用来发现当前进行中的会议，并拿到后续 `+meeting-events` 需要的长数字 `meeting_id`。
-2. 用户身份：`lark-cli vc +meeting-list-active --as user --format json`，用于发现当前登录用户正在参加的候选会议；后续 `+meeting-events` 仍使用 `--as bot`，并要求应用机器人在会中或曾参会。
+2. 用户身份：`lark-cli vc +meeting-list-active --as user --format json`，用于发现当前登录用户正在参加的会议；后续 `+meeting-events` 继续 `--as user`。
 3. 应用身份：`lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json`，`--user-id` 必须是目标用户 open_id，即 `ou_...`；返回该用户当前正在参加且应用机器人也在会中的会议。它不是全量会议搜索接口。后续 `+meeting-events` 继续 `--as bot`。
 4. 如果返回空，先按当前身份解释：用户身份下表示当前用户没有可见的进行中会议；应用身份下表示没有找到“目标用户在会中且应用机器人也在会中”的当前会。
 5. 如果返回多个会议，不要自动任选一个；按 `meeting_title` / `meeting_no` / `meeting_id` 展示候选，等待用户明确选择后再调用 `+meeting-events`。
@@ -121,11 +121,11 @@ lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
 lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
 ```
 
-如果只是回答当前登录用户所在会议发生了什么，先用用户身份发现候选会议；读取事件仍需要应用机器人视角：
+如果只是回答当前登录用户所在会议发生了什么，使用用户身份一路查：
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --view compact --format pretty
 ```
 
 ## Shortcuts

--- a/skills/lark-vc-agent/SKILL.md
+++ b/skills/lark-vc-agent/SKILL.md
@@ -72,7 +72,7 @@ metadata:
    - 再根据 `note_display_type`、`note_id`、`minute_token` 和用户意图，按 [`lark-vc`](../lark-vc/SKILL.md) 的产物决策读取正文、逐字稿或妙记。
    - 想看参会人快照：用 `vc meeting get --with-participants`（见 [`lark-vc`](../lark-vc/SKILL.md)）
 5. **默认必须使用** **`--page-all`**，除非用户明确要求“只查一页”，或确实需要控制返回体大小。
-6. 默认 `--view compact` 输出 normalized 契约：`meeting`、`identity`、`current_roster`、`events`、`has_more`、`page_token`，参会人含 `participant_type`、`role`、`is_self` 和可读 `label`。需要兼容旧事件包时用 `--view raw --format json`，raw 不支持 pretty/ndjson。
+6. 命令默认输出 normalized 事件契约：`meeting`、`identity`、`current_roster`、`events`、`has_more`、`page_token`，参会人含 `participant_type`、`role`、`is_self` 和可读 `label`；事件中的原始细节保留在 `payload/raw`。
 7. 输出格式默认优先 `--format pretty`（时间线更易读，并带当前身份与当前名单标签）；需要结构化处理时用 `--format json`；需要流式消费事件时用 `--format ndjson`。
 8. **必须识别分页信号**：只要响应里出现 `has_more=true`、pretty 里的 `more available`，或返回了非空 `page_token`，就不能把当前结果当作完整事件流；默认应继续分页，或明确告诉用户当前只是部分结果。
 9. 保留响应里的 `page_token`，下次增量拉取直接续，不要从头再拉。
@@ -106,7 +106,7 @@ MID=$(echo "$JOIN" | jq -r '.data.meeting.id')
 # 2. 会中轮询事件
 #    默认用 --page-all 拉全当前可见事件；下次增量优先复用 page_token
 #    典型间隔 10-30 秒
-lark-cli vc +meeting-events --as bot --meeting-id "$MID" --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id "$MID" --page-all --format pretty
 
 # 3. 会后可选：进入 lark-vc 获取会议产物信息，再按 note_display_type / minute_token 决策读取
 lark-cli vc +notes --meeting-ids "$MID"
@@ -118,14 +118,14 @@ lark-cli vc +notes --meeting-ids "$MID"
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --format pretty
 ```
 
 如果只是回答当前登录用户所在会议发生了什么，使用用户身份一路查：
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --format pretty
 ```
 
 ## Shortcuts

--- a/skills/lark-vc-agent/SKILL.md
+++ b/skills/lark-vc-agent/SKILL.md
@@ -118,14 +118,14 @@ lark-cli vc +notes --meeting-ids "$MID"
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
 ```
 
 如果只是回答当前登录用户所在会议发生了什么，先用用户身份发现候选会议；读取事件仍需要应用机器人视角：
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
 ```
 
 ## Shortcuts

--- a/skills/lark-vc-agent/SKILL.md
+++ b/skills/lark-vc-agent/SKILL.md
@@ -45,11 +45,11 @@ metadata:
 
 | 场景 | 使用身份 | 关键规则 |
 | ---- | -------- | -------- |
-| 查询当前登录用户正在参加的会议 | `--as user` | 不传 `--user-id`；拿到的 `meeting_id` 后续继续用 `--as user` 读事件 |
+| 查询当前登录用户正在参加的会议 | `--as user` | 不传 `--user-id`；只用于发现候选会议；读取会中事件时切到应用身份，并确保应用机器人已在会中或曾参会 |
 | 查询目标用户且应用机器人也在会中的会议 | `--as bot --user-id <user_open_id>` | `--user-id` 必须是 `ou_...`；拿到的 `meeting_id` 后续继续用 `--as bot` 读事件 |
 | 用户明确要求应用机器人入会/旁听/代参会 | `--as bot` | 这是写操作，会真实产生入会记录；返回的 `meeting.id` 后续继续用 `--as bot` |
 
-硬规则：`meeting_id` 从哪种身份路径拿到，后续 `+meeting-events` 就沿用哪种身份，除非用户明确要求切换场景（例如从“仅查询我当前会”改成“让应用机器人入会旁听”）。
+硬规则：`+meeting-events` 是应用机器人视角的事件读取契约，后续统一用 `--as bot`。如果 `meeting_id` 来自用户身份发现，必须先确认应用机器人也在会中或按用户确认执行入会，否则事件读取会失败或不可见。
 
 ## 核心场景
 
@@ -66,18 +66,19 @@ metadata:
 
 1. 用户要看"会议里正在发生什么"（参会人加入/离开、聊天、转写、屏幕共享）时，用 `+meeting-events`。
 2. 输入是 **`meeting_id`**（长数字 ID），不是 9 位会议号。
-3. 不依赖默认身份。`meeting_id` 来自用户身份发现时，继续用 `--as user`；来自应用身份发现或 `+meeting-join` 时，继续用 `--as bot`。身份不一致会导致空结果或权限错误。
+3. 不依赖默认身份。`+meeting-events` 必须显式使用 `--as bot`；`meeting_id` 来自用户身份发现时，只能作为候选输入，读取前必须确认应用机器人也在会中或曾参会。
 4. **不能做会后复盘**，**不能替代参会人快照查询**。如果会议已结束：
    - 先用 `lark-cli vc +notes --meeting-ids <meeting.id>` 获取会议产物信息。
    - 再根据 `note_display_type`、`note_id`、`minute_token` 和用户意图，按 [`lark-vc`](../lark-vc/SKILL.md) 的产物决策读取正文、逐字稿或妙记。
    - 想看参会人快照：用 `vc meeting get --with-participants`（见 [`lark-vc`](../lark-vc/SKILL.md)）
 5. **默认必须使用** **`--page-all`**，除非用户明确要求“只查一页”，或确实需要控制返回体大小。
-6. 输出格式默认优先 `--format pretty`（时间线更易读）；只有在需要完整保留原始消息流与结构化字段时，才使用 `--format json`。
-7. **必须识别分页信号**：只要响应里出现 `has_more=true`、pretty 里的 `more available`，或返回了非空 `page_token`，就不能把当前结果当作完整事件流；默认应继续分页，或明确告诉用户当前只是部分结果。
-8. 保留响应里的 `page_token`，下次增量拉取直接续，不要从头再拉。
-9. **只要你是基于** **`+meeting-events`** **来回答一场正在进行中的会议内容，就不能直接复用旧结果。** 无论用户是在问“现在/刚刚/最新”的状态，还是让你“总结一下这个会议讲什么”，都必须先重新拉一次当前事件流，确认拿到的是最新信息，再基于最新结果回答。只有在用户明确要求基于某次历史快照继续分析时，才可以复用旧结果。
-10. 用户直接问“这个会议讲了什么 / 现在讲到哪了”且上下文没有明确 `meeting_id` 时，先用用户身份发现当前会议；如果用户明确要求应用机器人视角，或上下文已经是应用机器人参会流程，再用应用身份发现。若返回多个会议，展示候选并让用户选择。
-11. 用户直接提供 **9 位会议号** 并询问会中事件/会议内容时，默认把它当作 active meeting 的筛选条件：先按当前身份查 active meetings，并在返回里匹配 `meeting_no == <9位会议号>`；匹配到唯一会议后取长数字 `meeting_id`，再用同一身份查事件。只有用户明确要求“入会 / 让应用机器人旁听 / 代我参会”时才改用 `+meeting-join`。
+6. 默认 `--view compact` 输出 normalized 契约：`meeting`、`bot`、`current_roster`、`events`、`has_more`、`page_token`，参会人含 `participant_type`、`role`、`is_self` 和可读 `label`。需要兼容旧事件包时用 `--view raw --format json`，raw 不支持 pretty/ndjson。
+7. 输出格式默认优先 `--format pretty`（时间线更易读，并带应用身份与当前名单标签）；需要结构化处理时用 `--format json`；需要流式消费事件时用 `--format ndjson`。
+8. **必须识别分页信号**：只要响应里出现 `has_more=true`、pretty 里的 `more available`，或返回了非空 `page_token`，就不能把当前结果当作完整事件流；默认应继续分页，或明确告诉用户当前只是部分结果。
+9. 保留响应里的 `page_token`，下次增量拉取直接续，不要从头再拉。
+10. **只要你是基于** **`+meeting-events`** **来回答一场正在进行中的会议内容，就不能直接复用旧结果。** 无论用户是在问“现在/刚刚/最新”的状态，还是让你“总结一下这个会议讲什么”，都必须先重新拉一次当前事件流，确认拿到的是最新信息，再基于最新结果回答。只有在用户明确要求基于某次历史快照继续分析时，才可以复用旧结果。
+11. 用户直接问“这个会议讲了什么 / 现在讲到哪了”且上下文没有明确 `meeting_id` 时，先发现当前会议；如果需要应用机器人读取事件，必须使用应用身份发现或先让应用机器人入会。若返回多个会议，展示候选并让用户选择。
+12. 用户直接提供 **9 位会议号** 并询问会中事件/会议内容时，默认把它当作 active meeting 的筛选条件：先查 active meetings 并匹配 `meeting_no == <9位会议号>`；匹配到唯一会议后取长数字 `meeting_id`，再用 `--as bot` 查事件。只有用户明确要求“入会 / 让应用机器人旁听 / 代我参会”时才改用 `+meeting-join`。
 
 ### 3. 离开会议（写操作）
 
@@ -89,7 +90,7 @@ metadata:
 ### 4. 获取当前可用的进行中会议 ID（读操作）
 
 1. `+meeting-list-active` 用来发现当前进行中的会议，并拿到后续 `+meeting-events` 需要的长数字 `meeting_id`。
-2. 用户身份：`lark-cli vc +meeting-list-active --as user --format json`，用于发现当前登录用户正在参加的会议；后续 `+meeting-events` 继续 `--as user`。
+2. 用户身份：`lark-cli vc +meeting-list-active --as user --format json`，用于发现当前登录用户正在参加的候选会议；后续 `+meeting-events` 仍使用 `--as bot`，并要求应用机器人在会中或曾参会。
 3. 应用身份：`lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json`，`--user-id` 必须是目标用户 open_id，即 `ou_...`；返回该用户当前正在参加且应用机器人也在会中的会议。它不是全量会议搜索接口。后续 `+meeting-events` 继续 `--as bot`。
 4. 如果返回空，先按当前身份解释：用户身份下表示当前用户没有可见的进行中会议；应用身份下表示没有找到“目标用户在会中且应用机器人也在会中”的当前会。
 5. 如果返回多个会议，不要自动任选一个；按 `meeting_title` / `meeting_no` / `meeting_id` 展示候选，等待用户明确选择后再调用 `+meeting-events`。
@@ -105,7 +106,7 @@ MID=$(echo "$JOIN" | jq -r '.data.meeting.id')
 # 2. 会中轮询事件
 #    默认用 --page-all 拉全当前可见事件；下次增量优先复用 page_token
 #    典型间隔 10-30 秒
-lark-cli vc +meeting-events --as bot --meeting-id "$MID" --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id "$MID" --page-all --view compact --format pretty
 
 # 3. 会后可选：进入 lark-vc 获取会议产物信息，再按 note_display_type / minute_token 决策读取
 lark-cli vc +notes --meeting-ids "$MID"
@@ -117,14 +118,14 @@ lark-cli vc +notes --meeting-ids "$MID"
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
 ```
 
-如果只是回答当前登录用户所在会议发生了什么，使用用户身份一路查：
+如果只是回答当前登录用户所在会议发生了什么，先用用户身份发现候选会议；读取事件仍需要应用机器人视角：
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
 ```
 
 ## Shortcuts

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
@@ -1,30 +1,30 @@
 
 # vc +meeting-events
 
-查询一场正在进行的视频会议中的会中事件列表。该命令是**读操作**，面向应用机器人视角，必须使用 `--as bot` 读取。对已结束会议，存在一个**结束后 5 分钟内的宽限窗口**；应用身份读取时，要求应用机器人曾经在这场会里出现过。
+查询一场正在进行的视频会议中的会中事件列表。该命令是**读操作**，必须沿用 `meeting_id` 的来源身份：用户身份发现的会议继续用用户身份读，应用身份发现或应用机器人入会得到的会议继续用应用身份读。对已结束会议，存在一个**结束后 5 分钟内的宽限窗口**；应用身份读取时，要求应用机器人曾经在这场会里出现过。
 
 本 skill 对应 shortcut：`lark-cli vc +meeting-events`（调用 `GET /open-apis/vc/v1/bots/events`）。
 
 可见性边界：
 
-- `meeting_id` 来自 `+meeting-list-active --as user`：只作为候选会议 ID；后续读取事件仍使用 `--as bot`，并要求应用机器人在会中或曾参会。
+- `meeting_id` 来自 `+meeting-list-active --as user`：后续读取事件继续 `--as user`。
 - `meeting_id` 来自 `+meeting-list-active --as bot --user-id <user_open_id>` 或 `+meeting-join --as bot`：后续读取事件继续 `--as bot`。
 - 应用身份下，应用机器人必须在该会中或参会过；应用身份 active meeting 返回的是“目标用户在会中且应用机器人也在会中”的会议，不表示可以读取任意 `meeting_id`。
 
 ## 命令
 
 ```bash
-# 默认用法：全量拉取应用机器人当前可见事件，输出 normalized compact 契约
-lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
+# 默认用法：全量拉取当前身份可见事件，输出 normalized compact 契约
+lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-all --view compact --format pretty
 
 # 指定时间范围，并拉全该时间窗内当前可见事件
-lark-cli vc +meeting-events --as bot --meeting-id <id> --start 2026-04-17T15:00:00+08:00 --end 2026-04-17T16:00:00+08:00 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --start 2026-04-17T15:00:00+08:00 --end 2026-04-17T16:00:00+08:00 --page-all --view compact --format pretty
 
 # 基于上一次保存的 page_token 继续查新增事件
-lark-cli vc +meeting-events --as bot --meeting-id <id> --page-token <last_page_token> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-token <last_page_token> --page-all --view compact --format pretty
 
 # 兼容旧事件包或调试服务端原始响应时，使用 raw escape hatch
-lark-cli vc +meeting-events --as bot --meeting-id <id> --page-size 20 --view raw --format json
+lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-size 20 --view raw --format json
 ```
 
 ## 参数
@@ -49,16 +49,16 @@ lark-cli vc +meeting-events --as bot --meeting-id <id> --page-size 20 --view raw
 - `+search` 结果中的 `id`
 
 **不要**把 9 位会议号（`--meeting-number`）传给这个命令。
-如果 `meeting_id` 来自 `+meeting-list-active --as user`，它只是候选会议 ID；后续 `+meeting-events` 仍必须使用 `--as bot`，并确保应用机器人在会中或曾参会。如果返回多个会议，先让用户选择具体 `meeting_id`。
+如果 `meeting_id` 来自 `+meeting-list-active --as user`，后续 `+meeting-events` 继续使用 `--as user`。如果返回多个会议，先让用户选择具体 `meeting_id`。
 
-如果用户提供的是 9 位会议号且没有明确要求应用机器人入会，先按当前场景身份查 active meetings 并按 `meeting_no` 匹配。匹配到唯一项后，取该项的长数字 `meeting_id`，再用应用身份调用本命令；匹配失败时不要自动入会，除非用户明确说“入会 / 让应用机器人旁听 / 代我参会”。
+如果用户提供的是 9 位会议号且没有明确要求应用机器人入会，先按当前场景身份查 active meetings 并按 `meeting_no` 匹配。匹配到唯一项后，取该项的长数字 `meeting_id`，再用同一身份调用本命令；匹配失败时不要自动入会，除非用户明确说“入会 / 让应用机器人旁听 / 代我参会”。
 
-### 2. 应用机器人身份是读取事件的权限锚点
+### 2. 身份来源是读取事件的权限锚点
 
-- `+meeting-events` 必须用 `--as bot`。
-- 用户身份路径只能用于发现当前登录用户的候选会议；读取事件前必须让应用机器人也在会中，或确认它曾参会且仍处于服务端允许的时间窗口。
+- `+meeting-events` 支持 `--as user` 和 `--as bot`。
+- 用户身份路径：用户身份发现的会议继续用用户身份读取。
 - 应用身份路径：应用机器人必须在会中或参会过；不要拿任意 `meeting_id` 直接查。
-- 不要把用户身份发现能力误当成用户身份事件读取能力。身份不一致时，常见结果是空列表、`no permission` 或 `bot is not in meeting`。
+- 不要在拿到 `meeting_id` 后随意切换身份。身份不一致时，常见结果是空列表、`no permission` 或 `bot is not in meeting`。
 
 ### 3. 读取事件前必须先拿到可见的 meeting_id
 
@@ -79,11 +79,11 @@ lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
 lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
 ```
 
-如果只是用当前登录用户发现候选会议：
+如果只是用当前登录用户发现会议：
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --view compact --format pretty
 ```
 
 若应用机器人已离会、未入会、或会议已经无法再判断身份，后端通常会报：
@@ -106,18 +106,18 @@ lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact
 
 执行准则：
 
-- **默认命令模板**：`lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty`
+- **默认命令模板**：`lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-all --view compact --format pretty`
 - 如果你发现自己执行成了不带 `--page-all` 的单页查询，而响应里又出现 `has_more=true` / `more available` / 非空 `page_token`，应立刻意识到这只是部分结果。
-- 遇到上述情况，默认补救方式是继续使用返回的 `page_token` 续拉，例如：`lark-cli vc +meeting-events --as bot --meeting-id <id> --page-token <returned_page_token> --page-all --view compact --format pretty`
+- 遇到上述情况，默认补救方式是继续使用返回的 `page_token` 续拉，例如：`lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-token <returned_page_token> --page-all --view compact --format pretty`
 - 只有在用户明确要求“就看第一页”“先不要翻页”时，才不要默认带 `--page-all`
 - 只要你是基于 `+meeting-events` 来回答一场**正在进行中的会议内容**，就不能直接复用上一次查询结果。无论用户是在问“现在是谁在说话”“刚刚发生了什么”“最新事件有哪些”，还是让你“总结一下这个会议讲什么”，都必须先重新执行一次 `+meeting-events`，确认拿到的是最新事件流，再回答用户。只有在用户明确要求基于某次历史快照继续分析时，才可以复用旧结果。
 
 ### 5. compact / raw / pretty / json / ndjson 输出差异
 
-- `--view compact --format json`：默认结构化契约，顶层包含 `meeting`、`bot`、`current_roster`、`events`、`has_more`、`page_token`。参会人身份统一含 `participant_type`、`role`、`is_self`、`label`。
-- `--view compact --format pretty`：输出应用身份、当前名单和逐条时间线，适合快速理解“发生了什么”。
+- `--view compact --format json`：默认结构化契约，顶层包含 `meeting`、`identity`、`current_roster`、`events`、`has_more`、`page_token`。参会人身份统一含 `participant_type`、`role`、`is_self`、`label`。
+- `--view compact --format pretty`：输出当前身份、当前名单和逐条时间线，适合快速理解“发生了什么”。
 - `--view compact --format ndjson`：输出事件行，并带 metadata 行，适合流式消费。
-- `--view raw --format json`：保留旧 `events/has_more/page_token` 服务端事件包，不预取 bot identity 或 current roster。raw 不支持 pretty/ndjson。
+- `--view raw --format json`：保留旧 `events/has_more/page_token` 服务端事件包，不预取 identity 或 current roster。raw 不支持 pretty/ndjson。
 
 **选型原则**：只要目标是告诉用户“发生了什么”，默认就用 `--page-all --view compact --format pretty`；需要稳定字段给 agent 消费时用 compact JSON；只有需要兼容旧事件包时才用 raw JSON。
 
@@ -136,10 +136,10 @@ lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact
 
 执行准则：
 
-- 如果上下文已有明确 `meeting_id`，直接用应用身份执行 `+meeting-events --as bot --page-all --view compact --format json`。
+- 如果上下文已有明确 `meeting_id`，沿用该 `meeting_id` 的来源身份执行 `+meeting-events --page-all --view compact --format json`。
 - 如果上下文没有明确 `meeting_id`，先按用户当前意图选择身份：问“我/当前用户所在会议”用 `lark-cli vc +meeting-list-active --as user --format pretty`；问“应用机器人可见的目标用户会议”用 `lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format pretty`。返回多个会议时先让用户选择。
 - 如果上下文只有 9 位会议号，先按当前身份执行 `+meeting-list-active` 并按 `meeting_no` 匹配；匹配到唯一会议后再查事件。不要为了总结会议而自动调用 `+meeting-join`。
-- 这类问题拿到 `meeting_id` 后，用 `lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format json` 拉取最新事件流。
+- 这类问题拿到 `meeting_id` 后，用同一身份执行 `lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-all --view compact --format json` 拉取最新事件流。
 - 如果事件中出现共享文档线索，例如：
   - `magic_share_started`
   - `share_doc.title`
@@ -164,7 +164,7 @@ lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact
 | 字段 | 说明 |
 |------|------|
 | `meeting` | 会议身份与时间状态，包含 `id/topic/meeting_no/start_time/end_time/status` |
-| `bot` | 当前应用机器人身份，包含 `id/name/participant_type/role/is_self/label` |
+| `identity` | 当前读取身份，包含 `id/name/participant_type/role/is_self/label` |
 | `current_roster` | 服务端当前名单，不从历史事件 replay 推导 |
 | `events` | normalized 事件列表；每条事件含 `actors` 和原始 `payload/raw` |
 | `has_more` | 是否还有下一页 |
@@ -225,7 +225,7 @@ lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --view compact --format pretty
 ```
 
 ### 场景 2：过滤某段时间内的事件

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
@@ -1,30 +1,30 @@
 
 # vc +meeting-events
 
-查询一场正在进行的视频会议中的会中事件列表。该命令是**读操作**，必须沿用 `meeting_id` 的来源身份：用户身份发现的会议继续用用户身份读，应用身份发现或应用机器人入会得到的会议继续用应用身份读。对已结束会议，存在一个**结束后 5 分钟内的宽限窗口**；应用身份读取时，要求应用机器人曾经在这场会里出现过。
+查询一场正在进行的视频会议中的会中事件列表。该命令是**读操作**，面向应用机器人视角，必须使用 `--as bot` 读取。对已结束会议，存在一个**结束后 5 分钟内的宽限窗口**；应用身份读取时，要求应用机器人曾经在这场会里出现过。
 
 本 skill 对应 shortcut：`lark-cli vc +meeting-events`（调用 `GET /open-apis/vc/v1/bots/events`）。
 
 可见性边界：
 
-- `meeting_id` 来自 `+meeting-list-active --as user`：后续读取事件继续 `--as user`。
+- `meeting_id` 来自 `+meeting-list-active --as user`：只作为候选会议 ID；后续读取事件仍使用 `--as bot`，并要求应用机器人在会中或曾参会。
 - `meeting_id` 来自 `+meeting-list-active --as bot --user-id <user_open_id>` 或 `+meeting-join --as bot`：后续读取事件继续 `--as bot`。
 - 应用身份下，应用机器人必须在该会中或参会过；应用身份 active meeting 返回的是“目标用户在会中且应用机器人也在会中”的会议，不表示可以读取任意 `meeting_id`。
 
 ## 命令
 
 ```bash
-# 默认用法：全量拉取当前可见事件
-lark-cli vc +meeting-events --as <same_identity> --meeting-id 69xxxxxxxxxxxxx28 --page-all --format pretty
+# 默认用法：全量拉取应用机器人当前可见事件，输出 normalized compact 契约
+lark-cli vc +meeting-events --as bot --meeting-id 69xxxxxxxxxxxxx28 --page-all --view compact --format pretty
 
 # 指定时间范围，并拉全该时间窗内当前可见事件
-lark-cli vc +meeting-events --as <same_identity> --meeting-id 69xxxxxxxxxxxxx28 --start 2026-04-17T15:00:00+08:00 --end 2026-04-17T16:00:00+08:00 --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 69xxxxxxxxxxxxx28 --start 2026-04-17T15:00:00+08:00 --end 2026-04-17T16:00:00+08:00 --page-all --view compact --format pretty
 
 # 基于上一次保存的 page_token 继续查新增事件
-lark-cli vc +meeting-events --as <same_identity> --meeting-id 69xxxxxxxxxxxxx28 --page-token <last_page_token> --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 69xxxxxxxxxxxxx28 --page-token <last_page_token> --page-all --view compact --format pretty
 
-# 调试或控制返回体大小时，显式只查一页
-lark-cli vc +meeting-events --as <same_identity> --meeting-id 69xxxxxxxxxxxxx28 --page-size 20 --format json
+# 兼容旧事件包或调试服务端原始响应时，使用 raw escape hatch
+lark-cli vc +meeting-events --as bot --meeting-id 69xxxxxxxxxxxxx28 --page-size 20 --view raw --format json
 ```
 
 ## 参数
@@ -37,6 +37,7 @@ lark-cli vc +meeting-events --as <same_identity> --meeting-id 69xxxxxxxxxxxxx28 
 | `--page-token <token>` | 否 | 从指定分页游标继续拉取下一页 |
 | `--page-size <n>` | 否 | 单页模式每页大小。CLI 会自动夹紧到 `20-100`；传 `--page-all` 时固定使用 `100` |
 | `--page-all` | 否 | 自动分页，直到没有更多页面为止（内部有安全上限） |
+| `--view compact\|raw` | 否 | 输出视图。默认 `compact` 为 agent-facing normalized 契约；`raw` 只支持 `--format json` 并保留旧事件包 |
 
 ## 核心约束
 
@@ -48,15 +49,16 @@ lark-cli vc +meeting-events --as <same_identity> --meeting-id 69xxxxxxxxxxxxx28 
 - `+search` 结果中的 `id`
 
 **不要**把 9 位会议号（`--meeting-number`）传给这个命令。
-如果 `meeting_id` 来自 `+meeting-list-active`，后续 `+meeting-events` 必须沿用同一身份；如果返回多个会议，先让用户选择具体 `meeting_id`。
+如果 `meeting_id` 来自 `+meeting-list-active --as user`，它只是候选会议 ID；后续 `+meeting-events` 仍必须使用 `--as bot`，并确保应用机器人在会中或曾参会。如果返回多个会议，先让用户选择具体 `meeting_id`。
 
-如果用户提供的是 9 位会议号且没有明确要求应用机器人入会，先按当前场景身份查 active meetings 并按 `meeting_no` 匹配。匹配到唯一项后，取该项的长数字 `meeting_id`，再用同一身份调用本命令；匹配失败时不要自动入会，除非用户明确说“入会 / 让应用机器人旁听 / 代我参会”。
+如果用户提供的是 9 位会议号且没有明确要求应用机器人入会，先按当前场景身份查 active meetings 并按 `meeting_no` 匹配。匹配到唯一项后，取该项的长数字 `meeting_id`，再用应用身份调用本命令；匹配失败时不要自动入会，除非用户明确说“入会 / 让应用机器人旁听 / 代我参会”。
 
-### 2. 身份来源是读取事件的权限锚点
+### 2. 应用机器人身份是读取事件的权限锚点
 
-- 用户身份路径：先用 `+meeting-list-active --as user` 发现当前登录用户的会议，再用 `+meeting-events --as user` 读取该 `meeting_id`。
-- 应用身份路径：应用机器人必须在会中或参会过；不要拿任意 `meeting_id` 直接用 `--as bot` 查。
-- 不要混用身份。身份不一致时，常见结果是空列表、`no permission` 或 `bot is not in meeting`。
+- `+meeting-events` 必须用 `--as bot`。
+- 用户身份路径只能用于发现当前登录用户的候选会议；读取事件前必须让应用机器人也在会中，或确认它曾参会且仍处于服务端允许的时间窗口。
+- 应用身份路径：应用机器人必须在会中或参会过；不要拿任意 `meeting_id` 直接查。
+- 不要把用户身份发现能力误当成用户身份事件读取能力。身份不一致时，常见结果是空列表、`no permission` 或 `bot is not in meeting`。
 
 ### 3. 读取事件前必须先拿到可见的 meeting_id
 
@@ -67,21 +69,21 @@ lark-cli vc +meeting-events --as <same_identity> --meeting-id 69xxxxxxxxxxxxx28 
 lark-cli vc +meeting-join --as bot --meeting-number 123456789
 
 # 再查询事件
-lark-cli vc +meeting-events --as bot --meeting-id <meeting.id>
+lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --view compact
 ```
 
 如果应用机器人已经在会中，也可以先通过 active meeting 找会：
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
 ```
 
-如果只是查询当前登录用户所在会议：
+如果只是用当前登录用户发现候选会议：
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
 ```
 
 若应用机器人已离会、未入会、或会议已经无法再判断身份，后端通常会报：
@@ -104,18 +106,20 @@ lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --for
 
 执行准则：
 
-- **默认命令模板**：`lark-cli vc +meeting-events --as <same_identity> --meeting-id <meeting.id> --page-all --format pretty`
+- **默认命令模板**：`lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --page-all --view compact --format pretty`
 - 如果你发现自己执行成了不带 `--page-all` 的单页查询，而响应里又出现 `has_more=true` / `more available` / 非空 `page_token`，应立刻意识到这只是部分结果。
-- 遇到上述情况，默认补救方式是继续使用返回的 `page_token` 续拉，例如：`lark-cli vc +meeting-events --as <same_identity> --meeting-id <meeting.id> --page-token <returned_page_token> --page-all --format pretty`
+- 遇到上述情况，默认补救方式是继续使用返回的 `page_token` 续拉，例如：`lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --page-token <returned_page_token> --page-all --view compact --format pretty`
 - 只有在用户明确要求“就看第一页”“先不要翻页”时，才不要默认带 `--page-all`
 - 只要你是基于 `+meeting-events` 来回答一场**正在进行中的会议内容**，就不能直接复用上一次查询结果。无论用户是在问“现在是谁在说话”“刚刚发生了什么”“最新事件有哪些”，还是让你“总结一下这个会议讲什么”，都必须先重新执行一次 `+meeting-events`，确认拿到的是最新事件流，再回答用户。只有在用户明确要求基于某次历史快照继续分析时，才可以复用旧结果。
 
-### 5. pretty / json 输出差异
+### 5. compact / raw / pretty / json / ndjson 输出差异
 
-- `--format pretty`：输出会议主题、会议时间和逐条时间线，适合快速理解“发生了什么”，也是本 skill 的默认推荐格式。
-- `--format json`：保留完整原始 `events[]` 结构——参会人 open_id、聊天原文、share_doc、分页字段都在原始响应里，适合提取字段、联动其他命令或做进一步程序处理。
+- `--view compact --format json`：默认结构化契约，顶层包含 `meeting`、`bot`、`current_roster`、`events`、`has_more`、`page_token`。参会人身份统一含 `participant_type`、`role`、`is_self`、`label`。
+- `--view compact --format pretty`：输出应用身份、当前名单和逐条时间线，适合快速理解“发生了什么”。
+- `--view compact --format ndjson`：输出事件行，并带 metadata 行，适合流式消费。
+- `--view raw --format json`：保留旧 `events/has_more/page_token` 服务端事件包，不预取 bot identity 或 current roster。raw 不支持 pretty/ndjson。
 
-**选型原则**：只要目标是告诉用户“发生了什么”，默认就用 `--page-all --format pretty`；只有在需要完整原始消息流和结构化字段时，才改用 `json`。
+**选型原则**：只要目标是告诉用户“发生了什么”，默认就用 `--page-all --view compact --format pretty`；需要稳定字段给 agent 消费时用 compact JSON；只有需要兼容旧事件包时才用 raw JSON。
 
 > **注意**：pretty 输出中的正文文本会做单行转义，真实换行会显示为 `\n`，避免打乱时间线布局。
 
@@ -132,10 +136,10 @@ lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --for
 
 执行准则：
 
-- 如果上下文已有明确 `meeting_id` 和来源身份，直接用同一身份执行 `+meeting-events --page-all --format json`。
+- 如果上下文已有明确 `meeting_id`，直接用应用身份执行 `+meeting-events --as bot --page-all --view compact --format json`。
 - 如果上下文没有明确 `meeting_id`，先按用户当前意图选择身份：问“我/当前用户所在会议”用 `lark-cli vc +meeting-list-active --as user --format pretty`；问“应用机器人可见的目标用户会议”用 `lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format pretty`。返回多个会议时先让用户选择。
 - 如果上下文只有 9 位会议号，先按当前身份执行 `+meeting-list-active` 并按 `meeting_no` 匹配；匹配到唯一会议后再查事件。不要为了总结会议而自动调用 `+meeting-join`。
-- 这类问题拿到 `meeting_id` 后，用 `lark-cli vc +meeting-events --as <same_identity> --meeting-id <meeting.id> --page-all --format json` 拉取最新事件流。
+- 这类问题拿到 `meeting_id` 后，用 `lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --page-all --view compact --format json` 拉取最新事件流。
 - 如果事件中出现共享文档线索，例如：
   - `magic_share_started`
   - `share_doc.title`
@@ -159,7 +163,10 @@ lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --for
 
 | 字段 | 说明 |
 |------|------|
-| `events` | 事件列表 |
+| `meeting` | 会议身份与时间状态，包含 `id/topic/meeting_no/start_time/end_time/status` |
+| `bot` | 当前应用机器人身份，包含 `id/name/participant_type/role/is_self/label` |
+| `current_roster` | 服务端当前名单，不从历史事件 replay 推导 |
+| `events` | normalized 事件列表；每条事件含 `actors` 和原始 `payload/raw` |
 | `has_more` | 是否还有下一页 |
 | `page_token` | 下一页游标 |
 
@@ -204,32 +211,33 @@ lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --for
 lark-cli vc +meeting-join --as bot --meeting-number 123456789
 
 # 第 2 步：查询事件流
-lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --page-all --view compact --format pretty
 ```
 
 ### 场景 1b：应用机器人已在会中，先发现 meeting_id 再读事件
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
 ```
 
 ### 场景 1c：当前登录用户正在会中，先发现 meeting_id 再读事件
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
 ```
 
 ### 场景 2：过滤某段时间内的事件
 
 ```bash
 lark-cli vc +meeting-events \
-  --as <same_identity> \
+  --as bot \
   --meeting-id <meeting.id> \
   --start 2026-04-17T15:00:00+08:00 \
   --end 2026-04-17T16:00:00+08:00 \
   --page-all \
+  --view compact \
   --format pretty
 ```
 
@@ -239,10 +247,11 @@ lark-cli vc +meeting-events \
 # 上一次查询结束后，保留最后返回的 page_token
 # 这次直接从该游标继续拉新增事件
 lark-cli vc +meeting-events \
-  --as <same_identity> \
+  --as bot \
   --meeting-id <meeting.id> \
   --page-token <last_page_token> \
   --page-all \
+  --view compact \
   --format pretty
 ```
 
@@ -258,7 +267,7 @@ lark-cli vc +meeting-events \
 |---------|---------|---------|
 | `--meeting-id is required` | 未传入 `--meeting-id` | 传入长数字 `meeting.id` |
 | `not a 9-digit meeting number` | 把 9 位会议号误传给 `--meeting-id` | 如果只是查询会中内容，先用 `+meeting-list-active` 按 `meeting_no` 匹配拿长数字 `meeting_id`；只有用户明确要求入会时才用 `+meeting-join --as bot --meeting-number <9位号>` |
-| `10005 bot is not in meeting` | 使用应用身份读取，但应用机器人从未真实入会该会议；或会议已结束但应用机器人从未在会中出现过 | 如果本来是用户身份发现的 `meeting_id`，改回 `--as user`；如果确实要应用身份读取，先 `+meeting-join --as bot --meeting-number <9位号>` 真实入会再查。**如果只是想看参会人快照，改用 `lark-cli vc meeting get --params '{"meeting_id":"<meeting.id>"}' --with-participants`** |
+| `10005 bot is not in meeting` | 使用应用身份读取，但应用机器人从未真实入会该会议；或会议已结束但应用机器人从未在会中出现过 | 如果 `meeting_id` 来自用户身份发现，先让应用机器人入会或确认它曾参会后再用 `--as bot` 读取。**如果只是想看参会人快照，改用 `lark-cli vc meeting get --params '{"meeting_id":"<meeting.id>"}' --with-participants`** |
 | 用户身份不支持 | 当前事件读取接口不支持用用户身份访问 | 不要反复执行 `auth login`。改用应用身份流程：先通过 `+meeting-list-active --as bot --user-id <user_open_id>` 获取应用身份可读的 `meeting_id`，或在用户明确同意后让应用机器人入会，再用 `+meeting-events --as bot` 读取 |
 | `20001 meeting_status_MEETING_END` | 会议已结束且已超出后端允许的 5 分钟宽限窗口 | 本接口不再适合继续拉取事件。先用 `lark-cli vc +notes --meeting-ids <meeting.id>` 获取会议产物信息，再根据 `note_display_type` / `note_id` / `minute_token` 和用户意图选择纪要正文、逐字稿或妙记；参会人请用 `lark-cli vc meeting get --params '{"meeting_id":"<meeting.id>"}' --with-participants` |
 | `20002 meeting not exist` | `meeting_id` 错误，或会议实例当前已不可获取（常见于把 9 位会议号当 meeting_id 传） | 确认传入的是长数字 `meeting_id`，不是 9 位会议号 |

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
@@ -15,16 +15,16 @@
 
 ```bash
 # 默认用法：全量拉取应用机器人当前可见事件，输出 normalized compact 契约
-lark-cli vc +meeting-events --as bot --meeting-id 69xxxxxxxxxxxxx28 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
 
 # 指定时间范围，并拉全该时间窗内当前可见事件
-lark-cli vc +meeting-events --as bot --meeting-id 69xxxxxxxxxxxxx28 --start 2026-04-17T15:00:00+08:00 --end 2026-04-17T16:00:00+08:00 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --start 2026-04-17T15:00:00+08:00 --end 2026-04-17T16:00:00+08:00 --page-all --view compact --format pretty
 
 # 基于上一次保存的 page_token 继续查新增事件
-lark-cli vc +meeting-events --as bot --meeting-id 69xxxxxxxxxxxxx28 --page-token <last_page_token> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-token <last_page_token> --page-all --view compact --format pretty
 
 # 兼容旧事件包或调试服务端原始响应时，使用 raw escape hatch
-lark-cli vc +meeting-events --as bot --meeting-id 69xxxxxxxxxxxxx28 --page-size 20 --view raw --format json
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-size 20 --view raw --format json
 ```
 
 ## 参数
@@ -69,21 +69,21 @@ lark-cli vc +meeting-events --as bot --meeting-id 69xxxxxxxxxxxxx28 --page-size 
 lark-cli vc +meeting-join --as bot --meeting-number 123456789
 
 # 再查询事件
-lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --view compact
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --view compact
 ```
 
 如果应用机器人已经在会中，也可以先通过 active meeting 找会：
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
 ```
 
 如果只是用当前登录用户发现候选会议：
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
 ```
 
 若应用机器人已离会、未入会、或会议已经无法再判断身份，后端通常会报：
@@ -106,9 +106,9 @@ lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view
 
 执行准则：
 
-- **默认命令模板**：`lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --page-all --view compact --format pretty`
+- **默认命令模板**：`lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty`
 - 如果你发现自己执行成了不带 `--page-all` 的单页查询，而响应里又出现 `has_more=true` / `more available` / 非空 `page_token`，应立刻意识到这只是部分结果。
-- 遇到上述情况，默认补救方式是继续使用返回的 `page_token` 续拉，例如：`lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --page-token <returned_page_token> --page-all --view compact --format pretty`
+- 遇到上述情况，默认补救方式是继续使用返回的 `page_token` 续拉，例如：`lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-token <returned_page_token> --page-all --view compact --format pretty`
 - 只有在用户明确要求“就看第一页”“先不要翻页”时，才不要默认带 `--page-all`
 - 只要你是基于 `+meeting-events` 来回答一场**正在进行中的会议内容**，就不能直接复用上一次查询结果。无论用户是在问“现在是谁在说话”“刚刚发生了什么”“最新事件有哪些”，还是让你“总结一下这个会议讲什么”，都必须先重新执行一次 `+meeting-events`，确认拿到的是最新事件流，再回答用户。只有在用户明确要求基于某次历史快照继续分析时，才可以复用旧结果。
 
@@ -139,7 +139,7 @@ lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view
 - 如果上下文已有明确 `meeting_id`，直接用应用身份执行 `+meeting-events --as bot --page-all --view compact --format json`。
 - 如果上下文没有明确 `meeting_id`，先按用户当前意图选择身份：问“我/当前用户所在会议”用 `lark-cli vc +meeting-list-active --as user --format pretty`；问“应用机器人可见的目标用户会议”用 `lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format pretty`。返回多个会议时先让用户选择。
 - 如果上下文只有 9 位会议号，先按当前身份执行 `+meeting-list-active` 并按 `meeting_no` 匹配；匹配到唯一会议后再查事件。不要为了总结会议而自动调用 `+meeting-join`。
-- 这类问题拿到 `meeting_id` 后，用 `lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --page-all --view compact --format json` 拉取最新事件流。
+- 这类问题拿到 `meeting_id` 后，用 `lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format json` 拉取最新事件流。
 - 如果事件中出现共享文档线索，例如：
   - `magic_share_started`
   - `share_doc.title`
@@ -211,21 +211,21 @@ lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view
 lark-cli vc +meeting-join --as bot --meeting-number 123456789
 
 # 第 2 步：查询事件流
-lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
 ```
 
 ### 场景 1b：应用机器人已在会中，先发现 meeting_id 再读事件
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
 ```
 
 ### 场景 1c：当前登录用户正在会中，先发现 meeting_id 再读事件
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
 ```
 
 ### 场景 2：过滤某段时间内的事件
@@ -233,7 +233,7 @@ lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view
 ```bash
 lark-cli vc +meeting-events \
   --as bot \
-  --meeting-id <meeting.id> \
+  --meeting-id 7628568141510692381 \
   --start 2026-04-17T15:00:00+08:00 \
   --end 2026-04-17T16:00:00+08:00 \
   --page-all \
@@ -248,7 +248,7 @@ lark-cli vc +meeting-events \
 # 这次直接从该游标继续拉新增事件
 lark-cli vc +meeting-events \
   --as bot \
-  --meeting-id <meeting.id> \
+  --meeting-id 7628568141510692381 \
   --page-token <last_page_token> \
   --page-all \
   --view compact \

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
@@ -14,17 +14,14 @@
 ## 命令
 
 ```bash
-# 默认用法：全量拉取当前身份可见事件，输出 normalized compact 契约
-lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-all --view compact --format pretty
+# 默认用法：全量拉取当前身份可见事件；输出 normalized 事件契约
+lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-all --format pretty
 
 # 指定时间范围，并拉全该时间窗内当前可见事件
-lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --start 2026-04-17T15:00:00+08:00 --end 2026-04-17T16:00:00+08:00 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --start 2026-04-17T15:00:00+08:00 --end 2026-04-17T16:00:00+08:00 --page-all --format pretty
 
 # 基于上一次保存的 page_token 继续查新增事件
-lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-token <last_page_token> --page-all --view compact --format pretty
-
-# 兼容旧事件包或调试服务端原始响应时，使用 raw escape hatch
-lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-size 20 --view raw --format json
+lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-token <last_page_token> --page-all --format pretty
 ```
 
 ## 参数
@@ -37,7 +34,6 @@ lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-size 2
 | `--page-token <token>` | 否 | 从指定分页游标继续拉取下一页 |
 | `--page-size <n>` | 否 | 单页模式每页大小。CLI 会自动夹紧到 `20-100`；传 `--page-all` 时固定使用 `100` |
 | `--page-all` | 否 | 自动分页，直到没有更多页面为止（内部有安全上限） |
-| `--view compact\|raw` | 否 | 输出视图。默认 `compact` 为 agent-facing normalized 契约；`raw` 只支持 `--format json` 并保留旧事件包 |
 
 ## 核心约束
 
@@ -69,21 +65,21 @@ lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-size 2
 lark-cli vc +meeting-join --as bot --meeting-number 123456789
 
 # 再查询事件
-lark-cli vc +meeting-events --as bot --meeting-id <id> --view compact
+lark-cli vc +meeting-events --as bot --meeting-id <id>
 ```
 
 如果应用机器人已经在会中，也可以先通过 active meeting 找会：
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --format pretty
 ```
 
 如果只是用当前登录用户发现会议：
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --format pretty
 ```
 
 若应用机器人已离会、未入会、或会议已经无法再判断身份，后端通常会报：
@@ -106,20 +102,19 @@ lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --view compac
 
 执行准则：
 
-- **默认命令模板**：`lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-all --view compact --format pretty`
+- **默认命令模板**：`lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-all --format pretty`
 - 如果你发现自己执行成了不带 `--page-all` 的单页查询，而响应里又出现 `has_more=true` / `more available` / 非空 `page_token`，应立刻意识到这只是部分结果。
-- 遇到上述情况，默认补救方式是继续使用返回的 `page_token` 续拉，例如：`lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-token <returned_page_token> --page-all --view compact --format pretty`
+- 遇到上述情况，默认补救方式是继续使用返回的 `page_token` 续拉，例如：`lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-token <returned_page_token> --page-all --format pretty`
 - 只有在用户明确要求“就看第一页”“先不要翻页”时，才不要默认带 `--page-all`
 - 只要你是基于 `+meeting-events` 来回答一场**正在进行中的会议内容**，就不能直接复用上一次查询结果。无论用户是在问“现在是谁在说话”“刚刚发生了什么”“最新事件有哪些”，还是让你“总结一下这个会议讲什么”，都必须先重新执行一次 `+meeting-events`，确认拿到的是最新事件流，再回答用户。只有在用户明确要求基于某次历史快照继续分析时，才可以复用旧结果。
 
-### 5. compact / raw / pretty / json / ndjson 输出差异
+### 5. 输出格式差异
 
-- `--view compact --format json`：默认结构化契约，顶层包含 `meeting`、`identity`、`current_roster`、`events`、`has_more`、`page_token`。参会人身份统一含 `participant_type`、`role`、`is_self`、`label`。
-- `--view compact --format pretty`：输出当前身份、当前名单和逐条时间线，适合快速理解“发生了什么”。
-- `--view compact --format ndjson`：输出事件行，并带 metadata 行，适合流式消费。
-- `--view raw --format json`：保留旧 `events/has_more/page_token` 服务端事件包，不预取 identity 或 current roster。raw 不支持 pretty/ndjson。
+- `--format json`：结构化契约，顶层包含 `meeting`、`identity`、`current_roster`、`events`、`has_more`、`page_token`。参会人身份统一含 `participant_type`、`role`、`is_self`、`label`；每条事件保留 `payload/raw` 便于追溯原始细节。
+- `--format pretty`：输出当前身份、当前名单和逐条时间线，适合快速理解“发生了什么”。
+- `--format ndjson`：输出事件行，并带 metadata 行，适合流式消费。
 
-**选型原则**：只要目标是告诉用户“发生了什么”，默认就用 `--page-all --view compact --format pretty`；需要稳定字段给 agent 消费时用 compact JSON；只有需要兼容旧事件包时才用 raw JSON。
+**选型原则**：只在 `pretty`、`json`、`ndjson` 之间选择。目标是告诉用户“发生了什么”时，用 `--page-all --format pretty`；需要稳定字段给 agent 消费时用 `--format json`；需要流式消费时用 `--format ndjson`。
 
 > **注意**：pretty 输出中的正文文本会做单行转义，真实换行会显示为 `\n`，避免打乱时间线布局。
 
@@ -136,10 +131,10 @@ lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --view compac
 
 执行准则：
 
-- 如果上下文已有明确 `meeting_id`，沿用该 `meeting_id` 的来源身份执行 `+meeting-events --page-all --view compact --format json`。
+- 如果上下文已有明确 `meeting_id`，沿用该 `meeting_id` 的来源身份执行 `+meeting-events --page-all --format json`。
 - 如果上下文没有明确 `meeting_id`，先按用户当前意图选择身份：问“我/当前用户所在会议”用 `lark-cli vc +meeting-list-active --as user --format pretty`；问“应用机器人可见的目标用户会议”用 `lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format pretty`。返回多个会议时先让用户选择。
 - 如果上下文只有 9 位会议号，先按当前身份执行 `+meeting-list-active` 并按 `meeting_no` 匹配；匹配到唯一会议后再查事件。不要为了总结会议而自动调用 `+meeting-join`。
-- 这类问题拿到 `meeting_id` 后，用同一身份执行 `lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-all --view compact --format json` 拉取最新事件流。
+- 这类问题拿到 `meeting_id` 后，用同一身份执行 `lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-all --format json` 拉取最新事件流。
 - 如果事件中出现共享文档线索，例如：
   - `magic_share_started`
   - `share_doc.title`
@@ -211,21 +206,21 @@ lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --view compac
 lark-cli vc +meeting-join --as bot --meeting-number 123456789
 
 # 第 2 步：查询事件流
-lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --format pretty
 ```
 
 ### 场景 1b：应用机器人已在会中，先发现 meeting_id 再读事件
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --format pretty
 ```
 
 ### 场景 1c：当前登录用户正在会中，先发现 meeting_id 再读事件
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --format pretty
 ```
 
 ### 场景 2：过滤某段时间内的事件
@@ -237,7 +232,6 @@ lark-cli vc +meeting-events \
   --start 2026-04-17T15:00:00+08:00 \
   --end 2026-04-17T16:00:00+08:00 \
   --page-all \
-  --view compact \
   --format pretty
 ```
 
@@ -251,7 +245,6 @@ lark-cli vc +meeting-events \
   --meeting-id <id> \
   --page-token <last_page_token> \
   --page-all \
-  --view compact \
   --format pretty
 ```
 

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
@@ -75,7 +75,7 @@ lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
 lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --format pretty
 ```
 
-如果只是用当前登录用户发现会议：
+如果要查询当前登录用户所在会议：
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
@@ -227,7 +227,7 @@ lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --format pret
 
 ```bash
 lark-cli vc +meeting-events \
-  --as bot \
+  --as <same_identity> \
   --meeting-id <id> \
   --start 2026-04-17T15:00:00+08:00 \
   --end 2026-04-17T16:00:00+08:00 \
@@ -241,7 +241,7 @@ lark-cli vc +meeting-events \
 # 上一次查询结束后，保留最后返回的 page_token
 # 这次直接从该游标继续拉新增事件
 lark-cli vc +meeting-events \
-  --as bot \
+  --as <same_identity> \
   --meeting-id <id> \
   --page-token <last_page_token> \
   --page-all \
@@ -260,8 +260,8 @@ lark-cli vc +meeting-events \
 |---------|---------|---------|
 | `--meeting-id is required` | 未传入 `--meeting-id` | 传入长数字 `meeting.id` |
 | `not a 9-digit meeting number` | 把 9 位会议号误传给 `--meeting-id` | 如果只是查询会中内容，先用 `+meeting-list-active` 按 `meeting_no` 匹配拿长数字 `meeting_id`；只有用户明确要求入会时才用 `+meeting-join --as bot --meeting-number <9位号>` |
-| `10005 bot is not in meeting` | 使用应用身份读取，但应用机器人从未真实入会该会议；或会议已结束但应用机器人从未在会中出现过 | 如果 `meeting_id` 来自用户身份发现，先让应用机器人入会或确认它曾参会后再用 `--as bot` 读取。**如果只是想看参会人快照，改用 `lark-cli vc meeting get --params '{"meeting_id":"<meeting.id>"}' --with-participants`** |
-| 用户身份不支持 | 当前事件读取接口不支持用用户身份访问 | 不要反复执行 `auth login`。改用应用身份流程：先通过 `+meeting-list-active --as bot --user-id <user_open_id>` 获取应用身份可读的 `meeting_id`，或在用户明确同意后让应用机器人入会，再用 `+meeting-events --as bot` 读取 |
+| `10005 bot is not in meeting` | 使用应用身份读取，但应用机器人从未真实入会该会议；或会议已结束但应用机器人从未在会中出现过 | 如果 `meeting_id` 来自用户身份发现，改回 `--as user`；如果确实要应用身份读取，先让应用机器人入会或确认它曾参会后再用 `--as bot`。**如果只是想看参会人快照，改用 `lark-cli vc meeting get --params '{"meeting_id":"<meeting.id>"}' --with-participants`** |
+| 用户身份无权限 / 不可见 | 当前用户不是该会议的可见参与者，或 `meeting_id` 不是从用户身份路径获得 | 不要反复执行 `auth login`。先确认 `meeting_id` 是否来自 `+meeting-list-active --as user`；如果用户明确要切到应用身份，再通过 `+meeting-list-active --as bot --user-id <user_open_id>` 获取应用身份可读的 `meeting_id`，或在用户明确同意后让应用机器人入会，再用 `+meeting-events --as bot` 读取 |
 | `20001 meeting_status_MEETING_END` | 会议已结束且已超出后端允许的 5 分钟宽限窗口 | 本接口不再适合继续拉取事件。先用 `lark-cli vc +notes --meeting-ids <meeting.id>` 获取会议产物信息，再根据 `note_display_type` / `note_id` / `minute_token` 和用户意图选择纪要正文、逐字稿或妙记；参会人请用 `lark-cli vc meeting get --params '{"meeting_id":"<meeting.id>"}' --with-participants` |
 | `20002 meeting not exist` | `meeting_id` 错误，或会议实例当前已不可获取（常见于把 9 位会议号当 meeting_id 传） | 确认传入的是长数字 `meeting_id`，不是 9 位会议号 |
 | 应用身份权限不足 | 应用权限、租户安装、权限可访问的数据范围或 VC Agent privilege 未配置完整 | 不要执行 `auth login`。以 CLI 返回的 metadata / error envelope 为准确认缺失权限；检查应用发布/安装，以及开放平台“权限可访问的数据范围”：选择“按条件筛选”，条件为“会议的归属者 包含 与应用的可用范围一致”；仍失败再排查内测 privilege / 灰度 |

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
@@ -15,16 +15,16 @@
 
 ```bash
 # 默认用法：全量拉取应用机器人当前可见事件，输出 normalized compact 契约
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
 
 # 指定时间范围，并拉全该时间窗内当前可见事件
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --start 2026-04-17T15:00:00+08:00 --end 2026-04-17T16:00:00+08:00 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --start 2026-04-17T15:00:00+08:00 --end 2026-04-17T16:00:00+08:00 --page-all --view compact --format pretty
 
 # 基于上一次保存的 page_token 继续查新增事件
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-token <last_page_token> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-token <last_page_token> --page-all --view compact --format pretty
 
 # 兼容旧事件包或调试服务端原始响应时，使用 raw escape hatch
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-size 20 --view raw --format json
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-size 20 --view raw --format json
 ```
 
 ## 参数
@@ -69,21 +69,21 @@ lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-siz
 lark-cli vc +meeting-join --as bot --meeting-number 123456789
 
 # 再查询事件
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --view compact
+lark-cli vc +meeting-events --as bot --meeting-id <id> --view compact
 ```
 
 如果应用机器人已经在会中，也可以先通过 active meeting 找会：
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
 ```
 
 如果只是用当前登录用户发现候选会议：
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
 ```
 
 若应用机器人已离会、未入会、或会议已经无法再判断身份，后端通常会报：
@@ -106,9 +106,9 @@ lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all
 
 执行准则：
 
-- **默认命令模板**：`lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty`
+- **默认命令模板**：`lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty`
 - 如果你发现自己执行成了不带 `--page-all` 的单页查询，而响应里又出现 `has_more=true` / `more available` / 非空 `page_token`，应立刻意识到这只是部分结果。
-- 遇到上述情况，默认补救方式是继续使用返回的 `page_token` 续拉，例如：`lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-token <returned_page_token> --page-all --view compact --format pretty`
+- 遇到上述情况，默认补救方式是继续使用返回的 `page_token` 续拉，例如：`lark-cli vc +meeting-events --as bot --meeting-id <id> --page-token <returned_page_token> --page-all --view compact --format pretty`
 - 只有在用户明确要求“就看第一页”“先不要翻页”时，才不要默认带 `--page-all`
 - 只要你是基于 `+meeting-events` 来回答一场**正在进行中的会议内容**，就不能直接复用上一次查询结果。无论用户是在问“现在是谁在说话”“刚刚发生了什么”“最新事件有哪些”，还是让你“总结一下这个会议讲什么”，都必须先重新执行一次 `+meeting-events`，确认拿到的是最新事件流，再回答用户。只有在用户明确要求基于某次历史快照继续分析时，才可以复用旧结果。
 
@@ -139,7 +139,7 @@ lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all
 - 如果上下文已有明确 `meeting_id`，直接用应用身份执行 `+meeting-events --as bot --page-all --view compact --format json`。
 - 如果上下文没有明确 `meeting_id`，先按用户当前意图选择身份：问“我/当前用户所在会议”用 `lark-cli vc +meeting-list-active --as user --format pretty`；问“应用机器人可见的目标用户会议”用 `lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format pretty`。返回多个会议时先让用户选择。
 - 如果上下文只有 9 位会议号，先按当前身份执行 `+meeting-list-active` 并按 `meeting_no` 匹配；匹配到唯一会议后再查事件。不要为了总结会议而自动调用 `+meeting-join`。
-- 这类问题拿到 `meeting_id` 后，用 `lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format json` 拉取最新事件流。
+- 这类问题拿到 `meeting_id` 后，用 `lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format json` 拉取最新事件流。
 - 如果事件中出现共享文档线索，例如：
   - `magic_share_started`
   - `share_doc.title`
@@ -211,21 +211,21 @@ lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all
 lark-cli vc +meeting-join --as bot --meeting-number 123456789
 
 # 第 2 步：查询事件流
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
 ```
 
 ### 场景 1b：应用机器人已在会中，先发现 meeting_id 再读事件
 
 ```bash
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
 ```
 
 ### 场景 1c：当前登录用户正在会中，先发现 meeting_id 再读事件
 
 ```bash
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
 ```
 
 ### 场景 2：过滤某段时间内的事件
@@ -233,7 +233,7 @@ lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all
 ```bash
 lark-cli vc +meeting-events \
   --as bot \
-  --meeting-id 7628568141510692381 \
+  --meeting-id <id> \
   --start 2026-04-17T15:00:00+08:00 \
   --end 2026-04-17T16:00:00+08:00 \
   --page-all \
@@ -248,7 +248,7 @@ lark-cli vc +meeting-events \
 # 这次直接从该游标继续拉新增事件
 lark-cli vc +meeting-events \
   --as bot \
-  --meeting-id 7628568141510692381 \
+  --meeting-id <id> \
   --page-token <last_page_token> \
   --page-all \
   --view compact \

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-events.md
@@ -49,7 +49,7 @@ lark-cli vc +meeting-events --as <same_identity> --meeting-id <id> --page-size 2
 - `+search` 结果中的 `id`
 
 **不要**把 9 位会议号（`--meeting-number`）传给这个命令。
-如果 `meeting_id` 来自 `+meeting-list-active --as user`，后续 `+meeting-events` 继续使用 `--as user`。如果返回多个会议，先让用户选择具体 `meeting_id`。
+如果 `meeting_id` 来自 `+meeting-list-active`，后续 `+meeting-events` 必须沿用同一身份；如果返回多个会议，先让用户选择具体 `meeting_id`。
 
 如果用户提供的是 9 位会议号且没有明确要求应用机器人入会，先按当前场景身份查 active meetings 并按 `meeting_no` 匹配。匹配到唯一项后，取该项的长数字 `meeting_id`，再用同一身份调用本命令；匹配失败时不要自动入会，除非用户明确说“入会 / 让应用机器人旁听 / 代我参会”。
 

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
@@ -44,7 +44,7 @@ lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --format prett
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
 lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --format pretty
 
-# 方式 3：只回答当前登录用户所在会议发生了什么
+# 方式 3：查询当前登录用户所在会议发生了什么
 lark-cli vc +meeting-list-active --as user --format json
 lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --format pretty
 ```
@@ -80,7 +80,7 @@ lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
 |---------|---------|---------|
 | `--user-id is required when --as bot` | 应用身份未传目标用户 | 传入目标用户 open_id |
 | 用户身份返回空列表 | 当前登录用户没有可见的进行中会议 | 确认用户是否在会中，或是否切错身份 |
-| 用户身份不支持 | 当前接口不支持用用户身份访问 | 不要反复执行 `auth login`。改用应用身份流程：先拿目标用户 open_id，再执行 `+meeting-list-active --as bot --user-id <user_open_id>`；同时按应用身份权限配置检查应用权限、安装、数据范围和灰度 |
+| 用户身份无权限 / 不可见 | 当前登录用户没有可见的进行中会议，或当前身份无法读取该会议 | 不要反复执行 `auth login`。先确认当前登录用户是否在会中、是否切错 profile；如果用户明确要查询应用机器人可见的会议，再拿目标用户 open_id 执行 `+meeting-list-active --as bot --user-id <user_open_id>`，并按应用身份权限配置检查应用权限、安装、数据范围和灰度 |
 | 应用身份返回空列表 | 没有满足“目标用户在会中且应用机器人也在会中”的当前会 | 先让应用机器人入会，或确认 `user_id` 和会议状态 |
 | `--user-id` 格式错误 | 传入了 internal user_id 或其他非 `ou_...` 值 | 改传目标用户 open_id |
 | 应用身份权限不足 | 应用权限、租户安装、权限可访问的数据范围或 VC Agent privilege 未配置完整 | 不要执行 `auth login`。以 CLI 返回的 metadata / error envelope 为准确认缺失权限；检查应用发布/安装，以及开放平台“权限可访问的数据范围”：选择“按条件筛选”，条件为“会议的归属者 包含 与应用的可用范围一致”；仍失败再排查内测 privilege / 灰度 |

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
@@ -26,10 +26,10 @@ lark-cli vc +meeting-list-active --as bot --user-id ou_xxx --format json
 
 | 身份 | 命令 | 返回范围 | 后续事件读取 |
 | ---- | ---- | -------- | ------------ |
-| 用户身份 | `--as user` | 当前登录用户正在参加的会议 | 继续 `+meeting-events --as user` |
+| 用户身份 | `--as user` | 当前登录用户正在参加的候选会议 | 后续 `+meeting-events --as bot`，并要求应用机器人在会中或曾参会 |
 | 应用身份 | `--as bot --user-id <user_open_id>` | 目标用户正在参加、且应用机器人也在会中的会议 | 继续 `+meeting-events --as bot` |
 
-硬规则：`meeting_id` 从哪种身份路径拿到，后续 `+meeting-events` 就沿用哪种身份。不要把用户身份拿到的 `meeting_id` 改用应用身份查，也不要把应用身份拿到的 `meeting_id` 改用用户身份查，除非用户明确要求切换场景。
+硬规则：`+meeting-list-active` 可以用用户身份发现候选会议，但 `+meeting-events` 统一是应用机器人视角，必须用 `--as bot`，并要求应用机器人在会中或曾参会。不要把应用身份拿到的 `meeting_id` 改用用户身份读事件。
 
 应用身份返回空，不代表目标用户不在任何会议中，只能说明没有找到“目标用户在会中且应用机器人也在会中”的当前会。
 
@@ -46,14 +46,14 @@ lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --form
 
 # 方式 3：只回答当前登录用户所在会议发生了什么
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as user --meeting-id <meeting_id> --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
 ```
 
 ## 多会议选择
 
 - 如果返回多个会议，不要自动挑第一个。
 - 向用户展示每个候选的 `meeting_title` / `meeting_no` / `meeting_id`，等待用户选择。
-- 选择后继续使用发现该会议时的同一身份调用 `+meeting-events`。
+- 选择后用 `+meeting-events --as bot` 读取事件，并确认应用机器人在会中或曾参会。
 
 ## 9 位会议号匹配
 

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
@@ -38,15 +38,15 @@ lark-cli vc +meeting-list-active --as bot --user-id ou_xxx --format json
 ```bash
 # 方式 1：先让应用机器人入会，直接从 join 响应拿 meeting.id
 lark-cli vc +meeting-join --as bot --meeting-number 123456789 --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting.id> --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --format pretty
 
 # 方式 2：应用机器人已经在会中时，用应用身份发现 meeting_id
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --format pretty
 
 # 方式 3：只回答当前登录用户所在会议发生了什么
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id <meeting_id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
 ```
 
 ## 多会议选择

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
@@ -26,10 +26,10 @@ lark-cli vc +meeting-list-active --as bot --user-id ou_xxx --format json
 
 | 身份 | 命令 | 返回范围 | 后续事件读取 |
 | ---- | ---- | -------- | ------------ |
-| 用户身份 | `--as user` | 当前登录用户正在参加的候选会议 | 后续 `+meeting-events --as bot`，并要求应用机器人在会中或曾参会 |
+| 用户身份 | `--as user` | 当前登录用户正在参加的会议 | 继续 `+meeting-events --as user` |
 | 应用身份 | `--as bot --user-id <user_open_id>` | 目标用户正在参加、且应用机器人也在会中的会议 | 继续 `+meeting-events --as bot` |
 
-硬规则：`+meeting-list-active` 可以用用户身份发现候选会议，但 `+meeting-events` 统一是应用机器人视角，必须用 `--as bot`，并要求应用机器人在会中或曾参会。不要把应用身份拿到的 `meeting_id` 改用用户身份读事件。
+硬规则：`meeting_id` 从哪种身份路径拿到，后续 `+meeting-events` 就沿用哪种身份。不要把应用身份拿到的 `meeting_id` 改用用户身份读事件，也不要把用户身份拿到的 `meeting_id` 强制切到应用身份。
 
 应用身份返回空，不代表目标用户不在任何会议中，只能说明没有找到“目标用户在会中且应用机器人也在会中”的当前会。
 
@@ -46,14 +46,14 @@ lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --format prett
 
 # 方式 3：只回答当前登录用户所在会议发生了什么
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --view compact --format pretty
 ```
 
 ## 多会议选择
 
 - 如果返回多个会议，不要自动挑第一个。
 - 向用户展示每个候选的 `meeting_title` / `meeting_no` / `meeting_id`，等待用户选择。
-- 选择后用 `+meeting-events --as bot` 读取事件，并确认应用机器人在会中或曾参会。
+- 选择后用同一身份执行 `+meeting-events` 读取事件。
 
 ## 9 位会议号匹配
 

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
@@ -38,15 +38,15 @@ lark-cli vc +meeting-list-active --as bot --user-id ou_xxx --format json
 ```bash
 # 方式 1：先让应用机器人入会，直接从 join 响应拿 meeting.id
 lark-cli vc +meeting-join --as bot --meeting-number 123456789 --format json
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --format pretty
 
 # 方式 2：应用机器人已经在会中时，用应用身份发现 meeting_id
 lark-cli vc +meeting-list-active --as bot --user-id <user_open_id> --format json
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --format pretty
 
 # 方式 3：只回答当前登录用户所在会议发生了什么
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as bot --meeting-id 7628568141510692381 --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --view compact --format pretty
 ```
 
 ## 多会议选择

--- a/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
+++ b/skills/lark-vc-agent/references/lark-vc-agent-meeting-list-active.md
@@ -46,7 +46,7 @@ lark-cli vc +meeting-events --as bot --meeting-id <id> --page-all --format prett
 
 # 方式 3：只回答当前登录用户所在会议发生了什么
 lark-cli vc +meeting-list-active --as user --format json
-lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --view compact --format pretty
+lark-cli vc +meeting-events --as user --meeting-id <id> --page-all --format pretty
 ```
 
 ## 多会议选择


### PR DESCRIPTION
## Summary
- normalize `vc +meeting-events` bot-facing compact output with bot identity, self markers, server current roster, normalized time/status fields, pretty labels, and raw escape hatch
- update focused tests and lark-vc-agent guidance for the bot-only contract

## Validation
- gofmt on changed Go files
- `go build ./shortcuts/vc` via controlled compile runner
- collector-backed commit/push completed for `features/F-vc-meeting-events-contract`

Gate4 acceptance will continue with MR checks, remote UT/semantic, FT, and QA lanes under the same verification identity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `+meeting-events --view` with `compact` (default) and `raw` output modes.
  * `compact` output now includes normalized `meeting`, bot identity, `current_roster`, and event fields.

* **Changed Behavior**
  * `+meeting-events` now supports **bot authentication only** (`--as bot`).
  * `--view raw` is available **only with** `--format json`, preserving the legacy event envelope (without bot/roster metadata).

* **Bug Fixes / Improvements**
  * NDJSON output now adds a metadata row; time strings are normalized.

* **Documentation**
  * Updated skill/reference guidance for bot-only event reads, pagination behavior, and meeting-visibility rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->