### PR TITLE
fix: complete mail rule reorder ids

### DIFF
--- a/cmd/service/mail_rule_reorder.go
+++ b/cmd/service/mail_rule_reorder.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/output"
+)
+
+const (
+	mailRuleReorderSchemaPath = "mail.user_mailbox.rules.reorder"
+	mailRuleIDsParam          = "rule_ids"
+	mailRuleDryRunRemainingID = "__remaining_rule_ids_from_list_response__"
+)
+
+func completeMailRuleReorderRequest(ctx context.Context, ac *client.APIClient, request client.RawApiRequest) (client.RawApiRequest, error) {
+	explicit, err := mailRuleReorderExplicitIDs(request.Data)
+	if err != nil {
+		return request, err
+	}
+	listReq := mailRuleReorderListRequest(request)
+	result, err := ac.CallAPI(ctx, listReq)
+	if err != nil {
+		return request, err
+	}
+	if err := ac.CheckResponse(result, request.As); err != nil {
+		return request, err
+	}
+	completed, err := mergeMailRuleIDs(explicit, extractMailRuleIDsFromListResponse(result))
+	if err != nil {
+		return request, err
+	}
+	body, ok := request.Data.(map[string]interface{})
+	if !ok {
+		return request, mailRuleReorderValidation("--data must be a JSON object").WithParam("--data")
+	}
+	body[mailRuleIDsParam] = completed
+	request.Data = body
+	return request, nil
+}
+
+func serviceDryRunMailRuleReorder(f *cmdutil.Factory, request client.RawApiRequest, config *core.CliConfig, format string) error {
+	explicit, err := mailRuleReorderExplicitIDs(request.Data)
+	if err != nil {
+		return err
+	}
+	completed := append([]string(nil), explicit...)
+	completed = append(completed, mailRuleDryRunRemainingID)
+
+	body := map[string]interface{}{}
+	if requestBody, ok := request.Data.(map[string]interface{}); ok {
+		for k, v := range requestBody {
+			body[k] = v
+		}
+	}
+	body[mailRuleIDsParam] = completed
+
+	dr := cmdutil.NewDryRunAPI().
+		GET(mailRuleReorderListRequest(request).URL).
+		Desc("List current mail rules").
+		POST(request.URL).
+		Desc("Reorder mail rules with completed rule_ids").
+		Body(body).
+		Set("as", string(request.As)).
+		Set("appId", config.AppID).
+		Set("completed_rule_ids", completed)
+	if config.UserOpenId != "" {
+		dr.Set("userOpenId", config.UserOpenId)
+	}
+
+	fmt.Fprintln(f.IOStreams.Out, "=== Dry Run ===")
+	if format == "pretty" {
+		fmt.Fprint(f.IOStreams.Out, dr.Format())
+		return nil
+	}
+	return outputDryRunJSON(f, dr)
+}
+
+func outputDryRunJSON(f *cmdutil.Factory, dr *cmdutil.DryRunAPI) error {
+	output.PrintJson(f.IOStreams.Out, dr)
+	return nil
+}
+
+func mailRuleReorderListRequest(request client.RawApiRequest) client.RawApiRequest {
+	return client.RawApiRequest{
+		Method: "GET",
+		URL:    trimReorderSuffix(request.URL),
+		As:     request.As,
+	}
+}
+
+func trimReorderSuffix(rawURL string) string {
+	const suffix = "/reorder"
+	if strings.HasSuffix(rawURL, suffix) {
+		return strings.TrimSuffix(rawURL, suffix)
+	}
+	return rawURL
+}
+
+func mailRuleReorderExplicitIDs(data interface{}) ([]string, error) {
+	body, ok := data.(map[string]interface{})
+	if !ok || body == nil {
+		return nil, mailRuleReorderValidation("--data must be a JSON object").WithParam("--data")
+	}
+	raw, ok := body[mailRuleIDsParam]
+	if !ok {
+		return nil, mailRuleReorderValidation("data.rule_ids is required").WithParam("data.rule_ids")
+	}
+	items, ok := raw.([]interface{})
+	if !ok {
+		return nil, mailRuleReorderValidation("data.rule_ids must be a non-empty string array").WithParam("data.rule_ids")
+	}
+	if len(items) == 0 {
+		return nil, mailRuleReorderValidation("data.rule_ids must be non-empty").WithParam("data.rule_ids")
+	}
+
+	ids := make([]string, 0, len(items))
+	seen := map[string]struct{}{}
+	for i, item := range items {
+		id, ok := item.(string)
+		if !ok {
+			return nil, mailRuleReorderValidation("data.rule_ids[%d] must be a string", i).WithParam("data.rule_ids")
+		}
+		if id == "" {
+			return nil, mailRuleReorderValidation("data.rule_ids[%d] must be non-empty", i).WithParam("data.rule_ids")
+		}
+		if _, exists := seen[id]; exists {
+			return nil, mailRuleReorderValidation("data.rule_ids contains duplicate rule id: %s", id).WithParam("data.rule_ids")
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func extractMailRuleIDsFromListResponse(result interface{}) []string {
+	resultMap, ok := result.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	data, ok := resultMap["data"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	items, ok := data["items"].([]interface{})
+	if !ok {
+		return nil
+	}
+	ids := make([]string, 0, len(items))
+	for _, item := range items {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, ok := itemMap["rule_id"].(string)
+		if ok && id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func mergeMailRuleIDs(explicit, all []string) ([]string, error) {
+	allSet := make(map[string]struct{}, len(all))
+	for _, id := range all {
+		allSet[id] = struct{}{}
+	}
+	for _, id := range explicit {
+		if _, ok := allSet[id]; !ok {
+			return nil, mailRuleReorderValidation("rule_ids contains unknown rule id: %s", id).WithParam("data.rule_ids")
+		}
+	}
+
+	completed := append([]string(nil), explicit...)
+	explicitSet := make(map[string]struct{}, len(explicit))
+	for _, id := range explicit {
+		explicitSet[id] = struct{}{}
+	}
+	for _, id := range all {
+		if _, ok := explicitSet[id]; ok {
+			continue
+		}
+		completed = append(completed, id)
+	}
+	return completed, nil
+}
+
+func mailRuleReorderValidation(format string, args ...interface{}) *errs.ValidationError {
+	return errs.NewValidationError(errs.SubtypeInvalidArgument, format, args...)
+}

--- a/cmd/service/mail_rule_reorder.go
+++ b/cmd/service/mail_rule_reorder.go
@@ -155,6 +155,7 @@ func extractMailRuleIDsFromListResponse(result interface{}) []string {
 		return nil
 	}
 	ids := make([]string, 0, len(items))
+	seen := make(map[string]struct{}, len(items))
 	for _, item := range items {
 		itemMap, ok := item.(map[string]interface{})
 		if !ok {
@@ -162,6 +163,10 @@ func extractMailRuleIDsFromListResponse(result interface{}) []string {
 		}
 		id, ok := itemMap["rule_id"].(string)
 		if ok && id != "" {
+			if _, exists := seen[id]; exists {
+				continue
+			}
+			seen[id] = struct{}{}
 			ids = append(ids, id)
 		}
 	}
@@ -180,15 +185,16 @@ func mergeMailRuleIDs(explicit, all []string) ([]string, error) {
 	}
 
 	completed := append([]string(nil), explicit...)
-	explicitSet := make(map[string]struct{}, len(explicit))
+	completedSet := make(map[string]struct{}, len(explicit)+len(all))
 	for _, id := range explicit {
-		explicitSet[id] = struct{}{}
+		completedSet[id] = struct{}{}
 	}
 	for _, id := range all {
-		if _, ok := explicitSet[id]; ok {
+		if _, ok := completedSet[id]; ok {
 			continue
 		}
 		completed = append(completed, id)
+		completedSet[id] = struct{}{}
 	}
 	return completed, nil
 }

--- a/cmd/service/mail_rule_reorder_test.go
+++ b/cmd/service/mail_rule_reorder_test.go
@@ -144,6 +144,18 @@ func TestMailRuleReorder_FullRuleIDsUnchanged(t *testing.T) {
 	}
 }
 
+func TestMailRuleReorder_DeduplicatesListRuleIDs(t *testing.T) {
+	_, posted, err := runMailRuleReorder(t, `{"rule_ids":["3"]}`, func(reg *httpmock.Registry, calls, posted *[]string) {
+		registerSuccessfulMailRuleFlow(reg, calls, posted, "1", "1", "2", "3")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := []string{"3", "1", "2"}; !reflect.DeepEqual(posted, want) {
+		t.Fatalf("posted rule_ids = %v, want %v", posted, want)
+	}
+}
+
 func TestMailRuleReorder_ValidationErrors(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/service/mail_rule_reorder_test.go
+++ b/cmd/service/mail_rule_reorder_test.go
@@ -1,0 +1,240 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/larksuite/cli/errs"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+	"github.com/larksuite/cli/internal/httpmock"
+	"github.com/larksuite/cli/internal/meta"
+	"github.com/spf13/cobra"
+)
+
+func mailRuleServiceSpec() meta.Service {
+	return meta.ServiceFromMap(map[string]interface{}{
+		"name":        "mail",
+		"servicePath": "/open-apis/mail/v1",
+	})
+}
+
+func mailRuleReorderMethod() meta.Method {
+	return meta.FromMap(map[string]interface{}{
+		"path":       "user_mailboxes/{user_mailbox_id}/rules/reorder",
+		"httpMethod": "POST",
+		"parameters": map[string]interface{}{
+			"user_mailbox_id": map[string]interface{}{
+				"type": "string", "location": "path", "required": true,
+			},
+		},
+		"requestBody": map[string]interface{}{
+			"rule_ids": map[string]interface{}{"type": "array", "required": true},
+		},
+	})
+}
+
+func newMailRuleReorderCommand(t *testing.T, f *cmdutil.Factory) *cobra.Command {
+	t.Helper()
+	return NewCmdServiceMethod(f, mailRuleServiceSpec(), mailRuleReorderMethod(), "reorder", "user_mailbox.rules", nil)
+}
+
+func registerMailRuleListStub(reg *httpmock.Registry, body interface{}, onMatch func()) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body:   body,
+	}
+	if onMatch != nil {
+		stub.OnMatch = func(_ *http.Request) { onMatch() }
+	}
+	reg.Register(stub)
+	return stub
+}
+
+func registerMailRuleReorderStub(reg *httpmock.Registry, onMatch func([]byte)) *httpmock.Stub {
+	stub := &httpmock.Stub{
+		Method: "POST",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules/reorder",
+		Body: map[string]interface{}{
+			"code": 0,
+			"msg":  "ok",
+			"data": map[string]interface{}{"success": true},
+		},
+	}
+	if onMatch != nil {
+		stub.OnMatch = func(req *http.Request) {
+			payload, _ := io.ReadAll(req.Body)
+			onMatch(payload)
+		}
+	}
+	reg.Register(stub)
+	return stub
+}
+
+func mailRuleListResponse(ids ...string) map[string]interface{} {
+	items := make([]interface{}, 0, len(ids))
+	for _, id := range ids {
+		items = append(items, map[string]interface{}{"rule_id": id})
+	}
+	return map[string]interface{}{
+		"code": 0,
+		"msg":  "ok",
+		"data": map[string]interface{}{"items": items},
+	}
+}
+
+func runMailRuleReorder(t *testing.T, data string, regFn func(*httpmock.Registry, *[]string, *[]string)) ([]string, []string, error) {
+	t.Helper()
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	var calls []string
+	var posted []string
+	if regFn != nil {
+		regFn(reg, &calls, &posted)
+	}
+	cmd := newMailRuleReorderCommand(t, f)
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", data})
+	return calls, posted, cmd.Execute()
+}
+
+func registerSuccessfulMailRuleFlow(reg *httpmock.Registry, calls *[]string, posted *[]string, listIDs ...string) {
+	registerMailRuleListStub(reg, mailRuleListResponse(listIDs...), func() {
+		*calls = append(*calls, "GET")
+	})
+	registerMailRuleReorderStub(reg, func(payload []byte) {
+		*calls = append(*calls, "POST")
+		var body map[string][]string
+		_ = json.Unmarshal(payload, &body)
+		*posted = append((*posted)[:0], body[mailRuleIDsParam]...)
+	})
+}
+
+func TestMailRuleReorder_CompletesPartialRuleIDs(t *testing.T) {
+	calls, posted, err := runMailRuleReorder(t, `{"rule_ids":["3"]}`, func(reg *httpmock.Registry, calls, posted *[]string) {
+		registerSuccessfulMailRuleFlow(reg, calls, posted, "1", "2", "3")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := []string{"GET", "POST"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+	if want := []string{"3", "1", "2"}; !reflect.DeepEqual(posted, want) {
+		t.Fatalf("posted rule_ids = %v, want %v", posted, want)
+	}
+}
+
+func TestMailRuleReorder_FullRuleIDsUnchanged(t *testing.T) {
+	_, posted, err := runMailRuleReorder(t, `{"rule_ids":["1","2","3"]}`, func(reg *httpmock.Registry, calls, posted *[]string) {
+		registerSuccessfulMailRuleFlow(reg, calls, posted, "1", "2", "3")
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := []string{"1", "2", "3"}; !reflect.DeepEqual(posted, want) {
+		t.Fatalf("posted rule_ids = %v, want %v", posted, want)
+	}
+}
+
+func TestMailRuleReorder_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{name: "empty array", data: `{"rule_ids":[]}`, want: "must be non-empty"},
+		{name: "non string", data: `{"rule_ids":["1",2]}`, want: "must be a string"},
+		{name: "empty string", data: `{"rule_ids":[""]}`, want: "must be non-empty"},
+		{name: "duplicate", data: `{"rule_ids":["1","1"]}`, want: "duplicate rule id"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := runMailRuleReorder(t, tt.data, nil)
+			assertMailRuleValidationError(t, err, tt.want)
+		})
+	}
+}
+
+func TestMailRuleReorder_UnknownExplicitID(t *testing.T) {
+	calls, _, err := runMailRuleReorder(t, `{"rule_ids":["9"]}`, func(reg *httpmock.Registry, calls, posted *[]string) {
+		registerMailRuleListStub(reg, mailRuleListResponse("1", "2"), func() {
+			*calls = append(*calls, "GET")
+		})
+	})
+	assertMailRuleValidationError(t, err, "unknown rule id: 9")
+	if want := []string{"GET"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestMailRuleReorder_ListAPIFailureStopsBeforePost(t *testing.T) {
+	f, _, _, reg := cmdutil.TestFactory(t, testConfig)
+	reg.Register(&httpmock.Stub{
+		Method: "GET",
+		URL:    "/open-apis/mail/v1/user_mailboxes/me/rules",
+		Body: map[string]interface{}{
+			"code": 230027,
+			"msg":  "user not authorized",
+		},
+	})
+	cmd := newMailRuleReorderCommand(t, f)
+	cmd.SetArgs([]string{"--as", "bot", "--params", `{"user_mailbox_id":"me"}`, "--data", `{"rule_ids":["1"]}`})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected list API failure")
+	}
+	requireProblem(t, err, errs.CategoryAuthorization, errs.SubtypeUserUnauthorized, 230027)
+}
+
+func TestMailRuleReorder_DryRunShowsTwoStepFlow(t *testing.T) {
+	f, stdout, _, _ := cmdutil.TestFactory(t, &core.CliConfig{
+		AppID: "test-app", AppSecret: "test-secret", Brand: core.BrandFeishu, UserOpenId: "ou_test",
+	})
+	cmd := newMailRuleReorderCommand(t, f)
+	cmd.SetArgs([]string{
+		"--as", "bot",
+		"--params", `{"user_mailbox_id":"me"}`,
+		"--data", `{"rule_ids":["3"]}`,
+		"--dry-run",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		`"method": "GET"`,
+		`"/open-apis/mail/v1/user_mailboxes/me/rules"`,
+		`"method": "POST"`,
+		`"/open-apis/mail/v1/user_mailboxes/me/rules/reorder"`,
+		mailRuleDryRunRemainingID,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func assertMailRuleValidationError(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	var validationErr *errs.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T: %v", err, err)
+	}
+	if validationErr.Category != errs.CategoryValidation || validationErr.Subtype != errs.SubtypeInvalidArgument {
+		t.Fatalf("problem = %s/%s, want validation/invalid_argument", validationErr.Category, validationErr.Subtype)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want substring %q", err.Error(), want)
+	}
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -401,6 +401,9 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		return err
 	}
 
+	if opts.SchemaPath == mailRuleReorderSchemaPath && opts.DryRun {
+		return serviceDryRunMailRuleReorder(f, request, config, opts.Format)
+	}
 	if opts.DryRun {
 		if fileMeta != nil {
 			return cmdutil.PrintDryRunWithFile(f.IOStreams.Out, request, config, opts.Format, fileMeta.FieldName, fileMeta.FilePath, fileMeta.FormFields)
@@ -417,6 +420,13 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	ac, err := f.NewAPIClientWithConfig(config)
 	if err != nil {
 		return err
+	}
+
+	if opts.SchemaPath == mailRuleReorderSchemaPath {
+		request, err = completeMailRuleReorderRequest(opts.Ctx, ac, request)
+		if err != nil {
+			return err
+		}
 	}
 
 	out := f.IOStreams.Out

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -400,9 +400,10 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 	if err != nil {
 		return err
 	}
+	extension := serviceMethodExtensionFor(opts.SchemaPath)
 
-	if opts.SchemaPath == mailRuleReorderSchemaPath && opts.DryRun {
-		return serviceDryRunMailRuleReorder(f, request, config, opts.Format)
+	if opts.DryRun && extension.dryRun != nil {
+		return extension.dryRun(f, request, config, opts.Format)
 	}
 	if opts.DryRun {
 		if fileMeta != nil {
@@ -422,8 +423,8 @@ func serviceMethodRun(opts *ServiceMethodOptions) error {
 		return err
 	}
 
-	if opts.SchemaPath == mailRuleReorderSchemaPath {
-		request, err = completeMailRuleReorderRequest(opts.Ctx, ac, request)
+	if extension.prepareRequest != nil {
+		request, err = extension.prepareRequest(opts.Ctx, ac, request)
 		if err != nil {
 			return err
 		}

--- a/cmd/service/service_method_extensions.go
+++ b/cmd/service/service_method_extensions.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Lark Technologies Pte. Ltd.
+// SPDX-License-Identifier: MIT
+
+package service
+
+import (
+	"context"
+
+	"github.com/larksuite/cli/internal/client"
+	"github.com/larksuite/cli/internal/cmdutil"
+	"github.com/larksuite/cli/internal/core"
+)
+
+type serviceMethodExtension struct {
+	dryRun         func(*cmdutil.Factory, client.RawApiRequest, *core.CliConfig, string) error
+	prepareRequest func(context.Context, *client.APIClient, client.RawApiRequest) (client.RawApiRequest, error)
+}
+
+var serviceMethodExtensions = map[string]serviceMethodExtension{
+	mailRuleReorderSchemaPath: {
+		dryRun:         serviceDryRunMailRuleReorder,
+		prepareRequest: completeMailRuleReorderRequest,
+	},
+}
+
+func serviceMethodExtensionFor(schemaPath string) serviceMethodExtension {
+	return serviceMethodExtensions[schemaPath]
+}


### PR DESCRIPTION
Adds handling for the mail rule reorder endpoint so partial `rule_ids` input is completed before the API call.

- Registers a pre-call hook for `mail.user_mailbox.rules.reorder`.
- Fetches the current rule list, validates explicit IDs, and appends remaining rules in their existing order.
- Updates dry-run output to show the list-and-reorder sequence and the completed request body.
- Adds unit coverage for completion, validation, and dry-run behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mail rule reordering that automatically completes and validates partial rule ID inputs against the current server list.
  * Dry-run for mail rule reordering now reports the full two-step flow and includes expected “remaining IDs” output (pretty or JSON).

* **Bug Fixes**
  * Improved validation for `rule_ids` (rejects empty, duplicate, non-string, or unknown IDs).
  * Prevents reordering when the server rule list cannot be fetched or when an explicit ID is not present.
  * Deduplicates rule IDs discovered from the server before submitting the reorder request.

* **Tests**
  * Added end-to-end CLI tests covering completion, validation, dry-run output, and failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->