### PR TITLE
docs(drive): document 30-char query limit for +search

### DIFF
--- a/shortcuts/drive/drive_search.go
+++ b/shortcuts/drive/drive_search.go
@@ -75,7 +75,7 @@ var DriveSearch = common.Shortcut{
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{
-		{Name: "query", Desc: "search keyword (may be empty to browse by filter only)"},
+		{Name: "query", Desc: "search keyword (may be empty to browse by filter only); max 30 characters by Unicode code point (CJK counts 1 each), over 30 the server rejects with 99992402 field validation failed"},
 
 		{Name: "mine", Type: "bool", Desc: "restrict to docs I own (server-side owner semantic, NOT original creator; uses current user's open_id)"},
 		{Name: "creator-ids", Desc: "comma-separated owner open_ids (API field is creator_ids but matched by owner); mutually exclusive with --mine"},

--- a/skills/lark-drive/references/lark-drive-search.md
+++ b/skills/lark-drive/references/lark-drive-search.md
@@ -21,6 +21,8 @@
 > 错误：`lark-cli drive +search 方案`
 > `+search` 不接受位置参数；空 `--query` 或省略 `--query` 表示纯靠 filter 浏览（合法）。
 >
+> **`--query` 最长 30 个字符**：按字符数（Unicode 码点）算，中文每字算 1 个，与 ASCII 同口径；超过 30 会被服务端拒绝（`99992402 field validation failed`，**是报错不是截断**）。长关键词必须先压缩成核心实体 + 主题词（如把整句问题压成「项目名 + 主题」再搜），不要把整句原问塞进 `--query`。
+>
 > **列表型请求不要硬塞关键词**：如果用户只是要求"我这月创建的所有文档"、"最近半年我编辑过的文档"、"按类型分类统计"这类范围浏览 / 汇总请求，且没有给出标题片段或业务关键词，应使用 `--query ""` 搭配 `--created-by-me`、`--mine`、`--created-*`、`--edited-*`、`--doc-types` 等过滤条件。不要把"查找"、"所有文档"、"最近更新过"、"按类型分类统计"这类动作词或统计意图放进 `--query`，否则会把本来应靠 filter 命中的结果过度收窄。
 
 ### 自然语言 → 命令映射速查
@@ -99,7 +101,7 @@ lark-cli drive +search --query 方案 --page-token '<PAGE_TOKEN>'
 
 | 参数 | 必填 | 说明 |
 |---|---|---|
-| `--query <text>` | 否 | 搜索关键词；支持服务端高级语法（`intitle:`、`""`、`OR`、`-`）。空字符串或省略表示纯 filter 浏览 |
+| `--query <text>` | 否 | 搜索关键词；支持服务端高级语法（`intitle:`、`""`、`OR`、`-`）。空字符串或省略表示纯 filter 浏览。**长度上限 30 个字符（按 Unicode 码点算，中文每字算 1 个，与 ASCII 同口径）；超过 30 服务端直接报 `99992402 field validation failed`，不会截断** |
 | `--page-size <n>` | 否 | 每页数量，默认 15，最大 20。超过 20 自动 clamp；非正数（≤0）回落 15；**非数字值直接返回 validation 错误** |
 | `--page-token <token>` | 否 | 上一次响应里的 `page_token`，用于翻页 |
 | `--format` | 否 | `json`（默认）/ `pretty` |


### PR DESCRIPTION
## What

The Search v2 API behind `drive +search` rejects any `--query` longer than **30 characters** with `99992402 field validation failed`. Two important details that were undocumented:

- The limit is counted by **Unicode code point**, not bytes — a CJK character counts as 1, same as an ASCII character (30 Chinese chars = 90 bytes still passes; 31 fails).
- It is a **hard error, not a truncation** — the request is rejected outright, so callers can't rely on the server silently cutting the query down.

## Verified behavior

| query | runes | bytes | result |
|---|---|---|---|
| `a` × 30 | 30 | 30 | OK |
| `a` × 31 | 31 | 31 | `99992402 field validation failed` |
| `测` × 29 | 29 | 87 | OK |
| `测` × 30 | 30 | 90 | OK |
| `测` × 31 | 31 | 93 | `99992402 field validation failed` |

Boundary is exactly 30 code points regardless of ASCII vs CJK.

## Changes

- `shortcuts/drive/drive_search.go` — add the limit to the `--query` flag description so it shows in `drive +search -h`.
- `skills/lark-drive/references/lark-drive-search.md` — add the constraint to the key-constraints block and the `--query` parameter table, with guidance to compress long queries into core entity + topic terms instead of pasting whole sentences.

Docs/help-text only; no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `drive +search` and `--query` guidance with a hard 30 Unicode code point limit.
  * Added the server-side validation behavior for overlong queries, including the relevant error code.
  * Noted that queries exceeding the limit are rejected rather than truncated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->