### PR TITLE
fix(plugin): create temp dir in project path to avoid cross-filesystem EXDEV on Rename

### DIFF
--- a/shortcuts/apps/apps_plugin_install.go
+++ b/shortcuts/apps/apps_plugin_install.go
@@ -226,7 +226,7 @@ func pluginInstallLocal(rctx *common.RuntimeContext, projectPath, tgzPath string
 	}
 
 	// Extract to a temp dir first to read package.json
-	tmpDir, err := os.MkdirTemp("", "plugin-local-*") //nolint:forbidigo
+	tmpDir, err := os.MkdirTemp(projectPath, ".plugin-tmp-*") //nolint:forbidigo // same FS as node_modules to avoid EXDEV on Rename
 	if err != nil {
 		return appsFileIOError(err, "cannot create temp dir")
 	}


### PR DESCRIPTION
## Summary

pluginInstallLocal uses os.MkdirTemp("") which puts temp dirs on the system temp partition. On Windows the temp partition is often on a different drive from the project, causing os.Rename to fail with EXDEV.

## Changes

- Changed os.MkdirTemp("", "plugin-local-*") to os.MkdirTemp(projectPath, ".plugin-tmp-*") so the temp directory is always on the same filesystem as node_modules/
- Used dot-prefix (.plugin-tmp-*) so the temp dir is hidden from casual directory listing

## Test Plan

- [x] gofmt passed
- [x] go vet passed
- [x] Plugin unit tests all PASS