### PR TITLE
fix(sheets): resolve wiki URL in +range-move/+range-copy Execute

### DIFF
--- a/shortcuts/sheets/execute_paths_test.go
+++ b/shortcuts/sheets/execute_paths_test.go
@@ -154,6 +154,40 @@ func TestExecute_WikiURLIncompleteNode(t *testing.T) {
 	}
 }
 
+// TestExecute_RangeMove_WikiURL guards the transformExecuteFn path: +range-move
+// and +range-copy use a named Execute helper (not an inline func), so they must
+// still resolve a /wiki/ URL to the backing spreadsheet token before calling
+// transform_range. The tool stub is keyed on the resolved obj_token, so an
+// unresolved node_token would miss it and fail this test.
+func TestExecute_RangeMove_WikiURL(t *testing.T) {
+	t.Parallel()
+	getNode := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "success",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":  "sheet",
+					"obj_token": testToken,
+				},
+			},
+		},
+	}
+	tool := toolOutputStub(testToken, "write", `{"updated_range":"A10:B11"}`)
+	out, err := runShortcutWithStubs(t, RangeMove,
+		[]string{
+			"--url", "https://example.feishu.cn/wiki/wikTestNODE",
+			"--sheet-id", testSheetID,
+			"--source-range", "A1:B2",
+			"--target-range", "A10",
+		}, getNode, tool)
+	if err != nil {
+		t.Fatalf("execute failed: %v\nout=%s", err, out)
+	}
+}
+
 // TestExecute_SheetMove_LookupsIndex covers the two-step path: SheetMove
 // when only --sheet-name is given (and --source-index omitted) first
 // reads the workbook structure to derive sheet_id + source_index, then

--- a/shortcuts/sheets/lark_sheet_range_operations.go
+++ b/shortcuts/sheets/lark_sheet_range_operations.go
@@ -540,7 +540,7 @@ func transformDryRunFn(op string, withPasteType, _ bool) func(context.Context, *
 
 func transformExecuteFn(op string, withPasteType, _ bool) func(context.Context, *common.RuntimeContext) error {
 	return func(ctx context.Context, runtime *common.RuntimeContext) error {
-		token, err := resolveSpreadsheetToken(runtime)
+		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## 背景

#1519(wiki URL 支持)已合并:它把 `--url` 的 wiki 解析推迟到 Execute(`resolveSpreadsheetTokenExec` 走 `get_node`),并把全仓 Execute hook 从 network-free 的 `resolveSpreadsheetToken` 切到 `...Exec`。

但那次批量切换只覆盖了 **inline `Execute: func` 闭包**,漏掉了唯一一个用**具名 helper** 包装的 Execute:`transformExecuteFn`(`lark_sheet_range_operations.go`),它是 `+range-move` / `+range-copy` 的 Execute。

## 后果

给 `+range-move` / `+range-copy` 传 `/wiki/<node_token>` URL 时:Validate 通过(node_token 非空透传),但 Execute 把**未解析的 node_token** 当 `excel_id` 直接发给 `transform_range` 工具 → 调用失败,且报错不指向真正原因。其余 shortcut 都支持 wiki URL,唯独这两个不支持。

## 修复

`transformExecuteFn` 里 `resolveSpreadsheetToken` → `resolveSpreadsheetTokenExec`(一行),与其它 Execute 对齐。Validate/DryRun(`validateRangeMoveOrCopy` / `transformDryRunFn`)保持 network-free 不变。

交叉验证:全仓 `Execute:` 赋值中只有 `+range-move` / `+range-copy` 用具名 helper,其余皆 inline 且 #1519 已正确切换——这是唯一漏网。

## 验证

- 新增 `TestExecute_RangeMove_WikiURL` 回归测试(tool stub 以解析后的 obj_token 为 key,未解析的 node_token 会 miss → 能 catch 此回归)。
- 全量 `go test ./shortcuts/sheets/...` 通过,`go vet` / `go build` OK。
