### PR TITLE
feat: embed mail sender control metadata

### DIFF
--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -599,6 +599,18 @@ lark-cli mail <resource> <method> [flags] # 调用 API
   - `modify` — 修改邮件会话
   - `trash` — 删除邮件会话
 
+### user_mailbox.allow_senders
+
+  - `batch_create` — 批量将发件人加入指定用户邮箱的「信任发件人」白名单。支持按邮箱地址 (sender_type=1) 或域名 (sender_type=2) 添加。单次最多 100 项，单用户黑白名单合计最多 2000 项；与黑名单互斥（添加白名单会从黑名单删除对侧记录）。
+  - `list` — 列表/搜索指定用户邮箱的「信任发件人」白名单。支持按发件人地址或域名前缀搜索 (keyword)。返回列表按创建时间倒序，使用 page_token + page_size 进行分页。
+  - `batch_remove` — 批量从指定用户邮箱的「信任发件人」白名单中删除发件人。senders 中每项可以是邮箱地址或域名（与添加时一致）。批量删除按字面值哈希匹配，可兼容历史大写数据。单次最多 100 项。
+
+### user_mailbox.blocked_senders
+
+  - `list` — 列表/搜索指定用户邮箱的「屏蔽发件人」黑名单。支持按发件人地址或域名前缀搜索 (keyword)。返回列表按创建时间倒序，使用 page_token + page_size 进行分页。
+  - `batch_remove` — 批量从指定用户邮箱的「屏蔽发件人」黑名单中删除发件人。senders 中每项可以是邮箱地址或域名（与添加时一致）。批量删除按字面值哈希匹配，可兼容历史大写数据。单次最多 100 项。
+  - `batch_create` — 批量将发件人加入指定用户邮箱的「屏蔽发件人」黑名单。支持按邮箱地址 (sender_type=1) 或域名 (sender_type=2) 添加。单次最多 100 项，单用户黑白名单合计最多 2000 项；与白名单互斥（添加黑名单会从白名单删除对侧记录）。
+
 ## 权限表
 
 | 方法 | 所需 scope |
@@ -660,3 +672,9 @@ lark-cli mail <resource> <method> [flags] # 调用 API
 | `user_mailbox.threads.list` | `mail:user_mailbox.message:readonly` |
 | `user_mailbox.threads.modify` | `mail:user_mailbox.message:modify` |
 | `user_mailbox.threads.trash` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.allow_senders.batch_create` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.allow_senders.list` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.allow_senders.batch_remove` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.blocked_senders.list` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.blocked_senders.batch_remove` | `mail:user_mailbox.message:modify` |
+| `user_mailbox.blocked_senders.batch_create` | `mail:user_mailbox.message:modify` |


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/e62ede0
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S7 | Sync generated mail registry metadata into lark-cli | passed | 2ad5d8a |

## Source specs

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the API reference to document sender allow/blocked mailbox resources.
  * Added usage details for batch add/remove, listing, and search, including constraints and mutual exclusivity behavior.
  * Updated the permissions (“权限表”) with the required access scope mappings for these sender management operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->