### PR TITLE
feat(base): add workflow enable-all-disabled shortcut

### DIFF
--- a/shortcuts/base/base_shortcuts_test.go
+++ b/shortcuts/base/base_shortcuts_test.go
@@ -164,7 +164,7 @@ func TestShortcutsCatalog(t *testing.T) {
 		"+record-history-list",
 		"+base-get", "+base-copy", "+base-create",
 		"+role-create", "+role-delete", "+role-update", "+role-list", "+role-get", "+advperm-enable", "+advperm-disable",
-		"+workflow-list", "+workflow-get", "+workflow-create", "+workflow-update", "+workflow-enable", "+workflow-disable",
+		"+workflow-list", "+workflow-get", "+workflow-create", "+workflow-update", "+workflow-enable", "+workflow-enable-all-disabled", "+workflow-disable",
 		"+data-query",
 		"+form-create", "+form-delete", "+form-list", "+form-update", "+form-get", "+form-detail",
 		"+form-questions-create", "+form-questions-delete", "+form-questions-update", "+form-questions-list",
@@ -644,6 +644,15 @@ func TestBaseWorkflowHelpGuidesAgents(t *testing.T) {
 				"workflow-id must start with wkf",
 				"does not modify steps",
 				"New workflows are created disabled",
+			},
+		},
+		{
+			name:     "workflow enable all disabled",
+			shortcut: BaseWorkflowEnableAllDisabled,
+			wantTips: []string{
+				"enable every disabled workflow",
+				"succeeded/failed/remaining_disabled summaries",
+				"do not switch to steps repair",
 			},
 		},
 		{

--- a/shortcuts/base/shortcuts.go
+++ b/shortcuts/base/shortcuts.go
@@ -70,6 +70,7 @@ func Shortcuts() []common.Shortcut {
 		BaseWorkflowCreate,
 		BaseWorkflowUpdate,
 		BaseWorkflowEnable,
+		BaseWorkflowEnableAllDisabled,
 		BaseWorkflowDisable,
 		BaseDataQuery,
 		BaseFormCreate,

--- a/shortcuts/base/workflow_enable_all_disabled.go
+++ b/shortcuts/base/workflow_enable_all_disabled.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"context"
+	"strings"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+var BaseWorkflowEnableAllDisabled = common.Shortcut{
+	Service:     "base",
+	Command:     "+workflow-enable-all-disabled",
+	Description: "Enable all currently disabled workflows in a base and summarize per-workflow failures",
+	Risk:        "write",
+	Scopes:      []string{"base:workflow:read", "base:workflow:update"},
+	AuthTypes:   []string{"user", "bot"},
+	Flags: []common.Flag{
+		{Name: "base-token", Desc: "base token", Required: true},
+		{Name: "page-size", Type: "int", Default: "100", Desc: "page size per list request, range 1-100"},
+	},
+	Tips: []string{
+		"Use this when the user asks to enable every disabled workflow in a Base.",
+		"The command lists disabled workflows, enables each one, continues after per-workflow API failures, and returns succeeded/failed/remaining_disabled summaries.",
+		"Per-workflow failures usually mean the platform rejected that workflow configuration; do not switch to steps repair unless the user explicitly asks to fix the workflow definition.",
+	},
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if strings.TrimSpace(runtime.Str("base-token")) == "" {
+			return baseFlagErrorf("--base-token must not be blank")
+		}
+		_, err := common.ValidatePageSizeTyped(runtime, "page-size", 100, 1, 100)
+		return err
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		return common.NewDryRunAPI().
+			POST("/open-apis/base/v3/bases/:base_token/workflows/list").
+			Body(map[string]interface{}{"page_size": runtime.Int("page-size"), "status": "disabled"}).
+			Set("base_token", runtime.Str("base-token")).
+			PATCH("/open-apis/base/v3/bases/:base_token/workflows/:workflow_id/enable").
+			Desc("For each disabled workflow_id returned by the list call. Per-item failures are collected and do not stop the batch.").
+			Set("workflow_id", "<workflow_id>")
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		disabled, err := listWorkflowsByStatus(runtime, runtime.Str("base-token"), "disabled", runtime.Int("page-size"))
+		if err != nil {
+			return err
+		}
+
+		succeeded := []interface{}{}
+		failed := []interface{}{}
+		for _, workflow := range disabled {
+			workflowID := strings.TrimSpace(common.GetString(workflow, "workflow_id"))
+			if workflowID == "" {
+				workflowID = strings.TrimSpace(common.GetString(workflow, "id"))
+			}
+			if workflowID == "" {
+				failed = append(failed, map[string]interface{}{
+					"workflow": workflow,
+					"error":    "missing workflow_id in list response",
+				})
+				continue
+			}
+			data, err := baseV3Call(runtime, "PATCH",
+				baseV3Path("bases", runtime.Str("base-token"), "workflows", workflowID, "enable"),
+				nil,
+				map[string]interface{}{},
+			)
+			if err != nil {
+				failed = append(failed, map[string]interface{}{
+					"workflow_id": workflowID,
+					"title":       common.GetString(workflow, "title"),
+					"error":       err.Error(),
+				})
+				continue
+			}
+			succeeded = append(succeeded, data)
+		}
+
+		remaining, err := listWorkflowsByStatus(runtime, runtime.Str("base-token"), "disabled", runtime.Int("page-size"))
+		if err != nil {
+			return err
+		}
+		runtime.Out(map[string]interface{}{
+			"summary": map[string]interface{}{
+				"initial_disabled":   len(disabled),
+				"enabled":            len(succeeded),
+				"failed":             len(failed),
+				"remaining_disabled": len(remaining),
+			},
+			"succeeded":          succeeded,
+			"failed":             failed,
+			"remaining_disabled": remaining,
+		}, nil)
+		return nil
+	},
+}
+
+func listWorkflowsByStatus(runtime *common.RuntimeContext, baseToken string, status string, pageSize int) ([]map[string]interface{}, error) {
+	allItems := []map[string]interface{}{}
+	pageToken := ""
+	for {
+		body := map[string]interface{}{
+			"page_size": pageSize,
+			"status":    status,
+		}
+		if pageToken != "" {
+			body["page_token"] = pageToken
+		}
+		data, err := baseV3Call(runtime, "POST", baseV3Path("bases", baseToken, "workflows", "list"), nil, body)
+		if err != nil {
+			return nil, err
+		}
+		if items, _ := data["items"].([]interface{}); len(items) > 0 {
+			for _, item := range items {
+				if obj, ok := item.(map[string]interface{}); ok {
+					allItems = append(allItems, obj)
+				}
+			}
+		}
+		hasMore, _ := data["has_more"].(bool)
+		if !hasMore {
+			break
+		}
+		nextToken, _ := data["page_token"].(string)
+		if nextToken == "" {
+			break
+		}
+		pageToken = nextToken
+	}
+	return allItems, nil
+}

--- a/shortcuts/base/workflow_execute_test.go
+++ b/shortcuts/base/workflow_execute_test.go
@@ -116,6 +116,63 @@ func TestBaseWorkflowExecuteDisable(t *testing.T) {
 	}
 }
 
+func TestBaseWorkflowExecuteEnableAllDisabledContinuesAfterItemFailure(t *testing.T) {
+	factory, stdout, reg := newExecuteFactory(t)
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/base/v3/bases/app_x/workflows/list",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"workflow_id": "wkf_ok", "title": "OK"},
+					map[string]interface{}{"workflow_id": "wkf_bad", "title": "Bad"},
+				},
+				"has_more": false,
+			},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/base/v3/bases/app_x/workflows/wkf_ok/enable",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{"workflow_id": "wkf_ok", "status": "enabled"},
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "PATCH",
+		URL:    "/open-apis/base/v3/bases/app_x/workflows/wkf_bad/enable",
+		Body: map[string]interface{}{
+			"code": 800004535,
+			"msg":  "compile workflow failed",
+		},
+	})
+	reg.Register(&httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/base/v3/bases/app_x/workflows/list",
+		Body: map[string]interface{}{
+			"code": 0,
+			"data": map[string]interface{}{
+				"items": []interface{}{
+					map[string]interface{}{"workflow_id": "wkf_bad", "title": "Bad"},
+				},
+				"has_more": false,
+			},
+		},
+	})
+
+	if err := runShortcut(t, BaseWorkflowEnableAllDisabled, []string{"+workflow-enable-all-disabled", "--base-token", "app_x"}, factory, stdout); err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	got := stdout.String()
+	for _, want := range []string{`"initial_disabled": 2`, `"enabled": 1`, `"failed": 1`, `"remaining_disabled": 1`, `"wkf_ok"`, `"wkf_bad"`} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestBaseWorkflowExecuteDisableValidate(t *testing.T) {
 	t.Run("missing base-token", func(t *testing.T) {
 		factory, stdout, _ := newExecuteFactory(t)

--- a/skills/lark-base/SKILL.md
+++ b/skills/lark-base/SKILL.md
@@ -65,7 +65,7 @@ metadata:
 | 表单题目创建/更新 | `+form-questions-create` / `+form-questions-update` | 读 [lark-base-form-questions-create.md](references/lark-base-form-questions-create.md) / [lark-base-form-questions-update.md](references/lark-base-form-questions-update.md) |
 | 其他表单管理 | `+form-list/get/detail/create/update/delete` / `+form-questions-list/delete` | `+form-detail` 读 [lark-base-form-detail.md](references/lark-base-form-detail.md)；删除前确认目标表单 |
 | 仪表盘与组件 | `+dashboard-*` / `+dashboard-block-*` | 提到图表/看板/block 时先读 [lark-base-dashboard.md](references/lark-base-dashboard.md)；组件 `data_config` 读 [dashboard-block-data-config.md](references/dashboard-block-data-config.md)；读取图表计算结果用 `+dashboard-block-get-data` |
-| Workflow | `+workflow-*` | 创建/更新或理解 steps 时读入口 [lark-base-workflow-guide.md](references/lark-base-workflow-guide.md) 和 steps JSON SSOT [lark-base-workflow-schema.md](references/lark-base-workflow-schema.md)；list/get/enable/disable 只处理 workflow ID 与启停状态 |
+| Workflow | `+workflow-*` | 启用所有禁用 workflow 用 `+workflow-enable-all-disabled`；创建/更新或理解 steps 时读入口 [lark-base-workflow-guide.md](references/lark-base-workflow-guide.md) 和 steps JSON SSOT [lark-base-workflow-schema.md](references/lark-base-workflow-schema.md)；list/get/enable/disable 只处理 workflow ID 与启停状态 |
 | 高级权限与角色 | `+advperm-*` / `+role-*` | 角色操作先读入口 [lark-base-role-guide.md](references/lark-base-role-guide.md)；角色 create/update 或解读完整配置再读权限 JSON SSOT [role-config.md](references/role-config.md)；系统角色不可删除；关闭高级权限会影响自定义角色 |
 
 ## Base 心智模型
@@ -123,7 +123,7 @@ metadata:
 ## Dashboard / Workflow / Role
 
 - Dashboard 的复杂点是 block 的 `data_config`，不是 list/get/create/delete 命令参数。创建或更新 block 前先读 [dashboard-block-data-config.md](references/dashboard-block-data-config.md)，组件必须串行创建；`+dashboard-arrange` 是服务端智能布局，只在用户明确要求重排/美化时执行。`+dashboard-block-get-data` 读取图表最终计算结果，不返回 block 名称、类型、布局或 `data_config`；需要元数据先用 `+dashboard-block-get`。
-- Workflow 的复杂点是 `steps` 结构。创建、更新或解释完整 workflow 时读入口 [lark-base-workflow-guide.md](references/lark-base-workflow-guide.md) 和 steps JSON SSOT [lark-base-workflow-schema.md](references/lark-base-workflow-schema.md)；enable/disable/list 只需确认 workflow ID、当前启停状态和用户意图。
+- Workflow 的复杂点是 `steps` 结构。用户要求启用全部未启用工作流时，直接用 `+workflow-enable-all-disabled --base-token <base_token> --as user --json`；它会批量启用并返回 succeeded / failed / remaining_disabled，单个 workflow 因平台编译失败时不要转入 steps 修复探索。创建、更新或解释完整 workflow 时读入口 [lark-base-workflow-guide.md](references/lark-base-workflow-guide.md) 和 steps JSON SSOT [lark-base-workflow-schema.md](references/lark-base-workflow-schema.md)；单个 enable/disable/list 只需确认 workflow ID、当前启停状态和用户意图。
 - Role 的复杂点是权限 JSON。角色操作先读入口 [lark-base-role-guide.md](references/lark-base-role-guide.md)；`+role-create` 只支持自定义角色；`+role-update` 是 delta merge；角色 create/update 或解读完整配置时读权限 JSON SSOT [role-config.md](references/role-config.md)。`+role-delete` 只适用于自定义角色，系统角色不可删除；删除角色和关闭高级权限前必须确认目标和影响。
 
 ## 常见恢复

--- a/tests/cli_e2e/base/base_workflow_enable_all_disabled_dryrun_test.go
+++ b/tests/cli_e2e/base/base_workflow_enable_all_disabled_dryrun_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package base
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clie2e "github.com/larksuite/cli/tests/cli_e2e"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestBaseWorkflowEnableAllDisabledDryRun(t *testing.T) {
+	setBaseDryRunConfigEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"base", "+workflow-enable-all-disabled",
+			"--base-token", "app_x",
+			"--page-size", "50",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+
+	out := result.Stdout
+	require.Equal(t, "POST", gjson.Get(out, "api.0.method").String(), out)
+	require.Equal(t, "/open-apis/base/v3/bases/app_x/workflows/list", gjson.Get(out, "api.0.url").String(), out)
+	require.Equal(t, int64(50), gjson.Get(out, "api.0.body.page_size").Int(), out)
+	require.Equal(t, "disabled", gjson.Get(out, "api.0.body.status").String(), out)
+	require.Equal(t, "PATCH", gjson.Get(out, "api.1.method").String(), out)
+	require.Equal(t, "/open-apis/base/v3/bases/app_x/workflows/%3Cworkflow_id%3E/enable", gjson.Get(out, "api.1.url").String(), out)
+}


### PR DESCRIPTION
## Summary
Add a Base workflow shortcut that enables every currently disabled workflow and reports per-workflow results.

## Changes
- Register `+workflow-enable-all-disabled` in the Base shortcut catalog.
- Implement disabled workflow listing, batch enable attempts, per-item failure collection, and remaining disabled summary output.
- Add unit and dry-run E2E coverage for the new workflow shortcut.
- Update the lark-base skill guidance to direct agents to the new batch-enable shortcut.

## Test Plan
- `git diff --check`

## Related Issues
Auto research task: 01KW59XW4VYEGQSJS7A0ZX6X0F


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new shortcut to enable all currently disabled workflows in one batch.
  * The command now reports counts for succeeded, failed, and remaining disabled workflows, along with per-workflow results.

* **Bug Fixes**
  * Batch execution continues even if one workflow fails to enable, so other workflows can still be processed.

* **Documentation**
  * Updated workflow guidance to include the new shortcut and how to interpret its output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->