### PR TITLE
fix(base): gate +form-submit behind high-risk-write confirmation

### DIFF
--- a/shortcuts/base/base_form_submit.go
+++ b/shortcuts/base/base_form_submit.go
@@ -26,7 +26,7 @@ var BaseFormSubmit = common.Shortcut{
 	Service:     "base",
 	Command:     "+form-submit",
 	Description: "Submit a form (fill and submit form data)",
-	Risk:        "write",
+	Risk:        "high-risk-write",
 	Scopes:      []string{"base:form:update", "docs:document.media:upload"},
 	AuthTypes:   authTypes(),
 	HasFormat:   true,
@@ -39,6 +39,8 @@ var BaseFormSubmit = common.Shortcut{
 		`Example (no attachments): --share-token shrXXXX --json '{"fields":{"Service Rating":5,"Review":"Good service"}}'`,
 		`Example (with attachments): --share-token shrXXXX --base-token basXXX --json '{"fields":{"Service Rating":5},"attachments":{"Attachment":["./report.pdf"]}}'`,
 		`Cell values in "fields" follow lark-base-cell-value.md conventions; "attachments" maps field names to local file path arrays — the CLI uploads them in parallel and merges them into the submission.`,
+		`Form submission is irreversible. Preview the exact fields with --dry-run, show them to the user, and only pass --yes after they confirm the content.`,
+		baseHighRiskYesTip,
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		return validateFormSubmit(runtime)

--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -201,6 +201,12 @@ func TestBaseFieldUpdateRisk(t *testing.T) {
 	}
 }
 
+func TestBaseFormSubmitRisk(t *testing.T) {
+	if BaseFormSubmit.Risk != "high-risk-write" {
+		t.Fatalf("risk=%q want=%q", BaseFormSubmit.Risk, "high-risk-write")
+	}
+}
+
 func TestBaseDeleteShortcutsRisk(t *testing.T) {
 	cases := map[string]string{
 		BaseFieldDelete.Command:            BaseFieldDelete.Risk,
@@ -1908,8 +1914,8 @@ func TestBaseFormSubmitShortcut(t *testing.T) {
 		if s.Service != "base" {
 			t.Fatalf("Service=%q want base", s.Service)
 		}
-		if s.Risk != "write" {
-			t.Fatalf("Risk=%q want write", s.Risk)
+		if s.Risk != "high-risk-write" {
+			t.Fatalf("Risk=%q want high-risk-write", s.Risk)
 		}
 		if !s.HasFormat {
 			t.Fatal("HasFormat should be true")
@@ -2209,6 +2215,7 @@ func TestExecuteFormSubmit(t *testing.T) {
 			"+form-submit",
 			"--share-token", "shr_exec1",
 			"--json", `{"fields":{"Name":"Alice","Rating":5}}`,
+			"--yes",
 		}
 		if err := runShortcut(t, BaseFormSubmit, args, factory, stdout); err != nil {
 			t.Fatalf("err=%v", err)
@@ -2277,6 +2284,7 @@ func TestExecuteFormSubmit(t *testing.T) {
 			"--share-token", "shr_exec6",
 			"--base-token", "bas_exec6",
 			"--json", `{"attachments":{"File":["./nonexistent.pdf"]}}`,
+			"--yes",
 		}
 		err := runShortcut(t, BaseFormSubmit, args, factory, stdout)
 		if err == nil {
@@ -2325,6 +2333,7 @@ func TestExecuteFormSubmit(t *testing.T) {
 			"--share-token", "shr_dedup",
 			"--base-token", "bas_dedup",
 			"--json", `{"attachments":{"FieldA":["./shared.pdf"],"FieldB":["./shared.pdf"]}}`,
+			"--yes",
 		}
 		if err := runShortcut(t, BaseFormSubmit, args, factory, stdout); err != nil {
 			t.Fatalf("err=%v", err)
@@ -2372,6 +2381,7 @@ func TestUploadAttachmentsParallel(t *testing.T) {
 			"--share-token", "shr_para1",
 			"--base-token", "bas_para1",
 			"--json", `{"attachments":{"Doc":["./doc.txt"]}}`,
+			"--yes",
 		}
 		if err := runShortcut(t, BaseFormSubmit, args, factory, stdout); err != nil {
 			t.Fatalf("err=%v", err)
@@ -2406,6 +2416,7 @@ func TestUploadAttachmentsParallel(t *testing.T) {
 			"--share-token", "shr_err",
 			"--base-token", "bas_err",
 			"--json", `{"attachments":{"Bad":["./bad.txt"]}}`,
+			"--yes",
 		}
 		err := runShortcut(t, BaseFormSubmit, args, factory, stdout)
 		if err == nil {

--- a/skills/lark-base/references/lark-base-form-submit.md
+++ b/skills/lark-base/references/lark-base-form-submit.md
@@ -72,6 +72,23 @@ lark-cli base +form-submit \
 | `--format` | 否 | 输出格式：json（默认）\| pretty \| table \| ndjson \| csv |
 | `--as` | 否 | 身份：user（默认）\| bot |
 | `--dry-run` | 否 | 预览 API 调用，不执行 |
+| `--yes` | 条件必填 | 确认提交。本命令为高风险写操作，不带 `--yes` 时不会提交，而是返回 `confirmation_required` 错误（退出码 10）；务必先用 `--dry-run` 预览并请用户确认内容后再加 `--yes` 提交 |
+
+### 提交前预览与确认（高风险写）
+
+`+form-submit` 是不可撤销的高风险写操作。Agent 必须遵循「预览 → 用户确认 → 提交」流程：
+
+```bash
+# 1️⃣ 预览将要提交的字段内容（不提交）
+lark-cli base +form-submit --share-token <share_token> --json '{"fields":{...}}' --dry-run
+
+# 2️⃣ 把 dry-run 输出的字段内容展示给用户，等用户确认无误
+
+# 3️⃣ 用户确认后再加 --yes 实际提交
+lark-cli base +form-submit --share-token <share_token> --json '{"fields":{...}}' --yes
+```
+
+不带 `--yes` 直接提交会被拦截并返回 `confirmation_required`（退出码 10），不会写入任何数据。
 
 ### --json 结构说明
 


### PR DESCRIPTION
## Summary
Promote `base +form-submit` from `write` to `high-risk-write` so the irreversible form submission requires explicit confirmation, giving AI agents a way to let users review content before it is written.

## Changes
- `shortcuts/base/base_form_submit.go`: set `Risk: "high-risk-write"`; add a preview→confirm tip plus the shared `baseHighRiskYesTip` agent guidance.
- `shortcuts/base/base_shortcuts_test.go`: add `TestBaseFormSubmitRisk`; update the metadata assertion; pass `--yes` in the execute-path tests now gated by confirmation.
- `skills/lark-base/references/lark-base-form-submit.md`: document the `--dry-run` → confirm → `--yes` flow and the `--yes` flag.

## Test Plan
- [x] Unit tests pass (`go test ./shortcuts/base/`)
- [x] Manual local verification confirms the `lark-cli base +form-submit` flow works as expected
  - Without `--yes`: returns `confirmation_required` (exit 10), no network call, nothing written.
  - With `--dry-run`: previews the exact submit body for review.

## Related Issues
- Closes larksuite/cli#1545


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form submission now requires explicit `--yes` confirmation flag to prevent accidental data changes.
  * Added preview capability using `--dry-run` before final submission.

* **Documentation**
  * Updated documentation for high-risk form submission confirmation workflow.

* **Tests**
  * Added test coverage for form submission risk level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->