### PR TITLE
fix: support bot identity for drive search

### DIFF
--- a/shortcuts/drive/drive_search.go
+++ b/shortcuts/drive/drive_search.go
@@ -72,7 +72,7 @@ var DriveSearch = common.Shortcut{
 	Description: "Search Lark docs, Wiki, and spreadsheet files with flat filters (Search v2: doc_wiki/search)",
 	Risk:        "read",
 	Scopes:      []string{"search:docs:read"},
-	AuthTypes:   []string{"user"},
+	AuthTypes:   []string{"user", "bot"},
 	HasFormat:   true,
 	Flags: []common.Flag{
 		{Name: "query", Desc: "search keyword (may be empty to browse by filter only)"},

--- a/shortcuts/drive/shortcuts_test.go
+++ b/shortcuts/drive/shortcuts_test.go
@@ -3,7 +3,10 @@
 
 package drive
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 // TestShortcutsIncludesExpectedCommands verifies the drive shortcut registry contains the expected commands.
 func TestShortcutsIncludesExpectedCommands(t *testing.T) {
@@ -56,5 +59,14 @@ func TestShortcutsIncludesExpectedCommands(t *testing.T) {
 		if !seen[command] {
 			t.Fatalf("missing shortcut command %q in Shortcuts()", command)
 		}
+	}
+}
+
+func TestDriveSearchSupportsUserAndBotIdentity(t *testing.T) {
+	t.Parallel()
+
+	want := []string{"user", "bot"}
+	if !reflect.DeepEqual(DriveSearch.AuthTypes, want) {
+		t.Fatalf("DriveSearch.AuthTypes = %v, want %v", DriveSearch.AuthTypes, want)
 	}
 }

--- a/skills/lark-drive/references/lark-drive-search.md
+++ b/skills/lark-drive/references/lark-drive-search.md
@@ -3,7 +3,7 @@
 
 > **前置条件：** 先阅读 [`../lark-shared/SKILL.md`](../../lark-shared/SKILL.md) 了解认证、全局参数和安全规则。
 
-基于 Search v2 接口 `POST /open-apis/search/v2/doc_wiki/search`，以**用户身份**统一搜索云空间（云盘/云存储）对象。
+基于 Search v2 接口 `POST /open-apis/search/v2/doc_wiki/search`，支持以**用户身份或应用身份**统一搜索云空间（云盘/云存储）对象。
 
 核心特性：
 
@@ -13,6 +13,8 @@
 - `--created-by-me` 一键从当前登录用户的 open_id 填 `original_creator_ids`，匹配“我最初创建的”；`--mine` 仍填 `creator_ids`，匹配 owner / 文档归属人
 
 > **资源发现入口统一**：`drive +search` 同样返回 `SHEET` / `Base` / `FOLDER` 等全部云空间（云盘/云存储）对象，不只是文档 / Wiki。用户说"找一个表格"、"找报表"、"最近打开的表格"时，也从这里开始；定位后再切到对应业务 skill（如 `lark-sheets`）做对象内部操作。
+
+> **身份边界**：普通关键词、类型、文件夹、Wiki 空间、owner/open_id 等显式过滤支持 `--as user` 或 `--as bot`。`--mine` / `--created-by-me` 依赖当前登录用户 open_id 自动填充过滤条件；应用身份下如果没有配置用户 open_id，请改用显式 `--creator-ids` / `--original-creator-ids`。
 
 ## 命令
 

--- a/tests/cli_e2e/drive/drive_search_dryrun_test.go
+++ b/tests/cli_e2e/drive/drive_search_dryrun_test.go
@@ -164,6 +164,45 @@ func TestDriveSearchDryRun_RequestShape(t *testing.T) {
 	}
 }
 
+func TestDriveSearchDryRun_BotIdentity(t *testing.T) {
+	setDriveSearchE2EEnv(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	result, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{
+			"drive", "+search",
+			"--query", "season report",
+			"--page-size", "5",
+			"--dry-run",
+		},
+		DefaultAs: "bot",
+	})
+	require.NoError(t, err)
+	result.AssertExitCode(t, 0)
+	require.Contains(t, result.Args, "--as")
+	require.Contains(t, result.Args, "bot")
+
+	out := result.Stdout
+	if got := gjson.Get(out, "api.0.method").String(); got != "POST" {
+		t.Fatalf("method=%q, want POST\nstdout:\n%s\nstderr:\n%s", got, out, result.Stderr)
+	}
+	if got := gjson.Get(out, "api.0.url").String(); got != "/open-apis/search/v2/doc_wiki/search" {
+		t.Fatalf("url=%q, want Search v2 doc_wiki/search\nstdout:\n%s\nstderr:\n%s", got, out, result.Stderr)
+	}
+	if got := gjson.Get(out, "api.0.body.query").String(); got != "season report" {
+		t.Fatalf("body.query=%q, want season report\nstdout:\n%s", got, out)
+	}
+
+	helpResult, err := clie2e.RunCmd(ctx, clie2e.Request{
+		Args: []string{"drive", "+search", "--help"},
+	})
+	require.NoError(t, err)
+	helpResult.AssertExitCode(t, 0)
+	require.Contains(t, helpResult.Stdout, "identity type: user | bot")
+}
+
 // TestDriveSearchDryRun_OpenedClamping locks in the agent-facing slice
 // notice for --opened-* spans over 90 days: the request body must carry
 // the most recent 90-day window, and stderr must list slice N's flag


### PR DESCRIPTION
## Summary
Enable `drive +search` to run with bot identity so app-only configurations can use Search v2 doc/wiki search without being blocked by identity pruning. The current-user convenience filters remain documented as requiring a user open_id.

## Changes
- Add bot identity support to `drive +search`.
- Add unit coverage for the shortcut identity declaration.
- Add dry-run E2E coverage for `drive +search --as bot`.
- Update the shortcut-specific drive search skill reference with the user/bot identity boundary.

## Test Plan
- [x] Unit tests pass: `go test ./shortcuts/drive`
- [x] Dry-run E2E passes: `go test ./tests/cli_e2e/drive -run TestDriveSearchDryRun`
- [x] Manual local verification confirms the `lark-cli drive +search --as bot --dry-run` flow works as expected

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drive search now supports both user and bot authentication identities.
* **Documentation**
  * Updated `drive +search` documentation to clarify identity boundary behavior and how to use explicit identity options when searching.
* **Tests**
  * Added unit coverage to confirm drive search advertises support for both user and bot.
  * Added an end-to-end dry-run test ensuring bot-identity search requests are constructed correctly and reflected in CLI output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->