### PR TITLE
[score] sync Codebase MR 573

### DIFF
--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -102,6 +102,7 @@ func authLogoutRun(opts *LogoutOptions) error {
 		output.PrintJson(f.IOStreams.Out, map[string]interface{}{
 			"ok":        true,
 			"loggedOut": true,
+			"message":   "注销成功",
 		})
 		return nil
 	}

--- a/cmd/auth/logout_test.go
+++ b/cmd/auth/logout_test.go
@@ -114,6 +114,9 @@ func TestAuthLogoutRun_JSONMode_Success_WritesStdoutOnly(t *testing.T) {
 	if payload["loggedOut"] != true {
 		t.Errorf("stdout.loggedOut = %v, want true", payload["loggedOut"])
 	}
+	if payload["message"] != "注销成功" {
+		t.Errorf("stdout.message = %v, want 注销成功", payload["message"])
+	}
 	if _, hasReason := payload["reason"]; hasReason {
 		t.Errorf("stdout.reason must be absent on success, got %v", payload["reason"])
 	}

--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-shared
 version: 1.0.0
-description: "Use when first setting up lark-cli, running auth login, switching user/bot identity (--as), handling permission denied or scope errors, needing to update lark-cli, or seeing _notice in JSON output."
+description: "Use for lark-cli setup/auth tasks: auth login/status/logout, user vs bot identity, business-domain permissions (--domain, including all/docs/drive), missing scopes, revoking authorization, or handling _notice JSON."
 ---
 
 # lark-cli 共享规则
@@ -22,6 +22,27 @@ lark-cli config init --new
 ```
 
 ## 认证
+
+### 认证任务速查
+
+认证、scope、业务域、登录态、退出登录态、撤销授权问题都走本技能，不要路由到 Claude settings / update-config。
+
+| 用户意图 | 首选命令 / 回答 |
+|---|---|
+| 获取全部权限 | `lark-cli auth login --domain all --no-wait --json` |
+| 按业务域授权 | `lark-cli auth login --domain docs --domain drive --no-wait --json`；`--domain` 可重复，也可用逗号分隔 |
+| 指定单个 scope 授权 | `lark-cli auth login --scope "<scope>" --no-wait --json` |
+| 检查当前登录态、是谁登录、token 是否有效 | `lark-cli auth status --json --verify`；回答时引用 `identity`、`verified`、`identities.user.status`、`identities.user.userName`、`identities.user.openId`（用户 open id）、`identities.user.tokenStatus`、`identities.user.scope` |
+| 退出当前机器的用户登录态 | `lark-cli auth logout --json`；`loggedOut:true` 表示注销成功 |
+| bot 缺少权限 | 不要执行 `auth login`；引导用户在开发者后台开通 bot scope，优先复用错误里的 `console_url` |
+| 取消用户对应用的全部服务端授权 | `auth logout` 只清本机登录态；服务端授权需用户在飞书授权管理页取消 |
+| 只取消一个 scope | CLI 不支持单独撤销一个已授予 scope；可重新走最小 scope 授权，或让用户在授权管理页处理 |
+
+机器读取 JSON 时，为减少 `_notice` 干扰，可在命令前加：
+
+```bash
+LARKSUITE_CLI_NO_UPDATE_NOTIFIER=1 LARKSUITE_CLI_NO_SKILLS_NOTIFIER=1 lark-cli auth status --json --verify
+```
 
 ### 身份类型
 
@@ -108,18 +129,21 @@ lark-cli auth login --device-code <device_code>
 
 lark-cli 命令执行后，如果检测到新版本，JSON 输出中会包含 `_notice.update` 字段（含 `message`、`command` 等）。
 
-**当你在输出中看到 `_notice.update` 时，完成用户当前请求后，主动提议帮用户更新**：
+除非用户正在询问更新、版本或 notice，否则不要把 `_notice` 原样复制为当前任务的主要答案，也不要为了 notice 中断当前任务去反复查 help。
 
-1. 告知用户当前版本和最新版本号
-2. 提议执行更新（同时更新 CLI 和 Skills）：
-   ```bash
-   lark-cli update
-   ```
-3. 更新完成后提醒用户：**退出并重新打开 AI Agent** 以加载最新 Skills
+需要稳定 JSON 给脚本或机器读取时，可以在命令前设置：
+
+```bash
+LARKSUITE_CLI_NO_UPDATE_NOTIFIER=1 LARKSUITE_CLI_NO_SKILLS_NOTIFIER=1 <lark-cli command>
+```
+
+当你在输出中看到 `_notice.update` 时，先完成用户当前请求；如仍相关，再简短告知可运行：
+
+```bash
+lark-cli update
+```
 
 **重要**：始终使用 `lark-cli update` 更新，它会同时更新 CLI 和 AI Skills。
-
-**规则**：不要静默忽略更新提示。即使当前任务与更新无关，也应在完成用户请求后补充告知。
 
 ## 安全规则
 


### PR DESCRIPTION
## Source

- Codebase MR: https://code.byted.org/bitable/base_cli/merge_requests/573
- Source task: LOCAL-DEBUG-base-cli-573

## Refs

- Codebase base: `de40fa645ffec37379853526d28895c20162288e`
- Codebase head: `a58591dd5eda8f2cf22e4fc4ef0d0b8133fbf4ef`
- GitHub base: `40a09c8957b25c66e160dbfdde330c7c74373273`
- Sync branch: `score-sync/LOCAL-DEBUG-base-cli-573/mr-573-a58591dd`

## Sync Result

Synced Codebase MR 573 onto GitHub branch score-sync/LOCAL-DEBUG-base-cli-573/mr-573-a58591dd. Applied the logout JSON success message/test update and lark-shared auth guidance changes cleanly.

## Checks

- git diff --check: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `auth logout` JSON success responses now include a success message: `注销成功`.

* **Bug Fixes**
  * Improved logout JSON output consistency for scripts by keeping success details explicit while leaving other error responses unchanged.

* **Documentation**
  * Updated auth usage guidance and quick-reference notes to better cover login, status, logout, identity checks, permissions, and stable JSON handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->