### PR TITLE
feat(authorization): expand lark-shared auth guidance and tighten logout JSON contract

### DIFF
--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: lark-shared
 version: 1.0.0
-description: "Use when first setting up lark-cli, running auth login, switching user/bot identity (--as), handling permission denied or scope errors, needing to update lark-cli, or seeing _notice in JSON output."
+description: "Use for lark-cli setup/auth tasks: auth login/status/logout, user vs bot identity, business-domain permissions (--domain, including all/docs/drive), missing scopes, revoking authorization, or handling _notice JSON."
 ---
 
 # lark-cli 共享规则
@@ -22,6 +22,27 @@ lark-cli config init --new
 ```
 
 ## 认证
+
+### 认证任务速查
+
+认证、scope、业务域、登录态、退出登录态、撤销授权问题都走本技能，不要路由到 Claude settings / update-config。
+
+| 用户意图 | 首选命令 / 回答 |
+|---|---|
+| 获取全部权限 | `lark-cli auth login --domain all --no-wait --json` |
+| 按业务域授权 | `lark-cli auth login --domain docs --domain drive --no-wait --json`；`--domain` 可重复，也可用逗号分隔 |
+| 指定单个 scope 授权 | `lark-cli auth login --scope "<scope>" --no-wait --json` |
+| 检查当前登录态、是谁登录、token 是否有效 | `lark-cli auth status --json --verify`；回答时引用 `identity`、`verified`、`identities.user.status`、`identities.user.userName`、`identities.user.openId`（用户 open id）、`identities.user.tokenStatus`、`identities.user.scope` |
+| 退出当前机器的用户登录态 | `lark-cli auth logout --json`；`loggedOut:true` 表示注销成功 |
+| bot 缺少权限 | 不要执行 `auth login`；引导用户在开发者后台开通 bot scope，优先复用错误里的 `console_url` |
+| 取消用户对应用的全部服务端授权 | `auth logout` 只清本机登录态；服务端授权需用户在飞书授权管理页取消 |
+| 只取消一个 scope | CLI 不支持单独撤销一个已授予 scope；可重新走最小 scope 授权，或让用户在授权管理页处理 |
+
+机器读取 JSON 时，为减少 `_notice` 干扰，可在命令前加：
+
+```bash
+LARKSUITE_CLI_NO_UPDATE_NOTIFIER=1 LARKSUITE_CLI_NO_SKILLS_NOTIFIER=1 lark-cli auth status --json --verify
+```
 
 ### 身份类型
 
@@ -108,18 +129,21 @@ lark-cli auth login --device-code <device_code>
 
 lark-cli 命令执行后，如果检测到新版本，JSON 输出中会包含 `_notice.update` 字段（含 `message`、`command` 等）。
 
-**当你在输出中看到 `_notice.update` 时，完成用户当前请求后，主动提议帮用户更新**：
+除非用户正在询问更新、版本或 notice，否则不要把 `_notice` 原样复制为当前任务的主要答案，也不要为了 notice 中断当前任务去反复查 help。
 
-1. 告知用户当前版本和最新版本号
-2. 提议执行更新（同时更新 CLI 和 Skills）：
-   ```bash
-   lark-cli update
-   ```
-3. 更新完成后提醒用户：**退出并重新打开 AI Agent** 以加载最新 Skills
+需要稳定 JSON 给脚本或机器读取时，可以在命令前设置：
+
+```bash
+LARKSUITE_CLI_NO_UPDATE_NOTIFIER=1 LARKSUITE_CLI_NO_SKILLS_NOTIFIER=1 <lark-cli command>
+```
+
+当你在输出中看到 `_notice.update` 时，先完成用户当前请求；如仍相关，再简短告知可运行：
+
+```bash
+lark-cli update
+```
 
 **重要**：始终使用 `lark-cli update` 更新，它会同时更新 CLI 和 AI Skills。
-
-**规则**：不要静默忽略更新提示。即使当前任务与更新无关，也应在完成用户请求后补充告知。
 
 ## 安全规则
 


### PR DESCRIPTION
## Summary

Expand the lark-shared skill so it owns the full lark-cli authorization surface (login, status, logout, business-domain scopes, missing scopes, authorization revocation, `_notice` handling), and tighten the auth logout JSON-mode test so success responses are asserted to carry only `loggedOut=true` with no stray `message` field.

## Changes

- `skills/lark-shared/SKILL.md`
  - Rewrite the skill `description` so authorization-related intents (auth login/status/logout, user vs bot identity, `--domain` business-domain permissions including `all`/`docs`/`drive`, missing scopes, authorization revocation, `_notice` JSON) route to this skill instead of `update-config` / Claude settings.
  - Add an 认证任务速查 table mapping user intents (full-permission login, per-domain login, single-scope login, current login status, logout, bot missing scope, revoking server-side authorization, revoking a single scope) to the canonical `lark-cli` commands and the JSON fields that should be cited in answers.
  - Document the `LARKSUITE_CLI_NO_UPDATE_NOTIFIER=1` and `LARKSUITE_CLI_NO_SKILLS_NOTIFIER=1` env vars for producing stable JSON when scripts or machines read the output.
  - Soften `_notice.update` handling: it must no longer interrupt the current task or be copied verbatim as the primary answer; surface the `lark-cli update` hint only after the user's request is complete and only when still relevant.
- `cmd/auth/logout_test.go`
  - In `TestAuthLogoutRun_JSONMode_Success_WritesStdoutOnly`, additionally assert that the success stdout payload does not contain a `message` field, locking in the contract that logout success carries only `loggedOut=true` (alongside the existing `reason`-absence check).

## Test Plan

- `git diff --check` on the synced worktree (passed; no whitespace errors or conflict markers).
- The new assertion in `TestAuthLogoutRun_JSONMode_Success_WritesStdoutOnly` is exercised by the existing Go test suite for `cmd/auth` whenever `go test ./cmd/auth/...` is run in CI; it only tightens an existing success-path assertion and does not introduce new fixtures or dependencies.
- Skill doc change is content-only (Markdown) and does not affect any build or runtime artifact.

## Related Issues

Auto research task: 01KVWPVKPPB9A5CE0W0C28VNSX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined the CLI skill guide for authentication and authorization scenarios, covering login/status/logout, user vs bot identity, domain-based access, required scopes, revocation, and interpreting `_notice` JSON.
  * Added a “认证任务速查” quick-reference mapping common intents to the recommended `lark-cli auth` commands and which JSON fields to cite for `auth status --json --verify`.
  * Improved guidance to suppress notifier interruptions during status checks and adjusted update-message handling to show advice only when relevant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->