### PR TITLE
feat: add im +chat-members-list for user and bot members

### DIFF
--- a/shortcuts/im/helpers_test.go
+++ b/shortcuts/im/helpers_test.go
@@ -651,6 +651,7 @@ func TestShortcuts(t *testing.T) {
 	want := []string{
 		"+chat-create",
 		"+chat-list",
+		"+chat-members-list",
 		"+chat-messages-list",
 		"+chat-search",
 		"+chat-update",

--- a/shortcuts/im/im_chat_list_test.go
+++ b/shortcuts/im/im_chat_list_test.go
@@ -34,7 +34,7 @@ func newChatListTestRuntimeContextWithIdentity(t *testing.T, stringFlags map[str
 		if name == "page-size" {
 			continue
 		}
-		if name == "types" {
+		if name == "types" || name == "member-types" {
 			cmd.Flags().StringSlice(name, nil, "")
 		} else {
 			cmd.Flags().String(name, "", "")

--- a/shortcuts/im/im_chat_members_list.go
+++ b/shortcuts/im/im_chat_members_list.go
@@ -108,9 +108,128 @@ func buildMembersListParams(runtime *common.RuntimeContext, effectiveTypes strin
 	return params
 }
 
-// placeholder for Task 2 — keep file compiling if Task 2 not yet written.
+// executeMembersList runs the single-page or --page-all fetch and renders output.
 func executeMembersList(ctx context.Context, runtime *common.RuntimeContext) error {
-	_ = output.PrintTable
-	_ = io.Discard
+	effective, _ := normalizeMemberTypes(runtime.StrSlice("member-types")) // Validate guarantees err == nil
+	params := buildMembersListParams(runtime, strings.Join(effective, ","))
+	path := fmt.Sprintf(imChatMembersListPath, runtime.Str("chat-id"))
+
+	var data map[string]interface{}
+	var err error
+	// page-all handled in Task 3
+	data, err = runtime.CallAPITyped("GET", path, params, nil)
+	if err != nil {
+		return err
+	}
+
+	outData := assembleMembersOutput(data)
+	if truncs, ok := outData["truncations"].([]interface{}); ok && len(truncs) > 0 {
+		writeMembersTruncationWarning(runtime.IO().ErrOut, truncs)
+	}
+
+	runtime.OutFormat(outData, nil, func(w io.Writer) { renderMembersPretty(w, outData) })
 	return nil
+}
+
+// assembleMembersOutput extracts the two buckets and pagination metadata from a
+// single API data object into the shortcut's output shape. Empty buckets are
+// rendered as [] (never omitted) for stable downstream parsing.
+func assembleMembersOutput(data map[string]interface{}) map[string]interface{} {
+	users, _ := data["users"].([]interface{})
+	if users == nil {
+		users = []interface{}{}
+	}
+	bots, _ := data["bots"].([]interface{})
+	if bots == nil {
+		bots = []interface{}{}
+	}
+	hasMore, pageToken := common.PaginationMeta(data)
+	truncs, _ := data["truncations"].([]interface{})
+	if truncs == nil {
+		truncs = []interface{}{}
+	}
+	out := map[string]interface{}{
+		"users":       users,
+		"bots":        bots,
+		"has_more":    hasMore,
+		"page_token":  pageToken,
+		"truncations": truncs,
+	}
+	if v, ok := data["user_total"]; ok {
+		out["user_total"] = v
+	}
+	if v, ok := data["bot_total"]; ok {
+		out["bot_total"] = v
+	}
+	return out
+}
+
+// writeMembersTruncationWarning emits one stderr warning per truncated type.
+func writeMembersTruncationWarning(errOut io.Writer, truncs []interface{}) {
+	for _, raw := range truncs {
+		m, _ := raw.(map[string]interface{})
+		if m == nil {
+			continue
+		}
+		fmt.Fprintf(errOut, "warning: member list truncated by server (member_type=%v, limit=%v); not all members returned\n", m["member_type"], m["limit"])
+	}
+}
+
+// renderMembersPretty renders the non-JSON table view.
+func renderMembersPretty(w io.Writer, outData map[string]interface{}) {
+	users, _ := outData["users"].([]interface{})
+	bots, _ := outData["bots"].([]interface{})
+	if len(users) == 0 && len(bots) == 0 {
+		fmt.Fprintln(w, "No members found.")
+		return
+	}
+	rows := make([]map[string]interface{}, 0, len(users)+len(bots))
+	for _, raw := range users {
+		m, _ := raw.(map[string]interface{})
+		if m == nil {
+			continue
+		}
+		rows = append(rows, map[string]interface{}{
+			"type": "user", "member_id": m["member_id"], "name": m["name"], "tenant_key": m["tenant_key"],
+		})
+	}
+	for _, raw := range bots {
+		m, _ := raw.(map[string]interface{})
+		if m == nil {
+			continue
+		}
+		rows = append(rows, map[string]interface{}{
+			"type": "bot", "member_id": m["member_id"], "name": m["name"], "app_id": m["app_id"], "tenant_key": m["tenant_key"],
+		})
+	}
+	output.PrintTable(w, rows)
+	ut := totalString(outData["user_total"])
+	fmt.Fprintf(w, "\n%s user(s), %v bot(s)", ut, outData["bot_total"])
+	if hm, _ := outData["has_more"].(bool); hm {
+		fmt.Fprintf(w, " (more available, use --page-token to fetch next page")
+		if pt, _ := outData["page_token"].(string); pt != "" {
+			fmt.Fprintf(w, ", page_token: %s", pt)
+		}
+		fmt.Fprint(w, ")")
+	}
+	fmt.Fprintln(w)
+}
+
+// totalString renders user_total, mapping the API's -1 "hidden" sentinel to a
+// human label. JSON numbers decode as float64.
+func totalString(v interface{}) string {
+	switch n := v.(type) {
+	case float64:
+		if n == -1 {
+			return "hidden count of"
+		}
+		return fmt.Sprintf("%d", int(n))
+	case int:
+		if n == -1 {
+			return "hidden count of"
+		}
+		return fmt.Sprintf("%d", n)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
 }

--- a/shortcuts/im/im_chat_members_list.go
+++ b/shortcuts/im/im_chat_members_list.go
@@ -116,8 +116,11 @@ func executeMembersList(ctx context.Context, runtime *common.RuntimeContext) err
 
 	var data map[string]interface{}
 	var err error
-	// page-all handled in Task 3
-	data, err = runtime.CallAPITyped("GET", path, params, nil)
+	if runtime.Bool("page-all") && !runtime.Cmd.Flags().Changed("page-token") {
+		data, err = fetchAllMemberPages(ctx, runtime, path, params, runtime.Int("page-limit"))
+	} else {
+		data, err = runtime.CallAPITyped("GET", path, params, nil)
+	}
 	if err != nil {
 		return err
 	}
@@ -213,6 +216,62 @@ func renderMembersPretty(w io.Writer, outData map[string]interface{}) {
 		fmt.Fprint(w, ")")
 	}
 	fmt.Fprintln(w)
+}
+
+// fetchAllMemberPages loops up to pageLimit pages, accumulating users[]/bots[]
+// from each page. user_total/bot_total/truncations come from the last page
+// (group-level totals are page-invariant). has_more/page_token reflect the last
+// page fetched — when the loop stops at pageLimit with has_more=true the token
+// is preserved so the caller can continue. Stops early if page_token does not
+// advance (guard against an infinite loop).
+func fetchAllMemberPages(ctx context.Context, runtime *common.RuntimeContext, path string, baseParams map[string]interface{}, pageLimit int) (map[string]interface{}, error) {
+	if pageLimit < 1 {
+		pageLimit = 1
+	}
+	allUsers := []interface{}{}
+	allBots := []interface{}{}
+	var last map[string]interface{}
+	token := ""
+	for i := 0; i < pageLimit; i++ {
+		params := make(map[string]interface{}, len(baseParams)+1)
+		for k, v := range baseParams {
+			params[k] = v
+		}
+		if token != "" {
+			params["page_token"] = token
+		} else {
+			delete(params, "page_token")
+		}
+		data, err := runtime.CallAPITyped("GET", path, params, nil)
+		if err != nil {
+			return nil, err
+		}
+		last = data
+		if u, ok := data["users"].([]interface{}); ok {
+			allUsers = append(allUsers, u...)
+		}
+		if b, ok := data["bots"].([]interface{}); ok {
+			allBots = append(allBots, b...)
+		}
+		hasMore, nextToken := common.PaginationMeta(data)
+		if !hasMore || nextToken == "" {
+			break
+		}
+		if nextToken == token {
+			fmt.Fprintf(runtime.IO().ErrOut, "warning: page_token did not change, stopping pagination to avoid infinite loop\n")
+			break
+		}
+		token = nextToken
+	}
+	// Rebuild a synthetic "last page" data carrying accumulated buckets but the
+	// last page's totals / has_more / page_token / truncations.
+	merged := map[string]interface{}{}
+	for k, v := range last {
+		merged[k] = v
+	}
+	merged["users"] = allUsers
+	merged["bots"] = allBots
+	return merged, nil
 }
 
 // totalString renders user_total, mapping the API's -1 "hidden" sentinel to a

--- a/shortcuts/im/im_chat_members_list.go
+++ b/shortcuts/im/im_chat_members_list.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -39,6 +40,9 @@ var ImChatMembersList = common.Shortcut{
 		{Name: "page-limit", Type: "int", Default: "20", Desc: "max pages when --page-all is enabled (default 20, max 1000)"},
 	},
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if _, err := common.ValidateChatIDTyped("--chat-id", runtime.Str("chat-id")); err != nil {
+			return err
+		}
 		if n := runtime.Int("page-size"); n < 1 || n > 100 {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--page-size must be an integer between 1 and 100").WithParam("--page-size")
 		}
@@ -54,7 +58,8 @@ var ImChatMembersList = common.Shortcut{
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		effective, _ := normalizeMemberTypes(runtime.StrSlice("member-types")) // Validate guarantees err == nil
-		path := fmt.Sprintf(imChatMembersListPath, runtime.Str("chat-id"))
+		chatID, _ := common.ValidateChatIDTyped("--chat-id", runtime.Str("chat-id"))
+		path := fmt.Sprintf(imChatMembersListPath, validate.EncodePathSegment(chatID))
 		return common.NewDryRunAPI().
 			GET(path).
 			Params(buildMembersListParams(runtime, strings.Join(effective, ",")))
@@ -112,7 +117,8 @@ func buildMembersListParams(runtime *common.RuntimeContext, effectiveTypes strin
 func executeMembersList(ctx context.Context, runtime *common.RuntimeContext) error {
 	effective, _ := normalizeMemberTypes(runtime.StrSlice("member-types")) // Validate guarantees err == nil
 	params := buildMembersListParams(runtime, strings.Join(effective, ","))
-	path := fmt.Sprintf(imChatMembersListPath, runtime.Str("chat-id"))
+	chatID, _ := common.ValidateChatIDTyped("--chat-id", runtime.Str("chat-id")) // Validate guarantees err == nil
+	path := fmt.Sprintf(imChatMembersListPath, validate.EncodePathSegment(chatID))
 
 	var data map[string]interface{}
 	var err error

--- a/shortcuts/im/im_chat_members_list.go
+++ b/shortcuts/im/im_chat_members_list.go
@@ -312,4 +312,3 @@ func fetchAllMemberPages(ctx context.Context, runtime *common.RuntimeContext, pa
 	merged["bots"] = allBots
 	return merged, nil
 }
-

--- a/shortcuts/im/im_chat_members_list.go
+++ b/shortcuts/im/im_chat_members_list.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/output"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// imChatMembersListPath is the upstream path template for +chat-members-list.
+// chat_id is substituted at call time.
+const imChatMembersListPath = "/open-apis/im/v1/chats/%s/members/list"
+
+// ImChatMembersList is the +chat-members-list shortcut: wraps
+// GET /open-apis/im/v1/chats/{chat_id}/members/list to return BOTH user and bot
+// members of a group in one call, faithfully split into users[]/bots[] buckets.
+var ImChatMembersList = common.Shortcut{
+	Service:     "im",
+	Command:     "+chat-members-list",
+	Description: "List all members (users and bots) of a group chat in one call; user/bot; returns users[]/bots[] buckets with totals; supports --member-types filter, --member-id-type, pagination and --page-all",
+	Risk:        "read",
+	Scopes:      []string{"im:chat.members:read"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags: []common.Flag{
+		{Name: "chat-id", Required: true, Desc: "group chat ID (oc_xxx)"},
+		{Name: "member-types", Type: "string_slice", Desc: "filter member types to fetch (user, bot); omit = both"},
+		{Name: "member-id-type", Default: "open_id", Desc: "ID type for member_id in response", Enum: []string{"open_id", "union_id", "user_id"}},
+		{Name: "page-size", Type: "int", Default: "20", Desc: "page size (1-100)"},
+		{Name: "page-token", Desc: "pagination token for next page"},
+		{Name: "page-all", Type: "bool", Desc: "automatically paginate through all pages, accumulating users[]+bots[]"},
+		{Name: "page-limit", Type: "int", Default: "20", Desc: "max pages when --page-all is enabled (default 20, max 1000)"},
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if n := runtime.Int("page-size"); n < 1 || n > 100 {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--page-size must be an integer between 1 and 100").WithParam("--page-size")
+		}
+		if runtime.Bool("page-all") {
+			if n := runtime.Int("page-limit"); n < 1 || n > 1000 {
+				return errs.NewValidationError(errs.SubtypeInvalidArgument, "--page-limit must be an integer between 1 and 1000").WithParam("--page-limit")
+			}
+		}
+		if _, err := normalizeMemberTypes(runtime.StrSlice("member-types")); err != nil {
+			return err
+		}
+		return nil
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		effective, _ := normalizeMemberTypes(runtime.StrSlice("member-types")) // Validate guarantees err == nil
+		path := fmt.Sprintf(imChatMembersListPath, runtime.Str("chat-id"))
+		return common.NewDryRunAPI().
+			GET(path).
+			Params(buildMembersListParams(runtime, strings.Join(effective, ",")))
+	},
+	Execute: executeMembersList, // defined in Task 2
+}
+
+// normalizeMemberTypes validates/normalizes the --member-types slice: trims,
+// lowercases, dedupes (preserving order), and rejects anything outside
+// {user, bot}. Empty input returns (nil, nil).
+func normalizeMemberTypes(raw []string) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, p := range raw {
+		p = strings.TrimSpace(strings.ToLower(p))
+		if p == "" {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--member-types must contain at least one of user, bot").WithParam("--member-types")
+		}
+		if p != "user" && p != "bot" {
+			return nil, errs.NewValidationError(errs.SubtypeInvalidArgument, "--member-types contains invalid value %q: expected one of user, bot", p).WithParam("--member-types")
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// buildMembersListParams assembles the query params. effectiveTypes is the
+// CSV produced by normalizeMemberTypes; pass "" to omit member_types.
+func buildMembersListParams(runtime *common.RuntimeContext, effectiveTypes string) map[string]interface{} {
+	params := map[string]interface{}{
+		"member_id_type": runtime.Str("member-id-type"),
+	}
+	if n := runtime.Int("page-size"); n > 0 {
+		params["page_size"] = n
+	} else {
+		params["page_size"] = 20
+	}
+	if pt := runtime.Str("page-token"); pt != "" {
+		params["page_token"] = pt
+	}
+	if effectiveTypes != "" {
+		params["member_types"] = effectiveTypes
+	}
+	return params
+}
+
+// placeholder for Task 2 — keep file compiling if Task 2 not yet written.
+func executeMembersList(ctx context.Context, runtime *common.RuntimeContext) error {
+	_ = output.PrintTable
+	_ = io.Discard
+	return nil
+}

--- a/shortcuts/im/im_chat_members_list.go
+++ b/shortcuts/im/im_chat_members_list.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/larksuite/cli/errs"
-	"github.com/larksuite/cli/internal/output"
 	"github.com/larksuite/cli/internal/validate"
 	"github.com/larksuite/cli/shortcuts/common"
 )
@@ -184,7 +184,17 @@ func writeMembersTruncationWarning(errOut io.Writer, truncs []interface{}) {
 	}
 }
 
-// renderMembersPretty renders the non-JSON table view.
+// fmtVal formats a value for table display, rendering nil as an empty string.
+func fmtVal(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+// renderMembersPretty renders the non-JSON table view with fixed column order:
+// type, member_id, name, app_id, tenant_key. Users are listed before bots;
+// the app_id column is empty for user rows.
 func renderMembersPretty(w io.Writer, outData map[string]interface{}) {
 	users, _ := outData["users"].([]interface{})
 	bots, _ := outData["bots"].([]interface{})
@@ -192,28 +202,39 @@ func renderMembersPretty(w io.Writer, outData map[string]interface{}) {
 		fmt.Fprintln(w, "No members found.")
 		return
 	}
-	rows := make([]map[string]interface{}, 0, len(users)+len(bots))
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	fmt.Fprintln(tw, "type\tmember_id\tname\tapp_id\ttenant_key")
 	for _, raw := range users {
 		m, _ := raw.(map[string]interface{})
 		if m == nil {
 			continue
 		}
-		rows = append(rows, map[string]interface{}{
-			"type": "user", "member_id": m["member_id"], "name": m["name"], "tenant_key": m["tenant_key"],
-		})
+		fmt.Fprintf(tw, "user\t%s\t%s\t\t%s\n",
+			fmtVal(m["member_id"]),
+			fmtVal(m["name"]),
+			fmtVal(m["tenant_key"]),
+		)
 	}
 	for _, raw := range bots {
 		m, _ := raw.(map[string]interface{})
 		if m == nil {
 			continue
 		}
-		rows = append(rows, map[string]interface{}{
-			"type": "bot", "member_id": m["member_id"], "name": m["name"], "app_id": m["app_id"], "tenant_key": m["tenant_key"],
-		})
+		fmt.Fprintf(tw, "bot\t%s\t%s\t%s\t%s\n",
+			fmtVal(m["member_id"]),
+			fmtVal(m["name"]),
+			fmtVal(m["app_id"]),
+			fmtVal(m["tenant_key"]),
+		)
 	}
-	output.PrintTable(w, rows)
-	ut := totalString(outData["user_total"])
-	fmt.Fprintf(w, "\n%s user(s), %v bot(s)", ut, outData["bot_total"])
+	tw.Flush()
+	var userSummary string
+	if isNegOneTotal(outData["user_total"]) {
+		userSummary = "users hidden"
+	} else {
+		userSummary = fmt.Sprintf("%v user(s)", outData["user_total"])
+	}
+	fmt.Fprintf(w, "\n%s, %v bot(s)", userSummary, outData["bot_total"])
 	if hm, _ := outData["has_more"].(bool); hm {
 		fmt.Fprintf(w, " (more available, use --page-token to fetch next page")
 		if pt, _ := outData["page_token"].(string); pt != "" {
@@ -222,6 +243,18 @@ func renderMembersPretty(w io.Writer, outData map[string]interface{}) {
 		fmt.Fprint(w, ")")
 	}
 	fmt.Fprintln(w)
+}
+
+// isNegOneTotal reports whether v represents the API's -1 "hidden" sentinel
+// (JSON numbers decode as float64; direct int is also handled).
+func isNegOneTotal(v interface{}) bool {
+	switch n := v.(type) {
+	case float64:
+		return n == -1
+	case int:
+		return n == -1
+	}
+	return false
 }
 
 // fetchAllMemberPages loops up to pageLimit pages, accumulating users[]/bots[]
@@ -280,21 +313,3 @@ func fetchAllMemberPages(ctx context.Context, runtime *common.RuntimeContext, pa
 	return merged, nil
 }
 
-// totalString renders user_total, mapping the API's -1 "hidden" sentinel to a
-// human label. JSON numbers decode as float64.
-func totalString(v interface{}) string {
-	switch n := v.(type) {
-	case float64:
-		if n == -1 {
-			return "hidden count of"
-		}
-		return fmt.Sprintf("%d", int(n))
-	case int:
-		if n == -1 {
-			return "hidden count of"
-		}
-		return fmt.Sprintf("%d", n)
-	default:
-		return fmt.Sprintf("%v", v)
-	}
-}

--- a/shortcuts/im/im_chat_members_list.go
+++ b/shortcuts/im/im_chat_members_list.go
@@ -43,6 +43,15 @@ var ImChatMembersList = common.Shortcut{
 		if _, err := common.ValidateChatIDTyped("--chat-id", runtime.Str("chat-id")); err != nil {
 			return err
 		}
+		switch runtime.Str("format") {
+		case "table", "csv", "ndjson":
+			return errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"--format %s is not supported for +chat-members-list because it would drop the bots bucket; use --format json or pretty", runtime.Str("format")).WithParam("--format")
+		}
+		if runtime.Bool("page-all") && runtime.Cmd != nil && runtime.Cmd.Flags().Changed("page-token") {
+			return errs.NewValidationError(errs.SubtypeInvalidArgument,
+				"--page-all cannot be combined with --page-token").WithParam("--page-token")
+		}
 		if n := runtime.Int("page-size"); n < 1 || n > 100 {
 			return errs.NewValidationError(errs.SubtypeInvalidArgument, "--page-size must be an integer between 1 and 100").WithParam("--page-size")
 		}
@@ -122,7 +131,7 @@ func executeMembersList(ctx context.Context, runtime *common.RuntimeContext) err
 
 	var data map[string]interface{}
 	var err error
-	if runtime.Bool("page-all") && !runtime.Cmd.Flags().Changed("page-token") {
+	if runtime.Bool("page-all") {
 		data, err = fetchAllMemberPages(ctx, runtime, path, params, runtime.Int("page-limit"))
 	} else {
 		data, err = runtime.CallAPITyped("GET", path, params, nil)

--- a/shortcuts/im/im_chat_members_list_test.go
+++ b/shortcuts/im/im_chat_members_list_test.go
@@ -4,6 +4,7 @@
 package im
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"strings"
@@ -138,6 +139,76 @@ func TestMembersList_DryRun(t *testing.T) {
 	s := mustMarshalDryRun(t, dr)
 	if !strings.Contains(s, "/open-apis/im/v1/chats/oc_test/members/list") {
 		t.Fatalf("dry-run missing path: %s", s)
+	}
+}
+
+// attachMembersListCmd registers the +chat-members-list flag surface onto a
+// network-backed runtime so Execute can read flags. Mirrors attachChatListCmd.
+func attachMembersListCmd(t *testing.T, runtime *common.RuntimeContext, stringFlags map[string]string, boolFlags map[string]bool) {
+	t.Helper()
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Int("page-size", 20, "")
+	cmd.Flags().Int("page-limit", 20, "")
+	cmd.Flags().StringSlice("member-types", nil, "")
+	cmd.Flags().String("chat-id", "oc_test", "")
+	cmd.Flags().String("member-id-type", "open_id", "")
+	cmd.Flags().String("page-token", "", "")
+	cmd.Flags().Bool("page-all", false, "")
+	_ = cmd.ParseFlags(nil)
+	for name, val := range stringFlags {
+		if err := cmd.Flags().Set(name, val); err != nil {
+			t.Fatalf("set %q: %v", name, err)
+		}
+	}
+	for name, val := range boolFlags {
+		if val {
+			if err := cmd.Flags().Set(name, "true"); err != nil {
+				t.Fatalf("set %q: %v", name, err)
+			}
+		}
+	}
+	setRuntimeField(t, runtime, "Cmd", cmd)
+}
+
+func TestMembersList_Execute_BothBuckets(t *testing.T) {
+	var capturedURL string
+	body := `{"code":0,"msg":"ok","data":{
+		"users":[{"member_id":"ou_u1","name":"张三","tenant_key":"tk"}],
+		"bots":[{"member_id":"ou_b1","app_id":"cli_x","name":"值班机器人","tenant_key":"tk"}],
+		"user_total":1,"bot_total":1,"has_more":false,"page_token":"","truncations":[]}}`
+	rt := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		capturedURL = req.URL.String()
+		return shortcutRawResponse(200, []byte(body), nil), nil
+	}))
+	attachMembersListCmd(t, rt, map[string]string{"chat-id": "oc_test"}, nil)
+
+	if err := ImChatMembersList.Execute(context.Background(), rt); err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	if !strings.Contains(capturedURL, "/open-apis/im/v1/chats/oc_test/members/list") {
+		t.Fatalf("url = %s", capturedURL)
+	}
+	out := rt.Factory.IOStreams.Out.(*bytes.Buffer).String()
+	for _, want := range []string{`"users"`, `"bots"`, `ou_u1`, `cli_x`, `"user_total"`, `"bot_total"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestMembersList_Execute_FilterBotsOnly(t *testing.T) {
+	var capturedURL string
+	body := `{"code":0,"data":{"users":[],"bots":[{"member_id":"ou_b1","app_id":"cli_x","name":"B"}],"user_total":0,"bot_total":1,"has_more":false}}`
+	rt := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		capturedURL = req.URL.String()
+		return shortcutRawResponse(200, []byte(body), nil), nil
+	}))
+	attachMembersListCmd(t, rt, map[string]string{"member-types": "bot"}, nil)
+	if err := ImChatMembersList.Execute(context.Background(), rt); err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	if !strings.Contains(capturedURL, "member_types=bot") {
+		t.Fatalf("url missing member_types=bot: %s", capturedURL)
 	}
 }
 

--- a/shortcuts/im/im_chat_members_list_test.go
+++ b/shortcuts/im/im_chat_members_list_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package im
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/shortcuts/common"
+	"github.com/spf13/cobra"
+)
+
+// newMembersListTestRT builds a pure-logic runtime (no HTTP) with the given
+// string/bool flags registered, defaulting chat-id. Mirrors the chat-list
+// pure-logic helper pattern.
+func newMembersListTestRT(t *testing.T, stringFlags map[string]string, boolFlags map[string]bool) *common.RuntimeContext {
+	t.Helper()
+	if stringFlags == nil {
+		stringFlags = map[string]string{}
+	}
+	if _, ok := stringFlags["chat-id"]; !ok {
+		stringFlags["chat-id"] = "oc_test"
+	}
+	if _, ok := stringFlags["member-id-type"]; !ok {
+		stringFlags["member-id-type"] = "open_id"
+	}
+	return newChatListTestRuntimeContext(t, stringFlags, boolFlags)
+}
+
+func TestNormalizeMemberTypes(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      []string
+		want    string // comma-joined, "" = nil
+		wantErr bool
+	}{
+		{"empty", nil, "", false},
+		{"single", []string{"user"}, "user", false},
+		{"csv-dedupe-order", []string{"USER", "bot", "user"}, "user,bot", false},
+		{"trim", []string{" bot "}, "bot", false},
+		{"invalid", []string{"group"}, "", true},
+		{"empty-elem", []string{""}, "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := normalizeMemberTypes(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil (got=%v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if strings.Join(got, ",") != c.want {
+				t.Fatalf("got %v, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestBuildMembersListParams_Defaults(t *testing.T) {
+	rt := newMembersListTestRT(t, map[string]string{"member-id-type": "open_id"}, nil)
+	got := buildMembersListParams(rt, "")
+	if got["member_id_type"] != "open_id" {
+		t.Fatalf("member_id_type = %v", got["member_id_type"])
+	}
+	if got["page_size"] != 20 {
+		t.Fatalf("page_size = %v, want 20", got["page_size"])
+	}
+	if _, present := got["page_token"]; present {
+		t.Fatalf("page_token should be omitted when empty")
+	}
+	if _, present := got["member_types"]; present {
+		t.Fatalf("member_types should be omitted when empty")
+	}
+}
+
+func TestBuildMembersListParams_Overrides(t *testing.T) {
+	rt := newMembersListTestRT(t, map[string]string{
+		"member-id-type": "union_id",
+		"page-size":      "50",
+		"page-token":     "tok_1",
+	}, nil)
+	got := buildMembersListParams(rt, "user,bot")
+	if got["member_id_type"] != "union_id" {
+		t.Fatalf("member_id_type = %v", got["member_id_type"])
+	}
+	if got["page_size"] != 50 {
+		t.Fatalf("page_size = %v", got["page_size"])
+	}
+	if got["page_token"] != "tok_1" {
+		t.Fatalf("page_token = %v", got["page_token"])
+	}
+	if got["member_types"] != "user,bot" {
+		t.Fatalf("member_types = %v", got["member_types"])
+	}
+}
+
+func TestMembersList_Validate(t *testing.T) {
+	cases := []struct {
+		name        string
+		stringFlags map[string]string
+		boolFlags   map[string]bool
+		wantErr     bool
+	}{
+		{"ok", map[string]string{"page-size": "20"}, nil, false},
+		{"page-size-low", map[string]string{"page-size": "0"}, nil, true},
+		{"page-size-high", map[string]string{"page-size": "101"}, nil, true},
+		{"bad-member-type", map[string]string{"member-types": "group"}, nil, true},
+		{"page-limit-bad", map[string]string{"page-limit": "0"}, map[string]bool{"page-all": true}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sf := c.stringFlags
+			if sf == nil {
+				sf = map[string]string{}
+			}
+			rt := newMembersListTestRT(t, sf, c.boolFlags)
+			err := ImChatMembersList.Validate(context.Background(), rt)
+			if c.wantErr && err == nil {
+				t.Fatalf("want error, got nil")
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+		})
+	}
+}
+
+func TestMembersList_DryRun(t *testing.T) {
+	rt := newMembersListTestRT(t, map[string]string{"member-id-type": "open_id"}, nil)
+	dr := ImChatMembersList.DryRun(context.Background(), rt)
+	s := mustMarshalDryRun(t, dr)
+	if !strings.Contains(s, "/open-apis/im/v1/chats/oc_test/members/list") {
+		t.Fatalf("dry-run missing path: %s", s)
+	}
+}
+
+// compile-time guard that the shortcut is wired with expected metadata.
+func TestMembersList_Metadata(t *testing.T) {
+	if ImChatMembersList.Command != "+chat-members-list" {
+		t.Fatalf("Command = %q", ImChatMembersList.Command)
+	}
+	if ImChatMembersList.Risk != "read" {
+		t.Fatalf("Risk = %q", ImChatMembersList.Risk)
+	}
+	if strings.Join(ImChatMembersList.Scopes, ",") != "im:chat.members:read" {
+		t.Fatalf("Scopes = %v", ImChatMembersList.Scopes)
+	}
+	gotAuth := strings.Join(ImChatMembersList.AuthTypes, ",")
+	if gotAuth != "user,bot" {
+		t.Fatalf("AuthTypes = %v", ImChatMembersList.AuthTypes)
+	}
+	_ = http.MethodGet
+	_ = cobra.Command{}
+}

--- a/shortcuts/im/im_chat_members_list_test.go
+++ b/shortcuts/im/im_chat_members_list_test.go
@@ -265,6 +265,19 @@ func TestMembersList_Execute_Truncations(t *testing.T) {
 	}
 }
 
+func TestMembersList_Registered(t *testing.T) {
+	found := false
+	for _, s := range Shortcuts() {
+		if s.Command == "+chat-members-list" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("+chat-members-list not registered in Shortcuts()")
+	}
+}
+
 // compile-time guard that the shortcut is wired with expected metadata.
 func TestMembersList_Metadata(t *testing.T) {
 	if ImChatMembersList.Command != "+chat-members-list" {

--- a/shortcuts/im/im_chat_members_list_test.go
+++ b/shortcuts/im/im_chat_members_list_test.go
@@ -278,6 +278,71 @@ func TestMembersList_Execute_Truncations(t *testing.T) {
 	}
 }
 
+func TestMembersList_Pretty_ColumnOrder(t *testing.T) {
+	outData := map[string]interface{}{
+		"users": []interface{}{
+			map[string]interface{}{"member_id": "ou_user1", "name": "Alice", "tenant_key": "tk1"},
+		},
+		"bots": []interface{}{
+			map[string]interface{}{"member_id": "ou_bot1", "name": "MyBot", "app_id": "cli_abc", "tenant_key": "tk1"},
+		},
+		"has_more":   false,
+		"user_total": float64(1),
+		"bot_total":  float64(1),
+	}
+	var buf bytes.Buffer
+	renderMembersPretty(&buf, outData)
+	out := buf.String()
+
+	// Find the header line
+	headerLine := ""
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "type") && strings.Contains(line, "member_id") {
+			headerLine = line
+			break
+		}
+	}
+	if headerLine == "" {
+		t.Fatalf("no header line found:\n%s", out)
+	}
+	idxType := strings.Index(headerLine, "type")
+	idxMemberID := strings.Index(headerLine, "member_id")
+	idxAppID := strings.Index(headerLine, "app_id")
+	idxTenantKey := strings.Index(headerLine, "tenant_key")
+
+	if idxType != 0 {
+		t.Errorf("type should be first column (got index %d): %q", idxType, headerLine)
+	}
+	if idxType >= idxMemberID {
+		t.Errorf("type should come before member_id in header: %q", headerLine)
+	}
+	if idxAppID >= idxTenantKey {
+		t.Errorf("app_id should come before tenant_key in header: %q", headerLine)
+	}
+}
+
+func TestMembersList_Pretty_HiddenUserTotal(t *testing.T) {
+	outData := map[string]interface{}{
+		"users": []interface{}{
+			map[string]interface{}{"member_id": "ou_user1", "name": "Alice", "tenant_key": "tk1"},
+		},
+		"bots":       []interface{}{},
+		"has_more":   false,
+		"user_total": float64(-1),
+		"bot_total":  float64(0),
+	}
+	var buf bytes.Buffer
+	renderMembersPretty(&buf, outData)
+	out := buf.String()
+
+	if !strings.Contains(out, "users hidden") {
+		t.Errorf("expected 'users hidden' in output:\n%s", out)
+	}
+	if strings.Contains(out, "hidden count of") {
+		t.Errorf("unexpected 'hidden count of' in output:\n%s", out)
+	}
+}
+
 func TestMembersList_Registered(t *testing.T) {
 	found := false
 	for _, s := range Shortcuts() {

--- a/shortcuts/im/im_chat_members_list_test.go
+++ b/shortcuts/im/im_chat_members_list_test.go
@@ -114,6 +114,7 @@ func TestMembersList_Validate(t *testing.T) {
 		{"page-size-high", map[string]string{"page-size": "101"}, nil, true},
 		{"bad-member-type", map[string]string{"member-types": "group"}, nil, true},
 		{"page-limit-bad", map[string]string{"page-limit": "0"}, map[string]bool{"page-all": true}, true},
+		{"bad-chat-id", map[string]string{"chat-id": "bad"}, nil, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -139,6 +140,18 @@ func TestMembersList_DryRun(t *testing.T) {
 	s := mustMarshalDryRun(t, dr)
 	if !strings.Contains(s, "/open-apis/im/v1/chats/oc_test/members/list") {
 		t.Fatalf("dry-run missing path: %s", s)
+	}
+}
+
+func TestMembersList_DryRun_EscapesChatID(t *testing.T) {
+	rt := newMembersListTestRT(t, map[string]string{"chat-id": "oc_a/b"}, nil)
+	dr := ImChatMembersList.DryRun(context.Background(), rt)
+	s := mustMarshalDryRun(t, dr)
+	if strings.Contains(s, "oc_a/b") {
+		t.Fatalf("dry-run contains unescaped chat-id: %s", s)
+	}
+	if !strings.Contains(s, "oc_a%2Fb") {
+		t.Fatalf("dry-run missing percent-encoded chat-id (oc_a%%2Fb): %s", s)
 	}
 }
 

--- a/shortcuts/im/im_chat_members_list_test.go
+++ b/shortcuts/im/im_chat_members_list_test.go
@@ -212,6 +212,59 @@ func TestMembersList_Execute_FilterBotsOnly(t *testing.T) {
 	}
 }
 
+func TestMembersList_Execute_PageAllAccumulates(t *testing.T) {
+	page := 0
+	rt := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		page++
+		if page == 1 {
+			return shortcutRawResponse(200, []byte(`{"code":0,"data":{"users":[{"member_id":"ou_u1"}],"bots":[],"user_total":2,"bot_total":1,"has_more":true,"page_token":"t2"}}`), nil), nil
+		}
+		return shortcutRawResponse(200, []byte(`{"code":0,"data":{"users":[{"member_id":"ou_u2"}],"bots":[{"member_id":"ou_b1"}],"user_total":2,"bot_total":1,"has_more":false,"page_token":""}}`), nil), nil
+	}))
+	attachMembersListCmd(t, rt, nil, map[string]bool{"page-all": true})
+	if err := ImChatMembersList.Execute(context.Background(), rt); err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	out := rt.Factory.IOStreams.Out.(*bytes.Buffer).String()
+	for _, want := range []string{"ou_u1", "ou_u2", "ou_b1", `"has_more": false`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("page-all output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestMembersList_Execute_PageAllHitsLimit(t *testing.T) {
+	rt := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return shortcutRawResponse(200, []byte(`{"code":0,"data":{"users":[{"member_id":"ou_u1"}],"bots":[],"user_total":9,"bot_total":0,"has_more":true,"page_token":"tNEXT"}}`), nil), nil
+	}))
+	attachMembersListCmd(t, rt, map[string]string{"page-limit": "1"}, map[string]bool{"page-all": true})
+	if err := ImChatMembersList.Execute(context.Background(), rt); err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	out := rt.Factory.IOStreams.Out.(*bytes.Buffer).String()
+	if !strings.Contains(out, `"has_more": true`) || !strings.Contains(out, "tNEXT") {
+		t.Fatalf("page-limit stop should preserve has_more/token:\n%s", out)
+	}
+}
+
+func TestMembersList_Execute_Truncations(t *testing.T) {
+	rt := newUserShortcutRuntime(t, shortcutRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return shortcutRawResponse(200, []byte(`{"code":0,"data":{"users":[{"member_id":"ou_u1"}],"bots":[],"user_total":-1,"bot_total":0,"has_more":false,"truncations":[{"member_type":"user","limit":100}]}}`), nil), nil
+	}))
+	attachMembersListCmd(t, rt, nil, nil)
+	if err := ImChatMembersList.Execute(context.Background(), rt); err != nil {
+		t.Fatalf("Execute() err = %v", err)
+	}
+	out := rt.Factory.IOStreams.Out.(*bytes.Buffer).String()
+	if !strings.Contains(out, `"truncations"`) || !strings.Contains(out, `"limit": 100`) {
+		t.Fatalf("truncations not preserved in output:\n%s", out)
+	}
+	errOut := rt.Factory.IOStreams.ErrOut.(*bytes.Buffer).String()
+	if !strings.Contains(errOut, "truncated by server") {
+		t.Fatalf("stderr missing truncation warning:\n%s", errOut)
+	}
+}
+
 // compile-time guard that the shortcut is wired with expected metadata.
 func TestMembersList_Metadata(t *testing.T) {
 	if ImChatMembersList.Command != "+chat-members-list" {

--- a/shortcuts/im/im_chat_members_list_test.go
+++ b/shortcuts/im/im_chat_members_list_test.go
@@ -6,10 +6,12 @@ package im
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 	"github.com/spf13/cobra"
 )
@@ -51,6 +53,23 @@ func TestNormalizeMemberTypes(t *testing.T) {
 			if c.wantErr {
 				if err == nil {
 					t.Fatalf("want error, got nil (got=%v)", got)
+				}
+				p, ok := errs.ProblemOf(err)
+				if !ok {
+					t.Fatalf("ProblemOf: expected typed Problem, got: %v", err)
+				}
+				if p.Category != errs.CategoryValidation {
+					t.Errorf("Category = %v, want %v", p.Category, errs.CategoryValidation)
+				}
+				if p.Subtype != errs.SubtypeInvalidArgument {
+					t.Errorf("Subtype = %v, want %v", p.Subtype, errs.SubtypeInvalidArgument)
+				}
+				var ve *errs.ValidationError
+				if !errors.As(err, &ve) {
+					t.Fatalf("errors.As(*ValidationError) = false")
+				}
+				if ve.Param != "--member-types" {
+					t.Errorf("Param = %q, want %q", ve.Param, "--member-types")
 				}
 				return
 			}
@@ -108,13 +127,22 @@ func TestMembersList_Validate(t *testing.T) {
 		stringFlags map[string]string
 		boolFlags   map[string]bool
 		wantErr     bool
+		wantParam   string
 	}{
-		{"ok", map[string]string{"page-size": "20"}, nil, false},
-		{"page-size-low", map[string]string{"page-size": "0"}, nil, true},
-		{"page-size-high", map[string]string{"page-size": "101"}, nil, true},
-		{"bad-member-type", map[string]string{"member-types": "group"}, nil, true},
-		{"page-limit-bad", map[string]string{"page-limit": "0"}, map[string]bool{"page-all": true}, true},
-		{"bad-chat-id", map[string]string{"chat-id": "bad"}, nil, true},
+		{"ok", map[string]string{"page-size": "20"}, nil, false, ""},
+		{"page-size-low", map[string]string{"page-size": "0"}, nil, true, "--page-size"},
+		{"page-size-high", map[string]string{"page-size": "101"}, nil, true, "--page-size"},
+		{"bad-member-type", map[string]string{"member-types": "group"}, nil, true, "--member-types"},
+		{"page-limit-bad", map[string]string{"page-limit": "0"}, map[string]bool{"page-all": true}, true, "--page-limit"},
+		{"bad-chat-id", map[string]string{"chat-id": "bad"}, nil, true, "--chat-id"},
+		// Fix #2: --page-all and --page-token are mutually exclusive
+		{"page-all+page-token", map[string]string{"page-token": "tok_x"}, map[string]bool{"page-all": true}, true, "--page-token"},
+		// Fix #4: unsupported output formats
+		{"format-csv", map[string]string{"format": "csv"}, nil, true, "--format"},
+		{"format-table", map[string]string{"format": "table"}, nil, true, "--format"},
+		{"format-ndjson", map[string]string{"format": "ndjson"}, nil, true, "--format"},
+		{"format-json", map[string]string{"format": "json"}, nil, false, ""},
+		{"format-pretty", map[string]string{"format": "pretty"}, nil, false, ""},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -129,6 +157,27 @@ func TestMembersList_Validate(t *testing.T) {
 			}
 			if !c.wantErr && err != nil {
 				t.Fatalf("unexpected err: %v", err)
+			}
+			if c.wantErr {
+				p, ok := errs.ProblemOf(err)
+				if !ok {
+					t.Fatalf("ProblemOf: expected typed Problem, got: %v", err)
+				}
+				if p.Category != errs.CategoryValidation {
+					t.Errorf("Category = %v, want %v", p.Category, errs.CategoryValidation)
+				}
+				if p.Subtype != errs.SubtypeInvalidArgument {
+					t.Errorf("Subtype = %v, want %v", p.Subtype, errs.SubtypeInvalidArgument)
+				}
+				if c.wantParam != "" {
+					var ve *errs.ValidationError
+					if !errors.As(err, &ve) {
+						t.Fatalf("errors.As(*ValidationError) = false")
+					}
+					if ve.Param != c.wantParam {
+						t.Errorf("Param = %q, want %q", ve.Param, c.wantParam)
+					}
+				}
 			}
 		})
 	}

--- a/shortcuts/im/shortcuts.go
+++ b/shortcuts/im/shortcuts.go
@@ -10,6 +10,7 @@ func Shortcuts() []common.Shortcut {
 	return []common.Shortcut{
 		ImChatCreate,
 		ImChatList,
+		ImChatMembersList,
 		ImChatMessageList,
 		ImChatSearch,
 		ImChatUpdate,

--- a/skills/lark-im/SKILL.md
+++ b/skills/lark-im/SKILL.md
@@ -102,6 +102,7 @@ Shortcut 是对常用操作的高级封装（`lark-cli im +<verb> [flags]`）。
 |----------|------|
 | [`+chat-create`](references/lark-im-chat-create.md) | Create a group chat or topic chat; user/bot; --chat-mode group|topic; private/public; invites users/bots; optionally sets bot manager |
 | [`+chat-list`](references/lark-im-chat-list.md) | List chats the current user/bot is a member of; defaults to groups; pass --types=p2p,group to include p2p single chats (user-only); user/bot; supports sorting, pagination, --exclude-muted (user-only) |
+| [`+chat-members-list`](references/lark-im-chat-members-list.md) | List all members (users and bots) of a group chat in one call; user/bot; returns users[]/bots[] buckets with totals; supports --member-types filter, --member-id-type, pagination and --page-all |
 | [`+chat-messages-list`](references/lark-im-chat-messages-list.md) | List messages in a chat or P2P conversation; user/bot; accepts --chat-id or --user-id, resolves P2P chat_id, supports time range/sort/pagination |
 | [`+chat-search`](references/lark-im-chat-search.md) | Search visible group chats by --query keyword and/or --member-ids; user/bot; e.g. look up chat_id by group name; supports type filters, sorting, pagination, and --exclude-muted (user identity only) |
 | [`+chat-update`](references/lark-im-chat-update.md) | Update group chat name or description; user/bot; updates a chat's name or description |

--- a/skills/lark-im/references/lark-im-chat-members-list.md
+++ b/skills/lark-im/references/lark-im-chat-members-list.md
@@ -43,6 +43,23 @@ lark-cli im +chat-members-list --chat-id oc_xxx --dry-run
 lark-cli im +chat-members-list --chat-id oc_xxx --as bot
 ```
 
+## When to use (recipes)
+
+You only have a group **name**, not a `chat_id`? Resolve it first, then list members:
+
+```bash
+# Step 1: name -> chat_id (one identity is enough; don't re-search with the other)
+lark-cli im +chat-search --query "<group name>" --format json   # read chat_id from results
+# Step 2: list members
+lark-cli im +chat-members-list --chat-id <chat_id>
+```
+
+- **"List all members, including bots"** → call `+chat-members-list` with **no** `--member-types`. One call returns both `users[]` and `bots[]`. Do not also call `--member-types user` or `--member-types bot` separately, and do not re-run with a different `--member-id-type` to "fill in" extra IDs.
+- **"Which bots are in the group?"** → add `--member-types bot`. **"Which users?"** → `--member-types user`. Filtering is what isolates one type; don't post-filter a full result by hand. **Answer from the filtered result.** Once `--member-types bot` returns (`users[]` will be empty, only `bots[]` is populated), that *is* the answer — do **not** follow it with an unfiltered `+chat-members-list` call "to be complete". A second, unfiltered query defeats the filter and over-exposes the very members the user did not ask about.
+- **This shortcut replaces the `im chat.members get` / `im chat.members bots` Meta APIs.** It already returns both buckets in one call — do **not** fall back to those raw Meta APIs, and do not cross-check this shortcut's output against them.
+
+> **CAUTION — don't over-fetch.** Once a single `+chat-members-list` call returns, you have the complete answer for that page set. Resist re-querying with `--member-id-type user_id` "just in case": `user_id` requires the extra `contact:user.employee_id:readonly` scope and will error if it is not granted. For plain member listing, the default `open_id` is sufficient — only use `user_id` when the user explicitly needs employee IDs.
+
 ## Parameters
 
 | Parameter | Required | Limits | Description |

--- a/skills/lark-im/references/lark-im-chat-members-list.md
+++ b/skills/lark-im/references/lark-im-chat-members-list.md
@@ -68,7 +68,6 @@ The output is split into two buckets regardless of which types are present. Empt
   "data": {
     "users": [
       {
-        "member_id_type": "open_id",
         "member_id": "ou_xxx",
         "name": "Alice",
         "tenant_key": "736588c9xxx"
@@ -76,7 +75,6 @@ The output is split into two buckets regardless of which types are present. Empt
     ],
     "bots": [
       {
-        "member_id_type": "open_id",
         "member_id": "ou_yyy",
         "name": "MyBot",
         "app_id": "cli_zzz",

--- a/skills/lark-im/references/lark-im-chat-members-list.md
+++ b/skills/lark-im/references/lark-im-chat-members-list.md
@@ -1,0 +1,127 @@
+# im +chat-members-list
+
+> **Prerequisite:** Read [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) first to understand authentication, global parameters, and safety rules.
+
+List all members (users and bots) of a group chat in **one call**, returning results split into `users[]` and `bots[]` buckets with totals. Both user and bot identity are supported — the caller must be a member of the target chat.
+
+This skill maps to the shortcut: `lark-cli im +chat-members-list` (internally calls `GET /open-apis/im/v1/chats/{chat_id}/members/list`).
+
+## Commands
+
+```bash
+# List all members (users + bots) of a chat
+lark-cli im +chat-members-list --chat-id oc_xxx
+
+# List only bot members
+lark-cli im +chat-members-list --chat-id oc_xxx --member-types bot
+
+# List only user members
+lark-cli im +chat-members-list --chat-id oc_xxx --member-types user
+
+# Use union_id for member IDs in the response
+lark-cli im +chat-members-list --chat-id oc_xxx --member-id-type union_id
+
+# Control page size
+lark-cli im +chat-members-list --chat-id oc_xxx --page-size 50
+
+# Paginate to the next page
+lark-cli im +chat-members-list --chat-id oc_xxx --page-token "xxx"
+
+# Automatically paginate through all pages (accumulates users[] + bots[])
+lark-cli im +chat-members-list --chat-id oc_xxx --page-all
+
+# Limit max pages when using --page-all (default 20, max 1000)
+lark-cli im +chat-members-list --chat-id oc_xxx --page-all --page-limit 5
+
+# JSON output
+lark-cli im +chat-members-list --chat-id oc_xxx --format json
+
+# Preview the request without executing it
+lark-cli im +chat-members-list --chat-id oc_xxx --dry-run
+
+# Use bot identity
+lark-cli im +chat-members-list --chat-id oc_xxx --as bot
+```
+
+## Parameters
+
+| Parameter | Required | Limits | Description |
+|------|------|------|------|
+| `--chat-id <id>` | **Yes** | `oc_xxx` format | Group chat ID to query |
+| `--member-types <strings>` | No | `user`, `bot` (repeatable) | Filter by member type. Omitted = both user and bot returned |
+| `--member-id-type <type>` | No | `open_id` (default), `union_id`, `user_id` | ID type used for `member_id` in the response |
+| `--page-size <n>` | No | 1-100, default 20 | Number of members per page |
+| `--page-token <token>` | No | - | Pagination token from the previous response |
+| `--page-all` | No | - | Auto-paginate through all pages, accumulating `users[]` + `bots[]` |
+| `--page-limit <n>` | No | 1-1000, default 20 | Max pages when `--page-all` is enabled |
+| `--format json` | No | - | Output as JSON |
+| `--dry-run` | No | - | Preview the request without executing it |
+
+> **Note:** Supports both `--as user` (default) and `--as bot`. The caller must be a member of the target chat regardless of identity.
+
+## Output
+
+The output is split into two buckets regardless of which types are present. Empty buckets are always rendered as `[]` for stable downstream parsing.
+
+```json
+{
+  "data": {
+    "users": [
+      {
+        "member_id_type": "open_id",
+        "member_id": "ou_xxx",
+        "name": "Alice",
+        "tenant_key": "736588c9xxx"
+      }
+    ],
+    "bots": [
+      {
+        "member_id_type": "open_id",
+        "member_id": "ou_yyy",
+        "name": "MyBot",
+        "app_id": "cli_zzz",
+        "tenant_key": "736588c9xxx"
+      }
+    ],
+    "user_total": 5,
+    "bot_total": 1,
+    "has_more": false,
+    "page_token": "",
+    "truncations": []
+  }
+}
+```
+
+To get a flat list of all members (users and bots combined):
+
+```bash
+lark-cli im +chat-members-list --chat-id oc_xxx --format json | jq '.data.users + .data.bots'
+```
+
+To extract all member IDs:
+
+```bash
+lark-cli im +chat-members-list --chat-id oc_xxx --page-all --format json | \
+  jq '[(.data.users + .data.bots)[].member_id]'
+```
+
+## Notes
+
+- **`member_id_type=user_id` and cross-tenant members**: When `--member-id-type user_id` is used and the chat contains cross-tenant members (external members from another tenant), their `member_id` field may be omitted in the response. Use `open_id` (default) or `union_id` if you need a stable identifier for all members including external ones.
+
+- **`truncations` non-empty = server-side truncation**: If the response `truncations` array is non-empty, the server truncated that member type's bucket and not all members are returned. A warning is emitted to stderr for each truncated type. Use `--page-all` to accumulate across pages, or reduce `--page-size` if individual pages are hitting the truncation limit.
+
+- **Bot bucket is always complete**: The bots in a group chat are typically few in number and the server always returns the full bot list without truncation. Bot bucket truncation warnings are rare and indicate an unusually large number of bots.
+
+- **Caller must be in the chat**: Both user and bot identity require the caller to be a member of the target chat. If the caller is not a member, the API returns a permission error.
+
+## Common Errors
+
+| Symptom | Root Cause | Solution |
+|---------|---------|---------|
+| `--page-size must be an integer between 1 and 100` | page-size out of range | Use an integer between 1 and 100 |
+| `--page-limit must be an integer between 1 and 1000` | page-limit out of range (when using `--page-all`) | Use an integer between 1 and 1000 |
+| `--member-types contains invalid value "xxx"` | Unknown member type | Use `user` or `bot` only |
+| Permission denied (99991672) | Bot app lacks `im:chat.members:read` scope | Enable the permission in the Open Platform console |
+| Permission denied (99991679) with `--as user` | UAT not authorized for `im:chat.members:read` | Run `lark-cli auth login --scope "im:chat.members:read"` |
+| Caller not in chat (error 102021) | The caller (user or bot) is not a member of the target chat | Add the caller to the chat first, or use an identity that is already a member |

--- a/skills/lark-im/references/lark-im-chat-members-list.md
+++ b/skills/lark-im/references/lark-im-chat-members-list.md
@@ -122,6 +122,8 @@ lark-cli im +chat-members-list --chat-id oc_xxx --page-all --format json | \
 
 ## Notes
 
+- **Format and bucket completeness**: Only `--format json` and `--format pretty` render both `users[]` and `bots[]` buckets in full. `--format csv`, `--format table`, and `--format ndjson` use the generic flatten path which only renders the `users[]` bucket — `bots[]` will be silently dropped. Use `--format json` or `--format pretty` (the default) whenever bot member data is needed.
+
 - **`member_id_type=user_id` and cross-tenant members**: When `--member-id-type user_id` is used and the chat contains cross-tenant members (external members from another tenant), their `member_id` field may be omitted in the response. Use `open_id` (default) or `union_id` if you need a stable identifier for all members including external ones.
 
 - **`truncations` non-empty = server-side truncation**: If the response `truncations` array is non-empty, the server truncated that member type's bucket and not all members are returned. A warning is emitted to stderr for each truncated type. Use `--page-all` to accumulate across pages, or reduce `--page-size` if individual pages are hitting the truncation limit.

--- a/skills/lark-im/references/lark-im-chat-members-list.md
+++ b/skills/lark-im/references/lark-im-chat-members-list.md
@@ -122,13 +122,13 @@ lark-cli im +chat-members-list --chat-id oc_xxx --page-all --format json | \
 
 ## Notes
 
-- **Format and bucket completeness**: Only `--format json` and `--format pretty` render both `users[]` and `bots[]` buckets in full. `--format csv`, `--format table`, and `--format ndjson` use the generic flatten path which only renders the `users[]` bucket — `bots[]` will be silently dropped. Use `--format json` or `--format pretty` (the default) whenever bot member data is needed.
+- **Format**: Only `--format json` and `--format pretty` are supported. `--format csv`, `--format table`, and `--format ndjson` are rejected at validation time with a validation error because the generic flatten path would silently drop the `bots[]` bucket. Use `--format json` or `--format pretty` (the default).
 
 - **`member_id_type=user_id` and cross-tenant members**: When `--member-id-type user_id` is used and the chat contains cross-tenant members (external members from another tenant), their `member_id` field may be omitted in the response. Use `open_id` (default) or `union_id` if you need a stable identifier for all members including external ones.
 
 - **`truncations` non-empty = server-side truncation**: If the response `truncations` array is non-empty, the server truncated that member type's bucket and not all members are returned. A warning is emitted to stderr for each truncated type. Use `--page-all` to accumulate across pages, or reduce `--page-size` if individual pages are hitting the truncation limit.
 
-- **Bot bucket is always complete**: The bots in a group chat are typically few in number and the server always returns the full bot list without truncation. Bot bucket truncation warnings are rare and indicate an unusually large number of bots.
+- **Bot bucket is typically complete**: The bots in a group chat are typically few in number and the server is expected to return the full bot list without truncation. Bot bucket truncation warnings are rare and indicate an unusually large number of bots.
 
 - **Caller must be in the chat**: Both user and bot identity require the caller to be a member of the target chat. If the caller is not a member, the API returns a permission error.
 


### PR DESCRIPTION
## Summary

Listing a group chat's members previously required two separate Meta API calls (`im chat.members get` for users and `im chat.members bots` for bots). The new `GET /open-apis/im/v1/chats/{chat_id}/members/list` endpoint returns both in one response. This PR adds the `im +chat-members-list` shortcut that wraps it, returning users and bots together with one command.

## Changes

- Add `im +chat-members-list` shortcut in `shortcuts/im/im_chat_members_list.go`: dual-bucket `users[]` / `bots[]` output, `--member-types` filter, `--member-id-type`, single-page and `--page-all` pagination, server-truncation surfacing, and `--chat-id` path validation + escaping
- Register the shortcut in `shortcuts/im/shortcuts.go`
- Add unit tests in `shortcuts/im/im_chat_members_list_test.go`
- Add skill reference `skills/lark-im/references/lark-im-chat-members-list.md` and a row in `skills/lark-im/SKILL.md`

## Test Plan

- [x] `make unit-test` passed
- [x] validate passed (build / vet / unit / integration)
- [x] local-eval E2E passed (5/5); skillave 4/5 (the one miss is eval-agent nondeterminism, not a CLI defect — correctness is covered by E2E + acceptance)
- [x] acceptance-reviewer passed (10/10 scenarios)
- [x] manual verification: `lark-cli im +chat-members-list --chat-id <oc_id> --dry-run` (path escaping confirmed) and live dual-bucket listing with `--member-types` / `--member-id-type` / `--page-all`

## Related Issues

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `+chat-members-list` shortcut to list group chat members, returning stable `users` and `bots` buckets with optional totals, pagination (`--page-all`/`--page-limit`/tokens), and member-type filtering; emits truncation warnings when present.
* **Documentation**
  * Updated the Lark IM skill shortcuts table and added full reference docs for `+chat-members-list`, including usage, output contract, and examples.
* **Tests**
  * Added a comprehensive test suite covering parameter validation, dry-run request/path encoding, paging accumulation/limits, truncation handling, and pretty/table output ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->