### PR TITLE
fix(credential): mint env app-secret tenant tokens

### DIFF
--- a/internal/credential/credential_provider.go
+++ b/internal/credential/credential_provider.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/larksuite/cli/errs"
 	extcred "github.com/larksuite/cli/extension/credential"
 	"github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/core"
@@ -38,12 +39,17 @@ type credentialSource interface {
 }
 
 type extensionTokenSource struct {
-	provider extcred.Provider
+	provider   extcred.Provider
+	account    *Account
+	httpClient func() (*http.Client, error)
+
+	tatMu     sync.Mutex
+	tatResult *TokenResult
 }
 
-func (s extensionTokenSource) Name() string { return s.provider.Name() }
+func (s *extensionTokenSource) Name() string { return s.provider.Name() }
 
-func (s extensionTokenSource) TryResolveToken(ctx context.Context, req TokenSpec) (*TokenResult, bool, error) {
+func (s *extensionTokenSource) TryResolveToken(ctx context.Context, req TokenSpec) (*TokenResult, bool, error) {
 	tok, err := s.provider.ResolveToken(ctx, extcred.TokenSpec{
 		Type:  extcred.TokenType(req.Type.String()),
 		AppID: req.AppID,
@@ -52,7 +58,7 @@ func (s extensionTokenSource) TryResolveToken(ctx context.Context, req TokenSpec
 		return nil, false, err
 	}
 	if tok == nil {
-		return nil, false, nil
+		return s.resolveTATFromAppSecret(ctx, req)
 	}
 	if tok.Value == "" {
 		return nil, false, &MalformedTokenResultError{Source: s.Name(), Type: req.Type, Reason: "empty token"}
@@ -60,7 +66,41 @@ func (s extensionTokenSource) TryResolveToken(ctx context.Context, req TokenSpec
 	return &TokenResult{Token: tok.Value, Scopes: tok.Scopes}, true, nil
 }
 
-func (s extensionTokenSource) ResolveIdentityHint(ctx context.Context, acct *Account) (*IdentityHint, error) {
+func (s *extensionTokenSource) resolveTATFromAppSecret(ctx context.Context, req TokenSpec) (*TokenResult, bool, error) {
+	if req.Type != TokenTypeTAT || s.account == nil || req.AppID != s.account.AppID || !HasRealAppSecret(s.account.AppSecret) || s.httpClient == nil {
+		return nil, false, nil
+	}
+	s.tatMu.Lock()
+	defer s.tatMu.Unlock()
+	if s.tatResult != nil {
+		return s.tatResult, true, nil
+	}
+	hc, err := s.httpClient()
+	if err != nil {
+		return nil, false, wrapTATMintError(err)
+	}
+	token, err := FetchTAT(ctx, hc, s.account.Brand, s.account.AppID, s.account.AppSecret)
+	if err != nil {
+		return nil, false, wrapTATMintError(err)
+	}
+	if token == "" {
+		return nil, false, &MalformedTokenResultError{Source: s.Name(), Type: req.Type, Reason: "empty token"}
+	}
+	s.tatResult = &TokenResult{Token: token}
+	return s.tatResult, true, nil
+}
+
+func wrapTATMintError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := errs.ProblemOf(err); ok {
+		return err
+	}
+	return errs.NewNetworkError(errs.SubtypeNetworkTransport, "tenant access token request failed: %v", err).WithCause(err)
+}
+
+func (s *extensionTokenSource) ResolveIdentityHint(ctx context.Context, acct *Account) (*IdentityHint, error) {
 	hint := &IdentityHint{}
 	if acct == nil {
 		return hint, nil
@@ -77,6 +117,8 @@ func (s extensionTokenSource) ResolveIdentityHint(ctx context.Context, acct *Acc
 	case ids.UserOnly():
 		hint.AutoAs = core.AsUser
 	case ids.BotOnly():
+		hint.AutoAs = core.AsBot
+	case HasRealAppSecret(acct.AppSecret):
 		hint.AutoAs = core.AsBot
 	}
 	return hint, nil
@@ -180,7 +222,7 @@ func (p *CredentialProvider) doResolveAccount(ctx context.Context) (*Account, er
 		}
 		if acct != nil {
 			internal := convertAccount(acct)
-			source := extensionTokenSource{provider: prov}
+			source := &extensionTokenSource{provider: prov, account: internal, httpClient: p.httpClient}
 			if err := p.enrichUserInfo(ctx, internal, source); err != nil {
 				if p.warnOut != nil {
 					_, _ = fmt.Fprintf(p.warnOut, "warning: unable to verify user identity from credential source %q: %v\n", source.Name(), err)
@@ -311,7 +353,7 @@ func (p *CredentialProvider) ResolveToken(ctx context.Context, req TokenSpec) (*
 	}
 
 	for _, prov := range p.providers {
-		source := extensionTokenSource{provider: prov}
+		source := &extensionTokenSource{provider: prov}
 		result, found, err := source.TryResolveToken(ctx, req)
 		if err != nil {
 			return nil, err

--- a/internal/credential/credential_provider_test.go
+++ b/internal/credential/credential_provider_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/larksuite/cli/errs"
 	extcred "github.com/larksuite/cli/extension/credential"
 	"github.com/larksuite/cli/internal/auth"
 	"github.com/larksuite/cli/internal/core"
@@ -191,6 +192,172 @@ func TestCredentialProvider_SelectedSourceWithoutTokenReturnsUnavailableError(t 
 	}
 	if unavailableErr.Source != "env" || unavailableErr.Type != TokenTypeUAT {
 		t.Fatalf("ResolveToken() unavailable error = %+v, want source env and type uat", unavailableErr)
+	}
+}
+
+func TestCredentialProvider_SelectedExtensionAppSecretMintsTAT(t *testing.T) {
+	rt := &stubRoundTripper{
+		respCode: 200,
+		respBody: `{"code":0,"access_token":"minted-tat","token_type":"Bearer","expires_in":7200}`,
+	}
+	httpClientCalls := 0
+	cp := NewCredentialProvider(
+		[]extcred.Provider{&mockExtProvider{
+			name: "env",
+			account: &extcred.Account{
+				AppID:     "ext_app",
+				AppSecret: "ext_secret",
+				Brand:     extcred.BrandFeishu,
+			},
+		}},
+		nil,
+		nil,
+		func() (*http.Client, error) {
+			httpClientCalls++
+			return &http.Client{Transport: rt}, nil
+		},
+	)
+
+	if _, err := cp.ResolveAccount(context.Background()); err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+
+	result, err := cp.ResolveToken(context.Background(), TokenSpec{Type: TokenTypeTAT, AppID: "ext_app"})
+	if err != nil {
+		t.Fatalf("ResolveToken() error = %v", err)
+	}
+	if result.Token != "minted-tat" {
+		t.Fatalf("ResolveToken() token = %q, want minted-tat", result.Token)
+	}
+	if httpClientCalls != 1 {
+		t.Fatalf("httpClient() calls = %d, want 1", httpClientCalls)
+	}
+	for _, want := range []string{"grant_type=client_credentials", "client_id=ext_app", "client_secret=ext_secret"} {
+		if !strings.Contains(rt.gotBody, want) {
+			t.Fatalf("TAT request body missing %q: %s", want, rt.gotBody)
+		}
+	}
+
+	result, err = cp.ResolveToken(context.Background(), TokenSpec{Type: TokenTypeTAT, AppID: "ext_app"})
+	if err != nil {
+		t.Fatalf("second ResolveToken() error = %v", err)
+	}
+	if result.Token != "minted-tat" {
+		t.Fatalf("second ResolveToken() token = %q, want minted-tat", result.Token)
+	}
+	if httpClientCalls != 1 {
+		t.Fatalf("httpClient() calls after cached token = %d, want 1", httpClientCalls)
+	}
+}
+
+func TestCredentialProvider_SelectedExtensionAppSecretDoesNotMintTATForDifferentApp(t *testing.T) {
+	httpClientCalls := 0
+	cp := NewCredentialProvider(
+		[]extcred.Provider{&mockExtProvider{
+			name: "env",
+			account: &extcred.Account{
+				AppID:     "ext_app",
+				AppSecret: "ext_secret",
+				Brand:     extcred.BrandFeishu,
+			},
+		}},
+		nil,
+		nil,
+		func() (*http.Client, error) {
+			httpClientCalls++
+			return &http.Client{Transport: &stubRoundTripper{}}, nil
+		},
+	)
+
+	if _, err := cp.ResolveAccount(context.Background()); err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+
+	_, err := cp.ResolveToken(context.Background(), TokenSpec{Type: TokenTypeTAT, AppID: "other_app"})
+	if err == nil {
+		t.Fatal("ResolveToken() error = nil, want unavailable token")
+	}
+	var unavailableErr *TokenUnavailableError
+	if !errors.As(err, &unavailableErr) {
+		t.Fatalf("ResolveToken() error type = %T, want *TokenUnavailableError", err)
+	}
+	if unavailableErr.Source != "env" || unavailableErr.Type != TokenTypeTAT {
+		t.Fatalf("ResolveToken() unavailable error = %+v, want source env and type tat", unavailableErr)
+	}
+	if httpClientCalls != 0 {
+		t.Fatalf("httpClient() calls = %d, want 0", httpClientCalls)
+	}
+}
+
+func TestCredentialProvider_SelectedExtensionAppSecretTATFailureRetries(t *testing.T) {
+	rt := &stubRoundTripper{
+		respCode: 200,
+		respBody: `{"code":0,"access_token":"minted-after-retry","token_type":"Bearer","expires_in":7200}`,
+	}
+	transientErr := errors.New("temporary transport failure")
+	httpClientCalls := 0
+	cp := NewCredentialProvider(
+		[]extcred.Provider{&mockExtProvider{
+			name: "env",
+			account: &extcred.Account{
+				AppID:     "ext_app",
+				AppSecret: "ext_secret",
+				Brand:     extcred.BrandFeishu,
+			},
+		}},
+		nil,
+		nil,
+		func() (*http.Client, error) {
+			httpClientCalls++
+			if httpClientCalls == 1 {
+				return nil, transientErr
+			}
+			return &http.Client{Transport: rt}, nil
+		},
+	)
+
+	if _, err := cp.ResolveAccount(context.Background()); err != nil {
+		t.Fatalf("ResolveAccount() error = %v", err)
+	}
+
+	_, err := cp.ResolveToken(context.Background(), TokenSpec{Type: TokenTypeTAT, AppID: "ext_app"})
+	if err == nil {
+		t.Fatal("first ResolveToken() error = nil, want typed network error")
+	}
+	problem, ok := errs.ProblemOf(err)
+	if !ok {
+		t.Fatalf("first ResolveToken() error type = %T, want typed problem", err)
+	}
+	if problem.Category != errs.CategoryNetwork {
+		t.Fatalf("first ResolveToken() category = %q, want %q", problem.Category, errs.CategoryNetwork)
+	}
+	if problem.Subtype != errs.SubtypeNetworkTransport {
+		t.Fatalf("first ResolveToken() subtype = %q, want %q", problem.Subtype, errs.SubtypeNetworkTransport)
+	}
+	if !errors.Is(err, transientErr) {
+		t.Fatalf("first ResolveToken() error does not preserve cause %v: %v", transientErr, err)
+	}
+
+	result, err := cp.ResolveToken(context.Background(), TokenSpec{Type: TokenTypeTAT, AppID: "ext_app"})
+	if err != nil {
+		t.Fatalf("second ResolveToken() error = %v", err)
+	}
+	if result.Token != "minted-after-retry" {
+		t.Fatalf("second ResolveToken() token = %q, want minted-after-retry", result.Token)
+	}
+	if httpClientCalls != 2 {
+		t.Fatalf("httpClient() calls after retry = %d, want 2", httpClientCalls)
+	}
+
+	result, err = cp.ResolveToken(context.Background(), TokenSpec{Type: TokenTypeTAT, AppID: "ext_app"})
+	if err != nil {
+		t.Fatalf("third ResolveToken() error = %v", err)
+	}
+	if result.Token != "minted-after-retry" {
+		t.Fatalf("third ResolveToken() token = %q, want minted-after-retry", result.Token)
+	}
+	if httpClientCalls != 2 {
+		t.Fatalf("httpClient() calls after cached success = %d, want 2", httpClientCalls)
 	}
 }
 

--- a/internal/credential/integration_test.go
+++ b/internal/credential/integration_test.go
@@ -5,6 +5,9 @@ package credential_test
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	extcred "github.com/larksuite/cli/extension/credential"
@@ -21,6 +24,22 @@ type noopKC struct{}
 func (n *noopKC) Get(service, account string) (string, error) { return "", nil }
 func (n *noopKC) Set(service, account, value string) error    { return nil }
 func (n *noopKC) Remove(service, account string) error        { return nil }
+
+type envTATRoundTripper struct {
+	gotBody string
+}
+
+func (rt *envTATRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Body != nil {
+		body, _ := io.ReadAll(req.Body)
+		rt.gotBody = string(body)
+	}
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader(`{"code":0,"access_token":"env_minted_tat","token_type":"Bearer","expires_in":7200}`)),
+		Header:     make(http.Header),
+	}, nil
+}
 
 func TestFullChain_EnvWins(t *testing.T) {
 	t.Setenv(envvars.CliAppID, "env_app")
@@ -49,6 +68,47 @@ func TestFullChain_EnvWins(t *testing.T) {
 	}
 	if result.Token != "env_uat" {
 		t.Errorf("expected env_uat, got %s", result.Token)
+	}
+}
+
+func TestFullChain_EnvAppSecretMintsTAT(t *testing.T) {
+	t.Setenv(envvars.CliAppID, "env_app")
+	t.Setenv(envvars.CliAppSecret, "env_secret")
+	t.Setenv(envvars.CliUserAccessToken, "")
+	t.Setenv(envvars.CliTenantAccessToken, "")
+
+	ep := &envprovider.Provider{}
+	rt := &envTATRoundTripper{}
+	cp := credential.NewCredentialProvider(
+		[]extcred.Provider{ep},
+		nil,
+		nil,
+		func() (*http.Client, error) {
+			return &http.Client{Transport: rt}, nil
+		},
+	)
+
+	acct, err := cp.ResolveAccount(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if acct.AppID != "env_app" || acct.AppSecret != "env_secret" {
+		t.Fatalf("unexpected account: %+v", acct)
+	}
+
+	result, err := cp.ResolveToken(context.Background(), credential.TokenSpec{
+		Type: credential.TokenTypeTAT, AppID: "env_app",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Token != "env_minted_tat" {
+		t.Errorf("expected env_minted_tat, got %s", result.Token)
+	}
+	for _, want := range []string{"grant_type=client_credentials", "client_id=env_app", "client_secret=env_secret"} {
+		if !strings.Contains(rt.gotBody, want) {
+			t.Fatalf("TAT request body missing %q: %s", want, rt.gotBody)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
Fix env-backed bot authentication so `LARKSUITE_CLI_APP_ID` + `LARKSUITE_CLI_APP_SECRET` can mint a tenant access token instead of failing with `token_missing`.

## Changes
- Let selected extension credential accounts mint TAT from their own real app secret when no explicit TAT is provided.
- Cache the minted TAT within the selected credential source for the current CLI invocation.
- Add unit and integration coverage for env app-secret TAT minting.

## Test Plan
- [x] Unit tests pass: `make unit-test`
- [x] Manual local verification confirms the `lark-cli wiki +space-list --as bot` flow reaches the token endpoint with env app credentials and no longer fails locally with `token_missing`
- [x] `go vet ./...`
- [x] `gofmt -l internal/credential/credential_provider.go internal/credential/credential_provider_test.go internal/credential/integration_test.go`
- [x] `go mod tidy`

## Related Issues
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for minting TAT tokens from an app secret when the extension provider doesn’t return a token, including the full environment-based flow.
  * Updated identity hints so bot assignment is set when a real app secret is available.
* **Bug Fixes**
  * Improved TAT resolution: validates token responses, treats empty tokens as malformed, wraps mint failures as typed network problems, and caches the first successful result.
  * Prevents token mint attempts for non-matching AppIDs.
* **Tests**
  * Added unit and end-to-end coverage for minting, negative selection, retry behavior, and request parameter correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->