### PR TITLE
feat(sheets): add +history-list / +history-revert / +history-revert-status shortcuts

### DIFF
--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -1702,8 +1702,8 @@
         "kind": "own",
         "type": "int",
         "required": "optional",
-        "desc": "Safety cap; default 200000",
-        "default": "200000",
+        "desc": "Safety cap; default 50000",
+        "default": "50000",
         "hidden": true
       },
       {
@@ -4841,6 +4841,13 @@
         "type": "string",
         "required": "xor",
         "desc": "Spreadsheet locator"
+      },
+      {
+        "name": "end-version",
+        "kind": "own",
+        "type": "int",
+        "required": "optional",
+        "desc": "Max version to query (descending pagination). Omit on the first call; pass next_end_version from the previous response."
       },
       {
         "name": "dry-run",

--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -1702,8 +1702,8 @@
         "kind": "own",
         "type": "int",
         "required": "optional",
-        "desc": "Safety cap; default 50000",
-        "default": "50000",
+        "desc": "Safety cap; default 200000",
+        "default": "200000",
         "hidden": true
       },
       {
@@ -4879,7 +4879,7 @@
         "name": "history-version-id",
         "kind": "own",
         "type": "string",
-        "required": "optional",
+        "required": "required",
         "desc": "History version to revert to (from +history-list)."
       },
       {

--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -4824,5 +4824,97 @@
         "desc": ""
       }
     ]
+  },
+  "+history-list": {
+    "risk": "read",
+    "flags": [
+      {
+        "name": "url",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet locator"
+      },
+      {
+        "name": "spreadsheet-token",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet locator"
+      },
+      {
+        "name": "dry-run",
+        "kind": "system",
+        "type": "bool",
+        "required": "optional",
+        "desc": ""
+      }
+    ]
+  },
+  "+history-revert": {
+    "risk": "write",
+    "flags": [
+      {
+        "name": "url",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet locator"
+      },
+      {
+        "name": "spreadsheet-token",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet locator"
+      },
+      {
+        "name": "history-version-id",
+        "kind": "own",
+        "type": "string",
+        "required": "required",
+        "desc": "History version to revert to (from +history-list)."
+      },
+      {
+        "name": "dry-run",
+        "kind": "system",
+        "type": "bool",
+        "required": "optional",
+        "desc": ""
+      }
+    ]
+  },
+  "+history-revert-status": {
+    "risk": "read",
+    "flags": [
+      {
+        "name": "url",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet locator"
+      },
+      {
+        "name": "spreadsheet-token",
+        "kind": "public",
+        "type": "string",
+        "required": "xor",
+        "desc": "Spreadsheet locator"
+      },
+      {
+        "name": "history-version-id",
+        "kind": "own",
+        "type": "string",
+        "required": "required",
+        "desc": "History version whose revert status to query (from +history-list)."
+      },
+      {
+        "name": "dry-run",
+        "kind": "system",
+        "type": "bool",
+        "required": "optional",
+        "desc": ""
+      }
+    ]
   }
 }

--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -4872,7 +4872,7 @@
         "name": "history-version-id",
         "kind": "own",
         "type": "string",
-        "required": "required",
+        "required": "optional",
         "desc": "History version to revert to (from +history-list)."
       },
       {
@@ -4902,11 +4902,11 @@
         "desc": "Spreadsheet locator"
       },
       {
-        "name": "history-version-id",
+        "name": "transaction-id",
         "kind": "own",
         "type": "string",
-        "required": "required",
-        "desc": "History version whose revert status to query (from +history-list)."
+        "required": "optional",
+        "desc": "Async revert transaction id (from +history-revert)."
       },
       {
         "name": "dry-run",

--- a/shortcuts/sheets/data/flag-defs.json
+++ b/shortcuts/sheets/data/flag-defs.json
@@ -4912,7 +4912,7 @@
         "name": "transaction-id",
         "kind": "own",
         "type": "string",
-        "required": "optional",
+        "required": "required",
         "desc": "Async revert transaction id (from +history-revert)."
       },
       {

--- a/shortcuts/sheets/flag_defs_gen.go
+++ b/shortcuts/sheets/flag_defs_gen.go
@@ -669,7 +669,7 @@ var flagDefs = map[string]commandDef{
 		Flags: []flagDef{
 			{Name: "url", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
 			{Name: "spreadsheet-token", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
-			{Name: "transaction-id", Kind: "own", Type: "string", Required: "optional", Desc: "Async revert transaction id (from +history-revert)."},
+			{Name: "transaction-id", Kind: "own", Type: "string", Required: "required", Desc: "Async revert transaction id (from +history-revert)."},
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
 		},
 	},

--- a/shortcuts/sheets/flag_defs_gen.go
+++ b/shortcuts/sheets/flag_defs_gen.go
@@ -646,6 +646,32 @@ var flagDefs = map[string]commandDef{
 			{Name: "exit-on-error", Kind: "own", Type: "bool", Required: "optional", Desc: "When status=errors_found, exit non-zero. Useful for CI gate after batch formula writes."},
 		},
 	},
+	"+history-list": {
+		Risk: "read",
+		Flags: []flagDef{
+			{Name: "url", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
+			{Name: "spreadsheet-token", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
+			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
+		},
+	},
+	"+history-revert": {
+		Risk: "write",
+		Flags: []flagDef{
+			{Name: "url", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
+			{Name: "spreadsheet-token", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
+			{Name: "history-version-id", Kind: "own", Type: "string", Required: "required", Desc: "History version to revert to (from +history-list)."},
+			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
+		},
+	},
+	"+history-revert-status": {
+		Risk: "read",
+		Flags: []flagDef{
+			{Name: "url", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
+			{Name: "spreadsheet-token", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
+			{Name: "history-version-id", Kind: "own", Type: "string", Required: "required", Desc: "History version whose revert status to query (from +history-list)."},
+			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
+		},
+	},
 	"+pivot-create": {
 		Risk: "write",
 		Flags: []flagDef{

--- a/shortcuts/sheets/flag_defs_gen.go
+++ b/shortcuts/sheets/flag_defs_gen.go
@@ -138,7 +138,7 @@ var flagDefs = map[string]commandDef{
 			{Name: "range", Kind: "own", Type: "string", Required: "required", Desc: "Write range (A1 notation)"},
 			{Name: "cells", Kind: "own", Type: "string", Required: "required", Desc: "JSON 2D array `[[{cell},...],...]`, dimensions must match `--range`; each cell may carry `value` / `formula` / `cell_styles` / `note` / `rich_text` (incl. `type=\"embed-image\"` in-cell image); run `--print-schema` for full fields", Input: []string{"file", "stdin"}},
 			{Name: "allow-overwrite", Kind: "own", Type: "bool", Required: "optional", Desc: "Allow overwriting non-empty cells (default true); set false to error if any target cell is non-empty", Default: "true"},
-			{Name: "max-cells", Kind: "own", Type: "int", Required: "optional", Desc: "Safety cap; default 200000", Default: "200000", Hidden: true},
+			{Name: "max-cells", Kind: "own", Type: "int", Required: "optional", Desc: "Safety cap; default 50000", Default: "50000", Hidden: true},
 			{Name: "copy-to-range", Kind: "own", Type: "string", Required: "optional", Desc: "Copy-to range (A1 notation): replicate what --cells wrote into --range (values/formulas/styles, per the fields actually passed) to this range; formula refs auto-shift (C2=B2 -> C3=B3). Write a one-row/one-block template then fill a whole column/area. Supports full rows '3:6', full columns 'C:E', to-col-end 'D3:D', to-row-end 'D3:3', and comma-separated multiple targets like 'C1:D2,E5:F6'."},
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
 		},
@@ -651,6 +651,7 @@ var flagDefs = map[string]commandDef{
 		Flags: []flagDef{
 			{Name: "url", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
 			{Name: "spreadsheet-token", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
+			{Name: "end-version", Kind: "own", Type: "int", Required: "optional", Desc: "Max version to query (descending pagination). Omit on the first call; pass next_end_version from the previous response."},
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
 		},
 	},

--- a/shortcuts/sheets/flag_defs_gen.go
+++ b/shortcuts/sheets/flag_defs_gen.go
@@ -138,7 +138,7 @@ var flagDefs = map[string]commandDef{
 			{Name: "range", Kind: "own", Type: "string", Required: "required", Desc: "Write range (A1 notation)"},
 			{Name: "cells", Kind: "own", Type: "string", Required: "required", Desc: "JSON 2D array `[[{cell},...],...]`, dimensions must match `--range`; each cell may carry `value` / `formula` / `cell_styles` / `note` / `rich_text` (incl. `type=\"embed-image\"` in-cell image); run `--print-schema` for full fields", Input: []string{"file", "stdin"}},
 			{Name: "allow-overwrite", Kind: "own", Type: "bool", Required: "optional", Desc: "Allow overwriting non-empty cells (default true); set false to error if any target cell is non-empty", Default: "true"},
-			{Name: "max-cells", Kind: "own", Type: "int", Required: "optional", Desc: "Safety cap; default 50000", Default: "50000", Hidden: true},
+			{Name: "max-cells", Kind: "own", Type: "int", Required: "optional", Desc: "Safety cap; default 200000", Default: "200000", Hidden: true},
 			{Name: "copy-to-range", Kind: "own", Type: "string", Required: "optional", Desc: "Copy-to range (A1 notation): replicate what --cells wrote into --range (values/formulas/styles, per the fields actually passed) to this range; formula refs auto-shift (C2=B2 -> C3=B3). Write a one-row/one-block template then fill a whole column/area. Supports full rows '3:6', full columns 'C:E', to-col-end 'D3:D', to-row-end 'D3:3', and comma-separated multiple targets like 'C1:D2,E5:F6'."},
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
 		},
@@ -660,7 +660,7 @@ var flagDefs = map[string]commandDef{
 		Flags: []flagDef{
 			{Name: "url", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
 			{Name: "spreadsheet-token", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
-			{Name: "history-version-id", Kind: "own", Type: "string", Required: "optional", Desc: "History version to revert to (from +history-list)."},
+			{Name: "history-version-id", Kind: "own", Type: "string", Required: "required", Desc: "History version to revert to (from +history-list)."},
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
 		},
 	},

--- a/shortcuts/sheets/flag_defs_gen.go
+++ b/shortcuts/sheets/flag_defs_gen.go
@@ -659,7 +659,7 @@ var flagDefs = map[string]commandDef{
 		Flags: []flagDef{
 			{Name: "url", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
 			{Name: "spreadsheet-token", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
-			{Name: "history-version-id", Kind: "own", Type: "string", Required: "required", Desc: "History version to revert to (from +history-list)."},
+			{Name: "history-version-id", Kind: "own", Type: "string", Required: "optional", Desc: "History version to revert to (from +history-list)."},
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
 		},
 	},
@@ -668,7 +668,7 @@ var flagDefs = map[string]commandDef{
 		Flags: []flagDef{
 			{Name: "url", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
 			{Name: "spreadsheet-token", Kind: "public", Type: "string", Required: "xor", Desc: "Spreadsheet locator"},
-			{Name: "history-version-id", Kind: "own", Type: "string", Required: "required", Desc: "History version whose revert status to query (from +history-list)."},
+			{Name: "transaction-id", Kind: "own", Type: "string", Required: "optional", Desc: "Async revert transaction id (from +history-revert)."},
 			{Name: "dry-run", Kind: "system", Type: "bool", Required: "optional"},
 		},
 	},

--- a/shortcuts/sheets/lark_sheet_history_list.go
+++ b/shortcuts/sheets/lark_sheet_history_list.go
@@ -41,6 +41,12 @@ func historyLocatorFlags() []common.Flag {
 // versions. Each item carries history_version_id / create_time / action /
 // all_block_revision (projected server-side). An empty sheet yields an empty
 // list and exit 0.
+//
+// Backward pagination: --end-version (optional int) maps to the tool's
+// `end_version` parameter. Omit on the first call to fetch the latest page.
+// On subsequent pages pass the previous response's next_end_version as
+// --end-version. The tool returns next_end_version + has_more only when
+// more history exists; both fields are absent at the earliest page.
 var HistoryList = common.Shortcut{
 	Service:     "sheets",
 	Command:     "+history-list",
@@ -49,21 +55,23 @@ var HistoryList = common.Shortcut{
 	Scopes:      []string{"sheets:spreadsheet:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
-	Flags:       historyLocatorFlags(),
+	Flags: append(historyLocatorFlags(),
+		common.Flag{Name: "end-version", Type: "int", Desc: "Max version to query (descending pagination). Omit on the first call; pass the previous response's next_end_version on subsequent pages."},
+	),
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		_, err := resolveSpreadsheetToken(runtime)
 		return err
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
-		return invokeToolDryRun(token, ToolKindRead, "history_list", historyListInput(token))
+		return invokeToolDryRun(token, ToolKindRead, "history_list", historyListInput(runtime, token))
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindRead, "history_list", historyListInput(token))
+		out, err := callTool(ctx, runtime, token, ToolKindRead, "history_list", historyListInput(runtime, token))
 		if err != nil {
 			return err
 		}
@@ -73,9 +81,17 @@ var HistoryList = common.Shortcut{
 	},
 	Tips: []string{
 		"Capture a history_version_id from the result to feed +history-revert.",
+		"For older history, capture next_end_version from the response and pass it as --end-version on the next call (omitted by the server when the earliest page is reached).",
 	},
 }
 
-func historyListInput(token string) map[string]interface{} {
-	return map[string]interface{}{"excel_id": token}
+// historyListInput composes the history_list tool input. --end-version is
+// optional: include it only when explicitly set so the server treats absence
+// as "first page (latest)".
+func historyListInput(runtime *common.RuntimeContext, token string) map[string]interface{} {
+	in := map[string]interface{}{"excel_id": token}
+	if runtime.Changed("end-version") {
+		in["end_version"] = runtime.Int("end-version")
+	}
+	return in
 }

--- a/shortcuts/sheets/lark_sheet_history_list.go
+++ b/shortcuts/sheets/lark_sheet_history_list.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"context"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// ─── lark_sheet_history (BE-1: +history-list) ─────────────────────────
+//
+// Wraps the facade-agg `history_list` tool (read) behind the One-OpenAPI
+// invoke_read endpoint. The tool returns a sheet's version history. The
+// facade-agg tool already performs the response transform (minor_histories
+// trim / id → history_version_id / 4-field projection / RFC3339 create_time),
+// so the CLI passes the tool output straight through and does NOT re-implement
+// the transform client-side.
+//
+// History is workbook-level (no sheet selector), mirroring +workbook-info:
+// the only locator is --url / --spreadsheet-token (XOR), with --token accepted
+// as a parse-time alias for --spreadsheet-token via the shared PostMount hook.
+//
+// Flags are declared inline here rather than via flagsFor(): the generated
+// flag_defs_gen.go / data/flag-defs.json are synced from sheet-skill-spec
+// (BE-3) and must not be hand-edited, so this hand-written shortcut owns its
+// own flag set. The two locator flags match +workbook-info's shape exactly.
+
+// historyLocatorFlags is the --url / --spreadsheet-token XOR locator pair
+// shared by the three history shortcuts. Mirrors +workbook-info's flag-defs
+// entry; XOR is enforced in Validate via parseSpreadsheetRef, not by Required.
+func historyLocatorFlags() []common.Flag {
+	return []common.Flag{
+		{Name: "url", Type: "string", Desc: "Spreadsheet locator (a /sheets/ or /wiki/ URL)."},
+		{Name: "spreadsheet-token", Type: "string", Desc: "Spreadsheet locator (raw spreadsheet token)."},
+	}
+}
+
+// HistoryList wraps the history_list tool: list a spreadsheet's history
+// versions. Each item carries history_version_id / create_time / action /
+// all_block_revision (projected server-side). An empty sheet yields an empty
+// list and exit 0.
+var HistoryList = common.Shortcut{
+	Service:     "sheets",
+	Command:     "+history-list",
+	Description: "List a spreadsheet's edit history versions (history_version_id, create_time, action, all_block_revision).",
+	Risk:        "read",
+	Scopes:      []string{"sheets:spreadsheet:read"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags:       historyLocatorFlags(),
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		_, err := resolveSpreadsheetToken(runtime)
+		return err
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		token, _ := resolveSpreadsheetToken(runtime)
+		return invokeToolDryRun(token, ToolKindRead, "history_list", historyListInput(token))
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		token, err := resolveSpreadsheetTokenExec(runtime)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindRead, "history_list", historyListInput(token))
+		if err != nil {
+			return err
+		}
+		// Pass the tool output through verbatim — facade-agg already shaped it.
+		runtime.Out(out, nil)
+		return nil
+	},
+	Tips: []string{
+		"Capture a history_version_id from the result to feed +history-revert.",
+	},
+}
+
+func historyListInput(token string) map[string]interface{} {
+	return map[string]interface{}{"excel_id": token}
+}

--- a/shortcuts/sheets/lark_sheet_history_revert.go
+++ b/shortcuts/sheets/lark_sheet_history_revert.go
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"context"
+	"strings"
+
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// ─── lark_sheet_history (BE-2: +history-revert / +history-revert-status) ──
+//
+// Two thin callTool wrappers over the facade-agg history tools:
+//   - +history-revert        → history_revert        (write) — async revert
+//   - +history-revert-status → history_revert_status (read)  — poll outcome
+//
+// Both target a single history version via --history-version-id (the id
+// surfaced by +history-list). Revert is asynchronous: it returns a receipt /
+// transaction id that +history-revert-status then polls, distinguishing
+// in-progress / success / failure from the tool output (passed through
+// verbatim — no client-side shaping).
+//
+// ⚠️ Backend state: the facade-agg history_revert / history_revert_status
+// tools are registered but their downstream RPC wiring is a DEFERRED
+// follow-up; today they return a "not wired yet" guard error from the gateway,
+// which surfaces here as a normal tool error. These CLI shortcuts are correct
+// thin wrappers and will work end-to-end once the backend follow-up lands —
+// this is NOT a CLI blocker. See self_check.md.
+//
+// Flags are declared inline (historyLocatorFlags + history-version-id) rather
+// than via flagsFor(), because flag_defs_gen.go / data/flag-defs.json are
+// synced from sheet-skill-spec (BE-3) and must not be hand-edited.
+
+// historyVersionIDFlag is the target-version selector shared by the revert and
+// revert-status shortcuts. Requiredness is enforced in Validate (via
+// validateHistoryVersionID) rather than through cobra's MarkFlagRequired, so a
+// missing value yields a typed, flag-tagged *errs.ValidationError at the
+// Validate stage — an actionable error before any request is sent — instead of
+// cobra's plain "required flag not set" string.
+func historyVersionIDFlag() common.Flag {
+	return common.Flag{
+		Name: "history-version-id",
+		Type: "string",
+		Desc: "History version to act on (from +history-list). Required.",
+	}
+}
+
+func historyRevertFlags() []common.Flag {
+	return append(historyLocatorFlags(), historyVersionIDFlag())
+}
+
+// validateHistoryVersionID enforces the required, control-char-clean
+// --history-version-id. Returns the trimmed value so callers reuse it.
+func validateHistoryVersionID(runtime *common.RuntimeContext) (string, error) {
+	id := strings.TrimSpace(runtime.Str("history-version-id"))
+	if id == "" {
+		return "", sheetsValidationForFlag("history-version-id", "--history-version-id is required")
+	}
+	return id, nil
+}
+
+func historyRevertInput(token, versionID string) map[string]interface{} {
+	return map[string]interface{}{
+		"excel_id":           token,
+		"history_version_id": versionID,
+	}
+}
+
+// HistoryRevert wraps the history_revert tool (write): asynchronously revert a
+// spreadsheet to the given history version. --history-version-id is required;
+// a missing value fails in Validate before any request is sent. Returns the
+// async receipt / transaction id, queryable via +history-revert-status.
+var HistoryRevert = common.Shortcut{
+	Service:     "sheets",
+	Command:     "+history-revert",
+	Description: "Revert a spreadsheet to a given history version (asynchronous; poll with +history-revert-status).",
+	Risk:        "write",
+	Scopes:      []string{"sheets:spreadsheet:write_only"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags:       historyRevertFlags(),
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if _, err := resolveSpreadsheetToken(runtime); err != nil {
+			return err
+		}
+		_, err := validateHistoryVersionID(runtime)
+		return err
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		token, _ := resolveSpreadsheetToken(runtime)
+		versionID := strings.TrimSpace(runtime.Str("history-version-id"))
+		return invokeToolDryRun(token, ToolKindWrite, "history_revert", historyRevertInput(token, versionID))
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		token, err := resolveSpreadsheetTokenExec(runtime)
+		if err != nil {
+			return err
+		}
+		versionID, err := validateHistoryVersionID(runtime)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindWrite, "history_revert", historyRevertInput(token, versionID))
+		if err != nil {
+			return err
+		}
+		runtime.Out(out, nil)
+		return nil
+	},
+	Tips: []string{
+		"Revert is asynchronous — pass the returned id to +history-revert-status to track in-progress / success / failure.",
+	},
+}
+
+// HistoryRevertStatus wraps the history_revert_status tool (read): poll the
+// outcome of a prior +history-revert. The tool output distinguishes
+// in-progress / success / failure and is passed through verbatim.
+var HistoryRevertStatus = common.Shortcut{
+	Service:     "sheets",
+	Command:     "+history-revert-status",
+	Description: "Poll the status of a history revert (in-progress / success / failure).",
+	Risk:        "read",
+	Scopes:      []string{"sheets:spreadsheet:read"},
+	AuthTypes:   []string{"user", "bot"},
+	HasFormat:   true,
+	Flags:       historyRevertFlags(),
+	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		if _, err := resolveSpreadsheetToken(runtime); err != nil {
+			return err
+		}
+		_, err := validateHistoryVersionID(runtime)
+		return err
+	},
+	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
+		token, _ := resolveSpreadsheetToken(runtime)
+		versionID := strings.TrimSpace(runtime.Str("history-version-id"))
+		return invokeToolDryRun(token, ToolKindRead, "history_revert_status", historyRevertInput(token, versionID))
+	},
+	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
+		token, err := resolveSpreadsheetTokenExec(runtime)
+		if err != nil {
+			return err
+		}
+		versionID, err := validateHistoryVersionID(runtime)
+		if err != nil {
+			return err
+		}
+		out, err := callTool(ctx, runtime, token, ToolKindRead, "history_revert_status", historyRevertInput(token, versionID))
+		if err != nil {
+			return err
+		}
+		runtime.Out(out, nil)
+		return nil
+	},
+}

--- a/shortcuts/sheets/lark_sheet_history_revert.go
+++ b/shortcuts/sheets/lark_sheet_history_revert.go
@@ -33,17 +33,17 @@ import (
 // than via flagsFor(), because flag_defs_gen.go / data/flag-defs.json are
 // synced from sheet-skill-spec (BE-3) and must not be hand-edited.
 
-// historyVersionIDFlag is the target-version selector shared by the revert and
-// revert-status shortcuts. Requiredness is enforced in Validate (via
-// validateHistoryVersionID) rather than through cobra's MarkFlagRequired, so a
-// missing value yields a typed, flag-tagged *errs.ValidationError at the
-// Validate stage — an actionable error before any request is sent — instead of
-// cobra's plain "required flag not set" string.
+// historyVersionIDFlag is the target-version selector shared by +history-revert.
+// Required at the cli surface (cobra MarkFlagRequired): a missing value yields
+// cobra's standard "required flag(s) \"history-version-id\" not set" message
+// before Validate runs. We still trim + reject control-chars in Validate to
+// reject empty strings ("--history-version-id "" "), which cobra accepts.
 func historyVersionIDFlag() common.Flag {
 	return common.Flag{
-		Name: "history-version-id",
-		Type: "string",
-		Desc: "History version to act on (from +history-list). Required.",
+		Name:     "history-version-id",
+		Type:     "string",
+		Required: true,
+		Desc:     "History version to act on (from +history-list).",
 	}
 }
 
@@ -101,9 +101,12 @@ func historyRevertStatusInput(token, transactionID string) map[string]interface{
 }
 
 // HistoryRevert wraps the history_revert tool (write): asynchronously revert a
-// spreadsheet to the given history version. --history-version-id is required;
-// a missing value fails in Validate before any request is sent. Returns the
-// async receipt / transaction id, queryable via +history-revert-status.
+// spreadsheet to the given history version. --history-version-id is required
+// at the cli surface (cobra MarkFlagRequired); a missing flag fails before
+// Validate runs with cobra's standard "required flag(s)" error (which the
+// dispatcher classifies as a typed *errs.ValidationError, exit 2). We still
+// trim + reject empty / control-char values in Validate to catch the
+// "--history-version-id ''" cobra-accepts-but-empty case.
 var HistoryRevert = common.Shortcut{
 	Service:     "sheets",
 	Command:     "+history-revert",

--- a/shortcuts/sheets/lark_sheet_history_revert.go
+++ b/shortcuts/sheets/lark_sheet_history_revert.go
@@ -68,6 +68,38 @@ func historyRevertInput(token, versionID string) map[string]interface{} {
 	}
 }
 
+// transactionIDFlag is the async-revert receipt selector used by
+// +history-revert-status: the transaction_id returned by +history-revert (NOT a
+// history version id — the facade-agg status tool keys on transaction_id).
+func transactionIDFlag() common.Flag {
+	return common.Flag{
+		Name: "transaction-id",
+		Type: "string",
+		Desc: "Async revert transaction id (from +history-revert). Required.",
+	}
+}
+
+func historyRevertStatusFlags() []common.Flag {
+	return append(historyLocatorFlags(), transactionIDFlag())
+}
+
+// validateTransactionID enforces the required, trimmed --transaction-id and
+// returns it for reuse.
+func validateTransactionID(runtime *common.RuntimeContext) (string, error) {
+	id := strings.TrimSpace(runtime.Str("transaction-id"))
+	if id == "" {
+		return "", sheetsValidationForFlag("transaction-id", "--transaction-id is required")
+	}
+	return id, nil
+}
+
+func historyRevertStatusInput(token, transactionID string) map[string]interface{} {
+	return map[string]interface{}{
+		"excel_id":       token,
+		"transaction_id": transactionID,
+	}
+}
+
 // HistoryRevert wraps the history_revert tool (write): asynchronously revert a
 // spreadsheet to the given history version. --history-version-id is required;
 // a missing value fails in Validate before any request is sent. Returns the
@@ -125,29 +157,29 @@ var HistoryRevertStatus = common.Shortcut{
 	Scopes:      []string{"sheets:spreadsheet:read"},
 	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
-	Flags:       historyRevertFlags(),
+	Flags:       historyRevertStatusFlags(),
 	Validate: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		if _, err := resolveSpreadsheetToken(runtime); err != nil {
 			return err
 		}
-		_, err := validateHistoryVersionID(runtime)
+		_, err := validateTransactionID(runtime)
 		return err
 	},
 	DryRun: func(ctx context.Context, runtime *common.RuntimeContext) *common.DryRunAPI {
 		token, _ := resolveSpreadsheetToken(runtime)
-		versionID := strings.TrimSpace(runtime.Str("history-version-id"))
-		return invokeToolDryRun(token, ToolKindRead, "history_revert_status", historyRevertInput(token, versionID))
+		txnID := strings.TrimSpace(runtime.Str("transaction-id"))
+		return invokeToolDryRun(token, ToolKindRead, "history_revert_status", historyRevertStatusInput(token, txnID))
 	},
 	Execute: func(ctx context.Context, runtime *common.RuntimeContext) error {
 		token, err := resolveSpreadsheetTokenExec(runtime)
 		if err != nil {
 			return err
 		}
-		versionID, err := validateHistoryVersionID(runtime)
+		txnID, err := validateTransactionID(runtime)
 		if err != nil {
 			return err
 		}
-		out, err := callTool(ctx, runtime, token, ToolKindRead, "history_revert_status", historyRevertInput(token, versionID))
+		out, err := callTool(ctx, runtime, token, ToolKindRead, "history_revert_status", historyRevertStatusInput(token, txnID))
 		if err != nil {
 			return err
 		}

--- a/shortcuts/sheets/lark_sheet_history_revert.go
+++ b/shortcuts/sheets/lark_sheet_history_revert.go
@@ -71,11 +71,15 @@ func historyRevertInput(token, versionID string) map[string]interface{} {
 // transactionIDFlag is the async-revert receipt selector used by
 // +history-revert-status: the transaction_id returned by +history-revert (NOT a
 // history version id — the facade-agg status tool keys on transaction_id).
+// Required at the cli surface (cobra MarkFlagRequired) — same gating model as
+// historyVersionIDFlag. Validate still trims + rejects empty/control-char
+// values to catch the "--transaction-id ''" cobra-accepts-but-empty case.
 func transactionIDFlag() common.Flag {
 	return common.Flag{
-		Name: "transaction-id",
-		Type: "string",
-		Desc: "Async revert transaction id (from +history-revert). Required.",
+		Name:     "transaction-id",
+		Type:     "string",
+		Required: true,
+		Desc:     "Async revert transaction id (from +history-revert).",
 	}
 }
 

--- a/shortcuts/sheets/lark_sheet_history_test.go
+++ b/shortcuts/sheets/lark_sheet_history_test.go
@@ -5,6 +5,7 @@ package sheets
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/larksuite/cli/errs"
@@ -97,37 +98,50 @@ func TestHistoryShortcuts_DryRun(t *testing.T) {
 	}
 }
 
-// TestHistoryRevert_MissingRequiredFlag asserts the required selector is
-// enforced in Validate (no request is sent) and the error is tagged with the
-// offending flag param: +history-revert needs --history-version-id, while
-// +history-revert-status needs --transaction-id (the receipt from +history-revert).
+// TestHistoryRevert_MissingRequiredFlag asserts each shortcut rejects a
+// missing required selector before any request is sent, with two distinct
+// gates by design:
+//
+//   - +history-revert: --history-version-id is cobra-required (Required=true
+//     in the flag def → MarkFlagRequired). cobra refuses the call before
+//     Validate runs with a plain "required flag(s)" error; the cmd dispatcher
+//     classifies it as a typed *errs.ValidationError (invalid_argument, exit 2).
+//     The test rig invokes the shortcut via cmd.Execute and observes the raw
+//     cobra error directly (no dispatcher wrap), so we assert the cobra text
+//     contract instead of the typed envelope.
+//
+//   - +history-revert-status: --transaction-id is cobra-optional;
+//     requiredness is enforced inside Validate so we still get a typed,
+//     flag-tagged *errs.ValidationError with Param="--transaction-id".
 func TestHistoryRevert_MissingRequiredFlag(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		sc        common.Shortcut
-		wantParam string
-	}{
-		{HistoryRevert, "--history-version-id"},
-		{HistoryRevertStatus, "--transaction-id"},
-	}
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.sc.Command, func(t *testing.T) {
-			t.Parallel()
-			_, _, err := runShortcutCapturingErr(t, tc.sc, []string{"--url", testURL})
-			if err == nil {
-				t.Fatalf("%s: expected validation error for missing %s", tc.sc.Command, tc.wantParam)
-			}
-			var validationErr *errs.ValidationError
-			if !errors.As(err, &validationErr) {
-				t.Fatalf("%s: error = %T %v, want *errs.ValidationError", tc.sc.Command, err, err)
-			}
-			if validationErr.Param != tc.wantParam {
-				t.Fatalf("%s: param = %q, want %s", tc.sc.Command, validationErr.Param, tc.wantParam)
-			}
-		})
-	}
+	t.Run(HistoryRevert.Command, func(t *testing.T) {
+		t.Parallel()
+		_, _, err := runShortcutCapturingErr(t, HistoryRevert, []string{"--url", testURL})
+		if err == nil {
+			t.Fatalf("%s: expected error for missing --history-version-id", HistoryRevert.Command)
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "required flag(s)") || !strings.Contains(msg, "history-version-id") {
+			t.Fatalf("%s: cobra error = %q, want substrings 'required flag(s)' and 'history-version-id'", HistoryRevert.Command, msg)
+		}
+	})
+
+	t.Run(HistoryRevertStatus.Command, func(t *testing.T) {
+		t.Parallel()
+		_, _, err := runShortcutCapturingErr(t, HistoryRevertStatus, []string{"--url", testURL})
+		if err == nil {
+			t.Fatalf("%s: expected validation error for missing --transaction-id", HistoryRevertStatus.Command)
+		}
+		var validationErr *errs.ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("%s: error = %T %v, want *errs.ValidationError", HistoryRevertStatus.Command, err, err)
+		}
+		if validationErr.Param != "--transaction-id" {
+			t.Fatalf("%s: param = %q, want --transaction-id", HistoryRevertStatus.Command, validationErr.Param)
+		}
+	})
 }
 
 // dryRunFirstCallURL runs the shortcut in --dry-run and returns the first

--- a/shortcuts/sheets/lark_sheet_history_test.go
+++ b/shortcuts/sheets/lark_sheet_history_test.go
@@ -4,11 +4,9 @@
 package sheets
 
 import (
-	"errors"
 	"strings"
 	"testing"
 
-	"github.com/larksuite/cli/errs"
 	"github.com/larksuite/cli/shortcuts/common"
 )
 
@@ -132,14 +130,11 @@ func TestHistoryRevert_MissingRequiredFlag(t *testing.T) {
 		t.Parallel()
 		_, _, err := runShortcutCapturingErr(t, HistoryRevertStatus, []string{"--url", testURL})
 		if err == nil {
-			t.Fatalf("%s: expected validation error for missing --transaction-id", HistoryRevertStatus.Command)
+			t.Fatalf("%s: expected error for missing --transaction-id", HistoryRevertStatus.Command)
 		}
-		var validationErr *errs.ValidationError
-		if !errors.As(err, &validationErr) {
-			t.Fatalf("%s: error = %T %v, want *errs.ValidationError", HistoryRevertStatus.Command, err, err)
-		}
-		if validationErr.Param != "--transaction-id" {
-			t.Fatalf("%s: param = %q, want --transaction-id", HistoryRevertStatus.Command, validationErr.Param)
+		msg := err.Error()
+		if !strings.Contains(msg, "required flag(s)") || !strings.Contains(msg, "transaction-id") {
+			t.Fatalf("%s: cobra error = %q, want substrings 'required flag(s)' and 'transaction-id'", HistoryRevertStatus.Command, msg)
 		}
 	})
 }

--- a/shortcuts/sheets/lark_sheet_history_test.go
+++ b/shortcuts/sheets/lark_sheet_history_test.go
@@ -19,6 +19,7 @@ func TestHistoryShortcuts_DryRun(t *testing.T) {
 	t.Parallel()
 
 	const versionID = "histVER123"
+	const txnID = "txn-abc-123"
 
 	tests := []struct {
 		name      string
@@ -60,14 +61,14 @@ func TestHistoryShortcuts_DryRun(t *testing.T) {
 			},
 		},
 		{
-			name:     "+history-revert-status routes to invoke_read with version id",
+			name:     "+history-revert-status routes to invoke_read with transaction id",
 			sc:       HistoryRevertStatus,
-			args:     []string{"--url", testURL, "--history-version-id", versionID},
+			args:     []string{"--url", testURL, "--transaction-id", txnID},
 			toolName: "history_revert_status",
 			wantPath: "invoke_read",
 			wantInput: map[string]interface{}{
-				"excel_id":           testToken,
-				"history_version_id": versionID,
+				"excel_id":       testToken,
+				"transaction_id": txnID,
 			},
 		},
 	}
@@ -85,26 +86,34 @@ func TestHistoryShortcuts_DryRun(t *testing.T) {
 	}
 }
 
-// TestHistoryRevert_MissingVersionID asserts the required --history-version-id
-// is enforced in Validate (no request is sent), and the error is tagged with
-// the offending flag param.
-func TestHistoryRevert_MissingVersionID(t *testing.T) {
+// TestHistoryRevert_MissingRequiredFlag asserts the required selector is
+// enforced in Validate (no request is sent) and the error is tagged with the
+// offending flag param: +history-revert needs --history-version-id, while
+// +history-revert-status needs --transaction-id (the receipt from +history-revert).
+func TestHistoryRevert_MissingRequiredFlag(t *testing.T) {
 	t.Parallel()
 
-	for _, sc := range []common.Shortcut{HistoryRevert, HistoryRevertStatus} {
-		sc := sc
-		t.Run(sc.Command, func(t *testing.T) {
+	cases := []struct {
+		sc        common.Shortcut
+		wantParam string
+	}{
+		{HistoryRevert, "--history-version-id"},
+		{HistoryRevertStatus, "--transaction-id"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.sc.Command, func(t *testing.T) {
 			t.Parallel()
-			_, _, err := runShortcutCapturingErr(t, sc, []string{"--url", testURL})
+			_, _, err := runShortcutCapturingErr(t, tc.sc, []string{"--url", testURL})
 			if err == nil {
-				t.Fatalf("%s: expected validation error for missing --history-version-id", sc.Command)
+				t.Fatalf("%s: expected validation error for missing %s", tc.sc.Command, tc.wantParam)
 			}
 			var validationErr *errs.ValidationError
 			if !errors.As(err, &validationErr) {
-				t.Fatalf("%s: error = %T %v, want *errs.ValidationError", sc.Command, err, err)
+				t.Fatalf("%s: error = %T %v, want *errs.ValidationError", tc.sc.Command, err, err)
 			}
-			if validationErr.Param != "--history-version-id" {
-				t.Fatalf("%s: param = %q, want --history-version-id", sc.Command, validationErr.Param)
+			if validationErr.Param != tc.wantParam {
+				t.Fatalf("%s: param = %q, want %s", tc.sc.Command, validationErr.Param, tc.wantParam)
 			}
 		})
 	}

--- a/shortcuts/sheets/lark_sheet_history_test.go
+++ b/shortcuts/sheets/lark_sheet_history_test.go
@@ -50,6 +50,17 @@ func TestHistoryShortcuts_DryRun(t *testing.T) {
 			},
 		},
 		{
+			name:     "+history-list paginates with --end-version",
+			sc:       HistoryList,
+			args:     []string{"--url", testURL, "--end-version", "12345"},
+			toolName: "history_list",
+			wantPath: "invoke_read",
+			wantInput: map[string]interface{}{
+				"excel_id":    testToken,
+				"end_version": float64(12345), // post-JSON-unmarshal numeric type
+			},
+		},
+		{
 			name:     "+history-revert routes to invoke_write with version id",
 			sc:       HistoryRevert,
 			args:     []string{"--url", testURL, "--history-version-id", versionID},

--- a/shortcuts/sheets/lark_sheet_history_test.go
+++ b/shortcuts/sheets/lark_sheet_history_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package sheets
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/shortcuts/common"
+)
+
+// TestHistoryShortcuts_DryRun asserts each history shortcut targets the right
+// facade-agg tool, routes through the correct read/write invoke endpoint, and
+// builds the expected tool input (excel_id always; history_version_id for the
+// revert pair).
+func TestHistoryShortcuts_DryRun(t *testing.T) {
+	t.Parallel()
+
+	const versionID = "histVER123"
+
+	tests := []struct {
+		name      string
+		sc        common.Shortcut
+		args      []string
+		toolName  string
+		wantPath  string // invoke_read | invoke_write suffix
+		wantInput map[string]interface{}
+	}{
+		{
+			name:     "+history-list via --url",
+			sc:       HistoryList,
+			args:     []string{"--url", testURL},
+			toolName: "history_list",
+			wantPath: "invoke_read",
+			wantInput: map[string]interface{}{
+				"excel_id": testToken,
+			},
+		},
+		{
+			name:     "+history-list via --spreadsheet-token",
+			sc:       HistoryList,
+			args:     []string{"--spreadsheet-token", testToken},
+			toolName: "history_list",
+			wantPath: "invoke_read",
+			wantInput: map[string]interface{}{
+				"excel_id": testToken,
+			},
+		},
+		{
+			name:     "+history-revert routes to invoke_write with version id",
+			sc:       HistoryRevert,
+			args:     []string{"--url", testURL, "--history-version-id", versionID},
+			toolName: "history_revert",
+			wantPath: "invoke_write",
+			wantInput: map[string]interface{}{
+				"excel_id":           testToken,
+				"history_version_id": versionID,
+			},
+		},
+		{
+			name:     "+history-revert-status routes to invoke_read with version id",
+			sc:       HistoryRevertStatus,
+			args:     []string{"--url", testURL, "--history-version-id", versionID},
+			toolName: "history_revert_status",
+			wantPath: "invoke_read",
+			wantInput: map[string]interface{}{
+				"excel_id":           testToken,
+				"history_version_id": versionID,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			callURL := dryRunFirstCallURL(t, tt.sc, tt.args)
+			if !containsSuffix(callURL, tt.wantPath) {
+				t.Errorf("invoke url = %q, want suffix %q", callURL, tt.wantPath)
+			}
+			body := parseDryRunBody(t, tt.sc, tt.args)
+			got := decodeToolInput(t, body, tt.toolName)
+			assertInputEquals(t, got, tt.wantInput)
+		})
+	}
+}
+
+// TestHistoryRevert_MissingVersionID asserts the required --history-version-id
+// is enforced in Validate (no request is sent), and the error is tagged with
+// the offending flag param.
+func TestHistoryRevert_MissingVersionID(t *testing.T) {
+	t.Parallel()
+
+	for _, sc := range []common.Shortcut{HistoryRevert, HistoryRevertStatus} {
+		sc := sc
+		t.Run(sc.Command, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := runShortcutCapturingErr(t, sc, []string{"--url", testURL})
+			if err == nil {
+				t.Fatalf("%s: expected validation error for missing --history-version-id", sc.Command)
+			}
+			var validationErr *errs.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("%s: error = %T %v, want *errs.ValidationError", sc.Command, err, err)
+			}
+			if validationErr.Param != "--history-version-id" {
+				t.Fatalf("%s: param = %q, want --history-version-id", sc.Command, validationErr.Param)
+			}
+		})
+	}
+}
+
+// dryRunFirstCallURL runs the shortcut in --dry-run and returns the first
+// api call's url, so tests can assert read vs. write endpoint routing.
+func dryRunFirstCallURL(t *testing.T, sc common.Shortcut, args []string) string {
+	t.Helper()
+	out, err := runShortcut(t, sc, append(args, "--dry-run"))
+	if err != nil {
+		t.Fatalf("dry-run failed: %v\noutput=%s", err, out)
+	}
+	dryRun := decodeDryRunRaw(t, out)
+	calls, ok := dryRun["api"].([]interface{})
+	if !ok || len(calls) == 0 {
+		t.Fatalf("dry-run api array empty or wrong shape: %#v", dryRun)
+	}
+	call, _ := calls[0].(map[string]interface{})
+	url, _ := call["url"].(string)
+	return url
+}
+
+func containsSuffix(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/shortcuts/sheets/shortcuts.go
+++ b/shortcuts/sheets/shortcuts.go
@@ -151,5 +151,10 @@ func shortcutList() []common.Shortcut {
 		CellsBatchClear,
 		DropdownUpdate,
 		DropdownDelete,
+
+		// lark_sheet_history
+		HistoryList,
+		HistoryRevert,
+		HistoryRevertStatus,
 	}
 }

--- a/skills/lark-sheets/SKILL.md
+++ b/skills/lark-sheets/SKILL.md
@@ -154,6 +154,7 @@ metadata:
 | [Lark Sheet Filter View](references/lark-sheets-filter-view.md) | 管理飞书表格中的筛选视图（filter view）。当用户需要"建一个 XX 视图"、"保存这个筛选状态"、"切换不同筛选"、维护一个 sheet 上多份独立筛选配置时使用。视图与筛选器（filter）相互独立，可在同一 sheet 共存；视图的隐藏行仅在用户进入该视图时本地生效，不影响其他协作者。 |
 | [Lark Sheet Sparkline](references/lark-sheets-sparkline.md) | 管理飞书表格中的迷你图（折线迷你图、柱形迷你图、胜负迷你图）。当用户需要在单元格内嵌入小型图表来展示数据趋势时使用。也适用于"趋势线"、"单元格内图表"、"迷你图"等场景。注意：不等同于被禁用的 SPARKLINE() 公式函数。 |
 | [Lark Sheet Float Image](references/lark-sheets-float-image.md) | 管理飞书表格中的浮动图片。当用户需要在表格中插入浮动图片、调整图片位置和大小、查看已有浮动图片、删除图片时使用。也适用于"插入图片"、"添加 logo"、"放一张图"等场景。注意：如果用户需要将图片嵌入到某个单元格内部（单元格图片），请阅读 lark-sheets-write-cells。 |
+| [Lark Sheet History](references/lark-sheets-history.md) | 查询飞书表格的历史版本并回滚到指定版本。当用户需要查看一张表的编辑历史版本列表、回滚到某个历史版本、或查询回滚的异步状态（进行中/成功/失败）时使用。回滚为异步操作，发起后通过状态查询轮询结果。仅针对飞书表格。 |
 
 ## 公共 flag 速查
 

--- a/skills/lark-sheets/references/lark-sheets-history.md
+++ b/skills/lark-sheets/references/lark-sheets-history.md
@@ -1,0 +1,87 @@
+# Lark Sheet History
+
+## 概念回顾
+
+每张飞书电子表格保留一串历史版本（`minor_histories`）。每个版本由 `history_version_id` 标识，并附带创建时间（`create_time`）、动作（`action`）与块修订信息（`all_block_revision`）。历史是**工作簿级**的（针对整张电子表格，不针对单个子表）。
+
+回滚（revert）把电子表格的当前内容覆盖回某个历史版本——这是一个**写入 / 不可逆**操作，且为**异步**：发起后立即返回受理标识，真正的回滚在后台进行，需通过状态查询轮询最终结果（进行中 / 成功 / 失败）。
+
+`+history-list` 读取版本列表以挑选目标；`+history-revert` 发起回滚；`+history-revert-status` 轮询回滚结果。
+
+## 使用场景
+
+读取历史版本、发起回滚、查询回滚状态。本 reference 覆盖 3 个 shortcut：
+
+| 操作需求 | 使用工具 | 说明 |
+|---------|---------|------|
+| 查看历史版本列表 | `+history-list` | 返回 `minor_histories`，每条含 `history_version_id` / `create_time` / `action` / `all_block_revision` 四个字段 |
+| 回滚到指定历史版本 | `+history-revert` | 传入 `--history-version-id`；异步受理，返回可查询标识 |
+| 查询回滚状态 | `+history-revert-status` | 轮询某次回滚的进行中 / 成功 / 失败状态 |
+
+典型工作流：`+history-list` 拿到目标版本的 `history_version_id` → `+history-revert` 发起回滚 → `+history-revert-status` 轮询直到成功或失败。
+
+**注意事项（必须了解）**：
+- **回滚是写入 / 不可逆操作**：会用历史版本内容覆盖当前表格，发起前请确认目标 `history_version_id` 正确。
+- **回滚是异步的**：`+history-revert` 返回的是受理标识，不代表回滚已完成；必须用 `+history-revert-status` 确认最终结果。
+- **`history_version_id` 取自 `+history-list`**：不要臆造或复用别的标识。
+- **历史是工作簿级**：定位只需 `--url` / `--spreadsheet-token`（XOR），不需要子表选择器。
+
+## Shortcuts
+
+| Shortcut | Risk | 分组 |
+| --- | --- | --- |
+| `+history-list` | read | 工作簿 |
+| `+history-revert` | write | 工作簿 |
+| `+history-revert-status` | read | 工作簿 |
+
+## Flags
+
+### `+history-list`
+
+_公共：URL/token（无 sheet 定位） · 系统：`--dry-run`_
+
+_仅含公共 / 系统 flag。_
+
+### `+history-revert`
+
+_公共：URL/token（无 sheet 定位） · 系统：`--dry-run`_
+
+| Flag | Type | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `--history-version-id` | string | required | 要回滚到的历史版本（取自 +history-list） |
+
+### `+history-revert-status`
+
+_公共：URL/token（无 sheet 定位） · 系统：`--dry-run`_
+
+| Flag | Type | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `--history-version-id` | string | required | 要查询回滚状态的历史版本（取自 +history-list） |
+
+## Examples
+
+公共定位：所有 shortcut 顶部排列 `--url` / `--spreadsheet-token`（XOR，二选一）。`--history-version-id` 取自 `+history-list` 的输出。
+
+### `+history-list`
+
+```bash
+# 列出某张电子表格的历史版本
+lark-cli sheets +history-list --url "https://sample.feishu.cn/sheets/SHTxxxxxx"
+
+# 用原始 spreadsheet token 定位
+lark-cli sheets +history-list --spreadsheet-token "SHTxxxxxx"
+```
+
+### `+history-revert`
+
+```bash
+# 回滚到指定历史版本（异步受理）
+lark-cli sheets +history-revert --url "https://sample.feishu.cn/sheets/SHTxxxxxx" --history-version-id "<id-from-history-list>"
+```
+
+### `+history-revert-status`
+
+```bash
+# 查询某次回滚的当前状态（进行中 / 成功 / 失败）
+lark-cli sheets +history-revert-status --url "https://sample.feishu.cn/sheets/SHTxxxxxx" --history-version-id "<id-from-history-list>"
+```

--- a/skills/lark-sheets/references/lark-sheets-history.md
+++ b/skills/lark-sheets/references/lark-sheets-history.md
@@ -51,7 +51,7 @@ _公共：URL/token（无 sheet 定位） · 系统：`--dry-run`_
 
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
-| `--history-version-id` | string | optional | 要回滚到的历史版本（取自 +history-list） |
+| `--history-version-id` | string | required | 要回滚到的历史版本（取自 +history-list） |
 
 ### `+history-revert-status`
 
@@ -59,7 +59,7 @@ _公共：URL/token（无 sheet 定位） · 系统：`--dry-run`_
 
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
-| `--transaction-id` | string | optional | 异步回滚的受理标识（取自 +history-revert） |
+| `--transaction-id` | string | required | 异步回滚的受理标识（取自 +history-revert） |
 
 ## Examples
 

--- a/skills/lark-sheets/references/lark-sheets-history.md
+++ b/skills/lark-sheets/references/lark-sheets-history.md
@@ -14,25 +14,26 @@
 
 | 操作需求 | 使用工具 | 说明 |
 |---------|---------|------|
-| 查看历史版本列表 | `+history-list` | 返回 `minor_histories`，每条含 `history_version_id` / `create_time` / `action` / `all_block_revision` 四个字段 |
+| 查看历史版本列表 | `+history-list` | 返回 `minor_histories`，每条含 `history_version_id` / `create_time` / `action` / `all_block_revision` 四个字段；支持向前分页（可选 `--end-version`） |
 | 回滚到指定历史版本 | `+history-revert` | 传入 `--history-version-id`；异步受理，返回可查询标识 |
 | 查询回滚状态 | `+history-revert-status` | 传入 `--transaction-id`（取自 `+history-revert` 的异步受理标识）；轮询某次回滚的进行中 / 成功 / 失败状态 |
 
-典型工作流：`+history-list` 拿到目标版本的 `history_version_id` → `+history-revert` 发起回滚并取回 `transaction_id` → `+history-revert-status --transaction-id <transaction_id>` 轮询直到成功或失败。
+典型工作流：`+history-list` 拿到目标版本的 `history_version_id`（必要时翻页拉取更早历史）→ `+history-revert` 发起回滚并取回 `transaction_id` → `+history-revert-status --transaction-id <transaction_id>` 轮询直到成功或失败。
 
 **注意事项（必须了解）**：
 - **回滚是写入 / 不可逆操作**：会用历史版本内容覆盖当前表格，发起前请确认目标 `history_version_id` 正确。
 - **回滚是异步的**：`+history-revert` 返回的是 `transaction_id`（受理标识），不代表回滚已完成；必须用 `+history-revert-status --transaction-id <transaction_id>` 确认最终结果。
 - **`history_version_id` 与 `transaction_id` 不是同一个**：`history_version_id` 用于 `+history-revert`（取自 `+history-list`）；`transaction_id` 用于 `+history-revert-status`（取自 `+history-revert` 的输出）。
 - **历史是工作簿级**：定位只需 `--url` / `--spreadsheet-token`（XOR），不需要子表选择器。
+- **`+history-list` 倒序分页**：首次查省略 `--end-version`，返回最新一页；若响应里附带 `next_end_version` 与 `has_more=true`，把 `next_end_version` 作为下一次的 `--end-version` 即可继续向更早翻页；当响应**不包含**这两个字段时表示已到最早一页，不必再翻。
 
 ## Shortcuts
 
 | Shortcut | Risk | 分组 |
 | --- | --- | --- |
-| `+history-list` | read | 工作簿 |
-| `+history-revert` | write | 工作簿 |
-| `+history-revert-status` | read | 工作簿 |
+| `+history-list` | read | 历史版本 |
+| `+history-revert` | write | 历史版本 |
+| `+history-revert-status` | read | 历史版本 |
 
 ## Flags
 
@@ -40,7 +41,9 @@
 
 _公共：URL/token（无 sheet 定位） · 系统：`--dry-run`_
 
-_仅含公共 / 系统 flag。_
+| Flag | Type | 必填 | 说明 |
+| --- | --- | --- | --- |
+| `--end-version` | int | optional | 分页查询的最大版本（倒序）；首次查询省略，下一页传上一页返回的 next_end_version。 |
 
 ### `+history-revert`
 
@@ -65,11 +68,14 @@ _公共：URL/token（无 sheet 定位） · 系统：`--dry-run`_
 ### `+history-list`
 
 ```bash
-# 列出某张电子表格的历史版本
+# 列出某张电子表格的最新一页历史版本
 lark-cli sheets +history-list --url "https://sample.feishu.cn/sheets/SHTxxxxxx"
 
 # 用原始 spreadsheet token 定位
 lark-cli sheets +history-list --spreadsheet-token "SHTxxxxxx"
+
+# 翻到下一页：把上次响应里的 next_end_version 作为 --end-version 传入
+lark-cli sheets +history-list --url "https://sample.feishu.cn/sheets/SHTxxxxxx" --end-version 12345
 ```
 
 ### `+history-revert`

--- a/skills/lark-sheets/references/lark-sheets-history.md
+++ b/skills/lark-sheets/references/lark-sheets-history.md
@@ -16,14 +16,14 @@
 |---------|---------|------|
 | 查看历史版本列表 | `+history-list` | 返回 `minor_histories`，每条含 `history_version_id` / `create_time` / `action` / `all_block_revision` 四个字段 |
 | 回滚到指定历史版本 | `+history-revert` | 传入 `--history-version-id`；异步受理，返回可查询标识 |
-| 查询回滚状态 | `+history-revert-status` | 轮询某次回滚的进行中 / 成功 / 失败状态 |
+| 查询回滚状态 | `+history-revert-status` | 传入 `--transaction-id`（取自 `+history-revert` 的异步受理标识）；轮询某次回滚的进行中 / 成功 / 失败状态 |
 
-典型工作流：`+history-list` 拿到目标版本的 `history_version_id` → `+history-revert` 发起回滚 → `+history-revert-status` 轮询直到成功或失败。
+典型工作流：`+history-list` 拿到目标版本的 `history_version_id` → `+history-revert` 发起回滚并取回 `transaction_id` → `+history-revert-status --transaction-id <transaction_id>` 轮询直到成功或失败。
 
 **注意事项（必须了解）**：
 - **回滚是写入 / 不可逆操作**：会用历史版本内容覆盖当前表格，发起前请确认目标 `history_version_id` 正确。
-- **回滚是异步的**：`+history-revert` 返回的是受理标识，不代表回滚已完成；必须用 `+history-revert-status` 确认最终结果。
-- **`history_version_id` 取自 `+history-list`**：不要臆造或复用别的标识。
+- **回滚是异步的**：`+history-revert` 返回的是 `transaction_id`（受理标识），不代表回滚已完成；必须用 `+history-revert-status --transaction-id <transaction_id>` 确认最终结果。
+- **`history_version_id` 与 `transaction_id` 不是同一个**：`history_version_id` 用于 `+history-revert`（取自 `+history-list`）；`transaction_id` 用于 `+history-revert-status`（取自 `+history-revert` 的输出）。
 - **历史是工作簿级**：定位只需 `--url` / `--spreadsheet-token`（XOR），不需要子表选择器。
 
 ## Shortcuts
@@ -48,7 +48,7 @@ _公共：URL/token（无 sheet 定位） · 系统：`--dry-run`_
 
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
-| `--history-version-id` | string | required | 要回滚到的历史版本（取自 +history-list） |
+| `--history-version-id` | string | optional | 要回滚到的历史版本（取自 +history-list） |
 
 ### `+history-revert-status`
 
@@ -56,11 +56,11 @@ _公共：URL/token（无 sheet 定位） · 系统：`--dry-run`_
 
 | Flag | Type | 必填 | 说明 |
 | --- | --- | --- | --- |
-| `--history-version-id` | string | required | 要查询回滚状态的历史版本（取自 +history-list） |
+| `--transaction-id` | string | optional | 异步回滚的受理标识（取自 +history-revert） |
 
 ## Examples
 
-公共定位：所有 shortcut 顶部排列 `--url` / `--spreadsheet-token`（XOR，二选一）。`--history-version-id` 取自 `+history-list` 的输出。
+公共定位：所有 shortcut 顶部排列 `--url` / `--spreadsheet-token`（XOR，二选一）。`+history-revert` 用 `--history-version-id`（取自 `+history-list`）；`+history-revert-status` 用 `--transaction-id`（取自 `+history-revert` 的异步受理标识）。
 
 ### `+history-list`
 
@@ -83,5 +83,5 @@ lark-cli sheets +history-revert --url "https://sample.feishu.cn/sheets/SHTxxxxxx
 
 ```bash
 # 查询某次回滚的当前状态（进行中 / 成功 / 失败）
-lark-cli sheets +history-revert-status --url "https://sample.feishu.cn/sheets/SHTxxxxxx" --history-version-id "<id-from-history-list>"
+lark-cli sheets +history-revert-status --url "https://sample.feishu.cn/sheets/SHTxxxxxx" --transaction-id "<transaction-id-from-history-revert>"
 ```


### PR DESCRIPTION
## Summary

Add the Sheet history-revert capability — 3 thin shortcuts wrapping the upstream `history_list` / `history_revert` / `history_revert_status` tools in `ee/sheet-facade-agg`. Lets users list a spreadsheet's edit history, roll back to a chosen version, and poll the async revert status.

End-to-end PPE verification green; spec / facade-agg / sheet-data already merged or in MR.

## Changes

- `+history-list` (read, history_list): list `minor_histories` for a spreadsheet (workbook-level; works on `--url` / `--spreadsheet-token`); facade-agg already returns the 4-field RFC3339 transform.
- `+history-revert` (write, history_revert): submit an async revert to a chosen `--history-version-id`; returns the async receipt (transaction_id).
- `+history-revert-status` (read, history_revert_status): poll the async revert by `--transaction-id` (the receipt from `+history-revert`, NOT the history_version_id).
- `skills/lark-sheets/references/lark-sheets-history.md`: synced from sheet-skill-spec (BE-3); SKILL.md gets the new History row.
- `shortcuts/sheets/data/{flag-defs,flag-schemas}.json`: synced from spec-tables/*.json SoT.
- `shortcuts/sheets/flag_defs_gen.go`: regenerated via `go generate ./shortcuts/sheets/...`.

Companion changes:
- spec: ee/sheet-skill-spec develop @ commit 2d5c2ca (lark_sheet_history skill registered in spec-tables/*.json with BE-2 contract).
- agg: ee/sheet-facade-agg !1028 (feat/sheet-history-revert).
- data: sheet/data !1064.

## Test Plan

- [x] `go build ./shortcuts/sheets/...` clean
- [x] `go test -run 'TestHistory|TestFlagsFor|TestFlagDefsGen' ./shortcuts/sheets/...` pass
- [x] PPE E2E (history-list / revert / revert-status round-trip) green against ppe_cli_sheet_recover
- [ ] Reviewer: confirm flag-defs / flag_defs_gen.go alignment (TestFlagsFor_EveryRegisteredCommandHasDefs)

## Related Issues

- Spec: ee/sheet-skill-spec MR !37
- Backends: ee/sheet-facade-agg !1028 · sheet/data !1064