### PR TITLE
fix(plugin): harden plugin commands against path traversal, DoS, and agent misuse

### DIFF
--- a/shortcuts/apps/apps_plugin_install.go
+++ b/shortcuts/apps/apps_plugin_install.go
@@ -68,6 +68,11 @@ var AppsPluginInstall = common.Shortcut{
 		if err != nil {
 			return err
 		}
+		if key := strings.TrimSpace(rctx.Str("name")); key != "" {
+			if err := validatePluginKey(key); err != nil {
+				return err
+			}
+		}
 		return pluginCheckProjectDir(projectPath)
 	},
 	Execute: func(ctx context.Context, rctx *common.RuntimeContext) error {
@@ -134,7 +139,10 @@ func pluginInstallOne(ctx context.Context, rctx *common.RuntimeContext, projectP
 	}
 
 	// Extract to node_modules
-	destDir := filepath.Join(projectPath, "node_modules", key)
+	destDir, err := secureModulePath(projectPath, key)
+	if err != nil {
+		return err
+	}
 	if err := os.RemoveAll(destDir); err != nil { //nolint:forbidigo // shortcuts cannot import internal/vfs; clean before extract.
 		return appsFileIOError(err, "cannot clean %s", destDir)
 	}
@@ -247,7 +255,10 @@ func pluginInstallLocal(rctx *common.RuntimeContext, projectPath, tgzPath string
 	}
 
 	// Move to node_modules
-	destDir := filepath.Join(projectPath, "node_modules", key)
+	destDir, err := secureModulePath(projectPath, key)
+	if err != nil {
+		return err
+	}
 	if err := os.RemoveAll(destDir); err != nil { //nolint:forbidigo
 		return appsFileIOError(err, "cannot clean %s", destDir)
 	}
@@ -355,6 +366,9 @@ func pluginFindVersionInItems(data map[string]interface{}, key, version string) 
 
 // pluginDownloadPackage downloads a plugin .tgz via the download_package API.
 // The endpoint is POST with JSON body {plugin_key, plugin_version}.
+
+const pluginDownloadMaxBytes = 10 * 1024 * 1024
+
 func pluginDownloadPackage(ctx context.Context, rctx *common.RuntimeContext, key, version string) ([]byte, error) {
 	apiPath := apiBasePath + "/plugin/versions/download_package"
 	body, _ := json.Marshal(map[string]string{
@@ -380,7 +394,7 @@ func pluginDownloadPackage(ctx context.Context, rctx *common.RuntimeContext, key
 			WithRetryable()
 	}
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(resp.Body)
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		hint := "check plugin key and version spelling"
 		if resp.StatusCode == 403 {
 			hint = "download token may have expired; retry the install to get a fresh token"
@@ -390,5 +404,16 @@ func pluginDownloadPackage(ctx context.Context, rctx *common.RuntimeContext, key
 		return nil, errs.NewAPIError(errs.SubtypeUnknown, "download failed for %s@%s: HTTP %d: %s", key, version, resp.StatusCode, string(respBody)).
 			WithHint(hint)
 	}
-	return io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, pluginDownloadMaxBytes+1))
+	if err != nil {
+		return nil, errs.NewNetworkError(errs.SubtypeNetworkTransport, "download failed for %s@%s: %v", key, version, err).
+			WithHint("check network connectivity and retry").
+			WithRetryable().
+			WithCause(err)
+	}
+	if len(data) > pluginDownloadMaxBytes {
+		return nil, errs.NewAPIError(errs.SubtypeUnknown, "plugin package %s@%s exceeds %d MB size limit", key, version, pluginDownloadMaxBytes/(1024*1024)).
+			WithHint("contact plugin maintainer to reduce package size")
+	}
+	return data, nil
 }

--- a/shortcuts/apps/apps_plugin_list.go
+++ b/shortcuts/apps/apps_plugin_list.go
@@ -17,7 +17,7 @@ import (
 var AppsPluginList = common.Shortcut{
 	Service:     appsService,
 	Command:     "+plugin-list",
-	Description: "List declared plugin packages and their installation status",
+	Description: "List locally installed plugin packages and their installation status",
 	Risk:        "read",
 	Scopes:      []string{},
 	Tips: []string{

--- a/shortcuts/apps/apps_plugin_uninstall.go
+++ b/shortcuts/apps/apps_plugin_uninstall.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/larksuite/cli/shortcuts/common"
@@ -38,8 +37,10 @@ var AppsPluginUninstall = common.Shortcut{
 			Set("update_file", "package.json actionPlugins")
 	},
 	Validate: func(ctx context.Context, rctx *common.RuntimeContext) error {
-		if strings.TrimSpace(rctx.Str("name")) == "" {
+		if key := strings.TrimSpace(rctx.Str("name")); key == "" {
 			return appsValidationParamError("--name", "--name is required")
+		} else if err := validatePluginKey(key); err != nil {
+			return err
 		}
 		projectPath, err := pluginResolveProjectPath("")
 		if err != nil {
@@ -59,7 +60,10 @@ var AppsPluginUninstall = common.Shortcut{
 			return err
 		}
 
-		pkgDir := filepath.Join(projectPath, "node_modules", key)
+		pkgDir, err := secureModulePath(projectPath, key)
+		if err != nil {
+			return err
+		}
 		if err := os.RemoveAll(pkgDir); err != nil { //nolint:forbidigo // shortcuts cannot import internal/vfs; remove plugin directory.
 			return appsFileIOError(err, "cannot remove %s", pkgDir)
 		}

--- a/shortcuts/apps/plugin_common.go
+++ b/shortcuts/apps/plugin_common.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/larksuite/cli/errs"
@@ -50,6 +51,41 @@ func pluginCheckProjectDir(projectPath string) error {
 	return nil
 }
 
+// validatePluginKey validates a plugin key for use in filesystem paths.
+// Rejects empty, ".", "..", absolute paths, path traversal, and control characters.
+func validatePluginKey(key string) error {
+	if key == "" || key == "." || key == ".." {
+		return appsValidationError("invalid plugin key: must not be empty, \".\", or \"..\"")
+	}
+	if filepath.IsAbs(key) {
+		return appsValidationError("invalid plugin key: must not be an absolute path: %q", key)
+	}
+	if strings.Contains(key, "..") {
+		return appsValidationError("invalid plugin key: must not contain path traversal: %q", key)
+	}
+	for _, r := range key {
+		if r < 32 || r == 127 {
+			return appsValidationError("invalid plugin key: contains control character (code %d)", r)
+		}
+	}
+	return nil
+}
+
+// secureModulePath validates the plugin key and joins it with
+// projectPath/node_modules, asserting the result stays within node_modules.
+func secureModulePath(projectPath, key string) (string, error) {
+	if err := validatePluginKey(key); err != nil {
+		return "", err
+	}
+	nodeModules := filepath.Join(projectPath, "node_modules")
+	resolved := filepath.Clean(filepath.Join(nodeModules, key))
+	expectedPrefix := filepath.Clean(nodeModules) + string(filepath.Separator)
+	if !strings.HasPrefix(resolved+string(filepath.Separator), expectedPrefix) {
+		return "", appsValidationError("plugin key %q resolves outside node_modules", key)
+	}
+	return resolved, nil
+}
+
 // pluginResolveCapDir resolves the capabilities directory using a 3-level fallback:
 //  1. MIAODA_CAPABILITIES_DIR env var
 //  2. MIAODA_APP_TYPE env var (2→server/capabilities, 6→shared/capabilities)
@@ -67,6 +103,12 @@ func pluginResolveCapDir(projectPath string) (string, error) {
 	appType := os.Getenv("MIAODA_APP_TYPE")
 	if appType == "" {
 		appType = pluginReadEnvLocalValue(projectPath, "MIAODA_APP_TYPE")
+	}
+	if appType != "" {
+		if _, err := strconv.Atoi(appType); err != nil {
+			return "", appsValidationError("MIAODA_APP_TYPE must be a number, got %q", appType).
+				WithHint("set MIAODA_APP_TYPE to a valid numeric value in .env.local")
+		}
 	}
 	if appType == "6" {
 		return filepath.Join(projectPath, "shared", "capabilities"), nil
@@ -302,6 +344,8 @@ func pluginInstalledVersion(projectPath, pluginKey string) string {
 
 // ── tgz extraction ──
 
+const pluginExtractMaxBytes = 10 * 1024 * 1024
+
 // pluginExtractTGZ extracts a gzipped tar archive into destDir, stripping the
 // first path component (npm convention: tarballs contain a "package/" prefix).
 // Path traversal entries are silently skipped.
@@ -338,6 +382,8 @@ func pluginExtractTGZ(r io.Reader, destDir string) error {
 		}
 
 		switch hdr.Typeflag {
+		case tar.TypeSymlink, tar.TypeLink:
+			continue
 		case tar.TypeDir:
 			if err := os.MkdirAll(target, 0o755); err != nil { //nolint:forbidigo // shortcuts cannot import internal/vfs; tgz extraction.
 				return err
@@ -350,7 +396,7 @@ func pluginExtractTGZ(r io.Reader, destDir string) error {
 			if err != nil {
 				return err
 			}
-			if _, err := io.Copy(f, tr); err != nil { //nolint:gosec // bounded by tar entry size
+			if _, err := io.Copy(f, io.LimitReader(tr, pluginExtractMaxBytes)); err != nil {
 				if cerr := f.Close(); cerr != nil {
 					return fmt.Errorf("copy tar entry: %w; close file: %w", err, cerr) //nolint:forbidigo // intermediate helper error; callers wrap as typed
 				}

--- a/skills/lark-apps/references/lark-apps-plugin-install.md
+++ b/skills/lark-apps/references/lark-apps-plugin-install.md
@@ -1,5 +1,7 @@
 # apps +plugin-install
 
+> **本地命令**：读当前目录的 `package.json`，在项目根目录下运行（和 npm 一样）。**不接受 `--app-id`**——它不是远端 API 命令。
+
 安装插件包到项目。运行时命令事实以 `lark-cli apps +plugin-install --help` 为准。
 
 ## 何时用

--- a/skills/lark-apps/references/lark-apps-plugin-list.md
+++ b/skills/lark-apps/references/lark-apps-plugin-list.md
@@ -1,5 +1,7 @@
 # apps +plugin-list
 
+> **本地命令**：读当前目录的 `package.json`，在项目根目录下运行（和 npm 一样）。**不接受 `--app-id`**——它不是远端 API 命令。
+
 列出已声明的插件包及安装状态。运行时命令事实以 `lark-cli apps +plugin-list --help` 为准。
 
 ## 何时用

--- a/skills/lark-apps/references/lark-apps-plugin-uninstall.md
+++ b/skills/lark-apps/references/lark-apps-plugin-uninstall.md
@@ -1,5 +1,7 @@
 # apps +plugin-uninstall
 
+> **本地命令**：读当前目录的 `package.json`，在项目根目录下运行（和 npm 一样）。**不接受 `--app-id`**——它不是远端 API 命令。
+
 卸载插件包。运行时命令事实以 `lark-cli apps +plugin-uninstall --help` 为准。
 
 ## 何时用


### PR DESCRIPTION
## Summary

Security fixes for the plugin package management commands based on the PR #1596 security audit, plus a usability fix for agent misuse of --app-id.

## Changes

### Security fixes (audit CRITICAL-1, HIGH-1, MEDIUM-2, LOW-3)

| Vulnerability | Fix |
|--------------|-----|
| **CRITICAL-1** TGZ Zip Slip — symlink entries not handled | Skip `TypeSymlink` / `TypeLink` entries; add `LimitReader(10MB)` to `io.Copy` |
| **HIGH-1** Download `io.ReadAll` with no size limit (OOM/DoS) | `LimitReader(10MB+1)` with explicit size check |
| **MEDIUM-2** `.env.local` value parsing — MIAODA_APP_TYPE not validated | `strconv.Atoi` validation, reject non-numeric |
| **LOW-3** Error response body with no size limit | `LimitReader(4KB)` on 4xx response reads |

### Blocker: Plugin name path traversal (review finding)

- **Root cause**: `--name` value (e.g. `../../.ssh`) used directly in `os.RemoveAll` / `filepath.Join` to `node_modules`
- **Fix**: Add `validatePluginKey()` (rejects empty, `.`, `..`, absolute paths, `../`, control chars) + `secureModulePath()` (validates key + asserts resolved path stays within `node_modules/`)
- Applied to `+plugin-install` and `+plugin-uninstall` in both Validate and Execute paths

### Usability fix: Agent --app-id misuse

- Agent incorrectly passes `--app-id` to plugin commands, treating them like other `apps +*` API commands
- Updated `Description` fields (visible in `--help`) and reference docs to explicitly state "local command, no --app-id"

## Test Plan

- [x] `go vet ./shortcuts/apps/` passed
- [x] 35 plugin-related unit tests all PASS
- [x] `gofmt -l` — zero formatting issues
- [x] `golangci-lint run --new-from-rev=origin/feat/apps-spark-capibilities` — 0 issues
- [x] Local manual build + `--help` output verified