### PR TITLE
fix(auth): remove ' useless settings'

### DIFF
--- a/skills/lark-shared/SKILL.md
+++ b/skills/lark-shared/SKILL.md
@@ -25,7 +25,7 @@ lark-cli config init --new
 
 ### 认证任务速查
 
-认证、scope、业务域、登录态、退出登录态、撤销授权问题都走本技能，不要路由到 Claude settings / update-config。
+认证、scope、业务域、登录态、退出登录态、撤销授权问题都走本技能。
 
 | 用户意图 | 首选命令 / 回答 |
 |---|---|


### PR DESCRIPTION
 ## Summary
  Refine the `lark-shared` auth guidance by removing the outdated reference to “Useless settings / update-config”. This keeps the auth flow instructions focused on the
  supported CLI path and avoids redirecting users to an unrelated setup flow.


  ## Test Plan
  - [x] Unit tests pass
  - [x] Manual local verification confirms the `lark-cli <domain> <command>` flow works as expected
  - Docs-only change; no runtime behavior changed

  ## Related Issues
  - None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified the authentication guidance by removing the explicit restriction about routing these questions to “Claude settings / update-config,” while still directing authentication-related questions through this skill and retaining coverage for scope, business domain, login/logout state, and authorization revocation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->