### PR TITLE
style: gofmt apps plugin files

### DIFF
--- a/shortcuts/apps/apps_plugin_install.go
+++ b/shortcuts/apps/apps_plugin_install.go
@@ -26,10 +26,10 @@ import (
 // Without --name it batch-installs all plugins declared in actionPlugins that
 // are not yet present in node_modules.
 var AppsPluginInstall = common.Shortcut{
-	Service:     appsService,
-	Command:     "+plugin-install",
-	Description: "Install a plugin package (download, extract, update package.json)",
-	Risk:             "write",
+	Service:           appsService,
+	Command:           "+plugin-install",
+	Description:       "Install a plugin package (download, extract, update package.json)",
+	Risk:              "write",
 	ConditionalScopes: []string{"spark:app:read"},
 	AuthTypes:         []string{"user"},
 	Tips: []string{

--- a/shortcuts/apps/apps_plugin_install_test.go
+++ b/shortcuts/apps/apps_plugin_install_test.go
@@ -31,10 +31,10 @@ func TestPluginInstall_SinglePlugin(t *testing.T) {
 			"data": map[string]interface{}{
 				"items": []interface{}{
 					map[string]interface{}{
-						"key":                "@test/my-plugin",
-						"version":            "1.0.0",
-						"download_approach":  "inner",
-						"status":             "active",
+						"key":               "@test/my-plugin",
+						"version":           "1.0.0",
+						"download_approach": "inner",
+						"status":            "active",
 					},
 				},
 			},
@@ -92,7 +92,7 @@ func TestPluginInstall_AlreadyInstalled(t *testing.T) {
 	})
 	// Create an existing installed plugin with package.json containing version
 	pkgDir := filepath.Join(dir, "node_modules", "@test/my-plugin")
-	os.MkdirAll(pkgDir, 0o755) //nolint:forbidigo
+	os.MkdirAll(pkgDir, 0o755)                                                                //nolint:forbidigo
 	os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(`{"version":"1.0.0"}`), 0o644) //nolint:forbidigo
 	chdirTest(t, dir)
 

--- a/shortcuts/apps/apps_plugin_list.go
+++ b/shortcuts/apps/apps_plugin_list.go
@@ -18,7 +18,7 @@ var AppsPluginList = common.Shortcut{
 	Service:     appsService,
 	Command:     "+plugin-list",
 	Description: "List declared plugin packages and their installation status",
-	Risk: "read",
+	Risk:        "read",
 	Tips: []string{
 		"Example: lark-cli apps +plugin-list",
 		"Example: lark-cli apps +plugin-list --format pretty",

--- a/shortcuts/apps/apps_plugin_list_test.go
+++ b/shortcuts/apps/apps_plugin_list_test.go
@@ -40,7 +40,7 @@ func TestPluginList_Installed(t *testing.T) {
 		},
 	})
 	manifestDir := filepath.Join(dir, "node_modules", "@test/my-plugin")
-	os.MkdirAll(manifestDir, 0o755) //nolint:forbidigo
+	os.MkdirAll(manifestDir, 0o755)                                                                //nolint:forbidigo
 	os.WriteFile(filepath.Join(manifestDir, "package.json"), []byte(`{"version":"1.0.0"}`), 0o644) //nolint:forbidigo
 	chdirTest(t, dir)
 

--- a/shortcuts/apps/apps_plugin_uninstall.go
+++ b/shortcuts/apps/apps_plugin_uninstall.go
@@ -20,7 +20,7 @@ var AppsPluginUninstall = common.Shortcut{
 	Service:     appsService,
 	Command:     "+plugin-uninstall",
 	Description: "Uninstall a plugin package (remove from node_modules and package.json)",
-	Risk: "write",
+	Risk:        "write",
 	Tips: []string{
 		"Example: lark-cli apps +plugin-uninstall --name @official-plugins/ai-text-generate",
 	},

--- a/shortcuts/apps/apps_plugin_uninstall_test.go
+++ b/shortcuts/apps/apps_plugin_uninstall_test.go
@@ -20,7 +20,7 @@ func TestPluginUninstall_Basic(t *testing.T) {
 		},
 	})
 	pluginDir := filepath.Join(dir, "node_modules", "@test/my-plugin")
-	os.MkdirAll(pluginDir, 0o755) //nolint:forbidigo
+	os.MkdirAll(pluginDir, 0o755)                                                //nolint:forbidigo
 	os.WriteFile(filepath.Join(pluginDir, "manifest.json"), []byte("{}"), 0o644) //nolint:forbidigo
 	chdirTest(t, dir)
 
@@ -77,7 +77,7 @@ func TestPluginUninstall_BlockedByDependentInstance(t *testing.T) {
 	})
 	// Install plugin
 	pluginDir := filepath.Join(dir, "node_modules", "@test/my-plugin")
-	os.MkdirAll(pluginDir, 0o755) //nolint:forbidigo
+	os.MkdirAll(pluginDir, 0o755)                                                //nolint:forbidigo
 	os.WriteFile(filepath.Join(pluginDir, "manifest.json"), []byte("{}"), 0o644) //nolint:forbidigo
 
 	// Create a capability that references this plugin
@@ -125,7 +125,7 @@ func TestPluginUninstall_WithUnrelatedInstances(t *testing.T) {
 		},
 	})
 	pluginDir := filepath.Join(dir, "node_modules", "@test/my-plugin")
-	os.MkdirAll(pluginDir, 0o755) //nolint:forbidigo
+	os.MkdirAll(pluginDir, 0o755)                                                //nolint:forbidigo
 	os.WriteFile(filepath.Join(pluginDir, "manifest.json"), []byte("{}"), 0o644) //nolint:forbidigo
 
 	// Create a capability that references a DIFFERENT plugin — should not block

--- a/shortcuts/apps/plugin_common_test.go
+++ b/shortcuts/apps/plugin_common_test.go
@@ -239,7 +239,6 @@ func TestPluginListCapabilities_SkipsMalformed(t *testing.T) {
 	}
 }
 
-
 // --- helpers ---
 
 func writeTestCapJSON(t *testing.T, dir, filename string, data map[string]interface{}) {


### PR DESCRIPTION
格式化 apps_plugin_*.go 和 plugin_common_test.go，修复 CI gofmt 检查失败