### PR TITLE
docs: fix lark-doc media token examples

### DIFF
--- a/skills/lark-doc/references/lark-doc-media-download.md
+++ b/skills/lark-doc/references/lark-doc-media-download.md
@@ -34,9 +34,9 @@ lark-cli docs +media-download --type whiteboard --token "wbcnxxxxxxxx" --output 
 
 ## token 从哪里来
 
-- 若你是从文档内容里提取：`lark-doc-fetch` 返回的 Markdown 里可能包含：
-  - 图片：`<image token="..." .../>`
-  - 文件：`<file token="..." name="..."/>`
+- 若你是从文档内容里提取：`lark-doc-fetch` 返回的内容里可能包含：
+  - 图片：`<img token="..." .../>`
+  - 文件：`<source token="..." name="..."/>`
   - 画板：`<whiteboard token="..."/>`
 
 ## 排障

--- a/skills/lark-doc/references/lark-doc-media-preview.md
+++ b/skills/lark-doc/references/lark-doc-media-preview.md
@@ -30,9 +30,9 @@ lark-cli docs +media-preview --token "Z1Fjxxxxxxxx" --output ./asset.png
 
 ## token 从哪里来
 
-- 若你是从文档内容里提取：`lark-doc-fetch` 返回的 Markdown 里可能包含：
-  - 图片：`<image token="..." .../>`
-  - 文件：`<file token="..." name="..."/>`
+- 若你是从文档内容里提取：`lark-doc-fetch` 返回的内容里可能包含：
+  - 图片：`<img token="..." .../>`
+  - 文件：`<source token="..." name="..."/>`
 
 ## 参考
 


### PR DESCRIPTION
## Summary
  Fix lark-doc media token examples to match the tags returned by `docs +fetch`.

  ## Changes
  - Use `<img>` instead of `<image>` for image token examples.
  - Use `<source>` instead of `<file>` for file token examples.
  - Avoid describing fetch output as Markdown in token extraction guidance.

  ## Test Plan
  - [x] `git diff --check`

  ## Related Issues
  - None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated media token examples to match the latest document content format.
  * Replaced outdated tag examples with the current image and file markup patterns for clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->