### PR TITLE
fix: simplify mail triage read hint

### DIFF
--- a/shortcuts/mail/mail_read_help_test.go
+++ b/shortcuts/mail/mail_read_help_test.go
@@ -89,7 +89,7 @@ func TestMailMessagesDryRunMentionsBatchGetChunkingAndMerge(t *testing.T) {
 	}
 }
 
-func TestMailTriageTableHintRoutesSingleAndMultipleReads(t *testing.T) {
+func TestMailTriageTableHintRecommendsBatchRead(t *testing.T) {
 	f, stdout, stderr, reg := mailShortcutTestFactory(t)
 	registerTriageReadHintStubs(reg)
 
@@ -102,13 +102,16 @@ func TestMailTriageTableHintRoutesSingleAndMultipleReads(t *testing.T) {
 	reg.Verify(t)
 
 	errOut := stderr.String()
-	for _, want := range []string{
-		"tip: read full content:",
-		"single message use mail +message --message-id <id>",
-		"multiple messages use mail +messages --message-ids <id1>,<id2>,<id3>",
+	want := "tip: read full content: use mail +messages --message-ids <id1>,<id2>,<id3>"
+	if !strings.Contains(errOut, want) {
+		t.Fatalf("stderr missing %q\n%s", want, errOut)
+	}
+	for _, disallowed := range []string{
+		"single message use mail +message",
+		"multiple messages use mail +messages",
 	} {
-		if !strings.Contains(errOut, want) {
-			t.Fatalf("stderr missing %q\n%s", want, errOut)
+		if strings.Contains(errOut, disallowed) {
+			t.Fatalf("stderr must not recommend legacy read hint %q\n%s", disallowed, errOut)
 		}
 	}
 }

--- a/shortcuts/mail/mail_triage.go
+++ b/shortcuts/mail/mail_triage.go
@@ -333,9 +333,9 @@ var MailTriage = common.Shortcut{
 			}
 			if mailbox != "me" {
 				quotedMailbox := shellQuote(mailbox)
-				fmt.Fprintln(runtime.IO().ErrOut, "tip: read full content: single message use mail +message --mailbox "+quotedMailbox+" --message-id <id>; multiple messages use mail +messages --mailbox "+quotedMailbox+" --message-ids <id1>,<id2>,<id3>")
+				fmt.Fprintln(runtime.IO().ErrOut, "tip: read full content: use mail +messages --mailbox "+quotedMailbox+" --message-ids <id1>,<id2>,<id3>")
 			} else {
-				fmt.Fprintln(runtime.IO().ErrOut, "tip: read full content: single message use mail +message --message-id <id>; multiple messages use mail +messages --message-ids <id1>,<id2>,<id3>")
+				fmt.Fprintln(runtime.IO().ErrOut, "tip: read full content: use mail +messages --message-ids <id1>,<id2>,<id3>")
 			}
 		}
 		return nil


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/7219331
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Simplify mail +triage full-content tip | passed | 6daeb5b |

## Summary

Update the lark-cli mail +triage output tip so it recommends only batch reading full content:

`tip: read full content: use mail +messages --message-ids <id1>,<id2>,<id3>`

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the read hint shown in mail triage views to recommend batch reading multiple messages with a single command.
  * Removed the older single-message and legacy multi-message suggestions from the tip message, keeping the guidance clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->