### PR TITLE
feat(transport): add LARK_CLI_NO_PROXY_WARN to silence proxy warning

### DIFF
--- a/internal/transport/warn.go
+++ b/internal/transport/warn.go
@@ -16,6 +16,14 @@ import (
 const (
 	// EnvNoProxy disables automatic proxy support when set to any non-empty value.
 	EnvNoProxy = "LARK_CLI_NO_PROXY"
+
+	// EnvNoProxyWarn suppresses the proxy-detected warning when set to any
+	// non-empty value, while leaving proxy behavior unchanged. Unlike
+	// EnvNoProxy (which both silences the warning AND disables the proxy), this
+	// keeps proxy egress active. It exists so agents consuming --format json can
+	// keep using the proxy without the human-oriented warning line landing in
+	// the output stream and breaking JSON parsing.
+	EnvNoProxyWarn = "LARK_CLI_NO_PROXY_WARN"
 )
 
 // proxyEnvKeys lists environment variables that Go's ProxyFromEnvironment reads.
@@ -73,6 +81,11 @@ func redactProxyURL(raw string) string {
 // are redacted. Safe to call multiple times; only the first call prints.
 func WarnIfProxied(w io.Writer) {
 	proxyWarningOnce.Do(func() {
+		// Explicit opt-out: silence the warning without touching proxy behavior.
+		// Checked before the plugin and env-proxy branches so it suppresses both.
+		if os.Getenv(EnvNoProxyWarn) != "" {
+			return
+		}
 		// Proxy plugin mode overrides env proxies and LARK_CLI_NO_PROXY (see
 		// Shared), so its warning and disable instructions take precedence.
 		// Emitting the env-proxy warning here would be misleading: it tells the
@@ -88,7 +101,7 @@ func WarnIfProxied(w io.Writer) {
 		if key == "" {
 			return
 		}
-		fmt.Fprintf(w, "[lark-cli] [WARN] proxy detected: %s=%s — requests (including credentials) will transit through this proxy. Set %s=1 to disable proxy.\n",
-			key, redactProxyURL(val), EnvNoProxy)
+		fmt.Fprintf(w, "[lark-cli] [WARN] proxy detected: %s=%s — requests (including credentials) will transit through this proxy. Set %s=1 to disable proxy, or %s=1 to keep the proxy and silence this warning.\n",
+			key, redactProxyURL(val), EnvNoProxy, EnvNoProxyWarn)
 	})
 }

--- a/internal/transport/warn_test.go
+++ b/internal/transport/warn_test.go
@@ -93,6 +93,47 @@ func TestWarnIfProxied_SilentWhenDisabled(t *testing.T) {
 	}
 }
 
+// TestWarnIfProxied_SilentWhenWarnOptOut verifies that LARK_CLI_NO_PROXY_WARN
+// suppresses the warning while the proxy stays configured (unlike
+// LARK_CLI_NO_PROXY, which also disables the proxy).
+func TestWarnIfProxied_SilentWhenWarnOptOut(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	unsetProxyPluginEnv(t)
+	resetProxyPluginState()
+	proxyWarningOnce = sync.Once{}
+
+	t.Setenv("HTTPS_PROXY", "http://proxy:8080")
+	t.Setenv(EnvNoProxyWarn, "1")
+
+	var buf bytes.Buffer
+	WarnIfProxied(&buf)
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no warning when %s is set, got: %s", EnvNoProxyWarn, buf.String())
+	}
+}
+
+// TestWarnIfProxied_WarnOptOutSuppressesPluginWarning verifies that
+// LARK_CLI_NO_PROXY_WARN also suppresses the proxy-plugin warning.
+func TestWarnIfProxied_WarnOptOutSuppressesPluginWarning(t *testing.T) {
+	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())
+	unsetProxyPluginEnv(t)
+	proxyWarningOnce = sync.Once{}
+
+	old := proxyPluginStatus
+	proxyPluginStatus = func() (string, string, bool) { return "http://127.0.0.1:3128", "", true }
+	t.Cleanup(func() { proxyPluginStatus = old })
+
+	t.Setenv(EnvNoProxyWarn, "1")
+
+	var buf bytes.Buffer
+	WarnIfProxied(&buf)
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no plugin warning when %s is set, got: %s", EnvNoProxyWarn, buf.String())
+	}
+}
+
 // TestWarnIfProxied_OnlyOnce verifies that proxy warnings are emitted only once.
 func TestWarnIfProxied_OnlyOnce(t *testing.T) {
 	t.Setenv("LARKSUITE_CLI_CONFIG_DIR", t.TempDir())


### PR DESCRIPTION
## Background

The `[lark-cli] [WARN] proxy detected: ...` line is a human-oriented warning written to stderr, and only when stderr is a terminal. But agents typically run the CLI inside a PTY and merge stderr into stdout, so the warning ends up in the `--format json` output stream and downstream consumers (models/scripts) fail to parse it as JSON.

The only existing way to silence it, `LARK_CLI_NO_PROXY=1`, also disables the proxy — not acceptable when the proxy is the required egress path.

## Change

Add `LARK_CLI_NO_PROXY_WARN`: set to any non-empty value to silence the warning while leaving proxy behavior unchanged.

| Env var | Behavior |
| --- | --- |
| `LARK_CLI_NO_PROXY_WARN=1` | Keep the proxy, only silence the warning |
| `LARK_CLI_NO_PROXY=1` | Existing behavior: disable the proxy (no warning as a side effect) |

- `internal/transport/warn.go`: add the `EnvNoProxyWarn` constant; short-circuit at the top of `WarnIfProxied`, covering both the env-proxy and proxy-plugin warnings; the warning message now advertises this option.
- `internal/transport/warn_test.go`: add two tests — the warning is silenced while the proxy stays configured, and the plugin-mode warning is silenced too.

## Verification

- `go build ./...`
- `go test ./internal/transport/ ./internal/cmdutil/`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new environment option to silence proxy-detected warnings while keeping proxy usage enabled.
  * Updated the warning message to clearly explain both available proxy-related options.

* **Bug Fixes**
  * Prevented proxy warnings from appearing when the new opt-out setting is enabled.
  * Kept proxy credentials hidden when proxy details are shown.

* **Tests**
  * Added coverage for the new warning-suppression behavior in both standard and proxy-plugin scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->