### PR TITLE
feat(mail): add message modify and trash shortcuts

### DIFF
--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -51,8 +51,7 @@ func hintSendDraft(runtime *common.RuntimeContext, mailboxID, draftID string) {
 // original message as read after a reply/reply-all/forward operation.
 func hintMarkAsRead(runtime *common.RuntimeContext, mailboxID, originalMessageID string) {
 	fmt.Fprintf(runtime.IO().ErrOut,
-		"tip: mark original as read? lark-cli mail user_mailbox.messages batch_modify_message"+
-			` --params '{"user_mailbox_id":"%s"}' --data '{"message_ids":["%s"],"remove_label_ids":["UNREAD"]}'`+"\n",
+		"tip: mark original as read? lark-cli mail +message-modify --mailbox %s --message-ids %s --remove-label-ids UNREAD\n",
 		sanitizeForTerminal(mailboxID), sanitizeForTerminal(originalMessageID))
 }
 

--- a/shortcuts/mail/helpers.go
+++ b/shortcuts/mail/helpers.go
@@ -51,8 +51,8 @@ func hintSendDraft(runtime *common.RuntimeContext, mailboxID, draftID string) {
 // original message as read after a reply/reply-all/forward operation.
 func hintMarkAsRead(runtime *common.RuntimeContext, mailboxID, originalMessageID string) {
 	fmt.Fprintf(runtime.IO().ErrOut,
-		"tip: mark original as read? lark-cli mail +message-modify --mailbox %s --message-ids %s --remove-label-ids UNREAD\n",
-		sanitizeForTerminal(mailboxID), sanitizeForTerminal(originalMessageID))
+		"tip: mark original as read? lark-cli mail +message-modify --mailbox '%s' --message-ids '%s' --remove-label-ids UNREAD\n",
+		shellQuoteForHint(mailboxID), shellQuoteForHint(originalMessageID))
 }
 
 // hintReadReceiptRequest prints a stderr tip when a message that the caller

--- a/shortcuts/mail/helpers_test.go
+++ b/shortcuts/mail/helpers_test.go
@@ -465,14 +465,19 @@ func TestPrintWatchOutputSchema(t *testing.T) {
 // TestHintMarkAsRead verifies hint mark as read.
 func TestHintMarkAsRead(t *testing.T) {
 	rt, _, stderr := newOutputRuntime(t)
-	// Inject ANSI escape + message ID to verify sanitization
-	hintMarkAsRead(rt, "me", "msg-\x1b[31m123")
+	hintMarkAsRead(rt, "mail box;$(whoami)", "msg-\x1b[31m123 'quoted'\nnext")
 	out := stderr.String()
 	if strings.Contains(out, "\x1b[") {
 		t.Errorf("hintMarkAsRead should sanitize ANSI escapes, got: %q", out)
 	}
-	if !strings.Contains(out, "msg-123") {
-		t.Errorf("hintMarkAsRead should contain sanitized message ID, got: %q", out)
+	if strings.Contains(out, "\nnext") {
+		t.Errorf("hintMarkAsRead should strip embedded newlines, got: %q", out)
+	}
+	if !strings.Contains(out, "--mailbox 'mail box;$(whoami)'") {
+		t.Errorf("hintMarkAsRead should quote mailbox for shell copy/paste, got: %q", out)
+	}
+	if !strings.Contains(out, "--message-ids 'msg-123 '\\''quoted'\\''next'") {
+		t.Errorf("hintMarkAsRead should quote message ID for shell copy/paste, got: %q", out)
 	}
 }
 

--- a/shortcuts/mail/mail_message_manage_test.go
+++ b/shortcuts/mail/mail_message_manage_test.go
@@ -5,10 +5,12 @@ package mail
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -41,6 +43,46 @@ func decodeMessageManageSummary(t *testing.T, data map[string]interface{}) ([]in
 	return success, failed
 }
 
+func requireMessageManageValidationParam(t *testing.T, err error, param string) *errs.ValidationError {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected validation error for %s, got nil", param)
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected *errs.ValidationError for %s, got %T", param, err)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed Problem for %s, got %T", param, err)
+	}
+	if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("problem = %s/%s, want validation/invalid_argument", problem.Category, problem.Subtype)
+	}
+	if validationErr.Param != param {
+		t.Fatalf("param = %q, want %q", validationErr.Param, param)
+	}
+	return validationErr
+}
+
+func requireMessageManageFailedPrecondition(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected failed precondition error, got nil")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected *errs.ValidationError, got %T", err)
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("expected typed Problem, got %T", err)
+	}
+	if problem.Category != errs.CategoryValidation || problem.Subtype != errs.SubtypeFailedPrecondition {
+		t.Fatalf("problem = %s/%s, want validation/failed_precondition", problem.Category, problem.Subtype)
+	}
+}
+
 func TestMessageManage_NormalizeMessageIDs(t *testing.T) {
 	id1 := messageManageID("1")
 	id2 := messageManageID("2")
@@ -71,9 +113,8 @@ func TestMessageManage_NormalizeMessageIDs(t *testing.T) {
 		{"msg_abcdefghijklmnop_1", "msg_abcdefghijklmnop_2 "},
 	}
 	for _, tc := range cases {
-		if _, err := normalizeMessageManageIDs(tc); err == nil {
-			t.Fatalf("normalizeMessageManageIDs(%q) expected validation error", tc)
-		}
+		_, err := normalizeMessageManageIDs(tc)
+		requireMessageManageValidationParam(t, err, "--message-ids")
 	}
 }
 
@@ -173,8 +214,9 @@ func TestMessageModify_RejectsLabelIntersectionAndTrashFolder(t *testing.T) {
 		"--add-label-ids", "unread",
 		"--remove-label-ids", "UNREAD",
 	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "label cannot be both added and removed") {
-		t.Fatalf("expected label intersection validation error, got %v", err)
+	requireMessageManageValidationParam(t, err, "--add-label-ids")
+	if !strings.Contains(err.Error(), "label cannot be both added and removed") {
+		t.Fatalf("error = %v, want label intersection validation", err)
 	}
 
 	err = runMountedMailShortcut(t, MailMessageModify, []string{
@@ -182,8 +224,9 @@ func TestMessageModify_RejectsLabelIntersectionAndTrashFolder(t *testing.T) {
 		"--message-ids", id,
 		"--add-folder", "trash",
 	}, f, stdout)
-	if err == nil || !strings.Contains(err.Error(), "use +message-trash") {
-		t.Fatalf("expected TRASH validation error, got %v", err)
+	requireMessageManageValidationParam(t, err, "--add-folder")
+	if !strings.Contains(err.Error(), "use +message-trash") {
+		t.Fatalf("error = %v, want TRASH validation", err)
 	}
 }
 
@@ -240,6 +283,19 @@ func TestMessageModify_BatchesAndAggregatesPartialFailure(t *testing.T) {
 	if len(success) != 21 || len(failed) != 20 {
 		t.Fatalf("success=%d failed=%d, want 21/20", len(success), len(failed))
 	}
+}
+
+func TestMessageModify_AllBatchesFailReturnsError(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	id := messageManageID("1")
+	stubMessageManagePost(reg, "batch_modify", map[string]interface{}{"code": 1230001, "msg": "bad request"})
+
+	err := runMountedMailShortcut(t, MailMessageModify, []string{
+		"+message-modify",
+		"--message-ids", id,
+		"--add-folder", "archive",
+	}, f, stdout)
+	requireMessageManageFailedPrecondition(t, err)
 }
 
 func TestMessageModify_DryRunShowsPlanWithoutValidationGET(t *testing.T) {
@@ -306,6 +362,19 @@ func TestMessageTrash_RequiresYesAndBatches(t *testing.T) {
 	if len(success) != 2 || len(failed) != 0 {
 		t.Fatalf("summary success=%v failed=%v", success, failed)
 	}
+}
+
+func TestMessageTrash_AllBatchesFailReturnsError(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	id := messageManageID("1")
+	stubMessageManagePost(reg, "batch_trash", map[string]interface{}{"code": 1230001, "msg": "bad request"})
+
+	err := runMountedMailShortcut(t, MailMessageTrash, []string{
+		"+message-trash",
+		"--message-ids", id,
+		"--yes",
+	}, f, stdout)
+	requireMessageManageFailedPrecondition(t, err)
 }
 
 func TestMessageManage_RejectsWhitespaceBeforeAPI(t *testing.T) {

--- a/shortcuts/mail/mail_message_manage_test.go
+++ b/shortcuts/mail/mail_message_manage_test.go
@@ -1,0 +1,286 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+func messageManageID(suffix string) string {
+	return "msg_abcdefghijklmnop_" + suffix
+}
+
+func stubMessageManagePost(reg *httpmock.Registry, endpoint string, body map[string]interface{}) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/user_mailboxes/me/messages/" + endpoint,
+		Body:   body,
+	}
+	reg.Register(stub)
+	return stub
+}
+
+func decodeMessageManageSummary(t *testing.T, data map[string]interface{}) ([]interface{}, []interface{}) {
+	t.Helper()
+	success, ok := data["success_message_ids"].([]interface{})
+	if !ok {
+		t.Fatalf("success_message_ids = %#v, want array", data["success_message_ids"])
+	}
+	failed, ok := data["failed_message_ids"].([]interface{})
+	if !ok {
+		t.Fatalf("failed_message_ids = %#v, want array", data["failed_message_ids"])
+	}
+	return success, failed
+}
+
+func TestMessageManage_NormalizeMessageIDs(t *testing.T) {
+	id1 := messageManageID("1")
+	id2 := messageManageID("2")
+	got, err := normalizeMessageManageIDs([]string{id1, id2, id1})
+	if err != nil {
+		t.Fatalf("normalizeMessageManageIDs returned error: %v", err)
+	}
+	if len(got) != 2 || got[0] != id1 || got[1] != id2 {
+		t.Fatalf("ids = %v, want [%s %s]", got, id1, id2)
+	}
+
+	cases := [][]string{
+		{""},
+		{" id_with_leading_space_12345"},
+		{"1234567890123456"},
+		{"short"},
+		{"msg_abcdefghijklmnop!"},
+		{"msg_abcdefghijklmnop\t"},
+	}
+	for _, tc := range cases {
+		if _, err := normalizeMessageManageIDs(tc); err == nil {
+			t.Fatalf("normalizeMessageManageIDs(%q) expected validation error", tc)
+		}
+	}
+}
+
+func TestMessageModify_Metadata(t *testing.T) {
+	if MailMessageModify.Command != "+message-modify" {
+		t.Fatalf("Command = %q", MailMessageModify.Command)
+	}
+	if MailMessageModify.Risk != "write" {
+		t.Errorf("Risk = %q, want write", MailMessageModify.Risk)
+	}
+	if len(MailMessageModify.AuthTypes) != 1 || MailMessageModify.AuthTypes[0] != "user" {
+		t.Errorf("AuthTypes = %v, want [user]", MailMessageModify.AuthTypes)
+	}
+	flags := map[string]common.Flag{}
+	for _, fl := range MailMessageModify.Flags {
+		flags[fl.Name] = fl
+	}
+	for _, name := range []string{"mailbox", "message-ids", "add-label-ids", "remove-label-ids", "add-folder"} {
+		if _, ok := flags[name]; !ok {
+			t.Fatalf("missing --%s flag", name)
+		}
+	}
+	if flags["message-ids"].Type != "string_slice" || !flags["message-ids"].Required {
+		t.Errorf("--message-ids = %#v, want required string_slice", flags["message-ids"])
+	}
+}
+
+func TestMessageTrash_Metadata(t *testing.T) {
+	if MailMessageTrash.Command != "+message-trash" {
+		t.Fatalf("Command = %q", MailMessageTrash.Command)
+	}
+	if MailMessageTrash.Risk != "high-risk-write" {
+		t.Errorf("Risk = %q, want high-risk-write", MailMessageTrash.Risk)
+	}
+	if len(MailMessageTrash.AuthTypes) != 1 || MailMessageTrash.AuthTypes[0] != "user" {
+		t.Errorf("AuthTypes = %v, want [user]", MailMessageTrash.AuthTypes)
+	}
+}
+
+func TestMessageModify_LabelFolderNormalizationAndValidationAPIs(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	id := messageManageID("1")
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/user_mailboxes/me/labels/customA", Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{"label_id": "customA"}}})
+	reg.Register(&httpmock.Stub{Method: "GET", URL: "/user_mailboxes/me/folders/folderA", Body: map[string]interface{}{"code": 0, "data": map[string]interface{}{"folder_id": "folderA"}}})
+	post := stubMessageManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
+
+	err := runMountedMailShortcut(t, MailMessageModify, []string{
+		"+message-modify",
+		"--message-ids", id,
+		"--add-label-ids", "unread,customA",
+		"--remove-label-ids", "FLAGGED",
+		"--add-folder", "folderA",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(post.CapturedBody, &body); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+	if got := body["add_folder"]; got != "folderA" {
+		t.Errorf("add_folder = %v, want folderA", got)
+	}
+	addLabels := body["add_label_ids"].([]interface{})
+	if addLabels[0] != "UNREAD" || addLabels[1] != "customA" {
+		t.Errorf("add_label_ids = %#v, want [UNREAD customA]", addLabels)
+	}
+	removeLabels := body["remove_label_ids"].([]interface{})
+	if removeLabels[0] != "FLAGGED" {
+		t.Errorf("remove_label_ids = %#v, want [FLAGGED]", removeLabels)
+	}
+	success, failed := decodeMessageManageSummary(t, decodeShortcutEnvelopeData(t, stdout))
+	if len(success) != 1 || success[0] != id || len(failed) != 0 {
+		t.Errorf("summary success=%v failed=%v", success, failed)
+	}
+}
+
+func TestMessageModify_RejectsLabelIntersectionAndTrashFolder(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	id := messageManageID("1")
+	err := runMountedMailShortcut(t, MailMessageModify, []string{
+		"+message-modify",
+		"--message-ids", id,
+		"--add-label-ids", "unread",
+		"--remove-label-ids", "UNREAD",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "label cannot be both added and removed") {
+		t.Fatalf("expected label intersection validation error, got %v", err)
+	}
+
+	err = runMountedMailShortcut(t, MailMessageModify, []string{
+		"+message-modify",
+		"--message-ids", id,
+		"--add-folder", "trash",
+	}, f, stdout)
+	if err == nil || !strings.Contains(err.Error(), "use +message-trash") {
+		t.Fatalf("expected TRASH validation error, got %v", err)
+	}
+}
+
+func TestMessageModify_EmptyOperationDoesNotCallPost(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	id1 := messageManageID("1")
+	id2 := messageManageID("2")
+	err := runMountedMailShortcut(t, MailMessageModify, []string{
+		"+message-modify",
+		"--message-ids", id1 + "," + id2 + "," + id1,
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	success, failed := decodeMessageManageSummary(t, decodeShortcutEnvelopeData(t, stdout))
+	if len(success) != 2 || success[0] != id1 || success[1] != id2 || len(failed) != 0 {
+		t.Fatalf("summary success=%v failed=%v", success, failed)
+	}
+}
+
+func TestMessageModify_BatchesAndAggregatesPartialFailure(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	ids := make([]string, 41)
+	for i := range ids {
+		ids[i] = messageManageID(fmt.Sprintf("%02d", i))
+	}
+	first := stubMessageManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
+	second := stubMessageManagePost(reg, "batch_modify", map[string]interface{}{"code": 1230001, "msg": "bad request"})
+	third := stubMessageManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
+
+	err := runMountedMailShortcut(t, MailMessageModify, []string{
+		"+message-modify",
+		"--message-ids", strings.Join(ids, ","),
+		"--add-folder", "archive",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	for idx, stub := range []*httpmock.Stub{first, second, third} {
+		var body map[string]interface{}
+		if err := json.Unmarshal(stub.CapturedBody, &body); err != nil {
+			t.Fatalf("batch %d body unmarshal: %v", idx+1, err)
+		}
+		messageIDs := body["message_ids"].([]interface{})
+		want := []int{20, 20, 1}[idx]
+		if len(messageIDs) != want {
+			t.Fatalf("batch %d size = %d, want %d", idx+1, len(messageIDs), want)
+		}
+		if body["add_folder"] != "ARCHIVED" {
+			t.Fatalf("batch %d add_folder = %v, want ARCHIVED", idx+1, body["add_folder"])
+		}
+	}
+	success, failed := decodeMessageManageSummary(t, decodeShortcutEnvelopeData(t, stdout))
+	if len(success) != 21 || len(failed) != 20 {
+		t.Fatalf("success=%d failed=%d, want 21/20", len(success), len(failed))
+	}
+}
+
+func TestMessageModify_DryRunShowsPlanWithoutValidationGET(t *testing.T) {
+	f, stdout, _, _ := mailShortcutTestFactory(t)
+	id1 := messageManageID("1")
+	id2 := messageManageID("2")
+	err := runMountedMailShortcut(t, MailMessageModify, []string{
+		"+message-modify",
+		"--message-ids", id1 + "," + id2,
+		"--add-label-ids", "customA",
+		"--add-folder", "folderA",
+		"--dry-run",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("dry-run failed: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		`/user_mailboxes/me/messages/batch_modify`,
+		`validation_api_plan`,
+		`/user_mailboxes/me/labels/customA`,
+		`/user_mailboxes/me/folders/folderA`,
+		`will_validate`,
+		`batch_size`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q; got %s", want, out)
+		}
+	}
+}
+
+func TestMessageTrash_RequiresYesAndBatches(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	id1 := messageManageID("1")
+	id2 := messageManageID("2")
+	err := runMountedMailShortcut(t, MailMessageTrash, []string{
+		"+message-trash",
+		"--message-ids", id1 + "," + id2,
+	}, f, stdout)
+	if err == nil {
+		t.Fatal("expected confirmation error, got nil")
+	}
+	if code := output.ExitCodeOf(err); code != output.ExitConfirmationRequired {
+		t.Fatalf("exit code = %d, want %d", code, output.ExitConfirmationRequired)
+	}
+
+	post := stubMessageManagePost(reg, "batch_trash", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
+	err = runMountedMailShortcut(t, MailMessageTrash, []string{
+		"+message-trash",
+		"--message-ids", id1 + "," + id2,
+		"--yes",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err with --yes: %v", err)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(post.CapturedBody, &body); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+	if got := len(body["message_ids"].([]interface{})); got != 2 {
+		t.Fatalf("message_ids len = %d, want 2", got)
+	}
+	success, failed := decodeMessageManageSummary(t, decodeShortcutEnvelopeData(t, stdout))
+	if len(success) != 2 || len(failed) != 0 {
+		t.Fatalf("summary success=%v failed=%v", success, failed)
+	}
+}

--- a/shortcuts/mail/mail_message_manage_test.go
+++ b/shortcuts/mail/mail_message_manage_test.go
@@ -51,14 +51,24 @@ func TestMessageManage_NormalizeMessageIDs(t *testing.T) {
 	if len(got) != 2 || got[0] != id1 || got[1] != id2 {
 		t.Fatalf("ids = %v, want [%s %s]", got, id1, id2)
 	}
+	got, err = normalizeMessageManageIDs([]string{id1 + "," + id2, id1})
+	if err != nil {
+		t.Fatalf("normalizeMessageManageIDs CSV/repeated returned error: %v", err)
+	}
+	if len(got) != 2 || got[0] != id1 || got[1] != id2 {
+		t.Fatalf("CSV/repeated ids = %v, want [%s %s]", got, id1, id2)
+	}
 
 	cases := [][]string{
 		{""},
 		{" id_with_leading_space_12345"},
+		{"msg_abcdefghijklmnop_1,msg_abcdefghijklmnop_2 "},
 		{"1234567890123456"},
 		{"short"},
 		{"msg_abcdefghijklmnop!"},
 		{"msg_abcdefghijklmnop\t"},
+		{"msg_abcdefghijklmnop_1\nmsg_abcdefghijklmnop_2"},
+		{"msg_abcdefghijklmnop_1", "msg_abcdefghijklmnop_2 "},
 	}
 	for _, tc := range cases {
 		if _, err := normalizeMessageManageIDs(tc); err == nil {
@@ -96,8 +106,8 @@ func TestMessageModify_Metadata(t *testing.T) {
 			t.Fatalf("missing --%s flag", name)
 		}
 	}
-	if flags["message-ids"].Type != "string_slice" || !flags["message-ids"].Required {
-		t.Errorf("--message-ids = %#v, want required string_slice", flags["message-ids"])
+	if flags["message-ids"].Type != "string_array" || !flags["message-ids"].Required {
+		t.Errorf("--message-ids = %#v, want required string_array", flags["message-ids"])
 	}
 }
 
@@ -295,5 +305,51 @@ func TestMessageTrash_RequiresYesAndBatches(t *testing.T) {
 	success, failed := decodeMessageManageSummary(t, decodeShortcutEnvelopeData(t, stdout))
 	if len(success) != 2 || len(failed) != 0 {
 		t.Fatalf("summary success=%v failed=%v", success, failed)
+	}
+}
+
+func TestMessageManage_RejectsWhitespaceBeforeAPI(t *testing.T) {
+	id1 := messageManageID("1")
+	id2 := messageManageID("2")
+	cases := []struct {
+		name     string
+		shortcut common.Shortcut
+		args     []string
+	}{
+		{
+			name:     "trash newline in repeated flag",
+			shortcut: MailMessageTrash,
+			args:     []string{"+message-trash", "--message-ids", id1 + "\n" + id2, "--yes"},
+		},
+		{
+			name:     "trash tab in csv flag",
+			shortcut: MailMessageTrash,
+			args:     []string{"+message-trash", "--message-ids", id1 + ",\t" + id2, "--yes"},
+		},
+		{
+			name:     "modify space in repeated flag",
+			shortcut: MailMessageModify,
+			args:     []string{"+message-modify", "--message-ids", id1, "--message-ids", id2 + " ", "--add-folder", "archive"},
+		},
+		{
+			name:     "modify space in csv flag",
+			shortcut: MailMessageModify,
+			args:     []string{"+message-modify", "--message-ids", id1 + ", " + id2, "--add-folder", "archive"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f, stdout, _, _ := mailShortcutTestFactory(t)
+			err := runMountedMailShortcut(t, tc.shortcut, tc.args, f, stdout)
+			if err == nil {
+				t.Fatal("expected validation error, got nil")
+			}
+			if code := output.ExitCodeOf(err); code != output.ExitValidation {
+				t.Fatalf("exit code = %d, want %d; err=%v", code, output.ExitValidation, err)
+			}
+			if !strings.Contains(err.Error(), "must not contain whitespace or control characters") {
+				t.Fatalf("error = %v, want whitespace/control validation", err)
+			}
+		})
 	}
 }

--- a/shortcuts/mail/mail_message_manage_test.go
+++ b/shortcuts/mail/mail_message_manage_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/httpmock"
 	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/shortcuts/common"
@@ -130,13 +131,15 @@ func TestMessageModify_Metadata(t *testing.T) {
 	}
 	requiredScopes := map[string]bool{
 		"mail:user_mailbox.message:modify": true,
-		"mail:user_mailbox.folder:read":    true,
 	}
 	for _, scope := range MailMessageModify.Scopes {
 		delete(requiredScopes, scope)
 	}
 	if len(requiredScopes) != 0 {
 		t.Errorf("Scopes missing %v", requiredScopes)
+	}
+	if len(MailMessageModify.ConditionalScopes) != 1 || MailMessageModify.ConditionalScopes[0] != "mail:user_mailbox.folder:read" {
+		t.Errorf("ConditionalScopes = %v, want [mail:user_mailbox.folder:read]", MailMessageModify.ConditionalScopes)
 	}
 	flags := map[string]common.Flag{}
 	for _, fl := range MailMessageModify.Flags {
@@ -164,6 +167,61 @@ func TestMessageTrash_Metadata(t *testing.T) {
 	}
 	if len(MailMessageTrash.Scopes) != 1 || MailMessageTrash.Scopes[0] != "mail:user_mailbox.message:modify" {
 		t.Errorf("Scopes = %v, want [mail:user_mailbox.message:modify]", MailMessageTrash.Scopes)
+	}
+}
+
+func TestMessageModify_LabelOnlyDoesNotRequireFolderReadScope(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	token := auth.GetStoredToken("test-app", "ou_testuser")
+	if token == nil {
+		t.Fatal("expected test token")
+	}
+	token.Scope = strings.ReplaceAll(token.Scope, " mail:user_mailbox.folder:read", "")
+	if err := auth.SetStoredToken(token); err != nil {
+		t.Fatalf("SetStoredToken() error = %v", err)
+	}
+
+	id := messageManageID("1")
+	post := stubMessageManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
+
+	err := runMountedMailShortcut(t, MailMessageModify, []string{
+		"+message-modify",
+		"--message-ids", id,
+		"--remove-label-ids", "UNREAD",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(post.CapturedBody, &body); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+	removeLabels := body["remove_label_ids"].([]interface{})
+	if len(removeLabels) != 1 || removeLabels[0] != "UNREAD" {
+		t.Fatalf("remove_label_ids = %#v, want [UNREAD]", removeLabels)
+	}
+}
+
+func TestMessageModify_ReadReceiptRequestLabelIsSystemLabel(t *testing.T) {
+	f, stdout, _, reg := mailShortcutTestFactory(t)
+	id := messageManageID("1")
+	post := stubMessageManagePost(reg, "batch_modify", map[string]interface{}{"code": 0, "data": map[string]interface{}{}})
+
+	err := runMountedMailShortcut(t, MailMessageModify, []string{
+		"+message-modify",
+		"--message-ids", id,
+		"--remove-label-ids", "read_receipt_request",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	var body map[string]interface{}
+	if err := json.Unmarshal(post.CapturedBody, &body); err != nil {
+		t.Fatalf("unmarshal captured body: %v", err)
+	}
+	removeLabels := body["remove_label_ids"].([]interface{})
+	if len(removeLabels) != 1 || removeLabels[0] != "READ_RECEIPT_REQUEST" {
+		t.Fatalf("remove_label_ids = %#v, want [READ_RECEIPT_REQUEST]", removeLabels)
 	}
 }
 

--- a/shortcuts/mail/mail_message_manage_test.go
+++ b/shortcuts/mail/mail_message_manage_test.go
@@ -77,6 +77,16 @@ func TestMessageModify_Metadata(t *testing.T) {
 	if len(MailMessageModify.AuthTypes) != 1 || MailMessageModify.AuthTypes[0] != "user" {
 		t.Errorf("AuthTypes = %v, want [user]", MailMessageModify.AuthTypes)
 	}
+	requiredScopes := map[string]bool{
+		"mail:user_mailbox.message:modify": true,
+		"mail:user_mailbox.folder:read":    true,
+	}
+	for _, scope := range MailMessageModify.Scopes {
+		delete(requiredScopes, scope)
+	}
+	if len(requiredScopes) != 0 {
+		t.Errorf("Scopes missing %v", requiredScopes)
+	}
 	flags := map[string]common.Flag{}
 	for _, fl := range MailMessageModify.Flags {
 		flags[fl.Name] = fl
@@ -100,6 +110,9 @@ func TestMessageTrash_Metadata(t *testing.T) {
 	}
 	if len(MailMessageTrash.AuthTypes) != 1 || MailMessageTrash.AuthTypes[0] != "user" {
 		t.Errorf("AuthTypes = %v, want [user]", MailMessageTrash.AuthTypes)
+	}
+	if len(MailMessageTrash.Scopes) != 1 || MailMessageTrash.Scopes[0] != "mail:user_mailbox.message:modify" {
+		t.Errorf("Scopes = %v, want [mail:user_mailbox.message:modify]", MailMessageTrash.Scopes)
 	}
 }
 

--- a/shortcuts/mail/mail_message_modify.go
+++ b/shortcuts/mail/mail_message_modify.go
@@ -31,7 +31,7 @@ var MailMessageModify = common.Shortcut{
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "mailbox", Desc: "Mailbox email address that owns the messages (default: me)."},
-		{Name: "message-ids", Type: "string_slice", Required: true, Desc: "Message IDs to modify; comma-separated or repeat the flag."},
+		{Name: "message-ids", Type: "string_array", Required: true, Desc: "Message IDs to modify; comma-separated or repeat the flag."},
 		{Name: "add-label-ids", Type: "string_slice", Desc: "Label IDs to add. System labels unread/important/other/flagged are normalized to upper case."},
 		{Name: "remove-label-ids", Type: "string_slice", Desc: "Label IDs to remove. System labels unread/important/other/flagged are normalized to upper case."},
 		{Name: "add-folder", Desc: "Folder ID to move messages to. System folders inbox/sent/spam/archive/archived are normalized; TRASH is rejected, use +message-trash."},
@@ -99,7 +99,7 @@ func executeMessageModify(ctx context.Context, rt *common.RuntimeContext) error 
 }
 
 func buildMessageModifyInput(rt *common.RuntimeContext) (messageModifyInput, error) {
-	messageIDs, err := normalizeMessageManageIDs(rt.StrSlice("message-ids"))
+	messageIDs, err := normalizeMessageManageIDs(rt.StrArray("message-ids"))
 	if err != nil {
 		return messageModifyInput{}, err
 	}

--- a/shortcuts/mail/mail_message_modify.go
+++ b/shortcuts/mail/mail_message_modify.go
@@ -26,9 +26,12 @@ var MailMessageModify = common.Shortcut{
 	Command:     "+message-modify",
 	Description: "Modify existing mail messages by adding/removing label IDs or moving them to a folder. Batches message IDs in groups of 20 and keeps output compact.",
 	Risk:        "write",
-	Scopes:      []string{"mail:user_mailbox.message:modify", "mail:user_mailbox.folder:read"},
-	AuthTypes:   []string{"user"},
-	HasFormat:   true,
+	Scopes:      []string{"mail:user_mailbox.message:modify"},
+	ConditionalScopes: []string{
+		"mail:user_mailbox.folder:read",
+	},
+	AuthTypes: []string{"user"},
+	HasFormat: true,
 	Flags: []common.Flag{
 		{Name: "mailbox", Desc: "Mailbox email address that owns the messages (default: me)."},
 		{Name: "message-ids", Type: "string_array", Required: true, Desc: "Message IDs to modify; comma-separated or repeat the flag."},

--- a/shortcuts/mail/mail_message_modify.go
+++ b/shortcuts/mail/mail_message_modify.go
@@ -26,7 +26,7 @@ var MailMessageModify = common.Shortcut{
 	Command:     "+message-modify",
 	Description: "Modify existing mail messages by adding/removing label IDs or moving them to a folder. Batches message IDs in groups of 20 and keeps output compact.",
 	Risk:        "write",
-	Scopes:      []string{"mail:user_mailbox.message:modify"},
+	Scopes:      []string{"mail:user_mailbox.message:modify", "mail:user_mailbox.folder:read"},
 	AuthTypes:   []string{"user"},
 	HasFormat:   true,
 	Flags: []common.Flag{

--- a/shortcuts/mail/mail_message_modify.go
+++ b/shortcuts/mail/mail_message_modify.go
@@ -95,6 +95,9 @@ func executeMessageModify(ctx context.Context, rt *common.RuntimeContext) error 
 		summary.SuccessMessageIDs = append(summary.SuccessMessageIDs, batch...)
 	}
 	emitMessageManageSummary(rt, summary, false)
+	if len(summary.SuccessMessageIDs) == 0 && len(summary.FailedMessageIDs) > 0 {
+		return mailFailedPreconditionError("all message modify batches failed")
+	}
 	return nil
 }
 

--- a/shortcuts/mail/mail_message_modify.go
+++ b/shortcuts/mail/mail_message_modify.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"context"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+type messageModifyInput struct {
+	MessageIDs         []string
+	AddLabelIDs        []string
+	RemoveLabelIDs     []string
+	AddFolder          string
+	CustomLabelIDs     []string
+	CustomFolderID     string
+	ValidationAPIPlans []validationAPIPlan
+}
+
+// MailMessageModify is the `+message-modify` shortcut: apply labels, unread
+// state labels, or a folder move to existing messages in batches of 20.
+var MailMessageModify = common.Shortcut{
+	Service:     "mail",
+	Command:     "+message-modify",
+	Description: "Modify existing mail messages by adding/removing label IDs or moving them to a folder. Batches message IDs in groups of 20 and keeps output compact.",
+	Risk:        "write",
+	Scopes:      []string{"mail:user_mailbox.message:modify"},
+	AuthTypes:   []string{"user"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "mailbox", Desc: "Mailbox email address that owns the messages (default: me)."},
+		{Name: "message-ids", Type: "string_slice", Required: true, Desc: "Message IDs to modify; comma-separated or repeat the flag."},
+		{Name: "add-label-ids", Type: "string_slice", Desc: "Label IDs to add. System labels unread/important/other/flagged are normalized to upper case."},
+		{Name: "remove-label-ids", Type: "string_slice", Desc: "Label IDs to remove. System labels unread/important/other/flagged are normalized to upper case."},
+		{Name: "add-folder", Desc: "Folder ID to move messages to. System folders inbox/sent/spam/archive/archived are normalized; TRASH is rejected, use +message-trash."},
+	},
+	Validate: validateMessageModify,
+	DryRun:   dryRunMessageModify,
+	Execute:  executeMessageModify,
+}
+
+func validateMessageModify(ctx context.Context, rt *common.RuntimeContext) error {
+	_, err := buildMessageModifyInput(rt)
+	return err
+}
+
+func dryRunMessageModify(ctx context.Context, rt *common.RuntimeContext) *common.DryRunAPI {
+	mailboxID := resolveMailboxID(rt)
+	input, _ := buildMessageModifyInput(rt)
+	api := common.NewDryRunAPI().
+		Desc("Modify messages sequentially in batches of 20; dry-run does not call label/folder validation APIs").
+		Set("batch_size", mailMessageManageBatchSize).
+		Set("batches", chunkMessageManageIDs(input.MessageIDs)).
+		Set("validation_api_plan", input.ValidationAPIPlans)
+	for _, batch := range chunkMessageManageIDs(input.MessageIDs) {
+		api = api.POST(mailboxPath(mailboxID, "messages", "batch_modify")).
+			Body(messageManageBody(batch, input.AddLabelIDs, input.RemoveLabelIDs, input.AddFolder))
+	}
+	return api
+}
+
+func executeMessageModify(ctx context.Context, rt *common.RuntimeContext) error {
+	mailboxID := resolveMailboxID(rt)
+	input, err := buildMessageModifyInput(rt)
+	if err != nil {
+		return err
+	}
+	if err := validateCustomMessageManageLabels(rt, mailboxID, input.CustomLabelIDs); err != nil {
+		return err
+	}
+	if err := validateCustomMessageManageFolder(rt, mailboxID, input.CustomFolderID); err != nil {
+		return err
+	}
+
+	if len(input.AddLabelIDs) == 0 && len(input.RemoveLabelIDs) == 0 && input.AddFolder == "" {
+		emitMessageManageSummary(rt, messageManageSummary{
+			SuccessMessageIDs: input.MessageIDs,
+			FailedMessageIDs:  []messageManageFailure{},
+		}, true)
+		return nil
+	}
+
+	summary := messageManageSummary{FailedMessageIDs: []messageManageFailure{}}
+	for _, batch := range chunkMessageManageIDs(input.MessageIDs) {
+		_, err := rt.CallAPITyped("POST", mailboxPath(mailboxID, "messages", "batch_modify"), nil,
+			messageManageBody(batch, input.AddLabelIDs, input.RemoveLabelIDs, input.AddFolder))
+		if err != nil {
+			for _, id := range batch {
+				summary.FailedMessageIDs = append(summary.FailedMessageIDs, messageManageFailure{MessageID: id, Reason: err.Error()})
+			}
+			continue
+		}
+		summary.SuccessMessageIDs = append(summary.SuccessMessageIDs, batch...)
+	}
+	emitMessageManageSummary(rt, summary, false)
+	return nil
+}
+
+func buildMessageModifyInput(rt *common.RuntimeContext) (messageModifyInput, error) {
+	messageIDs, err := normalizeMessageManageIDs(rt.StrSlice("message-ids"))
+	if err != nil {
+		return messageModifyInput{}, err
+	}
+	addLabels, customAddLabels, err := normalizeMessageManageLabels(rt.StrSlice("add-label-ids"), "--add-label-ids")
+	if err != nil {
+		return messageModifyInput{}, err
+	}
+	removeLabels, customRemoveLabels, err := normalizeMessageManageLabels(rt.StrSlice("remove-label-ids"), "--remove-label-ids")
+	if err != nil {
+		return messageModifyInput{}, err
+	}
+	if err := validateLabelIntersection(addLabels, removeLabels); err != nil {
+		return messageModifyInput{}, err
+	}
+	folder, customFolder, err := normalizeMessageManageFolder(rt.Str("add-folder"))
+	if err != nil {
+		return messageModifyInput{}, err
+	}
+	customLabels := append(customAddLabels, customRemoveLabels...)
+	customFolderID := ""
+	if customFolder {
+		customFolderID = folder
+	}
+	return messageModifyInput{
+		MessageIDs:         messageIDs,
+		AddLabelIDs:        addLabels,
+		RemoveLabelIDs:     removeLabels,
+		AddFolder:          folder,
+		CustomLabelIDs:     customLabels,
+		CustomFolderID:     customFolderID,
+		ValidationAPIPlans: messageManageValidationPlan(resolveMailboxID(rt), customLabels, customFolderID),
+	}, nil
+}

--- a/shortcuts/mail/mail_message_trash.go
+++ b/shortcuts/mail/mail_message_trash.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"context"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// MailMessageTrash is the `+message-trash` shortcut: soft-delete existing
+// messages in batches of 20 via batch_trash. Risk is high-risk-write, so the
+// runner requires --yes before Execute.
+var MailMessageTrash = common.Shortcut{
+	Service:     "mail",
+	Command:     "+message-trash",
+	Description: "Soft-delete existing mail messages. Batches message IDs in groups of 20 and calls batch_trash sequentially. Requires --yes.",
+	Risk:        "high-risk-write",
+	Scopes:      []string{"mail:user_mailbox.message:modify"},
+	AuthTypes:   []string{"user"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "mailbox", Desc: "Mailbox email address that owns the messages (default: me)."},
+		{Name: "message-ids", Type: "string_slice", Required: true, Desc: "Message IDs to soft-delete; comma-separated or repeat the flag."},
+	},
+	Validate: validateMessageTrash,
+	DryRun:   dryRunMessageTrash,
+	Execute:  executeMessageTrash,
+}
+
+func validateMessageTrash(ctx context.Context, rt *common.RuntimeContext) error {
+	_, err := normalizeMessageManageIDs(rt.StrSlice("message-ids"))
+	return err
+}
+
+func dryRunMessageTrash(ctx context.Context, rt *common.RuntimeContext) *common.DryRunAPI {
+	mailboxID := resolveMailboxID(rt)
+	messageIDs, _ := normalizeMessageManageIDs(rt.StrSlice("message-ids"))
+	api := common.NewDryRunAPI().
+		Desc("Soft-delete messages sequentially in batches of 20").
+		Set("batch_size", mailMessageManageBatchSize).
+		Set("batches", chunkMessageManageIDs(messageIDs))
+	for _, batch := range chunkMessageManageIDs(messageIDs) {
+		api = api.POST(mailboxPath(mailboxID, "messages", "batch_trash")).
+			Body(map[string]interface{}{"message_ids": batch})
+	}
+	return api
+}
+
+func executeMessageTrash(ctx context.Context, rt *common.RuntimeContext) error {
+	mailboxID := resolveMailboxID(rt)
+	messageIDs, err := normalizeMessageManageIDs(rt.StrSlice("message-ids"))
+	if err != nil {
+		return err
+	}
+
+	summary := messageManageSummary{FailedMessageIDs: []messageManageFailure{}}
+	for _, batch := range chunkMessageManageIDs(messageIDs) {
+		_, err := rt.CallAPITyped("POST", mailboxPath(mailboxID, "messages", "batch_trash"), nil,
+			map[string]interface{}{"message_ids": batch})
+		if err != nil {
+			for _, id := range batch {
+				summary.FailedMessageIDs = append(summary.FailedMessageIDs, messageManageFailure{MessageID: id, Reason: err.Error()})
+			}
+			continue
+		}
+		summary.SuccessMessageIDs = append(summary.SuccessMessageIDs, batch...)
+	}
+	emitMessageManageSummary(rt, summary, false)
+	return nil
+}

--- a/shortcuts/mail/mail_message_trash.go
+++ b/shortcuts/mail/mail_message_trash.go
@@ -22,7 +22,7 @@ var MailMessageTrash = common.Shortcut{
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "mailbox", Desc: "Mailbox email address that owns the messages (default: me)."},
-		{Name: "message-ids", Type: "string_slice", Required: true, Desc: "Message IDs to soft-delete; comma-separated or repeat the flag."},
+		{Name: "message-ids", Type: "string_array", Required: true, Desc: "Message IDs to soft-delete; comma-separated or repeat the flag."},
 	},
 	Validate: validateMessageTrash,
 	DryRun:   dryRunMessageTrash,
@@ -30,13 +30,13 @@ var MailMessageTrash = common.Shortcut{
 }
 
 func validateMessageTrash(ctx context.Context, rt *common.RuntimeContext) error {
-	_, err := normalizeMessageManageIDs(rt.StrSlice("message-ids"))
+	_, err := normalizeMessageManageIDs(rt.StrArray("message-ids"))
 	return err
 }
 
 func dryRunMessageTrash(ctx context.Context, rt *common.RuntimeContext) *common.DryRunAPI {
 	mailboxID := resolveMailboxID(rt)
-	messageIDs, _ := normalizeMessageManageIDs(rt.StrSlice("message-ids"))
+	messageIDs, _ := normalizeMessageManageIDs(rt.StrArray("message-ids"))
 	api := common.NewDryRunAPI().
 		Desc("Soft-delete messages sequentially in batches of 20").
 		Set("batch_size", mailMessageManageBatchSize).
@@ -50,7 +50,7 @@ func dryRunMessageTrash(ctx context.Context, rt *common.RuntimeContext) *common.
 
 func executeMessageTrash(ctx context.Context, rt *common.RuntimeContext) error {
 	mailboxID := resolveMailboxID(rt)
-	messageIDs, err := normalizeMessageManageIDs(rt.StrSlice("message-ids"))
+	messageIDs, err := normalizeMessageManageIDs(rt.StrArray("message-ids"))
 	if err != nil {
 		return err
 	}

--- a/shortcuts/mail/mail_message_trash.go
+++ b/shortcuts/mail/mail_message_trash.go
@@ -68,5 +68,8 @@ func executeMessageTrash(ctx context.Context, rt *common.RuntimeContext) error {
 		summary.SuccessMessageIDs = append(summary.SuccessMessageIDs, batch...)
 	}
 	emitMessageManageSummary(rt, summary, false)
+	if len(summary.SuccessMessageIDs) == 0 && len(summary.FailedMessageIDs) > 0 {
+		return mailFailedPreconditionError("all message trash batches failed")
+	}
 	return nil
 }

--- a/shortcuts/mail/mail_shortcut_test.go
+++ b/shortcuts/mail/mail_shortcut_test.go
@@ -44,7 +44,7 @@ func mailShortcutTestFactory(t *testing.T) (*cmdutil.Factory, *bytes.Buffer, *by
 		RefreshToken:     "test-refresh-token",
 		ExpiresAt:        time.Now().Add(1 * time.Hour).UnixMilli(),
 		RefreshExpiresAt: time.Now().Add(24 * time.Hour).UnixMilli(),
-		Scope:            "mail:user_mailbox.messages:write mail:user_mailbox.messages:read mail:user_mailbox.message:modify mail:user_mailbox.message:readonly mail:user_mailbox.message.address:read mail:user_mailbox.message.subject:read mail:user_mailbox.message.body:read mail:user_mailbox:readonly",
+		Scope:            "mail:user_mailbox.messages:write mail:user_mailbox.messages:read mail:user_mailbox.message:modify mail:user_mailbox.message:readonly mail:user_mailbox.message.address:read mail:user_mailbox.message.subject:read mail:user_mailbox.message.body:read mail:user_mailbox:readonly mail:user_mailbox.folder:read",
 		GrantedAt:        time.Now().Add(-1 * time.Hour).UnixMilli(),
 	}
 	if err := auth.SetStoredToken(token); err != nil {

--- a/shortcuts/mail/message_manage_helpers.go
+++ b/shortcuts/mail/message_manage_helpers.go
@@ -16,10 +16,11 @@ import (
 const mailMessageManageBatchSize = 20
 
 var messageManageSystemLabels = map[string]string{
-	"UNREAD":    "UNREAD",
-	"IMPORTANT": "IMPORTANT",
-	"OTHER":     "OTHER",
-	"FLAGGED":   "FLAGGED",
+	"UNREAD":               "UNREAD",
+	"IMPORTANT":            "IMPORTANT",
+	"OTHER":                "OTHER",
+	"FLAGGED":              "FLAGGED",
+	"READ_RECEIPT_REQUEST": "READ_RECEIPT_REQUEST",
 }
 
 var messageManageSystemFolders = map[string]string{

--- a/shortcuts/mail/message_manage_helpers.go
+++ b/shortcuts/mail/message_manage_helpers.go
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package mail
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"unicode"
+
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+const mailMessageManageBatchSize = 20
+
+var messageManageSystemLabels = map[string]string{
+	"UNREAD":    "UNREAD",
+	"IMPORTANT": "IMPORTANT",
+	"OTHER":     "OTHER",
+	"FLAGGED":   "FLAGGED",
+}
+
+var messageManageSystemFolders = map[string]string{
+	"INBOX":    "INBOX",
+	"SENT":     "SENT",
+	"SPAM":     "SPAM",
+	"ARCHIVE":  "ARCHIVED",
+	"ARCHIVED": "ARCHIVED",
+}
+
+type messageManageSummary struct {
+	SuccessMessageIDs []string               `json:"success_message_ids"`
+	FailedMessageIDs  []messageManageFailure `json:"failed_message_ids"`
+}
+
+type messageManageFailure struct {
+	MessageID string `json:"message_id"`
+	Reason    string `json:"reason"`
+}
+
+type validationAPIPlan struct {
+	Method       string `json:"method"`
+	Path         string `json:"path"`
+	WillValidate bool   `json:"will_validate"`
+}
+
+func normalizeMessageManageIDs(raw []string) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, mailValidationParamError("--message-ids", "--message-ids is required")
+	}
+	ids := make([]string, 0, len(raw))
+	seen := make(map[string]struct{}, len(raw))
+	for i, part := range raw {
+		if part == "" {
+			return nil, mailValidationParamError("--message-ids", "--message-ids entry %d is empty; remove extra commas or provide valid message IDs", i+1)
+		}
+		id := strings.TrimSpace(part)
+		if id == "" {
+			return nil, mailValidationParamError("--message-ids", "--message-ids entry %d is empty; remove extra commas or provide valid message IDs", i+1)
+		}
+		if id != part {
+			return nil, mailValidationParamError("--message-ids", "--message-ids entry %d (%q): must not contain leading or trailing whitespace", i+1, part)
+		}
+		if err := validateMessageManageID(id, i); err != nil {
+			return nil, err
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil, mailValidationParamError("--message-ids", "--message-ids is required")
+	}
+	return ids, nil
+}
+
+func validateMessageManageID(id string, index int) error {
+	if len(id) < 16 {
+		return mailValidationParamError("--message-ids", "--message-ids entry %d (%q): length must be at least 16 characters", index+1, id)
+	}
+	if strings.Trim(id, "0123456789") == "" {
+		return mailValidationParamError("--message-ids", "--message-ids entry %d (%q): numeric primary IDs are not supported; pass the Open API message_id from mail output", index+1, id)
+	}
+	for _, r := range id {
+		if unicode.IsSpace(r) || unicode.IsControl(r) {
+			return mailValidationParamError("--message-ids", "--message-ids entry %d (%q): must not contain whitespace or control characters", index+1, id)
+		}
+		if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		switch r {
+		case '+', '/', '=', '_', '-':
+			continue
+		default:
+			return mailValidationParamError("--message-ids", "--message-ids entry %d (%q): contains characters outside the Open API message_id character set", index+1, id)
+		}
+	}
+	return nil
+}
+
+func normalizeMessageManageLabels(raw []string, flagName string) ([]string, []string, error) {
+	labels := make([]string, 0, len(raw))
+	custom := make([]string, 0, len(raw))
+	seen := make(map[string]struct{}, len(raw))
+	for i, part := range raw {
+		id := strings.TrimSpace(part)
+		if id == "" {
+			return nil, nil, mailValidationParamError(flagName, "%s entry %d is empty; remove extra commas or provide valid label IDs", flagName, i+1)
+		}
+		if id != part {
+			return nil, nil, mailValidationParamError(flagName, "%s entry %d (%q): must not contain leading or trailing whitespace", flagName, i+1, part)
+		}
+		normalized := id
+		if system, ok := messageManageSystemLabels[strings.ToUpper(id)]; ok {
+			normalized = system
+		} else {
+			custom = append(custom, id)
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		labels = append(labels, normalized)
+	}
+	if len(labels) > 20 {
+		return nil, nil, mailValidationParamError(flagName, "%s accepts at most 20 label IDs (got %d)", flagName, len(labels))
+	}
+	return labels, custom, nil
+}
+
+func validateLabelIntersection(add, remove []string) error {
+	removeSet := make(map[string]struct{}, len(remove))
+	for _, id := range remove {
+		removeSet[id] = struct{}{}
+	}
+	for _, id := range add {
+		if _, ok := removeSet[id]; ok {
+			return mailValidationParamError("--add-label-ids", "label cannot be both added and removed: %s", id)
+		}
+	}
+	return nil
+}
+
+func normalizeMessageManageFolder(raw string) (string, bool, error) {
+	if raw == "" {
+		return "", false, nil
+	}
+	folder := strings.TrimSpace(raw)
+	if folder == "" {
+		return "", false, mailValidationParamError("--add-folder", "--add-folder must not be empty")
+	}
+	if folder != raw {
+		return "", false, mailValidationParamError("--add-folder", "--add-folder %q must not contain leading or trailing whitespace", raw)
+	}
+	if strings.EqualFold(folder, "TRASH") {
+		return "", false, mailValidationParamError("--add-folder", "TRASH is not supported by +message-modify; use +message-trash")
+	}
+	if system, ok := messageManageSystemFolders[strings.ToUpper(folder)]; ok {
+		return system, false, nil
+	}
+	return folder, true, nil
+}
+
+func chunkMessageManageIDs(ids []string) [][]string {
+	if len(ids) == 0 {
+		return nil
+	}
+	chunks := make([][]string, 0, (len(ids)+mailMessageManageBatchSize-1)/mailMessageManageBatchSize)
+	for start := 0; start < len(ids); start += mailMessageManageBatchSize {
+		end := start + mailMessageManageBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		chunks = append(chunks, ids[start:end])
+	}
+	return chunks
+}
+
+func validateCustomMessageManageLabels(rt *common.RuntimeContext, mailboxID string, ids []string) error {
+	seen := map[string]struct{}{}
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		if _, err := rt.CallAPITyped("GET", mailboxPath(mailboxID, "labels", id), nil, nil); err != nil {
+			return mailDecorateProblemMessage(err, "label not found: %s", id)
+		}
+	}
+	return nil
+}
+
+func validateCustomMessageManageFolder(rt *common.RuntimeContext, mailboxID, id string) error {
+	if id == "" {
+		return nil
+	}
+	if err := validateFolderReadScope(rt); err != nil {
+		return err
+	}
+	if _, err := rt.CallAPITyped("GET", mailboxPath(mailboxID, "folders", id), nil, nil); err != nil {
+		return mailDecorateProblemMessage(err, "folder not found: %s", id)
+	}
+	return nil
+}
+
+func messageManageBody(ids, addLabels, removeLabels []string, addFolder string) map[string]interface{} {
+	body := map[string]interface{}{"message_ids": ids}
+	if len(addLabels) > 0 {
+		body["add_label_ids"] = addLabels
+	}
+	if len(removeLabels) > 0 {
+		body["remove_label_ids"] = removeLabels
+	}
+	if addFolder != "" {
+		body["add_folder"] = addFolder
+	}
+	return body
+}
+
+func messageManageValidationPlan(mailboxID string, customLabels []string, customFolder string) []validationAPIPlan {
+	plans := make([]validationAPIPlan, 0, len(customLabels)+1)
+	seenLabels := map[string]struct{}{}
+	for _, id := range customLabels {
+		if _, ok := seenLabels[id]; ok {
+			continue
+		}
+		seenLabels[id] = struct{}{}
+		plans = append(plans, validationAPIPlan{
+			Method:       "GET",
+			Path:         mailboxPath(mailboxID, "labels", id),
+			WillValidate: true,
+		})
+	}
+	if customFolder != "" {
+		plans = append(plans, validationAPIPlan{
+			Method:       "GET",
+			Path:         mailboxPath(mailboxID, "folders", customFolder),
+			WillValidate: true,
+		})
+	}
+	return plans
+}
+
+func emitMessageManageSummary(rt *common.RuntimeContext, summary messageManageSummary, noAPICalls bool) {
+	rt.OutFormat(summary, &output.Meta{Count: len(summary.SuccessMessageIDs)}, func(w io.Writer) {
+		fmt.Fprintf(w, "success_message_ids: %d\n", len(summary.SuccessMessageIDs))
+		fmt.Fprintf(w, "failed_message_ids: %d\n", len(summary.FailedMessageIDs))
+		if noAPICalls {
+			fmt.Fprintln(w, "No changes requested; no API calls were made.")
+		}
+		for _, item := range summary.FailedMessageIDs {
+			fmt.Fprintf(w, "- %s: %s\n", item.MessageID, item.Reason)
+		}
+	})
+}

--- a/shortcuts/mail/message_manage_helpers.go
+++ b/shortcuts/mail/message_manage_helpers.go
@@ -50,9 +50,13 @@ func normalizeMessageManageIDs(raw []string) ([]string, error) {
 	if len(raw) == 0 {
 		return nil, mailValidationParamError("--message-ids", "--message-ids is required")
 	}
-	ids := make([]string, 0, len(raw))
-	seen := make(map[string]struct{}, len(raw))
-	for i, part := range raw {
+	parts, err := splitMessageManageIDTokens(raw)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for i, part := range parts {
 		if part == "" {
 			return nil, mailValidationParamError("--message-ids", "--message-ids entry %d is empty; remove extra commas or provide valid message IDs", i+1)
 		}
@@ -76,6 +80,19 @@ func normalizeMessageManageIDs(raw []string) ([]string, error) {
 		return nil, mailValidationParamError("--message-ids", "--message-ids is required")
 	}
 	return ids, nil
+}
+
+func splitMessageManageIDTokens(raw []string) ([]string, error) {
+	parts := make([]string, 0, len(raw))
+	for i, token := range raw {
+		for _, r := range token {
+			if unicode.IsSpace(r) || unicode.IsControl(r) {
+				return nil, mailValidationParamError("--message-ids", "--message-ids entry %d (%q): must not contain whitespace or control characters", i+1, token)
+			}
+		}
+		parts = append(parts, strings.Split(token, ",")...)
+	}
+	return parts, nil
 }
 
 func validateMessageManageID(id string, index int) error {

--- a/shortcuts/mail/message_manage_helpers.go
+++ b/shortcuts/mail/message_manage_helpers.go
@@ -198,6 +198,12 @@ func chunkMessageManageIDs(ids []string) [][]string {
 }
 
 func validateCustomMessageManageLabels(rt *common.RuntimeContext, mailboxID string, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if err := validateLabelReadScope(rt); err != nil {
+		return err
+	}
 	seen := map[string]struct{}{}
 	for _, id := range ids {
 		if _, ok := seen[id]; ok {

--- a/shortcuts/mail/shortcuts.go
+++ b/shortcuts/mail/shortcuts.go
@@ -10,6 +10,8 @@ func Shortcuts() []common.Shortcut {
 	return []common.Shortcut{
 		MailMessage,
 		MailMessages,
+		MailMessageModify,
+		MailMessageTrash,
 		MailThread,
 		MailTriage,
 		MailWatch,

--- a/skill-template/domains/mail.md
+++ b/skill-template/domains/mail.md
@@ -65,7 +65,7 @@
 
 1. `+triage --from spam@x.com` → 列出 N 条结果
 2. 展示："将删除 N 封邮件（发件人 spam@x.com，主题：…），确认？"
-3. 用户确认后 → `*.batch_trash`
+3. 用户确认后 → `+message-trash --message-ids ... --yes`
 
 ## 身份选择：优先使用 user 身份
 
@@ -82,12 +82,13 @@
 1. **确认身份** — 首次操作邮箱前先调用 `lark-cli mail user_mailboxes profile --params '{"user_mailbox_id":"me"}'` 获取当前用户的真实邮箱地址（`primary_email_address`），不要通过系统用户名猜测。后续判断"发件人是否为用户本人"时以此地址为准。
 2. **浏览** — `+triage` 查看收件箱摘要，获取 `message_id` / `thread_id`
 3. **阅读** — `+message` 读单封邮件，`+thread` 读整个会话
-4. **回复** — `+reply` / `+reply-all`（默认存草稿，加 `--confirm-send` 则立即发送）
-5. **转发** — `+forward`（默认存草稿，加 `--confirm-send` 则立即发送）
-6. **新邮件** — `+send` 存草稿（默认），加 `--confirm-send` 发送
-7. **确认投递** — 立即发送后用 `send_status` 查询投递状态，定时发送后在预定时间后再查询；取消定时发送用 `cancel_scheduled_send`
-8. **编辑草稿** — `+draft-edit` 修改已有草稿。正文编辑通过 `--patch-file`：回复/转发草稿用 `set_reply_body` op 保留引用区，普通草稿用 `set_body` op
-9. **已读回执** —
+4. **整理** — 标签、已读/未读状态和移动文件夹优先用 `+message-modify`；软删除优先用 `+message-trash`
+5. **回复** — `+reply` / `+reply-all`（默认存草稿，加 `--confirm-send` 则立即发送）
+6. **转发** — `+forward`（默认存草稿，加 `--confirm-send` 则立即发送）
+7. **新邮件** — `+send` 存草稿（默认），加 `--confirm-send` 发送
+8. **确认投递** — 立即发送后用 `send_status` 查询投递状态，定时发送后在预定时间后再查询；取消定时发送用 `cancel_scheduled_send`
+9. **编辑草稿** — `+draft-edit` 修改已有草稿。正文编辑通过 `--patch-file`：回复/转发草稿用 `set_reply_body` op 保留引用区，普通草稿用 `set_body` op
+10. **已读回执** —
    - **请求回执（写信侧）**：`--request-receipt` 仅在**用户显式要求**时添加，**不要从 subject / body 内容推断意图**。
    - **响应回执（拉信侧）**：拉信看到 `label_ids` 含 `READ_RECEIPT_REQUEST`（或 `-607`）时，**必须先问用户**是否回执（不要自动回执，涉及隐私）。用户同意 → `+send-receipt` 响应；用户不同意但想消掉提示 → `+decline-receipt` 只清本地标签、不发邮件。
 
@@ -417,7 +418,7 @@ lark-cli mail +message --message-id <id>
 
 ## 原生 API 调用规则
 
-没有 Shortcut 覆盖的操作才使用原生 API。调用步骤以本节为准（API Resources 章节的 resource/method 列表可辅助查阅）。
+没有 Shortcut 覆盖的操作才使用原生 API。标签、已读状态、移动文件夹优先使用 `+message-modify`；软删除优先使用 `+message-trash`。调用步骤以本节为准（API Resources 章节的 resource/method 列表可辅助查阅）。
 
 ### Step 1 — 用 `-h` 确定要调用的 API（必须，不可跳过）
 

--- a/skills/lark-mail/SKILL.md
+++ b/skills/lark-mail/SKILL.md
@@ -79,7 +79,7 @@ metadata:
 
 1. `+triage --from spam@x.com` → 列出 N 条结果
 2. 展示："将删除 N 封邮件（发件人 spam@x.com，主题：…），确认？"
-3. 用户确认后 → `*.batch_trash`
+3. 用户确认后 → `+message-trash --message-ids ... --yes`
 
 ## 身份选择：优先使用 user 身份
 
@@ -96,13 +96,14 @@ metadata:
 1. **确认身份** — 首次操作邮箱前先调用 `lark-cli mail user_mailboxes profile --params '{"user_mailbox_id":"me"}'` 获取当前用户的真实邮箱地址（`primary_email_address`），不要通过系统用户名猜测。后续判断"发件人是否为用户本人"时以此地址为准。
 2. **浏览** — `+triage` 查看收件箱摘要，获取 `message_id` / `thread_id`
 3. **阅读** — `+message` 只读单封邮件；已有多个 `message_id` 时用 `+messages` 批量读取，不要循环调用 `+message`；`+thread` 读整个会话
-4. **回复** — `+reply` / `+reply-all`（默认存草稿，加 `--confirm-send` 则立即发送）
-5. **转发** — `+forward`（默认存草稿，加 `--confirm-send` 则立即发送）
-6. **新邮件** — `+send` 存草稿（默认），加 `--confirm-send` 发送
-7. **HTML body 预检（可选）** — 复杂 HTML body 提交前可先跑 `+lint-html` 看 lint 会改 / 删什么；写信路径（`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` / `+draft-edit` body op）已内置 autofix，普通正文不必先跑。详见 [references/lark-mail-html.md](references/lark-mail-html.md) 中的「写入路径内置 HTML lint」章节
-8. **确认投递** — 立即发送后用 `send_status` 查询投递状态，定时发送后在预定时间后再查询；取消定时发送用 `cancel_scheduled_send`
-9. **编辑草稿** — `+draft-edit` 修改已有草稿。正文编辑通过 `--patch-file`：回复/转发草稿用 `set_reply_body` op 保留引用区，普通草稿用 `set_body` op
-10. **已读回执** —
+4. **整理** — 标签、已读/未读状态和移动文件夹优先用 `+message-modify`；软删除优先用 `+message-trash`
+5. **回复** — `+reply` / `+reply-all`（默认存草稿，加 `--confirm-send` 则立即发送）
+6. **转发** — `+forward`（默认存草稿，加 `--confirm-send` 则立即发送）
+7. **新邮件** — `+send` 存草稿（默认），加 `--confirm-send` 发送
+8. **HTML body 预检（可选）** — 复杂 HTML body 提交前可先跑 `+lint-html` 看 lint 会改 / 删什么；写信路径（`+send` / `+draft-create` / `+reply` / `+reply-all` / `+forward` / `+draft-edit` body op）已内置 autofix，普通正文不必先跑。详见 [references/lark-mail-html.md](references/lark-mail-html.md) 中的「写入路径内置 HTML lint」章节
+9. **确认投递** — 立即发送后用 `send_status` 查询投递状态，定时发送后在预定时间后再查询；取消定时发送用 `cancel_scheduled_send`
+10. **编辑草稿** — `+draft-edit` 修改已有草稿。正文编辑通过 `--patch-file`：回复/转发草稿用 `set_reply_body` op 保留引用区，普通草稿用 `set_body` op
+11. **已读回执** —
    - **请求回执（写信侧）**：`--request-receipt` 仅在**用户显式要求**时添加，**不要从 subject / body 内容推断意图**。
    - **响应回执（拉信侧）**：拉信看到 `label_ids` 含 `READ_RECEIPT_REQUEST`（或 `-607`）时，**必须先问用户**是否回执（不要自动回执，涉及隐私）。用户同意 → `+send-receipt` 响应；用户不同意但想消掉提示 → `+decline-receipt` 只清本地标签、不发邮件。
 
@@ -119,6 +120,8 @@ metadata:
 - 查看发送邮件后的投递状态：发送成功后查看邮件投递状态；也覆盖发送拦截。ref: [lark-mail-send-status](references/lark-mail-send-status.md)
 - 使用邮件模板：区分个人模板和静态 HTML 模板，发信类 shortcut 用 `--template-id` 套用模板。ref: [lark-mail-template](references/lark-mail-template.md)
 - 撤回已发送邮件：撤回邮件并查询异步撤回状态。ref: [lark-mail-recall](references/lark-mail-recall.md)
+- 修改邮件标签/已读状态/文件夹：优先使用 `+message-modify`。ref: [`+message-modify`](references/lark-mail-message-modify.md)
+- 软删除邮件：优先使用 `+message-trash`。ref: [`+message-trash`](references/lark-mail-message-trash.md)
 - 收信规则：创建、验证、删除自动处理收到邮件的规则。ref: [lark-mail-rules](references/lark-mail-rules.md)
 - 分享邮件到 IM：分享邮件或会话到群聊、个人会话。ref: [lark-mail-share-to-chat](references/lark-mail-share-to-chat.md)
 - 发送日程邀请邮件：在邮件中嵌入 `text/calendar` 日程邀请。ref: [lark-mail-calendar-invite](references/lark-mail-calendar-invite.md)
@@ -192,7 +195,7 @@ lark-cli mail +messages --message-ids <id1>,<id2>,<id3> --html=false
 
 ## 原生 API 调用规则
 
-没有 Shortcut 覆盖的操作才使用原生 API。调用步骤以本节为准；资源和 method 用 `lark-cli mail -h` / `lark-cli mail <resource> -h` 发现，不在入口保留完整资源表。
+没有 Shortcut 覆盖的操作才使用原生 API。标签、已读状态、移动文件夹优先使用 `+message-modify`；软删除优先使用 `+message-trash`。调用步骤以本节为准；资源和 method 用 `lark-cli mail -h` / `lark-cli mail <resource> -h` 发现，不在入口保留完整资源表。
 
 ### Step 1 — 用 `-h` 确定要调用的 API（必须，不可跳过）
 

--- a/skills/lark-mail/references/lark-mail-forward.md
+++ b/skills/lark-mail/references/lark-mail-forward.md
@@ -215,7 +215,7 @@ lark-cli mail user_mailbox.drafts cancel_scheduled_send --params '{"user_mailbox
 **2. 标记已读**（可选）— 询问用户是否需要将原邮件标记为已读。如果用户同意：
 
 ```bash
-lark-cli mail user_mailbox.messages batch_modify --params '{"user_mailbox_id":"me"}' --data '{"message_ids":["<原邮件ID>"],"remove_label_ids":["UNREAD"]}'
+lark-cli mail +message-modify --message-ids <原邮件ID> --remove-label-ids UNREAD
 ```
 
 ## 编辑转发草稿

--- a/skills/lark-mail/references/lark-mail-message-modify.md
+++ b/skills/lark-mail/references/lark-mail-message-modify.md
@@ -1,0 +1,48 @@
+# mail +message-modify
+
+`mail +message-modify` is the preferred shortcut for changing labels, read-state labels, or folder placement on existing messages.
+
+Use it instead of raw `user_mailbox.messages batch_modify` when the operation targets concrete `message_id` values from `+triage`, `+message`, or `+messages`.
+
+## Common Commands
+
+```bash
+lark-cli mail +message-modify --message-ids <id1>,<id2> --add-label-ids unread
+lark-cli mail +message-modify --message-ids <id> --remove-label-ids FLAGGED
+lark-cli mail +message-modify --message-ids <id> --add-folder archive
+lark-cli mail +message-modify --mailbox shared@example.com --message-ids <id> --add-folder folder_xxx
+lark-cli mail +message-modify --message-ids <id> --add-label-ids custom_label_id --dry-run
+```
+
+## Flags
+
+| Flag | Required | Notes |
+| --- | --- | --- |
+| `--mailbox` | No | Mailbox that owns the messages. Defaults to `me`. |
+| `--message-ids` | Yes | `string_slice`; supports comma-separated values and repeated flags. |
+| `--add-label-ids` | No | Adds labels. System labels `unread`, `important`, `other`, `flagged` normalize to upper case. |
+| `--remove-label-ids` | No | Removes labels. Cannot overlap with `--add-label-ids`. |
+| `--add-folder` | No | Moves to one folder. `inbox`, `sent`, `spam`, `archive`, `archived` normalize to system folder IDs. |
+
+`TRASH` is intentionally rejected by this shortcut. Use `mail +message-trash --message-ids <id> --yes` for soft deletion.
+
+## Behavior
+
+- Message IDs are locally validated, de-duplicated in first-seen order, and sent in batches of 20.
+- Custom label IDs are checked with `labels.get`; custom folder IDs are checked with `folders.get`.
+- If no label or folder operation is requested, the command succeeds locally, emits all message IDs as `success_message_ids`, and makes no POST request.
+- Single batch POST failures mark every message in that batch with the same failure reason; later batches still run.
+- JSON output is intentionally compact:
+
+```json
+{
+  "success_message_ids": ["id1"],
+  "failed_message_ids": [
+    {"message_id": "id2", "reason": "api error"}
+  ]
+}
+```
+
+## When Raw API Is Still Appropriate
+
+Use raw `mail user_mailbox.messages batch_modify` only when you need a request shape that the shortcut intentionally does not expose, or when reproducing backend/API behavior exactly for diagnostics.

--- a/skills/lark-mail/references/lark-mail-message-modify.md
+++ b/skills/lark-mail/references/lark-mail-message-modify.md
@@ -19,7 +19,7 @@ lark-cli mail +message-modify --message-ids <id> --add-label-ids custom_label_id
 | Flag | Required | Notes |
 | --- | --- | --- |
 | `--mailbox` | No | Mailbox that owns the messages. Defaults to `me`. |
-| `--message-ids` | Yes | `string_slice`; supports comma-separated values and repeated flags. |
+| `--message-ids` | Yes | `string_array`; supports comma-separated values and repeated flags. |
 | `--add-label-ids` | No | Adds labels. System labels `unread`, `important`, `other`, `flagged` normalize to upper case. |
 | `--remove-label-ids` | No | Removes labels. Cannot overlap with `--add-label-ids`. |
 | `--add-folder` | No | Moves to one folder. `inbox`, `sent`, `spam`, `archive`, `archived` normalize to system folder IDs. |

--- a/skills/lark-mail/references/lark-mail-message-trash.md
+++ b/skills/lark-mail/references/lark-mail-message-trash.md
@@ -17,7 +17,7 @@ lark-cli mail +message-trash --message-ids <id1> --message-ids <id2> --dry-run
 | Flag | Required | Notes |
 | --- | --- | --- |
 | `--mailbox` | No | Mailbox that owns the messages. Defaults to `me`. |
-| `--message-ids` | Yes | `string_slice`; supports comma-separated values and repeated flags. |
+| `--message-ids` | Yes | `string_array`; supports comma-separated values and repeated flags. |
 | `--yes` | Yes for execution | Required by the high-risk write confirmation framework. |
 
 ## Behavior

--- a/skills/lark-mail/references/lark-mail-message-trash.md
+++ b/skills/lark-mail/references/lark-mail-message-trash.md
@@ -1,0 +1,41 @@
+# mail +message-trash
+
+`mail +message-trash` is the preferred shortcut for soft-deleting existing messages.
+
+Use it after obtaining real `message_id` values from `+triage`, `+message`, or `+messages`, and after the user has confirmed the deletion preview.
+
+## Common Commands
+
+```bash
+lark-cli mail +message-trash --message-ids <id1>,<id2> --yes
+lark-cli mail +message-trash --mailbox shared@example.com --message-ids <id> --yes
+lark-cli mail +message-trash --message-ids <id1> --message-ids <id2> --dry-run
+```
+
+## Flags
+
+| Flag | Required | Notes |
+| --- | --- | --- |
+| `--mailbox` | No | Mailbox that owns the messages. Defaults to `me`. |
+| `--message-ids` | Yes | `string_slice`; supports comma-separated values and repeated flags. |
+| `--yes` | Yes for execution | Required by the high-risk write confirmation framework. |
+
+## Behavior
+
+- Message IDs are locally validated, de-duplicated in first-seen order, and sent in batches of 20.
+- The shortcut calls `POST /open-apis/mail/v1/user_mailboxes/<mailbox>/messages/batch_trash` sequentially.
+- Single batch POST failures mark every message in that batch with the same failure reason; later batches still run.
+- JSON output is intentionally compact:
+
+```json
+{
+  "success_message_ids": ["id1"],
+  "failed_message_ids": [
+    {"message_id": "id2", "reason": "api error"}
+  ]
+}
+```
+
+## When Raw API Is Still Appropriate
+
+Use raw `mail user_mailbox.messages batch_trash` only when reproducing backend/API behavior exactly for diagnostics. For normal soft deletion, prefer this shortcut because it handles validation, batching, compact output, and `--yes` confirmation consistently.

--- a/skills/lark-mail/references/lark-mail-reply-all.md
+++ b/skills/lark-mail/references/lark-mail-reply-all.md
@@ -203,7 +203,7 @@ lark-cli mail user_mailbox.drafts cancel_scheduled_send --params '{"user_mailbox
 **2. 标记已读**（可选）— 询问用户是否需要将原邮件标记为已读。如果用户同意：
 
 ```bash
-lark-cli mail user_mailbox.messages batch_modify --params '{"user_mailbox_id":"me"}' --data '{"message_ids":["<原邮件ID>"],"remove_label_ids":["UNREAD"]}'
+lark-cli mail +message-modify --message-ids <原邮件ID> --remove-label-ids UNREAD
 ```
 
 ## 相关命令

--- a/skills/lark-mail/references/lark-mail-reply.md
+++ b/skills/lark-mail/references/lark-mail-reply.md
@@ -218,7 +218,7 @@ lark-cli mail user_mailbox.drafts cancel_scheduled_send --params '{"user_mailbox
 **2. 标记已读**（可选）— 询问用户是否需要将原邮件标记为已读。如果用户同意：
 
 ```bash
-lark-cli mail user_mailbox.messages batch_modify --params '{"user_mailbox_id":"me"}' --data '{"message_ids":["<原邮件ID>"],"remove_label_ids":["UNREAD"]}'
+lark-cli mail +message-modify --message-ids <原邮件ID> --remove-label-ids UNREAD
 ```
 
 ## 编辑回复草稿

--- a/tests/cli_e2e/mail/coverage.md
+++ b/tests/cli_e2e/mail/coverage.md
@@ -1,9 +1,9 @@
 # Mail CLI E2E Coverage
 
 ## Metrics
-- Denominator: 63 leaf commands
-- Covered: 14
-- Coverage: 22.2%
+- Denominator: 65 leaf commands
+- Covered: 16
+- Coverage: 24.6%
 
 ## Summary
 - TestMail_DraftLifecycleWorkflowAsUser: proves a self-contained user draft workflow across `mail user_mailboxes profile`, `mail +draft-create`, `mail user_mailbox.drafts list`, `mail user_mailbox.drafts get`, `mail +draft-edit`, and `mail user_mailbox.drafts delete`; key `t.Run(...)` proof points are `get mailbox profile as user`, `create draft with shortcut as user`, `list draft as user`, `get created draft as user`, `inspect created draft as user`, `update draft subject with shortcut as user`, `inspect updated draft as user`, `delete draft as user`, and `verify draft removed from list as user`.
@@ -20,6 +20,8 @@
 | ✓ | mail +draft-send | shortcut | mail_draft_send_workflow_test.go::TestMail_DraftSendWorkflowAsUser/send draft with shortcut as user; mail_draft_send_dryrun_test.go::TestMail_DraftSendDryRun | `--draft-id`; `--mailbox me`; `--yes`; dry-run repeated/comma-separated `--draft-id` | sends a self-addressed draft through the batch shortcut and locks dry-run request shape |
 | ✓ | mail +forward | shortcut | mail_send_workflow_test.go::TestMail_SendWorkflowAsUser/forward received message with shortcut as user; mail_send_workflow_test.go::TestMail_SendWorkflowAsUser/inspect forward draft as user | `--message-id`; `--to`; `--body`; `--plain-text` | uses self-generated inbox message as source and inspects forwarded draft projection |
 | ✓ | mail +message | shortcut | mail_send_workflow_test.go::TestMail_SendWorkflowAsUser/get sent message as user; mail_send_workflow_test.go::TestMail_SendWorkflowAsUser/get received message as user | `--mailbox me`; `--message-id` | verifies both SENT and INBOX copies after self-send |
+| ✓ | mail +message-modify | shortcut | shortcuts/mail/mail_message_manage_test.go::TestMessageModify_DryRunShowsPlanWithoutValidationGET; shortcuts/mail/mail_message_manage_test.go::TestMessageModify_BatchesAndAggregatesPartialFailure | `--message-ids`; `--add-label-ids`; `--remove-label-ids`; `--add-folder`; `--dry-run` | unit/dry-run coverage locks validation, batching, request shape, and partial failure aggregation; live E2E needs controlled disposable messages/labels/folders |
+| ✓ | mail +message-trash | shortcut | shortcuts/mail/mail_message_manage_test.go::TestMessageTrash_RequiresYesAndBatches | `--message-ids`; `--yes`; `--dry-run` | unit coverage locks high-risk confirmation and batch_trash request shape; live E2E needs controlled disposable messages |
 | ✓ | mail +messages | shortcut | mail_send_workflow_test.go::TestMail_SendWorkflowAsUser/get both self sent messages as user | `--mailbox me`; `--message-ids` | batch reads both sent and received message copies |
 | ✓ | mail +reply | shortcut | mail_send_workflow_test.go::TestMail_SendWorkflowAsUser/reply to received message with shortcut as user; mail_send_workflow_test.go::TestMail_SendWorkflowAsUser/inspect reply draft as user | `--message-id`; `--body`; `--plain-text` | creates reply draft from self-generated inbox message and inspects quoted content |
 | ✕ | mail +reply-all | shortcut |  | none | self-send traffic leaves no stable non-self recipient set for deterministic reply-all assertions |


### PR DESCRIPTION
Generated by the harness-coding skill.

- **Branch**: feat/c8c09bb
- **Target**: main

## Sprints

| ID | Title | Status | Commit |
|----|-------|--------|--------|
| S1 | Add mail message modify/trash shortcuts | passed | 2eb534d |

---
This MR was created autonomously. Quality gates were enforced by the repo's own pre-commit hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mail +message-modify` for add/remove label and/or move-to-folder actions with 20-message batching and `--dry-run` planning.
  * Added `mail +message-trash` for soft-deletes in 20-message batches, requiring `--yes`.
* **Bug Fixes**
  * Updated “mark as read” follow-up examples to use `+message-modify` to remove `UNREAD`.
  * Strengthened validation to reject whitespace/control characters and prevent conflicting label operations (including adding `trash`).
* **Documentation**
  * Refreshed mail workflow guidance and command references to prefer `+message-modify` / `+message-trash`.
* **Tests**
  * Added extensive shortcut behavior tests and refreshed E2E coverage and OAuth scope expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->