### PR TITLE
fix(docs): resolve wiki links before fetch

### DIFF
--- a/internal/cmdutil/dryrun.go
+++ b/internal/cmdutil/dryrun.go
@@ -4,6 +4,7 @@
 package cmdutil
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -126,7 +127,17 @@ func (d *DryRunAPI) MarshalJSON() ([]byte, error) {
 	for k, v := range d.extra {
 		m[k] = v
 	}
-	return json.Marshal(m)
+	return marshalJSONNoHTMLEscape(m)
+}
+
+func marshalJSONNoHTMLEscape(v interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }
 
 // Format renders the dry-run output as plain text for AI/human consumption.
@@ -255,7 +266,7 @@ func PrintDryRunWithFile(w io.Writer, request client.RawApiRequest, config *core
 	if format == "pretty" {
 		fmt.Fprint(w, dr.Format())
 	} else {
-		output.PrintJson(w, dr)
+		output.PrintJsonNoHTMLEscape(w, dr)
 	}
 	return nil
 }
@@ -291,7 +302,7 @@ func PrintDryRun(w io.Writer, request client.RawApiRequest, config *core.CliConf
 	if format == "pretty" {
 		fmt.Fprint(w, dr.Format())
 	} else {
-		output.PrintJson(w, dr)
+		output.PrintJsonNoHTMLEscape(w, dr)
 	}
 	return nil
 }

--- a/internal/cmdutil/dryrun_test.go
+++ b/internal/cmdutil/dryrun_test.go
@@ -92,6 +92,31 @@ func TestDryRunAPI_MarshalJSON(t *testing.T) {
 	}
 }
 
+func TestPrintDryRunJSONDoesNotHTMLEscape(t *testing.T) {
+	var buf bytes.Buffer
+	err := PrintDryRun(&buf, client.RawApiRequest{
+		Method: "POST",
+		URL:    "/open-apis/docs_ai/v1/documents/<obj_token from step 1>/fetch",
+		Data:   map[string]interface{}{"content": "<docx>hello</docx>"},
+		As:     "bot",
+	}, &core.CliConfig{AppID: "app123"}, "json")
+	if err != nil {
+		t.Fatalf("PrintDryRun failed: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		`/open-apis/docs_ai/v1/documents/<obj_token from step 1>/fetch`,
+		`"<docx>hello</docx>"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("JSON output missing unescaped %q: %s", want, out)
+		}
+	}
+	if strings.Contains(out, `\u003c`) || strings.Contains(out, `\u003e`) {
+		t.Fatalf("JSON output HTML-escaped angle brackets: %s", out)
+	}
+}
+
 func TestDryRunAPI_MultipleCalls(t *testing.T) {
 	dr := NewDryRunAPI().
 		GET("/open-apis/first").Desc("step 1").

--- a/internal/output/print.go
+++ b/internal/output/print.go
@@ -4,6 +4,7 @@
 package output
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -21,6 +22,22 @@ func PrintJson(w io.Writer, data interface{}) {
 		return
 	}
 	fmt.Fprintln(w, string(b))
+}
+
+// PrintJsonNoHTMLEscape prints formatted JSON without escaping HTML-sensitive
+// characters such as < and >. Use it for outputs that intentionally carry XML,
+// HTML, or human-readable placeholders.
+func PrintJsonNoHTMLEscape(w io.Writer, data interface{}) {
+	injectNotice(data)
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(data); err != nil {
+		fmt.Fprintf(os.Stderr, "json marshal error: %v\n", err)
+		return
+	}
+	fmt.Fprint(w, buf.String())
 }
 
 // injectNotice adds a "_notice" field into CLI envelope maps.

--- a/shortcuts/common/runner.go
+++ b/shortcuts/common/runner.go
@@ -1132,7 +1132,7 @@ func handleShortcutDryRun(f *cmdutil.Factory, rctx *RuntimeContext, s *Shortcut)
 	if rctx.Format == "pretty" {
 		fmt.Fprint(f.IOStreams.Out, dryResult.Format())
 	} else {
-		output.PrintJson(f.IOStreams.Out, dryResult)
+		output.PrintJsonNoHTMLEscape(f.IOStreams.Out, dryResult)
 	}
 	return nil
 }

--- a/shortcuts/doc/doc_media_test.go
+++ b/shortcuts/doc/doc_media_test.go
@@ -819,6 +819,7 @@ type docDryRunOutput struct {
 	Description string `json:"description"`
 	API         []struct {
 		Desc   string                 `json:"desc"`
+		Method string                 `json:"method"`
 		URL    string                 `json:"url"`
 		Params map[string]interface{} `json:"params"`
 		Body   map[string]interface{} `json:"body"`

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -77,7 +78,7 @@ func executeFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 		return err
 	}
 
-	apiPath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s/fetch", documentID)
+	apiPath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s/fetch", validate.EncodePathSegment(documentID))
 	body := buildFetchBody(runtime)
 
 	data, err := doDocAPI(runtime, "POST", apiPath, body)

--- a/shortcuts/doc/docs_fetch_v2.go
+++ b/shortcuts/doc/docs_fetch_v2.go
@@ -51,9 +51,20 @@ func dryRunFetchV2(_ context.Context, runtime *common.RuntimeContext) *common.Dr
 	// Validate has already accepted --doc; parseDocumentRef cannot fail here.
 	ref, _ := parseDocumentRef(runtime.Str("doc"))
 	body := buildFetchBody(runtime)
+	dry := common.NewDryRunAPI()
+	if ref.Kind == "wiki" {
+		dry.Desc("2-step: resolve wiki node, then fetch document")
+		dry.GET(wikiGetNodePath).
+			Desc("[1] Resolve wiki node to underlying document").
+			Params(map[string]interface{}{"token": ref.Token})
+		dry.POST("/open-apis/docs_ai/v1/documents/<obj_token from step 1>/fetch").
+			Desc("[2] OpenAPI: fetch resolved document").
+			Body(body)
+		return dry
+	}
+
 	apiPath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s/fetch", ref.Token)
-	return common.NewDryRunAPI().
-		POST(apiPath).
+	return dry.POST(apiPath).
 		Desc("OpenAPI: fetch document").
 		Body(body).
 		Set("document_id", ref.Token)
@@ -61,8 +72,12 @@ func dryRunFetchV2(_ context.Context, runtime *common.RuntimeContext) *common.Dr
 
 func executeFetchV2(_ context.Context, runtime *common.RuntimeContext) error {
 	ref, _ := parseDocumentRef(runtime.Str("doc"))
+	documentID, err := resolveDocumentID(runtime, ref)
+	if err != nil {
+		return err
+	}
 
-	apiPath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s/fetch", ref.Token)
+	apiPath := fmt.Sprintf("/open-apis/docs_ai/v1/documents/%s/fetch", documentID)
 	body := buildFetchBody(runtime)
 
 	data, err := doDocAPI(runtime, "POST", apiPath, body)

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/cmdutil"
 	"github.com/larksuite/cli/internal/core"
 	"github.com/larksuite/cli/internal/httpmock"
@@ -124,6 +125,37 @@ func TestDocsFetchDryRunDefaultsToV2Endpoint(t *testing.T) {
 	}
 }
 
+func TestDocsFetchDryRunWikiAddsResolveStep(t *testing.T) {
+	t.Parallel()
+
+	runtime := newFetchShortcutTestRuntime(t, "", map[string]string{
+		"doc": "https://tenant.feishu.cn/wiki/wikcnABC?from=wiki",
+	})
+	if err := validateFetchV2(context.Background(), runtime); err != nil {
+		t.Fatalf("validateFetchV2() error = %v", err)
+	}
+
+	dry := decodeDocDryRun(t, DocsFetch.DryRun(context.Background(), runtime))
+	if len(dry.API) != 2 {
+		t.Fatalf("expected 2 dry-run API calls, got %d", len(dry.API))
+	}
+	if got, want := dry.API[0].Method, "GET"; got != want {
+		t.Fatalf("resolve method = %q, want %q", got, want)
+	}
+	if got, want := dry.API[0].URL, "/open-apis/wiki/v2/spaces/get_node"; got != want {
+		t.Fatalf("resolve URL = %q, want %q", got, want)
+	}
+	if got, want := dry.API[0].Params["token"], "wikcnABC"; got != want {
+		t.Fatalf("resolve token = %#v, want %q", got, want)
+	}
+	if got := dry.API[1].URL; strings.Contains(got, "wikcnABC") {
+		t.Fatalf("fetch URL used raw wiki token: %q", got)
+	}
+	if got := dry.API[1].URL; !strings.Contains(got, "<obj_token from step 1>") {
+		t.Fatalf("fetch URL missing resolved token placeholder: %q", got)
+	}
+}
+
 func TestDocsFetchAPIVersionV1StillUsesV2Endpoint(t *testing.T) {
 	t.Parallel()
 
@@ -138,6 +170,92 @@ func TestDocsFetchAPIVersionV1StillUsesV2Endpoint(t *testing.T) {
 	}
 	if got, want := dry.API[0].URL, "/open-apis/docs_ai/v1/documents/doxcnFetchDryRun/fetch"; got != want {
 		t.Fatalf("dry-run URL = %q, want %q", got, want)
+	}
+}
+
+func TestDocsFetchWikiUsesResolvedDocumentToken(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-fetch-wiki"))
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":  "docx",
+					"obj_token": "doxcnREAL",
+				},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/docs_ai/v1/documents/doxcnREAL/fetch",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"document": map[string]interface{}{
+					"document_id": "doxcnREAL",
+					"content":     "<docx>resolved</docx>",
+				},
+			},
+		},
+	})
+
+	err := mountAndRunDocs(t, DocsFetch, []string{
+		"+fetch",
+		"--doc", "https://tenant.feishu.cn/wiki/wikcnABC",
+		"--format", "pretty",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	reg.Verify(t)
+
+	if got := stdout.String(); got != "<docx>resolved</docx>\n" {
+		t.Fatalf("stdout = %q, want resolved document content", got)
+	}
+}
+
+func TestDocsFetchWikiRejectsNonDocumentNode(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+
+	f, _, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-fetch-wiki-sheet"))
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":  "sheet",
+					"obj_token": "shtcnREAL",
+				},
+			},
+		},
+	})
+
+	err := mountAndRunDocs(t, DocsFetch, []string{
+		"+fetch",
+		"--doc", "https://tenant.feishu.cn/wiki/wikcnABC",
+		"--as", "bot",
+	}, f, nil)
+	if err == nil {
+		t.Fatal("expected non-document validation error, got nil")
+	}
+	reg.Verify(t)
+	assertValidationContract(t, err, errs.SubtypeInvalidArgument, "--doc")
+
+	for _, want := range []string{"sheet", "docs +fetch requires a doc/docx wiki node", "sheets", "drive +inspect"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err)
+		}
 	}
 }
 

--- a/shortcuts/doc/docs_fetch_v2_test.go
+++ b/shortcuts/doc/docs_fetch_v2_test.go
@@ -174,8 +174,6 @@ func TestDocsFetchAPIVersionV1StillUsesV2Endpoint(t *testing.T) {
 }
 
 func TestDocsFetchWikiUsesResolvedDocumentToken(t *testing.T) {
-	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
-
 	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-fetch-wiki"))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",
@@ -222,9 +220,54 @@ func TestDocsFetchWikiUsesResolvedDocumentToken(t *testing.T) {
 	}
 }
 
-func TestDocsFetchWikiRejectsNonDocumentNode(t *testing.T) {
-	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+func TestDocsFetchWikiEncodesResolvedDocumentTokenInPath(t *testing.T) {
+	f, stdout, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-fetch-wiki-encoded"))
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/wiki/v2/spaces/get_node",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"node": map[string]interface{}{
+					"obj_type":  "docx",
+					"obj_token": "doxcnREAL/with?meta",
+				},
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/docs_ai/v1/documents/doxcnREAL%2Fwith%3Fmeta/fetch",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{
+				"document": map[string]interface{}{
+					"document_id": "doxcnREAL/with?meta",
+					"content":     "<docx>encoded</docx>",
+				},
+			},
+		},
+	})
 
+	err := mountAndRunDocs(t, DocsFetch, []string{
+		"+fetch",
+		"--doc", "https://tenant.feishu.cn/wiki/wikcnABC",
+		"--format", "pretty",
+		"--as", "bot",
+	}, f, stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	reg.Verify(t)
+
+	if got := stdout.String(); got != "<docx>encoded</docx>\n" {
+		t.Fatalf("stdout = %q, want encoded document content", got)
+	}
+}
+
+func TestDocsFetchWikiRejectsNonDocumentNode(t *testing.T) {
 	f, _, _, reg := cmdutil.TestFactory(t, docsTestConfigWithAppID("docs-fetch-wiki-sheet"))
 	reg.Register(&httpmock.Stub{
 		Method: "GET",

--- a/shortcuts/doc/helpers.go
+++ b/shortcuts/doc/helpers.go
@@ -21,6 +21,8 @@ type documentRef struct {
 	Token string
 }
 
+const wikiGetNodePath = "/open-apis/wiki/v2/spaces/get_node"
+
 func parseDocumentRef(input string) (documentRef, error) {
 	raw := strings.TrimSpace(input)
 	if raw == "" {
@@ -68,6 +70,51 @@ func extractDocumentToken(raw, marker string) (string, bool) {
 // surfaces for support escalations even when the body omits it.
 func doDocAPI(runtime *common.RuntimeContext, method, apiPath string, body interface{}) (map[string]interface{}, error) {
 	return runtime.CallAPITyped(method, apiPath, nil, body)
+}
+
+func resolveDocumentID(runtime *common.RuntimeContext, ref documentRef) (string, error) {
+	switch ref.Kind {
+	case "docx", "doc":
+		return ref.Token, nil
+	case "wiki":
+		data, err := runtime.CallAPITyped(
+			"GET",
+			wikiGetNodePath,
+			map[string]interface{}{"token": ref.Token},
+			nil,
+		)
+		if err != nil {
+			return "", err
+		}
+
+		node := common.GetMap(data, "node")
+		objType := common.GetString(node, "obj_type")
+		objToken := common.GetString(node, "obj_token")
+		if objType == "" || objToken == "" {
+			return "", errs.NewInternalError(errs.SubtypeInvalidResponse, "wiki get_node returned incomplete node data (obj_type=%q, obj_token=%q)", objType, objToken)
+		}
+		if objType != "docx" && objType != "doc" {
+			return "", errs.NewValidationError(errs.SubtypeInvalidArgument, "wiki resolved to %q, but docs +fetch requires a doc/docx wiki node; use the matching %s shortcut or run drive +inspect to inspect the underlying type", objType, docShortcutHintForWikiType(objType)).WithParam("--doc")
+		}
+		return objToken, nil
+	default:
+		return "", errs.NewInternalError(errs.SubtypeUnknown, "unsupported document ref kind %q", ref.Kind)
+	}
+}
+
+func docShortcutHintForWikiType(objType string) string {
+	switch objType {
+	case "sheet":
+		return "sheets"
+	case "bitable":
+		return "base"
+	case "slides":
+		return "slides"
+	case "mindnote":
+		return "mindnote"
+	default:
+		return "document"
+	}
 }
 
 func docsSceneFromContext(ctx context.Context) string {


### PR DESCRIPTION
## 业务背景

Fixes https://github.com/larksuite/cli/issues/1034.

When users pass a Wiki URL to `docs +fetch`, the CLI should not treat the wiki node token as a document token. It must resolve the Wiki node first, then fetch the underlying `doc` / `docx` object token. Prompt-only guidance is not stable enough for this behavior.

## 实现要点

- Added Wiki node resolution for `docs +fetch` execution via `GET /open-apis/wiki/v2/spaces/get_node`.
- Added dry-run output for the two-step flow: resolve Wiki node, then fetch the resolved document token.
- Preserved existing doc/docx URL and raw token behavior.
- Added typed validation errors for non-document Wiki nodes with actionable hints.
- Added tests for dry-run, resolved docx fetch, and non-document rejection.

## 降级与局限

无。本 PR only changes `docs +fetch`; it does not implement cross-shortcut dispatch for Sheets/Base/Slides.

## 验证

- `go test ./shortcuts/doc -run 'TestDocsFetchWiki|TestDocsFetchDryRunWiki'`
- `go test ./shortcuts/doc`
- `git diff --check origin/main...HEAD`
- `make fmt-check`
- `make vet`
- `GOFLAGS=-buildvcs=false make unit-test`

Note: plain `make unit-test` failed in this RFC 209 worktree because `go list` could not obtain VCS status in `internal/qualitygate/deptest` and suggested `-buildvcs=false`; the identical target passed with `GOFLAGS=-buildvcs=false`.

<details>
<summary>AI Review Context</summary>

- req_id: issue-1034
- spec_hash: ecd83f429f36744bd8734710aa90b10e35ea1c93f974288da42551032cb7201e
- spec_path: docs/specs/issue-1034/spec.md
- subtasks: BE-1
- acceptance_scenarios:
  - BE-1-AC-1: Wiki URL dry-run shows `wiki/v2/spaces/get_node` before docs fetch and does not use the raw wiki token as document_id.
  - BE-1-AC-2: `obj_type=docx` resolves to `obj_token` and fetches that document.
  - BE-1-AC-3: non-document Wiki nodes return typed validation error with `--doc` param and actionable hint.
- scope: `shortcuts/doc`
- idl_branch: N/A
- security_knowledge_ref: UNCONFIGURED
- security_design_summary: Adds read-only Wiki node resolution before document fetch; no write operation or server contract change.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki-based document fetch now performs an initial wiki-node resolution step, then fetches the resolved document content.
* **Bug Fixes**
  * Fetch commands now use the resolved document identifier (instead of the raw wiki token) and URL-encode it correctly.
  * Dry-run JSON output no longer HTML-escapes angle brackets, making previews easier to read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->